### PR TITLE
fix: recognize prisma.config.ts as an entry-point (#281)

### DIFF
--- a/crates/core/src/plugins/prisma.rs
+++ b/crates/core/src/plugins/prisma.rs
@@ -1,7 +1,7 @@
 //! Prisma ORM plugin.
 //!
 //! Detects Prisma projects and marks seed files as entry points
-//! and schema files as always used.
+//! and schema/config files as always used.
 
 use super::Plugin;
 
@@ -9,7 +9,15 @@ const ENABLERS: &[&str] = &["prisma", "@prisma/client"];
 
 const ENTRY_PATTERNS: &[&str] = &["prisma/seed.{ts,js}"];
 
-const ALWAYS_USED: &[&str] = &["prisma/schema.prisma"];
+// `prisma.config.{ts,mts,cts,js,mjs,cjs}` is the officially-supported config
+// file location introduced in Prisma 6.x. Prisma loads it directly, so no
+// source file imports it; without this entry it is reported as unused.
+const CONFIG_PATTERNS: &[&str] = &["prisma.config.{ts,mts,cts,js,mjs,cjs}"];
+
+const ALWAYS_USED: &[&str] = &[
+    "prisma/schema.prisma",
+    "prisma.config.{ts,mts,cts,js,mjs,cjs}",
+];
 
 const TOOLING_DEPENDENCIES: &[&str] = &["prisma", "@prisma/client"];
 
@@ -17,6 +25,7 @@ define_plugin! {
     struct PrismaPlugin => "prisma",
     enablers: ENABLERS,
     entry_patterns: ENTRY_PATTERNS,
+    config_patterns: CONFIG_PATTERNS,
     always_used: ALWAYS_USED,
     tooling_dependencies: TOOLING_DEPENDENCIES,
 }

--- a/crates/core/tests/integration_test/false_positive_fixes.rs
+++ b/crates/core/tests/integration_test/false_positive_fixes.rs
@@ -298,3 +298,53 @@ fn interface_member_usage_does_not_flag_implementer_members() {
         "unrelated members should still be reported: {unused_members:?}"
     );
 }
+
+// ── Prisma config file (issue #281) ─────────────────────────
+
+#[test]
+fn prisma_config_ts_is_recognized_as_entry_point() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("prisma")).expect("prisma dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+            "name": "prisma-config-entry",
+            "private": true,
+            "devDependencies": {
+                "prisma": "6.0.0"
+            }
+        }"#,
+    )
+    .expect("package json");
+    std::fs::write(
+        root.join("prisma/schema.prisma"),
+        "generator client { provider = \"prisma-client-js\" }\n",
+    )
+    .expect("schema.prisma");
+    std::fs::write(
+        root.join("prisma.config.ts"),
+        r#"import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+    schema: "prisma/schema.prisma",
+});
+"#,
+    )
+    .expect("prisma.config.ts");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    assert!(
+        !unused.iter().any(|p| p.ends_with("prisma.config.ts")),
+        "prisma.config.ts is the Prisma 6.x config-file location and should not be reported \
+         as unused. Got: {unused:?}"
+    );
+}


### PR DESCRIPTION
Closes #281.

Prisma 6.x [introduced](https://www.prisma.io/docs/orm/reference/prisma-config-reference) `prisma.config.ts` as the officially-supported root config-file location. The Prisma CLI loads it directly, so no source file imports it, which means `fallow list` and `fallow dead-code` currently report it as an unused file:

```
$ npx -y fallow list
Active plugins:
  - prisma
Discovered 1 files
prisma.config.ts
Found 0 entry points
```

## Change

Adds `prisma.config.{ts,mts,cts,js,mjs,cjs}` to the prisma plugin's `CONFIG_PATTERNS` and `ALWAYS_USED` lists in `crates/core/src/plugins/prisma.rs`. The plugin is already activated by the `prisma` / `@prisma/client` enablers, so the new entry only takes effect when prisma is actually a dependency.

Six extensions match the supported ESM/CJS variants for both TypeScript and JavaScript:

| extension      | notes                          |
| -------------- | ------------------------------ |
| `.ts`          | default per Prisma docs        |
| `.mts` / `.cts`| explicit ESM / CJS TypeScript  |
| `.js`          | plain JavaScript               |
| `.mjs` / `.cjs`| explicit ESM / CJS JavaScript  |

This mirrors the convention already used by sibling plugins (`cypress.config.{ts,js,mjs,cjs}`, `tsdown.config.{ts,js,cjs,mjs}`).

## Test

Adds `prisma_config_ts_is_recognized_as_entry_point` to `false_positive_fixes.rs`. Builds a temp project with:

```
package.json          { devDependencies: { prisma: "6.0.0" } }
prisma/schema.prisma
prisma.config.ts      (defineConfig({ schema: "prisma/schema.prisma" }))
```

and asserts that `prisma.config.ts` is not reported in `unused_files`.

## Verification

- `cargo test -p fallow-core` — 316 integration tests pass, 110 plugin-registry unit tests pass
- `cargo test -p fallow-cli --bin fallow` — 1737 tests pass