### PR TITLE
chore(ci): unblock Documentation + Windows ARM64 jobs

### DIFF
--- a/crates/cli/src/signal/windows.rs
+++ b/crates/cli/src/signal/windows.rs
@@ -19,11 +19,16 @@
 
 use std::io;
 
-use windows_sys::Win32::Foundation::BOOL;
+// `BOOL` moved from `Win32::Foundation` to `windows_sys::core` in
+// windows-sys 0.61 (matches the `SetConsoleCtrlHandler` signature
+// `add: windows_sys::core::BOOL -> windows_sys::core::BOOL`). The old
+// `Win32::Foundation::BOOL` path no longer resolves and broke the
+// Windows ARM64 native compile on every PR.
 use windows_sys::Win32::System::Console::{
     CTRL_BREAK_EVENT, CTRL_C_EVENT, CTRL_CLOSE_EVENT, CTRL_LOGOFF_EVENT, CTRL_SHUTDOWN_EVENT,
     SetConsoleCtrlHandler,
 };
+use windows_sys::core::BOOL;
 
 use super::handle_signal;
 

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -67,10 +67,12 @@ pub struct WorkspaceInfo {
 /// hard exits.
 ///
 /// This wrapper goes through the silent collector path that does NOT call
-/// [`emit_warn`]. Without that split, sibling callers in `core/src/lib.rs`
-/// (analyze) and `core/src/discover/mod.rs` (file discovery) would re-emit
-/// `tracing::warn!` on paths the user already excluded via `ignorePatterns`,
-/// because the back-compat wrapper has no access to the user's globset.
+/// `emit_warn` (private helper in `crates/config/src/workspace/diagnostics.rs`
+/// that does the `tracing::warn!` emission). Without that split, sibling
+/// callers in `core/src/lib.rs` (analyze) and `core/src/discover/mod.rs`
+/// (file discovery) would re-emit `tracing::warn!` on paths the user already
+/// excluded via `ignorePatterns`, because the back-compat wrapper has no
+/// access to the user's globset.
 #[must_use]
 pub fn discover_workspaces(root: &Path) -> Vec<WorkspaceInfo> {
     collect_workspaces_and_diagnostics(root, &globset::GlobSet::empty())


### PR DESCRIPTION
## Summary

Two one-line follow-ups for failures landed on main in the back-to-back merges of #473 (workspace diagnostics) and #477 (signal handlers). Both surfaced on #466's post-merge CI run.

- `crates/config/src/workspace/mod.rs:70` — replace rustdoc intra-doc link `[\`emit_warn\`]` to the `pub(super)` helper with a plain backtick code span plus a pointer to where the helper lives. `rustdoc::private_intra_doc_links` was being promoted to a hard error under `-D warnings`.
- `crates/cli/src/signal/windows.rs:22` — update `BOOL` import from `windows_sys::Win32::Foundation::BOOL` to `windows_sys::core::BOOL` (the type moved in windows-sys 0.61; the matching `SetConsoleCtrlHandler` signature already uses the new path). Unblocks the Windows ARM64 Native Compile job.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`: clean.
- [x] `cargo check --workspace`: clean (cannot exercise Windows ARM64 locally on darwin; CI is the verification path).
- [x] Confirmed `windows-sys 0.61.2/src/core/mod.rs` line 6: `pub type BOOL = i32;` and `Win32/System/Console/mod.rs::SetConsoleCtrlHandler` returns `windows_sys::core::BOOL`.