### PR TITLE
fix(extract): follow Astro `<script src>` and inline `<script>` imports

### DIFF
--- a/crates/extract/src/astro.rs
+++ b/crates/extract/src/astro.rs
@@ -1,6 +1,9 @@
-//! Astro component frontmatter extraction.
+//! Astro component frontmatter and template-script extraction.
 //!
-//! Extracts the TypeScript code between `---` delimiters in `.astro` files.
+//! Extracts the TypeScript code between `---` delimiters in `.astro` files,
+//! and follows `<script src="...">` and inline `<script>` blocks in the
+//! component template so the targets stay reachable from the .astro file
+//! (Astro bundles them into the page output at build time).
 
 use std::path::Path;
 use std::sync::LazyLock;
@@ -8,12 +11,15 @@ use std::sync::LazyLock;
 use oxc_allocator::Allocator;
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{Span, SourceType};
 
-use crate::ModuleInfo;
-use crate::sfc::SfcScript;
+use crate::asset_url::normalize_asset_url;
+use crate::html::is_remote_url;
+use crate::sfc::{SfcScript, extract_sfc_scripts};
 use crate::visitor::ModuleInfoExtractor;
+use crate::{ImportInfo, ImportedName, ModuleInfo};
 use fallow_types::discover::FileId;
+
 
 /// Regex to extract Astro frontmatter (content between `---` delimiters at file start).
 static ASTRO_FRONTMATTER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
@@ -43,7 +49,17 @@ pub(crate) fn is_astro_file(path: &Path) -> bool {
         .is_some_and(|ext| ext == "astro")
 }
 
