### PR TITLE
fix: tighten runtime coverage mapping

### DIFF
--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -832,7 +832,7 @@ fn match_cloud_function(
     static_index: &StaticIndex,
 ) -> Option<StaticFunctionInfo> {
     let path = normalize_runtime_path(Path::new(&function.file_path));
-    let line = function.start_line.or(function.line_number).unwrap_or(0);
+    let line = function.start_line.or(function.line_number)?;
     if let Some(info) =
         static_index
             .by_key
@@ -843,17 +843,54 @@ fn match_cloud_function(
     static_index
         .by_path_name
         .get(&(path, function.function_name.clone()))
-        .and_then(|candidates| {
-            candidates
-                .iter()
-                .find(|candidate| {
-                    let end = function.end_line.unwrap_or(candidate.end_line);
-                    candidate.start_line.abs_diff(line) <= 5
-                        && candidate.end_line.abs_diff(end) <= 5
-                })
-                .cloned()
-                .or_else(|| candidates.first().cloned())
-        })
+        .and_then(|candidates| nearest_cloud_candidate(candidates, line, function.end_line))
+}
+
+fn nearest_cloud_candidate(
+    candidates: &[StaticFunctionInfo],
+    start_line: u32,
+    end_line: Option<u32>,
+) -> Option<StaticFunctionInfo> {
+    let mut best: Option<(&StaticFunctionInfo, (u32, u32))> = None;
+    let mut tied = false;
+
+    for candidate in candidates {
+        let start_delta = candidate.start_line.abs_diff(start_line);
+        if start_delta > 5 {
+            continue;
+        }
+        let end_delta = match end_line {
+            Some(line) => {
+                let delta = candidate.end_line.abs_diff(line);
+                if delta > 5 {
+                    continue;
+                }
+                delta
+            }
+            None => 0,
+        };
+        let distance = (start_delta, end_delta);
+        match best {
+            None => {
+                best = Some((candidate, distance));
+                tied = false;
+            }
+            Some((_, current)) if distance < current => {
+                best = Some((candidate, distance));
+                tied = false;
+            }
+            Some((_, current)) if distance == current => {
+                tied = true;
+            }
+            Some(_) => {}
+        }
+    }
+
+    if tied {
+        None
+    } else {
+        best.map(|(candidate, _)| candidate.clone())
+    }
 }
 
 fn normalize_runtime_path(path: &Path) -> String {
@@ -1153,6 +1190,46 @@ mod tests {
     }
 
     #[test]
+    fn cloud_match_rejects_same_name_when_line_does_not_match() {
+        let static_index = static_index_with(vec![
+            static_info("src/api.ts", "handler", 10, 20),
+            static_info("src/api.ts", "handler", 80, 90),
+        ]);
+        let function = cloud_function("src/api.ts", "handler", Some(40), Some(40), Some(50));
+
+        assert!(match_cloud_function(&function, &static_index).is_none());
+    }
+
+    #[test]
+    fn cloud_match_allows_small_line_drift() {
+        let static_index = static_index_with(vec![static_info("src/api.ts", "handler", 10, 20)]);
+        let function = cloud_function("src/api.ts", "handler", Some(12), Some(12), Some(22));
+
+        let matched = match_cloud_function(&function, &static_index).expect("nearby line matches");
+        assert_eq!(matched.start_line, 10);
+        assert_eq!(matched.end_line, 20);
+    }
+
+    #[test]
+    fn cloud_match_requires_line_data_for_fuzzy_match() {
+        let static_index = static_index_with(vec![static_info("src/api.ts", "handler", 10, 20)]);
+        let function = cloud_function("src/api.ts", "handler", None, None, Some(20));
+
+        assert!(match_cloud_function(&function, &static_index).is_none());
+    }
+
+    #[test]
+    fn cloud_match_rejects_ambiguous_fuzzy_match() {
+        let static_index = static_index_with(vec![
+            static_info("src/api.ts", "handler", 10, 20),
+            static_info("src/api.ts", "handler", 14, 20),
+        ]);
+        let function = cloud_function("src/api.ts", "handler", Some(12), Some(12), Some(20));
+
+        assert!(match_cloud_function(&function, &static_index).is_none());
+    }
+
+    #[test]
     fn cloud_never_called_static_used_emits_review_runtime_action() {
         let actions = runtime_actions(RuntimeCoverageVerdict::ReviewRequired);
         assert_eq!(actions.len(), 1);
@@ -1353,6 +1430,57 @@ mod tests {
                 deployments_observed: 0,
             },
             actions: vec![],
+        }
+    }
+
+    fn static_info(path: &str, name: &str, start_line: u32, end_line: u32) -> StaticFunctionInfo {
+        StaticFunctionInfo {
+            path: PathBuf::from(path),
+            name: name.to_owned(),
+            start_line,
+            end_line,
+            static_used: false,
+            test_covered: false,
+            cyclomatic: 1,
+            caller_count: 0,
+            owner_count: None,
+        }
+    }
+
+    fn static_index_with(functions: Vec<StaticFunctionInfo>) -> StaticIndex {
+        let mut static_index = StaticIndex::default();
+        for function in functions {
+            let path = normalize_runtime_path(&function.path);
+            static_index.by_key.insert(
+                (path.clone(), function.name.clone(), function.start_line),
+                function.clone(),
+            );
+            static_index
+                .by_path_name
+                .entry((path, function.name.clone()))
+                .or_default()
+                .push(function);
+        }
+        static_index
+    }
+
+    fn cloud_function(
+        path: &str,
+        name: &str,
+        line_number: Option<u32>,
+        start_line: Option<u32>,
+        end_line: Option<u32>,
+    ) -> CloudRuntimeFunction {
+        CloudRuntimeFunction {
+            file_path: path.to_owned(),
+            function_name: name.to_owned(),
+            line_number,
+            start_line,
+            end_line,
+            hit_count: Some(0),
+            tracking_state: CloudTrackingState::NeverCalled,
+            deployments_observed: 1,
+            untracked_reason: None,
         }
     }
 

--- a/crates/cli/src/coverage/upload_source_maps.rs
+++ b/crates/cli/src/coverage/upload_source_maps.rs
@@ -171,6 +171,11 @@ fn parse_repo_name_from_url(url: &str) -> Option<String> {
         .trim_end_matches('/')
         .trim_end_matches(".git")
         .trim_end_matches('/');
+    if !stripped_suffix.contains(':')
+        && let Some(project_id) = take_last_two_segments(stripped_suffix)
+    {
+        return Some(project_id);
+    }
     if let Some((_, path)) = stripped_suffix.split_once(':')
         && let Some(project_id) = take_last_two_segments(path)
     {
@@ -748,6 +753,10 @@ mod tests {
         assert_eq!(
             parse_repo_name_from_url("ssh://git@gitlab.com/acme/team/widgets"),
             Some("team/widgets".to_owned())
+        );
+        assert_eq!(
+            parse_repo_name_from_url("acme/widgets"),
+            Some("acme/widgets".to_owned())
         );
     }
 

--- a/crates/cli/src/coverage/upload_source_maps.rs
+++ b/crates/cli/src/coverage/upload_source_maps.rs
@@ -166,16 +166,37 @@ fn git_origin_repo_name(root: &Path) -> Option<String> {
 }
 
 fn parse_repo_name_from_url(url: &str) -> Option<String> {
-    let trimmed = url.trim().trim_end_matches(".git").trim_end_matches('/');
-    let last = trimmed
-        .rsplit(['/', ':'])
-        .find(|segment| !segment.trim().is_empty())?;
-    let repo = last.trim();
-    if repo.is_empty() {
-        None
-    } else {
-        Some(repo.to_owned())
+    let stripped_suffix = url
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
+    if let Some((_, path)) = stripped_suffix.split_once(':')
+        && let Some(project_id) = take_last_two_segments(path)
+    {
+        return Some(project_id);
     }
+    if let Some(path_part) = stripped_suffix.split("://").nth(1)
+        && let Some((_, tail)) = path_part.split_once('/')
+        && let Some(project_id) = take_last_two_segments(tail)
+    {
+        return Some(project_id);
+    }
+    None
+}
+
+fn take_last_two_segments(path: &str) -> Option<String> {
+    let mut parts: Vec<&str> = path
+        .trim_end_matches('/')
+        .split('/')
+        .filter(|segment| !segment.trim().is_empty())
+        .collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let repo = parts.pop()?.trim();
+    let owner = parts.pop()?.trim();
+    (!owner.is_empty() && !repo.is_empty()).then(|| format!("{owner}/{repo}"))
 }
 
 fn validate_repo_name(repo: &str) -> Result<&str, UploadSourceMapsError> {
@@ -718,15 +739,15 @@ mod tests {
     fn parses_repo_name_from_common_urls() {
         assert_eq!(
             parse_repo_name_from_url("https://github.com/acme/widgets.git"),
-            Some("widgets".to_owned())
+            Some("acme/widgets".to_owned())
         );
         assert_eq!(
             parse_repo_name_from_url("git@github.com:acme/widgets.git"),
-            Some("widgets".to_owned())
+            Some("acme/widgets".to_owned())
         );
         assert_eq!(
             parse_repo_name_from_url("ssh://git@gitlab.com/acme/team/widgets"),
-            Some("widgets".to_owned())
+            Some("team/widgets".to_owned())
         );
     }
 

--- a/crates/cli/src/health/coverage.rs
+++ b/crates/cli/src/health/coverage.rs
@@ -1154,56 +1154,13 @@ fn remap_script_with_source_map(
 fn line_offsets_for_script(
     script: &fallow_v8_coverage::ScriptCoverage,
     entry: &SourceMapCacheEntry,
-) -> Option<Vec<u32>> {
+) -> Option<fallow_v8_coverage::LineOffsetTable> {
     if let Some(path) = file_url_to_path(&script.url)
         && let Ok(source) = fs::read_to_string(path)
     {
-        return Some(build_line_offsets_from_source(&source));
+        return Some(fallow_v8_coverage::LineOffsetTable::from_source(&source));
     }
-    build_line_offsets_from_lengths(&entry.line_lengths)
-}
-
-fn build_line_offsets_from_source(source: &str) -> Vec<u32> {
-    let mut line_starts = Vec::with_capacity(source.lines().count().saturating_add(1));
-    line_starts.push(0);
-    let bytes = source.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'\n' => {
-                line_starts.push((i + 1) as u32);
-                i += 1;
-            }
-            b'\r' => {
-                let next = if bytes.get(i + 1) == Some(&b'\n') {
-                    i + 2
-                } else {
-                    i + 1
-                };
-                line_starts.push(next as u32);
-                i = next;
-            }
-            _ => i += 1,
-        }
-    }
-    line_starts
-}
-
-fn build_line_offsets_from_lengths(line_lengths: &[u32]) -> Option<Vec<u32>> {
-    if line_lengths.is_empty() {
-        return None;
-    }
-    let mut line_starts = Vec::with_capacity(line_lengths.len());
-    line_starts.push(0);
-    let mut offset = 0u32;
-    for length in line_lengths
-        .iter()
-        .take(line_lengths.len().saturating_sub(1))
-    {
-        offset = offset.saturating_add(*length).saturating_add(1);
-        line_starts.push(offset);
-    }
-    Some(line_starts)
+    fallow_v8_coverage::LineOffsetTable::from_v8_line_lengths(&entry.line_lengths)
 }
 
 fn remap_function(
@@ -1211,7 +1168,7 @@ fn remap_function(
     function: &fallow_v8_coverage::FunctionCoverage,
     entry: &SourceMapCacheEntry,
     sourcemap: &SourceMap,
-    line_offsets: &[u32],
+    line_offsets: &fallow_v8_coverage::LineOffsetTable,
 ) -> Option<RemappedFunction> {
     let outer = function.ranges.first().copied()?;
     let start = offset_to_position(line_offsets, outer.start_offset);
@@ -1268,15 +1225,14 @@ fn remap_function(
     })
 }
 
-fn offset_to_position(line_offsets: &[u32], byte_offset: u32) -> Position {
-    let line_index = match line_offsets.binary_search(&byte_offset) {
-        Ok(exact) => exact,
-        Err(insertion_point) => insertion_point.saturating_sub(1),
-    };
-    let line_start = line_offsets[line_index];
+fn offset_to_position(
+    line_offsets: &fallow_v8_coverage::LineOffsetTable,
+    source_offset: u32,
+) -> Position {
+    let pos = line_offsets.position(source_offset);
     Position {
-        line: line_index as u32 + 1,
-        column: byte_offset.saturating_sub(line_start),
+        line: pos.line,
+        column: pos.column,
     }
 }
 
@@ -2760,6 +2716,85 @@ mod tests {
             "expected remapped file key {key}"
         );
         assert_eq!(parsed[&key]["path"], key);
+        assert_eq!(parsed[&key]["fnMap"]["0"]["name"], "alpha");
+        assert_eq!(parsed[&key]["fnMap"]["0"]["line"], 1);
+        assert_eq!(parsed[&key]["f"]["0"], 3);
+
+        std::fs::remove_dir_all(&root)
+            .unwrap_or_else(|err| panic!("failed to clean temp dir {}: {err}", root.display()));
+    }
+
+    #[test]
+    fn remaps_v8_offsets_as_utf16_source_positions() {
+        let root = make_temp_dir("coverage-remap-utf16");
+        let src_dir = root.join("src");
+        let dist_dir = root.join("dist");
+        std::fs::create_dir_all(&src_dir)
+            .unwrap_or_else(|err| panic!("failed to create {}: {err}", src_dir.display()));
+        std::fs::create_dir_all(&dist_dir)
+            .unwrap_or_else(|err| panic!("failed to create {}: {err}", dist_dir.display()));
+
+        let original = src_dir.join("app.ts");
+        std::fs::write(&original, "export function alpha() {}\n")
+            .unwrap_or_else(|err| panic!("failed to write {}: {err}", original.display()));
+
+        let generated = "const smile = \"😀\";\nfunction alpha() {}\n";
+        let generated_path = dist_dir.join("bundle.js");
+        std::fs::write(&generated_path, generated)
+            .unwrap_or_else(|err| panic!("failed to write {}: {err}", generated_path.display()));
+        let function_byte_offset = generated
+            .find("function")
+            .expect("generated source should contain function");
+        let function_v8_offset = generated[..function_byte_offset].encode_utf16().count() as u32;
+        assert_ne!(function_v8_offset, function_byte_offset as u32);
+
+        let v8_file = root.join("coverage-v8.json");
+        let v8_json = serde_json::json!({
+            "result": [{
+                "scriptId": "1",
+                "url": file_url(&generated_path),
+                "functions": [{
+                    "functionName": "alpha",
+                    "ranges": [{"startOffset": function_v8_offset, "endOffset": function_v8_offset + 19, "count": 3}],
+                    "isBlockCoverage": false
+                }]
+            }],
+            "source-map-cache": {
+                file_url(&generated_path): {
+                    "url": "bundle.js.map",
+                    "data": {
+                        "version": 3,
+                        "sources": ["../src/app.ts"],
+                        "names": [],
+                        "mappings": ";AAAA"
+                    },
+                    "lineLengths": [20, 19]
+                }
+            }
+        });
+        std::fs::write(&v8_file, serde_json::to_vec(&v8_json).unwrap())
+            .unwrap_or_else(|err| panic!("failed to write {}: {err}", v8_file.display()));
+
+        let prepared = prepare_coverage_sources(&v8_file)
+            .unwrap_or_else(|err| panic!("failed to preprocess coverage: {err}"));
+
+        assert_eq!(prepared.sources.len(), 1);
+        let CoverageSource::Istanbul { path } = &prepared.sources[0] else {
+            panic!("expected remapped istanbul coverage source");
+        };
+        let output = std::fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read remapped coverage {path}: {err}"));
+        let parsed: serde_json::Value = serde_json::from_str(&output)
+            .unwrap_or_else(|err| panic!("failed to parse remapped coverage: {err}"));
+        let key = dunce::canonicalize(&original)
+            .unwrap_or_else(|err| panic!("failed to canonicalize {}: {err}", original.display()))
+            .to_string_lossy()
+            .into_owned();
+
+        assert!(
+            parsed.get(&key).is_some(),
+            "expected remapped file key {key}"
+        );
         assert_eq!(parsed[&key]["fnMap"]["0"]["name"], "alpha");
         assert_eq!(parsed[&key]["fnMap"]["0"]["line"], 1);
         assert_eq!(parsed[&key]["f"]["0"], 3);

--- a/crates/cli/src/health/coverage.rs
+++ b/crates/cli/src/health/coverage.rs
@@ -111,6 +111,11 @@ struct RemappedFunction {
     hits: u32,
 }
 
+struct RemappedScript {
+    functions: Vec<RemappedFunction>,
+    residual_script: Option<fallow_v8_coverage::ScriptCoverage>,
+}
+
 #[derive(Debug, Clone)]
 struct AccumulatedFunction {
     entry: FnEntry,
@@ -1077,7 +1082,10 @@ fn preprocess_v8_coverage_file(
             residual_scripts.push(script);
             continue;
         };
-        merge_remapped_functions(&mut remapped_files, mapped);
+        merge_remapped_functions(&mut remapped_files, mapped.functions);
+        if let Some(residual_script) = mapped.residual_script {
+            residual_scripts.push(residual_script);
+        }
     }
 
     if remapped_files.is_empty() {
@@ -1138,17 +1146,33 @@ fn ensure_temp_dir(temp_dir: &mut Option<TempDir>) -> Result<&Path, String> {
 fn remap_script_with_source_map(
     script: &fallow_v8_coverage::ScriptCoverage,
     entry: &SourceMapCacheEntry,
-) -> Option<Vec<RemappedFunction>> {
+) -> Option<RemappedScript> {
     let sourcemap = SourceMap::from_json(&entry.data.to_string()).ok()?;
     let offsets = line_offsets_for_script(script, entry)?;
     let mut remapped = Vec::new();
+    let mut residual_functions = Vec::new();
 
     for function in &script.functions {
-        let mapped = remap_function(script, function, entry, &sourcemap, &offsets)?;
-        remapped.push(mapped);
+        match remap_function(script, function, entry, &sourcemap, &offsets) {
+            Some(mapped) => remapped.push(mapped),
+            None => residual_functions.push(function.clone()),
+        }
     }
 
-    (!remapped.is_empty()).then_some(remapped)
+    if remapped.is_empty() {
+        return None;
+    }
+
+    let residual_script = (!residual_functions.is_empty()).then(|| {
+        let mut script = script.clone();
+        script.functions = residual_functions;
+        script
+    });
+
+    Some(RemappedScript {
+        functions: remapped,
+        residual_script,
+    })
 }
 
 fn line_offsets_for_script(
@@ -2804,7 +2828,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_raw_v8_when_any_function_in_script_cannot_be_remapped() {
+    fn keeps_mapped_functions_when_other_functions_cannot_be_remapped() {
         let root = make_temp_dir("coverage-remap-partial");
         let src_dir = root.join("src");
         let dist_dir = root.join("dist");
@@ -2854,11 +2878,42 @@ mod tests {
         let prepared = prepare_coverage_sources(&v8_file)
             .unwrap_or_else(|err| panic!("failed to preprocess coverage: {err}"));
 
-        assert_eq!(prepared.sources.len(), 1);
-        assert!(matches!(
-            &prepared.sources[0],
-            CoverageSource::V8 { path } if path.ends_with("coverage-v8.json")
-        ));
+        assert_eq!(prepared.sources.len(), 2);
+        let CoverageSource::Istanbul {
+            path: remapped_path,
+        } = &prepared.sources[0]
+        else {
+            panic!("expected remapped istanbul coverage source");
+        };
+        let remapped_output = std::fs::read_to_string(remapped_path).unwrap_or_else(|err| {
+            panic!("failed to read remapped coverage {remapped_path}: {err}")
+        });
+        let remapped: serde_json::Value = serde_json::from_str(&remapped_output)
+            .unwrap_or_else(|err| panic!("failed to parse remapped coverage: {err}"));
+        let key = dunce::canonicalize(&original)
+            .unwrap_or_else(|err| panic!("failed to canonicalize {}: {err}", original.display()))
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(remapped[&key]["fnMap"]["0"]["name"], "alpha");
+        assert_eq!(remapped[&key]["f"]["0"], 3);
+
+        let CoverageSource::V8 {
+            path: residual_path,
+        } = &prepared.sources[1]
+        else {
+            panic!("expected residual v8 coverage source");
+        };
+        let residual_output = std::fs::read_to_string(residual_path).unwrap_or_else(|err| {
+            panic!("failed to read residual coverage {residual_path}: {err}")
+        });
+        let residual: serde_json::Value = serde_json::from_str(&residual_output)
+            .unwrap_or_else(|err| panic!("failed to parse residual coverage: {err}"));
+        let residual_functions = residual["result"][0]["functions"]
+            .as_array()
+            .expect("residual functions array");
+        assert_eq!(residual_functions.len(), 1);
+        assert_eq!(residual_functions[0]["functionName"], "broken");
 
         std::fs::remove_dir_all(&root)
             .unwrap_or_else(|err| panic!("failed to clean temp dir {}: {err}", root.display()));

--- a/crates/v8-coverage/src/lib.rs
+++ b/crates/v8-coverage/src/lib.rs
@@ -133,17 +133,21 @@ where
     Ok(Option::<u32>::deserialize(deserializer)?.unwrap_or(0))
 }
 
-// -- Byte-offset to line/column mapper -------------------------------------
+// -- V8 offset to line/column mapper ---------------------------------------
 
-/// Pre-computed line-start byte-offset table for converting V8 byte offsets
-/// into Istanbul line/column positions in O(log n) per lookup.
+/// Pre-computed line-start table for converting V8 source offsets into
+/// Istanbul line/column positions in O(log n) per lookup.
+///
+/// V8 reports offsets in JavaScript source positions: UTF-16 code units, not
+/// UTF-8 bytes. Istanbul columns use the same 0-indexed source-position model,
+/// so this table stores line starts in UTF-16 units.
 ///
 /// The source is consumed once at construction; subsequent lookups are
 /// allocation-free.
 #[derive(Debug)]
 pub struct LineOffsetTable {
-    /// Byte offset of the first character of each line. `line_starts[0]` is
-    /// always `0` (the start of the file).
+    /// UTF-16 offset of the first character of each line. `line_starts[0]`
+    /// is always `0` (the start of the file).
     line_starts: Vec<u32>,
 }
 
@@ -154,44 +158,67 @@ impl LineOffsetTable {
     pub fn from_source(source: &str) -> Self {
         let mut line_starts = Vec::with_capacity(source.lines().count() + 1);
         line_starts.push(0);
-        let bytes = source.as_bytes();
-        let mut i = 0;
-        while i < bytes.len() {
-            match bytes[i] {
-                b'\n' => {
-                    line_starts.push((i + 1) as u32);
-                    i += 1;
+        let mut offset = 0u32;
+        let mut chars = source.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '\n' => {
+                    offset = offset.saturating_add(1);
+                    line_starts.push(offset);
                 }
-                b'\r' => {
-                    let next_offset = if bytes.get(i + 1) == Some(&b'\n') {
-                        i + 2
-                    } else {
-                        i + 1
-                    };
-                    line_starts.push(next_offset as u32);
-                    i = next_offset;
+                '\r' => {
+                    offset = offset.saturating_add(1);
+                    if chars.peek() == Some(&'\n') {
+                        chars.next();
+                        offset = offset.saturating_add(1);
+                    }
+                    line_starts.push(offset);
                 }
-                _ => i += 1,
+                _ => offset = offset.saturating_add(ch.len_utf16() as u32),
             }
         }
         Self { line_starts }
     }
 
-    /// Convert a byte offset to a 1-indexed line + 0-indexed column.
+    /// Build a table from V8's `source-map-cache.lineLengths` data.
+    ///
+    /// `lineLengths` are already measured in JavaScript source positions. The
+    /// cache does not carry line-ending widths, so this preserves the existing
+    /// Node fallback behavior and advances one source position between lines.
+    #[must_use]
+    pub fn from_v8_line_lengths(line_lengths: &[u32]) -> Option<Self> {
+        if line_lengths.is_empty() {
+            return None;
+        }
+
+        let mut line_starts = Vec::with_capacity(line_lengths.len());
+        line_starts.push(0);
+        let mut offset = 0u32;
+        for length in line_lengths
+            .iter()
+            .take(line_lengths.len().saturating_sub(1))
+        {
+            offset = offset.saturating_add(*length).saturating_add(1);
+            line_starts.push(offset);
+        }
+        Some(Self { line_starts })
+    }
+
+    /// Convert a V8 source offset to a 1-indexed line + 0-indexed column.
     ///
     /// Offsets at or past the end of the source clamp to the last line +
     /// remaining column.
     #[must_use]
-    pub fn position(&self, byte_offset: u32) -> IstanbulPosition {
-        // Binary search for the last line_start <= byte_offset.
-        let line_zero_indexed = match self.line_starts.binary_search(&byte_offset) {
+    pub fn position(&self, source_offset: u32) -> IstanbulPosition {
+        // Binary search for the last line_start <= source_offset.
+        let line_zero_indexed = match self.line_starts.binary_search(&source_offset) {
             Ok(exact) => exact,
             Err(insertion_point) => insertion_point.saturating_sub(1),
         };
         let line_start = self.line_starts[line_zero_indexed];
         IstanbulPosition {
             line: (line_zero_indexed as u32) + 1,
-            column: byte_offset.saturating_sub(line_start),
+            column: source_offset.saturating_sub(line_start),
         }
     }
 }
@@ -288,6 +315,34 @@ mod tests {
         let table = LineOffsetTable::from_source("a\rbb");
         assert_eq!(table.position(2).line, 2);
         assert_eq!(table.position(2).column, 0);
+    }
+
+    #[test]
+    fn line_table_uses_utf16_offsets_for_non_ascii_source() {
+        let source = "const smile = \"😀\";\nfunction after_emoji() {}\n";
+        let function_byte_offset = source
+            .find("function")
+            .expect("test source should contain function");
+        let function_v8_offset = source[..function_byte_offset].encode_utf16().count() as u32;
+
+        assert_ne!(function_v8_offset, function_byte_offset as u32);
+
+        let table = LineOffsetTable::from_source(source);
+        let pos = table.position(function_v8_offset);
+
+        assert_eq!(pos.line, 2);
+        assert_eq!(pos.column, 0);
+    }
+
+    #[test]
+    fn line_table_builds_from_v8_line_lengths() {
+        let table = LineOffsetTable::from_v8_line_lengths(&[20, 12])
+            .expect("line lengths should build table");
+
+        assert_eq!(table.position(20).line, 1);
+        assert_eq!(table.position(20).column, 20);
+        assert_eq!(table.position(21).line, 2);
+        assert_eq!(table.position(21).column, 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes a few runtime coverage accuracy issues.

V8 offsets now use UTF-16 source positions.
Partial source map remaps keep the mapped functions.
Source map uploads keep owner/repo when inferring the project.
Cloud coverage matching now requires matching line data.

Validated with the focused runtime coverage tests and cargo fmt.