### PR TITLE
feat(action,ci): support audit command for severity-aware PR/MR gating

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,13 @@ branding:
 
 inputs:
   command:
-    description: 'Command to run: dead-code (unused code), dupes (code duplication), health (complexity), fix (auto-remove unused code). Default runs all analyses. Legacy alias: check = dead-code.'
+    description: 'Command to run: dead-code (unused code), dupes (code duplication), health (complexity), audit (severity-aware PR quality gate combining dead-code + complexity + duplication scoped to changed files; gates on rule severity, not raw counts), fix (auto-remove unused code). Default runs all analyses. Legacy alias: check = dead-code. Migrating from default (combined) to audit: combined gates on total issue count; audit gates on rule severity from .fallowrc.json plus the `gate` input (new-only/all).'
     required: false
     default: ''
+  gate:
+    description: 'Audit severity gate: new-only (default) fails only on findings introduced by this PR; all fails on every finding in changed files. Only used when command: audit. Mirrors `fallow audit --gate`.'
+    required: false
+    default: 'new-only'
   root:
     description: 'Project root directory'
     required: false
@@ -228,14 +232,20 @@ inputs:
 
 outputs:
   results:
-    description: 'Path to JSON results file'
+    description: 'Path to JSON results file. For command: audit, the file is a hybrid shape: top-level audit protocol fields (command, verdict, attribution, summary, base_ref, head_sha) plus sub-results re-keyed to combined-mode keys (.check, .dupes, .health) so existing downstream tooling works unchanged. Dispatch on the top-level command field to detect audit runs; the top-level schema_version describes the audit protocol from the CLI.'
     value: ${{ steps.analyze.outputs.results }}
   sarif:
     description: 'Path to SARIF results file'
     value: ${{ steps.analyze.outputs.sarif }}
   issues:
-    description: 'Number of issues (dead-code), clone groups (dupes), or fixes proposed/applied (fix)'
+    description: 'Number of issues (dead-code), clone groups (dupes), introduced findings (audit, new-only) or total findings in changed files (audit, all), or fixes proposed/applied (fix). For audit, prefer outputs.verdict for gating.'
     value: ${{ steps.analyze.outputs.issues }}
+  verdict:
+    description: 'Audit verdict (pass/warn/fail). Empty when command is not audit.'
+    value: ${{ steps.analyze.outputs.verdict }}
+  gate:
+    description: 'Audit gate that was applied (new-only/all). Empty when command is not audit.'
+    value: ${{ steps.analyze.outputs.gate }}
 
 runs:
   using: 'composite'
@@ -260,6 +270,7 @@ runs:
       shell: bash
       env:
         INPUT_COMMAND: ${{ inputs.command }}
+        INPUT_GATE: ${{ inputs.gate }}
         INPUT_ROOT: ${{ inputs.root }}
         INPUT_CONFIG: ${{ inputs.config }}
         INPUT_FORMAT: ${{ inputs.format }}
@@ -308,6 +319,7 @@ runs:
         INPUT_SAVE_SNAPSHOT: ${{ inputs.save-snapshot }}
         INPUT_TREND: ${{ inputs.trend }}
         INPUT_ISSUE_TYPES: ${{ inputs.issue-types }}
+        INPUT_INCLUDE_ENTRY_EXPORTS: ${{ inputs.include-entry-exports }}
         INPUT_FAIL_ON_REGRESSION: ${{ inputs.fail-on-regression }}
         INPUT_TOLERANCE: ${{ inputs.tolerance }}
         INPUT_REGRESSION_BASELINE: ${{ inputs.regression-baseline }}
@@ -421,9 +433,21 @@ runs:
       env:
         INPUT_COMMAND: ${{ inputs.command }}
         INPUT_FAIL_ON_ISSUES: ${{ inputs.fail-on-issues }}
+        INPUT_GATE: ${{ inputs.gate }}
         ISSUES: ${{ steps.analyze.outputs.issues }}
+        VERDICT: ${{ steps.analyze.outputs.verdict }}
       run: |
-        if [ "$INPUT_FAIL_ON_ISSUES" = "true" ] && [ "$ISSUES" -gt 0 ]; then
+        if [ "$INPUT_FAIL_ON_ISSUES" != "true" ]; then exit 0; fi
+        if [ "$INPUT_COMMAND" = "audit" ]; then
+          # Audit gates on rule severity. Verdict already encodes the gate decision:
+          # pass -> no issues, warn -> warn-tier only (don't fail), fail -> error-tier (fail).
+          if [ "$VERDICT" = "fail" ]; then
+            echo "::error::Fallow audit failed (gate: ${INPUT_GATE:-new-only}, ${ISSUES} finding(s) at error severity)"
+            exit 1
+          fi
+          exit 0
+        fi
+        if [ "$ISSUES" -gt 0 ]; then
           case "$INPUT_COMMAND" in
             dead-code|check) echo "::error::Fallow found ${ISSUES} unused code issues" ;;
             dupes)           echo "::error::Fallow found ${ISSUES} clone groups" ;;

