### PR TITLE
fix: avoid duplicate JSON in combined output when hotspot has no Git repo (#294)

### DIFF
--- a/crates/cli/src/health/hotspots.rs
+++ b/crates/cli/src/health/hotspots.rs
@@ -27,8 +27,11 @@ pub(super) struct ChurnFetchResult {
 
 /// Validate git prerequisites and return churn data for hotspot analysis.
 ///
-/// Uses disk cache when available. Returns `None` (with an error printed) if
-/// the repo is invalid, `--since` is malformed, or git analysis fails.
+/// Uses disk cache when available. Returns `None` if the repo is missing,
+/// `--since` is malformed, or git analysis fails. A missing git repo is treated
+/// as unavailable data rather than a hard error so combined-mode `--format
+/// json` never emits a second JSON document alongside the combined report
+/// (#294); a non-fatal note goes to stderr unless `--quiet` is set.
 pub(super) fn fetch_churn_data(
     opts: &HealthOptions<'_>,
     cache_dir: &std::path::Path,
@@ -36,7 +39,9 @@ pub(super) fn fetch_churn_data(
     use fallow_core::churn;
 
     if !churn::is_git_repo(opts.root) {
-        let _ = emit_error("hotspot analysis requires a git repository", 2, opts.output);
+        if !opts.quiet {
+            eprintln!("note: hotspot analysis skipped — no git repository found at project root");
+        }
         return None;
     }
 

--- a/crates/cli/tests/exit_code_tests.rs
+++ b/crates/cli/tests/exit_code_tests.rs
@@ -1,7 +1,9 @@
 #[path = "common/mod.rs"]
 mod common;
 
-use common::{parse_json, run_fallow, run_fallow_combined, run_fallow_in_root, run_fallow_raw};
+use common::{
+    fallow_bin, parse_json, run_fallow, run_fallow_combined, run_fallow_in_root, run_fallow_raw,
+};
 
 // ---------------------------------------------------------------------------
 // --fail-on-issues across commands
@@ -431,5 +433,76 @@ fn no_package_json_returns_empty_results() {
         json["total_issues"].as_u64().unwrap_or(0),
         0,
         "should have 0 issues without package.json"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Combined-mode JSON contract: stdout is exactly one JSON document even when
+// the project is outside a Git repository (regression for #294).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn combined_json_outside_git_repo_emits_single_document() {
+    use std::process::Command;
+
+    // Build a minimal TS project in a tempdir whose parent chain has no `.git`,
+    // so the hotspot pipeline's `is_git_repo` check returns false. We isolate
+    // from any inherited `GIT_DIR` / `GIT_WORK_TREE` set by parent test hooks
+    // and from any global git config that could redirect rev-parse upward.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"no-git-combined","type":"module","main":"src/index.ts"}"#,
+    )
+    .expect("write package.json");
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"target":"ES2020","module":"ES2020","strict":true},"include":["src"]}"#,
+    )
+    .expect("write tsconfig.json");
+    std::fs::create_dir_all(root.join("src")).expect("create src");
+    std::fs::write(
+        root.join("src/index.ts"),
+        "export function add(a: number, b: number): number { return a + b; }\n",
+    )
+    .expect("write index.ts");
+
+    let mut cmd = Command::new(fallow_bin());
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg("--quiet")
+        .env("RUST_LOG", "")
+        .env("NO_COLOR", "1")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    let output = cmd.output().expect("failed to run fallow binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // The bug in #294 was that stdout contained an inline `{"error": true,
+    // "message": "hotspot analysis requires a git repository", ...}` followed
+    // by the combined report — two top-level JSON values. Parsing as a single
+    // value catches that exactly: serde_json rejects trailing input.
+    serde_json::from_str::<serde_json::Value>(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "combined mode outside a git repo must emit exactly one JSON document on stdout: {e}\nstdout was:\n{stdout}\nstderr was:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+
+    // And the parsed envelope should be the combined report — schema_version is
+    // the canonical marker.
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("already parsed");
+    assert!(
+        json.get("schema_version").is_some(),
+        "stdout should be the combined report envelope, got: {json}"
+    );
+    assert!(
+        json.get("error").is_none(),
+        "combined report must not surface a top-level `error` key from a nested hotspot bail-out"
     );
 }


### PR DESCRIPTION
Closes #294.

Combined-mode `--format json` writes two top-level JSON documents to stdout when the project is outside a Git repository: first a `{ "error": true, "message": "hotspot analysis requires a git repository", ... }` blob, then the normal combined report. That breaks `fallow --format json | jq .` and any agent or CI parser that assumes a single document. The nixpkgs build of 2.65.0 hit this in five combined-mode integration tests whose temp fixtures live outside any Git checkout.

## Where the second blob comes from

`crates/cli/src/health/hotspots.rs::fetch_churn_data` is called from inside the health pipeline. When `is_git_repo(opts.root)` returns false it does:

```rust
if !churn::is_git_repo(opts.root) {
    let _ = emit_error("hotspot analysis requires a git repository", 2, opts.output);
    return None;
}
```

`emit_error` with `OutputFormat::Json` `println!`s a structured error object to stdout regardless of who called it. The function then returns `None`, which the caller already handles gracefully (`(Vec::new(), None)` for hotspots — see `crates/cli/src/health/mod.rs:520`). Combined mode then continues, builds the combined report, and `print_combined_json` `println!`s it. Two documents on stdout, one well-formed parser per side.

## Fix

Treat a missing Git repo as unavailable hotspot data rather than a hard error. The hotspot pipeline already silently degrades to an empty section when `fetch_churn_data` returns `None`, so dropping the JSON emission lets combined mode keep its single-document contract. A non-fatal `note: hotspot analysis skipped — no git repository found at project root` goes to stderr unless `--quiet` is set.

This also fixes standalone `fallow health --hotspots --format json` outside a Git repo: it now emits one well-formed health report with empty hotspots and exits 0, which lines up with the first acceptable resolution suggested in the issue ("treat missing Git history for hotspot analysis as unavailable data in the combined report").

The other `emit_error` paths in `fetch_churn_data` cover `--since` malformed input — those are user-error invariants and are not reachable from combined mode (`build_health_opts` hard-codes `since: None`), so they keep their existing exit-2 contract.

## Test

Adds `combined_json_outside_git_repo_emits_single_document` to `crates/cli/tests/exit_code_tests.rs`. The test:

1. Creates a minimal TS project in a tempdir (`/tmp/...`), so `is_git_repo` walks up and returns false.
2. Strips inherited `GIT_DIR` / `GIT_WORK_TREE` and points `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` at `/dev/null` so a parent-process git env can't redirect rev-parse upward (this matches the isolation pattern already used by `health_tests.rs::git`).
3. Runs `fallow --root <tempdir> --format json --quiet` (combined mode).
4. Asserts stdout parses as exactly one `serde_json::Value` (the original failure mode `failed to parse JSON: trailing characters at line 6 column 1` reproduces here without the fix).
5. Asserts the parsed envelope has `schema_version` and no top-level `error` key.

I confirmed the test fails on `main` and passes with the patch applied locally.

## Verification

- `cargo test -p fallow-extract -p fallow-cli --bin fallow` — 1755 pass, 0 fail
- `cargo test -p fallow-cli --test exit_code_tests` — 16 pass, 0 fail (includes the new case)
- `cargo test -p fallow-cli --test health_tests` — 30 pass, 0 fail
- `cargo test -p fallow-cli --lib` — 1226 pass, 0 fail
- `cargo test -p fallow-extract --lib` — 1392 pass, 0 fail
- `cargo clippy -p fallow-cli --bin fallow --tests` — clean
- `cargo fmt --check` — clean