### PR TITLE
chore(fix): rename test comment to describe BOM-preservation invariant

### DIFF
--- a/crates/cli/src/fix/plan.rs
+++ b/crates/cli/src/fix/plan.rs
@@ -782,15 +782,16 @@ mod tests {
 
     #[test]
     fn staged_content_round_trip_through_second_fixer_preserves_bom() {
-        // Load-bearing test per panel feedback (Maeve, tech lead). Two
-        // fixers stage on the same BOM-bearing file in sequence: the first
-        // fixer's `stage_fixed_content` re-prepends the BOM; the second
-        // fixer reads via `read_source_with_hash_check` which routes
-        // through the `staged_content` fast path, must re-detect the BOM
-        // on the staged bytes via `classify_source`, propagate
-        // `had_bom = true` on its returned `EncodingMetadata`, and the
-        // second `stage_fixed_content` must re-prepend the BOM again.
-        // After commit, on-disk bytes must STILL start with the BOM.
+        // BOM-preservation invariant across the two-fixer staged-content
+        // round trip. Two fixers stage on the same BOM-bearing file in
+        // sequence: the first fixer's `stage_fixed_content` re-prepends
+        // the BOM; the second fixer reads via
+        // `read_source_with_hash_check` which routes through the
+        // `staged_content` fast path, must re-detect the BOM on the
+        // staged bytes via `classify_source`, propagate `had_bom = true`
+        // on its returned `EncodingMetadata`, and the second
+        // `stage_fixed_content` must re-prepend the BOM again. After
+        // commit, on-disk bytes must STILL start with the BOM.
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("bom-multi.ts");
         let body = "line a\nline b\nline c\n";


### PR DESCRIPTION
## Summary

- Rename the comment on `staged_content_round_trip_through_second_fixer_preserves_bom` in `crates/cli/src/fix/plan.rs` so it describes the BOM-preservation invariant the test pins, rather than referencing the review-process source of the invariant.
- No behavioral change. Existing test passes unchanged.

## Test plan

- [x] `cargo test -p fallow-cli --lib staged_content_round_trip_through_second_fixer_preserves_bom` passes.
- [x] `cargo check -p fallow-cli` clean.
- [x] `grep -rE "panel feedback|panel BLOCK|panel persona|panel decision|panel reversed|team review" crates/ tests/` returns zero hits.