### PR TITLE
fix(config): drop is_absolute gate from existing-entry dedup

### DIFF
--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -233,11 +233,15 @@ fn print_list_json(
     if (opts.files || show_all)
         && let Some(disc) = discovered
     {
+        // Normalise to forward slashes on Windows so JSON consumers (CI
+        // glob filters, MCP agents, downstream pipelines) get the same
+        // path shape they get on POSIX. Mirrors the workspaces / nudge /
+        // rollup path normalisation that ships through `format_display_path`.
         let paths: Vec<serde_json::Value> = disc
             .iter()
             .map(|f| {
                 let relative = f.path.strip_prefix(opts.root).unwrap_or(&f.path);
-                serde_json::json!(relative.display().to_string())
+                serde_json::json!(relative.display().to_string().replace('\\', "/"))
             })
             .collect();
         result.insert("file_count".to_string(), serde_json::json!(paths.len()));
@@ -250,7 +254,7 @@ fn print_list_json(
             .map(|ep| {
                 let relative = ep.path.strip_prefix(opts.root).unwrap_or(&ep.path);
                 serde_json::json!({
-                    "path": relative.display().to_string(),
+                    "path": relative.display().to_string().replace('\\', "/"),
                     "source": ep.source.to_string(),
                 })
             })

--- a/crates/config/src/config_writer.rs
+++ b/crates/config/src/config_writer.rs
@@ -277,16 +277,21 @@ fn files_from_inline_array(array: &Array, config_dir: &Path) -> FxHashSet<String
 
 /// Insert an existing-entry path into the dedupe set under its canonical key.
 ///
-/// The canonical key is the entry as written. When the existing entry is an
-/// absolute path that resolves under the config dir, also insert the
-/// dir-relative form so a new entry emitted by the action builder (which is
-/// always config-dir-relative) is recognised as a duplicate.
+/// The canonical key is the entry as written. When the existing entry resolves
+/// under the config dir, also insert the dir-relative form so a new entry
+/// emitted by the action builder (which is always config-dir-relative) is
+/// recognised as a duplicate.
+///
+/// `strip_prefix` is called unconditionally: it naturally returns `Err` for
+/// values that do not start with `config_dir` (already-relative entries,
+/// entries pointing outside the project), so a `Path::is_absolute` /
+/// `Path::has_root` pre-gate is redundant. The pre-gate was actively wrong
+/// on Windows because `Path::is_absolute` requires a drive letter (`C:\`),
+/// so a POSIX-rooted entry like `/project/src/a.ts` written from Linux CI
+/// silently skipped the dir-relative dedup key.
 fn record_existing_file(seen: &mut FxHashSet<String>, file: &str, config_dir: &Path) {
     seen.insert(file.to_owned());
-    let path = Path::new(file);
-    if path.is_absolute()
-        && let Ok(relative) = path.strip_prefix(config_dir)
-    {
+    if let Ok(relative) = Path::new(file).strip_prefix(config_dir) {
         seen.insert(relative.to_string_lossy().replace('\\', "/"));
     }
 }


### PR DESCRIPTION
## Summary

Fourth fix in the #561 push-to-main Windows chain. \`record_existing_file\` in \`crates/config/src/config_writer.rs\` only inserted the dir-relative dedup key when the existing entry was \`Path::is_absolute\`. On Windows that gate rejects POSIX-rooted paths (\`/project/src/a.ts\`) because Windows requires a drive letter (\`C:\\\`) or UNC prefix for \`is_absolute\`. A config written from Linux CI with absolute project paths therefore lost the dedup signal on Windows and the writer happily appended a relative duplicate of every entry on every run.

\`strip_prefix\` already returns \`Err\` for entries that do not start with \`config_dir\` (already-relative entries, sibling-project entries), so the absoluteness pre-gate is redundant. Drop it: try \`strip_prefix\` unconditionally, insert the dir-relative form on success.

## Same shape as #574

Both PRs hit the same Windows trap: \`Path::is_absolute\` returns true for \`/project/src/a.ts\` on POSIX and false on Windows. The validator fix in #574 used \`Path::has_root\` as the relaxation; this one drops the gate entirely because the downstream call returns the right error for free.

## Tests

\`dedupes_existing_absolute_paths_against_relative_emissions\` and its TOML twin already pinned the contract on POSIX and were silently failing on the push-to-main Windows matrix. They are exactly the regression coverage; no new tests added.

## Progression on #561

22+ -> 8 -> 3 -> 2 -> 1 -> 2 (different failures surfaced after #573/574) -> 2 (list_tests fixed in #575) -> 2 (config_writer surfaced after #575) -> expected **0** on Windows after this merges.

Refs #561