### PR TITLE
feat(npm): ship schema.json inside the fallow package (#275)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
 
       - name: Check npm package contents
         run: |
+          cp schema.json npm/fallow/schema.json
           npm pack --dry-run --json ./npm/fallow > /tmp/fallow-pack.json
           node <<'NODE'
           const fs = require('fs');
@@ -177,6 +178,7 @@ jobs:
             'skills/fallow/references/cli-reference.md',
             'skills/fallow/references/gotchas.md',
             'skills/fallow/references/patterns.md',
+            'schema.json',
           ];
           const missing = required.filter((file) => !files.has(file));
           if (missing.length > 0) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,6 +504,18 @@ jobs:
             exit 1
           fi
 
+      # Bundle the JSON schema into the fallow npm package so consumers
+      # can reference it from `node_modules/fallow/schema.json`. Without
+      # this, users either pin to a remote URL that drifts from the
+      # installed CLI version, or have to run `fallow config-schema`
+      # themselves and refresh on every upgrade. See
+      # https://github.com/fallow-rs/fallow/issues/275.
+      #
+      # `--ignore-scripts` is set on the publish below, so we copy at
+      # workflow level rather than relying on a prepublishOnly hook.
+      - name: Bundle schema.json into fallow package
+        run: cp schema.json npm/fallow/schema.json
+
       - name: Publish fallow
         run: |
           VERSION="${TAG_REF#refs/tags/v}"

--- a/npm/fallow/package.json
+++ b/npm/fallow/package.json
@@ -41,7 +41,8 @@
     "scripts",
     "skills",
     "!skills/_artifacts",
-    "README.md"
+    "README.md",
+    "schema.json"
   ],
   "scripts": {
     "postinstall": "node scripts/postinstall.js",


### PR DESCRIPTION
Closes #275.

Two-line fix to bundle the JSON schema into the published \`fallow\` npm package so consumers can reference \`./node_modules/fallow/schema.json\` instead of the \`raw.githubusercontent.com\` URL. That fixes the three downsides @OmerGronich called out:

- **Drift** — \`./node_modules/fallow/schema.json\` is always version-aligned with the installed CLI; the URL tracks \`main\` and can disagree with a pinned install.
- **Network on every IDE open** — the URL needs to be fetched and cached, and corporate proxies sometimes block \`raw.githubusercontent.com\`.
- **Offline / airgapped** — local schema lookup, no generator step, no refresh policy on upgrade.

## What changed

- \`npm/fallow/package.json\`: \`schema.json\` added to the \`files\` array.
- \`.github/workflows/release.yml\`: new \`Bundle schema.json into fallow package\` step right before \`Publish fallow\` that copies \`schema.json\` from the repo root into \`npm/fallow/schema.json\`. Doing it at workflow level rather than via a \`prepublishOnly\` hook because the existing publish call uses \`--ignore-scripts\`.

After this, the issue's recommended consumer config works:

\`\`\`jsonc
// .fallowrc.json
{
  "\$schema": "./node_modules/fallow/schema.json",
  ...
}
\`\`\`

The existing remote URL (\`raw.githubusercontent.com/fallow-rs/fallow/main/schema.json\`) keeps working as a fallback for users without a local install — nothing about this change breaks the remote-URL path.

## What's not in this PR

The optional \`fallow init\` template polish (emit \`./node_modules/fallow/schema.json\` by default) lives in the Rust CLI and is a separate change that's only meaningful once this artifact has actually been published. Happy to do that as a follow-up after the next release if you'd like.

## Test plan

- [x] \`package.json\` valid JSON, \`files\` array includes \`schema.json\`
- [x] \`release.yml\` valid YAML, copy step ordered before \`npm publish ./npm/fallow\`
- [x] \`schema.json\` already lives at the repo root (56 KB, the canonical artifact \`fallow config-schema\` would emit), so the \`cp\` source path is correct
- [ ] (For maintainer) — next \`v*.*.*\` tag should produce a published \`fallow\` package containing \`schema.json\` at the package root; \`npm pack ./npm/fallow\` locally on a tagged build would confirm without a real publish