### PR TITLE
fix(unused-class-members): trace Angular signal queries and plural QueryList iteration (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Angular signal-based query factories and plural decorator queries are now traced for `unused-class-members`.** `viewChild()`, `viewChildren()`, `contentChild()`, `contentChildren()` properties (`readonly vc = viewChild<ChildComponent>('vc')`) and `@ViewChildren` / `@ContentChildren` properties typed as `QueryList<T>` previously produced false `unused-class-member` findings on the child component's methods because the call-graph could not see through `this.vc()?.refresh()` (signal queries return a callable signal) or `this.dvcs?.forEach(c => c.refresh())` (the iteration parameter had no resolved type). The visitor now extracts the query's element type — explicit `<T>` type argument or first identifier argument for the signal factories, peeled `QueryList<T>` annotation for the plural decorators — and registers it against a synthetic call-form binding (`this.vc()` → `T`) for the singular signal queries, and against an iterable map (`this.vcs()` / `this.dvcs` → `T`) for the plural cases. `forEach` arrow callbacks on a registered iterable bind their first parameter to the element type so the existing bound-member-access pipeline credits the child's methods. The pre-existing `@ViewChild` and `@ContentChild` paths continue to work unchanged. Thanks [@OmerGronich](https://github.com/OmerGronich) for the eight-pattern reproducer. (Closes [#274](https://github.com/fallow-rs/fallow/issues/274))
+
 ## [2.64.0] - 2026-05-04
 
 ### Added

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -430,9 +430,7 @@ pub(super) fn extract_angular_signal_query(value: &Expression<'_>) -> Option<Ang
 ///
 /// Used for `@ViewChildren` / `@ContentChildren` properties where the type
 /// annotation is the only place the element type appears.
-pub(super) fn extract_query_list_element_type(
-    annotation: &TSTypeAnnotation<'_>,
-) -> Option<String> {
+pub(super) fn extract_query_list_element_type(annotation: &TSTypeAnnotation<'_>) -> Option<String> {
     extract_query_list_from_type(&annotation.type_annotation)
 }
 
@@ -476,7 +474,9 @@ fn extract_query_list_from_type(ty: &TSType<'_>) -> Option<String> {
 /// Recognize a `@ViewChildren(...)` or `@ContentChildren(...)` decorator on a
 /// class property. Used in conjunction with [`extract_query_list_element_type`]
 /// to wire up `forEach`-style iteration through the property.
-pub(super) fn has_angular_plural_query_decorator(decorators: &[oxc_ast::ast::Decorator<'_>]) -> bool {
+pub(super) fn has_angular_plural_query_decorator(
+    decorators: &[oxc_ast::ast::Decorator<'_>],
+) -> bool {
     decorators.iter().any(|decorator| {
         let Expression::CallExpression(call) = &decorator.expression else {
             return false;

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -375,6 +375,119 @@ fn is_angular_signal_initializer(value: &Expression<'_>) -> bool {
     }
 }
 
+/// Result of recognizing an Angular signal-query property initializer.
+pub(super) struct AngularSignalQuery {
+    /// The element type `T` from `viewChild<T>(...)` etc.
+    pub type_arg: String,
+    /// `true` for `viewChildren`/`contentChildren` (returns a signal of an
+    /// array of children), `false` for the singular factories.
+    pub plural: bool,
+}
+
+/// Recognize `viewChild<T>(...)` / `viewChildren<T>(...)` /
+/// `contentChild<T>(...)` / `contentChildren<T>(...)` initializers and return
+/// the element type `T` plus whether the factory is plural.
+///
+/// Falls back to the first call-argument identifier when no explicit type
+/// argument is supplied (e.g. `contentChild(ChildComponent)`), matching how
+/// Angular infers `T` from the locator class.
+pub(super) fn extract_angular_signal_query(value: &Expression<'_>) -> Option<AngularSignalQuery> {
+    let Expression::CallExpression(call) = value else {
+        return None;
+    };
+    let Expression::Identifier(id) = &call.callee else {
+        return None;
+    };
+    let plural = match id.name.as_str() {
+        "viewChild" | "contentChild" => false,
+        "viewChildren" | "contentChildren" => true,
+        _ => return None,
+    };
+    if let Some(type_args) = call.type_arguments.as_deref()
+        && let Some(first) = type_args.params.first()
+        && let Some(name) = extract_type_reference_name(first)
+        && !is_builtin_constructor(&name)
+    {
+        return Some(AngularSignalQuery {
+            type_arg: name,
+            plural,
+        });
+    }
+    if let Some(Argument::Identifier(arg_id)) = call.arguments.first()
+        && !is_builtin_constructor(arg_id.name.as_str())
+    {
+        return Some(AngularSignalQuery {
+            type_arg: arg_id.name.to_string(),
+            plural,
+        });
+    }
+    None
+}
+
+/// Peel `QueryList<T>` (and the nullable variants `QueryList<T> | undefined`,
+/// `QueryList<T> | null`) out of a TypeScript type annotation, returning `T`
+/// when `T` is a single class identifier.
+///
+/// Used for `@ViewChildren` / `@ContentChildren` properties where the type
+/// annotation is the only place the element type appears.
+pub(super) fn extract_query_list_element_type(
+    annotation: &TSTypeAnnotation<'_>,
+) -> Option<String> {
+    extract_query_list_from_type(&annotation.type_annotation)
+}
+
+fn extract_query_list_from_type(ty: &TSType<'_>) -> Option<String> {
+    match ty {
+        TSType::TSTypeReference(type_ref) => {
+            let name = extract_type_name(&type_ref.type_name)?;
+            if name != "QueryList" {
+                return None;
+            }
+            let type_args = type_ref.type_arguments.as_deref()?;
+            let first = type_args.params.first()?;
+            let element = extract_type_reference_name(first)?;
+            if is_builtin_constructor(&element) {
+                None
+            } else {
+                Some(element)
+            }
+        }
+        TSType::TSParenthesizedType(paren) => extract_query_list_from_type(&paren.type_annotation),
+        TSType::TSUnionType(union) => {
+            let mut found: Option<String> = None;
+            for branch in &union.types {
+                match branch {
+                    TSType::TSNullKeyword(_) | TSType::TSUndefinedKeyword(_) => {}
+                    other => {
+                        if found.is_some() {
+                            return None;
+                        }
+                        found = extract_query_list_from_type(other);
+                        found.as_ref()?;
+                    }
+                }
+            }
+            found
+        }
+        _ => None,
+    }
+}
+
+/// Recognize a `@ViewChildren(...)` or `@ContentChildren(...)` decorator on a
+/// class property. Used in conjunction with [`extract_query_list_element_type`]
+/// to wire up `forEach`-style iteration through the property.
+pub(super) fn has_angular_plural_query_decorator(decorators: &[oxc_ast::ast::Decorator<'_>]) -> bool {
+    decorators.iter().any(|decorator| {
+        let Expression::CallExpression(call) = &decorator.expression else {
+            return false;
+        };
+        let Expression::Identifier(id) = &call.callee else {
+            return false;
+        };
+        matches!(id.name.as_str(), "ViewChildren" | "ContentChildren")
+    })
+}
+
 /// Extract class members (methods and properties) from a class declaration.
 ///
 /// When `is_angular_class` is true, properties initialized with Angular signal

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -93,6 +93,14 @@ pub(crate) struct ModuleInfoExtractor {
     /// Used so `x.method()` or `this.service.method()` can be mapped back to the
     /// imported/exported class or interface that owns the member.
     binding_target_names: FxHashMap<String, String>,
+    /// Iterable receivers whose element type is known (Angular plural queries:
+    /// `viewChildren<T>()` / `contentChildren<T>()` initializers and
+    /// `@ViewChildren`/`@ContentChildren` decorated `QueryList<T>` properties).
+    /// When the visitor sees `<receiver>.forEach(c => c.method())` (or the
+    /// optional-chained `?.forEach`), the arrow's first parameter is bound to
+    /// `T` so the inner `c.method` access can be resolved. Keys are the same
+    /// dotted/parenthesized form produced by `static_member_object_name`.
+    iterable_element_types: FxHashMap<String, String>,
     /// Object literal aliases resolved after the full AST walk so later import
     /// declarations can still seed namespace bindings.
     object_binding_candidates: Vec<ObjectBindingCandidate>,

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -3821,7 +3821,7 @@ fn angular_signal_and_plural_queries_trace_child_method_calls() {
         }
         ",
     );
-    let traced: std::collections::HashSet<&str> = info
+    let traced: rustc_hash::FxHashSet<&str> = info
         .member_accesses
         .iter()
         .filter(|a| a.object == "ChildComponent")

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -3768,6 +3768,82 @@ fn angular_output_from_observable_marks_as_decorated() {
     );
 }
 
+// ── Angular signal/plural query call-graph tracing (issue #274) ──
+
+/// All eight Angular query patterns (4 signal + 4 decorator) should produce
+/// `MemberAccess { object: "ChildComponent", member: <method> }` entries so
+/// the analyzer's call-graph traces methods on the queried child.
+#[test]
+fn angular_signal_and_plural_queries_trace_child_method_calls() {
+    let info = parse(
+        r"
+        import {
+            Component,
+            ContentChild,
+            ContentChildren,
+            QueryList,
+            ViewChild,
+            ViewChildren,
+            contentChild,
+            contentChildren,
+            viewChild,
+            viewChildren
+        } from '@angular/core';
+
+        import { ChildComponent } from './child.component';
+
+        @Component({
+            selector: 'app-parent',
+            template: '<app-child #vc />'
+        })
+        export class ParentComponent {
+            readonly vc = viewChild<ChildComponent>('vc');
+            readonly vcs = viewChildren<ChildComponent>('vcs');
+            readonly cc = contentChild<ChildComponent>(ChildComponent);
+            readonly ccs = contentChildren<ChildComponent>(ChildComponent);
+
+            @ViewChild('dvc') readonly dvc?: ChildComponent;
+            @ViewChildren('dvcs') readonly dvcs?: QueryList<ChildComponent>;
+            @ContentChild(ChildComponent) readonly dcc?: ChildComponent;
+            @ContentChildren(ChildComponent) readonly dccs?: QueryList<ChildComponent>;
+
+            triggerRefresh(): void {
+                this.vc()?.refreshViewChild();
+                this.vcs().forEach((c) => c.refreshViewChildren());
+                this.cc()?.refreshContentChild();
+                this.ccs().forEach((c) => c.refreshContentChildren());
+
+                this.dvc?.refreshDecoratorViewChild();
+                this.dvcs?.forEach((c) => c.refreshDecoratorViewChildren());
+                this.dcc?.refreshDecoratorContentChild();
+                this.dccs?.forEach((c) => c.refreshDecoratorContentChildren());
+            }
+        }
+        ",
+    );
+    let traced: std::collections::HashSet<&str> = info
+        .member_accesses
+        .iter()
+        .filter(|a| a.object == "ChildComponent")
+        .map(|a| a.member.as_str())
+        .collect();
+    for method in &[
+        "refreshViewChild",
+        "refreshViewChildren",
+        "refreshContentChild",
+        "refreshContentChildren",
+        "refreshDecoratorViewChild",
+        "refreshDecoratorViewChildren",
+        "refreshDecoratorContentChild",
+        "refreshDecoratorContentChildren",
+    ] {
+        assert!(
+            traced.contains(method),
+            "expected ChildComponent.{method} to be traced via Angular query (got {traced:?})"
+        );
+    }
+}
+
 // ── Angular combined metadata extraction ──────────────────────
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -25,9 +25,8 @@ use super::helpers::{
     extract_angular_component_metadata, extract_angular_signal_query, extract_class_members,
     extract_concat_parts, extract_custom_elements_define, extract_implemented_interface_names,
     extract_nested_type_bindings, extract_query_list_element_type, extract_super_class_name,
-    extract_type_annotation_name, has_angular_class_decorator,
-    has_angular_plural_query_decorator, is_meta_url_arg, lit_custom_element_decorator,
-    regex_pattern_to_suffix,
+    extract_type_annotation_name, has_angular_class_decorator, has_angular_plural_query_decorator,
+    is_meta_url_arg, lit_custom_element_decorator, regex_pattern_to_suffix,
 };
 use super::{
     ModuleInfoExtractor, SideEffectRegistrationTarget, try_extract_arrow_wrapped_import,
@@ -592,14 +591,12 @@ impl ModuleInfoExtractor {
             return;
         };
         let param_name = match first_arg {
-            Argument::ArrowFunctionExpression(arrow) => arrow
-                .params
-                .items
-                .first()
-                .and_then(|p| match &p.pattern {
+            Argument::ArrowFunctionExpression(arrow) => {
+                arrow.params.items.first().and_then(|p| match &p.pattern {
                     BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
                     _ => None,
-                }),
+                })
+            }
             Argument::FunctionExpression(func) => {
                 func.params.items.first().and_then(|p| match &p.pattern {
                     BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
@@ -842,8 +839,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             {
                 let call_key = format!("this.{name}()");
                 if query.plural {
-                    self.iterable_element_types
-                        .insert(call_key, query.type_arg);
+                    self.iterable_element_types.insert(call_key, query.type_arg);
                 } else {
                     self.binding_target_names.insert(call_key, query.type_arg);
                 }

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -22,10 +22,11 @@ use crate::asset_url::normalize_asset_url;
 use crate::html::is_remote_url;
 
 use super::helpers::{
-    extract_angular_component_metadata, extract_class_members, extract_concat_parts,
-    extract_custom_elements_define, extract_implemented_interface_names,
-    extract_nested_type_bindings, extract_super_class_name, extract_type_annotation_name,
-    has_angular_class_decorator, is_meta_url_arg, lit_custom_element_decorator,
+    extract_angular_component_metadata, extract_angular_signal_query, extract_class_members,
+    extract_concat_parts, extract_custom_elements_define, extract_implemented_interface_names,
+    extract_nested_type_bindings, extract_query_list_element_type, extract_super_class_name,
+    extract_type_annotation_name, has_angular_class_decorator,
+    has_angular_plural_query_decorator, is_meta_url_arg, lit_custom_element_decorator,
     regex_pattern_to_suffix,
 };
 use super::{
@@ -561,6 +562,57 @@ impl ModuleInfoExtractor {
         }
     }
 
+    /// Recognize `<receiver>.forEach(c => ...)` (and the optional-chained
+    /// `<receiver>?.forEach(c => ...)`) where `<receiver>` was previously
+    /// registered as an iterable with a known element type, and bind the
+    /// arrow callback's first parameter to that element type. The binding is
+    /// stored in `binding_target_names` so subsequent `c.method()` accesses
+    /// flow through the existing bound-member-access resolution at end-of-visit.
+    fn bind_iterable_callback_parameter(&mut self, expr: &CallExpression<'_>) {
+        let (receiver_expr, method_name) = match &expr.callee {
+            Expression::StaticMemberExpression(member) => (&member.object, &member.property.name),
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::StaticMemberExpression(member) => {
+                    (&member.object, &member.property.name)
+                }
+                _ => return,
+            },
+            _ => return,
+        };
+        if method_name.as_str() != "forEach" {
+            return;
+        }
+        let Some(receiver_name) = static_member_object_name(receiver_expr) else {
+            return;
+        };
+        let Some(element_type) = self.iterable_element_types.get(&receiver_name).cloned() else {
+            return;
+        };
+        let Some(first_arg) = expr.arguments.first() else {
+            return;
+        };
+        let param_name = match first_arg {
+            Argument::ArrowFunctionExpression(arrow) => arrow
+                .params
+                .items
+                .first()
+                .and_then(|p| match &p.pattern {
+                    BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
+                    _ => None,
+                }),
+            Argument::FunctionExpression(func) => {
+                func.params.items.first().and_then(|p| match &p.pattern {
+                    BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
+                    _ => None,
+                })
+            }
+            _ => None,
+        };
+        if let Some(name) = param_name {
+            self.binding_target_names.insert(name, element_type);
+        }
+    }
+
     fn is_named_import_from(&self, local_name: &str, source: &str, imported_name: &str) -> bool {
         self.imports.iter().any(|import| {
             import.source == source
@@ -752,6 +804,16 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if let Some(name) = prop.key.static_name() {
             if let Some(type_annotation) = prop.type_annotation.as_deref() {
                 self.record_typed_binding(format!("this.{name}").as_str(), type_annotation);
+
+                // `@ViewChildren ... readonly dvcs?: QueryList<ChildComponent>`:
+                // peel the element type out of the `QueryList<T>` annotation so
+                // `this.dvcs?.forEach(c => c.method())` can resolve `c` to `T`.
+                if has_angular_plural_query_decorator(&prop.decorators)
+                    && let Some(element_type) = extract_query_list_element_type(type_annotation)
+                {
+                    self.iterable_element_types
+                        .insert(format!("this.{name}"), element_type);
+                }
             }
 
             if let Some(Expression::NewExpression(new_expr)) = &prop.value
@@ -767,6 +829,24 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             {
                 self.binding_target_names
                     .insert(format!("this.{name}"), type_name);
+            }
+
+            // Angular signal queries: `readonly vc = viewChild<T>(...)` etc.
+            // Singular factories produce `Signal<T>`, called as `this.vc()`,
+            // so the synthetic key `this.<name>()` is bound to `T`. Plural
+            // factories produce `Signal<readonly T[]>`, iterated via
+            // `this.vcs().forEach(c => c.method())`, so the same call-form
+            // key is recorded as an iterable whose element type is `T`.
+            if let Some(value) = prop.value.as_ref()
+                && let Some(query) = extract_angular_signal_query(value)
+            {
+                let call_key = format!("this.{name}()");
+                if query.plural {
+                    self.iterable_element_types
+                        .insert(call_key, query.type_arg);
+                } else {
+                    self.binding_target_names.insert(call_key, query.type_arg);
+                }
             }
         }
 
@@ -1303,6 +1383,13 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if let Some((_tag, class_name)) = extract_custom_elements_define(expr) {
             self.side_effect_registered_class_names.insert(class_name);
         }
+
+        // Angular plural-query iteration: `this.vcs().forEach(c => c.m())`,
+        // `this.dvcs?.forEach(c => c.m())`. When the receiver was registered
+        // as an iterable with a known element type, bind the arrow callback's
+        // first parameter to that type so the inner `c.m()` member access
+        // resolves through `binding_target_names`.
+        self.bind_iterable_callback_parameter(expr);
 
         if let Some(mock_source) =
             vitest_mock_source(expr).and_then(|source| vitest_auto_mock_source(&source))
@@ -1865,6 +1952,28 @@ fn static_member_object_name(expr: &Expression<'_>) -> Option<String> {
             static_member_object_name(&member.object)?,
             member.property.name
         )),
+        // `this.vc()` — Angular signal query call. The synthetic name
+        // `this.vc()` is registered in `binding_target_names` so the
+        // surrounding chain `this.vc()?.method()` can be resolved through
+        // the existing bound-member-access pipeline. Restricted to zero-arg
+        // calls so non-getter call sites do not steal the member access.
+        Expression::CallExpression(call) if call.arguments.is_empty() => {
+            Some(format!("{}()", static_member_object_name(&call.callee)?))
+        }
+        // `(this.vc()?.method)` and similar optional chains wrap the
+        // member-access in a `ChainExpression`; descend into the wrapped form
+        // so `this.vc()?.refresh()` resolves the same way as `this.vc().refresh()`.
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(call) if call.arguments.is_empty() => {
+                Some(format!("{}()", static_member_object_name(&call.callee)?))
+            }
+            ChainElement::StaticMemberExpression(member) => Some(format!(
+                "{}.{}",
+                static_member_object_name(&member.object)?,
+                member.property.name
+            )),
+            _ => None,
+        },
         _ => None,
     }
 }


### PR DESCRIPTION
## Closes #274

`unused-class-members` already credits methods called through `@ViewChild` / `@ContentChild` decorator queries because the property's TS type annotation feeds the bound-member-access pipeline. Six other first-class Angular query patterns were silently missed.

### Truth table from the OP

| Pattern              | Method on `ChildComponent`           | Before | After |
| -------------------- | ------------------------------------ | ------ | ----- |
| `viewChild()`        | `refreshViewChild`                   | not traced | traced |
| `viewChildren()`     | `refreshViewChildren`                | not traced | traced |
| `contentChild()`     | `refreshContentChild`                | not traced | traced |
| `contentChildren()`  | `refreshContentChildren`             | not traced | traced |
| `@ViewChild`         | `refreshDecoratorViewChild`          | traced | traced |
| `@ViewChildren`      | `refreshDecoratorViewChildren`       | not traced | traced |
| `@ContentChild`      | `refreshDecoratorContentChild`       | traced | traced |
| `@ContentChildren`   | `refreshDecoratorContentChildren`    | not traced | traced |

### Why the existing path missed them

- **Signal-based factories** (`viewChild`, `viewChildren`, `contentChild`, `contentChildren`) return `Signal<T>` / `Signal<readonly T[]>`. The property has no explicit TS type annotation, and the call site `this.vc()?.method()` puts a `CallExpression` between `this.vc` and `method`. `static_member_object_name` resolved only `Identifier` / `ThisExpression` / `StaticMemberExpression` and returned `None` for the call-result, so the member access was never emitted.
- **Plural decorator queries** (`@ViewChildren` / `@ContentChildren`) declare the property as `QueryList<T> | undefined`. `extract_type_annotation_name` flattens that to the bare `"QueryList"` identifier, so the element type was never reachable.
- **`forEach` arrow callbacks** had no resolved type for the iteration parameter `c`, so `c.method()` fell on the floor regardless of how the receiver was typed.

### Approach

Smallest change that closes the gap, structured to extend the existing `binding_target_names` machinery rather than introduce a parallel pipeline:

1. **`extract_angular_signal_query`** in `helpers.rs` recognizes the four signal-query factories and pulls `T` from either the explicit `<T>` type argument or the first identifier argument (the locator-class form, `contentChild(ChildComponent)`).
2. **`extract_query_list_element_type`** peels `QueryList<T>` out of a TS type annotation, including the nullable `QueryList<T> | null|undefined` variants. **`has_angular_plural_query_decorator`** recognizes `@ViewChildren` / `@ContentChildren`.
3. **`visit_property_definition`** registers the element type on `ModuleInfoExtractor`:
   - Singular signal queries → `binding_target_names["this.<name>()"] = T`
   - Plural signal queries → `iterable_element_types["this.<name>()"] = T`
   - Plural decorator queries → `iterable_element_types["this.<name>"] = T`
4. **`static_member_object_name`** is extended to descend into a zero-argument `CallExpression` (yielding the synthetic key `"this.vc()"`) and into a `ChainExpression`, so `this.vc()?.method()` and `this.dvcs?.forEach(...)` flow through the pipeline.
5. **`visit_call_expression`** detects `<receiver>.forEach` (and the optional-chained form), looks the receiver up in `iterable_element_types`, and binds the arrow callback's first parameter to the element type via the existing flat `binding_target_names` map. The convention matches the scope-unaware comment already in `visit_impl.rs`.

### Patterns now covered (six new)

1. `this.vc()?.method()` where `vc = viewChild<T>(...)`
2. `this.cc()?.method()` where `cc = contentChild<T>(...)`
3. `this.vcs().forEach(c => c.method())` where `vcs = viewChildren<T>(...)`
4. `this.ccs().forEach(c => c.method())` where `ccs = contentChildren<T>(...)`
5. `this.dvcs?.forEach(c => c.method())` where `dvcs: QueryList<T>` is `@ViewChildren`-decorated
6. `this.dccs?.forEach(c => c.method())` where `dccs: QueryList<T>` is `@ContentChildren`-decorated

### Limitations

- The plural-iteration path matches `forEach` only. `.map`, `.filter`, `.find`, etc. on a `QueryList` or `viewChildren()` result remain untraced. Easy to extend (single match arm) when the demand surfaces; held back here to keep the diff minimal.
- The element type must be syntactically discoverable from a single TS type argument or argument identifier. Mapped types, wider unions, or generic-parameter-relayed `T` are not resolved (matches the existing constraints on `extract_type_reference_name`).
- `forEach` callbacks bind only when the parameter is a plain `BindingIdentifier`. Destructuring patterns (`forEach(({ inner }) => ...)`) fall back to no binding.

### Tests

`cargo test -p fallow-extract` — 1391 pass.

Adds `angular_signal_and_plural_queries_trace_child_method_calls` in `crates/extract/src/visitor/tests.rs`, which is the issue's eight-pattern reproducer verbatim and asserts all eight `ChildComponent` methods are emitted as `MemberAccess { object: "ChildComponent", member: <name> }`.