### PR TITLE
fix: support the client and server modules folders appropriately

### DIFF
--- a/crates/cli/src/check/output.rs
+++ b/crates/cli/src/check/output.rs
@@ -118,7 +118,7 @@ pub fn run_cross_reference(
     unfiltered_results: &fallow_core::results::AnalysisResults,
     quiet: bool,
 ) {
-    let files = fallow_core::discover::discover_files(config);
+    let files = fallow_core::discover::discover_files_with_plugin_scopes(config);
     let dupe_report =
         fallow_core::duplicates::find_duplicates(&config.root, &files, &config.duplicates);
     let cross_ref = fallow_core::cross_reference::cross_reference(&dupe_report, unfiltered_results);

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -304,7 +304,7 @@ fn build_static_index(ctx: &RunContext<'_>, production: bool) -> Result<StaticIn
         ctx.quiet,
         fallow_config::ProductionAnalysis::Health,
     )?;
-    let files = fallow_core::discover::discover_files(&config);
+    let files = fallow_core::discover::discover_files_with_plugin_scopes(&config);
     let cache = if config.no_cache {
         None
     } else {

--- a/crates/cli/src/coverage/upload_inventory.rs
+++ b/crates/cli/src/coverage/upload_inventory.rs
@@ -408,7 +408,7 @@ fn collect_inventory(
     exclude_matcher: &GlobSet,
     path_prefix: Option<&str>,
 ) -> Vec<InventoryFunction> {
-    let files = fallow_core::discover::discover_files(config);
+    let files = fallow_core::discover::discover_files_with_plugin_scopes(config);
     let mut seen: FxHashSet<(String, String, u32)> = FxHashSet::default();
     let mut out: Vec<InventoryFunction> = Vec::new();
     for file in files {

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -206,7 +206,8 @@ fn execute_dupes_inner(
     )?;
 
     let dupes_config = build_dupes_config(opts, &config.duplicates);
-    let files = pre_discovered.unwrap_or_else(|| fallow_core::discover::discover_files(&config));
+    let files = pre_discovered
+        .unwrap_or_else(|| fallow_core::discover::discover_files_with_plugin_scopes(&config));
 
     let changed_files_from_since = resolve_changed_since(opts);
     let effective_changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>> =

--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -83,7 +83,7 @@ pub fn run_flags(opts: &FlagsOptions<'_>) -> ExitCode {
     };
 
     // Discover files
-    let files = fallow_core::discover::discover_files(&config);
+    let files = fallow_core::discover::discover_files_with_plugin_scopes(&config);
     if files.is_empty() {
         return emit_error("no files discovered", 2, opts.output);
     }

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -200,7 +200,7 @@ pub fn execute_health(opts: &HealthOptions<'_>) -> Result<HealthResult, ExitCode
 
     // Discover and parse files
     let t = Instant::now();
-    let files = fallow_core::discover::discover_files(&config);
+    let files = fallow_core::discover::discover_files_with_plugin_scopes(&config);
     let discover_ms = t.elapsed().as_secs_f64() * 1000.0;
 
     let cache = if config.no_cache {

--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -36,7 +36,7 @@ pub fn run_list(opts: &ListOptions<'_>) -> ExitCode {
     // Run plugin detection when plugin output is requested or when entry-point
     // discovery needs plugin-provided entry points.
     let plugin_result = if opts.plugins || opts.entry_points || show_all {
-        let disc = fallow_core::discover::discover_files(&config);
+        let disc = fallow_core::discover::discover_files_with_plugin_scopes(&config);
         let file_paths: Vec<std::path::PathBuf> = disc.iter().map(|f| f.path.clone()).collect();
         let registry = fallow_core::plugins::PluginRegistry::new(config.external_plugins.clone());
 
@@ -67,7 +67,9 @@ pub fn run_list(opts: &ListOptions<'_>) -> ExitCode {
     // Discover files once if needed by files, entry_points, or boundaries
     let need_files = needs_file_discovery(opts.files, show_all, opts.entry_points, opts.boundaries);
     let discovered = if need_files {
-        Some(fallow_core::discover::discover_files(&config))
+        Some(fallow_core::discover::discover_files_with_plugin_scopes(
+            &config,
+        ))
     } else {
         None
     };

--- a/crates/cli/tests/dupes_tests.rs
+++ b/crates/cli/tests/dupes_tests.rs
@@ -247,3 +247,38 @@ fn dupes_human_output_snapshot() {
     let redacted = redact_all(&output.stdout, &root);
     insta::assert_snapshot!("dupes_human_output", redacted);
 }
+
+// ---------------------------------------------------------------------------
+// Plugin-scoped hidden directory traversal
+// ---------------------------------------------------------------------------
+
+/// Standalone `fallow dupes` must include React Router's `.client` / `.server`
+/// folders in its file walk. The threshold is dropped to the minimum so the
+/// small fixture files survive dupes' token / line filters and surface in
+/// `stats.total_files`.
+#[test]
+fn dupes_includes_plugin_scoped_hidden_dirs_for_react_router() {
+    let output = run_fallow(
+        "dupes",
+        "react-router-conventions",
+        &[
+            "--format",
+            "json",
+            "--quiet",
+            "--min-tokens",
+            "1",
+            "--min-lines",
+            "1",
+        ],
+    );
+    assert_eq!(output.code, 0, "stderr was: {}", output.stderr);
+
+    let json = parse_json(&output);
+    let total_files = json["stats"]["total_files"]
+        .as_u64()
+        .expect("stats.total_files is a number");
+    assert!(
+        total_files >= 5,
+        "expected stats.total_files >= 5 (root + routes + .client + .server), got {total_files}"
+    );
+}

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -1798,3 +1798,40 @@ fn health_human_output_snapshot() {
     let redacted = redact_all(&output.stdout, &root);
     insta::assert_snapshot!("health_human_complexity", redacted);
 }
+
+// ---------------------------------------------------------------------------
+// Plugin-scoped hidden directory traversal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn health_file_scores_include_plugin_scoped_hidden_dirs_for_react_router() {
+    // `fallow health --file-scores` must analyze React Router's `.client` /
+    // `.server` convention folders; otherwise its file-level metrics ignore a
+    // real chunk of the project.
+    let output = run_fallow(
+        "health",
+        "react-router-conventions",
+        &["--file-scores", "--format", "json", "--quiet"],
+    );
+    assert_eq!(output.code, 0, "stderr was: {}", output.stderr);
+
+    let json = parse_json(&output);
+    let files_analyzed = json["summary"]["files_analyzed"]
+        .as_u64()
+        .expect("files_analyzed is a number");
+    assert!(
+        files_analyzed >= 5,
+        "expected files_analyzed >= 5 (root + routes + .client + .server), got {files_analyzed}"
+    );
+
+    let scored_paths: Vec<&str> = json["file_scores"]
+        .as_array()
+        .expect("file_scores array")
+        .iter()
+        .filter_map(|fs| fs["path"].as_str())
+        .collect();
+    assert!(
+        scored_paths.contains(&"app/.client/analytics.ts"),
+        "expected app/.client/analytics.ts in file_scores: {scored_paths:?}"
+    );
+}

--- a/crates/cli/tests/list_tests.rs
+++ b/crates/cli/tests/list_tests.rs
@@ -915,3 +915,54 @@ fn list_nextjs_project_app_page_is_plugin_entry_point() {
         "page.tsx should be discovered by nextjs plugin. Got source: {source}"
     );
 }
+
+// ── Plugin-scoped hidden directory traversal ────────────────────
+
+#[test]
+fn list_files_includes_plugin_scoped_hidden_dirs_for_react_router() {
+    // React Router's `.client` and `.server` convention folders must surface in
+    // `fallow list --files`; otherwise commands that consume the file walk lose
+    // visibility into a real chunk of the project.
+    let output = run_list("react-router-conventions", &["--files", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr was: {}", output.stderr);
+
+    let json = parse_json(&output);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .expect("files array")
+        .iter()
+        .map(|v| v.as_str().expect("file path string"))
+        .collect();
+
+    assert!(
+        files.contains(&"app/.client/analytics.ts"),
+        "expected app/.client/analytics.ts in files: {files:?}"
+    );
+    assert!(
+        files.contains(&"app/.server/db.ts"),
+        "expected app/.server/db.ts in files: {files:?}"
+    );
+}
+
+#[test]
+fn list_files_includes_plugin_scoped_hidden_dirs_for_remix() {
+    let output = run_list("remix-conventions", &["--files", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr was: {}", output.stderr);
+
+    let json = parse_json(&output);
+    let files: Vec<&str> = json["files"]
+        .as_array()
+        .expect("files array")
+        .iter()
+        .map(|v| v.as_str().expect("file path string"))
+        .collect();
+
+    assert!(
+        files.contains(&"app/.client/analytics.ts"),
+        "expected app/.client/analytics.ts in files: {files:?}"
+    );
+    assert!(
+        files.contains(&"app/.server/db.ts"),
+        "expected app/.server/db.ts in files: {files:?}"
+    );
+}

--- a/crates/core/src/discover/mod.rs
+++ b/crates/core/src/discover/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use entry_points::{
     discover_workspace_entry_points_with_warnings_from_pkg, warn_skipped_entry_summary,
 };
 pub use infrastructure::discover_infrastructure_entry_points;
+pub(crate) use walk::{HiddenDirScope, discover_files_with_additional_hidden_dirs};
 pub use walk::{PRODUCTION_EXCLUDE_PATTERNS, SOURCE_EXTENSIONS, discover_files};
 
 /// Hidden (dot-prefixed) directories that should be included in file discovery.

--- a/crates/core/src/discover/mod.rs
+++ b/crates/core/src/discover/mod.rs
@@ -3,6 +3,10 @@ mod infrastructure;
 mod parse_scripts;
 mod walk;
 
+use std::path::Path;
+
+use fallow_config::{PackageJson, ResolvedConfig};
+
 // Re-export types from fallow-types
 pub use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
 
@@ -17,8 +21,66 @@ pub(crate) use entry_points::{
     discover_workspace_entry_points_with_warnings_from_pkg, warn_skipped_entry_summary,
 };
 pub use infrastructure::discover_infrastructure_entry_points;
-pub(crate) use walk::{HiddenDirScope, discover_files_with_additional_hidden_dirs};
-pub use walk::{PRODUCTION_EXCLUDE_PATTERNS, SOURCE_EXTENSIONS, discover_files};
+pub use walk::{
+    HiddenDirScope, PRODUCTION_EXCLUDE_PATTERNS, SOURCE_EXTENSIONS, discover_files,
+    discover_files_with_additional_hidden_dirs,
+};
+
+/// Collect package-scoped hidden directory traversal rules for active plugins.
+///
+/// Source discovery runs before full plugin execution, so this consults
+/// package-activation checks and static plugin metadata only. Callers that have
+/// already loaded the root `package.json` and discovered workspaces should pass
+/// them in to avoid redoing the work; standalone CLI command paths can use
+/// [`discover_files_with_plugin_scopes`] instead.
+#[must_use]
+pub fn collect_plugin_hidden_dir_scopes(
+    config: &ResolvedConfig,
+    root_pkg: Option<&PackageJson>,
+    workspaces: &[fallow_config::WorkspaceInfo],
+) -> Vec<HiddenDirScope> {
+    let registry = crate::plugins::PluginRegistry::new(config.external_plugins.clone());
+    let mut scopes = Vec::new();
+
+    if let Some(pkg) = root_pkg {
+        push_plugin_hidden_dir_scope(&mut scopes, &registry, pkg, &config.root);
+    }
+
+    for ws in workspaces {
+        if let Ok(pkg) = PackageJson::load(&ws.root.join("package.json")) {
+            push_plugin_hidden_dir_scope(&mut scopes, &registry, &pkg, &ws.root);
+        }
+    }
+
+    scopes
+}
+
+fn push_plugin_hidden_dir_scope(
+    scopes: &mut Vec<HiddenDirScope>,
+    registry: &crate::plugins::PluginRegistry,
+    pkg: &PackageJson,
+    root: &Path,
+) {
+    let dirs = registry.discovery_hidden_dirs(pkg, root);
+    if !dirs.is_empty() {
+        scopes.push(HiddenDirScope::new(root.to_path_buf(), dirs));
+    }
+}
+
+/// Discover files with plugin-aware hidden directory traversal.
+///
+/// Convenience wrapper for command paths (list, dupes, health, flags, coverage)
+/// that don't already have workspaces / root `package.json` on hand. Internally
+/// loads the root `package.json` and discovers workspaces so plugin-contributed
+/// hidden directories (e.g. React Router's `.client` / `.server` folders) are
+/// traversed consistently across every command.
+#[must_use]
+pub fn discover_files_with_plugin_scopes(config: &ResolvedConfig) -> Vec<DiscoveredFile> {
+    let root_pkg = PackageJson::load(&config.root.join("package.json")).ok();
+    let workspaces = fallow_config::discover_workspaces(&config.root);
+    let scopes = collect_plugin_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces);
+    discover_files_with_additional_hidden_dirs(config, &scopes)
+}
 
 /// Hidden (dot-prefixed) directories that should be included in file discovery.
 ///

--- a/crates/core/src/discover/walk.rs
+++ b/crates/core/src/discover/walk.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use fallow_config::ResolvedConfig;
@@ -7,6 +7,23 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 use ignore::WalkBuilder;
 
 use super::ALLOWED_HIDDEN_DIRS;
+
+/// Package-scoped hidden directories that source discovery should traverse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HiddenDirScope {
+    root: PathBuf,
+    dirs: Vec<String>,
+}
+
+impl HiddenDirScope {
+    pub fn new(root: PathBuf, dirs: Vec<String>) -> Self {
+        Self { root, dirs }
+    }
+
+    fn allows(&self, path: &Path, name: &OsStr) -> bool {
+        path.starts_with(&self.root) && self.dirs.iter().any(|dir| OsStr::new(dir) == name)
+    }
+}
 
 /// Per-thread file collector for the parallel walker.
 struct FileVisitor<'a> {
@@ -113,12 +130,29 @@ pub fn is_allowed_hidden_dir(name: &OsStr) -> bool {
     ALLOWED_HIDDEN_DIRS.iter().any(|&d| OsStr::new(d) == name)
 }
 
+fn is_allowed_scoped_hidden_dir(
+    name: &OsStr,
+    path: &Path,
+    additional_hidden_dir_scopes: &[HiddenDirScope],
+) -> bool {
+    additional_hidden_dir_scopes
+        .iter()
+        .any(|scope| scope.allows(path, name))
+}
+
 /// Check if a hidden directory entry should be allowed through the filter.
 ///
 /// Returns `true` if the entry is not hidden or is on the allowlist.
 /// Hidden files (not directories) are always allowed through since the type
 /// filter handles them.
 fn is_allowed_hidden(entry: &ignore::DirEntry) -> bool {
+    is_allowed_hidden_with_scopes(entry, &[])
+}
+
+fn is_allowed_hidden_with_scopes(
+    entry: &ignore::DirEntry,
+    additional_hidden_dir_scopes: &[HiddenDirScope],
+) -> bool {
     let name = entry.file_name();
     let name_str = name.to_string_lossy();
 
@@ -134,9 +168,19 @@ fn is_allowed_hidden(entry: &ignore::DirEntry) -> bool {
 
     // Hidden directory — check against the allowlist
     is_allowed_hidden_dir(name)
+        || is_allowed_scoped_hidden_dir(name, entry.path(), additional_hidden_dir_scopes)
 }
 
 /// Discover all source files in the project.
+///
+/// # Panics
+///
+/// Panics if the file type glob or progress template is invalid (compile-time constants).
+pub fn discover_files(config: &ResolvedConfig) -> Vec<DiscoveredFile> {
+    discover_files_with_additional_hidden_dirs(config, &[])
+}
+
+/// Discover all source files in the project, with package-scoped hidden dirs.
 ///
 /// # Panics
 ///
@@ -145,7 +189,10 @@ fn is_allowed_hidden(entry: &ignore::DirEntry) -> bool {
     clippy::cast_possible_truncation,
     reason = "file count is bounded by project size, well under u32::MAX"
 )]
-pub fn discover_files(config: &ResolvedConfig) -> Vec<DiscoveredFile> {
+pub fn discover_files_with_additional_hidden_dirs(
+    config: &ResolvedConfig,
+    additional_hidden_dir_scopes: &[HiddenDirScope],
+) -> Vec<DiscoveredFile> {
     let _span = tracing::info_span!("discover_files").entered();
 
     let mut types_builder = ignore::types::TypesBuilder::new();
@@ -164,8 +211,13 @@ pub fn discover_files(config: &ResolvedConfig) -> Vec<DiscoveredFile> {
         .git_global(true)
         .git_exclude(true)
         .types(types)
-        .threads(config.threads)
-        .filter_entry(is_allowed_hidden);
+        .threads(config.threads);
+    if additional_hidden_dir_scopes.is_empty() {
+        walk_builder.filter_entry(is_allowed_hidden);
+    } else {
+        let scopes = additional_hidden_dir_scopes.to_vec();
+        walk_builder.filter_entry(move |entry| is_allowed_hidden_with_scopes(entry, &scopes));
+    }
 
     // Build production exclude matcher if needed
     let production_excludes = if config.production {
@@ -529,6 +581,69 @@ mod tests {
                 names.contains(&".changeset/config.js".to_string()),
                 "files in .changeset should be discovered"
             );
+        }
+
+        #[test]
+        fn default_discovery_excludes_client_and_server_hidden_directories() {
+            let dir = tempfile::tempdir().expect("create temp dir");
+            let app = dir.path().join("app");
+            std::fs::create_dir_all(app.join(".client")).unwrap();
+            std::fs::create_dir_all(app.join(".server")).unwrap();
+            std::fs::write(app.join(".client/analytics.ts"), "export const a = 1;").unwrap();
+            std::fs::write(app.join(".server/db.ts"), "export const db = {};").unwrap();
+            std::fs::write(app.join("root.tsx"), "export default function Root() {}").unwrap();
+
+            let config = make_config(dir.path().to_path_buf(), false);
+            let files = discover_files(&config);
+            let names = file_names(&files, dir.path());
+
+            assert!(names.contains(&"app/root.tsx".to_string()));
+            assert!(!names.contains(&"app/.client/analytics.ts".to_string()));
+            assert!(!names.contains(&"app/.server/db.ts".to_string()));
+        }
+
+        #[test]
+        fn scoped_hidden_dirs_include_client_and_server_under_package_root() {
+            let dir = tempfile::tempdir().expect("create temp dir");
+            let package = dir.path().join("packages/app");
+            std::fs::create_dir_all(package.join("app/.client")).unwrap();
+            std::fs::create_dir_all(package.join("app/.server")).unwrap();
+            std::fs::write(
+                package.join("app/.client/analytics.ts"),
+                "export const track = () => {};",
+            )
+            .unwrap();
+            std::fs::write(package.join("app/.server/db.ts"), "export const db = {};").unwrap();
+
+            let config = make_config(dir.path().to_path_buf(), false);
+            let scopes = [HiddenDirScope::new(
+                package,
+                vec![".client".to_string(), ".server".to_string()],
+            )];
+            let files = discover_files_with_additional_hidden_dirs(&config, &scopes);
+            let names = file_names(&files, dir.path());
+
+            assert!(names.contains(&"packages/app/app/.client/analytics.ts".to_string()));
+            assert!(names.contains(&"packages/app/app/.server/db.ts".to_string()));
+        }
+
+        #[test]
+        fn scoped_hidden_dirs_do_not_include_unscoped_packages() {
+            let dir = tempfile::tempdir().expect("create temp dir");
+            let active = dir.path().join("packages/active");
+            let inactive = dir.path().join("packages/inactive");
+            std::fs::create_dir_all(active.join("app/.server")).unwrap();
+            std::fs::create_dir_all(inactive.join("app/.server")).unwrap();
+            std::fs::write(active.join("app/.server/db.ts"), "export const db = {};").unwrap();
+            std::fs::write(inactive.join("app/.server/db.ts"), "export const db = {};").unwrap();
+
+            let config = make_config(dir.path().to_path_buf(), false);
+            let scopes = [HiddenDirScope::new(active, vec![".server".to_string()])];
+            let files = discover_files_with_additional_hidden_dirs(&config, &scopes);
+            let names = file_names(&files, dir.path());
+
+            assert!(names.contains(&"packages/active/app/.server/db.ts".to_string()));
+            assert!(!names.contains(&"packages/inactive/app/.server/db.ts".to_string()));
         }
 
         #[test]

--- a/crates/core/src/duplicates/mod.rs
+++ b/crates/core/src/duplicates/mod.rs
@@ -426,7 +426,7 @@ fn apply_line_suppressions(
 #[must_use]
 pub fn find_duplicates_in_project(root: &Path, config: &DuplicatesConfig) -> DuplicationReport {
     let resolved = crate::default_config(root);
-    let files = discover::discover_files(&resolved);
+    let files = discover::discover_files_with_plugin_scopes(&resolved);
     find_duplicates(root, &files, config)
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -330,18 +330,21 @@ pub fn analyze_with_parse_result(
         &config.ignore_patterns,
         config.quiet,
     );
+    let root_pkg = load_root_package_json(config);
+    let discovery_hidden_dir_scopes =
+        collect_discovery_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces_vec);
 
     // Stage 1: Discover files (cheap — needed for file registry and resolution)
     let t = Instant::now();
     let pb = progress.stage_spinner("Discovering files...");
-    let discovered_files = discover::discover_files(config);
+    let discovered_files =
+        discover::discover_files_with_additional_hidden_dirs(config, &discovery_hidden_dir_scopes);
     let discover_ms = t.elapsed().as_secs_f64() * 1000.0;
     pb.finish_and_clear();
 
     let project = project::ProjectState::new(discovered_files, workspaces_vec);
     let files = project.files();
     let workspaces = project.workspaces();
-    let root_pkg = load_root_package_json(config);
     let workspace_pkgs = load_workspace_packages(workspaces);
 
     // Stage 1.5: Run plugin system
@@ -553,11 +556,15 @@ fn analyze_full(
         &config.ignore_patterns,
         config.quiet,
     );
+    let root_pkg = load_root_package_json(config);
+    let discovery_hidden_dir_scopes =
+        collect_discovery_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces_vec);
 
     // Stage 1: Discover all source files
     let t = Instant::now();
     let pb = progress.stage_spinner("Discovering files...");
-    let discovered_files = discover::discover_files(config);
+    let discovered_files =
+        discover::discover_files_with_additional_hidden_dirs(config, &discovery_hidden_dir_scopes);
     let discover_ms = t.elapsed().as_secs_f64() * 1000.0;
     pb.finish_and_clear();
 
@@ -566,7 +573,6 @@ fn analyze_full(
     let project = project::ProjectState::new(discovered_files, workspaces_vec);
     let files = project.files();
     let workspaces = project.workspaces();
-    let root_pkg = load_root_package_json(config);
     let workspace_pkgs = load_workspace_packages(workspaces);
 
     // Stage 1.5: Run plugin system — parse config files, discover dynamic entries
@@ -787,6 +793,39 @@ fn load_workspace_packages(
                 .map(|pkg| (ws, pkg))
         })
         .collect()
+}
+
+fn collect_discovery_hidden_dir_scopes(
+    config: &ResolvedConfig,
+    root_pkg: Option<&PackageJson>,
+    workspaces: &[fallow_config::WorkspaceInfo],
+) -> Vec<discover::HiddenDirScope> {
+    let registry = plugins::PluginRegistry::new(config.external_plugins.clone());
+    let mut scopes = Vec::new();
+
+    if let Some(pkg) = root_pkg {
+        push_discovery_hidden_dir_scope(&mut scopes, &registry, pkg, &config.root);
+    }
+
+    for ws in workspaces {
+        if let Ok(pkg) = PackageJson::load(&ws.root.join("package.json")) {
+            push_discovery_hidden_dir_scope(&mut scopes, &registry, &pkg, &ws.root);
+        }
+    }
+
+    scopes
+}
+
+fn push_discovery_hidden_dir_scope(
+    scopes: &mut Vec<discover::HiddenDirScope>,
+    registry: &plugins::PluginRegistry,
+    pkg: &PackageJson,
+    root: &Path,
+) {
+    let dirs = registry.discovery_hidden_dirs(pkg, root);
+    if !dirs.is_empty() {
+        scopes.push(discover::HiddenDirScope::new(root.to_path_buf(), dirs));
+    }
 }
 
 fn analyze_all_scripts(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -332,7 +332,7 @@ pub fn analyze_with_parse_result(
     );
     let root_pkg = load_root_package_json(config);
     let discovery_hidden_dir_scopes =
-        collect_discovery_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces_vec);
+        discover::collect_plugin_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces_vec);
 
     // Stage 1: Discover files (cheap — needed for file registry and resolution)
     let t = Instant::now();
@@ -558,7 +558,7 @@ fn analyze_full(
     );
     let root_pkg = load_root_package_json(config);
     let discovery_hidden_dir_scopes =
-        collect_discovery_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces_vec);
+        discover::collect_plugin_hidden_dir_scopes(config, root_pkg.as_ref(), &workspaces_vec);
 
     // Stage 1: Discover all source files
     let t = Instant::now();
@@ -793,39 +793,6 @@ fn load_workspace_packages(
                 .map(|pkg| (ws, pkg))
         })
         .collect()
-}
-
-fn collect_discovery_hidden_dir_scopes(
-    config: &ResolvedConfig,
-    root_pkg: Option<&PackageJson>,
-    workspaces: &[fallow_config::WorkspaceInfo],
-) -> Vec<discover::HiddenDirScope> {
-    let registry = plugins::PluginRegistry::new(config.external_plugins.clone());
-    let mut scopes = Vec::new();
-
-    if let Some(pkg) = root_pkg {
-        push_discovery_hidden_dir_scope(&mut scopes, &registry, pkg, &config.root);
-    }
-
-    for ws in workspaces {
-        if let Ok(pkg) = PackageJson::load(&ws.root.join("package.json")) {
-            push_discovery_hidden_dir_scope(&mut scopes, &registry, &pkg, &ws.root);
-        }
-    }
-
-    scopes
-}
-
-fn push_discovery_hidden_dir_scope(
-    scopes: &mut Vec<discover::HiddenDirScope>,
-    registry: &plugins::PluginRegistry,
-    pkg: &PackageJson,
-    root: &Path,
-) {
-    let dirs = registry.discovery_hidden_dirs(pkg, root);
-    if !dirs.is_empty() {
-        scopes.push(discover::HiddenDirScope::new(root.to_path_buf(), dirs));
-    }
 }
 
 fn analyze_all_scripts(

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -649,6 +649,14 @@ pub trait Plugin: Send + Sync {
         &[]
     }
 
+    /// Hidden directory names that should be traversed when this plugin is active.
+    ///
+    /// These are consulted before normal plugin execution because source discovery
+    /// runs first. Keep entries static and package-convention scoped.
+    fn discovery_hidden_dirs(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Dependencies that are tooling (used via CLI/config, not source imports).
     /// These should not be flagged as unused devDependencies.
     fn tooling_dependencies(&self) -> &'static [&'static str] {
@@ -791,6 +799,7 @@ macro_rules! define_plugin {
         $(, always_used: $always:expr)?
         $(, tooling_dependencies: $tooling:expr)?
         $(, fixture_glob_patterns: $fixtures:expr)?
+        $(, discovery_hidden_dirs: $hidden_dirs:expr)?
         $(, virtual_module_prefixes: $virtual:expr)?
         $(, virtual_package_suffixes: $virtual_suffixes:expr)?
         $(, used_exports: [$( ($pat:expr, $exports:expr) ),* $(,)?])?
@@ -813,6 +822,7 @@ macro_rules! define_plugin {
             $( fn always_used(&self) -> &'static [&'static str] { $always } )?
             $( fn tooling_dependencies(&self) -> &'static [&'static str] { $tooling } )?
             $( fn fixture_glob_patterns(&self) -> &'static [&'static str] { $fixtures } )?
+            $( fn discovery_hidden_dirs(&self) -> &'static [&'static str] { $hidden_dirs } )?
             $( fn virtual_module_prefixes(&self) -> &'static [&'static str] { $virtual } )?
             $( fn virtual_package_suffixes(&self) -> &'static [&'static str] { $virtual_suffixes } )?
 
@@ -850,6 +860,7 @@ macro_rules! define_plugin {
         $(, always_used: $always:expr)?
         $(, tooling_dependencies: $tooling:expr)?
         $(, fixture_glob_patterns: $fixtures:expr)?
+        $(, discovery_hidden_dirs: $hidden_dirs:expr)?
         $(, virtual_module_prefixes: $virtual:expr)?
         $(, virtual_package_suffixes: $virtual_suffixes:expr)?
         $(, package_json_config_key: $pkg_key:expr)?
@@ -873,6 +884,7 @@ macro_rules! define_plugin {
             $( fn always_used(&self) -> &'static [&'static str] { $always } )?
             $( fn tooling_dependencies(&self) -> &'static [&'static str] { $tooling } )?
             $( fn fixture_glob_patterns(&self) -> &'static [&'static str] { $fixtures } )?
+            $( fn discovery_hidden_dirs(&self) -> &'static [&'static str] { $hidden_dirs } )?
             $( fn virtual_module_prefixes(&self) -> &'static [&'static str] { $virtual } )?
             $( fn virtual_package_suffixes(&self) -> &'static [&'static str] { $virtual_suffixes } )?
 
@@ -907,6 +919,7 @@ macro_rules! define_plugin {
         $(, always_used: $always:expr)?
         $(, tooling_dependencies: $tooling:expr)?
         $(, fixture_glob_patterns: $fixtures:expr)?
+        $(, discovery_hidden_dirs: $hidden_dirs:expr)?
         $(, virtual_module_prefixes: $virtual:expr)?
         $(, virtual_package_suffixes: $virtual_suffixes:expr)?
         $(, used_exports: [$( ($pat:expr, $exports:expr) ),* $(,)?])?
@@ -928,6 +941,7 @@ macro_rules! define_plugin {
             $( fn always_used(&self) -> &'static [&'static str] { $always } )?
             $( fn tooling_dependencies(&self) -> &'static [&'static str] { $tooling } )?
             $( fn fixture_glob_patterns(&self) -> &'static [&'static str] { $fixtures } )?
