### PR TITLE
fix(migrate): accept trailing commas in jsonc input (#276)

### DIFF
--- a/crates/cli/src/migrate/mod.rs
+++ b/crates/cli/src/migrate/mod.rs
@@ -288,7 +288,7 @@ fn migrate_from_file(path: &Path) -> Result<MigrationResult, String> {
     })
 }
 
-/// Load a JSON or JSONC file, stripping comments if present.
+/// Load a JSON or JSONC file, stripping comments and trailing commas if present.
 fn load_json_or_jsonc(path: &Path) -> Result<serde_json::Value, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
@@ -304,7 +304,60 @@ fn load_json_or_jsonc(path: &Path) -> Result<serde_json::Value, String> {
         .read_to_string(&mut stripped)
         .map_err(|e| format!("failed to strip comments from {}: {e}", path.display()))?;
 
-    serde_json::from_str(&stripped).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&stripped) {
+        return Ok(value);
+    }
+
+    // Real-world JSONC (e.g. knip.jsonc, tsconfig.json) frequently uses
+    // trailing commas. serde_json rejects them, so strip them as a final
+    // pass before reporting a parse error to the user.
+    let cleaned = strip_trailing_commas(&stripped);
+    serde_json::from_str(&cleaned).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
+
+/// Strip JSONC-style trailing commas (`,` immediately before `}` or `]`)
+/// without touching commas inside string literals.
+fn strip_trailing_commas(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut last_emit = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'"' {
+            in_string = true;
+            i += 1;
+            continue;
+        }
+        if b == b',' {
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
+                out.push_str(&input[last_emit..i]);
+                last_emit = i + 1;
+            }
+        }
+        i += 1;
+    }
+
+    out.push_str(&input[last_emit..]);
+    out
 }
 
 /// Extract a string-or-array field as a `Vec<String>`.

