### PR TITLE
fix(action, ci): gate audit threshold on verdict, not introduced count

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -250,8 +250,14 @@ outputs:
     description: 'Path to SARIF results file'
     value: ${{ steps.analyze.outputs.sarif }}
   issues:
-    description: 'Number of issues (dead-code), clone groups (dupes), introduced findings counted by the audit verdict (audit), or fixes proposed/applied (fix). Audit count is gate-aware: with `gate: new-only` (default) it sums attribution.*_introduced; with `gate: all` it sums summary.* totals.'
+    description: 'Number of issues (dead-code), clone groups (dupes), introduced findings counted by the audit verdict (audit), or fixes proposed/applied (fix). Audit count is gate-aware: with `gate: new-only` (default) it sums attribution.*_introduced; with `gate: all` it sums summary.* totals. For audit, prefer `outputs.verdict` for severity-aware gating.'
     value: ${{ steps.analyze.outputs.issues }}
+  verdict:
+    description: 'Audit verdict (pass/warn/fail). Empty when command is not audit. The threshold step gates on this for audit so warn-tier findings do not fail CI.'
+    value: ${{ steps.analyze.outputs.verdict }}
+  gate:
+    description: 'Audit gate that was applied (new-only/all). Empty when command is not audit.'
+    value: ${{ steps.analyze.outputs.gate }}
 
 runs:
   using: 'composite'
@@ -443,14 +449,27 @@ runs:
       env:
         INPUT_COMMAND: ${{ inputs.command }}
         INPUT_FAIL_ON_ISSUES: ${{ inputs.fail-on-issues }}
+        INPUT_GATE: ${{ inputs.gate }}
         ISSUES: ${{ steps.analyze.outputs.issues }}
+        VERDICT: ${{ steps.analyze.outputs.verdict }}
       run: |
-        if [ "$INPUT_FAIL_ON_ISSUES" = "true" ] && [ "$ISSUES" -gt 0 ]; then
+        if [ "$INPUT_FAIL_ON_ISSUES" != "true" ]; then exit 0; fi
+        if [ "$INPUT_COMMAND" = "audit" ]; then
+          # Audit gates on rule severity. Verdict already encodes the gate
+          # decision: pass -> no issues, warn -> warn-tier only (do not fail),
+          # fail -> error-tier (fail). Counting introduced findings instead
+          # would re-introduce the bug issue #302 was filed to fix.
+          if [ "$VERDICT" = "fail" ]; then
+            echo "::error::Fallow audit failed (gate: ${INPUT_GATE:-new-only}, ${ISSUES} finding(s) at error severity in changed files)"
+            exit 1
+          fi
+          exit 0
+        fi
+        if [ "$ISSUES" -gt 0 ]; then
           case "$INPUT_COMMAND" in
             dead-code|check) echo "::error::Fallow found ${ISSUES} unused code issues" ;;
             dupes)           echo "::error::Fallow found ${ISSUES} clone groups" ;;
             health)          echo "::error::Fallow found ${ISSUES} health findings" ;;
-            audit)           echo "::error::Fallow audit found ${ISSUES} introduced issues in changed files" ;;
             fix)             echo "::error::Fallow found ${ISSUES} fixable issues" ;;
             "")              echo "::error::Fallow found ${ISSUES} issues" ;;
           esac

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -308,7 +308,17 @@ if [ -s fallow-stderr.log ]; then
   done < fallow-stderr.log
 fi
 
-# --- Extract issue count ---
+# --- Extract verdict / gate (audit only) and issue count ---
+# Audit's verdict (pass/warn/fail) is the load-bearing severity-aware signal:
+# warn means "warn-tier issues only, do not fail CI". Threshold step gates on
+# verdict for audit; raw issue counts only gate non-audit commands.
+
+VERDICT=""
+GATE=""
+if [ "$INPUT_COMMAND" = "audit" ]; then
+  VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
+  GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
+fi
 
 case "$INPUT_COMMAND" in
   dead-code|check) ISSUES=$(jq -r '.total_issues' fallow-results.json) ;;
@@ -327,6 +337,8 @@ fi
 echo "issues=${ISSUES}" >> "$GITHUB_OUTPUT"
 echo "results=fallow-results.json" >> "$GITHUB_OUTPUT"
 echo "command=${INPUT_COMMAND}" >> "$GITHUB_OUTPUT"
+echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+echo "gate=${GATE}" >> "$GITHUB_OUTPUT"
 
 if [ -f fallow-results.sarif ]; then
   echo "sarif=fallow-results.sarif" >> "$GITHUB_OUTPUT"

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -162,6 +162,52 @@ else
 fi
 assert_contains "$OUT" "dead-code-baseline" "analyze: baseline error points to audit baselines"
 