+            $( fn discovery_hidden_dirs(&self) -> &'static [&'static str] { $hidden_dirs } )?
             $( fn virtual_module_prefixes(&self) -> &'static [&'static str] { $virtual } )?
             $( fn virtual_package_suffixes(&self) -> &'static [&'static str] { $virtual_suffixes } )?
 

--- a/crates/core/src/plugins/react_router.rs
+++ b/crates/core/src/plugins/react_router.rs
@@ -43,6 +43,8 @@ const TOOLING_DEPENDENCIES: &[&str] = &[
     "@react-router/node",
 ];
 
+const BUNDLE_BOUNDARY_DIRS: &[&str] = &[".client", ".server"];
+
 macro_rules! route_module_exports {
     ($($export:literal),+ $(,)?) => {
         const ROUTE_EXPORTS: &[&str] = &[$($export),+];
@@ -76,6 +78,7 @@ define_plugin! {
     config_patterns: CONFIG_PATTERNS,
     always_used: ALWAYS_USED,
     tooling_dependencies: TOOLING_DEPENDENCIES,
+    discovery_hidden_dirs: BUNDLE_BOUNDARY_DIRS,
     used_exports: [
         ("app/routes/**/*.{ts,tsx,js,jsx}", ROUTE_EXPORTS),
         ("app/root.{ts,tsx,js,jsx}", ROOT_EXPORTS),
@@ -452,6 +455,12 @@ mod tests {
         assert!(exports.iter().any(|(pattern, names)| {
             pattern == &"app/routes.{ts,js,mts,mjs}" && names == &["default"]
         }));
+    }
+
+    #[test]
+    fn discovery_hidden_dirs_include_bundle_boundaries() {
+        let plugin = ReactRouterPlugin;
+        assert_eq!(plugin.discovery_hidden_dirs(), [".client", ".server"]);
     }
 
     fn has_entry_pattern(result: &PluginResult, pattern: &str) -> bool {

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -92,6 +92,30 @@ impl PluginRegistry {
         }
     }
 
+    /// Hidden directory names that should be traversed before full plugin execution.
+    ///
+    /// Source discovery runs before plugin config parsing, so this helper only uses
+    /// package-activation checks and static plugin metadata.
+    #[must_use]
+    pub fn discovery_hidden_dirs(&self, pkg: &PackageJson, root: &Path) -> Vec<String> {
+        let all_deps = pkg.all_dependency_names();
+        let mut seen = FxHashSet::default();
+        let mut dirs = Vec::new();
+
+        for plugin in &self.plugins {
+            if !plugin.is_enabled_with_deps(&all_deps, root) {
+                continue;
+            }
+            for dir in plugin.discovery_hidden_dirs() {
+                if seen.insert(*dir) {
+                    dirs.push((*dir).to_string());
+                }
+            }
+        }
+
+        dirs
+    }
+
     /// Run all plugins against a project, returning aggregated results.
     ///
     /// This discovers which plugins are active, collects their static patterns,

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -201,6 +201,33 @@ fn no_plugins_for_empty_deps() {
     );
 }
 
+#[test]
+fn react_router_contributes_discovery_hidden_dirs_when_active() {
+    let registry = PluginRegistry::default();
+    let pkg = make_pkg_dev(&["@react-router/dev"]);
+    let dirs = registry.discovery_hidden_dirs(&pkg, Path::new("/project"));
+
+    assert_eq!(dirs, vec![".client".to_string(), ".server".to_string()]);
+}
+
+#[test]
+fn remix_contributes_discovery_hidden_dirs_when_active() {
+    let registry = PluginRegistry::default();
+    let pkg = make_pkg(&["@remix-run/react"]);
+    let dirs = registry.discovery_hidden_dirs(&pkg, Path::new("/project"));
+
+    assert_eq!(dirs, vec![".client".to_string(), ".server".to_string()]);
+}
+
+#[test]
+fn discovery_hidden_dirs_empty_without_router_plugins() {
+    let registry = PluginRegistry::default();
+    let pkg = make_pkg(&["react", "react-dom"]);
+    let dirs = registry.discovery_hidden_dirs(&pkg, Path::new("/project"));
+
+    assert!(dirs.is_empty());
+}
+
 // ── Aggregation: entry patterns, tooling deps ────────────────
 
 #[test]

--- a/crates/core/src/plugins/remix.rs
+++ b/crates/core/src/plugins/remix.rs
@@ -30,6 +30,8 @@ const TOOLING_DEPENDENCIES: &[&str] = &[
     "@remix-run/serve",
 ];
 
+const BUNDLE_BOUNDARY_DIRS: &[&str] = &[".client", ".server"];
+
 macro_rules! route_module_exports {
     ($($export:literal),+ $(,)?) => {
         const ROUTE_EXPORTS: &[&str] = &[$($export),+];
@@ -58,6 +60,7 @@ define_plugin! {
     entry_patterns: ENTRY_PATTERNS,
     always_used: ALWAYS_USED,
     tooling_dependencies: TOOLING_DEPENDENCIES,
+    discovery_hidden_dirs: BUNDLE_BOUNDARY_DIRS,
     used_exports: [
         ("app/routes/**/*.{ts,tsx,js,jsx}", ROUTE_EXPORTS),
         ("app/root.{ts,tsx,js,jsx}", ROOT_EXPORTS),
@@ -85,5 +88,11 @@ mod tests {
                 && names.contains(&"clientLoader")
                 && names.contains(&"clientAction")
         }));
+    }
+
+    #[test]
+    fn discovery_hidden_dirs_include_bundle_boundaries() {
+        let plugin = RemixPlugin;
+        assert_eq!(plugin.discovery_hidden_dirs(), [".client", ".server"]);
     }
 }

--- a/crates/core/tests/integration_test/framework_convention_coverage_router.rs
+++ b/crates/core/tests/integration_test/framework_convention_coverage_router.rs
@@ -3,11 +3,54 @@ use super::framework_convention_coverage_common::{
     collect_unused_exports, collect_unused_files, has_unused_export,
 };
 
+fn assert_bundle_boundary_modules_are_traversed(
+    root: &std::path::Path,
+    results: &fallow_core::results::AnalysisResults,
+) {
+    let unresolved: Vec<(String, String)> = results
+        .unresolved_imports
+        .iter()
+        .map(|import| {
+            (
+                import
+                    .path
+                    .strip_prefix(root)
+                    .unwrap_or(&import.path)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                import.specifier.clone(),
+            )
+        })
+        .collect();
+
+    for specifier in ["../.client/analytics", "../.server/db"] {
+        assert!(
+            !unresolved
+                .iter()
+                .any(|(path, spec)| path == "app/routes/_index.tsx" && spec == specifier),
+            "{specifier} should resolve through .client/.server discovery, found: {unresolved:?}"
+        );
+    }
+
+    let unused_dep_names: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|dep| dep.package_name.as_str())
+        .collect();
+    for dep in ["@prisma/client", "browser-analytics"] {
+        assert!(
+            !unused_dep_names.contains(&dep),
+            "{dep} is imported from .client/.server code and should be marked used: {unused_dep_names:?}"
+        );
+    }
+}
+
 #[test]
 fn react_router_route_config_root_and_route_exports_are_covered() {
     let root = fixture_path("react-router-conventions");
     let config = create_config(root.clone());
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    assert_bundle_boundary_modules_are_traversed(&root, &results);
 
     let unused_files = collect_unused_files(&root, &results);
     assert!(
@@ -49,6 +92,7 @@ fn remix_root_and_client_data_exports_are_covered() {
     let root = fixture_path("remix-conventions");
     let config = create_config(root.clone());
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    assert_bundle_boundary_modules_are_traversed(&root, &results);
 
     let unused_exports = collect_unused_exports(&root, &results);
     for (path, export) in [

--- a/tests/fixtures/react-router-conventions/app/.client/analytics.ts
+++ b/tests/fixtures/react-router-conventions/app/.client/analytics.ts
@@ -1,0 +1,5 @@
+import { track } from "browser-analytics";
+
+export function trackRouteView(route: string) {
+  track(route);
+}

--- a/tests/fixtures/react-router-conventions/app/.server/db.ts
+++ b/tests/fixtures/react-router-conventions/app/.server/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const db = new PrismaClient();

--- a/tests/fixtures/react-router-conventions/app/routes/_index.tsx
+++ b/tests/fixtures/react-router-conventions/app/routes/_index.tsx
@@ -1,3 +1,9 @@
+import { trackRouteView } from "../.client/analytics";
+import { db } from "../.server/db";
+
+void db;
+trackRouteView("index");
+
 export async function loader() {
   return null;
 }

--- a/tests/fixtures/react-router-conventions/package.json
+++ b/tests/fixtures/react-router-conventions/package.json
@@ -1,5 +1,9 @@
 {
   "name": "react-router-conventions",
+  "dependencies": {
+    "@prisma/client": "^5.0.0",
+    "browser-analytics": "^1.0.0"
+  },
   "devDependencies": {
     "@react-router/dev": "^7.0.0"
   }

--- a/tests/fixtures/remix-conventions/app/.client/analytics.ts
+++ b/tests/fixtures/remix-conventions/app/.client/analytics.ts
@@ -1,0 +1,5 @@
+import { track } from "browser-analytics";
+
+export function trackRouteView(route: string) {
+  track(route);
+}

--- a/tests/fixtures/remix-conventions/app/.server/db.ts
+++ b/tests/fixtures/remix-conventions/app/.server/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const db = new PrismaClient();

--- a/tests/fixtures/remix-conventions/app/routes/_index.tsx
+++ b/tests/fixtures/remix-conventions/app/routes/_index.tsx
@@ -1,3 +1,9 @@
+import { trackRouteView } from "../.client/analytics";
+import { db } from "../.server/db";
+
+void db;
+trackRouteView("index");
+
 export async function loader() {
   return null;
 }

--- a/tests/fixtures/remix-conventions/package.json
+++ b/tests/fixtures/remix-conventions/package.json
@@ -1,7 +1,9 @@
 {
   "name": "remix-conventions",
   "dependencies": {
+    "@prisma/client": "^5.0.0",
     "@remix-run/node": "^2.0.0",
-    "@remix-run/react": "^2.0.0"
+    "@remix-run/react": "^2.0.0",
+    "browser-analytics": "^1.0.0"
   }
 }


### PR DESCRIPTION
## What

This PR adds support for exposing additional hidden directories to walk when discovering files to a plugin. The current list of "hidden folders" that get included in the file walk are hardcoded, but miss certain framework specific folder names that will contain important files for dead code and duplicate code analysis. 

Disclaimer: I wrote this change with Cursor and GPT 5.5, reviewed the code and thought it looked reasonable, but I'm not particularly knowledgeable about Rust so I could be missing something and I'm open to you just telling me this is slop and fixing the issues (or scrapping it altogether). I'm just quite interested in getting this feature to work because I would like to use fallow on my react router 7 projects.

Thanks.

## Why

<!-- What problem does this solve? Link to an issue if applicable -->
React Router 7 (and Remix 2) support this concept of [client](https://reactrouter.com/api/framework-conventions/client-modules) and [server](https://reactrouter.com/api/framework-conventions/server-modules) modules. tldr; if a file is suffixed `.client.ts` it will only be compiled for the client bundle and if it is suffixed `.server.ts` it will only be added to the server bundle. However, it is also supported that you can have a folder called `.client/` and a folder called `.server/` and any files in those folders will only be included in the respective bundles. 

Currently, this feature does not work with fallow because fallow is coded to ignore dot prefixed folders, except for a hardcoded list, regardless of which plugin is activated.

## Test plan

This PR adds new integration tests that cover the use case of properly detecting `.client/` and `.server/` folder files. These tests cover both react-router 7 and remix 2.

<!-- How was this tested? -->
