### PR TITLE
chore(ci): re-enable Windows in main Rust Check job on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporarily reduced to ubuntu-only to conserve CI minutes (macOS is 10x multiplier).
-        # Run macos + windows locally before release.
-        os: [ubuntu-latest]
+        # PR runs ubuntu only (fast feedback, free for public repos).
+        # Push to main also runs windows-latest as a pre-release safety net so
+        # Windows path bugs (backslash separators, UNC paths, long-path `\\?\`,
+        # case insensitivity) surface before a release tag is cut rather than
+        # via user reports. Same structural pattern as the `zed` job below.
+        # macOS minutes are 10x quota multiplier on GitHub Free org plans;
+        # Windows is 2x. macOS coverage is via local pre-release runs.
+        # Refs #447.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **The main Rust `Check` job now runs on Windows in addition to Linux on push to `main`.** PR runs stay ubuntu-only for fast feedback, but every push to `main` exercises the full test + clippy + fmt + NAPI build pipeline on `windows-latest` as a pre-release safety net. Before, `.github/workflows/ci.yml`'s `check` job was hard-coded to `ubuntu-latest` and Windows path bugs (backslash separators, UNC paths, long-path `\\?\` prefix, case insensitivity) only surfaced at release time or via user reports. The matrix mirrors the existing `zed` job's push-conditional pattern; macOS coverage continues to come from local pre-release runs (10x quota multiplier on the Free org plan vs 2x for Windows). (Closes [#447](https://github.com/fallow-rs/fallow/issues/447).)
+
 ## [2.77.0] - 2026-05-21
 
 ### Changed


### PR DESCRIPTION
## Summary

- Expand the `check` job's matrix in `.github/workflows/ci.yml` to run on `windows-latest` in addition to `ubuntu-latest` on push to `main`. PR runs stay ubuntu-only for fast feedback.
- Mirror the structural pattern already in use for the `zed` job at ci.yml:267 (`${{ github.event_name == 'push' && fromJSON('[..., ...]') || fromJSON('[...]') }}`).
- macOS stays out of the matrix (10x multiplier on the Free org plan vs 2x for Windows; local pre-release runs continue to cover macOS).
- Update the inline comment to name the budget trade-off and reference the Zed precedent.

Fixes #447.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"` exits 0.
- [x] `actionlint .github/workflows/ci.yml` clean.
- [x] Diff is a 12-line edit to one block + a 4-line CHANGELOG entry under `[Unreleased]` -> `### Internal`.
- [ ] Post-merge: first push to `main` triggers `Check (ubuntu-latest)` AND `Check (windows-latest)` in parallel; any pre-existing Windows-specific test failures (path normalization, line endings) surface as follow-up commits rather than as release-time discoveries.

## Concerns to watch on first Windows run

These are not blockers; both are documented in the plan and the review verdict as advisory:

1. **Wall-clock budget on cold cache**: `timeout-minutes: 30` applies per matrix leg. Windows cold-cache `cargo test --workspace --all-targets` + clippy + clippy --features + NAPI build is typically 2-3x slower than Linux. If the first push to `main` times out, bump the budget on a follow-up commit rather than reverting the matrix expansion.
2. **`Check for uncommitted changes` step** (`git diff --exit-code` at ci.yml:151): may flap on Windows due to CRLF normalization on checkout (no `.gitattributes` exists in the repo today). If it fails, the follow-up is a separate PR introducing `.gitattributes` with `* text=auto eol=lf`.