### PR TITLE
fix(dupes): honor scalar config fields when CLI flags are omitted

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -2061,10 +2061,13 @@ fn run_audit_dupes<'a>(
         no_cache: opts.no_cache,
         threads: opts.threads,
         quiet: opts.quiet,
-        mode: DupesMode::from(dupes_cfg.mode),
-        min_tokens: dupes_cfg.min_tokens,
-        min_lines: dupes_cfg.min_lines,
-        threshold: dupes_cfg.threshold,
+        // The audit pipeline has already merged config + global flags into
+        // `dupes_cfg`; pass them as explicit overrides so `build_dupes_config`
+        // doesn't re-merge with stale toml values.
+        mode: Some(DupesMode::from(dupes_cfg.mode)),
+        min_tokens: Some(dupes_cfg.min_tokens),
+        min_lines: Some(dupes_cfg.min_lines),
+        threshold: Some(dupes_cfg.threshold),
         skip_local: dupes_cfg.skip_local,
         cross_language: dupes_cfg.cross_language,
         ignore_imports: dupes_cfg.ignore_imports,

--- a/crates/cli/src/combined.rs
+++ b/crates/cli/src/combined.rs
@@ -688,12 +688,17 @@ fn run_combined_dupes(
         no_cache: opts.no_cache,
         threads: opts.threads,
         quiet: opts.quiet,
-        mode: opts
-            .dupes_mode
-            .unwrap_or_else(|| DupesMode::from(dupes_cfg.mode)),
-        min_tokens: dupes_cfg.min_tokens,
-        min_lines: dupes_cfg.min_lines,
-        threshold: opts.dupes_threshold.unwrap_or(dupes_cfg.threshold),
+        // Combined mode has already resolved CLI overrides against
+        // `dupes_cfg`; pass each as an explicit `Some(...)` so
+        // `build_dupes_config` treats them as authoritative instead of
+        // re-merging with the toml values a second time.
+        mode: Some(
+            opts.dupes_mode
+                .unwrap_or_else(|| DupesMode::from(dupes_cfg.mode)),
+        ),
+        min_tokens: Some(dupes_cfg.min_tokens),
+        min_lines: Some(dupes_cfg.min_lines),
+        threshold: Some(opts.dupes_threshold.unwrap_or(dupes_cfg.threshold)),
         skip_local: dupes_cfg.skip_local,
         cross_language: dupes_cfg.cross_language,
         ignore_imports: dupes_cfg.ignore_imports,

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -35,10 +35,16 @@ pub struct DupesOptions<'a> {
     pub no_cache: bool,
     pub threads: usize,
     pub quiet: bool,
-    pub mode: DupesMode,
-    pub min_tokens: usize,
-    pub min_lines: usize,
-    pub threshold: f64,
+    /// CLI override for detection mode. `None` falls back to the value from
+    /// the config file (or its default if unspecified there).
+    pub mode: Option<DupesMode>,
+    /// CLI override for minimum token count. `None` falls back to config.
+    pub min_tokens: Option<usize>,
+    /// CLI override for minimum line count. `None` falls back to config.
+    pub min_lines: Option<usize>,
+    /// CLI override for failure threshold percentage. `None` falls back to
+    /// config (where `0.0` disables the gate).
+    pub threshold: Option<f64>,
     pub skip_local: bool,
     pub cross_language: bool,
     pub ignore_imports: bool,
@@ -82,24 +88,32 @@ fn parse_trace_spec(spec: &str) -> Result<(&str, usize), &'static str> {
 }
 
 /// Build a `DuplicatesConfig` from CLI options, merging with values from the config file.