+# Audit verdict + gate are emitted to GITHUB_OUTPUT for the Check threshold step.
+# Without this, the threshold step gates on raw introduced count, re-introducing
+# the issue #302 bug where warn-tier findings fail CI.
+cat > "$ANALYZE_TMP/bin/fallow" <<'SH'
+#!/usr/bin/env bash
+# Synthesize an audit JSON with verdict=warn, dead_code_introduced=1.
+# Mimics the warn-tier scenario from issue #302: a project with
+# `unused-exports: warn` has a PR introducing a new unused export.
+case "$*" in
+  *audit*)
+    printf '%s\n' '{"command":"audit","verdict":"warn","attribution":{"gate":"new-only","dead_code_introduced":1,"dead_code_inherited":0,"complexity_introduced":0,"complexity_inherited":0,"duplication_introduced":0,"duplication_inherited":0},"summary":{"dead_code_issues":1,"dead_code_has_errors":false,"complexity_findings":0,"max_cyclomatic":null,"duplication_clone_groups":0}}'
+    ;;
+  *) printf '{"total_issues":0}\n' ;;
+esac
+SH
+chmod +x "$ANALYZE_TMP/bin/fallow"
+
+cd "$ANALYZE_TMP/work" && rm -f "$ANALYZE_TMP/output"
+OUT=$(PATH="$ANALYZE_TMP/bin:$PATH" GITHUB_OUTPUT="$ANALYZE_TMP/output" \
+  INPUT_ROOT="." INPUT_COMMAND="audit" INPUT_FORMAT="json" \
+  bash "$DIR/../scripts/analyze.sh" 2>&1) || true
+cd "$DIR"
+VERDICT=$(grep '^verdict=' "$ANALYZE_TMP/output" | cut -d= -f2)
+GATE=$(grep '^gate=' "$ANALYZE_TMP/output" | cut -d= -f2)
+ISSUES=$(grep '^issues=' "$ANALYZE_TMP/output" | cut -d= -f2)
+[ "$VERDICT" = "warn" ] && pass "analyze: emits verdict to GITHUB_OUTPUT for audit" || fail "analyze: verdict output" "expected warn, got '$VERDICT'"
+[ "$GATE" = "new-only" ] && pass "analyze: emits gate to GITHUB_OUTPUT for audit" || fail "analyze: gate output" "expected new-only, got '$GATE'"
+[ "$ISSUES" = "1" ] && pass "analyze: still emits issues count for audit" || fail "analyze: issues output" "expected 1, got '$ISSUES'"
+
+# Non-audit commands must NOT emit verdict / gate (empty values are fine).
+cat > "$ANALYZE_TMP/bin/fallow" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *dead-code*) printf '{"total_issues":3}\n' ;;
+  *) printf '{"check":{"total_issues":3}}\n' ;;
+esac
+SH
+chmod +x "$ANALYZE_TMP/bin/fallow"
+cd "$ANALYZE_TMP/work" && rm -f "$ANALYZE_TMP/output"
+OUT=$(PATH="$ANALYZE_TMP/bin:$PATH" GITHUB_OUTPUT="$ANALYZE_TMP/output" \
+  INPUT_ROOT="." INPUT_COMMAND="dead-code" INPUT_FORMAT="json" \
+  bash "$DIR/../scripts/analyze.sh" 2>&1) || true
+cd "$DIR"
+VERDICT=$(grep '^verdict=' "$ANALYZE_TMP/output" | cut -d= -f2)
+[ -z "$VERDICT" ] && pass "analyze: verdict empty for non-audit command" || fail "analyze: non-audit verdict" "expected empty, got '$VERDICT'"
+
 # --- Summary jq tests ---
 
 echo ""

--- a/ci/gitlab-ci.yml
+++ b/ci/gitlab-ci.yml
@@ -553,7 +553,17 @@ variables:
         echo "---"
       fi
 
-      # ── Extract issue count ──────────────────────────────────────────
+      # ── Extract verdict / gate (audit only) and issue count ─────────
+      # Audit's verdict (pass/warn/fail) is the load-bearing severity-aware
+      # signal: warn means "warn-tier only, do not fail". Fail check gates
+      # on verdict for audit; raw counts only gate non-audit commands.
+      VERDICT=""
+      AUDIT_GATE=""
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
+        AUDIT_GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
+      fi
+
       case "$FALLOW_COMMAND" in
         dead-code|check) ISSUES=$(jq -r '.total_issues // 0' fallow-results.json) ;;
         dupes)           ISSUES=$(jq -r '.stats.clone_groups // 0' fallow-results.json) ;;
@@ -623,16 +633,26 @@ variables:
       fi
 
       # ── Fail check ───────────────────────────────────────────────────
