### PR TITLE
fix(list): emit forward-slashed paths in --files and --entry-points JSON

### DIFF
--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -233,11 +233,15 @@ fn print_list_json(
     if (opts.files || show_all)
         && let Some(disc) = discovered
     {
+        // Normalise to forward slashes on Windows so JSON consumers (CI
+        // glob filters, MCP agents, downstream pipelines) get the same
+        // path shape they get on POSIX. Mirrors the workspaces / nudge /
+        // rollup path normalisation that ships through `format_display_path`.
         let paths: Vec<serde_json::Value> = disc
             .iter()
             .map(|f| {
                 let relative = f.path.strip_prefix(opts.root).unwrap_or(&f.path);
-                serde_json::json!(relative.display().to_string())
+                serde_json::json!(relative.display().to_string().replace('\\', "/"))
             })
             .collect();
         result.insert("file_count".to_string(), serde_json::json!(paths.len()));
@@ -250,7 +254,7 @@ fn print_list_json(
             .map(|ep| {
                 let relative = ep.path.strip_prefix(opts.root).unwrap_or(&ep.path);
                 serde_json::json!({
-                    "path": relative.display().to_string(),
+                    "path": relative.display().to_string().replace('\\', "/"),
                     "source": ep.source.to_string(),
                 })
             })


### PR DESCRIPTION
## Summary

After PRs #573 and #574 closed the audit-side Windows failures from #561, the rerun of the push-to-main matrix surfaced two more red tests, this time in \`list_tests.rs\`: \`fallow list --files --format json\` and \`--entry-points --format json\` were emitting backslashed paths (\`app\\.client\\analytics.ts\`) on Windows because the per-path JSON projection skipped the \`.replace('\\\\', \"/\")\` normalisation that the workspaces array already applies.

Mirror the workspaces / nudge / rollup path-normalisation convention so JSON consumers (CI glob filters, MCP agents, downstream pipelines) get a stable forward-slash shape regardless of host OS. Matches the \`format_display_path\` convention #565 / #567 locked in for the rest of the CLI's JSON output.

## Tests

\`list_files_includes_plugin_scoped_hidden_dirs_for_react_router\` and \`list_files_includes_plugin_scoped_hidden_dirs_for_remix\` already asserted on the forward-slash shape; they were silently passing on POSIX (where the separator already matches) and failing on the push-to-main Windows matrix. No new test needed, the existing ones are exactly the regression coverage.

## Scope

Only the JSON projection in \`print_list_json\` is changed. Human-format output (\`print_list_human\`) is intentionally left alone in this PR; if it should also normalise, that follows the broader \`format_display_path\` migration tracked separately.

## Progression on #561

22+ -> 8 -> 3 -> 2 -> 1 -> expected **0** on Windows after this merges.

Refs #561