### PR TITLE
fix: vite.config default export reachable under includeEntryExports (#282)

### DIFF
--- a/crates/core/src/plugins/vite.rs
+++ b/crates/core/src/plugins/vite.rs
@@ -6,6 +6,8 @@
 use super::config_parser;
 use super::{Plugin, PluginResult};
 
+const CONFIG_EXPORTS: &[&str] = &["default"];
+
 fn additional_data_entry_pattern(
     root: &std::path::Path,
     source: &fallow_extract::css::CssImportSource,
@@ -94,6 +96,10 @@ define_plugin!(
     // Vite plugins create virtual modules with `virtual:` prefix
     // (e.g., `virtual:pwa-register`, `virtual:emoji-mart-lang-importer`)
     virtual_module_prefixes: &["virtual:"],
+    // Under --include-entry-exports, the default export of vite.config.* is the
+    // entry: Vite's CLI consumes it. Marking it framework-used prevents the
+    // false-positive in #282 (mirrors the vitest fix in #271).
+    used_exports: [("vite.config.{ts,js,mts,mjs}", CONFIG_EXPORTS)],
     resolve_config(config_path, source, root) {
         let mut result = PluginResult::default();
 

--- a/crates/core/tests/integration_test/entry_export_validation.rs
+++ b/crates/core/tests/integration_test/entry_export_validation.rs
@@ -117,6 +117,39 @@ fn vitest_config_default_export_is_framework_used_with_include_entry_exports() {
 }
 
 #[test]
+fn vite_config_default_export_is_framework_used_with_include_entry_exports() {
+    // Issue #282: vite.config.* default export is consumed by Vite itself; under
+    // --include-entry-exports it must not be reported. Mirrors #271 for vitest.
+    let root = fixture_path("vite-include-entry-exports-workspace");
+    let mut config = create_config(root);
+    config.include_entry_exports = true;
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|export| {
+            (
+                export
+                    .path
+                    .strip_prefix(&config.root)
+                    .unwrap_or(&export.path)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                export.export_name.clone(),
+            )
+        })
+        .collect();
+
+    assert!(
+        !unused_exports.iter().any(|(path, export)| {
+            path == "packages/web/charts/vite.config.mts" && export == "default"
+        }),
+        "Vite config default export should be framework-used, found: {unused_exports:?}"
+    );
+}
+
+#[test]
 fn storybook_exports_are_framework_used_with_include_entry_exports() {
     let root = fixture_path("storybook-include-entry-exports");
     let mut config = create_config(root);

--- a/tests/fixtures/vite-include-entry-exports-workspace/package.json
+++ b/tests/fixtures/vite-include-entry-exports-workspace/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "vite-include-entry-exports-workspace",
+  "private": true,
+  "workspaces": [
+    "packages/web/charts"
+  ]
+}

--- a/tests/fixtures/vite-include-entry-exports-workspace/packages/web/charts/package.json
+++ b/tests/fixtures/vite-include-entry-exports-workspace/packages/web/charts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixture/charts",
+  "private": true,
+  "scripts": {
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/tests/fixtures/vite-include-entry-exports-workspace/packages/web/charts/vite.config.mts
+++ b/tests/fixtures/vite-include-entry-exports-workspace/packages/web/charts/vite.config.mts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: __dirname,
+});


### PR DESCRIPTION
Closes #282.

## Problem

`vite.config.{ts,js,mts,mjs}` exports a `defineConfig({...})` value as `default`, and Vite's CLI consumes that default export — that *is* the entry. With `includeEntryExports: true`, fallow flags it as unused:

```ts
// vite.config.mts
import { defineConfig } from "vite";
export default defineConfig({ /* ... */ });
//      ^^^^^^^ reported as unused
```

OP repro on #282: same shape as #271 (vitest), now for plain Vite configs.

## Fix

Same approach as #271 (commit ce5580c1): the vite plugin contributes `used_exports` for `vite.config.{ts,js,mts,mjs}` (`default`), so under `--include-entry-exports` the framework-supplied entry export is recognised as reachable.

Smallest viable diff — one `used_exports: [(...)]` line on `VitePlugin` plus a `CONFIG_EXPORTS` const, mirroring `VitestPlugin`.

## Before / after (on the OP's repro)

Before: `vite.config.mts` `default` reported under `unused-exports`.
After: `vite.config.mts` `default` no longer reported.

## Regression pin

Existing tests in `crates/core/tests/integration_test/entry_export_validation.rs` already cover the case where `--include-entry-exports` *should* flag genuinely-unused named exports on non-config entries (`entry_exports_detected_when_include_entry_exports_enabled`, `entry_exports_detected_via_config_file_include_entry_exports`). They continue to pass — the new used_exports rule is glob-scoped to `vite.config.{ts,js,mts,mjs}` only, so non-config entry files are unaffected.

## Test coverage

New integration test `vite_config_default_export_is_framework_used_with_include_entry_exports` + fixture `tests/fixtures/vite-include-entry-exports-workspace/` (workspace shape matches the vitest sibling fixture).

```
cargo test -p fallow-extract        → 1391 passed
cargo test -p fallow-cli --bin fallow → 1737 passed
cargo test -p fallow-core           → 316 passed
cargo test -p fallow-core --test integration_test -- entry_export → 6 passed (incl. new + #271 sibling)
```