+///
+/// CLI scalar fields (`mode`, `min_tokens`, `min_lines`, `threshold`) are
+/// `Option<T>` so an absent flag falls through to the value declared in
+/// `toml_dupes`. This is what lets users set e.g. `duplicates.minLines = 8`
+/// in `.fallowrc.jsonc` and have `fallow dupes` honor it. Boolean toggles
+/// (`skip_local`, `cross_language`, `ignore_imports`) use OR-merge, so any
+/// `true` (CLI or config) wins.
 fn build_dupes_config(
     opts: &DupesOptions<'_>,
     toml_dupes: &fallow_config::DuplicatesConfig,
 ) -> fallow_config::DuplicatesConfig {
+    let mode = opts.mode.map_or(toml_dupes.mode, |m| match m {
+        DupesMode::Strict => fallow_config::DetectionMode::Strict,
+        DupesMode::Mild => fallow_config::DetectionMode::Mild,
+        DupesMode::Weak => fallow_config::DetectionMode::Weak,
+        DupesMode::Semantic => fallow_config::DetectionMode::Semantic,
+    });
     fallow_config::DuplicatesConfig {
         enabled: true,
-        mode: match opts.mode {
-            DupesMode::Strict => fallow_config::DetectionMode::Strict,
-            DupesMode::Mild => fallow_config::DetectionMode::Mild,
-            DupesMode::Weak => fallow_config::DetectionMode::Weak,
-            DupesMode::Semantic => fallow_config::DetectionMode::Semantic,
-        },
-        min_tokens: opts.min_tokens,
-        min_lines: opts.min_lines,
-        threshold: opts.threshold,
+        mode,
+        min_tokens: opts.min_tokens.unwrap_or(toml_dupes.min_tokens),
+        min_lines: opts.min_lines.unwrap_or(toml_dupes.min_lines),
+        threshold: opts.threshold.unwrap_or(toml_dupes.threshold),
         ignore: toml_dupes.ignore.clone(),
         ignore_defaults: toml_dupes.ignore_defaults,
-        skip_local: opts.skip_local,
+        skip_local: opts.skip_local || toml_dupes.skip_local,
         cross_language: opts.cross_language || toml_dupes.cross_language,
         ignore_imports: opts.ignore_imports || toml_dupes.ignore_imports,
         normalization: toml_dupes.normalization.clone(),
@@ -348,7 +362,9 @@ fn execute_dupes_inner(
         default_ignore_skips,
         config,
         elapsed,
-        threshold: opts.threshold,
+        // Use the merged threshold so the failure gate honors `.fallowrc.jsonc`
+        // when `--threshold` is omitted on the CLI.
+        threshold: dupes_config.threshold,
         explain_skipped: opts.explain_skipped,
     })
 }
@@ -635,6 +651,12 @@ mod tests {
         }
     }
 
