### PR TITLE
chore(ci): re-enable 12 workflows disabled during quota scare

### DIFF
--- a/.github/workflows/allocs.yml
+++ b/.github/workflows/allocs.yml
@@ -1,23 +1,24 @@
 name: Allocation Tracking
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - 'alloc-baseline.json'
-  #     - '.github/workflows/allocs.yml'
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - 'alloc-baseline.json'
-  #     - '.github/workflows/allocs.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'alloc-baseline.json'
+      - '.github/workflows/allocs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'alloc-baseline.json'
+      - '.github/workflows/allocs.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bench-real-world.yml
+++ b/.github/workflows/bench-real-world.yml
@@ -1,10 +1,9 @@
 name: Real-World Benchmarks
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # schedule:
-  #   # Run daily at 07:00 UTC (after conformance at 06:00)
-  #   - cron: '0 7 * * *'
+  schedule:
+    # Run daily at 07:00 UTC (after conformance at 06:00)
+    - cron: '0 7 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,21 +1,22 @@
 name: Benchmarks
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/bench.yml'
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/bench.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/bench.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/bench.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -1,21 +1,22 @@
 name: Binary Size
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/bloat.yml'
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/bloat.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/bloat.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/bloat.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,10 +1,9 @@
 name: Conformance
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # schedule:
-  #   # Run daily at 06:00 UTC
-  #   - cron: '0 6 * * *'
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/coupling.yml
+++ b/.github/workflows/coupling.yml
@@ -1,23 +1,24 @@
 name: Module Coupling
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/coupling.yml'
-  #     - '.github/scripts/coupling-check.py'
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/coupling.yml'
-  #     - '.github/scripts/coupling-check.py'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/coupling.yml'
+      - '.github/scripts/coupling-check.py'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/coupling.yml'
+      - '.github/scripts/coupling-check.py'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,8 @@
 name: Coverage
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cross-arch.yml
+++ b/.github/workflows/cross-arch.yml
@@ -1,12 +1,21 @@
 name: Cross-Architecture
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # pull_request:
-  #   paths: ['crates/**', '.github/workflows/cross-arch.yml']
-  # push:
-  #   branches: [main]
-  #   paths: ['crates/**', '.github/workflows/cross-arch.yml']
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/cross-arch.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/cross-arch.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ecosystem-full.yml
+++ b/.github/workflows/ecosystem-full.yml
@@ -1,10 +1,9 @@
 name: Ecosystem (Full)
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # schedule:
-  #   # Every Sunday at 04:00 UTC
-  #   - cron: '0 4 * * 0'
+  schedule:
+    # Every Sunday at 04:00 UTC
+    - cron: '0 4 * * 0'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -1,21 +1,24 @@
 name: Ecosystem CI
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/ecosystem.yml'
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - 'crates/**/*.rs'
-  #     - 'Cargo.toml'
-  #     - 'Cargo.lock'
-  #     - '.github/workflows/ecosystem.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'tests/ecosystem/**'
+      - '.github/workflows/ecosystem.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'tests/ecosystem/**'
+      - '.github/workflows/ecosystem.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,12 +1,11 @@
 name: Scorecard
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # branch_protection_rule:
-  # schedule:
-  #   - cron: '15 6 * * 1'
-  # push:
-  #   branches: [main]
+  branch_protection_rule:
+  schedule:
+    - cron: '15 6 * * 1'
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -382,6 +382,7 @@ jobs:
           format: json
           fail-on-issues: false
           comment: true
+          comment-id: action-smoke-test
 
       - name: Verify comment was posted
         env:
@@ -391,9 +392,23 @@ jobs:
         run: |
           COMMENTS=$(gh api \
             "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | contains("<!-- fallow-id: fallow-results -->"))] | length')
+            --jq '[.[] | select(.body | contains("<!-- fallow-id: action-smoke-test -->"))] | length')
           if [ "$COMMENTS" -eq 0 ]; then
             echo "::error::Expected a fallow PR comment but found none"
             exit 1
           fi
           echo "Found $COMMENTS fallow comment(s)"
+
+      - name: Clean up smoke-test comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- fallow-id: action-smoke-test -->")) | .id' |
+            while read -r COMMENT_ID; do
+              [ -n "$COMMENT_ID" ] || continue
+              gh api --method DELETE "repos/${GH_REPO}/issues/comments/${COMMENT_ID}"
+            done

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,9 +1,12 @@
 name: Test GitHub Action
 
 on:
-  # Temporarily disabled to conserve CI minutes; run locally or via workflow_dispatch.
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'action/**'
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -391,7 +391,7 @@ jobs:
         run: |
           COMMENTS=$(gh api \
             "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.body | contains("<!-- fallow-results -->"))] | length')
+            --jq '[.[] | select(.body | contains("<!-- fallow-id: fallow-results -->"))] | length')
           if [ "$COMMENTS" -eq 0 ]; then
             echo "::error::Expected a fallow PR comment but found none"
             exit 1


### PR DESCRIPTION
## Why

Twelve workflows were set to \`workflow_dispatch\`-only during the April 2026 Actions quota incident with the comment "Temporarily disabled to conserve CI minutes". The decision was based on a misreading of the bill: all 12 are ubuntu-only, and Linux runners are **free for public repos**. The actual quota burn came from the macOS/Windows multipliers in \`ci.yml\`'s zed matrix (10x and 2x respectively), which is being tightened in #484.

Re-enabling these workflows restores months of lost signal at zero budget cost.

## What this PR does

### Triggers restored

| Workflow | Trigger | Avg duration |
|---|---|---|
| \`allocs.yml\` | push + PR on rust changes | 1.7 min |
| \`bench.yml\` | push + PR on rust changes | 4.7 min |
| \`bench-real-world.yml\` | daily 07:00 UTC | 6.0 min |
| \`bloat.yml\` | push + PR on rust changes | 3.7 min |
| \`conformance.yml\` | daily 06:00 UTC | 6.2 min |
| \`coupling.yml\` | push + PR on rust changes | 0.4 min |
| \`coverage.yml\` | push to main | 1.6 min |
| \`cross-arch.yml\` | push + PR on rust changes | 0.9 min |
| \`ecosystem.yml\` | push + PR on rust changes | 3.2 min |
| \`ecosystem-full.yml\` | weekly Sun 04:00 UTC | 5.7 min |
| \`scorecard.yml\` | branch_protection_rule + weekly + push to main | 0.6 min |
| \`test-action.yml\` | PR on action changes | 1.2 min |

\`workflow_dispatch\` stays on each so manual runs remain available.

### Path-filter audit (alignment with ci.yml)

While uncommenting, fixed gaps where the previous filters would have missed real triggers:

- All rust-affecting workflows: \`crates/**/*.rs\` → \`crates/**\`. Catches per-crate \`Cargo.toml\` and other non-rust changes that affect alloc/bloat/bench output.
- All rust-affecting workflows: added \`rust-toolchain.toml\`. A toolchain bump changes allocation patterns, binary size, and optimization behaviour; missing this gate would mask regressions.
- \`cross-arch.yml\`: added \`Cargo.toml\`, \`Cargo.lock\`, \`rust-toolchain.toml\`. Dep and toolchain changes affect cross-compile success.
- \`ecosystem.yml\`: added \`tests/ecosystem/**\` so test-infra changes re-trigger the matrix.
- \`test-action.yml\`: added a path filter (\`action/**\`, \`action.yml\`, workflow file) so PRs that do not touch the action skip the workflow.

### Drift audit before re-enable

- All referenced scripts exist on disk (\`benchmarks/bench-ci.sh\`, \`tests/conformance/run-all.sh\`, \`tests/ecosystem/run.sh\`).
- All cargo bench targets exist in \`crates/core/Cargo.toml\` (\`analysis\`, \`large_analysis\`, \`allocations\`).
- All composite actions (\`./.github/actions/setup-rust\`, \`store-benchmark\`) exist.
- Action pins are current SHAs matching the conventions in \`ci.yml\`.
- No stale \`fallow check\` references.

## Expected impact

- ~400 to 600 extra Linux minutes/month, **all free** for public repos.
- ~10 to 15 extra workflow runs per day visible in the Actions dashboard.
- macOS and Windows minutes: unchanged.

## Caveats

These workflows have not run for months. The first runs after merge may surface drift that is not statically detectable (broken external fixture URLs, changed external project structure, etc.). Plan to land small follow-up fixes as needed.

## Related

- #484 tightens the budget on the path that actually overshot (zed matrix, pre-push hook).