### PR TITLE
chore(cli): route dupes + health file headers through format_display_path

### DIFF
--- a/crates/cli/src/report/human/dupes.rs
+++ b/crates/cli/src/report/human/dupes.rs
@@ -237,7 +237,7 @@ pub(in crate::report) fn build_duplication_human_lines(
                 .files
                 .iter()
                 .map(|f| {
-                    let path_str = relative_path(f, root).display().to_string();
+                    let path_str = crate::report::format_display_path(f, root);
                     format_path(&path_str)
                 })
                 .collect();

--- a/crates/cli/src/report/human/health.rs
+++ b/crates/cli/src/report/human/health.rs
@@ -858,7 +858,7 @@ fn render_findings(
 
     let mut last_file = String::new();
     for finding in &report.findings {
-        let file_str = relative_path(&finding.path, root).display().to_string();
+        let file_str = crate::report::format_display_path(&finding.path, root);
         if file_str != last_file {
             lines.push(format!("  {}", format_path(&file_str)));
             last_file = file_str;


### PR DESCRIPTION
## Summary

Follow-up to #547 / PR #565. Two human-output sites (`crates/cli/src/report/human/dupes.rs:240`, `crates/cli/src/report/human/health.rs:861`) still rendered file paths via `relative_path(...).display().to_string()` without forward-slash normalisation, so on Windows the dupes section and the complexity-findings file header emitted backslashes while the four sites updated in #547 emitted forward slashes within the same combined run. Both sites now flow through the shared `format_display_path` helper.

Cross-line consistency on Windows; no behavior change on macOS / Linux. JSON / SARIF / CodeClimate / MCP outputs unaffected.

## Test plan

- [x] `cargo test --workspace --all-targets`: all buckets pass, zero failures.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Inspect: every call site that piped a path string into `format_path(...)` or `split_dir_filename(...)` is what the helper is for. The remaining `relative_path(...).display().to_string()` call sites that feed inline `format!` or string comparison are out of scope for this targeted follow-up.