### PR TITLE
Fix workspace dependency ownership

### DIFF
--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -648,12 +648,22 @@ pub fn is_package_listed_for_file(
     root_deps: &FxHashSet<String>,
     ws_dep_map: &[(PathBuf, FxHashSet<String>)],
 ) -> bool {
-    if root_deps.contains(package_name) {
-        return true;
+    if let Some(ws_deps) = owning_workspace_deps(file_path, ws_dep_map) {
+        return ws_deps.contains(package_name);
     }
+
+    root_deps.contains(package_name)
+}
+
+fn owning_workspace_deps<'a>(
+    file_path: &Path,
+    ws_dep_map: &'a [(PathBuf, FxHashSet<String>)],
+) -> Option<&'a FxHashSet<String>> {
     ws_dep_map
         .iter()
-        .any(|(ws_root, ws_deps)| file_path.starts_with(ws_root) && ws_deps.contains(package_name))
+        .filter(|(ws_root, _)| file_path.starts_with(ws_root))
+        .max_by_key(|(ws_root, _)| ws_root.components().count())
+        .map(|(_, ws_deps)| ws_deps)
 }
 
 /// Check if a corresponding `@types/<package>` is listed in dependencies.
@@ -664,13 +674,22 @@ pub fn is_package_listed_for_file(
 /// regardless of whether it uses the `import type` syntax.
 ///
 /// For scoped packages like `@scope/pkg`, the DefinitelyTyped convention is `@types/scope__pkg`.
-fn has_types_package(package_name: &str, all_workspace_deps: &FxHashSet<String>) -> bool {
-    let types_name = package_name.strip_prefix('@').map_or_else(
+fn types_package_name(package_name: &str) -> String {
+    package_name.strip_prefix('@').map_or_else(
         || format!("@types/{package_name}"),
         // @scope/pkg -> @types/scope__pkg
         |scoped| format!("@types/{}", scoped.replacen('/', "__", 1)),
-    );
-    all_workspace_deps.contains(&types_name)
+    )
+}
+
+fn has_types_package_for_file(
+    file_path: &Path,
+    package_name: &str,
+    root_deps: &FxHashSet<String>,
+    ws_dep_map: &[(PathBuf, FxHashSet<String>)],
+) -> bool {
+    let types_name = types_package_name(package_name);
+    is_package_listed_for_file(file_path, &types_name, root_deps, ws_dep_map)
 }
 
 /// Look up the import location (line, col) for a given package in a given file.
@@ -707,17 +726,10 @@ pub fn find_unlisted_dependencies(
 ) -> Vec<UnlistedDependency> {
     let all_deps: FxHashSet<String> = pkg.all_dependency_names().into_iter().collect();
 
-    // Build a set of all deps across all workspace package.json files.
-    // In monorepos, imports in workspace files reference deps from that workspace's package.json.
-    let mut all_workspace_deps: FxHashSet<String> = all_deps.clone();
-    // Also collect workspace package names so internal workspace deps can be
-    // checked against the declaring workspace instead of skipped globally.
-    let mut workspace_names: FxHashSet<String> = FxHashSet::default();
     // Map: canonical workspace root -> set of dep names (for per-file checks)
     let mut ws_dep_map: Vec<(PathBuf, FxHashSet<String>)> = Vec::new();
 
     for ws in workspaces {
-        workspace_names.insert(ws.name.clone());
         let ws_pkg_path = ws.root.join("package.json");
         if is_package_json_ignored(&ws_pkg_path, config) {
             continue;
@@ -726,7 +738,6 @@ pub fn find_unlisted_dependencies(
             let mut ws_deps: FxHashSet<String> =
                 ws_pkg.all_dependency_names().into_iter().collect();
             ws_deps.insert(ws.name.clone());
-            all_workspace_deps.extend(ws_deps.iter().cloned());
             // Use raw workspace root path for starts_with checks (avoids per-file canonicalize)
             ws_dep_map.push((ws.root.clone(), ws_deps));
         }
@@ -813,20 +824,7 @@ pub fn find_unlisted_dependencies(
         {
             continue;
         }
-        // Quick check: if an external dependency is listed in any root or workspace
-        // deps, skip. Internal workspace package names need the slower per-file
-        // check below so imports from workspaces that did not declare the internal
-        // dependency are still reported.
-        if all_workspace_deps.contains(package_name) && !workspace_names.contains(package_name) {
-            continue;
-        }
-        // When @types/<package> is listed, the bare package is used for types only —
-        // TypeScript resolves types from @types/ and erases the import at compile time.
-        if has_types_package(package_name, &all_workspace_deps) {
-            continue;
-        }
-
-        // Slower fallback: check if each importing file belongs to a workspace that lists this dep.
+        // Check each importing file against the package.json that owns that file.
         // Uses raw path comparison (module paths are absolute) to avoid per-file canonicalize().
         let mut unlisted_sites: Vec<ImportSite> = Vec::new();
         for id in file_ids {
@@ -834,6 +832,12 @@ pub fn find_unlisted_dependencies(
                 continue;
             };
             if is_package_listed_for_file(&module.path, package_name, &all_deps, &ws_dep_map) {
+                continue;
+            }
+            // When @types/<package> is listed in the owning manifest, the bare
+            // package is used for types only. TypeScript resolves types from
+            // @types/ and erases the import at compile time.
+            if has_types_package_for_file(&module.path, package_name, &all_deps, &ws_dep_map) {
                 continue;
             }
             let (line, col) = find_import_location(

--- a/crates/core/src/analyze/unused_deps_tests/collect_unused.rs
+++ b/crates/core/src/analyze/unused_deps_tests/collect_unused.rs
@@ -273,6 +273,20 @@ fn listed_in_root_deps() {
 }
 
 #[test]
+fn workspace_file_does_not_inherit_root_deps() {
+    let mut root_deps = FxHashSet::default();
+    root_deps.insert("react".to_string());
+    let ws_dep_map = vec![(PathBuf::from("/project/packages/app"), FxHashSet::default())];
+
+    assert!(!is_package_listed_for_file(
+        Path::new("/project/packages/app/src/index.ts"),
+        "react",
+        &root_deps,
+        &ws_dep_map,
+    ));
+}
+
+#[test]
 fn listed_in_workspace_deps() {
     let root_deps = FxHashSet::default();
     let mut ws_deps = FxHashSet::default();
@@ -309,6 +323,35 @@ fn listed_in_different_workspace_not_matching() {
     assert!(!is_package_listed_for_file(
         Path::new("/project/packages/app/src/index.ts"),
         "lodash",
+        &root_deps,
+        &ws_dep_map,
+    ));
+}
+
+#[test]
+fn nested_workspace_uses_most_specific_manifest() {
+    let root_deps = FxHashSet::default();
+    let mut parent_deps = FxHashSet::default();
+    parent_deps.insert("react".to_string());
+    let mut child_deps = FxHashSet::default();
+    child_deps.insert("vue".to_string());
+    let ws_dep_map = vec![
+        (PathBuf::from("/project/packages/app"), parent_deps),
+        (
+            PathBuf::from("/project/packages/app/plugins/widget"),
+            child_deps,
+        ),
+    ];
+
+    assert!(is_package_listed_for_file(
+        Path::new("/project/packages/app/plugins/widget/src/index.ts"),
+        "vue",
+        &root_deps,
+        &ws_dep_map,
+    ));
+    assert!(!is_package_listed_for_file(
+        Path::new("/project/packages/app/plugins/widget/src/index.ts"),
+        "react",
         &root_deps,
         &ws_dep_map,
     ));

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -783,7 +783,7 @@ fn sibling_at_types_package_does_not_suppress_unlisted_check() {
 }
 
 struct WorkspaceImportCase {
-    #[allow(dead_code, reason = "keeps tempdir alive for workspace package files")]
+    #[expect(dead_code, reason = "keeps tempdir alive for workspace package files")]
     tmp: tempfile::TempDir,
     root: PathBuf,
     graph: ModuleGraph,

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -731,3 +731,140 @@ fn ignore_dependencies_suppresses_unlisted() {
         "axios in ignoreDependencies should not be flagged as unlisted"
     );
 }
+
+#[test]
+fn workspace_file_does_not_use_root_manifest_for_unlisted_check() {
+    let case = workspace_import_case("react", false, None);
+    let pkg = make_pkg(&["react"], &[], &[]);
+    let config = test_config(case.root);
+    let line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+
+    let unlisted = find_unlisted_dependencies(
+        &case.graph,
+        &pkg,
+        &config,
+        &case.workspaces,
+        None,
+        &case.resolved_modules,
+        &line_offsets,
+    );
+
+    assert!(
+        unlisted.iter().any(|dep| dep.package_name == "react"),
+        "workspace imports must be checked against their own package.json, not root deps"
+    );
+}
+
+#[test]
+fn sibling_at_types_package_does_not_suppress_unlisted_check() {
+    let case = workspace_import_case(
+        "geojson",
+        true,
+        Some(r#"{"name":"types-owner","devDependencies":{"@types/geojson":"^1.0.0"}}"#),
+    );
+    let pkg = make_pkg(&[], &[], &[]);
+    let config = test_config(case.root);
+    let line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+
+    let unlisted = find_unlisted_dependencies(
+        &case.graph,
+        &pkg,
+        &config,
+        &case.workspaces,
+        None,
+        &case.resolved_modules,
+        &line_offsets,
+    );
+
+    assert!(
+        unlisted.iter().any(|dep| dep.package_name == "geojson"),
+        "a sibling workspace's @types package must not satisfy the importing workspace"
+    );
+}
+
+struct WorkspaceImportCase {
+    #[allow(dead_code, reason = "keeps tempdir alive for workspace package files")]
+    tmp: tempfile::TempDir,
+    root: PathBuf,
+    graph: ModuleGraph,
+    resolved_modules: Vec<ResolvedModule>,
+    workspaces: Vec<WorkspaceInfo>,
+}
+
+fn workspace_import_case(
+    package_name: &str,
+    is_type_only: bool,
+    sibling_package_json: Option<&str>,
+) -> WorkspaceImportCase {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let root = tmp.path().join("repo");
+    let app_root = root.join("packages/app");
+    std::fs::create_dir_all(app_root.join("src")).expect("create workspace source");
+    std::fs::write(app_root.join("package.json"), r#"{"name":"app"}"#)
+        .expect("write app package json");
+
+    let mut workspaces = vec![WorkspaceInfo {
+        root: app_root.clone(),
+        name: "app".to_string(),
+        is_internal_dependency: false,
+    }];
+
+    if let Some(package_json) = sibling_package_json {
+        let sibling_root = root.join("packages/types-owner");
+        std::fs::create_dir_all(sibling_root.join("src")).expect("create sibling source");
+        std::fs::write(sibling_root.join("package.json"), package_json)
+            .expect("write sibling package json");
+        workspaces.push(WorkspaceInfo {
+            root: sibling_root,
+            name: "types-owner".to_string(),
+            is_internal_dependency: false,
+        });
+    }
+
+    let file_path = app_root.join("src/index.ts");
+    let files = vec![DiscoveredFile {
+        id: FileId(0),
+        path: file_path.clone(),
+        size_bytes: 100,
+    }];
+    let entry_points = vec![EntryPoint {
+        path: file_path.clone(),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: file_path,
+        exports: vec![],
+        re_exports: vec![],
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: package_name.to_string(),
+                imported_name: ImportedName::Named("value".to_string()),
+                local_name: "value".to_string(),
+                is_type_only,
+                from_style: false,
+                span: oxc_span::Span::new(0, 35),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::NpmPackage(package_name.to_string()),
+        }],
+        resolved_dynamic_imports: vec![],
+        resolved_dynamic_patterns: vec![],
+        member_accesses: vec![],
+        whole_object_uses: vec![],
+        has_cjs_exports: false,
+        unused_import_bindings: FxHashSet::default(),
+        type_referenced_import_bindings: vec![],
+        value_referenced_import_bindings: vec![],
+        namespace_object_aliases: vec![],
+    }];
+    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+
+    WorkspaceImportCase {
+        tmp,
+        root,
+        graph,
+        resolved_modules,
+        workspaces,
+    }
+}

--- a/crates/core/tests/integration_test/dependencies.rs
+++ b/crates/core/tests/integration_test/dependencies.rs
@@ -154,6 +154,24 @@ fn unused_workspace_dependency_reports_other_workspace_usage() {
         vec![root.join("packages/consumer")],
         "unused dependency should identify the sibling workspace importing it"
     );
+
+    let unlisted = results
+        .unlisted_dependencies
+        .iter()
+        .find(|dep| dep.package_name == "lodash-es")
+        .expect("lodash-es should be unlisted in the consumer workspace");
+    assert_eq!(
+        unlisted.imported_from.len(),
+        1,
+        "lodash-es should have one unlisted import site"
+    );
+    assert!(
+        unlisted.imported_from[0]
+            .path
+            .ends_with("packages/consumer/src/index.ts"),
+        "finding should point at the importing consumer file, got {}",
+        unlisted.imported_from[0].path.display()
+    );
 }
 
 // ── Peer dependencies ─────────────────────────────────────────

--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -1,7 +1,9 @@
 #[cfg(unix)]
 use rmcp::model::*;
+#[cfg(unix)]
+use std::time::Duration;
 
-use crate::tools::{run_fallow, run_fallow_with_top_level_warnings};
+use crate::tools::{run_fallow, run_fallow_with_timeout, run_fallow_with_top_level_warnings};
 
 use super::super::resolve_binary;
 
@@ -463,18 +465,13 @@ async fn run_fallow_stdin_is_not_inherited() {
 
 #[cfg(unix)]
 #[tokio::test]
-#[expect(unsafe_code, reason = "env var mutation requires unsafe")]
 async fn run_fallow_timeout_returns_mcp_error() {
-    // Set a very short timeout to trigger it reliably.
-    // Note: env var mutation can race with parallel tests that call timeout_duration().
-    // In practice the 1s window is narrow and no other test depends on this env var.
-    // SAFETY: test-only, sequential env access within this function
-    unsafe { std::env::set_var("FALLOW_TIMEOUT_SECS", "1") };
-
-    let result = run_fallow("/bin/sh", &["-c".to_string(), "sleep 10".to_string()]).await;
-
-    // SAFETY: test-only cleanup
-    unsafe { std::env::remove_var("FALLOW_TIMEOUT_SECS") };
+    let result = run_fallow_with_timeout(
+        "/bin/sh",
+        &["-c".to_string(), "sleep 10".to_string()],
+        Duration::from_millis(20),
+    )
+    .await;
 
     assert!(result.is_err(), "timeout should produce an MCP error");
     let err = result.unwrap_err();

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -155,8 +155,14 @@ fn timeout_duration() -> Duration {
 
 /// Execute the fallow CLI binary with the given arguments and return the result.
 pub async fn run_fallow(binary: &str, args: &[String]) -> Result<CallToolResult, McpError> {
-    let timeout = timeout_duration();
+    run_fallow_with_timeout(binary, args, timeout_duration()).await
+}
 
+pub async fn run_fallow_with_timeout(
+    binary: &str,
+    args: &[String],
+    timeout: Duration,
+) -> Result<CallToolResult, McpError> {
     let output = tokio::time::timeout(
         timeout,
         Command::new(binary)


### PR DESCRIPTION
This fixes dependency ownership checks in workspaces.

A package declared in one workspace should not hide a missing dependency in another workspace. The same scoping now applies to @types packages.

Also cleaned up a flaky MCP timeout test that was mutating process env during parallel test runs.

Checked with fmt, clippy, and the full workspace test suite.