-/// Parse an Astro file by extracting the frontmatter section.
+/// Byte offset where the Astro component template begins (after the closing
+/// frontmatter `---`). Returns `0` for files without frontmatter, so the whole
+/// source is scanned.
+fn template_start_offset(source: &str) -> usize {
+    ASTRO_FRONTMATTER_RE
+        .find(source)
+        .map_or(0, |m| m.end())
+}
+
+/// Parse an Astro file by extracting the frontmatter section and any
+/// `<script>` blocks in the component template.
 pub(crate) fn parse_astro_to_module(
     file_id: FileId,
     source: &str,
@@ -52,20 +68,81 @@ pub(crate) fn parse_astro_to_module(
     let suppressions = crate::suppress::parse_suppressions_from_source(source);
     let line_offsets = fallow_types::extract::compute_line_offsets(source);
 
-    if let Some(script) = extract_astro_frontmatter(source) {
+    let mut info = if let Some(script) = extract_astro_frontmatter(source) {
         let source_type = SourceType::ts();
         let allocator = Allocator::default();
         let parser_return = Parser::new(&allocator, &script.body, source_type).parse();
         let mut extractor = ModuleInfoExtractor::new();
         extractor.visit_program(&parser_return.program);
-        let mut info = extractor.into_module_info(file_id, content_hash, suppressions);
-        info.line_offsets = line_offsets;
-        return info;
+        extractor.into_module_info(file_id, content_hash, suppressions)
+    } else {
+        ModuleInfoExtractor::new().into_module_info(file_id, content_hash, suppressions)
+    };
+
+    info.line_offsets = line_offsets;
+
+    // Astro components mount per-page client JS via `<script src="...">` and
+    // inline `<script>` blocks in the template body. Scan the post-frontmatter
+    // section so the targets stay reachable.
+    extract_template_script_imports(source, template_start_offset(source), &mut info);
+
+    info
+}
+
+/// Scan the Astro component template (everything after the closing frontmatter
+/// `---` delimiter) for `<script src="...">` and inline `<script>` blocks, and
+/// merge their references into `info.imports`.
+fn extract_template_script_imports(source: &str, template_offset: usize, info: &mut ModuleInfo) {
+    if template_offset >= source.len() {
+        return;
+    }
+    let template = &source[template_offset..];
+    let scripts = extract_sfc_scripts(template);
+    if scripts.is_empty() {
+        return;
     }
 
-    let mut info = ModuleInfoExtractor::new().into_module_info(file_id, content_hash, suppressions);
-    info.line_offsets = line_offsets;
-    info
+    let allocator = Allocator::default();
+    for script in &scripts {
+        if let Some(src) = &script.src {
+            let trimmed = src.trim();
+            if !trimmed.is_empty() && !is_remote_url(trimmed) {
+                info.imports.push(ImportInfo {
+                    source: normalize_asset_url(trimmed),
+                    imported_name: ImportedName::SideEffect,
+                    local_name: String::new(),
+                    is_type_only: false,
+                    from_style: false,
+                    span: Span::default(),
+                    source_span: Span::default(),
+                });
+            }
+            // <script src="..."> with a body is unusual; Astro treats the body
+            // as ignored when src is set, so don't parse it.
+            continue;
+        }
+
+        if script.body.trim().is_empty() {
+            continue;
+        }
+
+        // Astro client `<script>` blocks default to TypeScript-compatible JS
+        // (the build pipeline runs them through esbuild). Match the frontmatter
+        // path and parse as TS unless an explicit `lang="*sx"` enables JSX.
+        let source_type = if script.is_jsx {
+            if script.is_typescript {
+                SourceType::tsx()
+            } else {
+                SourceType::jsx()
+            }
+        } else {
+            SourceType::ts()
+        };
+        let parser_return = Parser::new(&allocator, &script.body, source_type).parse();
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.visit_program(&parser_return.program);
+        extractor.merge_into(info);
+    }
 }
 
 // Astro tests exercise regex-based frontmatter extraction — no unsafe code,
@@ -280,5 +357,91 @@ mod tests {
     #[test]
     fn is_astro_file_rejects_no_extension() {
         assert!(!is_astro_file(Path::new("Makefile")));
+    }
+
+    // ── Template <script> extraction (issue #295) ────────────────
+
+    #[test]
+    fn template_script_src_emits_side_effect_import() {
+        let source = "---\n---\n<script src=\"../scripts/foo.ts\"></script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(
+            info.imports.iter().any(|i| i.source == "../scripts/foo.ts"
+                && matches!(i.imported_name, ImportedName::SideEffect)),
+            "expected side-effect import for <script src>, got: {:?}",
+            info.imports.iter().map(|i| &i.source).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn template_script_src_without_frontmatter() {
+        let source = "<html><body><script src=\"./foo.ts\"></script></body></html>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.iter().any(|i| i.source == "./foo.ts"));
+    }
+
+    #[test]
+    fn template_inline_script_imports_followed() {
+        let source = "---\n---\n<script>\n  import '../scripts/bar';\n</script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(
+            info.imports.iter().any(|i| i.source == "../scripts/bar"),
+            "expected inline-script import to be extracted, got: {:?}",
+            info.imports.iter().map(|i| &i.source).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn template_script_src_remote_url_skipped() {
+        let source = "---\n---\n<script src=\"https://cdn.example.com/x.js\"></script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.is_empty());
+    }
+
+    #[test]
+    fn template_script_src_bare_filename_normalized() {
+        let source = "---\n---\n<script src=\"logic.ts\"></script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.iter().any(|i| i.source == "./logic.ts"));
+    }
+
+    #[test]
+    fn template_script_inside_html_comment_skipped() {
+        let source = "---\n---\n<!-- <script src=\"./bad.ts\"></script> -->\n<script src=\"./good.ts\"></script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.iter().any(|i| i.source == "./good.ts"));
+        assert!(!info.imports.iter().any(|i| i.source == "./bad.ts"));
+    }
+
+    #[test]
+    fn template_script_combined_with_frontmatter_imports() {
+        let source = "---\nimport Layout from '../layouts/Layout.astro';\n---\n<script src=\"./client.ts\"></script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.iter().any(|i| i.source == "../layouts/Layout.astro"));
+        assert!(info.imports.iter().any(|i| i.source == "./client.ts"));
+    }
+
+    #[test]
+    fn template_script_src_with_body_uses_src_only() {
+        // Per Astro's HTML semantics, when `src` is set the body is ignored.
+        let source = "---\n---\n<script src=\"./external.ts\">import './ignored';</script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.iter().any(|i| i.source == "./external.ts"));
+        assert!(!info.imports.iter().any(|i| i.source == "./ignored"));
+    }
+
+    #[test]
+    fn template_inline_script_typescript_syntax() {
+        // Inline <script> defaults to TS so type annotations parse cleanly.
+        let source = "---\n---\n<script>\n  import { foo } from './bar';\n  const x: number = foo();\n</script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.iter().any(|i| i.source == "./bar"));
+    }
+
+    #[test]
+    fn template_empty_script_block_no_panic() {
+        let source = "---\n---\n<script></script>";
+        let info = parse_astro_to_module(FileId(0), source, 0);
+        assert!(info.imports.is_empty());
     }
 }

--- a/crates/extract/src/tests/astro.rs
+++ b/crates/extract/src/tests/astro.rs
@@ -91,3 +91,73 @@ export { default as Layout } from '../layouts/Layout.astro';
     );
     assert_eq!(info.re_exports.len(), 1);
 }
+
+#[test]
+fn astro_template_script_src_followed() {
+    let info = parse_source_to_module(
+        FileId(0),
+        Path::new("Page.astro"),
+        r#"---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout>
+  <script src="../scripts/foo.ts"></script>
+</Layout>
+"#,
+        0,
+        false,
+    );
+    assert!(
+        info.imports
+            .iter()
+            .any(|i| i.source == "../scripts/foo.ts"),
+        "<script src> in template should be followed (issue #295)"
+    );
+    assert!(
+        info.imports
+            .iter()
+            .any(|i| i.source == "../layouts/Layout.astro"),
+        "frontmatter imports should still be extracted"
+    );
+}
+
+#[test]
+fn astro_template_inline_script_imports_followed() {
+    let info = parse_source_to_module(
+        FileId(0),
+        Path::new("Page.astro"),
+        r"---
+---
+<script>
+  import '../scripts/bar';
+</script>
+",
+        0,
+        false,
+    );
+    assert!(
+        info.imports.iter().any(|i| i.source == "../scripts/bar"),
+        "side-effect import inside inline <script> should be followed (issue #295)"
+    );
+}
+
+#[test]
+fn astro_template_script_combines_both_patterns() {
+    // Reproduces the exact issue #295 case: a single .astro file with both a
+    // src= reference and a side-effect import inside an inline <script>.
+    let info = parse_source_to_module(
+        FileId(0),
+        Path::new("index.astro"),
+        r#"---
+---
+<script src="../scripts/foo.ts"></script>
+<script>
+  import '../scripts/bar';
+</script>
+"#,
+        0,
+        false,
+    );
+    assert!(info.imports.iter().any(|i| i.source == "../scripts/foo.ts"));
+    assert!(info.imports.iter().any(|i| i.source == "../scripts/bar"));
+}


### PR DESCRIPTION
Closes #295.

## Background

Astro components mount per-page client JS in two ways:

```astro
<!-- pattern 1: src= reference -->
<script src="../scripts/foo.ts"></script>

<!-- pattern 2: side-effect import inside inline <script> -->
<script>
  import '../scripts/bar';
</script>
```

Both are bundled into the page output at build time. Before this PR the extractor only parsed the frontmatter, so the targets were flagged as unused files even when reachable through these template scripts.

## Approach

After the existing frontmatter pass, scan the post-frontmatter slice with the same `<script>` regex that powers the Vue/Svelte SFC pipeline (`extract_sfc_scripts`):

- `<script src="...">` — emit a side-effect `ImportInfo`, skipping `http://` / `https://` / `//` / `data:` URLs and routing bare filenames through `normalize_asset_url` so they resolve relative to the component (mirrors the SFC and HTML parsers).
- Inline `<script>` body — parse as TS (Astro client scripts run through esbuild and accept TS by default) and merge imports / dynamic imports / re-exports via `ModuleInfoExtractor::merge_into`.
- `<script lang="jsx">` / `lang="tsx">` flow through the existing SFC attribute parser.

HTML comments inside the template are filtered the same way as in the SFC path.

## Tests

10 new unit tests in `crates/extract/src/astro.rs` cover:

- `<script src>` emits a side-effect import (with and without frontmatter)
- inline `<script>` imports are followed
- combined frontmatter + template-script imports
- bare-filename normalization (`logic.ts` → `./logic.ts`)
- remote URLs (`https://cdn…`) are skipped
- `<script>` inside `<!-- -->` is skipped
- `<script src>` with a body uses src only
- inline TypeScript syntax (type annotations) parses cleanly
- empty `<script></script>` does not panic

3 new tests in `crates/extract/src/tests/astro.rs` reproduce the issue's exact case end-to-end through `parse_source_to_module`.

Verified manually against the issue's reproduction:

```
src/pages/index.astro    # both patterns
src/scripts/foo.ts       # ← was Unused, now reachable
src/scripts/bar.ts       # ← was Unused, now reachable
```

Before: `dead files 66.7% (2 of 3)` — both `foo.ts` and `bar.ts` flagged.
After: `dead files 0.0% (0 of 3)`.

## Validation

- `cargo test -p fallow-extract` — 1412 passed
- `cargo test -p fallow-cli --bin fallow` — 1757 passed
- `cargo test --workspace` — all green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean