### PR TITLE
fix(core): detect Turborepo generator config

### DIFF
--- a/crates/core/src/plugins/turborepo.rs
+++ b/crates/core/src/plugins/turborepo.rs
@@ -1,18 +1,25 @@
 //! Turborepo monorepo build system plugin.
 //!
-//! Detects Turborepo projects and marks turbo.json as always used.
+//! Detects Turborepo projects and marks turbo.json and generator config files
+//! as always used.
 
-use super::Plugin;
+use super::{Plugin, PluginResult};
 
 const ENABLERS: &[&str] = &["turbo"];
 
-const ALWAYS_USED: &[&str] = &["turbo.json"];
+const GENERATOR_CONFIG: &str = "turbo/generators/config.{ts,js}";
+
+const CONFIG_PATTERNS: &[&str] = &[GENERATOR_CONFIG];
+
+const ALWAYS_USED: &[&str] = &["turbo.json", GENERATOR_CONFIG];
 
 const TOOLING_DEPENDENCIES: &[&str] = &["turbo"];
 
 define_plugin! {
     struct TurborepoPlugin => "turborepo",
     enablers: ENABLERS,
+    config_patterns: CONFIG_PATTERNS,
     always_used: ALWAYS_USED,
     tooling_dependencies: TOOLING_DEPENDENCIES,
+    resolve_config: imports_only,
 }

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -160,6 +160,82 @@ fn nextjs_config_referenced_dependencies_are_not_flagged_unused() {
     );
 }
 
+#[test]
+fn turborepo_generator_config_is_used_without_globbing_generator_directory() {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let root = tmp.path().to_path_buf();
+    std::fs::create_dir_all(root.join("turbo/generators")).unwrap();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+            "name": "turborepo-generator-fixture",
+            "devDependencies": {
+                "@turbo/gen": "*",
+                "turbo": "*"
+            }
+        }"#,
+    )
+    .unwrap();
+    std::fs::write(root.join("turbo.json"), "{}").unwrap();
+    std::fs::write(
+        root.join("turbo/generators/config.ts"),
+        r#"
+            import type { PlopTypes } from "@turbo/gen";
+            import { registerGenerator } from "./helper";
+
+            export default function generator(plop: PlopTypes.NodePlopAPI): void {
+                registerGenerator(plop);
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("turbo/generators/helper.ts"),
+        "export function registerGenerator(_plop: unknown): void {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("turbo/generators/orphan.ts"),
+        "export const orphan = true;\n",
+    )
+    .unwrap();
+
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_files: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|file| {
+            file.path
+                .strip_prefix(&root)
+                .unwrap_or(&file.path)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect();
+
+    assert!(
+        !unused_files
+            .iter()
+            .any(|path| path == "turbo/generators/config.ts"),
+        "generator config should be treated as a Turborepo config file, unused files: {unused_files:?}"
+    );
+    assert!(
+        !unused_files
+            .iter()
+            .any(|path| path == "turbo/generators/helper.ts"),
+        "helper should be reachable through the generator config import, unused files: {unused_files:?}"
+    );
+    assert!(
+        unused_files
+            .iter()
+            .any(|path| path == "turbo/generators/orphan.ts"),
+        "unimported generator files should not be kept alive by directory globbing, unused files: {unused_files:?}"
+    );
+}
+
 // ── Test runner entry points ──────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## What

- Treat `turbo/generators/config.{ts,js}` as a Turborepo config (https://turborepo.dev/docs/guides/generating-code).
- Parse its imports so referenced generator files stay live.

## Why

Prevents unused-file false positives for Turborepo custom generators.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p fallow-core turborepo_generator_config`
- `cargo clippy -p fallow-core -- -D warnings`