--- a/crates/cli/src/migrate/mod.rs
+++ b/crates/cli/src/migrate/mod.rs
@@ -348,7 +348,10 @@ fn strip_trailing_commas(input: &str) -> String {
             while j < bytes.len() && bytes[j].is_ascii_whitespace() {
                 j += 1;
             }
-            if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
+            if j < bytes.len()
+                && (bytes[j] == b'}' || bytes[j] == b']')
+                && comma_follows_json_value(bytes, i)
+            {
                 out.push_str(&input[last_emit..i]);
                 last_emit = i + 1;
             }
@@ -358,6 +361,19 @@ fn strip_trailing_commas(input: &str) -> String {
 
     out.push_str(&input[last_emit..]);
     out
+}
+
+fn comma_follows_json_value(bytes: &[u8], comma_index: usize) -> bool {
+    let Some(prev) = bytes[..comma_index]
+        .iter()
+        .rev()
+        .copied()
+        .find(|b| !b.is_ascii_whitespace())
+    else {
+        return false;
+    };
+
+    matches!(prev, b'"' | b'}' | b']' | b'0'..=b'9' | b'e' | b'l')
 }
 
 /// Extract a string-or-array field as a `Vec<String>`.

--- a/crates/cli/src/migrate/tests.rs
+++ b/crates/cli/src/migrate/tests.rs
@@ -312,6 +312,20 @@ fn load_json_or_jsonc_invalid_json_and_invalid_jsonc() {
 }
 
 #[test]
+fn load_json_or_jsonc_rejects_malformed_leading_comma() {
+    let tmpdir = std::env::temp_dir().join("fallow-test-migrate-jsonc-leading-comma");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let path = tmpdir.join("knip.jsonc");
+    std::fs::write(&path, "{,}").unwrap();
+
+    let err = load_json_or_jsonc(&path).unwrap_err();
+    assert!(err.contains("failed to parse"));
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
 fn load_json_or_jsonc_accepts_trailing_commas() {
     // Reproduces issue #276: knip.jsonc with trailing commas was rejected
     // as `trailing comma at line 6 column 3`.
@@ -365,8 +379,14 @@ fn load_json_or_jsonc_handles_comments_and_trailing_commas_together() {
     .unwrap();
 
     let value = load_json_or_jsonc(&path).expect("comments + trailing commas should parse");
-    assert_eq!(value.get("entry").unwrap(), &serde_json::json!(["src/index.ts"]));
-    assert_eq!(value.get("ignore").unwrap(), &serde_json::json!(["dist/**"]));
+    assert_eq!(
+        value.get("entry").unwrap(),
+        &serde_json::json!(["src/index.ts"])
+    );
+    assert_eq!(
+        value.get("ignore").unwrap(),
+        &serde_json::json!(["dist/**"])
+    );
 
     let _ = std::fs::remove_dir_all(&tmpdir);
 }
@@ -380,7 +400,13 @@ fn strip_trailing_commas_drops_simple_object_comma() {
 
 #[test]
 fn strip_trailing_commas_drops_simple_array_comma() {
-    assert_eq!(strip_trailing_commas(r#"[1,2,3,]"#), r#"[1,2,3]"#);
+    assert_eq!(strip_trailing_commas(r"[1,2,3,]"), r"[1,2,3]");
+}
+
+#[test]
+fn strip_trailing_commas_preserves_malformed_leading_comma() {
+    assert_eq!(strip_trailing_commas(r"{,}"), r"{,}");
+    assert_eq!(strip_trailing_commas(r"[, ]"), r"[, ]");
 }
 
 #[test]

--- a/crates/cli/src/migrate/tests.rs
+++ b/crates/cli/src/migrate/tests.rs
@@ -6,7 +6,7 @@ use super::knip::migrate_knip;
 use super::toml_gen::generate_toml;
 use super::{
     MigrationResult, MigrationWarning, load_json_or_jsonc, migrate_auto_detect, migrate_from_file,
-    string_or_array,
+    string_or_array, strip_trailing_commas,
 };
 
 fn empty_config() -> serde_json::Map<String, serde_json::Value> {
@@ -309,6 +309,112 @@ fn load_json_or_jsonc_invalid_json_and_invalid_jsonc() {
     assert!(err.contains("failed to parse"));
 
     let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn load_json_or_jsonc_accepts_trailing_commas() {
+    // Reproduces issue #276: knip.jsonc with trailing commas was rejected
+    // as `trailing comma at line 6 column 3`.
+    let tmpdir = std::env::temp_dir().join("fallow-test-migrate-jsonc-trailing");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let path = tmpdir.join("knip.jsonc");
+    std::fs::write(
+        &path,
+        r#"{
+  "entry": [
+    "src/index.ts",
+    "src/main.ts",
+  ],
+  "ignore": [
+    "dist/**",
+  ],
+}"#,
+    )
+    .unwrap();
+
+    let value = load_json_or_jsonc(&path).expect("trailing commas should parse");
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "entry": ["src/index.ts", "src/main.ts"],
+            "ignore": ["dist/**"],
+        })
+    );
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+#[test]
+fn load_json_or_jsonc_handles_comments_and_trailing_commas_together() {
+    // knip.jsonc users routinely combine line comments with trailing
+    // commas — both must be accepted in the same file.
+    let tmpdir = std::env::temp_dir().join("fallow-test-migrate-jsonc-mixed");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir).unwrap();
+    let path = tmpdir.join("knip.jsonc");
+    std::fs::write(
+        &path,
+        r#"{
+  // Entry points
+  "entry": ["src/index.ts",],
+  /* block comment */
+  "ignore": ["dist/**",],
+}"#,
+    )
+    .unwrap();
+
+    let value = load_json_or_jsonc(&path).expect("comments + trailing commas should parse");
+    assert_eq!(value.get("entry").unwrap(), &serde_json::json!(["src/index.ts"]));
+    assert_eq!(value.get("ignore").unwrap(), &serde_json::json!(["dist/**"]));
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+}
+
+// -- strip_trailing_commas helper ----------------------------------------
+
+#[test]
+fn strip_trailing_commas_drops_simple_object_comma() {
+    assert_eq!(strip_trailing_commas(r#"{"a":1,}"#), r#"{"a":1}"#);
+}
+
+#[test]
+fn strip_trailing_commas_drops_simple_array_comma() {
+    assert_eq!(strip_trailing_commas(r#"[1,2,3,]"#), r#"[1,2,3]"#);
+}
+
+#[test]
+fn strip_trailing_commas_preserves_separator_commas() {
+    assert_eq!(
+        strip_trailing_commas(r#"{"a":1,"b":2}"#),
+        r#"{"a":1,"b":2}"#,
+    );
+}
+
+#[test]
+fn strip_trailing_commas_ignores_commas_inside_strings() {
+    // Trailing comma inside a string literal must be preserved verbatim.
+    let input = r#"{"msg":"hello, world,"}"#;
+    assert_eq!(strip_trailing_commas(input), input);
+}
+
+#[test]
+fn strip_trailing_commas_handles_escaped_quote_in_string() {
+    // Escaped quotes inside the string must not flip in_string state, so
+    // the comma inside `"hi,\","` stays put while the trailing comma
+    // before `}` is stripped.
+    let input = r#"{"msg":"he said \"hi,\",","n":1,}"#;
+    let expected = r#"{"msg":"he said \"hi,\",","n":1}"#;
+    assert_eq!(strip_trailing_commas(input), expected);
+}
+
+#[test]
+fn strip_trailing_commas_handles_whitespace_before_brace() {
+    // Pretty-printed input puts the comma on its own line before the
+    // closing brace — still must be stripped.
+    let input = "{\n  \"a\": 1,\n}";
+    let expected = "{\n  \"a\": 1\n}";
+    assert_eq!(strip_trailing_commas(input), expected);
 }
 
 // -- migrate_from_file tests ---------------------------------------------


### PR DESCRIPTION
Closes #276.

## Summary

Real-world JSONC files (knip.jsonc, tsconfig.json, .vscode/settings.json, etc.) routinely use trailing commas. `load_json_or_jsonc` ran the input through `json_comments::StripComments` and then handed the result to serde_json, which rejects trailing commas with `trailing comma at line N column M` — exactly the symptom in the issue.

## Fix

Add a final pass that drops `,` immediately before `}` or `]` while leaving commas inside string literals untouched. The pass runs only when the comment-stripped parse fails, so already-valid input pays zero cost on the happy path:

1. Try plain `serde_json::from_str` — works for normal JSON.
2. Strip comments via `json_comments::StripComments`, retry parse.
3. If that still fails, run `strip_trailing_commas` on the comment-stripped text and retry.

`strip_trailing_commas` is a small byte-level state machine (no new deps) that walks the input, tracks in-string + escaped state, and emits the original text minus any `,` that's followed only by whitespace before `}` or `]`. Multi-byte UTF-8 chars are preserved verbatim because their continuation bytes never collide with the `,` / `\"` / `\\` / `}` / `]` markers we look at.

## Tests

`crates/cli/src/migrate/tests.rs` adds:

- `load_json_or_jsonc_accepts_trailing_commas` — reproduces the issue exactly: a `knip.jsonc` shaped file with trailing commas after `"src/main.ts"` and `"dist/**"` and the outermost object closer. Was failing before, parses correctly now.
- `load_json_or_jsonc_handles_comments_and_trailing_commas_together` — `// line comment`, `/* block comment */`, and trailing commas all in the same file.
- Six unit tests on the helper itself: simple object/array trailing comma, separator-comma preservation, comma-in-string preservation (`"hello, world,"`), escaped quotes (`"he said \"hi,\","`), and pretty-printed-with-newlines input.

`cargo test -p fallow-cli` — 1745 passed, 0 failed.

## Backwards compatibility

Strict JSON inputs hit branch 1 and bypass the new pass entirely, so anything that worked before still works. The new pass only runs when both branch 1 and branch 2 already failed, so it's a strictly additive fallback.