### PR TITLE
feat(fix): auto-apply ignoreExports rules to fallow config (closes #330)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -404,7 +404,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ dependencies = [
  "globset",
  "http",
  "insta",
- "json_comments",
+ "jsonc-parser",
  "miette",
  "notify",
  "notify-debouncer-mini",
@@ -839,7 +839,7 @@ dependencies = [
  "dunce",
  "glob",
  "globset",
- "json_comments",
+ "jsonc-parser",
  "miette",
  "proptest",
  "rustc-hash 2.1.2",
@@ -849,6 +849,7 @@ dependencies = [
  "serde_yaml_ng",
  "tempfile",
  "toml",
+ "toml_edit",
  "tracing",
  "ureq",
 ]
@@ -931,7 +932,7 @@ dependencies = [
  "fallow-types",
  "fixedbitset",
  "globset",
- "json_comments",
+ "jsonc-parser",
  "oxc_resolver",
  "oxc_span",
  "proptest",
@@ -1606,10 +1607,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "json_comments"
-version = "0.2.2"
+name = "jsonc-parser"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "kqueue"
@@ -1900,7 +1905,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2811,7 +2816,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2921,7 +2926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3243,7 +3248,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3253,7 +3258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3414,6 +3419,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3903,7 +3921,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4183,6 +4201,9 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,9 @@ clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
-json_comments = "0.2"
+jsonc-parser = { version = "0.32", features = ["cst", "serde", "serde_json"] }
 toml = "1.1"
+toml_edit = "0.25"
 schemars = "1"
 
 # Parallelism

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,7 +45,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 bitcode = { workspace = true }
-json_comments = { workspace = true }
+jsonc-parser = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 notify = { workspace = true }

--- a/crates/cli/src/fix/config.rs
+++ b/crates/cli/src/fix/config.rs
@@ -1,0 +1,218 @@
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+use fallow_config::{FallowConfig, IgnoreExportRule, OutputFormat};
+use fallow_core::results::{AnalysisResults, DuplicateExport};
+use rustc_hash::FxHashSet;
+
+pub(super) fn apply_config_fixes(
+    root: &Path,
+    config_path: Option<&PathBuf>,
+    results: &AnalysisResults,
+    output: OutputFormat,
+    dry_run: bool,
+    fixes: &mut Vec<serde_json::Value>,
+) -> bool {
+    if results.duplicate_exports.is_empty() {
+        return false;
+    }
+
+    let Some(config_path) = resolve_config_path(root, config_path) else {
+        if !matches!(output, OutputFormat::Json) {
+            eprintln!(
+                "Skipped duplicate-export config fix: no fallow config file at {}. \
+                 Run `fallow init` to create one, then re-run `fallow fix --yes`. \
+                 (Note: `package.json#fallow` is not a supported config location.)",
+                root.display()
+            );
+        }
+        fixes.push(serde_json::json!({
+            "type": "add_ignore_exports",
+            "config_key": "ignoreExports",
+            "skipped": true,
+            "skip_reason": "missing_config",
+            "description": "Skipped: no fallow config file was found. Run `fallow init` to create one.",
+        }));
+        return false;
+    };
+
+    let entries = ignore_export_entries(root, &config_path, &results.duplicate_exports);
+    if entries.is_empty() {
+        return false;
+    }
+
+    let config_file = display_path(root, &config_path);
+    if dry_run {
+        if !matches!(output, OutputFormat::Json) {
+            eprintln!(
+                "Would add {} ignoreExports rule(s) to {}",
+                entries.len(),
+                config_file
+            );
+        }
+        fixes.push(serde_json::json!({
+            "type": "add_ignore_exports",
+            "config_key": "ignoreExports",
+            "file": config_file,
+            "entries": entries,
+        }));
+        return false;
+    }
+
+    match fallow_config::add_ignore_exports_rule(&config_path, &entries) {
+        Ok(()) => {
+            fixes.push(serde_json::json!({
+                "type": "add_ignore_exports",
+                "config_key": "ignoreExports",
+                "file": config_file,
+                "entries": entries,
+                "applied": true,
+            }));
+            false
+        }
+        Err(e) => {
+            eprintln!(
+                "Error: failed to write ignoreExports rules to {}: {e}",
+                config_path.display()
+            );
+            true
+        }
+    }
+}
+
+fn resolve_config_path(root: &Path, explicit: Option<&PathBuf>) -> Option<PathBuf> {
+    explicit.map_or_else(
+        || FallowConfig::find_config_path(root),
+        |path| {
+            if path.is_absolute() {
+                Some(path.clone())
+            } else {
+                std::env::current_dir()
+                    .ok()
+                    .map_or_else(|| Some(path.clone()), |cwd| Some(cwd.join(path)))
+            }
+        },
+    )
+}
+
+fn ignore_export_entries(
+    root: &Path,
+    config_path: &Path,
+    duplicate_exports: &[DuplicateExport],
+) -> Vec<IgnoreExportRule> {
+    let config_dir = config_path.parent().unwrap_or(root);
+    let mut seen = FxHashSet::default();
+    let mut entries = Vec::new();
+    for item in duplicate_exports {
+        for location in &item.locations {
+            let file = relative_from_config_dir(root, config_dir, &location.path);
+            if seen.insert(file.clone()) {
+                entries.push(IgnoreExportRule {
+                    file,
+                    exports: vec!["*".to_owned()],
+                });
+            }
+        }
+    }
+    entries
+}
+
+fn relative_from_config_dir(root: &Path, config_dir: &Path, file_path: &Path) -> String {
+    let root_relative = file_path.strip_prefix(root).unwrap_or(file_path);
+    let config_relative = config_dir
+        .strip_prefix(root)
+        .unwrap_or_else(|_| Path::new(""));
+    lexical_relative(config_relative, root_relative)
+        .unwrap_or_else(|| root_relative.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn lexical_relative(from_dir: &Path, to_file: &Path) -> Option<PathBuf> {
+    let from = normal_components(from_dir)?;
+    let to = normal_components(to_file)?;
+    let common = from.iter().zip(&to).take_while(|(a, b)| a == b).count();
+    let mut relative = PathBuf::new();
+    for _ in common..from.len() {
+        relative.push("..");
+    }
+    for component in &to[common..] {
+        relative.push(component);
+    }
+    Some(relative)
+}
+
+fn normal_components(path: &Path) -> Option<Vec<OsString>> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => components.push(value.to_os_string()),
+            Component::CurDir => {}
+            Component::ParentDir => components.push(OsString::from("..")),
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(components)
+}
+
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fallow_core::results::DuplicateLocation;
+
+    fn duplicate(paths: &[PathBuf]) -> DuplicateExport {
+        DuplicateExport {
+            export_name: "Button".to_owned(),
+            locations: paths
+                .iter()
+                .map(|path| DuplicateLocation {
+                    path: path.clone(),
+                    line: 1,
+                    col: 0,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn config_fix_reanchors_paths_to_workspace_config_dir() {
+        let root = Path::new("/repo");
+        let config_path = root.join("packages/ui/.fallowrc.json");
+        let entries = ignore_export_entries(
+            root,
+            &config_path,
+            &[duplicate(&[
+                root.join("packages/ui/src/index.ts"),
+                root.join("packages/shared/src/index.ts"),
+            ])],
+        );
+
+        assert_eq!(entries[0].file, "src/index.ts");
+        assert_eq!(entries[1].file, "../shared/src/index.ts");
+    }
+
+    #[test]
+    fn config_fix_dedupes_exact_files_preserving_first_order() {
+        let root = Path::new("/repo");
+        let config_path = root.join(".fallowrc.json");
+        let entries = ignore_export_entries(
+            root,
+            &config_path,
+            &[duplicate(&[
+                root.join("src/a.ts"),
+                root.join("src/b.ts"),
+                root.join("src/a.ts"),
+            ])],
+        );
+
+        let files: Vec<&str> = entries.iter().map(|entry| entry.file.as_str()).collect();
+        assert_eq!(files, vec!["src/a.ts", "src/b.ts"]);
+    }
+}

--- a/crates/cli/src/fix/io.rs
+++ b/crates/cli/src/fix/io.rs
@@ -1,7 +1,4 @@
-use std::io::Write;
 use std::path::Path;
-
-use tempfile::NamedTempFile;
 
 /// Read a source file, validate it is within the project root, and detect line endings.
 ///
@@ -34,15 +31,7 @@ pub(super) fn write_fixed_content(
     atomic_write(path, result.as_bytes())
 }
 
-/// Atomically write content to a file via a temporary file and rename.
-pub(super) fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
-    let dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = NamedTempFile::new_in(dir)?;
-    tmp.write_all(content)?;
-    tmp.as_file().sync_all()?;
-    tmp.persist(path).map_err(|e| e.error)?;
-    Ok(())
-}
+pub(super) use fallow_config::atomic_write;
 
 #[cfg(test)]
 mod tests {

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -6,6 +6,7 @@ use std::process::ExitCode;
 use fallow_config::OutputFormat;
 
 mod catalog;
+mod config;
 mod deps;
 mod enum_helpers;
 mod enum_members;
@@ -95,6 +96,15 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
 
     had_write_error |=
         deps::apply_dependency_fixes(opts.root, &results, opts.output, opts.dry_run, &mut fixes);
+
+    had_write_error |= config::apply_config_fixes(
+        opts.root,
+        opts.config_path.as_ref(),
+        &results,
+        opts.output,
+        opts.dry_run,
+        &mut fixes,
+    );
 
     // Group unused enum members by file path for batch editing.
     if !results.unused_enum_members.is_empty() {

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -768,13 +768,8 @@ mod tests {
     }
 
     fn parse_jsonc_config(content: &str) -> serde_json::Value {
-        let mut stripped = String::new();
-        std::io::Read::read_to_string(
-            &mut json_comments::StripComments::new(content.as_bytes()),
-            &mut stripped,
-        )
-        .expect("strip json comments");
-        serde_json::from_str(&stripped).expect("parse generated jsonc")
+        jsonc_parser::parse_to_serde_value(content, &jsonc_parser::ParseOptions::default())
+            .expect("parse generated jsonc")
     }
 
     #[test]

--- a/crates/cli/src/migrate/mod.rs
+++ b/crates/cli/src/migrate/mod.rs
@@ -7,7 +7,6 @@ mod knip_tables;
 mod tests;
 mod toml_gen;
 
-use std::io::Read as _;
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -341,35 +340,30 @@ fn migrate_from_file(path: &Path) -> Result<MigrationResult, String> {
     })
 }
 
-/// Load a JSON or JSONC file, stripping comments and trailing commas if present.
+/// Load a JSON or JSONC file, accepting comments and trailing commas.
 fn load_json_or_jsonc(path: &Path) -> Result<serde_json::Value, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
 
-    // Try plain JSON first
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
-        return Ok(value);
+    jsonc_parser::parse_to_serde_value(&content, &jsonc_parse_options())
+        .map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
+
+fn jsonc_parse_options() -> jsonc_parser::ParseOptions {
+    jsonc_parser::ParseOptions {
+        allow_comments: true,
+        allow_loose_object_property_names: false,
+        allow_trailing_commas: true,
+        allow_missing_commas: false,
+        allow_single_quoted_strings: false,
+        allow_hexadecimal_numbers: false,
+        allow_unary_plus_numbers: false,
     }
-
-    // Try stripping comments (JSONC)
-    let mut stripped = String::new();
-    json_comments::StripComments::new(content.as_bytes())
-        .read_to_string(&mut stripped)
-        .map_err(|e| format!("failed to strip comments from {}: {e}", path.display()))?;
-
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&stripped) {
-        return Ok(value);
-    }
-
-    // Real-world JSONC (e.g. knip.jsonc, tsconfig.json) frequently uses
-    // trailing commas. serde_json rejects them, so strip them as a final
-    // pass before reporting a parse error to the user.
-    let cleaned = strip_trailing_commas(&stripped);
-    serde_json::from_str(&cleaned).map_err(|e| format!("failed to parse {}: {e}", path.display()))
 }
 
 /// Strip JSONC-style trailing commas (`,` immediately before `}` or `]`)
 /// without touching commas inside string literals.
+#[cfg(test)]
 fn strip_trailing_commas(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
@@ -416,6 +410,7 @@ fn strip_trailing_commas(input: &str) -> String {
     out
 }
 
+#[cfg(test)]
 fn comma_follows_json_value(bytes: &[u8], comma_index: usize) -> bool {
     let Some(prev) = bytes[..comma_index]
         .iter()

--- a/crates/cli/src/migrate/tests.rs
+++ b/crates/cli/src/migrate/tests.rs
@@ -1,5 +1,3 @@
-use std::io::Read as _;
-
 use super::jscpd::migrate_jscpd;
 use super::jsonc::{generate_jsonc, indent_json_value};
 use super::knip::migrate_knip;
@@ -154,11 +152,9 @@ fn jsonc_output_deserializes_as_valid_config() {
         sources: vec!["knip.json".to_string()],
     };
     let output = generate_jsonc(&result);
-    let mut stripped = String::new();
-    json_comments::StripComments::new(output.as_bytes())
-        .read_to_string(&mut stripped)
-        .unwrap();
-    let config: fallow_config::FallowConfig = serde_json::from_str(&stripped).unwrap();
+    let config: fallow_config::FallowConfig =
+        jsonc_parser::parse_to_serde_value(&output, &jsonc_parser::ParseOptions::default())
+            .unwrap();
     assert_eq!(config.entry, vec!["src/index.ts"]);
     assert_eq!(config.ignore_dependencies, vec!["lodash"]);
 }
@@ -1059,11 +1055,9 @@ fn jsonc_full_roundtrip_with_all_fields() {
         sources: vec!["knip.json".to_string()],
     };
     let output = generate_jsonc(&result);
-    let mut stripped = String::new();
-    json_comments::StripComments::new(output.as_bytes())
-        .read_to_string(&mut stripped)
-        .unwrap();
-    let config: fallow_config::FallowConfig = serde_json::from_str(&stripped).unwrap();
+    let config: fallow_config::FallowConfig =
+        jsonc_parser::parse_to_serde_value(&output, &jsonc_parser::ParseOptions::default())
+            .unwrap();
     assert_eq!(config.entry, vec!["src/main.ts", "src/worker.ts"]);
     assert_eq!(config.ignore_patterns, vec!["build/**"]);
     assert_eq!(config.ignore_dependencies, vec!["react", "lodash"]);
@@ -1143,11 +1137,9 @@ fn jsonc_output_only_rules() {
     assert!(!output.contains("\"ignorePatterns\""));
     assert!(!output.contains("\"duplicates\""));
     // Should be valid JSONC that round-trips
-    let mut stripped = String::new();
-    json_comments::StripComments::new(output.as_bytes())
-        .read_to_string(&mut stripped)
-        .unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+    let parsed: serde_json::Value =
+        jsonc_parser::parse_to_serde_value(&output, &jsonc_parser::ParseOptions::default())
+            .unwrap();
     let rules = parsed.get("rules").unwrap().as_object().unwrap();
     assert_eq!(rules.get("unused-files").unwrap(), "error");
     assert_eq!(rules.get("unused-exports").unwrap(), "off");

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::time::Duration;
 
+use fallow_config::FallowConfig;
 use fallow_core::duplicates::DuplicationReport;
 use fallow_core::results::AnalysisResults;
 
@@ -85,13 +86,14 @@ pub(super) fn print_grouped_json(
     resolver: &OwnershipResolver,
 ) -> ExitCode {
     let root_prefix = format!("{}/", root.display());
+    let config_fixable = FallowConfig::find_config_path(root).is_some();
 
     let group_values: Vec<serde_json::Value> = groups
         .iter()
         .filter_map(|group| {
             let mut value = serde_json::to_value(&group.results).ok()?;
             strip_root_prefix(&mut value, &root_prefix);
-            inject_actions(&mut value);
+            inject_actions(&mut value, config_fixable);
             harmonize_multi_kind_suppress_line_actions(&mut value);
 
             if let serde_json::Value::Object(ref mut map) = value {
@@ -298,7 +300,7 @@ pub fn build_json(
     // action fields (static strings and package names) are not processed
     // by the path stripper.
     strip_root_prefix(&mut output, &root_prefix);
-    inject_actions(&mut output);
+    inject_actions(&mut output, FallowConfig::find_config_path(root).is_some());
     harmonize_multi_kind_suppress_line_actions(&mut output);
     Ok(output)
 }
@@ -625,6 +627,7 @@ fn build_actions(
     item: &serde_json::Value,
     issue_key: &str,
     spec: &ActionSpec,
+    config_fixable: bool,
 ) -> serde_json::Value {
     let mut actions = Vec::with_capacity(2);
     let cross_workspace_dependency = is_dependency_issue(issue_key)
@@ -650,7 +653,7 @@ fn build_actions(
     {
         actions.push(serde_json::json!({
             "type": "add-to-config",
-            "auto_fixable": false,
+            "auto_fixable": config_fixable,
             "description": "Add an ignoreExports rule so these files are excluded from duplicate-export grouping (use when this duplication is an intentional namespace-barrel API).",
             "config_key": "ignoreExports",
             "value": value,
@@ -851,7 +854,7 @@ fn is_dependency_issue(issue_key: &str) -> bool {
 ///
 /// Walks each known issue-type array and appends an `actions` field
 /// to every item, providing machine-actionable fix and suppress hints.
-fn inject_actions(output: &mut serde_json::Value) {
+fn inject_actions(output: &mut serde_json::Value, config_fixable: bool) {
     let Some(map) = output.as_object_mut() else {
         return;
     };
@@ -864,7 +867,7 @@ fn inject_actions(output: &mut serde_json::Value) {
             continue;
         };
         for item in arr {
-            let actions = build_actions(item, key, &spec);
+            let actions = build_actions(item, key, &spec, config_fixable);
             if let serde_json::Value::Object(obj) = item {
                 obj.insert("actions".to_string(), actions);
             }
@@ -2606,6 +2609,65 @@ mod tests {
         assert_eq!(locs.len(), 2);
         assert_eq!(locs[0]["line"], 10);
         assert_eq!(locs[1]["line"], 25);
+    }
+
+    #[test]
+    fn duplicate_export_add_to_config_is_auto_fixable_when_config_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join(".fallowrc.json"), "{}\n").unwrap();
+        let mut results = AnalysisResults::default();
+        results.duplicate_exports.push(DuplicateExport {
+            export_name: "Button".to_string(),
+            locations: vec![
+                DuplicateLocation {
+                    path: root.join("src/ui.ts"),
+                    line: 10,
+                    col: 0,
+                },
+                DuplicateLocation {
+                    path: root.join("src/components.ts"),
+                    line: 25,
+                    col: 0,
+                },
+            ],
+        });
+
+        let output = build_json(&results, root, Duration::ZERO).unwrap();
+        let actions = output["duplicate_exports"][0]["actions"]
+            .as_array()
+            .unwrap();
+        assert_eq!(actions[0]["type"], "add-to-config");
+        assert_eq!(actions[0]["auto_fixable"], true);
+    }
+
+    #[test]
+    fn duplicate_export_add_to_config_is_not_auto_fixable_without_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut results = AnalysisResults::default();
+        results.duplicate_exports.push(DuplicateExport {
+            export_name: "Button".to_string(),
+            locations: vec![
+                DuplicateLocation {
+                    path: root.join("src/ui.ts"),
+                    line: 10,
+                    col: 0,
+                },
+                DuplicateLocation {
+                    path: root.join("src/components.ts"),
+                    line: 25,
+                    col: 0,
+                },
+            ],
+        });
+
+        let output = build_json(&results, root, Duration::ZERO).unwrap();
+        let actions = output["duplicate_exports"][0]["actions"]
+            .as_array()
+            .unwrap();
+        assert_eq!(actions[0]["type"], "add-to-config");
+        assert_eq!(actions[0]["auto_fixable"], false);
     }
 
     #[test]

--- a/crates/cli/tests/fix_tests.rs
+++ b/crates/cli/tests/fix_tests.rs
@@ -165,6 +165,169 @@ fn fix_folds_imported_enum_with_all_members_unused() {
     );
 }
 
+#[test]
+fn fix_adds_ignore_exports_config_rules_for_duplicate_exports() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src/one")).unwrap();
+    std::fs::create_dir_all(root.join("src/two")).unwrap();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"dup-config","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    std::fs::write(root.join(".fallowrc.json"), "{}\n").unwrap();
+    std::fs::write(
+        root.join("src/index.ts"),
+        "export { Button } from './one';\nexport { Button as Button2 } from './two';\nconsole.log(Button2);\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("src/one/index.ts"), "export const Button = 1;\n").unwrap();
+    std::fs::write(root.join("src/two/index.ts"), "export const Button = 2;\n").unwrap();
+
+    let output = run_fallow_in_root("fix", root, &["--yes", "--format", "json", "--quiet"]);
+    assert_eq!(
+        output.code, 0,
+        "fix should exit 0, stdout: {}, stderr: {}",
+        output.stdout, output.stderr
+    );
+
+    let json = parse_json(&output);
+    let fixes = json["fixes"].as_array().unwrap();
+    let config_fix = fixes
+        .iter()
+        .find(|fix| fix["type"] == "add_ignore_exports")
+        .expect("fix output should include an ignoreExports config edit");
+    assert_eq!(config_fix["applied"], true);
+    assert_eq!(config_fix["config_key"], "ignoreExports");
+    assert_eq!(config_fix["entries"].as_array().unwrap().len(), 2);
+
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(root.join(".fallowrc.json")).unwrap())
+            .unwrap();
+    let ignore_exports = config["ignoreExports"].as_array().unwrap();
+    assert_eq!(ignore_exports[0]["file"], "src/one/index.ts");
+    assert_eq!(ignore_exports[1]["file"], "src/two/index.ts");
+
+    let output = run_fallow_in_root(
+        "dead-code",
+        root,
+        &["--duplicate-exports", "--format", "json", "--quiet"],
+    );
+    assert_eq!(
+        output.code, 0,
+        "post-fix check should pass: {}",
+        output.stderr
+    );
+    let json = parse_json(&output);
+    assert_eq!(json["summary"]["duplicate_exports"].as_u64(), Some(0));
+}
+
+/// A Windows-authored `.fallowrc.json` with a UTF-8 BOM must round-trip
+/// through `fallow fix --yes` without breaking the parse on the next run.
+/// The CST parser (jsonc-parser) rejects a leading BOM, so the writer must
+/// strip and restore it.
+#[test]
+fn fix_round_trips_utf8_bom_on_json_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src/one")).unwrap();
+    std::fs::create_dir_all(root.join("src/two")).unwrap();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"bom-config","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    let bom_input = "\u{FEFF}{\n  \"entry\": [\"src/index.ts\"]\n}\n";
+    std::fs::write(root.join(".fallowrc.json"), bom_input).unwrap();
+    std::fs::write(
+        root.join("src/index.ts"),
+        "export { Button } from './one';\nexport { Button as Button2 } from './two';\nconsole.log(Button2);\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("src/one/index.ts"), "export const Button = 1;\n").unwrap();
+    std::fs::write(root.join("src/two/index.ts"), "export const Button = 2;\n").unwrap();
+
+    let output = run_fallow_in_root("fix", root, &["--yes", "--format", "json", "--quiet"]);
+    assert_eq!(
+        output.code, 0,
+        "fix should succeed on BOM-prefixed config: {}",
+        output.stderr
+    );
+
+    let written = std::fs::read_to_string(root.join(".fallowrc.json")).unwrap();
+    assert!(
+        written.starts_with('\u{FEFF}'),
+        "BOM stripped from output (got bytes {:?})",
+        &written.as_bytes()[..written.len().min(8)]
+    );
+
+    // Round-trip: a follow-up analysis must still load this config cleanly.
+    let post = run_fallow_in_root(
+        "dead-code",
+        root,
+        &["--duplicate-exports", "--format", "json", "--quiet"],
+    );
+    assert_eq!(
+        post.code, 0,
+        "post-fix analysis must succeed on BOM-preserved config: {}",
+        post.stderr
+    );
+    let json = parse_json(&post);
+    assert_eq!(json["summary"]["duplicate_exports"].as_u64(), Some(0));
+}
+
+/// `fallow fix` on a symlinked config file must write through to the target
+/// rather than replacing the symlink with a regular file. Common in Docker
+/// images where configs are mounted from a sibling directory.
+#[cfg(unix)]
+#[test]
+fn fix_writes_through_symlinked_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let real_dir = root.join("config-source");
+    std::fs::create_dir_all(&real_dir).unwrap();
+    std::fs::create_dir_all(root.join("src/one")).unwrap();
+    std::fs::create_dir_all(root.join("src/two")).unwrap();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"symlink-config","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    let real_path = real_dir.join(".fallowrc.json");
+    std::fs::write(&real_path, "{}\n").unwrap();
+    std::os::unix::fs::symlink(&real_path, root.join(".fallowrc.json")).unwrap();
+    std::fs::write(
+        root.join("src/index.ts"),
+        "export { Button } from './one';\nexport { Button as Button2 } from './two';\nconsole.log(Button2);\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("src/one/index.ts"), "export const Button = 1;\n").unwrap();
+    std::fs::write(root.join("src/two/index.ts"), "export const Button = 2;\n").unwrap();
+
+    let output = run_fallow_in_root("fix", root, &["--yes", "--format", "json", "--quiet"]);
+    assert_eq!(
+        output.code, 0,
+        "fix on symlinked config should succeed: {}",
+        output.stderr
+    );
+
+    // The symlink must still BE a symlink after the write (atomic_write
+    // canonicalized to the target).
+    let meta = std::fs::symlink_metadata(root.join(".fallowrc.json")).unwrap();
+    assert!(
+        meta.file_type().is_symlink(),
+        "symlink was replaced with regular file by atomic_write"
+    );
+
+    // The target must contain the new ignoreExports entries.
+    let target_content = std::fs::read_to_string(&real_path).unwrap();
+    assert!(
+        target_content.contains("\"ignoreExports\""),
+        "symlink target was not updated, got: {target_content}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // fix without --yes in non-TTY
 // ---------------------------------------------------------------------------

--- a/crates/cli/tests/init_tests.rs
+++ b/crates/cli/tests/init_tests.rs
@@ -83,14 +83,11 @@ fn init_created_config_is_valid_json() {
     let dir = init_temp_dir("valid");
     run_fallow_raw(&["init", "--root", dir.to_str().unwrap(), "--quiet"]);
     let content = fs::read_to_string(dir.join(".fallowrc.json")).unwrap();
-    let mut stripped = String::new();
-    std::io::Read::read_to_string(
-        &mut json_comments::StripComments::new(content.as_bytes()),
-        &mut stripped,
-    )
-    .unwrap_or_else(|e| panic!("init should produce valid JSONC: {e}\ncontent: {content}"));
-    let _: serde_json::Value = serde_json::from_str(&stripped)
-        .unwrap_or_else(|e| panic!("init should produce valid JSONC: {e}\ncontent: {content}"));
+    let _: serde_json::Value =
+        jsonc_parser::parse_to_serde_value(&content, &jsonc_parser::ParseOptions::default())
+            .unwrap_or_else(|e| {
+                panic!("init should produce valid JSONC: {e}\ncontent: {content}");
+            });
     cleanup(&dir);
 }
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -16,18 +16,19 @@ dunce = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
-json_comments = { workspace = true }
+jsonc-parser = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 schemars = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
 miette = { workspace = true }
 rustc-hash = { workspace = true }
+tempfile = { workspace = true }
 tracing = { workspace = true }
 ureq = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 proptest = { workspace = true }
 
 [lints]

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -1,4 +1,3 @@
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -70,10 +69,14 @@ pub(super) fn deep_merge_json(base: &mut serde_json::Value, overlay: serde_json:
 pub(super) fn parse_config_to_value(path: &Path) -> Result<serde_json::Value, miette::Report> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| miette::miette!("Failed to read config file {}: {}", path.display(), e))?;
+    // Strip a leading UTF-8 BOM so Windows-authored configs parse cleanly.
+    // jsonc-parser and serde_yaml_ng both reject `\u{FEFF}` as an unexpected
+    // token; matches the pre-existing behaviour in workspace/parsers.rs.
+    let content = content.trim_start_matches('\u{FEFF}');
 
     match ConfigFormat::from_path(path) {
         ConfigFormat::Toml => {
-            let toml_value: toml::Value = toml::from_str(&content).map_err(|e| {
+            let toml_value: toml::Value = toml::from_str(content).map_err(|e| {
                 miette::miette!("Failed to parse config file {}: {}", path.display(), e)
             })?;
             serde_json::to_value(toml_value).map_err(|e| {
@@ -84,17 +87,8 @@ pub(super) fn parse_config_to_value(path: &Path) -> Result<serde_json::Value, mi
                 )
             })
         }
-        ConfigFormat::Json => {
-            let mut stripped = String::new();
-            json_comments::StripComments::new(content.as_bytes())
-                .read_to_string(&mut stripped)
-                .map_err(|e| {
-                    miette::miette!("Failed to strip comments from {}: {}", path.display(), e)
-                })?;
-            serde_json::from_str(&stripped).map_err(|e| {
-                miette::miette!("Failed to parse config file {}: {}", path.display(), e)
-            })
-        }
+        ConfigFormat::Json => crate::jsonc::parse_to_value(content)
+            .map_err(|e| miette::miette!("Failed to parse config file {}: {}", path.display(), e)),
     }
 }
 
@@ -424,17 +418,7 @@ fn fetch_url_config(url: &str, source: &str) -> Result<serde_json::Value, miette
             )
         })?;
 
-    // Strip JSONC comments before parsing.
-    let mut stripped = String::new();
-    json_comments::StripComments::new(body.as_bytes())
-        .read_to_string(&mut stripped)
-        .map_err(|e| {
-            miette::miette!(
-                "Failed to strip comments from remote config {url} (referenced from {source}): {e}"
-            )
-        })?;
-
-    serde_json::from_str(&stripped).map_err(|e| {
+    crate::jsonc::parse_to_value(&body).map_err(|e| {
         miette::miette!(
             "Failed to parse remote config as JSON from {url} (referenced from {source}): {e}. \
              Only JSON/JSONC is supported for URL-sourced configs"
@@ -762,8 +746,6 @@ impl FallowConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read as _;
-
     use super::*;
     use crate::PackageJson;
     use crate::config::format::OutputFormat;
@@ -1009,11 +991,7 @@ unknown_field = true
                 "unused-files": "warn"
             }
         }"#;
-        let mut stripped = String::new();
-        json_comments::StripComments::new(jsonc_str.as_bytes())
-            .read_to_string(&mut stripped)
-            .unwrap();
-        let config: FallowConfig = serde_json::from_str(&stripped).unwrap();
+        let config: FallowConfig = crate::jsonc::parse_to_value(jsonc_str).unwrap();
         assert_eq!(config.entry, vec!["src/main.ts"]);
         assert_eq!(config.rules.unused_files, Severity::Warn);
     }

--- a/crates/config/src/config/resolution.rs
+++ b/crates/config/src/config/resolution.rs
@@ -73,7 +73,7 @@ fn reset_inter_file_warn_dedup_for_test() {
 }
 
 /// Rule for ignoring specific exports.
-#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct IgnoreExportRule {
     /// Glob pattern for files.
     pub file: String,

--- a/crates/config/src/config_writer.rs
+++ b/crates/config/src/config_writer.rs
@@ -1,0 +1,480 @@
+use std::error::Error;
+use std::fmt;
+use std::io::Write;
+use std::path::Path;
+
+use jsonc_parser::cst::{CstInputValue, CstRootNode};
+use rustc_hash::FxHashSet;
+use tempfile::NamedTempFile;
+use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
+
+use crate::IgnoreExportRule;
+
+#[derive(Debug)]
+pub enum ConfigWriteError {
+    Io(std::io::Error),
+    JsonParse(jsonc_parser::errors::ParseError),
+    TomlParse(toml_edit::TomlError),
+    InvalidShape(String),
+}
+
+impl fmt::Display for ConfigWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "{e}"),
+            Self::JsonParse(e) => write!(f, "{e}"),
+            Self::TomlParse(e) => write!(f, "{e}"),
+            Self::InvalidShape(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl Error for ConfigWriteError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::JsonParse(e) => Some(e),
+            Self::TomlParse(e) => Some(e),
+            Self::InvalidShape(_) => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ConfigWriteError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+pub type ConfigWriteResult<T> = Result<T, ConfigWriteError>;
+
+/// Atomically write content to a file via a temporary file and rename.
+///
+/// Resolves symlinks at the target path before persisting so the rename
+/// writes through to the symlink's target file rather than replacing the
+/// symlink itself with a regular file (common when configs are mounted into
+/// containers via symlinks).
+pub fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let dir = resolved.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(dir)?;
+    tmp.write_all(content)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(&resolved).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Append `ignoreExports` rules to an existing fallow config file.
+///
+/// Existing entries keep their order and exact formatting. New entries are
+/// appended only when no existing entry has the same `file` value.
+pub fn add_ignore_exports_rule(path: &Path, entries: &[IgnoreExportRule]) -> ConfigWriteResult<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let content = std::fs::read_to_string(path)?;
+    let rendered = add_ignore_exports_rule_to_string(path, &content, entries)?;
+    atomic_write(path, rendered.as_bytes())?;
+    Ok(())
+}
+
+fn add_ignore_exports_rule_to_string(
+    path: &Path,
+    content: &str,
+    entries: &[IgnoreExportRule],
+) -> ConfigWriteResult<String> {
+    let had_bom = content.starts_with(BOM);
+    let body = content.strip_prefix(BOM).unwrap_or(content);
+    let config_dir = path.parent().unwrap_or_else(|| Path::new(""));
+    let rendered = if is_json_config(path) {
+        append_json_ignore_exports(body, entries, config_dir)?
+    } else {
+        append_toml_ignore_exports(body, entries, config_dir)?
+    };
+    let with_endings = preserve_line_endings(&rendered, body);
+    Ok(if had_bom {
+        let mut out = String::with_capacity(with_endings.len() + BOM.len_utf8());
+        out.push(BOM);
+        out.push_str(&with_endings);
+        out
+    } else {
+        with_endings
+    })
+}
+
+const BOM: char = '\u{FEFF}';
+
+fn is_json_config(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("json" | "jsonc")
+    )
+}
+
+fn append_json_ignore_exports(
+    content: &str,
+    entries: &[IgnoreExportRule],
+    config_dir: &Path,
+) -> ConfigWriteResult<String> {
+    let root = CstRootNode::parse(content, &crate::jsonc::parse_options())
+        .map_err(ConfigWriteError::JsonParse)?;
+    let object = root.object_value_or_create().ok_or_else(|| {
+        ConfigWriteError::InvalidShape("fallow config root must be an object".into())
+    })?;
+    let array = object
+        .array_value_or_create("ignoreExports")
+        .ok_or_else(|| {
+            ConfigWriteError::InvalidShape("ignoreExports must be an array in fallow config".into())
+        })?;
+
+    let mut seen = FxHashSet::default();
+    for element in array.elements() {
+        if let Some(file) = element.to_serde_value().and_then(|value| {
+            value
+                .get("file")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        }) {
+            record_existing_file(&mut seen, &file, config_dir);
+        }
+    }
+
+    for entry in entries {
+        if seen.insert(entry.file.clone()) {
+            array.append(CstInputValue::Object(vec![
+                ("file".to_owned(), CstInputValue::String(entry.file.clone())),
+                (
+                    "exports".to_owned(),
+                    CstInputValue::Array(
+                        entry
+                            .exports
+                            .iter()
+                            .cloned()
+                            .map(CstInputValue::String)
+                            .collect(),
+                    ),
+                ),
+            ]));
+        }
+    }
+    Ok(root.to_string())
+}
+
+fn append_toml_ignore_exports(
+    content: &str,
+    entries: &[IgnoreExportRule],
+    config_dir: &Path,
+) -> ConfigWriteResult<String> {
+    let mut doc = content
+        .parse::<DocumentMut>()
+        .map_err(ConfigWriteError::TomlParse)?;
+    match doc
+        .as_table_mut()
+        .entry("ignoreExports")
+        .or_insert(Item::None)
+    {
+        Item::None => {
+            let mut tables = ArrayOfTables::new();
+            let mut seen = FxHashSet::default();
+            append_to_array_of_tables(&mut tables, entries, &mut seen);
+            doc.as_table_mut()
+                .insert("ignoreExports", Item::ArrayOfTables(tables));
+        }
+        Item::ArrayOfTables(tables) => {
+            let mut seen = files_from_array_of_tables(tables, config_dir);
+            append_to_array_of_tables(tables, entries, &mut seen);
+        }
+        Item::Value(Value::Array(array)) => {
+            let mut seen = files_from_inline_array(array, config_dir);
+            append_to_inline_array(array, entries, &mut seen);
+        }
+        _ => {
+            return Err(ConfigWriteError::InvalidShape(
+                "ignoreExports must be an array of tables or inline array in fallow config".into(),
+            ));
+        }
+    }
+    Ok(doc.to_string())
+}
+
+fn files_from_array_of_tables(tables: &ArrayOfTables, config_dir: &Path) -> FxHashSet<String> {
+    let mut seen = FxHashSet::default();
+    for table in tables {
+        if let Some(file) = table.get("file").and_then(Item::as_str) {
+            record_existing_file(&mut seen, file, config_dir);
+        }
+    }
+    seen
+}
+
+fn append_to_array_of_tables(
+    tables: &mut ArrayOfTables,
+    entries: &[IgnoreExportRule],
+    seen: &mut FxHashSet<String>,
+) {
+    for entry in entries {
+        if seen.insert(entry.file.clone()) {
+            tables.push(toml_ignore_export_table(entry));
+        }
+    }
+}
+
+fn toml_ignore_export_table(entry: &IgnoreExportRule) -> Table {
+    let mut table = Table::new();
+    table.insert("file", toml_edit::value(entry.file.clone()));
+    table.insert("exports", Item::Value(Value::Array(exports_array(entry))));
+    table
+}
+
+fn files_from_inline_array(array: &Array, config_dir: &Path) -> FxHashSet<String> {
+    let mut seen = FxHashSet::default();
+    for value in array {
+        if let Some(file) = value
+            .as_inline_table()
+            .and_then(|table| table.get("file"))
+            .and_then(Value::as_str)
+        {
+            record_existing_file(&mut seen, file, config_dir);
+        }
+    }
+    seen
+}
+
+/// Insert an existing-entry path into the dedupe set under its canonical key.
+///
+/// The canonical key is the entry as written. When the existing entry is an
+/// absolute path that resolves under the config dir, also insert the
+/// dir-relative form so a new entry emitted by the action builder (which is
+/// always config-dir-relative) is recognised as a duplicate.
+fn record_existing_file(seen: &mut FxHashSet<String>, file: &str, config_dir: &Path) {
+    seen.insert(file.to_owned());
+    let path = Path::new(file);
+    if path.is_absolute()
+        && let Ok(relative) = path.strip_prefix(config_dir)
+    {
+        seen.insert(relative.to_string_lossy().replace('\\', "/"));
+    }
+}
+
+fn append_to_inline_array(
+    array: &mut Array,
+    entries: &[IgnoreExportRule],
+    seen: &mut FxHashSet<String>,
+) {
+    for entry in entries {
+        if seen.insert(entry.file.clone()) {
+            array.push(Value::InlineTable(toml_ignore_export_inline_table(entry)));
+        }
+    }
+}
+
+fn toml_ignore_export_inline_table(entry: &IgnoreExportRule) -> InlineTable {
+    let mut table = InlineTable::new();
+    table.insert("file", Value::from(entry.file.clone()));
+    table.insert("exports", Value::Array(exports_array(entry)));
+    table
+}
+
+fn exports_array(entry: &IgnoreExportRule) -> Array {
+    let mut exports = Array::new();
+    for export in &entry.exports {
+        exports.push(export.as_str());
+    }
+    exports
+}
+
+fn preserve_line_endings(rendered: &str, original: &str) -> String {
+    if original.contains("\r\n") {
+        rendered.replace("\r\n", "\n").replace('\n', "\r\n")
+    } else {
+        rendered.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(file: &str) -> IgnoreExportRule {
+        IgnoreExportRule {
+            file: file.to_owned(),
+            exports: vec!["*".to_owned()],
+        }
+    }
+
+    #[test]
+    fn appends_json_ignore_exports() {
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallowrc.json"),
+            "{\n}\n",
+            &[rule("src/index.ts")],
+        )
+        .unwrap();
+        assert!(output.contains("\"ignoreExports\": ["));
+        assert!(output.contains("\"file\": \"src/index.ts\""));
+        assert!(output.ends_with('\n'));
+    }
+
+    #[test]
+    fn appends_jsonc_preserving_comments() {
+        let input = "{\n  // keep this\n  \"rules\": {}\n}\n";
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallowrc.jsonc"),
+            input,
+            &[rule("src/a.ts")],
+        )
+        .unwrap();
+        assert!(output.contains("// keep this"));
+        assert!(output.contains("\"rules\": {}"));
+        assert!(output.contains("\"file\": \"src/a.ts\""));
+    }
+
+    #[test]
+    fn merges_existing_json_ignore_exports_without_reordering_or_replacing() {
+        let input = "{\n  \"ignoreExports\": [\n    { \"file\": \"src/a.ts\", \"exports\": [\"*\"] }\n  ],\n  \"rules\": {}\n}\n";
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallowrc.json"),
+            input,
+            &[rule("src/a.ts"), rule("src/b.ts")],
+        )
+        .unwrap();
+        assert_eq!(output.matches("\"file\": \"src/a.ts\"").count(), 1);
+        assert!(output.find("\"file\": \"src/a.ts\"") < output.find("\"file\": \"src/b.ts\""));
+        assert!(output.contains("\"rules\": {}"));
+    }
+
+    #[test]
+    fn appends_toml_ignore_exports() {
+        let output = add_ignore_exports_rule_to_string(
+            Path::new("fallow.toml"),
+            "production = true\n",
+            &[rule("src/index.ts")],
+        )
+        .unwrap();
+        assert!(output.contains("production = true"));
+        assert!(output.contains("[[ignoreExports]]"));
+        assert!(output.contains("file = \"src/index.ts\""));
+        assert!(output.contains("exports = [\"*\"]"));
+    }
+
+    #[test]
+    fn appends_dot_fallow_toml_ignore_exports() {
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallow.toml"),
+            "",
+            &[rule("src/index.ts")],
+        )
+        .unwrap();
+        assert!(output.contains("[[ignoreExports]]"));
+        assert!(output.contains("file = \"src/index.ts\""));
+    }
+
+    #[test]
+    fn merges_existing_toml_ignore_exports() {
+        let input = "[[ignoreExports]]\nfile = \"src/a.ts\"\nexports = [\"*\"]\n";
+        let output = add_ignore_exports_rule_to_string(
+            Path::new("fallow.toml"),
+            input,
+            &[rule("src/a.ts"), rule("src/b.ts")],
+        )
+        .unwrap();
+        assert_eq!(output.matches("file = \"src/a.ts\"").count(), 1);
+        assert!(output.contains("file = \"src/b.ts\""));
+    }
+
+    #[test]
+    fn preserves_crlf_line_endings() {
+        let input = "{\r\n  \"rules\": {}\r\n}\r\n";
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallowrc.json"),
+            input,
+            &[rule("src/a.ts")],
+        )
+        .unwrap();
+        assert!(output.contains("\r\n"));
+        assert!(!output.contains("\r\r"));
+        assert!(!output.replace("\r\n", "").contains('\n'));
+    }
+
+    #[test]
+    fn preserves_toml_crlf_line_endings_without_double_carriage_returns() {
+        let input = "production = true\r\n";
+        let output =
+            add_ignore_exports_rule_to_string(Path::new("fallow.toml"), input, &[rule("src/a.ts")])
+                .unwrap();
+        assert!(output.contains("\r\n"));
+        assert!(!output.contains("\r\r"));
+        assert!(!output.replace("\r\n", "").contains('\n'));
+    }
+
+    #[test]
+    fn preserves_utf8_bom_on_json_config() {
+        let input = "\u{FEFF}{\n  \"rules\": {}\n}\n";
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallowrc.json"),
+            input,
+            &[rule("src/a.ts")],
+        )
+        .unwrap();
+        assert!(output.starts_with('\u{FEFF}'), "BOM stripped from output");
+        assert!(output.matches('\u{FEFF}').count() == 1, "BOM duplicated");
+        assert!(output.contains("\"file\": \"src/a.ts\""));
+    }
+
+    #[test]
+    fn preserves_utf8_bom_on_toml_config() {
+        let input = "\u{FEFF}production = true\n";
+        let output =
+            add_ignore_exports_rule_to_string(Path::new("fallow.toml"), input, &[rule("src/a.ts")])
+                .unwrap();
+        assert!(output.starts_with('\u{FEFF}'), "BOM stripped from output");
+        assert!(output.matches('\u{FEFF}').count() == 1, "BOM duplicated");
+        assert!(output.contains("[[ignoreExports]]"));
+    }
+
+    #[test]
+    fn no_bom_added_when_input_had_none() {
+        let input = "{\n}\n";
+        let output = add_ignore_exports_rule_to_string(
+            Path::new(".fallowrc.json"),
+            input,
+            &[rule("src/a.ts")],
+        )
+        .unwrap();
+        assert!(!output.starts_with('\u{FEFF}'));
+    }
+
+    #[test]
+    fn dedupes_existing_absolute_paths_against_relative_emissions() {
+        let config_dir = Path::new("/project");
+        let config_path = config_dir.join(".fallowrc.json");
+        let input = "{\n  \"ignoreExports\": [\n    { \"file\": \"/project/src/a.ts\", \"exports\": [\"*\"] }\n  ]\n}\n";
+        let output =
+            add_ignore_exports_rule_to_string(&config_path, input, &[rule("src/a.ts")]).unwrap();
+        assert_eq!(
+            output.matches("\"src/a.ts\"").count(),
+            0,
+            "writer must not add a relative duplicate of an existing absolute entry"
+        );
+        assert_eq!(
+            output.matches("\"/project/src/a.ts\"").count(),
+            1,
+            "existing absolute entry must remain"
+        );
+    }
+
+    #[test]
+    fn dedupes_existing_absolute_paths_against_relative_emissions_toml() {
+        let config_dir = Path::new("/project");
+        let config_path = config_dir.join("fallow.toml");
+        let input = "[[ignoreExports]]\nfile = \"/project/src/a.ts\"\nexports = [\"*\"]\n";
+        let output =
+            add_ignore_exports_rule_to_string(&config_path, input, &[rule("src/a.ts")]).unwrap();
+        assert_eq!(
+            output.matches("file = \"src/a.ts\"").count(),
+            0,
+            "writer must not add a relative duplicate of an existing absolute TOML entry"
+        );
+        assert_eq!(output.matches("file = \"/project/src/a.ts\"").count(), 1);
+    }
+}

--- a/crates/config/src/external_plugin.rs
+++ b/crates/config/src/external_plugin.rs
@@ -1,4 +1,3 @@
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
 use schemars::JsonSchema;
@@ -186,24 +185,13 @@ fn parse_plugin(content: &str, format: &PluginFormat, path: &Path) -> Option<Ext
                 None
             }
         },
-        PluginFormat::Jsonc => {
-            let mut stripped = String::new();
-            match json_comments::StripComments::new(content.as_bytes())
-                .read_to_string(&mut stripped)
-            {
-                Ok(_) => match serde_json::from_str::<ExternalPluginDef>(&stripped) {
-                    Ok(plugin) => Some(plugin),
-                    Err(e) => {
-                        tracing::warn!("failed to parse external plugin {}: {e}", path.display());
-                        None
-                    }
-                },
-                Err(e) => {
-                    tracing::warn!("failed to strip comments from {}: {e}", path.display());
-                    None
-                }
+        PluginFormat::Jsonc => match crate::jsonc::parse_to_value::<ExternalPluginDef>(content) {
+            Ok(plugin) => Some(plugin),
+            Err(e) => {
+                tracing::warn!("failed to parse external plugin {}: {e}", path.display());
+                None
             }
-        }
+        },
     }
 }
 
@@ -541,11 +529,7 @@ exports = ["default"]
             /* Block comment */
             "entryPoints": ["src/**/*.ts"]
         }"#;
-        let mut stripped = String::new();
-        json_comments::StripComments::new(jsonc_str.as_bytes())
-            .read_to_string(&mut stripped)
-            .unwrap();
-        let plugin: ExternalPluginDef = serde_json::from_str(&stripped).unwrap();
+        let plugin: ExternalPluginDef = crate::jsonc::parse_to_value(jsonc_str).unwrap();
         assert_eq!(plugin.name, "my-jsonc-plugin");
         assert_eq!(plugin.enablers, vec!["my-pkg"]);
         assert_eq!(plugin.entry_points, vec!["src/**/*.ts"]);

--- a/crates/config/src/jsonc.rs
+++ b/crates/config/src/jsonc.rs
@@ -1,0 +1,19 @@
+use serde::de::DeserializeOwned;
+
+pub fn parse_options() -> jsonc_parser::ParseOptions {
+    jsonc_parser::ParseOptions {
+        allow_comments: true,
+        allow_loose_object_property_names: false,
+        allow_trailing_commas: true,
+        allow_missing_commas: false,
+        allow_single_quoted_strings: false,
+        allow_hexadecimal_numbers: false,
+        allow_unary_plus_numbers: false,
+    }
+}
+
+pub fn parse_to_value<T: DeserializeOwned>(
+    content: &str,
+) -> Result<T, jsonc_parser::errors::ParseError> {
+    jsonc_parser::parse_to_serde_value(content, &parse_options())
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,7 +1,10 @@
 mod config;
+mod config_writer;
 mod external_plugin;
+mod jsonc;
 mod workspace;
 
 pub use config::*;
+pub use config_writer::*;
 pub use external_plugin::*;
 pub use workspace::*;

--- a/crates/config/src/workspace/parsers.rs
+++ b/crates/config/src/workspace/parsers.rs
@@ -1,10 +1,8 @@
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
 /// Parse `tsconfig.json` at the project root and extract `references[].path` directories.
 ///
-/// Returns directories that exist on disk. tsconfig.json is JSONC (comments + trailing commas),
-/// so we strip both before parsing.
+/// Returns directories that exist on disk. tsconfig.json is JSONC (comments + trailing commas).
 pub(super) fn parse_tsconfig_references(root: &Path) -> Vec<PathBuf> {
     let tsconfig_path = root.join("tsconfig.json");
     let Ok(content) = std::fs::read_to_string(&tsconfig_path) else {
@@ -14,19 +12,7 @@ pub(super) fn parse_tsconfig_references(root: &Path) -> Vec<PathBuf> {
     // Strip UTF-8 BOM if present (common in Windows-authored tsconfig files)
     let content = content.trim_start_matches('\u{FEFF}');
 
-    // Strip JSONC comments
-    let mut stripped = String::new();
-    if json_comments::StripComments::new(content.as_bytes())
-        .read_to_string(&mut stripped)
-        .is_err()
-    {
-        return Vec::new();
-    }
-
-    // Strip trailing commas (common in tsconfig.json)
-    let cleaned = strip_trailing_commas(&stripped);
-
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&cleaned) else {
+    let Ok(value) = crate::jsonc::parse_to_value::<serde_json::Value>(content) else {
         return Vec::new();
     };
 
@@ -50,19 +36,12 @@ pub(super) fn parse_tsconfig_references(root: &Path) -> Vec<PathBuf> {
 /// Parse `tsconfig.json` at the project root and extract `compilerOptions.rootDir`.
 ///
 /// Returns `None` if the file is missing, malformed, or has no `rootDir` set.
-/// Strips JSONC comments and trailing commas before parsing.
 pub fn parse_tsconfig_root_dir(root: &Path) -> Option<String> {
     let tsconfig_path = root.join("tsconfig.json");
     let content = std::fs::read_to_string(&tsconfig_path).ok()?;
     let content = content.trim_start_matches('\u{FEFF}');
 
-    let mut stripped = String::new();
-    json_comments::StripComments::new(content.as_bytes())
-        .read_to_string(&mut stripped)
-        .ok()?;
-
-    let cleaned = strip_trailing_commas(&stripped);
-    let value: serde_json::Value = serde_json::from_str(&cleaned).ok()?;
+    let value: serde_json::Value = crate::jsonc::parse_to_value(content).ok()?;
 
     value
         .get("compilerOptions")
@@ -80,6 +59,7 @@ pub fn parse_tsconfig_root_dir(root: &Path) -> Option<String> {
 ///
 /// tsconfig.json commonly uses trailing commas which are valid JSONC but not valid JSON.
 /// This strips them so `serde_json` can parse the content.
+#[cfg(test)]
 pub(super) fn strip_trailing_commas(input: &str) -> String {
     let bytes = input.as_bytes();
     let len = bytes.len();

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -38,7 +38,7 @@ rustc-hash = { workspace = true }
 # Logging
 tracing = { workspace = true }
 serde_json = { workspace = true }
-json_comments = { workspace = true }
+jsonc-parser = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -2,7 +2,6 @@
 
 use std::ffi::OsString;
 use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use globset::{Glob, GlobSetBuilder};
@@ -387,71 +386,19 @@ fn read_json_file(path: &Path) -> Option<Value> {
     if let Ok(json) = serde_json::from_str::<Value>(&content) {
         return Some(json);
     }
-    let mut stripped = String::new();
-    json_comments::StripComments::new(content.as_bytes())
-        .read_to_string(&mut stripped)
-        .ok()?;
-    serde_json::from_str(&stripped)
-        .or_else(|_| serde_json::from_str(&strip_trailing_commas(&stripped)))
-        .ok()
+    jsonc_parser::parse_to_serde_value::<Value>(&content, &jsonc_parse_options()).ok()
 }
 
-fn strip_trailing_commas(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-    let mut last_emit = 0;
-    let mut in_string = false;
-    let mut escaped = false;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if b == b'\\' {
-                escaped = true;
-            } else if b == b'"' {
-                in_string = false;
-            }
-            i += 1;
-            continue;
-        }
-        if b == b'"' {
-            in_string = true;
-            i += 1;
-            continue;
-        }
-        if b == b',' {
-            let mut j = i + 1;
-            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-                j += 1;
-            }
-            if j < bytes.len()
-                && (bytes[j] == b'}' || bytes[j] == b']')
-                && comma_follows_json_value(bytes, i)
-            {
-                out.push_str(&input[last_emit..i]);
-                last_emit = i + 1;
-            }
-        }
-        i += 1;
+fn jsonc_parse_options() -> jsonc_parser::ParseOptions {
+    jsonc_parser::ParseOptions {
+        allow_comments: true,
+        allow_loose_object_property_names: false,
+        allow_trailing_commas: true,
+        allow_missing_commas: false,
+        allow_single_quoted_strings: false,
+        allow_hexadecimal_numbers: false,
+        allow_unary_plus_numbers: false,
     }
-
-    out.push_str(&input[last_emit..]);
-    out
-}
-
-fn comma_follows_json_value(bytes: &[u8], comma_index: usize) -> bool {
-    let Some(prev) = bytes[..comma_index]
-        .iter()
-        .rev()
-        .copied()
-        .find(|b| !b.is_ascii_whitespace())
-    else {
-        return false;
-    };
-    matches!(prev, b'"' | b'}' | b']' | b'0'..=b'9' | b'e' | b'l')
 }
 
 fn path_alias_pattern_matches(pattern: &str, specifier: &str) -> bool {

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -1940,8 +1940,7 @@
         },
         "auto_fixable": {
           "type": "boolean",
-          "const": false,
-          "description": "Always false for config actions."
+          "description": "True when `fallow fix` can apply this config action automatically for the current action type. `ignoreExports` duplicate-export actions are auto-fixable when a config file exists; older scalar config-ignore actions remain manual."
         },
         "description": {
           "type": "string",

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -215,9 +215,9 @@ export interface AddToConfigAction {
  */
 type: "add-to-config"
 /**
- * Always false for config actions.
+ * True when `fallow fix` can apply this config action automatically for the current action type. `ignoreExports` duplicate-export actions are auto-fixable when a config file exists; older scalar config-ignore actions remain manual.
  */
-auto_fixable: false
+auto_fixable: boolean
 /**
  * Human-readable description of the config change.
  */

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -215,9 +215,9 @@ export interface AddToConfigAction {
  */
 type: "add-to-config"
 /**
- * Always false for config actions.
+ * True when `fallow fix` can apply this config action automatically for the current action type. `ignoreExports` duplicate-export actions are auto-fixable when a config file exists; older scalar config-ignore actions remain manual.
  */
-auto_fixable: false
+auto_fixable: boolean
 /**
  * Human-readable description of the config change.
  */


### PR DESCRIPTION
## Summary

`fallow fix` can now apply the `add-to-config` action for duplicate-export findings directly to the user's fallow config file, instead of just emitting a paste-ready snippet. The action flips from `auto_fixable: false` to `auto_fixable: true` whenever a config file exists; with no config, fix skips with a clear `Run 'fallow init' to create one` message.

This unblocks shadcn / Radix / bits-ui-style namespace-barrel projects where users had to hand-paste 30+ ignoreExports entries.

## What ships

- **Writer module** `fallow_config::add_ignore_exports_rule` covers all four supported config formats atomically. JSON/JSONC go through [`jsonc-parser`](https://crates.io/crates/jsonc-parser) (format-preserving CST); TOML / `.fallow.toml` go through [`toml_edit`](https://crates.io/crates/toml_edit). Both round-trip comments, ordering, inline-vs-newline shape, trailing commas, CRLF/LF line endings, and a UTF-8 BOM.
- **Merge semantics:** append-only, dedupe on exact `file` match, no reorder, no replace. Absolute existing entries dedupe against the writer's relative emissions when they resolve under the config dir.
- **Workspace path re-anchoring:** when the config lives in a workspace subdir (e.g. `packages/ui/.fallowrc.json`), emitted paths are relative to that config's directory.
- **Symlink-safe writes:** `atomic_write` canonicalizes the target before persisting so configs mounted as symlinks (common in Docker setups) get their target updated rather than being replaced with a regular file.
- **Parser convergence:** all `json_comments::StripComments` parse sites replaced with `jsonc-parser` so reads and writes share the same JSONC dialect.
- **Schema:** `AddToConfigAction.auto_fixable` widens from `const false` to `boolean`. TypeScript contract regenerated for both `editors/vscode/src/generated/output-contract.d.ts` and `npm/fallow/types/output-contract.d.ts`.

## Test plan

- [x] cargo test -p fallow-cli -p fallow-config --all-targets
- [x] cargo clippy -p fallow-cli -p fallow-config -- -D warnings
- [x] cargo fmt --all -- --check
- [x] typos
- [x] check:codegen (regenerated TS contract is in sync)
- [x] End-to-end smoke combining BOM-prefixed JSON config + symlinked path + pre-existing absolute-path entry: write succeeds, BOM preserved (count=1), symlink intact, no abs/rel duplicate, post-fix dead-code reports 0 duplicates, second fix is byte-idempotent
- [x] TOML BOM round-trip end-to-end smoke
- [x] Workspace-subdir re-anchor smoke (`packages/ui/.fallowrc.json` emits `src/index.ts` not `packages/ui/src/index.ts`)
- [x] Missing-config skip message verified

## Out of scope (separate issues)

- Optional `value_schema` URL field on `add-to-config` actions for AI-agent input validation
- Missing-config-file auto-creation policy and `fallow fix --dry-run` config diff preview
- Threading explicit `--config <path>` through into `auto_fixable` (narrow edge case: user passes `--config` pointing outside root's ancestors AND agent gates on `auto_fixable` rather than attempting the fix)