-      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ] && [ "$ISSUES" -gt 0 ]; then
-        case "$FALLOW_COMMAND" in
-          dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
-          dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
-          health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
-          audit)           echo "ERROR: Fallow audit found ${ISSUES} introduced issues in changed files" ;;
-          fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
-          "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
-        esac
-        exit 1
+      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ]; then
+        if [ "$FALLOW_COMMAND" = "audit" ]; then
+          # Audit gates on rule severity. Verdict encodes the gate decision:
+          # pass -> no issues, warn -> warn-tier only (do not fail),
+          # fail -> error-tier (fail). Counting introduced findings instead
+          # would re-introduce the bug issue #302 was filed to fix.
+          if [ "$VERDICT" = "fail" ]; then
+            echo "ERROR: Fallow audit failed (gate: ${AUDIT_GATE:-new-only}, ${ISSUES} finding(s) at error severity in changed files)"
+            exit 1
+          fi
+        elif [ "$ISSUES" -gt 0 ]; then
+          case "$FALLOW_COMMAND" in
+            dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
+            dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
+            health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
+            fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
+            "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
+          esac
+          exit 1
+        fi
       fi
       FALLOW_SCRIPT_EOF
       chmod +x /tmp/fallow-run.sh

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -272,6 +272,29 @@ else
     "asymmetric: action=$ACTION_HAS_ERROR_TRAP, gitlab=$CI_HAS_ERROR_TRAP"
 fi
 
+# Verdict-driven threshold for audit: both wrappers must gate on
+# `verdict == "fail"` for audit (severity-aware), not on raw issue count.
+# Otherwise warn-tier findings fail CI even though the verdict says "warn"
+# (the original issue #302 bug).
+ACTION_HAS_VERDICT_GATE=$(grep -cE 'VERDICT.*=.*"fail"|VERDICT" = "fail"' "$ACTION_ANALYZE_SH" "$DIR/../../action.yml" 2>/dev/null | awk -F: '{s+=$2} END {print s}')
+CI_HAS_VERDICT_GATE=$(grep -cE 'VERDICT.*=.*"fail"|VERDICT" = "fail"' "$CI_TEMPLATE_YAML" 2>/dev/null || echo 0)
+if [ "$ACTION_HAS_VERDICT_GATE" != "0" ] && [ "$CI_HAS_VERDICT_GATE" != "0" ]; then
+  pass "parity: both wrappers gate audit on verdict, not raw count"
+else
+  fail "parity: verdict-driven threshold" \
+    "asymmetric: action=$ACTION_HAS_VERDICT_GATE, gitlab=$CI_HAS_VERDICT_GATE"
+fi
+
+# Both wrappers must extract verdict + gate from audit JSON before issue count.
+ACTION_HAS_VERDICT_EXTRACT=$(grep -cE 'VERDICT=\$\(jq -r .*\.verdict' "$ACTION_ANALYZE_SH" 2>/dev/null || echo 0)
+CI_HAS_VERDICT_EXTRACT=$(grep -cE 'VERDICT=\$\(jq -r .*\.verdict' "$CI_TEMPLATE_YAML" 2>/dev/null || echo 0)
+if [ "$ACTION_HAS_VERDICT_EXTRACT" != "0" ] && [ "$CI_HAS_VERDICT_EXTRACT" != "0" ]; then
+  pass "parity: both wrappers extract verdict from audit JSON"
+else
+  fail "parity: verdict extraction" \
+    "asymmetric: action=$ACTION_HAS_VERDICT_EXTRACT, gitlab=$CI_HAS_VERDICT_EXTRACT"
+fi
+
 # =========================================================================
 # GitLab-specific summary jq tests
 # =========================================================================

--- a/crates/cli/templates/ci/gitlab-ci.yml
+++ b/crates/cli/templates/ci/gitlab-ci.yml
@@ -553,7 +553,17 @@ variables:
         echo "---"
       fi
 
-      # ── Extract issue count ──────────────────────────────────────────
+      # ── Extract verdict / gate (audit only) and issue count ─────────
+      # Audit's verdict (pass/warn/fail) is the load-bearing severity-aware
+      # signal: warn means "warn-tier only, do not fail". Fail check gates
+      # on verdict for audit; raw counts only gate non-audit commands.
+      VERDICT=""
+      AUDIT_GATE=""
+      if [ "$FALLOW_COMMAND" = "audit" ]; then
+        VERDICT=$(jq -r '.verdict // ""' fallow-results.json)
+        AUDIT_GATE=$(jq -r '.attribution.gate // ""' fallow-results.json)
+      fi
+
       case "$FALLOW_COMMAND" in
         dead-code|check) ISSUES=$(jq -r '.total_issues // 0' fallow-results.json) ;;
         dupes)           ISSUES=$(jq -r '.stats.clone_groups // 0' fallow-results.json) ;;