+    /// Build a `DupesOptions` with the legacy CLI-default scalars preset
+    /// (`min_tokens=50`, `min_lines=5`, `threshold=0.0`). Tests that exercise
+    /// CLI-override semantics still need a concrete value, so we wrap each
+    /// scalar in `Some(...)` here. Tests that want the config-fallback path
+    /// should mutate the returned struct's scalars to `None` before calling
+    /// `build_dupes_config`.
     fn default_opts_for_config(root: &Path, mode: DupesMode) -> DupesOptions<'_> {
         DupesOptions {
             root,
@@ -643,10 +665,10 @@ mod tests {
             no_cache: true,
             threads: 1,
             quiet: true,
-            mode,
-            min_tokens: 50,
-            min_lines: 5,
-            threshold: 0.0,
+            mode: Some(mode),
+            min_tokens: Some(50),
+            min_lines: Some(5),
+            threshold: Some(0.0),
             skip_local: false,
             cross_language: false,
             ignore_imports: false,
@@ -874,8 +896,8 @@ mod tests {
     fn build_config_uses_cli_min_tokens_and_lines() {
         let root = PathBuf::from("/project");
         let mut opts = default_opts_for_config(&root, DupesMode::Mild);
-        opts.min_tokens = 100;
-        opts.min_lines = 10;
+        opts.min_tokens = Some(100);
+        opts.min_lines = Some(10);
         let toml = DuplicatesConfig::default();
         let config = build_dupes_config(&opts, &toml);
         assert_eq!(config.min_tokens, 100);
@@ -886,7 +908,7 @@ mod tests {
     fn build_config_uses_cli_threshold() {
         let root = PathBuf::from("/project");
         let mut opts = default_opts_for_config(&root, DupesMode::Mild);
-        opts.threshold = 7.5;
+        opts.threshold = Some(7.5);
         let toml = DuplicatesConfig::default();
         let config = build_dupes_config(&opts, &toml);
         assert!((config.threshold - 7.5).abs() < f64::EPSILON);
@@ -900,6 +922,106 @@ mod tests {
         let toml = DuplicatesConfig::default();
         let config = build_dupes_config(&opts, &toml);
         assert!(config.skip_local);
+    }
+
+    // ── Config-fallback tests ────────────────────────────────────────
+    // These regression tests cover the bug where CLI scalars wiped out
+    // the values declared in `.fallowrc.jsonc`. With `Option<T>` opts,
+    // a `None` must fall through to the toml value.
+
+    #[test]
+    fn build_config_falls_back_to_toml_min_lines_when_cli_unset() {
+        let root = PathBuf::from("/project");
+        let mut opts = default_opts_for_config(&root, DupesMode::Mild);
+        opts.min_lines = None;
+        let toml = DuplicatesConfig {
+            min_lines: 8,
+            ..DuplicatesConfig::default()
+        };
+        let config = build_dupes_config(&opts, &toml);
+        assert_eq!(
+            config.min_lines, 8,
+            "config minLines must win when --min-lines is omitted"
+        );
+    }
+
+    #[test]
+    fn build_config_falls_back_to_toml_min_tokens_when_cli_unset() {
+        let root = PathBuf::from("/project");
+        let mut opts = default_opts_for_config(&root, DupesMode::Mild);
+        opts.min_tokens = None;
+        let toml = DuplicatesConfig {
+            min_tokens: 200,
+            ..DuplicatesConfig::default()
+        };
+        let config = build_dupes_config(&opts, &toml);
+        assert_eq!(
+            config.min_tokens, 200,
+            "config minTokens must win when --min-tokens is omitted"
+        );
+    }
+
+    #[test]
+    fn build_config_falls_back_to_toml_threshold_when_cli_unset() {
+        let root = PathBuf::from("/project");
+        let mut opts = default_opts_for_config(&root, DupesMode::Mild);
+        opts.threshold = None;
+        let toml = DuplicatesConfig {
+            threshold: 12.5,
+            ..DuplicatesConfig::default()
+        };
+        let config = build_dupes_config(&opts, &toml);
+        assert!(
+            (config.threshold - 12.5).abs() < f64::EPSILON,
+            "config threshold must win when --threshold is omitted"
+        );
+    }
+
+    #[test]
+    fn build_config_falls_back_to_toml_mode_when_cli_unset() {
+        let root = PathBuf::from("/project");
+        let mut opts = default_opts_for_config(&root, DupesMode::Mild);
+        opts.mode = None;
+        let toml = DuplicatesConfig {
+            mode: fallow_config::DetectionMode::Strict,
+            ..DuplicatesConfig::default()
+        };
+        let config = build_dupes_config(&opts, &toml);
+        assert!(
+            matches!(config.mode, fallow_config::DetectionMode::Strict),
+            "config mode must win when --mode is omitted"
+        );
+    }
+
+    #[test]
+    fn build_config_cli_min_lines_overrides_toml() {
+        let root = PathBuf::from("/project");
+        let mut opts = default_opts_for_config(&root, DupesMode::Mild);
+        opts.min_lines = Some(3);
+        let toml = DuplicatesConfig {
+            min_lines: 8,
+            ..DuplicatesConfig::default()
+        };
+        let config = build_dupes_config(&opts, &toml);
+        assert_eq!(
+            config.min_lines, 3,
+            "explicit --min-lines must override config minLines"
+        );
+    }
+
+    #[test]
+    fn build_config_skip_local_or_merges_with_toml() {
+        let root = PathBuf::from("/project");
+        let opts = default_opts_for_config(&root, DupesMode::Mild);
+        let toml = DuplicatesConfig {
+            skip_local: true,
+            ..DuplicatesConfig::default()
+        };
+        let config = build_dupes_config(&opts, &toml);
+        assert!(
+            config.skip_local,
+            "config skipLocal=true must win even when --skip-local is omitted"
+        );
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -429,20 +429,24 @@ enum Command {
     /// Find code duplication / clones across the project
     Dupes {
         /// Detection mode: strict, mild, weak, or semantic
-        #[arg(long, default_value = "mild")]
-        mode: DupesMode,
+        /// (defaults to the value in `.fallowrc.jsonc`, or `mild` if unset).
+        #[arg(long)]
+        mode: Option<DupesMode>,
 
         /// Minimum token count for a clone
-        #[arg(long, default_value = "50")]
-        min_tokens: usize,
+        /// (defaults to the value in `.fallowrc.jsonc`, or `50` if unset).
+        #[arg(long)]
+        min_tokens: Option<usize>,
 
         /// Minimum line count for a clone
-        #[arg(long, default_value = "5")]
-        min_lines: usize,
+        /// (defaults to the value in `.fallowrc.jsonc`, or `5` if unset).
+        #[arg(long)]
+        min_lines: Option<usize>,
 
         /// Fail if duplication exceeds this percentage (0 = no limit)
-        #[arg(long, default_value = "0")]
-        threshold: f64,
+        /// (defaults to the value in `.fallowrc.jsonc`, or `0` if unset).
+        #[arg(long)]
+        threshold: Option<f64>,
 
         /// Only report cross-directory duplicates
         #[arg(long)]
@@ -2449,10 +2453,10 @@ fn dispatch_check(dispatch: &DispatchContext<'_>, args: &CheckDispatchArgs) -> E
 }
 
 struct DupesDispatchArgs {
-    mode: DupesMode,
-    min_tokens: usize,
-    min_lines: usize,
-    threshold: f64,
+    mode: Option<DupesMode>,
+    min_tokens: Option<usize>,
+    min_lines: Option<usize>,
+    threshold: Option<f64>,
     skip_local: bool,
     cross_language: bool,
     ignore_imports: bool,

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -557,10 +557,13 @@ pub fn detect_duplication(options: &DuplicationOptions) -> ProgrammaticResult<se
         no_cache: resolved.no_cache,
         threads: resolved.threads,
         quiet: true,
-        mode: options.mode.to_cli(),
-        min_tokens: options.min_tokens,
-        min_lines: options.min_lines,
-        threshold: options.threshold,
+        // The programmatic API requires callers to provide concrete values
+        // (the public `DuplicationOptions` has no Optional scalars), so we
+        // forward each as an explicit override.
+        mode: Some(options.mode.to_cli()),
+        min_tokens: Some(options.min_tokens),
+        min_lines: Some(options.min_lines),
+        threshold: Some(options.threshold),
         skip_local: options.skip_local,
         cross_language: options.cross_language,
         ignore_imports: options.ignore_imports,


### PR DESCRIPTION
## Summary

Standalone `fallow dupes` ignores `duplicates.minLines`, `duplicates.minTokens`, `duplicates.threshold`, `duplicates.mode`, and `duplicates.skipLocal` declared in `.fallowrc.jsonc` whenever the matching CLI flag is omitted. The `Command::Dupes` clap definitions use `default_value = "5"` (etc.), so `min_lines: usize` is **always** populated with the clap default — `build_dupes_config` then overwrites the toml value unconditionally.

## Reproduction

```bash
mkdir /tmp/repro && cd /tmp/repro
cat > a.ts << 'TS'
function foo() {
  const a = 1
  const b = 2
  const c = 3
  return a + b + c
}
TS
cp a.ts b.ts && sed -i '' 's/foo/bar/' b.ts
cat > .fallowrc.jsonc << 'JSON'
{ "duplicates": { "minLines": 100, "minTokens": 1000 } }
JSON

# Before this PR: still reports the 4-line clone, ignoring config
fallow dupes
```

The same problem affects `mode`, `threshold`, and `skipLocal`. `audit`/`combined`/`programmatic` paths are *not* affected because they merge config into their own structs before constructing `DupesOptions`.

## Root cause

`crates/cli/src/dupes.rs::build_dupes_config` overwrote each toml scalar with the corresponding `opts.*` value:

```rust
min_tokens: opts.min_tokens,           // clap default of 50 wins, always
min_lines: opts.min_lines,             // clap default of 5 wins, always
threshold: opts.threshold,             // clap default of 0.0 wins, always
skip_local: opts.skip_local,           // CLI false stomps config true
```

`Option<T>` with `default_value` is the only way to distinguish *user-passed* from *clap-supplied default* with non-Optional types — so we can't fix this without touching the CLI signature.

## Fix

- Switch `mode`, `min_tokens`, `min_lines`, `threshold` on `DupesOptions` and the `Command::Dupes` clap args to `Option<T>` and drop their `default_value`s.
- `build_dupes_config` now uses `opts.x.unwrap_or(toml_dupes.x)` for those four fields.
- `skip_local` adopts the OR-merge already used for `cross_language`/`ignore_imports`, so config-driven `skipLocal: true` is honored.
- `DupesResult.threshold` is now sourced from the merged `dupes_config.threshold` (was `opts.threshold`), so the failure gate honors `.fallowrc.jsonc` too.
- `audit.rs`, `combined.rs`, and `programmatic.rs` already have explicit values from their own merges; they forward each as `Some(...)` (no behavior change at those entry points).

Help text now reads:

```
--min-lines <MIN_LINES>
    Minimum line count for a clone
    (defaults to the value in `.fallowrc.jsonc`, or `5` if unset).
```

## Test plan

- [x] Updated existing `build_config_uses_cli_*` tests to wrap CLI values in `Some(...)`
- [x] Added regression tests for each fallback path:
  - `falls_back_to_toml_min_lines_when_cli_unset`
  - `falls_back_to_toml_min_tokens_when_cli_unset`
  - `falls_back_to_toml_threshold_when_cli_unset`
  - `falls_back_to_toml_mode_when_cli_unset`
  - `cli_min_lines_overrides_toml`
  - `skip_local_or_merges_with_toml`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test --workspace` (all suites green)
- [x] End-to-end repro project verified — config `minLines: 100` now suppresses the toy clone, and `--min-lines 100` still overrides config

## Compatibility

- CLI surface: `--mode`, `--min-tokens`, `--min-lines`, `--threshold` still accept the same values; the only observable difference is "flag omitted" no longer wins over config. Users who relied on the old behavior can migrate by either setting `duplicates.* = <prior_default>` in their config or by passing the flag explicitly.
- Public Rust API (`DuplicationOptions`): unchanged. Callers still pass concrete values; we forward each as `Some(...)` internally.