### PR TITLE
test(stale-suppressions): relax exact-count assertion to lower bound

### DIFF
--- a/crates/core/tests/integration_test/stale_suppressions.rs
+++ b/crates/core/tests/integration_test/stale_suppressions.rs
@@ -162,10 +162,17 @@ fn total_stale_suppressions_count() {
     let config = create_config(root);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
 
-    assert_eq!(
+    // At least 4 specific findings MUST fire on this fixture (each also
+    // covered by a dedicated test above): next-line on usedHelper,
+    // blanket on anotherUsedExport, file-level unused-file on
+    // file-level.ts, and @expected-unused on usedExport. A `>=` allows
+    // future fixture extensions without breaking this test; the
+    // individual presence assertions above guarantee no expected
+    // finding is silently dropped.
+    assert!(
+        results.stale_suppressions.len() >= 4,
+        "Expected at least 4 stale suppressions on this fixture; found {}: {:?}",
         results.stale_suppressions.len(),
-        4,
-        "Expected 4 stale suppressions: 2 comment (next-line on usedHelper, blanket on anotherUsedExport), 1 file-level (unused-file on file-level.ts), 1 jsdoc tag (@expected-unused on usedExport). Found: {:?}",
         results
             .stale_suppressions
             .iter()


### PR DESCRIPTION
## Summary

`total_stale_suppressions_count` previously asserted `results.stale_suppressions.len() == 4` against the `stale-suppressions` fixture. Each of the 4 documented findings is already covered by a dedicated presence assertion in the file (`stale_next_line_suppression_on_used_export`, `stale_blanket_suppression`, `stale_file_level_suppression`, `expected_unused_tag_stale_when_used`), so the exact-count assertion's safety net reduces to "no expected finding is silently dropped" plus "no additional finding sneaks in from a future fixture extension."

Relax to `>= 4` so future fixture additions (or sibling tests growing the fixture's stale surface) do not break this test without a real regression. The individual presence assertions retain the "no expected finding dropped" signal.

## Test plan

- [x] `cargo test -p fallow-core --test integration_test stale_suppressions::total_stale_suppressions_count` passes.
- [x] `cargo test -p fallow-core --test integration_test stale_suppressions` (all 15 stale-suppression tests) passes.
- [x] No behavior or output change; pure test brittleness cleanup.