### PR TITLE
fix: include literal dynamic imports in analyzers

### DIFF
--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -725,7 +725,7 @@ pub fn find_unlisted_dependencies(
     // so we can recover the import location when building UnlistedDependency results.
     let mut import_spans_by_file: FxHashMap<FileId, Vec<(&str, u32)>> = FxHashMap::default();
     for rm in resolved_modules {
-        for import in &rm.resolved_imports {
+        for import in rm.all_resolved_imports() {
             if let crate::resolve::ResolveResult::NpmPackage(name) = &import.target {
                 import_spans_by_file
                     .entry(rm.file_id)
@@ -839,7 +839,7 @@ pub fn find_unresolved_imports(
     let mut unresolved = Vec::new();
 
     for module in resolved_modules {
-        for import in &module.resolved_imports {
+        for import in module.all_resolved_imports() {
             if let crate::resolve::ResolveResult::Unresolvable(spec) = &import.target {
                 // Skip virtual module imports using the `virtual:` convention
                 // (e.g., `virtual:pwa-register`, `virtual:uno.css`)

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -407,6 +407,67 @@ fn unlisted_dep_detected_across_multiple_files() {
     );
 }
 
+#[test]
+fn dynamic_import_unlisted_dep_has_import_site() {
+    let files = vec![DiscoveredFile {
+        id: FileId(0),
+        path: PathBuf::from("/project/src/index.ts"),
+        size_bytes: 100,
+    }];
+    let entry_points = vec![EntryPoint {
+        path: PathBuf::from("/project/src/index.ts"),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/src/index.ts"),
+        exports: vec![],
+        re_exports: vec![],
+        resolved_imports: vec![],
+        resolved_dynamic_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "unlisted-pkg".to_string(),
+                imported_name: ImportedName::SideEffect,
+                local_name: String::new(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(14, 40),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::NpmPackage("unlisted-pkg".to_string()),
+        }],
+        resolved_dynamic_patterns: vec![],
+        member_accesses: vec![],
+        whole_object_uses: vec![],
+        has_cjs_exports: false,
+        unused_import_bindings: FxHashSet::default(),
+        type_referenced_import_bindings: vec![],
+        value_referenced_import_bindings: vec![],
+    }];
+    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    let pkg = make_pkg(&[], &[], &[]);
+    let config = test_config(PathBuf::from("/project"));
+    let offsets = vec![0, 12];
+    let mut line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+    line_offsets.insert(FileId(0), offsets.as_slice());
+
+    let unlisted = find_unlisted_dependencies(
+        &graph,
+        &pkg,
+        &config,
+        &[],
+        None,
+        &resolved_modules,
+        &line_offsets,
+    );
+
+    assert_eq!(unlisted.len(), 1);
+    assert_eq!(unlisted[0].package_name, "unlisted-pkg");
+    assert_eq!(unlisted[0].imported_from.len(), 1);
+    assert_eq!(unlisted[0].imported_from[0].line, 2);
+    assert_eq!(unlisted[0].imported_from[0].col, 2);
+}
+
 // ---- virtual_package_suffixes suppression ----
 
 #[test]

--- a/crates/core/src/analyze/unused_deps_tests/unresolved_imports.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unresolved_imports.rs
@@ -49,6 +49,56 @@ fn unresolved_import_detected() {
 }
 
 #[test]
+fn unresolved_dynamic_import_detected_with_real_location() {
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/src/index.ts"),
+        exports: vec![],
+        re_exports: vec![],
+        resolved_imports: vec![],
+        resolved_dynamic_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "./missing-dynamic".to_string(),
+                imported_name: ImportedName::SideEffect,
+                local_name: String::new(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(14, 41),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::Unresolvable("./missing-dynamic".to_string()),
+        }],
+        resolved_dynamic_patterns: vec![],
+        member_accesses: vec![],
+        whole_object_uses: vec![],
+        has_cjs_exports: false,
+        unused_import_bindings: FxHashSet::default(),
+        type_referenced_import_bindings: vec![],
+        value_referenced_import_bindings: vec![],
+    }];
+
+    let config = test_config(PathBuf::from("/project"));
+    let suppressions = SuppressionContext::empty();
+    let offsets = vec![0, 12];
+    let mut line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+    line_offsets.insert(FileId(0), offsets.as_slice());
+
+    let unresolved = find_unresolved_imports(
+        &resolved_modules,
+        &config,
+        &suppressions,
+        &[],
+        &[],
+        &line_offsets,
+    );
+
+    assert_eq!(unresolved.len(), 1);
+    assert_eq!(unresolved[0].specifier, "./missing-dynamic");
+    assert_eq!(unresolved[0].line, 2);
+    assert_eq!(unresolved[0].col, 2);
+}
+
+#[test]
 fn unresolved_virtual_module_not_reported() {
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -271,6 +321,63 @@ fn unresolved_import_suppressed_by_inline_comment() {
     assert!(
         unresolved.is_empty(),
         "suppressed unresolved import should not be reported"
+    );
+}
+
+#[test]
+fn unresolved_dynamic_import_suppressed_by_inline_comment() {
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/src/index.ts"),
+        exports: vec![],
+        re_exports: vec![],
+        resolved_imports: vec![],
+        resolved_dynamic_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "./broken-dynamic".to_string(),
+                imported_name: ImportedName::SideEffect,
+                local_name: String::new(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(14, 40),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::Unresolvable("./broken-dynamic".to_string()),
+        }],
+        resolved_dynamic_patterns: vec![],
+        member_accesses: vec![],
+        whole_object_uses: vec![],
+        has_cjs_exports: false,
+        unused_import_bindings: FxHashSet::default(),
+        type_referenced_import_bindings: vec![],
+        value_referenced_import_bindings: vec![],
+    }];
+
+    let config = test_config(PathBuf::from("/project"));
+    let supps = vec![Suppression {
+        line: 2,
+        comment_line: 1,
+        kind: Some(suppress::IssueKind::UnresolvedImport),
+    }];
+    let mut supp_map: FxHashMap<FileId, &[Suppression]> = FxHashMap::default();
+    supp_map.insert(FileId(0), &supps);
+    let suppressions = SuppressionContext::from_map(supp_map);
+    let offsets = vec![0, 12];
+    let mut line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+    line_offsets.insert(FileId(0), offsets.as_slice());
+
+    let unresolved = find_unresolved_imports(
+        &resolved_modules,
+        &config,
+        &suppressions,
+        &[],
+        &[],
+        &line_offsets,
+    );
+
+    assert!(
+        unresolved.is_empty(),
+        "suppressed dynamic unresolved import should not be reported"
     );
 }
 

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -246,7 +246,7 @@ fn push_local_export_key<'a>(
 fn build_local_to_export_keys(resolved: &ResolvedModule) -> FxHashMap<&str, Vec<ExportKey>> {
     let mut local_to_export_keys = FxHashMap::default();
 
-    for import in &resolved.resolved_imports {
+    for import in resolved.all_resolved_imports() {
         let Some(imported_name) = imported_export_name(&import.info.imported_name) else {
             continue;
         };
@@ -889,7 +889,7 @@ pub fn find_unused_members(
                 }
             }
             // Case 2: sentinel accesses on an imported file (external templateUrl)
-            for import in &resolved.resolved_imports {
+            for import in resolved.all_resolved_imports() {
                 if let ResolveResult::InternalModule(target_id) = &import.target
                     && let Some(refs) = angular_tpl_refs.get(target_id)
                 {
@@ -931,7 +931,7 @@ pub fn find_unused_members(
                 continue;
             }
             let local_to_export_keys = build_local_to_export_keys(resolved);
-            for import in &resolved.resolved_imports {
+            for import in resolved.all_resolved_imports() {
                 let ResolveResult::InternalModule(target_id) = &import.target else {
                     continue;
                 };

--- a/crates/core/src/external_style_usage.rs
+++ b/crates/core/src/external_style_usage.rs
@@ -24,20 +24,14 @@ pub fn augment_external_style_package_usage(
     for module in resolved_modules {
         let mut synthetic_packages = FxHashSet::default();
         let existing_packages: FxHashSet<String> = module
-            .resolved_imports
-            .iter()
-            .chain(module.resolved_dynamic_imports.iter())
+            .all_resolved_imports()
             .filter_map(|import| match &import.target {
                 ResolveResult::NpmPackage(name) => Some(name.clone()),
                 _ => None,
             })
             .collect();
 
-        for import in module
-            .resolved_imports
-            .iter()
-            .chain(module.resolved_dynamic_imports.iter())
-        {
+        for import in module.all_resolved_imports() {
             let ResolveResult::ExternalFile(path) = &import.target else {
                 continue;
             };
@@ -149,7 +143,7 @@ impl<'a> ExternalStylePackageScanner<'a> {
         );
 
         if let Some(resolved_module) = resolved.first() {
-            for import in &resolved_module.resolved_imports {
+            for import in resolved_module.all_resolved_imports() {
                 match &import.target {
                     ResolveResult::NpmPackage(name) => {
                         packages.insert(name.clone());

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -79,11 +79,7 @@ fn credit_workspace_package_usage(
 
     let workspace_names: FxHashSet<&str> = workspaces.iter().map(|ws| ws.name.as_str()).collect();
     for module in resolved {
-        for import in module
-            .resolved_imports
-            .iter()
-            .chain(module.resolved_dynamic_imports.iter())
-        {
+        for import in module.all_resolved_imports() {
             if matches!(import.target, resolve::ResolveResult::InternalModule(_))
                 && let Some(package_name) =
                     workspace_package_name(&import.info.source, &workspace_names)

--- a/crates/core/tests/integration_test/dynamic_imports.rs
+++ b/crates/core/tests/integration_test/dynamic_imports.rs
@@ -28,6 +28,58 @@ fn dynamic_import_makes_module_reachable() {
 }
 
 #[test]
+fn dynamic_import_literal_edges_match_static_imports() {
+    let root = fixture_path("dynamic-import-literals");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        !unused_file_names.contains(&"notes.ts".to_string()),
+        "parent-relative literal dynamic import should keep notes.ts reachable: {unused_file_names:?}"
+    );
+    assert!(
+        unused_file_names.contains(&"orphan.ts".to_string()),
+        "unreferenced files should still be reported: {unused_file_names:?}"
+    );
+
+    let unresolved_specs: Vec<&str> = results
+        .unresolved_imports
+        .iter()
+        .map(|import| import.specifier.as_str())
+        .collect();
+    assert!(
+        unresolved_specs.contains(&"./missing"),
+        "missing literal dynamic import should be reported unresolved: {unresolved_specs:?}"
+    );
+
+    let unlisted_names: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|dep| dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unlisted_names.contains(&"@some/package"),
+        "listed package used through literal dynamic import should not be unlisted: {unlisted_names:?}"
+    );
+
+    let unused_dep_names: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|dep| dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unused_dep_names.contains(&"@some/package"),
+        "literal dynamic package import should credit dependency usage: {unused_dep_names:?}"
+    );
+}
+
+#[test]
 fn vitest_vi_mock_makes_auto_mock_reachable() {
     let root = fixture_path("vitest-auto-mocks");
     let config = create_config(root.clone());

--- a/crates/graph/src/resolve/types.rs
+++ b/crates/graph/src/resolve/types.rs
@@ -90,6 +90,19 @@ impl Default for ResolvedModule {
     }
 }
 
+impl ResolvedModule {
+    /// Iterate over all concrete resolved imports in source order buckets.
+    ///
+    /// Includes static `import`/`require` edges and literal dynamic `import()`
+    /// edges. Dynamic import patterns are intentionally excluded because they
+    /// resolve to sets of files rather than single import specifiers.
+    pub fn all_resolved_imports(&self) -> impl Iterator<Item = &ResolvedImport> {
+        self.resolved_imports
+            .iter()
+            .chain(self.resolved_dynamic_imports.iter())
+    }
+}
+
 /// Shared context for resolving import specifiers.
 ///
 /// Groups the immutable lookup tables and caches that are shared across all

--- a/tests/fixtures/dynamic-import-literals/notes.ts
+++ b/tests/fixtures/dynamic-import-literals/notes.ts
@@ -1,0 +1,1 @@
+export const notes = "loaded from parent path";

--- a/tests/fixtures/dynamic-import-literals/package.json
+++ b/tests/fixtures/dynamic-import-literals/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dynamic-import-literals",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@some/package": "1.0.0"
+  }
+}

--- a/tests/fixtures/dynamic-import-literals/src/index.ts
+++ b/tests/fixtures/dynamic-import-literals/src/index.ts
@@ -1,0 +1,5 @@
+const notes = import("../notes");
+const packageModule = import("@some/package");
+const missing = import("./missing");
+
+console.log(notes, packageModule, missing);

--- a/tests/fixtures/dynamic-import-literals/src/orphan.ts
+++ b/tests/fixtures/dynamic-import-literals/src/orphan.ts
@@ -1,0 +1,1 @@
+export const orphan = "unreachable";


### PR DESCRIPTION
Add a shared ResolvedModule::all_resolved_imports() iterator and use it in analyzer paths that should treat import("literal") like static imports.

This covers unresolved import reporting, unlisted dependency import sites, dependency usage, unused member lookup, and external style package resolution while keeping dynamic pattern imports and graph edge construction behavior unchanged.

Add unit and integration coverage for unresolved dynamic imports, suppression, unlisted bare-package imports, reachable relative dynamic imports, and missing literal imports.

Closes fallow-rs/fallow#304.