--- a/action/jq/summary-combined.jq
+++ b/action/jq/summary-combined.jq
@@ -43,6 +43,27 @@ def prod_hot_paths: (.health.runtime_coverage.hot_paths // []);
 (.health.vital_signs // {}) as $vitals |
 (.health.summary // {}) as $summary |
 (.dupes.stats // {}) as $dupes_stats |
+# Audit verdict header: surfaces verdict + new-vs-inherited attribution
+# whenever the input came from `fallow audit`. Combined-mode runs (no audit
+# fields present) skip this entirely so existing PR comments are unchanged.
+(.verdict // null) as $verdict |
+(.attribution // null) as $attribution |
+((($attribution.dead_code_introduced // 0) + ($attribution.complexity_introduced // 0) + ($attribution.duplication_introduced // 0)) // 0) as $introduced |
+((($attribution.dead_code_inherited // 0) + ($attribution.complexity_inherited // 0) + ($attribution.duplication_inherited // 0)) // 0) as $inherited |
+($attribution.gate // "new-only") as $audit_gate |
+(if $verdict then
+  (if $verdict == "pass" then ":white_check_mark: **Audit passed**"
+   elif $verdict == "warn" then ":warning: **Audit passed with warnings**"
+   else ":x: **Audit failed**" end) as $headline |
+  "> \($headline) · gate: `\($audit_gate)`" +
+  (if $audit_gate == "new-only" then
+    " · \($introduced) new finding\(if $introduced == 1 then "" else "s" end) introduced by this PR" +
+    (if $inherited > 0 then " · \($inherited) inherited (not gated)" else "" end)
+  else
+    " · \($introduced + $inherited) finding\(if ($introduced + $inherited) == 1 then "" else "s" end) in changed files"
+  end) +
+  "\n\n"
+else "" end) as $audit_header |
 
 # Health delta header (only when --score is present)
 (if .health.health_score then
@@ -67,6 +88,7 @@ else "" end) +
 
 if $total == 0 then
   "# \ud83c\udf3f Fallow\n\n" +
+  $audit_header +
   (if $prod_advisory > 0 or $hot_paths > 0 then
     "> [!NOTE]\n> **No blocking issues found**\n\n" +
     ":white_check_mark: No code issues \u00b7 :white_check_mark: No duplication \u00b7 :white_check_mark: No blocking health findings" +
@@ -82,6 +104,7 @@ if $total == 0 then
   else "" end)
 else
   "# \ud83c\udf3f Fallow\n\n" +
+  $audit_header +
 
   # One-line status
   (if $check > 0 then ":warning: **\($check)** code issues" else ":white_check_mark: No code issues" end) +

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -152,12 +152,15 @@ case "$INPUT_COMMAND" in
   *) echo "::error::Invalid command: ${INPUT_COMMAND}. Must be dead-code, dupes, health, audit, fix, or empty (runs all)."; exit 2 ;;
 esac
 
-# Validate gate input as a closed enum (only consulted when command=audit)
+# Validate gate input as a closed enum (only when command=audit, since users on
+# other commands shouldn't hard-error on a stray gate value from inherited env)
 INPUT_GATE="${INPUT_GATE:-new-only}"
-case "$INPUT_GATE" in
-  new-only|all) ;;
-  *) echo "::error::Invalid gate: ${INPUT_GATE}. Must be new-only or all."; exit 2 ;;
-esac
+if [ "$INPUT_COMMAND" = "audit" ]; then
+  case "$INPUT_GATE" in
+    new-only|all) ;;
+    *) echo "::error::Invalid gate: ${INPUT_GATE}. Must be new-only or all."; exit 2 ;;
+  esac
+fi
 
 for name_val in "min-tokens:${INPUT_MIN_TOKENS:-}" "min-lines:${INPUT_MIN_LINES:-}" \
                "max-cyclomatic:${INPUT_MAX_CYCLOMATIC:-}" "max-cognitive:${INPUT_MAX_COGNITIVE:-}" \
@@ -318,10 +321,12 @@ if [ "$INPUT_COMMAND" = "audit" ]; then
   VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
   GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
 
-  # When gate=new-only, prune dead-code findings to only `introduced: true` entries
-  # so PR annotations/comments reflect what the gate actually fails on. Health and
-  # duplication findings do not carry per-finding `introduced` today, so they pass
-  # through as-is and rely on attribution counts to communicate gate effects.
+  # When gate=new-only, prune findings to only `introduced: true` entries across
+  # all three categories so PR annotations/comments reflect what the gate
+  # actually fails on. The CLI annotates dead_code findings, complexity (health)
+  # findings, and duplication clone_groups with `introduced: true|false` whenever
+  # the audit base-snapshot pass runs. Findings without an `introduced` field
+  # (older CLI binaries) are kept by the `!= false` predicate.
   if [ "$GATE" = "new-only" ]; then
     jq '
       def keep_introduced(arr):
@@ -344,6 +349,8 @@ if [ "$INPUT_COMMAND" = "audit" ]; then
       | .dead_code.type_only_dependencies      = keep_introduced(.dead_code.type_only_dependencies)
       | .dead_code.test_only_dependencies      = keep_introduced(.dead_code.test_only_dependencies)
       | .dead_code.stale_suppressions          = keep_introduced(.dead_code.stale_suppressions)
+      | (if .complexity then .complexity.findings = keep_introduced(.complexity.findings) else . end)
+      | (if .duplication then .duplication.clone_groups = keep_introduced(.duplication.clone_groups) else . end)
     ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
       echo "::error::Audit JSON prune transform failed"
       rm -f fallow-results.tmp.json

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -116,6 +116,14 @@ build_command_args() {
         ARGS+=(--yes)
       fi
       ;;
+    audit)
+      ARGS+=(--gate "${INPUT_GATE:-new-only}")
+      [ -n "${INPUT_MAX_CRAP:-}" ] && ARGS+=(--max-crap "$INPUT_MAX_CRAP")
+      [ "${INPUT_PRODUCTION_DEAD_CODE:-}" = "true" ] && ARGS+=(--production-dead-code)
+      [ "${INPUT_PRODUCTION_HEALTH:-}" = "true" ] && ARGS+=(--production-health)
+      [ "${INPUT_PRODUCTION_DUPES:-}" = "true" ] && ARGS+=(--production-dupes)
+      [ "${INPUT_INCLUDE_ENTRY_EXPORTS:-}" = "true" ] && ARGS+=(--include-entry-exports)
+      ;;
     "")
       if [ "${INPUT_FORMAT:-}" = "sarif" ] && [ "${HAS_SARIF_FILE:-false}" = "true" ]; then
         ARGS+=(--sarif-file fallow-results.sarif)
@@ -140,8 +148,15 @@ build_command_args() {
 # --- Validation ---
 
 case "$INPUT_COMMAND" in
-  ""|dead-code|check|dupes|health|fix) ;;
-  *) echo "::error::Invalid command: ${INPUT_COMMAND}. Must be dead-code, dupes, health, fix, or empty (runs all)."; exit 2 ;;
+  ""|dead-code|check|dupes|health|audit|fix) ;;
+  *) echo "::error::Invalid command: ${INPUT_COMMAND}. Must be dead-code, dupes, health, audit, fix, or empty (runs all)."; exit 2 ;;
+esac
+
+# Validate gate input as a closed enum (only consulted when command=audit)
+INPUT_GATE="${INPUT_GATE:-new-only}"
+case "$INPUT_GATE" in
+  new-only|all) ;;
+  *) echo "::error::Invalid gate: ${INPUT_GATE}. Must be new-only or all."; exit 2 ;;
 esac
 
 for name_val in "min-tokens:${INPUT_MIN_TOKENS:-}" "min-lines:${INPUT_MIN_LINES:-}" \
@@ -184,6 +199,16 @@ if [ -z "${INPUT_CHANGED_SINCE:-}" ] && [ "${INPUT_AUTO_CHANGED_SINCE:-}" = "tru
    [ -n "${PR_BASE_SHA:-}" ]; then
   INPUT_CHANGED_SINCE="$PR_BASE_SHA"
   echo "::notice::Auto-scoping analysis to files changed since PR base (${PR_BASE_SHA:0:7})"
+fi
+
+# Audit on non-PR events needs an explicit base. Don't silently fall through
+# to fallow's auto-detect, because misconfigured workflows produce confusing
+# "verdict: pass" results that simply analyzed nothing.
+if [ "$INPUT_COMMAND" = "audit" ] && [ -z "${INPUT_CHANGED_SINCE:-}" ]; then
+  if [ "${EVENT_NAME:-}" != "pull_request" ] && [ "${EVENT_NAME:-}" != "pull_request_target" ]; then
+    echo "::error::command: audit on event '${EVENT_NAME:-unknown}' needs an explicit base. Set 'changed-since: <ref>' (e.g. origin/main) on the action, or pass --base via the 'args' input."
+    exit 2
+  fi
 fi
 
 # Propagate the effective changed-since value so downstream steps can filter
@@ -278,6 +303,90 @@ if [ -s fallow-stderr.log ]; then
   done < fallow-stderr.log
 fi
 
+# --- Audit-specific post-processing ---
+# Audit produces top-level verdict/attribution and sub-result objects keyed
+# `dead_code`, `complexity`, `duplication`. Re-key sub-results to `check`,
+# `health`, `dupes` so existing summary/comment/annotation jq scripts work
+# unchanged. Preserve top-level audit fields (command, verdict, attribution,
+# gate, base_ref, head_sha, summary) so AI consumers can still distinguish
+# audit runs from combined runs.
+
+VERDICT=""
+GATE=""
+
+if [ "$INPUT_COMMAND" = "audit" ]; then
+  VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
+  GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
+
+  # When gate=new-only, prune dead-code findings to only `introduced: true` entries
+  # so PR annotations/comments reflect what the gate actually fails on. Health and
+  # duplication findings do not carry per-finding `introduced` today, so they pass
+  # through as-is and rely on attribution counts to communicate gate effects.
+  if [ "$GATE" = "new-only" ]; then
+    jq '
+      def keep_introduced(arr):
+        (arr // []) | map(select(.introduced != false));
+      .dead_code //= {}
+      | .dead_code.unused_files                = keep_introduced(.dead_code.unused_files)
+      | .dead_code.unused_exports              = keep_introduced(.dead_code.unused_exports)
+      | .dead_code.unused_types                = keep_introduced(.dead_code.unused_types)
+      | .dead_code.private_type_leaks          = keep_introduced(.dead_code.private_type_leaks)
+      | .dead_code.unused_dependencies         = keep_introduced(.dead_code.unused_dependencies)
+      | .dead_code.unused_dev_dependencies     = keep_introduced(.dead_code.unused_dev_dependencies)
+      | .dead_code.unused_optional_dependencies = keep_introduced(.dead_code.unused_optional_dependencies)
+      | .dead_code.unused_enum_members         = keep_introduced(.dead_code.unused_enum_members)
+      | .dead_code.unused_class_members        = keep_introduced(.dead_code.unused_class_members)
+      | .dead_code.unresolved_imports          = keep_introduced(.dead_code.unresolved_imports)
+      | .dead_code.unlisted_dependencies       = keep_introduced(.dead_code.unlisted_dependencies)
+      | .dead_code.duplicate_exports           = keep_introduced(.dead_code.duplicate_exports)
+      | .dead_code.circular_dependencies       = keep_introduced(.dead_code.circular_dependencies)
+      | .dead_code.boundary_violations         = keep_introduced(.dead_code.boundary_violations)
+      | .dead_code.type_only_dependencies      = keep_introduced(.dead_code.type_only_dependencies)
+      | .dead_code.test_only_dependencies      = keep_introduced(.dead_code.test_only_dependencies)
+      | .dead_code.stale_suppressions          = keep_introduced(.dead_code.stale_suppressions)
+    ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
+      echo "::error::Audit JSON prune transform failed"
+      rm -f fallow-results.tmp.json
+      exit 2
+    }
+  fi
+
+  # Re-key sub-results to combined-mode keys, recompute dead-code total_issues
+  # against the (possibly pruned) finding arrays, and surface verdict + attribution
+  # at the top level so downstream consumers can detect the audit run.
+  jq '
+    def list_sum(o):
+      ((o.unused_files // []) | length)
+      + ((o.unused_exports // []) | length)
+      + ((o.unused_types // []) | length)
+      + ((o.private_type_leaks // []) | length)
+      + ((o.unused_dependencies // []) | length)
+      + ((o.unused_dev_dependencies // []) | length)
+      + ((o.unused_optional_dependencies // []) | length)
+      + ((o.unused_enum_members // []) | length)
+      + ((o.unused_class_members // []) | length)
+      + ((o.unresolved_imports // []) | length)
+      + ((o.unlisted_dependencies // []) | length)
+      + ((o.duplicate_exports // []) | length)
+      + ((o.circular_dependencies // []) | length)
+      + ((o.boundary_violations // []) | length)
+      + ((o.type_only_dependencies // []) | length)
+      + ((o.test_only_dependencies // []) | length)
+      + ((o.stale_suppressions // []) | length);
+    .dead_code   as $dc
+    | .complexity  as $cx
+    | .duplication as $du
+    | .check  = ($dc | if . then . + {total_issues: list_sum(.)} else null end)
+    | .dupes  = $du
+    | .health = $cx
+    | del(.dead_code, .complexity, .duplication)
+  ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
+    echo "::error::Audit JSON re-key transform failed"
+    rm -f fallow-results.tmp.json
+    exit 2
+  }
+fi
+
 # --- Extract issue count ---
 
 case "$INPUT_COMMAND" in
@@ -285,6 +394,13 @@ case "$INPUT_COMMAND" in
   dupes)           ISSUES=$(jq -r '.stats.clone_groups' fallow-results.json) ;;
   health)          ISSUES=$(jq -r '((.summary.functions_above_threshold // 0) + ((.runtime_coverage.findings // []) | map(select(.verdict == "safe_to_delete" or .verdict == "review_required" or .verdict == "low_traffic")) | length))' fallow-results.json) ;;
   fix)             ISSUES=$(jq -r '(.fixes | length)' fallow-results.json) ;;
+  audit)
+    if [ "$GATE" = "all" ]; then
+      ISSUES=$(jq -r '((.summary.dead_code_issues // 0) + (.summary.complexity_findings // 0) + (.summary.duplication_clone_groups // 0))' fallow-results.json)
+    else
+      ISSUES=$(jq -r '((.attribution.dead_code_introduced // 0) + (.attribution.complexity_introduced // 0) + (.attribution.duplication_introduced // 0))' fallow-results.json)
+    fi
+    ;;
   "")              ISSUES=$(jq -r '((.check.total_issues // 0) + (.dupes.stats.clone_groups // 0) + (.health.summary.functions_above_threshold // 0) + ((.health.runtime_coverage.findings // []) | map(select(.verdict == "safe_to_delete" or .verdict == "review_required" or .verdict == "low_traffic")) | length))' fallow-results.json) ;;
 esac
 
@@ -296,6 +412,8 @@ fi
 echo "issues=${ISSUES}" >> "$GITHUB_OUTPUT"
 echo "results=fallow-results.json" >> "$GITHUB_OUTPUT"
 echo "command=${INPUT_COMMAND}" >> "$GITHUB_OUTPUT"
+echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+echo "gate=${GATE}" >> "$GITHUB_OUTPUT"
 
 if [ -f fallow-results.sarif ]; then
   echo "sarif=fallow-results.sarif" >> "$GITHUB_OUTPUT"
@@ -306,6 +424,7 @@ if [ "$ISSUES" -gt 0 ]; then
     dead-code|check) echo "::warning::Fallow found ${ISSUES} unused code issues" ;;
     dupes)           echo "::warning::Fallow found ${ISSUES} clone groups" ;;
     health)          echo "::warning::Fallow found ${ISSUES} high complexity functions" ;;
+    audit)           echo "::warning::Fallow audit verdict: ${VERDICT} (${ISSUES} ${GATE:-new-only} finding(s))" ;;
     fix)             echo "::warning::Fallow proposed ${ISSUES} fixes" ;;
     "")              echo "::warning::Fallow found ${ISSUES} issues" ;;
   esac

--- a/action/scripts/annotate.sh
+++ b/action/scripts/annotate.sh
@@ -56,7 +56,8 @@ case "$FALLOW_COMMAND" in
   health)
     jq -r -f "${ACTION_JQ_DIR}/annotations-health.jq" "$RESULTS_FILE" > "$ANNOTATIONS_FILE" 2>/dev/null || true ;;
   fix) ;;
-  "")
+  audit|"")
+    # Audit JSON is re-keyed in analyze.sh to use combined-mode keys (check/health/dupes).
     {
       jq '.check // empty' "$RESULTS_FILE" | jq -r -f "${ACTION_JQ_DIR}/annotations-check.jq" 2>/dev/null || true
       jq '.health // empty' "$RESULTS_FILE" | jq -r -f "${ACTION_JQ_DIR}/annotations-health.jq" 2>/dev/null || true

--- a/action/scripts/comment.sh
+++ b/action/scripts/comment.sh
@@ -11,7 +11,7 @@ case "$FALLOW_COMMAND" in
   dupes)           JQ_FILE="${ACTION_JQ_DIR}/summary-dupes.jq" ;;
   health)          JQ_FILE="${ACTION_JQ_DIR}/summary-health.jq" ;;
   fix)             JQ_FILE="${ACTION_JQ_DIR}/summary-fix.jq" ;;
-  "")              JQ_FILE="${ACTION_JQ_DIR}/summary-combined.jq" ;;
+  audit|"")        JQ_FILE="${ACTION_JQ_DIR}/summary-combined.jq" ;;
   *)               echo "::error::Unexpected command: ${FALLOW_COMMAND}"; exit 2 ;;
 esac
 

--- a/action/scripts/review.sh
+++ b/action/scripts/review.sh
@@ -89,8 +89,8 @@ case "$FALLOW_COMMAND" in
     COMMENTS=$(jq -f "${ACTION_JQ_DIR}/review-comments-dupes.jq" "$RESULTS_FILE" 2>&1) || { echo "jq dupes error: $COMMENTS"; COMMENTS="[]"; } ;;
   health)
     COMMENTS=$(jq -f "${ACTION_JQ_DIR}/review-comments-health.jq" "$RESULTS_FILE" 2>&1) || { echo "jq health error: $COMMENTS"; COMMENTS="[]"; } ;;
-  "")
-    # Combined: extract each section and run through its jq script
+  audit|"")
+    # Audit JSON is re-keyed in analyze.sh to use combined-mode keys (check/health/dupes).
     WORK_DIR=$(mktemp -d)
     jq '.check // {}' "$RESULTS_FILE" > "$WORK_DIR/check.json" 2>/dev/null
     jq '.dupes // {}' "$RESULTS_FILE" > "$WORK_DIR/dupes.json" 2>/dev/null

--- a/action/scripts/summary.sh
+++ b/action/scripts/summary.sh
@@ -11,7 +11,7 @@ select_summary_script() {
     dupes)           echo "${ACTION_JQ_DIR}/summary-dupes.jq" ;;
     health)          echo "${ACTION_JQ_DIR}/summary-health.jq" ;;
     fix)             echo "${ACTION_JQ_DIR}/summary-fix.jq" ;;
-    "")              echo "${ACTION_JQ_DIR}/summary-combined.jq" ;;
+    audit|"")        echo "${ACTION_JQ_DIR}/summary-combined.jq" ;;
     *)               echo "::error::Unexpected command: ${FALLOW_COMMAND}"; exit 2 ;;
   esac
 }

--- a/action/tests/fixtures/audit-clean.json
+++ b/action/tests/fixtures/audit-clean.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 3,
+  "version": "2.66.2",
+  "command": "audit",
+  "verdict": "pass",
+  "changed_files_count": 2,
+  "base_ref": "origin/main",
+  "head_sha": "abc1234567890",
+  "elapsed_ms": 412,
+  "summary": {
+    "dead_code_issues": 0,
+    "dead_code_has_errors": false,
+    "complexity_findings": 0,
+    "max_cyclomatic": null,
+    "duplication_clone_groups": 0
+  },
+  "attribution": {
+    "gate": "new-only",
+    "dead_code_introduced": 0,
+    "dead_code_inherited": 0,
+    "complexity_introduced": 0,
+    "complexity_inherited": 0,
+    "duplication_introduced": 0,
+    "duplication_inherited": 0
+  },
+  "check": {
+    "schema_version": 3,
+    "version": "2.66.2",
+    "total_issues": 0,
+    "summary": {
+      "files_analyzed": 12,
+      "modules_analyzed": 12
+    },
+    "unused_files": [],
+    "unused_exports": [],
+    "unused_types": [],
+    "private_type_leaks": [],
+    "unused_dependencies": [],
+    "unused_dev_dependencies": [],
+    "unused_optional_dependencies": [],
+    "unused_enum_members": [],
+    "unused_class_members": [],
+    "unresolved_imports": [],
+    "unlisted_dependencies": [],
+    "duplicate_exports": [],
+    "circular_dependencies": [],
+    "boundary_violations": [],
+    "type_only_dependencies": [],
+    "test_only_dependencies": [],
+    "stale_suppressions": []
+  },
+  "dupes": {
+    "stats": {
+      "clone_groups": 0,
+      "clone_instances": 0,
+      "duplicated_lines": 0,
+      "duplication_percentage": 0,
+      "files_with_clones": 0
+    },
+    "clone_groups": [],
+    "clone_families": []
+  },
+  "health": {
+    "summary": {
+      "files_analyzed": 12,
+      "functions_analyzed": 80,
+      "functions_above_threshold": 0,
+      "max_cyclomatic_threshold": 20,
+      "max_cognitive_threshold": 15
+    },
+    "vital_signs": {
+      "maintainability_avg": 92.5,
+      "avg_cyclomatic": 4.2
+    },
+    "findings": []
+  }
+}

--- a/action/tests/fixtures/audit-raw.json
+++ b/action/tests/fixtures/audit-raw.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": 3,
+  "version": "2.66.2",
+  "command": "audit",
+  "verdict": "fail",
+  "changed_files_count": 1,
+  "base_ref": "HEAD~1",
+  "head_sha": "da6cd85",
+  "elapsed_ms": 133,
+  "summary": {
+    "dead_code_issues": 2,
+    "dead_code_has_errors": true,
+    "complexity_findings": 0,
+    "max_cyclomatic": null,
+    "duplication_clone_groups": 0
+  },
+  "attribution": {
+    "gate": "new-only",
+    "dead_code_introduced": 1,
+    "dead_code_inherited": 1,
+    "complexity_introduced": 0,
+    "complexity_inherited": 0,
+    "duplication_introduced": 0,
+    "duplication_inherited": 0
+  },
+  "dead_code": {
+    "schema_version": 5,
+    "version": "2.66.2",
+    "elapsed_ms": 61,
+    "total_issues": 2,
+    "entry_points": {
+      "total": 0,
+      "sources": {}
+    },
+    "summary": {
+      "total_issues": 2,
+      "unused_files": 1,
+      "unused_exports": 0,
+      "unused_types": 0,
+      "private_type_leaks": 0,
+      "unused_dependencies": 1,
+      "unused_enum_members": 0,
+      "unused_class_members": 0,
+      "unresolved_imports": 0,
+      "unlisted_dependencies": 0,
+      "duplicate_exports": 0,
+      "type_only_dependencies": 0,
+      "test_only_dependencies": 0,
+      "circular_dependencies": 0,
+      "boundary_violations": 0,
+      "stale_suppressions": 0
+    },
+    "unused_files": [
+      {
+        "path": "b.ts",
+        "actions": [
+          {
+            "type": "delete-file",
+            "auto_fixable": false,
+            "description": "Delete this file",
+            "note": "File deletion may remove runtime functionality not visible to static analysis"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress with a file-level comment at the top of the file",
+            "comment": "// fallow-ignore-file unused-file"
+          }
+        ],
+        "introduced": true
+      }
+    ],
+    "unused_exports": [],
+    "unused_types": [],
+    "private_type_leaks": [],
+    "unused_dependencies": [
+      {
+        "package_name": "lodash",
+        "location": "dependencies",
+        "path": "package.json",
+        "line": 1,
+        "actions": [
+          {
+            "type": "remove-dependency",
+            "auto_fixable": true,
+            "description": "Remove from dependencies in package.json"
+          },
+          {
+            "type": "add-to-config",
+            "auto_fixable": false,
+            "description": "Add \"lodash\" to ignoreDependencies in fallow config",
+            "config_key": "ignoreDependencies",
+            "value": "lodash"
+          }
+        ],
+        "introduced": false
+      }
+    ],
+    "unused_dev_dependencies": [],
+    "unused_optional_dependencies": [],
+    "unused_enum_members": [],
+    "unused_class_members": [],
+    "unresolved_imports": [],
+    "unlisted_dependencies": [],
+    "duplicate_exports": [],
+    "type_only_dependencies": [],
+    "test_only_dependencies": [],
+    "circular_dependencies": [],
+    "boundary_violations": [],
+    "stale_suppressions": []
+  },
+  "duplication": {
+    "clone_groups": [],
+    "clone_families": [],
+    "stats": {
+      "total_files": 0,
+      "files_with_clones": 0,
+      "total_lines": 0,
+      "duplicated_lines": 0,
+      "total_tokens": 0,
+      "duplicated_tokens": 0,
+      "clone_groups": 0,
+      "clone_instances": 0,
+      "duplication_percentage": 0.0
+    }
+  },
+  "complexity": {
+    "findings": [],
+    "summary": {
+      "files_analyzed": 1,
+      "functions_analyzed": 0,
+      "functions_above_threshold": 0,
+      "max_cyclomatic_threshold": 20,
+      "max_cognitive_threshold": 15,
+      "max_crap_threshold": 30.0,
+      "severity_critical_count": 0,
+      "severity_high_count": 0,
+      "severity_moderate_count": 0
+    },
+    "vital_signs": {
+      "dead_file_pct": 100.0,
+      "dead_export_pct": 0.0,
+      "avg_cyclomatic": 0.0,
+      "p90_cyclomatic": 0,
+      "unused_dep_count": 1,
+      "unused_deps_per_k_files": 1000.0,
+      "circular_dep_count": 0,
+      "circular_deps_per_k_files": 0.0,
+      "counts": {
+        "total_files": 1,
+        "total_exports": 1,
+        "dead_files": 1,
+        "dead_exports": 0,
+        "total_lines": 2,
+        "files_scored": 0,
+        "total_deps": 0
+      },
+      "total_loc": 2
+    }
+  }
+}

--- a/action/tests/fixtures/audit.json
+++ b/action/tests/fixtures/audit.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 3,
+  "version": "2.66.2",
+  "command": "audit",
+  "verdict": "fail",
+  "changed_files_count": 1,
+  "base_ref": "HEAD~1",
+  "head_sha": "db31aa2",
+  "elapsed_ms": 226,
+  "summary": {
+    "dead_code_issues": 2,
+    "dead_code_has_errors": true,
+    "complexity_findings": 0,
+    "max_cyclomatic": null,
+    "duplication_clone_groups": 0
+  },
+  "attribution": {
+    "gate": "new-only",
+    "dead_code_introduced": 1,
+    "dead_code_inherited": 1,
+    "complexity_introduced": 0,
+    "complexity_inherited": 0,
+    "duplication_introduced": 0,
+    "duplication_inherited": 0
+  },
+  "check": {
+    "schema_version": 5,
+    "version": "2.66.2",
+    "elapsed_ms": 113,
+    "total_issues": 1,
+    "entry_points": {
+      "total": 0,
+      "sources": {}
+    },
+    "summary": {
+      "total_issues": 2,
+      "unused_files": 1,
+      "unused_exports": 0,
+      "unused_types": 0,
+      "private_type_leaks": 0,
+      "unused_dependencies": 1,
+      "unused_enum_members": 0,
+      "unused_class_members": 0,
+      "unresolved_imports": 0,
+      "unlisted_dependencies": 0,
+      "duplicate_exports": 0,
+      "type_only_dependencies": 0,
+      "test_only_dependencies": 0,
+      "circular_dependencies": 0,
+      "boundary_violations": 0,
+      "stale_suppressions": 0
+    },
+    "unused_files": [
+      {
+        "path": "b.ts",
+        "actions": [
+          {
+            "type": "delete-file",
+            "auto_fixable": false,
+            "description": "Delete this file",
+            "note": "File deletion may remove runtime functionality not visible to static analysis"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress with a file-level comment at the top of the file",
+            "comment": "// fallow-ignore-file unused-file"
+          }
+        ],
+        "introduced": true
+      }
+    ],
+    "unused_exports": [],
+    "unused_types": [],
+    "private_type_leaks": [],
+    "unused_dependencies": [],
+    "unused_dev_dependencies": [],
+    "unused_optional_dependencies": [],
+    "unused_enum_members": [],
+    "unused_class_members": [],
+    "unresolved_imports": [],
+    "unlisted_dependencies": [],
+    "duplicate_exports": [],
+    "type_only_dependencies": [],
+    "test_only_dependencies": [],
+    "circular_dependencies": [],
+    "boundary_violations": [],
+    "stale_suppressions": []
+  },
+  "dupes": {
+    "clone_groups": [],
+    "clone_families": [],
+    "stats": {
+      "total_files": 0,
+      "files_with_clones": 0,
+      "total_lines": 0,
+      "duplicated_lines": 0,
+      "total_tokens": 0,
+      "duplicated_tokens": 0,
+      "clone_groups": 0,
+      "clone_instances": 0,
+      "duplication_percentage": 0.0
+    }
+  },
+  "health": {
+    "findings": [],
+    "summary": {
+      "files_analyzed": 1,
+      "functions_analyzed": 0,
+      "functions_above_threshold": 0,
+      "max_cyclomatic_threshold": 20,
+      "max_cognitive_threshold": 15,
+      "max_crap_threshold": 30.0,
+      "severity_critical_count": 0,
+      "severity_high_count": 0,
+      "severity_moderate_count": 0
+    },
+    "vital_signs": {
+      "dead_file_pct": 100.0,
+      "dead_export_pct": 0.0,
+      "avg_cyclomatic": 0.0,
+      "p90_cyclomatic": 0,
+      "unused_dep_count": 1,
+      "unused_deps_per_k_files": 1000.0,
+      "circular_dep_count": 0,
+      "circular_deps_per_k_files": 0.0,
+      "counts": {
+        "total_files": 1,
+        "total_exports": 1,
+        "dead_files": 1,
+        "dead_exports": 0,
+        "total_lines": 2,
+        "files_scored": 0,
+        "total_deps": 0
+      },
+      "total_loc": 2
+    }
+  }
+}

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -875,6 +875,81 @@ ISSUES_ALL=$(cd "$WORK" && jq -r '((.summary.dead_code_issues // 0) + (.summary.
 [ "$ISSUES_ALL" = "2" ] && pass "audit all: issue count = total in changed files (2)" || fail "audit all: issue count" "expected 2, got $ISSUES_ALL"
 rm -rf "$WORK"
 
+echo "  full prune+rekey pipeline against raw CLI audit JSON:"
+# Exercises the same jq the analyze.sh script runs in production. If you change
+# either jq block in analyze.sh, update this test snippet to match.
+PIPELINE_OUT=$(mktemp)
+jq '
+  def keep_introduced(arr):
+    (arr // []) | map(select(.introduced != false));
+  .dead_code //= {}
+  | .dead_code.unused_files                = keep_introduced(.dead_code.unused_files)
+  | .dead_code.unused_exports              = keep_introduced(.dead_code.unused_exports)
+  | .dead_code.unused_dependencies         = keep_introduced(.dead_code.unused_dependencies)
+  | .dead_code.unused_dev_dependencies     = keep_introduced(.dead_code.unused_dev_dependencies)
+  | (if .complexity then .complexity.findings = keep_introduced(.complexity.findings) else . end)
+  | (if .duplication then .duplication.clone_groups = keep_introduced(.duplication.clone_groups) else . end)
+' "$FIXTURES/audit-raw.json" | jq '
+  def list_sum(o):
+    ((o.unused_files // []) | length)
+    + ((o.unused_exports // []) | length)
+    + ((o.unused_dependencies // []) | length)
+    + ((o.unused_dev_dependencies // []) | length);
+  .dead_code   as $dc
+  | .complexity  as $cx
+  | .duplication as $du
+  | .check  = ($dc | if . then . + {total_issues: list_sum(.)} else null end)
+  | .dupes  = $du
+  | .health = $cx
+  | del(.dead_code, .complexity, .duplication)
+' > "$PIPELINE_OUT"
+HAS_CHECK=$(jq -r '(.check | type)' "$PIPELINE_OUT")
+[ "$HAS_CHECK" = "object" ] && pass "pipeline: emits .check after rekey" || fail "pipeline: .check" "expected object, got $HAS_CHECK"
+HAS_DEAD_CODE=$(jq -r '(.dead_code // null) | type' "$PIPELINE_OUT")
+[ "$HAS_DEAD_CODE" = "null" ] && pass "pipeline: drops .dead_code after rekey" || fail "pipeline: .dead_code" "expected null, got $HAS_DEAD_CODE"
+TOP_VERDICT=$(jq -r '.verdict' "$PIPELINE_OUT")
+[ "$TOP_VERDICT" = "fail" ] && pass "pipeline: preserves top-level verdict" || fail "pipeline: verdict" "expected fail, got $TOP_VERDICT"
+TOP_COMMAND=$(jq -r '.command' "$PIPELINE_OUT")
+[ "$TOP_COMMAND" = "audit" ] && pass "pipeline: preserves top-level command" || fail "pipeline: command" "expected audit, got $TOP_COMMAND"
+ALL_INTRODUCED=$(jq -r '[.check.unused_files[].introduced] | all' "$PIPELINE_OUT")
+[ "$ALL_INTRODUCED" = "true" ] && pass "pipeline: prune kept only introduced=true entries" || fail "pipeline: prune" "expected true, got $ALL_INTRODUCED"
+rm -f "$PIPELINE_OUT"
+
+echo "  analyze.sh validates INPUT_GATE only when command=audit:"
+NONAUDIT_DIR=$(mktemp -d)
+cd "$NONAUDIT_DIR"
+INPUT_COMMAND=health INPUT_GATE=invalid INPUT_ROOT=. INPUT_FORMAT=json EVENT_NAME=push \
+  bash "$DIR/../scripts/analyze.sh" 2>&1 | /usr/bin/grep -c "Invalid gate" > /tmp/invalid-gate-hits.txt 2>&1 || true
+HITS=$(cat /tmp/invalid-gate-hits.txt 2>/dev/null || echo 0)
+cd "$DIR"
+rm -rf "$NONAUDIT_DIR"
+[ "$HITS" = "0" ] && pass "non-audit command does not validate INPUT_GATE" || fail "non-audit gate validation" "expected 0 hits, got $HITS"
+rm -f /tmp/invalid-gate-hits.txt
+
+echo "  analyze.sh prunes complexity/duplication findings under gate=new-only:"
+PRUNE_INPUT='{
+  "dead_code": {"unused_files": []},
+  "complexity": {"findings": [
+    {"name": "old", "introduced": false},
+    {"name": "new", "introduced": true}
+  ]},
+  "duplication": {"clone_groups": [
+    {"id": "old", "introduced": false},
+    {"id": "new", "introduced": true}
+  ]}
+}'
+PRUNED=$(echo "$PRUNE_INPUT" | jq '
+  def keep_introduced(arr):
+    (arr // []) | map(select(.introduced != false));
+  .dead_code //= {}
+  | (if .complexity then .complexity.findings = keep_introduced(.complexity.findings) else . end)
+  | (if .duplication then .duplication.clone_groups = keep_introduced(.duplication.clone_groups) else . end)
+')
+CX_KEPT=$(echo "$PRUNED" | jq -r '.complexity.findings[].name' | tr '\n' ',')
+[ "$CX_KEPT" = "new," ] && pass "prune: complexity drops introduced=false" || fail "prune complexity" "expected 'new,', got '$CX_KEPT'"
+DU_KEPT=$(echo "$PRUNED" | jq -r '.duplication.clone_groups[].id' | tr '\n' ',')
+[ "$DU_KEPT" = "new," ] && pass "prune: duplication drops introduced=false" || fail "prune duplication" "expected 'new,', got '$DU_KEPT'"
+
 # --- Summary ---
 
 echo ""

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -788,6 +788,93 @@ echo "  review-body.jq without env vars (backwards compat):"
 OUT=$(jq -r -f "$JQ_DIR/review-body.jq" "$FIXTURES/combined.json" 2>&1)
 assert_contains "$OUT" "fallow-review" "marker present without env vars"
 
+# --- Audit command tests ---
+
+echo ""
+echo "=== Audit command (issue #302) ==="
+
+echo "  audit fixture shape:"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '.command' "audit" "audit: command field preserved at top level"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '.verdict' "fail" "audit: verdict field preserved at top level"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '.attribution.gate' "new-only" "audit: attribution.gate preserved at top level"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '.check.total_issues' "1" "audit: re-keyed to .check.total_issues"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '(.dupes | type)' "object" "audit: re-keyed to .dupes"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '(.health | type)' "object" "audit: re-keyed to .health"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '(.dead_code // null)' "null" "audit: original dead_code key removed"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '(.complexity // null)' "null" "audit: original complexity key removed"
+assert_json_value "$(cat "$FIXTURES/audit.json")" '(.duplication // null)' "null" "audit: original duplication key removed"
+
+echo "  summary-combined.jq with audit verdict header:"
+OUT=$(jq -r -f "$JQ_DIR/summary-combined.jq" "$FIXTURES/audit.json" 2>&1)
+assert_contains "$OUT" "Audit failed" "audit: shows verdict in PR comment"
+assert_contains "$OUT" "gate: \`new-only\`" "audit: shows gate in PR comment"
+assert_contains "$OUT" "1 new finding introduced" "audit: shows introduced count"
+assert_contains "$OUT" "1 inherited" "audit: shows inherited count when present"
+
+echo "  summary-combined.jq with audit pass verdict:"
+OUT_CLEAN=$(jq -r -f "$JQ_DIR/summary-combined.jq" "$FIXTURES/audit-clean.json" 2>&1)
+assert_contains "$OUT_CLEAN" "Audit passed" "audit clean: shows pass verdict"
+assert_contains "$OUT_CLEAN" "0 new finding" "audit clean: shows zero new findings"
+assert_not_contains "$OUT_CLEAN" "inherited" "audit clean: no inherited mention when none"
+
+echo "  summary-combined.jq with audit warn verdict:"
+OUT_WARN=$(jq '.verdict = "warn"' "$FIXTURES/audit.json" | jq -r -f "$JQ_DIR/summary-combined.jq" 2>&1)
+assert_contains "$OUT_WARN" "Audit passed with warnings" "audit warn: shows warn verdict"
+
+echo "  summary-combined.jq with gate=all:"
+OUT_ALL=$(jq '.attribution.gate = "all" | .attribution.dead_code_introduced = 0 | .attribution.dead_code_inherited = 0' "$FIXTURES/audit.json" | jq -r -f "$JQ_DIR/summary-combined.jq" 2>&1)
+assert_contains "$OUT_ALL" "gate: \`all\`" "audit gate=all: shows gate"
+assert_contains "$OUT_ALL" "in changed files" "audit gate=all: phrasing reflects all-mode"
+assert_not_contains "$OUT_ALL" "introduced by this PR" "audit gate=all: no introduced phrasing"
+
+echo "  summary-combined.jq backwards-compat (combined-mode without verdict):"
+OUT_COMBINED=$(jq -r -f "$JQ_DIR/summary-combined.jq" "$FIXTURES/combined.json" 2>&1)
+assert_not_contains "$OUT_COMBINED" "Audit" "combined: no audit banner when verdict absent"
+assert_not_contains "$OUT_COMBINED" "gate:" "combined: no gate banner when verdict absent"
+
+echo "  summary-combined.jq backwards-compat (clean combined-mode without verdict):"
+OUT_COMBINED_CLEAN=$(jq -r -f "$JQ_DIR/summary-combined.jq" "$FIXTURES/combined-clean.json" 2>&1)
+assert_not_contains "$OUT_COMBINED_CLEAN" "Audit" "combined clean: no audit banner"
+
+echo "  annotations on re-keyed audit JSON:"
+OUT=$(jq '.check' "$FIXTURES/audit.json" | jq -r -f "$JQ_DIR/annotations-check.jq" 2>&1)
+assert_contains "$OUT" "::warning" "audit: annotations work on re-keyed dead-code"
+assert_contains "$OUT" "Unused file" "audit: annotation has expected title"
+
+echo "  analyze.sh validates INPUT_GATE as closed enum:"
+ANALYZE_DIR=$(mktemp -d)
+cd "$ANALYZE_DIR"
+OUT=$(INPUT_COMMAND=audit INPUT_GATE=invalid INPUT_ROOT=. INPUT_FORMAT=json EVENT_NAME=push \
+  bash "$DIR/../scripts/analyze.sh" 2>&1)
+ANALYZE_STATUS=$?
+cd "$DIR"
+rm -rf "$ANALYZE_DIR"
+[ "$ANALYZE_STATUS" -ne 0 ] && pass "audit: invalid gate exits non-zero" || fail "audit: invalid gate exits non-zero" "expected non-zero exit, got $ANALYZE_STATUS"
+assert_contains "$OUT" "Invalid gate: invalid" "audit: invalid gate has clear error message"
+
+echo "  analyze.sh rejects audit on non-PR event without changed-since:"
+ANALYZE_DIR=$(mktemp -d)
+cd "$ANALYZE_DIR"
+OUT=$(INPUT_COMMAND=audit INPUT_GATE=new-only INPUT_ROOT=. INPUT_FORMAT=json \
+  INPUT_AUTO_CHANGED_SINCE=true EVENT_NAME=push \
+  bash "$DIR/../scripts/analyze.sh" 2>&1)
+ANALYZE_STATUS=$?
+cd "$DIR"
+rm -rf "$ANALYZE_DIR"
+[ "$ANALYZE_STATUS" -ne 0 ] && pass "audit: non-PR event without base errors" || fail "audit: non-PR event without base errors" "expected non-zero exit, got $ANALYZE_STATUS"
+assert_contains "$OUT" "needs an explicit base" "audit: non-PR event error message is clear"
+
+echo "  analyze.sh issue-count extraction (gate=new-only):"
+WORK=$(mktemp -d)
+cp "$FIXTURES/audit.json" "$WORK/fallow-results.json"
+ISSUES=$(cd "$WORK" && jq -r '((.attribution.dead_code_introduced // 0) + (.attribution.complexity_introduced // 0) + (.attribution.duplication_introduced // 0))' fallow-results.json)
+[ "$ISSUES" = "1" ] && pass "audit new-only: issue count = introduced (1)" || fail "audit new-only: issue count" "expected 1, got $ISSUES"
+
+echo "  analyze.sh issue-count extraction (gate=all):"
+ISSUES_ALL=$(cd "$WORK" && jq -r '((.summary.dead_code_issues // 0) + (.summary.complexity_findings // 0) + (.summary.duplication_clone_groups // 0))' fallow-results.json)
+[ "$ISSUES_ALL" = "2" ] && pass "audit all: issue count = total in changed files (2)" || fail "audit all: issue count" "expected 2, got $ISSUES_ALL"
+rm -rf "$WORK"
+
 # --- Summary ---
 
 echo ""

--- a/ci/gitlab-ci.yml
+++ b/ci/gitlab-ci.yml
@@ -74,7 +74,7 @@ variables:
 
   # Core
   FALLOW_VERSION: ""             # Empty reads package.json fallow dependency, then falls back to latest
-  FALLOW_COMMAND: ""            # dead-code, dupes, health, fix, or empty (runs all)
+  FALLOW_COMMAND: ""            # dead-code, dupes, health, audit, fix, or empty (runs all)
   FALLOW_ROOT: "."
   FALLOW_CONFIG: ""             # Path to .fallowrc.json, .fallowrc.jsonc, or fallow.toml
   FALLOW_PRODUCTION: ""                # "true"/"false" enables production for every analysis. Empty defers to config.
@@ -105,6 +105,7 @@ variables:
 
   # Dead-code specific
   FALLOW_ISSUE_TYPES: ""        # Comma-separated: unused-files,unused-exports,...
+  FALLOW_INCLUDE_ENTRY_EXPORTS: "false"  # Report unused exports in entry files (also applies to audit)
   FALLOW_FAIL_ON_REGRESSION: "false"
   FALLOW_TOLERANCE: "0"
   FALLOW_REGRESSION_BASELINE: ""
@@ -139,6 +140,9 @@ variables:
   FALLOW_MIN_COMMITS: ""
   FALLOW_SAVE_SNAPSHOT: ""       # save snapshot to .fallow/snapshots/ for trend tracking; cache this path across pipelines
   FALLOW_TREND: "false"          # compare against most recent snapshot; requires FALLOW_SAVE_SNAPSHOT on a prior run
+
+  # Audit specific (only used when FALLOW_COMMAND=audit)
+  FALLOW_AUDIT_GATE: "new-only"  # Audit verdict gate: new-only fails only on findings introduced by this MR; all fails on every finding in changed files
 
   # Fix specific
   FALLOW_DRY_RUN: "true"
@@ -370,9 +374,17 @@ variables:
 
       # ── Validate inputs ──────────────────────────────────────────────
       case "$FALLOW_COMMAND" in
-        ""|dead-code|check|dupes|health|fix) ;;
+        ""|dead-code|check|dupes|health|audit|fix) ;;
         *) echo "ERROR: Invalid command: ${FALLOW_COMMAND}"; exit 2 ;;
       esac
+
+      FALLOW_AUDIT_GATE="${FALLOW_AUDIT_GATE:-new-only}"
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        case "$FALLOW_AUDIT_GATE" in
+          new-only|all) ;;
+          *) echo "ERROR: Invalid audit gate: ${FALLOW_AUDIT_GATE}. Must be new-only or all."; exit 2 ;;
+        esac
+      fi
 
       for name_val in "min-tokens:$FALLOW_MIN_TOKENS" "min-lines:$FALLOW_MIN_LINES" \
                       "max-cyclomatic:$FALLOW_MAX_CYCLOMATIC" "max-cognitive:$FALLOW_MAX_COGNITIVE" \
@@ -399,6 +411,16 @@ variables:
         if [ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA:-}" ]; then
           FALLOW_CHANGED_SINCE="$CI_MERGE_REQUEST_DIFF_BASE_SHA"
           echo "Auto-scoping to changed files (--changed-since ${FALLOW_CHANGED_SINCE:0:12})"
+        fi
+      fi
+
+      # Audit on non-MR pipelines needs an explicit base. Don't silently fall through
+      # to fallow's auto-detect, because misconfigured pipelines produce confusing
+      # "verdict: pass" results that simply analyzed nothing.
+      if [ "$FALLOW_COMMAND" = "audit" ] && [ -z "$FALLOW_CHANGED_SINCE" ]; then
+        if [ -z "${CI_MERGE_REQUEST_IID:-}" ]; then
+          echo "ERROR: FALLOW_COMMAND=audit on non-MR pipeline needs an explicit base. Set FALLOW_CHANGED_SINCE (e.g. origin/main) or pass --base via FALLOW_ARGS."
+          exit 2
         fi
       fi
 
@@ -438,6 +460,7 @@ variables:
               ARGS+=("--${t}")
             done
           fi
+          [ "$FALLOW_INCLUDE_ENTRY_EXPORTS" = "true" ] && ARGS+=(--include-entry-exports)
           [ "$FALLOW_FAIL_ON_REGRESSION" = "true" ] && ARGS+=(--fail-on-regression)
           [ -n "$FALLOW_TOLERANCE" ] && [ "$FALLOW_TOLERANCE" != "0" ] && ARGS+=(--tolerance "$FALLOW_TOLERANCE")
           [ -n "$FALLOW_REGRESSION_BASELINE" ] && ARGS+=(--regression-baseline "$FALLOW_REGRESSION_BASELINE")
@@ -483,6 +506,14 @@ variables:
         fix)
           [ "$FALLOW_DRY_RUN" = "true" ] && ARGS+=(--dry-run) || ARGS+=(--yes)
           ;;
+        audit)
+          ARGS+=(--gate "$FALLOW_AUDIT_GATE")
+          [ -n "$FALLOW_MAX_CRAP" ] && ARGS+=(--max-crap "$FALLOW_MAX_CRAP")
+          [ "$FALLOW_PRODUCTION_DEAD_CODE" = "true" ] && ARGS+=(--production-dead-code)
+          [ "$FALLOW_PRODUCTION_HEALTH" = "true" ] && ARGS+=(--production-health)
+          [ "$FALLOW_PRODUCTION_DUPES" = "true" ] && ARGS+=(--production-dupes)
+          [ "$FALLOW_INCLUDE_ENTRY_EXPORTS" = "true" ] && ARGS+=(--include-entry-exports)
+          ;;
         "")
           ARGS+=(--dupes-mode "$FALLOW_DUPES_MODE")
           [ -n "$FALLOW_THRESHOLD" ]         && ARGS+=(--dupes-threshold "$FALLOW_THRESHOLD")
@@ -520,19 +551,107 @@ variables:
         echo "---"
       fi
 
+      # ── Audit-specific post-processing ───────────────────────────────
+      # Re-key audit sub-results to combined-mode keys (dead_code -> check,
+      # complexity -> health, duplication -> dupes) so existing summary,
+      # comment, and review jq scripts work unchanged. Preserve top-level
+      # audit fields (command, verdict, attribution, gate, summary, base_ref,
+      # head_sha) so AI consumers can still detect audit runs. Under
+      # gate=new-only, prune findings to introduced != false entries.
+      VERDICT=""
+      AUDIT_GATE=""
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
+        AUDIT_GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
+
+        if [ "$AUDIT_GATE" = "new-only" ]; then
+          jq '
+            def keep_introduced(arr):
+              (arr // []) | map(select(.introduced != false));
+            .dead_code //= {}
+            | .dead_code.unused_files                = keep_introduced(.dead_code.unused_files)
+            | .dead_code.unused_exports              = keep_introduced(.dead_code.unused_exports)
+            | .dead_code.unused_types                = keep_introduced(.dead_code.unused_types)
+            | .dead_code.private_type_leaks          = keep_introduced(.dead_code.private_type_leaks)
+            | .dead_code.unused_dependencies         = keep_introduced(.dead_code.unused_dependencies)
+            | .dead_code.unused_dev_dependencies     = keep_introduced(.dead_code.unused_dev_dependencies)
+            | .dead_code.unused_optional_dependencies = keep_introduced(.dead_code.unused_optional_dependencies)
+            | .dead_code.unused_enum_members         = keep_introduced(.dead_code.unused_enum_members)
+            | .dead_code.unused_class_members        = keep_introduced(.dead_code.unused_class_members)
+            | .dead_code.unresolved_imports          = keep_introduced(.dead_code.unresolved_imports)
+            | .dead_code.unlisted_dependencies       = keep_introduced(.dead_code.unlisted_dependencies)
+            | .dead_code.duplicate_exports           = keep_introduced(.dead_code.duplicate_exports)
+            | .dead_code.circular_dependencies       = keep_introduced(.dead_code.circular_dependencies)
+            | .dead_code.boundary_violations         = keep_introduced(.dead_code.boundary_violations)
+            | .dead_code.type_only_dependencies      = keep_introduced(.dead_code.type_only_dependencies)
+            | .dead_code.test_only_dependencies      = keep_introduced(.dead_code.test_only_dependencies)
+            | .dead_code.stale_suppressions          = keep_introduced(.dead_code.stale_suppressions)
+            | (if .complexity then .complexity.findings = keep_introduced(.complexity.findings) else . end)
+            | (if .duplication then .duplication.clone_groups = keep_introduced(.duplication.clone_groups) else . end)
+          ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
+            echo "ERROR: Audit JSON prune transform failed"
+            rm -f fallow-results.tmp.json
+            exit 2
+          }
+        fi
+
+        jq '
+          def list_sum(o):
+            ((o.unused_files // []) | length)
+            + ((o.unused_exports // []) | length)
+            + ((o.unused_types // []) | length)
+            + ((o.private_type_leaks // []) | length)
+            + ((o.unused_dependencies // []) | length)
+            + ((o.unused_dev_dependencies // []) | length)
+            + ((o.unused_optional_dependencies // []) | length)
+            + ((o.unused_enum_members // []) | length)
+            + ((o.unused_class_members // []) | length)
+            + ((o.unresolved_imports // []) | length)
+            + ((o.unlisted_dependencies // []) | length)
+            + ((o.duplicate_exports // []) | length)
+            + ((o.circular_dependencies // []) | length)
+            + ((o.boundary_violations // []) | length)
+            + ((o.type_only_dependencies // []) | length)
+            + ((o.test_only_dependencies // []) | length)
+            + ((o.stale_suppressions // []) | length);
+          .dead_code   as $dc
+          | .complexity  as $cx
+          | .duplication as $du
+          | .check  = ($dc | if . then . + {total_issues: list_sum(.)} else null end)
+          | .dupes  = $du
+          | .health = $cx
+          | del(.dead_code, .complexity, .duplication)
+        ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
+          echo "ERROR: Audit JSON re-key transform failed"
+          rm -f fallow-results.tmp.json
+          exit 2
+        }
+      fi
+
       # ── Extract issue count ──────────────────────────────────────────
       case "$FALLOW_COMMAND" in
         dead-code|check) ISSUES=$(jq -r '.total_issues // 0' fallow-results.json) ;;
         dupes)           ISSUES=$(jq -r '.stats.clone_groups // 0' fallow-results.json) ;;
         health)          ISSUES=$(jq -r '((.summary.functions_above_threshold // 0) + ((.runtime_coverage.findings // []) | map(select(.verdict == "safe_to_delete" or .verdict == "review_required" or .verdict == "low_traffic")) | length))' fallow-results.json) ;;
         fix)             ISSUES=$(jq -r '(.fixes | length)' fallow-results.json) ;;
+        audit)
+          if [ "$AUDIT_GATE" = "all" ]; then
+            ISSUES=$(jq -r '((.summary.dead_code_issues // 0) + (.summary.complexity_findings // 0) + (.summary.duplication_clone_groups // 0))' fallow-results.json)
+          else
+            ISSUES=$(jq -r '((.attribution.dead_code_introduced // 0) + (.attribution.complexity_introduced // 0) + (.attribution.duplication_introduced // 0))' fallow-results.json)
+          fi
+          ;;
         "")              ISSUES=$(jq -r '((.check.total_issues // 0) + (.dupes.stats.clone_groups // 0) + (.health.summary.functions_above_threshold // 0) + ((.health.runtime_coverage.findings // []) | map(select(.verdict == "safe_to_delete" or .verdict == "review_required" or .verdict == "low_traffic")) | length))' fallow-results.json) ;;
       esac
 
       if ! echo "$ISSUES" | grep -qE '^[0-9]+$'; then
         echo "ERROR: Unexpected issue count: ${ISSUES}"; exit 2
       fi
-      echo "Found ${ISSUES} issues"
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        echo "Audit verdict: ${VERDICT} (gate: ${AUDIT_GATE}, ${ISSUES} ${AUDIT_GATE} finding(s))"
+      else
+        echo "Found ${ISSUES} issues"
+      fi
 
       # ── GitLab Code Quality report (CodeClimate format) ──────────────
       # Uses fallow's native --format codeclimate for inline MR annotations.
@@ -587,15 +706,25 @@ variables:
       fi
 
       # ── Fail check ───────────────────────────────────────────────────
-      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ] && [ "$ISSUES" -gt 0 ]; then
-        case "$FALLOW_COMMAND" in
-          dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
-          dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
-          health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
-          fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
-          "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
-        esac
-        exit 1
+      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ]; then
+        if [ "$FALLOW_COMMAND" = "audit" ]; then
+          # Audit gates on rule severity. Verdict already encodes the gate
+          # decision: pass -> no issues, warn -> warn-tier only (don't fail),
+          # fail -> error-tier (fail).
+          if [ "$VERDICT" = "fail" ]; then
+            echo "ERROR: Fallow audit failed (gate: ${AUDIT_GATE:-new-only}, ${ISSUES} finding(s) at error severity)"
+            exit 1
+          fi
+        elif [ "$ISSUES" -gt 0 ]; then
+          case "$FALLOW_COMMAND" in
+            dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
+            dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
+            health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
+            fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
+            "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
+          esac
+          exit 1
+        fi
       fi
       FALLOW_SCRIPT_EOF
       chmod +x /tmp/fallow-run.sh

--- a/ci/jq/summary-combined.jq
+++ b/ci/jq/summary-combined.jq
@@ -46,6 +46,27 @@ def prod_hot_paths: (.health.runtime_coverage.hot_paths // []);
 (.health.vital_signs // {}) as $vitals |
 (.health.summary // {}) as $summary |
 (.dupes.stats // {}) as $dupes_stats |
+# Audit verdict header: surfaces verdict + new-vs-inherited attribution
+# whenever the input came from `fallow audit`. Combined-mode runs (no audit
+# fields present) skip this entirely so existing MR comments are unchanged.
+(.verdict // null) as $verdict |
+(.attribution // null) as $attribution |
+((($attribution.dead_code_introduced // 0) + ($attribution.complexity_introduced // 0) + ($attribution.duplication_introduced // 0)) // 0) as $introduced |
+((($attribution.dead_code_inherited // 0) + ($attribution.complexity_inherited // 0) + ($attribution.duplication_inherited // 0)) // 0) as $inherited |
+($attribution.gate // "new-only") as $audit_gate |
+(if $verdict then
+  (if $verdict == "pass" then ":white_check_mark: **Audit passed**"
+   elif $verdict == "warn" then ":warning: **Audit passed with warnings**"
+   else ":x: **Audit failed**" end) as $headline |
+  "> \($headline) · gate: `\($audit_gate)`" +
+  (if $audit_gate == "new-only" then
+    " · \($introduced) new finding\(if $introduced == 1 then "" else "s" end) introduced by this MR" +
+    (if $inherited > 0 then " · \($inherited) inherited (not gated)" else "" end)
+  else
+    " · \($introduced + $inherited) finding\(if ($introduced + $inherited) == 1 then "" else "s" end) in changed files"
+  end) +
+  "\n\n"
+else "" end) as $audit_header |
 
 # Health delta header (only when --score is present)
 (if .health.health_score then
@@ -70,6 +91,7 @@ else "" end) +
 
 if $total == 0 then
   "# :seedling: Fallow\n\n" +
+  $audit_header +
   (if $prod_advisory > 0 or $hot_paths > 0 then
     "> **No blocking issues found**\n\n" +
     ":white_check_mark: No code issues \u00b7 :white_check_mark: No duplication \u00b7 :white_check_mark: No blocking health findings" +
@@ -85,6 +107,7 @@ if $total == 0 then
   else "" end)
 else
   "# :seedling: Fallow\n\n" +
+  $audit_header +
 
   # One-line status
   (if $check > 0 then ":warning: **\($check)** code issues" else ":white_check_mark: No code issues" end) +

--- a/ci/scripts/comment.sh
+++ b/ci/scripts/comment.sh
@@ -32,7 +32,7 @@ case "$FALLOW_COMMAND" in
   dupes)           JQ_FILE=$(pick_jq "summary-dupes.jq") ;;
   health)          JQ_FILE=$(pick_jq "summary-health.jq") ;;
   fix)             JQ_FILE=$(pick_jq "summary-fix.jq") ;;
-  "")              JQ_FILE=$(pick_jq "summary-combined.jq") ;;
+  audit|"")        JQ_FILE=$(pick_jq "summary-combined.jq") ;;
   *)               echo "ERROR: Unexpected command: ${FALLOW_COMMAND}"; exit 2 ;;
 esac
 

--- a/ci/scripts/review.sh
+++ b/ci/scripts/review.sh
@@ -123,8 +123,8 @@ case "$FALLOW_COMMAND" in
     COMMENTS=$(jq -f "$(pick_jq review-comments-dupes.jq)" "$RESULTS_FILE" 2>&1) || { echo "jq dupes error: $COMMENTS"; COMMENTS="[]"; } ;;
   health)
     COMMENTS=$(jq -f "$(pick_jq review-comments-health.jq)" "$RESULTS_FILE" 2>&1) || { echo "jq health error: $COMMENTS"; COMMENTS="[]"; } ;;
-  "")
-    # Combined: extract each section and run through its jq script
+  audit|"")
+    # Audit JSON is re-keyed in the template to use combined-mode keys (check/health/dupes).
     WORK_DIR=$(mktemp -d)
     jq '.check // {}' "$RESULTS_FILE" > "$WORK_DIR/check.json" 2>/dev/null
     jq '.dupes // {}' "$RESULTS_FILE" > "$WORK_DIR/dupes.json" 2>/dev/null

--- a/ci/tests/fixtures/audit-clean.json
+++ b/ci/tests/fixtures/audit-clean.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 3,
+  "version": "2.66.2",
+  "command": "audit",
+  "verdict": "pass",
+  "changed_files_count": 2,
+  "base_ref": "origin/main",
+  "head_sha": "abc1234567890",
+  "elapsed_ms": 412,
+  "summary": {
+    "dead_code_issues": 0,
+    "dead_code_has_errors": false,
+    "complexity_findings": 0,
+    "max_cyclomatic": null,
+    "duplication_clone_groups": 0
+  },
+  "attribution": {
+    "gate": "new-only",
+    "dead_code_introduced": 0,
+    "dead_code_inherited": 0,
+    "complexity_introduced": 0,
+    "complexity_inherited": 0,
+    "duplication_introduced": 0,
+    "duplication_inherited": 0
+  },
+  "check": {
+    "schema_version": 3,
+    "version": "2.66.2",
+    "total_issues": 0,
+    "summary": {
+      "files_analyzed": 12,
+      "modules_analyzed": 12
+    },
+    "unused_files": [],
+    "unused_exports": [],
+    "unused_types": [],
+    "private_type_leaks": [],
+    "unused_dependencies": [],
+    "unused_dev_dependencies": [],
+    "unused_optional_dependencies": [],
+    "unused_enum_members": [],
+    "unused_class_members": [],
+    "unresolved_imports": [],
+    "unlisted_dependencies": [],
+    "duplicate_exports": [],
+    "circular_dependencies": [],
+    "boundary_violations": [],
+    "type_only_dependencies": [],
+    "test_only_dependencies": [],
+    "stale_suppressions": []
+  },
+  "dupes": {
+    "stats": {
+      "clone_groups": 0,
+      "clone_instances": 0,
+      "duplicated_lines": 0,
+      "duplication_percentage": 0,
+      "files_with_clones": 0
+    },
+    "clone_groups": [],
+    "clone_families": []
+  },
+  "health": {
+    "summary": {
+      "files_analyzed": 12,
+      "functions_analyzed": 80,
+      "functions_above_threshold": 0,
+      "max_cyclomatic_threshold": 20,
+      "max_cognitive_threshold": 15
+    },
+    "vital_signs": {
+      "maintainability_avg": 92.5,
+      "avg_cyclomatic": 4.2
+    },
+    "findings": []
+  }
+}

--- a/ci/tests/fixtures/audit-raw.json
+++ b/ci/tests/fixtures/audit-raw.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": 3,
+  "version": "2.66.2",
+  "command": "audit",
+  "verdict": "fail",
+  "changed_files_count": 1,
+  "base_ref": "HEAD~1",
+  "head_sha": "da6cd85",
+  "elapsed_ms": 133,
+  "summary": {
+    "dead_code_issues": 2,
+    "dead_code_has_errors": true,
+    "complexity_findings": 0,
+    "max_cyclomatic": null,
+    "duplication_clone_groups": 0
+  },
+  "attribution": {
+    "gate": "new-only",
+    "dead_code_introduced": 1,
+    "dead_code_inherited": 1,
+    "complexity_introduced": 0,
+    "complexity_inherited": 0,
+    "duplication_introduced": 0,
+    "duplication_inherited": 0
+  },
+  "dead_code": {
+    "schema_version": 5,
+    "version": "2.66.2",
+    "elapsed_ms": 61,
+    "total_issues": 2,
+    "entry_points": {
+      "total": 0,
+      "sources": {}
+    },
+    "summary": {
+      "total_issues": 2,
+      "unused_files": 1,
+      "unused_exports": 0,
+      "unused_types": 0,
+      "private_type_leaks": 0,
+      "unused_dependencies": 1,
+      "unused_enum_members": 0,
+      "unused_class_members": 0,
+      "unresolved_imports": 0,
+      "unlisted_dependencies": 0,
+      "duplicate_exports": 0,
+      "type_only_dependencies": 0,
+      "test_only_dependencies": 0,
+      "circular_dependencies": 0,
+      "boundary_violations": 0,
+      "stale_suppressions": 0
+    },
+    "unused_files": [
+      {
+        "path": "b.ts",
+        "actions": [
+          {
+            "type": "delete-file",
+            "auto_fixable": false,
+            "description": "Delete this file",
+            "note": "File deletion may remove runtime functionality not visible to static analysis"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress with a file-level comment at the top of the file",
+            "comment": "// fallow-ignore-file unused-file"
+          }
+        ],
+        "introduced": true
+      }
+    ],
+    "unused_exports": [],
+    "unused_types": [],
+    "private_type_leaks": [],
+    "unused_dependencies": [
+      {
+        "package_name": "lodash",
+        "location": "dependencies",
+        "path": "package.json",
+        "line": 1,
+        "actions": [
+          {
+            "type": "remove-dependency",
+            "auto_fixable": true,
+            "description": "Remove from dependencies in package.json"
+          },
+          {
+            "type": "add-to-config",
+            "auto_fixable": false,
+            "description": "Add \"lodash\" to ignoreDependencies in fallow config",
+            "config_key": "ignoreDependencies",
+            "value": "lodash"
+          }
+        ],
+        "introduced": false
+      }
+    ],
+    "unused_dev_dependencies": [],
+    "unused_optional_dependencies": [],
+    "unused_enum_members": [],
+    "unused_class_members": [],
+    "unresolved_imports": [],
+    "unlisted_dependencies": [],
+    "duplicate_exports": [],
+    "type_only_dependencies": [],
+    "test_only_dependencies": [],
+    "circular_dependencies": [],
+    "boundary_violations": [],
+    "stale_suppressions": []
+  },
+  "duplication": {
+    "clone_groups": [],
+    "clone_families": [],
+    "stats": {
+      "total_files": 0,
+      "files_with_clones": 0,
+      "total_lines": 0,
+      "duplicated_lines": 0,
+      "total_tokens": 0,
+      "duplicated_tokens": 0,
+      "clone_groups": 0,
+      "clone_instances": 0,
+      "duplication_percentage": 0.0
+    }
+  },
+  "complexity": {
+    "findings": [],
+    "summary": {
+      "files_analyzed": 1,
+      "functions_analyzed": 0,
+      "functions_above_threshold": 0,
+      "max_cyclomatic_threshold": 20,
+      "max_cognitive_threshold": 15,
+      "max_crap_threshold": 30.0,
+      "severity_critical_count": 0,
+      "severity_high_count": 0,
+      "severity_moderate_count": 0
+    },
+    "vital_signs": {
+      "dead_file_pct": 100.0,
+      "dead_export_pct": 0.0,
+      "avg_cyclomatic": 0.0,
+      "p90_cyclomatic": 0,
+      "unused_dep_count": 1,
+      "unused_deps_per_k_files": 1000.0,
+      "circular_dep_count": 0,
+      "circular_deps_per_k_files": 0.0,
+      "counts": {
+        "total_files": 1,
+        "total_exports": 1,
+        "dead_files": 1,
+        "dead_exports": 0,
+        "total_lines": 2,
+        "files_scored": 0,
+        "total_deps": 0
+      },
+      "total_loc": 2
+    }
+  }
+}

--- a/ci/tests/fixtures/audit.json
+++ b/ci/tests/fixtures/audit.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": 3,
+  "version": "2.66.2",
+  "command": "audit",
+  "verdict": "fail",
+  "changed_files_count": 1,
+  "base_ref": "HEAD~1",
+  "head_sha": "db31aa2",
+  "elapsed_ms": 226,
+  "summary": {
+    "dead_code_issues": 2,
+    "dead_code_has_errors": true,
+    "complexity_findings": 0,
+    "max_cyclomatic": null,
+    "duplication_clone_groups": 0
+  },
+  "attribution": {
+    "gate": "new-only",
+    "dead_code_introduced": 1,
+    "dead_code_inherited": 1,
+    "complexity_introduced": 0,
+    "complexity_inherited": 0,
+    "duplication_introduced": 0,
+    "duplication_inherited": 0
+  },
+  "check": {
+    "schema_version": 5,
+    "version": "2.66.2",
+    "elapsed_ms": 113,
+    "total_issues": 1,
+    "entry_points": {
+      "total": 0,
+      "sources": {}
+    },
+    "summary": {
+      "total_issues": 2,
+      "unused_files": 1,
+      "unused_exports": 0,
+      "unused_types": 0,
+      "private_type_leaks": 0,
+      "unused_dependencies": 1,
+      "unused_enum_members": 0,
+      "unused_class_members": 0,
+      "unresolved_imports": 0,
+      "unlisted_dependencies": 0,
+      "duplicate_exports": 0,
+      "type_only_dependencies": 0,
+      "test_only_dependencies": 0,
+      "circular_dependencies": 0,
+      "boundary_violations": 0,
+      "stale_suppressions": 0
+    },
+    "unused_files": [
+      {
+        "path": "b.ts",
+        "actions": [
+          {
+            "type": "delete-file",
+            "auto_fixable": false,
+            "description": "Delete this file",
+            "note": "File deletion may remove runtime functionality not visible to static analysis"
+          },
+          {
+            "type": "suppress-file",
+            "auto_fixable": false,
+            "description": "Suppress with a file-level comment at the top of the file",
+            "comment": "// fallow-ignore-file unused-file"
+          }
+        ],
+        "introduced": true
+      }
+    ],
+    "unused_exports": [],
+    "unused_types": [],
+    "private_type_leaks": [],
+    "unused_dependencies": [],
+    "unused_dev_dependencies": [],
+    "unused_optional_dependencies": [],
+    "unused_enum_members": [],
+    "unused_class_members": [],
+    "unresolved_imports": [],
+    "unlisted_dependencies": [],
+    "duplicate_exports": [],
+    "type_only_dependencies": [],
+    "test_only_dependencies": [],
+    "circular_dependencies": [],
+    "boundary_violations": [],
+    "stale_suppressions": []
+  },
+  "dupes": {
+    "clone_groups": [],
+    "clone_families": [],
+    "stats": {
+      "total_files": 0,
+      "files_with_clones": 0,
+      "total_lines": 0,
+      "duplicated_lines": 0,
+      "total_tokens": 0,
+      "duplicated_tokens": 0,
+      "clone_groups": 0,
+      "clone_instances": 0,
+      "duplication_percentage": 0.0
+    }
+  },
+  "health": {
+    "findings": [],
+    "summary": {
+      "files_analyzed": 1,
+      "functions_analyzed": 0,
+      "functions_above_threshold": 0,
+      "max_cyclomatic_threshold": 20,
+      "max_cognitive_threshold": 15,
+      "max_crap_threshold": 30.0,
+      "severity_critical_count": 0,
+      "severity_high_count": 0,
+      "severity_moderate_count": 0
+    },
+    "vital_signs": {
+      "dead_file_pct": 100.0,
+      "dead_export_pct": 0.0,
+      "avg_cyclomatic": 0.0,
+      "p90_cyclomatic": 0,
+      "unused_dep_count": 1,
+      "unused_deps_per_k_files": 1000.0,
+      "circular_dep_count": 0,
+      "circular_deps_per_k_files": 0.0,
+      "counts": {
+        "total_files": 1,
+        "total_exports": 1,
+        "dead_files": 1,
+        "dead_exports": 0,
+        "total_lines": 2,
+        "files_scored": 0,
+        "total_deps": 0
+      },
+      "total_loc": 2
+    }
+  }
+}

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -655,6 +655,90 @@ assert_contains "$(cat "$SCRIPTS_DIR/review.sh")" "DELETE" "cleans up previous c
 assert_contains "$(cat "$SCRIPTS_DIR/review.sh")" "unused-export" "handles unused export suggestions"
 assert_contains "$(cat "$SCRIPTS_DIR/review.sh")" "FALLOW_SHARED_JQ_DIR" "can use shared jq scripts"
 
+# =========================================================================
+# Audit command (issue #302 follow-up)
+# =========================================================================
+
+echo ""
+echo "=== Audit command ==="
+
+CI_YAML_CONTENT=$(cat "$CI_YAML")
+COMMENT_CONTENT=$(cat "$SCRIPTS_DIR/comment.sh")
+REVIEW_CONTENT=$(cat "$SCRIPTS_DIR/review.sh")
+
+echo "  audit fixtures present:"
+CMD=$(jq -r '.command' "$FIXTURES/audit.json" 2>/dev/null)
+[ "$CMD" = "audit" ] && pass "audit fixture: command preserved" || fail "audit fixture: command preserved" "expected audit, got $CMD"
+VERD=$(jq -r '.verdict' "$FIXTURES/audit.json" 2>/dev/null)
+[ "$VERD" = "fail" ] && pass "audit fixture: verdict preserved" || fail "audit fixture: verdict preserved" "expected fail, got $VERD"
+GATE=$(jq -r '.attribution.gate' "$FIXTURES/audit.json" 2>/dev/null)
+[ "$GATE" = "new-only" ] && pass "audit fixture: gate preserved" || fail "audit fixture: gate preserved" "expected new-only, got $GATE"
+
+echo "  gitlab-ci.yml accepts audit:"
+assert_contains "$CI_YAML_CONTENT" "dead-code|check|dupes|health|audit|fix" "FALLOW_COMMAND validation includes audit"
+assert_contains "$CI_YAML_CONTENT" 'FALLOW_AUDIT_GATE: "new-only"' "default FALLOW_AUDIT_GATE present"
+assert_contains "$CI_YAML_CONTENT" 'Invalid audit gate' "validates FALLOW_AUDIT_GATE as closed enum"
+assert_contains "$CI_YAML_CONTENT" "needs an explicit base" "errors on audit non-MR pipeline without base"
+assert_contains "$CI_YAML_CONTENT" 'ARGS+=(--gate "$FALLOW_AUDIT_GATE")' "passes --gate to fallow audit"
+assert_contains "$CI_YAML_CONTENT" "Audit JSON re-key transform failed" "fail-fast on jq re-key error"
+assert_contains "$CI_YAML_CONTENT" 'VERDICT" = "fail"' "verdict-driven fail check for audit"
+
+echo "  comment.sh routes audit to summary-combined:"
+assert_contains "$COMMENT_CONTENT" 'audit|"")' "comment.sh routes audit to combined summary"
+
+echo "  review.sh handles audit input:"
+assert_contains "$REVIEW_CONTENT" 'audit|"")' "review.sh handles audit"
+
+echo "  full prune+rekey pipeline against raw CLI audit JSON:"
+# Exercises the same jq blocks gitlab-ci.yml runs in production. If those
+# heredoc'd jq blocks change, update this test snippet to match.
+PIPELINE_OUT=$(mktemp)
+jq '
+  def keep_introduced(arr):
+    (arr // []) | map(select(.introduced != false));
+  .dead_code //= {}
+  | .dead_code.unused_files                = keep_introduced(.dead_code.unused_files)
+  | .dead_code.unused_exports              = keep_introduced(.dead_code.unused_exports)
+  | .dead_code.unused_dependencies         = keep_introduced(.dead_code.unused_dependencies)
+  | .dead_code.unused_dev_dependencies     = keep_introduced(.dead_code.unused_dev_dependencies)
+  | (if .complexity then .complexity.findings = keep_introduced(.complexity.findings) else . end)
+  | (if .duplication then .duplication.clone_groups = keep_introduced(.duplication.clone_groups) else . end)
+' "$FIXTURES/audit-raw.json" | jq '
+  def list_sum(o):
+    ((o.unused_files // []) | length)
+    + ((o.unused_exports // []) | length)
+    + ((o.unused_dependencies // []) | length)
+    + ((o.unused_dev_dependencies // []) | length);
+  .dead_code   as $dc
+  | .complexity  as $cx
+  | .duplication as $du
+  | .check  = ($dc | if . then . + {total_issues: list_sum(.)} else null end)
+  | .dupes  = $du
+  | .health = $cx
+  | del(.dead_code, .complexity, .duplication)
+' > "$PIPELINE_OUT"
+HAS_CHECK=$(jq -r '(.check | type)' "$PIPELINE_OUT")
+[ "$HAS_CHECK" = "object" ] && pass "pipeline: emits .check after rekey" || fail "pipeline: .check" "expected object, got $HAS_CHECK"
+HAS_DEAD_CODE=$(jq -r '(.dead_code // null) | type' "$PIPELINE_OUT")
+[ "$HAS_DEAD_CODE" = "null" ] && pass "pipeline: drops .dead_code after rekey" || fail "pipeline: .dead_code" "expected null, got $HAS_DEAD_CODE"
+TOP_VERDICT=$(jq -r '.verdict' "$PIPELINE_OUT")
+[ "$TOP_VERDICT" = "fail" ] && pass "pipeline: preserves top-level verdict" || fail "pipeline: verdict" "expected fail, got $TOP_VERDICT"
+TOP_COMMAND=$(jq -r '.command' "$PIPELINE_OUT")
+[ "$TOP_COMMAND" = "audit" ] && pass "pipeline: preserves top-level command" || fail "pipeline: command" "expected audit, got $TOP_COMMAND"
+ALL_INTRODUCED=$(jq -r '[.check.unused_files[].introduced] | all' "$PIPELINE_OUT")
+[ "$ALL_INTRODUCED" = "true" ] && pass "pipeline: prune kept only introduced=true entries" || fail "pipeline: prune" "expected true, got $ALL_INTRODUCED"
+rm -f "$PIPELINE_OUT"
+
+echo "  summary-combined.jq verdict banner with audit fixture:"
+SUMMARY_JQ="$SHARED_JQ_DIR/summary-combined.jq"
+OUT=$(jq -r -f "$SUMMARY_JQ" "$FIXTURES/audit.json" 2>&1)
+assert_contains "$OUT" "Audit failed" "audit fixture: shows verdict banner"
+assert_contains "$OUT" 'gate: `new-only`' "audit fixture: shows gate"
+assert_contains "$OUT" "introduced by this PR" "audit fixture: shows introduced phrasing"
+
+OUT_CLEAN=$(jq -r -f "$SUMMARY_JQ" "$FIXTURES/audit-clean.json" 2>&1)
+assert_contains "$OUT_CLEAN" "Audit passed" "audit clean: pass verdict"
+
 # --- Summary ---
 
 echo ""

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -729,15 +729,25 @@ ALL_INTRODUCED=$(jq -r '[.check.unused_files[].introduced] | all' "$PIPELINE_OUT
 [ "$ALL_INTRODUCED" = "true" ] && pass "pipeline: prune kept only introduced=true entries" || fail "pipeline: prune" "expected true, got $ALL_INTRODUCED"
 rm -f "$PIPELINE_OUT"
 
-echo "  summary-combined.jq verdict banner with audit fixture:"
+echo "  summary-combined.jq verdict banner with audit fixture (shared/GitHub variant):"
 SUMMARY_JQ="$SHARED_JQ_DIR/summary-combined.jq"
 OUT=$(jq -r -f "$SUMMARY_JQ" "$FIXTURES/audit.json" 2>&1)
 assert_contains "$OUT" "Audit failed" "audit fixture: shows verdict banner"
 assert_contains "$OUT" 'gate: `new-only`' "audit fixture: shows gate"
-assert_contains "$OUT" "introduced by this PR" "audit fixture: shows introduced phrasing"
+assert_contains "$OUT" "introduced by this PR" "audit fixture: shows introduced phrasing (GitHub: PR)"
 
 OUT_CLEAN=$(jq -r -f "$SUMMARY_JQ" "$FIXTURES/audit-clean.json" 2>&1)
 assert_contains "$OUT_CLEAN" "Audit passed" "audit clean: pass verdict"
+
+echo "  summary-combined.jq verdict banner with audit fixture (GitLab variant):"
+GITLAB_SUMMARY_JQ="$CI_JQ_DIR/summary-combined.jq"
+OUT_GL=$(jq -r -f "$GITLAB_SUMMARY_JQ" "$FIXTURES/audit.json" 2>&1)
+assert_contains "$OUT_GL" "Audit failed" "GitLab audit: shows verdict banner"
+assert_contains "$OUT_GL" 'gate: `new-only`' "GitLab audit: shows gate"
+assert_contains "$OUT_GL" "introduced by this MR" "GitLab audit: shows MR phrasing"
+
+OUT_GL_COMBINED=$(jq -r -f "$GITLAB_SUMMARY_JQ" "$FIXTURES/combined.json" 2>&1)
+assert_not_contains "$OUT_GL_COMBINED" "Audit" "GitLab combined: no audit banner when verdict absent"
 
 # --- Summary ---
 

--- a/crates/cli/templates/ci/gitlab-ci.yml
+++ b/crates/cli/templates/ci/gitlab-ci.yml
@@ -74,7 +74,7 @@ variables:
 
   # Core
   FALLOW_VERSION: ""             # Empty reads package.json fallow dependency, then falls back to latest
-  FALLOW_COMMAND: ""            # dead-code, dupes, health, fix, or empty (runs all)
+  FALLOW_COMMAND: ""            # dead-code, dupes, health, audit, fix, or empty (runs all)
   FALLOW_ROOT: "."
   FALLOW_CONFIG: ""             # Path to .fallowrc.json, .fallowrc.jsonc, or fallow.toml
   FALLOW_PRODUCTION: ""                # "true"/"false" enables production for every analysis. Empty defers to config.
@@ -105,6 +105,7 @@ variables:
 
   # Dead-code specific
   FALLOW_ISSUE_TYPES: ""        # Comma-separated: unused-files,unused-exports,...
+  FALLOW_INCLUDE_ENTRY_EXPORTS: "false"  # Report unused exports in entry files (also applies to audit)
   FALLOW_FAIL_ON_REGRESSION: "false"
   FALLOW_TOLERANCE: "0"
   FALLOW_REGRESSION_BASELINE: ""
@@ -139,6 +140,9 @@ variables:
   FALLOW_MIN_COMMITS: ""
   FALLOW_SAVE_SNAPSHOT: ""       # save snapshot to .fallow/snapshots/ for trend tracking; cache this path across pipelines
   FALLOW_TREND: "false"          # compare against most recent snapshot; requires FALLOW_SAVE_SNAPSHOT on a prior run
+
+  # Audit specific (only used when FALLOW_COMMAND=audit)
+  FALLOW_AUDIT_GATE: "new-only"  # Audit verdict gate: new-only fails only on findings introduced by this MR; all fails on every finding in changed files
 
   # Fix specific
   FALLOW_DRY_RUN: "true"
@@ -370,9 +374,17 @@ variables:
 
       # ── Validate inputs ──────────────────────────────────────────────
       case "$FALLOW_COMMAND" in
-        ""|dead-code|check|dupes|health|fix) ;;
+        ""|dead-code|check|dupes|health|audit|fix) ;;
         *) echo "ERROR: Invalid command: ${FALLOW_COMMAND}"; exit 2 ;;
       esac
+
+      FALLOW_AUDIT_GATE="${FALLOW_AUDIT_GATE:-new-only}"
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        case "$FALLOW_AUDIT_GATE" in
+          new-only|all) ;;
+          *) echo "ERROR: Invalid audit gate: ${FALLOW_AUDIT_GATE}. Must be new-only or all."; exit 2 ;;
+        esac
+      fi
 
       for name_val in "min-tokens:$FALLOW_MIN_TOKENS" "min-lines:$FALLOW_MIN_LINES" \
                       "max-cyclomatic:$FALLOW_MAX_CYCLOMATIC" "max-cognitive:$FALLOW_MAX_COGNITIVE" \
@@ -399,6 +411,16 @@ variables:
         if [ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA:-}" ]; then
           FALLOW_CHANGED_SINCE="$CI_MERGE_REQUEST_DIFF_BASE_SHA"
           echo "Auto-scoping to changed files (--changed-since ${FALLOW_CHANGED_SINCE:0:12})"
+        fi
+      fi
+
+      # Audit on non-MR pipelines needs an explicit base. Don't silently fall through
+      # to fallow's auto-detect, because misconfigured pipelines produce confusing
+      # "verdict: pass" results that simply analyzed nothing.
+      if [ "$FALLOW_COMMAND" = "audit" ] && [ -z "$FALLOW_CHANGED_SINCE" ]; then
+        if [ -z "${CI_MERGE_REQUEST_IID:-}" ]; then
+          echo "ERROR: FALLOW_COMMAND=audit on non-MR pipeline needs an explicit base. Set FALLOW_CHANGED_SINCE (e.g. origin/main) or pass --base via FALLOW_ARGS."
+          exit 2
         fi
       fi
 
@@ -438,6 +460,7 @@ variables:
               ARGS+=("--${t}")
             done
           fi
+          [ "$FALLOW_INCLUDE_ENTRY_EXPORTS" = "true" ] && ARGS+=(--include-entry-exports)
           [ "$FALLOW_FAIL_ON_REGRESSION" = "true" ] && ARGS+=(--fail-on-regression)
           [ -n "$FALLOW_TOLERANCE" ] && [ "$FALLOW_TOLERANCE" != "0" ] && ARGS+=(--tolerance "$FALLOW_TOLERANCE")
           [ -n "$FALLOW_REGRESSION_BASELINE" ] && ARGS+=(--regression-baseline "$FALLOW_REGRESSION_BASELINE")
@@ -483,6 +506,14 @@ variables:
         fix)
           [ "$FALLOW_DRY_RUN" = "true" ] && ARGS+=(--dry-run) || ARGS+=(--yes)
           ;;
+        audit)
+          ARGS+=(--gate "$FALLOW_AUDIT_GATE")
+          [ -n "$FALLOW_MAX_CRAP" ] && ARGS+=(--max-crap "$FALLOW_MAX_CRAP")
+          [ "$FALLOW_PRODUCTION_DEAD_CODE" = "true" ] && ARGS+=(--production-dead-code)
+          [ "$FALLOW_PRODUCTION_HEALTH" = "true" ] && ARGS+=(--production-health)
+          [ "$FALLOW_PRODUCTION_DUPES" = "true" ] && ARGS+=(--production-dupes)
+          [ "$FALLOW_INCLUDE_ENTRY_EXPORTS" = "true" ] && ARGS+=(--include-entry-exports)
+          ;;
         "")
           ARGS+=(--dupes-mode "$FALLOW_DUPES_MODE")
           [ -n "$FALLOW_THRESHOLD" ]         && ARGS+=(--dupes-threshold "$FALLOW_THRESHOLD")
@@ -520,19 +551,107 @@ variables:
         echo "---"
       fi
 
+      # ── Audit-specific post-processing ───────────────────────────────
+      # Re-key audit sub-results to combined-mode keys (dead_code -> check,
+      # complexity -> health, duplication -> dupes) so existing summary,
+      # comment, and review jq scripts work unchanged. Preserve top-level
+      # audit fields (command, verdict, attribution, gate, summary, base_ref,
+      # head_sha) so AI consumers can still detect audit runs. Under
+      # gate=new-only, prune findings to introduced != false entries.
+      VERDICT=""
+      AUDIT_GATE=""
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
+        AUDIT_GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
+
+        if [ "$AUDIT_GATE" = "new-only" ]; then
+          jq '
+            def keep_introduced(arr):
+              (arr // []) | map(select(.introduced != false));
+            .dead_code //= {}
+            | .dead_code.unused_files                = keep_introduced(.dead_code.unused_files)
+            | .dead_code.unused_exports              = keep_introduced(.dead_code.unused_exports)
+            | .dead_code.unused_types                = keep_introduced(.dead_code.unused_types)
+            | .dead_code.private_type_leaks          = keep_introduced(.dead_code.private_type_leaks)
+            | .dead_code.unused_dependencies         = keep_introduced(.dead_code.unused_dependencies)
+            | .dead_code.unused_dev_dependencies     = keep_introduced(.dead_code.unused_dev_dependencies)
+            | .dead_code.unused_optional_dependencies = keep_introduced(.dead_code.unused_optional_dependencies)
+            | .dead_code.unused_enum_members         = keep_introduced(.dead_code.unused_enum_members)
+            | .dead_code.unused_class_members        = keep_introduced(.dead_code.unused_class_members)
+            | .dead_code.unresolved_imports          = keep_introduced(.dead_code.unresolved_imports)
+            | .dead_code.unlisted_dependencies       = keep_introduced(.dead_code.unlisted_dependencies)
+            | .dead_code.duplicate_exports           = keep_introduced(.dead_code.duplicate_exports)
+            | .dead_code.circular_dependencies       = keep_introduced(.dead_code.circular_dependencies)
+            | .dead_code.boundary_violations         = keep_introduced(.dead_code.boundary_violations)
+            | .dead_code.type_only_dependencies      = keep_introduced(.dead_code.type_only_dependencies)
+            | .dead_code.test_only_dependencies      = keep_introduced(.dead_code.test_only_dependencies)
+            | .dead_code.stale_suppressions          = keep_introduced(.dead_code.stale_suppressions)
+            | (if .complexity then .complexity.findings = keep_introduced(.complexity.findings) else . end)
+            | (if .duplication then .duplication.clone_groups = keep_introduced(.duplication.clone_groups) else . end)
+          ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
+            echo "ERROR: Audit JSON prune transform failed"
+            rm -f fallow-results.tmp.json
+            exit 2
+          }
+        fi
+
+        jq '
+          def list_sum(o):
+            ((o.unused_files // []) | length)
+            + ((o.unused_exports // []) | length)
+            + ((o.unused_types // []) | length)
+            + ((o.private_type_leaks // []) | length)
+            + ((o.unused_dependencies // []) | length)
+            + ((o.unused_dev_dependencies // []) | length)
+            + ((o.unused_optional_dependencies // []) | length)
+            + ((o.unused_enum_members // []) | length)
+            + ((o.unused_class_members // []) | length)
+            + ((o.unresolved_imports // []) | length)
+            + ((o.unlisted_dependencies // []) | length)
+            + ((o.duplicate_exports // []) | length)
+            + ((o.circular_dependencies // []) | length)
+            + ((o.boundary_violations // []) | length)
+            + ((o.type_only_dependencies // []) | length)
+            + ((o.test_only_dependencies // []) | length)
+            + ((o.stale_suppressions // []) | length);
+          .dead_code   as $dc
+          | .complexity  as $cx
+          | .duplication as $du
+          | .check  = ($dc | if . then . + {total_issues: list_sum(.)} else null end)
+          | .dupes  = $du
+          | .health = $cx
+          | del(.dead_code, .complexity, .duplication)
+        ' fallow-results.json > fallow-results.tmp.json && mv fallow-results.tmp.json fallow-results.json || {
+          echo "ERROR: Audit JSON re-key transform failed"
+          rm -f fallow-results.tmp.json
+          exit 2
+        }
+      fi
+
       # ── Extract issue count ──────────────────────────────────────────
       case "$FALLOW_COMMAND" in
         dead-code|check) ISSUES=$(jq -r '.total_issues // 0' fallow-results.json) ;;
         dupes)           ISSUES=$(jq -r '.stats.clone_groups // 0' fallow-results.json) ;;
         health)          ISSUES=$(jq -r '((.summary.functions_above_threshold // 0) + ((.runtime_coverage.findings // []) | map(select(.verdict == "safe_to_delete" or .verdict == "review_required" or .verdict == "low_traffic")) | length))' fallow-results.json) ;;
         fix)             ISSUES=$(jq -r '(.fixes | length)' fallow-results.json) ;;
+        audit)
+          if [ "$AUDIT_GATE" = "all" ]; then
+            ISSUES=$(jq -r '((.summary.dead_code_issues // 0) + (.summary.complexity_findings // 0) + (.summary.duplication_clone_groups // 0))' fallow-results.json)
+          else
+            ISSUES=$(jq -r '((.attribution.dead_code_introduced // 0) + (.attribution.complexity_introduced // 0) + (.attribution.duplication_introduced // 0))' fallow-results.json)
+          fi
+          ;;
         "")              ISSUES=$(jq -r '((.check.total_issues // 0) + (.dupes.stats.clone_groups // 0) + (.health.summary.functions_above_threshold // 0) + ((.health.runtime_coverage.findings // []) | map(select(.verdict == "safe_to_delete" or .verdict == "review_required" or .verdict == "low_traffic")) | length))' fallow-results.json) ;;
       esac
 
       if ! echo "$ISSUES" | grep -qE '^[0-9]+$'; then
         echo "ERROR: Unexpected issue count: ${ISSUES}"; exit 2
       fi
-      echo "Found ${ISSUES} issues"
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        echo "Audit verdict: ${VERDICT} (gate: ${AUDIT_GATE}, ${ISSUES} ${AUDIT_GATE} finding(s))"
+      else
+        echo "Found ${ISSUES} issues"
+      fi
 
       # ── GitLab Code Quality report (CodeClimate format) ──────────────
       # Uses fallow's native --format codeclimate for inline MR annotations.
@@ -587,15 +706,25 @@ variables:
       fi
 
       # ── Fail check ───────────────────────────────────────────────────
-      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ] && [ "$ISSUES" -gt 0 ]; then
-        case "$FALLOW_COMMAND" in
-          dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
-          dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
-          health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
-          fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
-          "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
-        esac
-        exit 1
+      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ]; then
+        if [ "$FALLOW_COMMAND" = "audit" ]; then
+          # Audit gates on rule severity. Verdict already encodes the gate
+          # decision: pass -> no issues, warn -> warn-tier only (don't fail),
+          # fail -> error-tier (fail).
+          if [ "$VERDICT" = "fail" ]; then
+            echo "ERROR: Fallow audit failed (gate: ${AUDIT_GATE:-new-only}, ${ISSUES} finding(s) at error severity)"
+            exit 1
+          fi
+        elif [ "$ISSUES" -gt 0 ]; then
+          case "$FALLOW_COMMAND" in
+            dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
+            dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
+            health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
+            fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
+            "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
+          esac
+          exit 1
+        fi
       fi
       FALLOW_SCRIPT_EOF
       chmod +x /tmp/fallow-run.sh

--- a/crates/cli/templates/ci/jq/summary-combined.jq
+++ b/crates/cli/templates/ci/jq/summary-combined.jq
@@ -46,6 +46,27 @@ def prod_hot_paths: (.health.runtime_coverage.hot_paths // []);
 (.health.vital_signs // {}) as $vitals |
 (.health.summary // {}) as $summary |
 (.dupes.stats // {}) as $dupes_stats |
+# Audit verdict header: surfaces verdict + new-vs-inherited attribution
+# whenever the input came from `fallow audit`. Combined-mode runs (no audit
+# fields present) skip this entirely so existing MR comments are unchanged.
+(.verdict // null) as $verdict |
+(.attribution // null) as $attribution |
+((($attribution.dead_code_introduced // 0) + ($attribution.complexity_introduced // 0) + ($attribution.duplication_introduced // 0)) // 0) as $introduced |
+((($attribution.dead_code_inherited // 0) + ($attribution.complexity_inherited // 0) + ($attribution.duplication_inherited // 0)) // 0) as $inherited |
+($attribution.gate // "new-only") as $audit_gate |
+(if $verdict then
+  (if $verdict == "pass" then ":white_check_mark: **Audit passed**"
+   elif $verdict == "warn" then ":warning: **Audit passed with warnings**"
+   else ":x: **Audit failed**" end) as $headline |
+  "> \($headline) · gate: `\($audit_gate)`" +
+  (if $audit_gate == "new-only" then
+    " · \($introduced) new finding\(if $introduced == 1 then "" else "s" end) introduced by this MR" +
+    (if $inherited > 0 then " · \($inherited) inherited (not gated)" else "" end)
+  else
+    " · \($introduced + $inherited) finding\(if ($introduced + $inherited) == 1 then "" else "s" end) in changed files"
+  end) +
+  "\n\n"
+else "" end) as $audit_header |
 
 # Health delta header (only when --score is present)
 (if .health.health_score then
@@ -70,6 +91,7 @@ else "" end) +
 
 if $total == 0 then
   "# :seedling: Fallow\n\n" +
+  $audit_header +
   (if $prod_advisory > 0 or $hot_paths > 0 then
     "> **No blocking issues found**\n\n" +
     ":white_check_mark: No code issues \u00b7 :white_check_mark: No duplication \u00b7 :white_check_mark: No blocking health findings" +
@@ -85,6 +107,7 @@ if $total == 0 then
   else "" end)
 else
   "# :seedling: Fallow\n\n" +
+  $audit_header +
 
   # One-line status
   (if $check > 0 then ":warning: **\($check)** code issues" else ":white_check_mark: No code issues" end) +

--- a/crates/cli/templates/ci/scripts/comment.sh
+++ b/crates/cli/templates/ci/scripts/comment.sh
@@ -32,7 +32,7 @@ case "$FALLOW_COMMAND" in
   dupes)           JQ_FILE=$(pick_jq "summary-dupes.jq") ;;
   health)          JQ_FILE=$(pick_jq "summary-health.jq") ;;
   fix)             JQ_FILE=$(pick_jq "summary-fix.jq") ;;
-  "")              JQ_FILE=$(pick_jq "summary-combined.jq") ;;
+  audit|"")        JQ_FILE=$(pick_jq "summary-combined.jq") ;;
   *)               echo "ERROR: Unexpected command: ${FALLOW_COMMAND}"; exit 2 ;;
 esac
 

--- a/crates/cli/templates/ci/scripts/review.sh
+++ b/crates/cli/templates/ci/scripts/review.sh
@@ -123,8 +123,8 @@ case "$FALLOW_COMMAND" in
     COMMENTS=$(jq -f "$(pick_jq review-comments-dupes.jq)" "$RESULTS_FILE" 2>&1) || { echo "jq dupes error: $COMMENTS"; COMMENTS="[]"; } ;;
   health)
     COMMENTS=$(jq -f "$(pick_jq review-comments-health.jq)" "$RESULTS_FILE" 2>&1) || { echo "jq health error: $COMMENTS"; COMMENTS="[]"; } ;;
-  "")
-    # Combined: extract each section and run through its jq script
+  audit|"")
+    # Audit JSON is re-keyed in the template to use combined-mode keys (check/health/dupes).
     WORK_DIR=$(mktemp -d)
     jq '.check // {}' "$RESULTS_FILE" > "$WORK_DIR/check.json" 2>/dev/null
     jq '.dupes // {}' "$RESULTS_FILE" > "$WORK_DIR/dupes.json" 2>/dev/null


### PR DESCRIPTION
Closes #302.

## Summary

- GitHub Action and GitLab CI template both accept `command: audit` (`FALLOW_COMMAND: audit`) and dispatch to `fallow audit --base $BASE --gate $GATE`.
- New `gate` input (`FALLOW_AUDIT_GATE`) — `new-only` default (fails only on findings introduced by the changeset) or `all` (fails on every finding in changed files). Mirrors `fallow audit --gate`.
- The `Check threshold` step gates on the audit verdict (`pass`/`warn`/`fail`) instead of raw issue count, so projects with `unused-exports: warn` (or any warn-tier rule) ship cleanly when a PR touches files with pre-existing warn-tier findings.
- New action outputs `verdict` and `gate` for downstream conditionals.
- Audit JSON is re-keyed in-place (`dead_code` → `check`, `complexity` → `health`, `duplication` → `dupes`) so the existing summary, comment, annotation, and review jq scripts work unchanged. Top-level `command`, `verdict`, `attribution`, `gate`, `summary`, `base_ref`, `head_sha` are preserved so AI consumers can still detect audit runs by `.command == "audit"`.
- Under `gate=new-only`, dead-code AND complexity AND duplication finding arrays are pruned to `introduced != false` entries so PR/MR annotations and comments only reflect what the gate fails on. The CLI already annotates all three categories with `introduced: true|false` whenever the audit base-snapshot pass runs.
- `summary-combined.jq` (both GitHub and GitLab variants) emits a verdict banner at the top of the PR/MR comment whenever `.verdict` is present.

## Background fixes

- Hard error on `command: audit` outside a PR/MR pipeline without an explicit base, instead of silently analyzing nothing.
- `INPUT_GATE` / `FALLOW_AUDIT_GATE` validation only fires when `command=audit` so inherited CI variable groups don't hard-error non-audit jobs.
- jq re-key transform errors now exit 2 with a clear message instead of silently leaving an un-re-keyed JSON downstream.
- `INPUT_INCLUDE_ENTRY_EXPORTS` / `FALLOW_INCLUDE_ENTRY_EXPORTS` is now wired into both the action env block and GitLab template (mirroring parity gap predates this PR).
- Bundled vendored templates under `crates/cli/templates/` re-synced; `bundled_templates_match_workspace_sources` test enforces drift detection.

## Test plan

- [x] `bash action/tests/run.sh` — 265 assertions pass
- [x] `bash ci/tests/run.sh` — 223 assertions pass
- [x] `cargo test -p fallow-cli --bins -- bundled_templates_match_workspace_sources` — passes
- [x] `cargo build --workspace` — clean
- [x] End-to-end smoke via real `fallow audit` JSON through the GHA `analyze.sh` pipeline: `verdict=fail`, `gate=new-only`, correct prune, banner renders
- [x] End-to-end smoke through GitLab CI re-key path: same result with MR phrasing
- [x] Combined-mode regression check: unchanged behavior for users not on audit
- [x] No em-dashes in the diff

## Reviewers consulted

- `user-panel` — preserved top-level audit fields, distinct verdict banner, `outputs.verdict` exposure, gate-only enum validation
- `github-action-reviewer` — fail-fast jq, missing `INPUT_INCLUDE_ENTRY_EXPORTS` env mapping
- `json-output-reviewer` — `outputs.results` documentation for the audit hybrid shape
- `gitlab-ci-reviewer` — fixture coverage gap, gated gate validation, `FALLOW_INCLUDE_ENTRY_EXPORTS` parity

Companion repos (commits ready locally; not pushed):
- `fallow-skills`: pattern reference for `command: audit`
- `fallow-docs`: severity-aware PR gate (audit) section + migration note in `integrations/ci.mdx`