@@ -623,16 +633,26 @@ variables:
       fi
 
       # ── Fail check ───────────────────────────────────────────────────
-      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ] && [ "$ISSUES" -gt 0 ]; then
-        case "$FALLOW_COMMAND" in
-          dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
-          dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
-          health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
-          audit)           echo "ERROR: Fallow audit found ${ISSUES} introduced issues in changed files" ;;
-          fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
-          "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
-        esac
-        exit 1
+      if [ "$FALLOW_FAIL_ON_ISSUES" = "true" ]; then
+        if [ "$FALLOW_COMMAND" = "audit" ]; then
+          # Audit gates on rule severity. Verdict encodes the gate decision:
+          # pass -> no issues, warn -> warn-tier only (do not fail),
+          # fail -> error-tier (fail). Counting introduced findings instead
+          # would re-introduce the bug issue #302 was filed to fix.
+          if [ "$VERDICT" = "fail" ]; then
+            echo "ERROR: Fallow audit failed (gate: ${AUDIT_GATE:-new-only}, ${ISSUES} finding(s) at error severity in changed files)"
+            exit 1
+          fi
+        elif [ "$ISSUES" -gt 0 ]; then
+          case "$FALLOW_COMMAND" in
+            dead-code|check) echo "ERROR: Fallow found ${ISSUES} unused code issues" ;;
+            dupes)           echo "ERROR: Fallow found ${ISSUES} clone groups" ;;
+            health)          echo "ERROR: Fallow found ${ISSUES} health findings" ;;
+            fix)             echo "ERROR: Fallow found ${ISSUES} fixable issues" ;;
+            "")              echo "ERROR: Fallow found ${ISSUES} issues" ;;
+          esac
+          exit 1
+        fi
       fi
       FALLOW_SCRIPT_EOF
       chmod +x /tmp/fallow-run.sh


### PR DESCRIPTION
Refs #302.

## Summary

The wrapper-side regression of issue #302: the merged audit support in #303 (`fed294c`) extracts `attribution.*_introduced` (severity-blind count) as `outputs.issues` and the `Check threshold` step gates on `ISSUES > 0`. Result: a project with `unused-exports: warn` and `fail-on-issues: true` (the action default) sees CI fail on every PR that introduces a warn-tier finding, even though the audit verdict correctly says `warn` ("do not fail").

The CLI's audit verdict (`pass` / `warn` / `fail`) is the load-bearing severity-aware signal. This PR threads it through both wrappers.

## Reproducer

```yaml
# .fallowrc.json: {"rules": {"unused-exports": "warn"}}
# PR introduces a new unused export.

# Before this fix:
verdict=warn  ISSUES=1  →  threshold exits 1  →  CI fails (BUG)

# After this fix:
verdict=warn  ISSUES=1  →  threshold exits 0  →  CI ships (CORRECT)

# Fail-tier unchanged:
verdict=fail  ISSUES=1  →  threshold exits 1  →  CI fails (CORRECT)
```

## Changes

- **GitHub Action**:
  - `analyze.sh` extracts `.verdict` and `.attribution.gate` from audit JSON before issue count, emits both to `GITHUB_OUTPUT` (only for `command=audit`; empty otherwise).
  - `action.yml` exposes `outputs.verdict` and `outputs.gate` for downstream steps.
  - `Check threshold` step branches on `command=audit`: gates on `VERDICT == "fail"` (severity-aware) for audit; falls through to existing `ISSUES > 0` for every other command (unchanged).

- **GitLab CI**: same `VERDICT` / `AUDIT_GATE` extraction and `Fail check` branching inside the heredoc'd `run.sh` in `gitlab-ci.yml`. Bundled vendor copy at `crates/cli/templates/ci/gitlab-ci.yml` re-synced.

- **Tests**:
  - `action/tests/run.sh`: synthetic warn-tier audit JSON exercises the full `analyze.sh` path; asserts `verdict` + `gate` land in GITHUB_OUTPUT and non-audit commands get empty values.
  - `ci/tests/run.sh`: parity tests assert both wrappers extract `verdict` from audit JSON AND gate the threshold on `VERDICT == "fail"` (not raw count). Mirrors the existing baseline-rejection / structured-error parity tests.

## Test plan

- [x] `bash action/tests/run.sh` (253 pass, +4 from main)
- [x] `bash ci/tests/run.sh` (228 pass, +2 from main)
- [x] `cargo test -p fallow-cli --bins -- bundled_templates_match_workspace_sources` passes
- [x] End-to-end smoke against a real warn-tier project: warn-tier no longer fails CI; fail-tier still does
- [x] No em-dashes in the diff

Companion repos unchanged.