### PR TITLE
chore(ci): tighten Actions budget after April quota overshoot

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,34 +13,22 @@ set -e
 # children fall back to discovering the repo from their own cwd.
 unset GIT_DIR GIT_WORK_TREE
 
-echo "=== Pre-push CI check ==="
+echo "=== Pre-push fast guard ==="
 
-# Quick checks first (fail fast)
 echo "→ cargo fmt"
 cargo fmt --all -- --check
 
 echo "→ cargo clippy"
 cargo clippy --workspace --all-targets -- -D warnings
 
-echo "→ cargo test"
-cargo test --workspace --all-targets
+# Test, doc, and miri intentionally moved to CI on PRs.
+# CI runs them on Linux runners which are free for public repos
+# (macOS and Windows count against the org Actions quota at
+# 10x / 2x multipliers, so we keep those off the local chain too;
+# they live in CI matrices that are budget-tuned separately).
+# If you want to run the full suite locally before opening a PR:
+#   cargo test --workspace --all-targets
+#   RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
+#   rustup run nightly cargo miri test -p fallow-types --lib --tests
 
-echo "→ cargo doc (rustdoc warnings)"
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items 2>&1 | tail -1
-
-# Miri on fast crates (~10s) — skip if nightly/miri not installed.
-# Use `rustup run nightly cargo miri` consistently rather than mixing with
-# `cargo +nightly`. The `+toolchain` shorthand only works when `cargo` resolves
-# to rustup's proxy (~/.cargo/bin/cargo); on machines where Homebrew's bare
-# cargo wins the PATH lookup, `cargo +nightly` errors with `no such command:
-# +nightly`. `rustup run` is identical in effect and works regardless of which
-# `cargo` is first in PATH.
-if rustup run nightly cargo miri --version &>/dev/null; then
-    echo "→ miri (types + graph)"
-    rustup run nightly cargo miri test -p fallow-types --lib --tests
-    rustup run nightly cargo miri test -p fallow-graph --lib --tests -- --skip proptests
-else
-    echo "→ miri (skipped: nightly or miri not installed)"
-fi
-
-echo "=== All checks passed ==="
+echo "=== Done (~1 min). CI handles test, doc, miri on the PR ==="

--- a/.github/workflows/bench-real-world.yml
+++ b/.github/workflows/bench-real-world.yml
@@ -7,6 +7,10 @@ on:
   #   - cron: '0 7 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: bench-real-world-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # PR runs ubuntu only (fast feedback, free for public repos).
+        # Push to main runs the full matrix as a pre-release safety net.
+        # macOS minutes are 10x quota multiplier on GitHub Free org plans;
+        # Windows is 2x. The April 2026 quota overshoot was driven by this
+        # matrix running on every PR push.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -7,6 +7,10 @@ on:
   #   - cron: '0 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: conformance-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:


### PR DESCRIPTION
## Why

The fallow-rs org hit 100% of its 2000 included Actions minutes on 2026-04-20 and went $5 over budget for April. macOS runners cost 10x quota minutes and Windows 2x on GitHub Free org plans, so the overshoot came from matrix jobs running on every PR push, not from Linux usage (which is free for public repos).

This PR moves slow Linux work off the local pre-push hook (which was costing ~15 min wait per push without saving any budget) and reserves macOS/Windows runner time for push-to-main events only.

## Changes

- **`.githooks/pre-push`**: trimmed to `cargo fmt` + `cargo clippy` (~1 min). Tests, doc, and miri move to CI on PR. One-liners for the full local suite are kept in the hook comment for ad-hoc verification.
- **`.github/workflows/ci.yml`** `zed` job matrix becomes conditional: ubuntu-only on `pull_request`, all three OSes on `push` to `main` as a pre-release safety net. PRs get fast free ubuntu feedback; merge commits validate against macOS + Windows.
- **`.github/workflows/bench-real-world.yml`** and **`conformance.yml`**: add `concurrency: cancel-in-progress: true`. Both are `workflow_dispatch`-only today, so this is defensive against rapid re-triggers.

## Expected impact

- Pre-push wait time: ~15 min → ~1 min
- macOS minutes per PR: drops to zero (was ~7-10 min/PR via zed matrix)
- Linux minutes per PR: unchanged (still free)
- macOS minutes on merge: ~7-10 min per push to main (matches release validation cadence)

## Not in this PR

- CI still triggers on `push: branches: [main]` in addition to `pull_request`. Could be tightened further if PR discipline holds, but kept as-is for safety on direct pushes (release flows, hotfixes).
- macOS in `cross-arch.yml` is essential for multi-platform release binaries and stays as-is.