### PR TITLE
feat(cli): plumb --explain through human + combined JSON output

### DIFF
--- a/crates/cli/src/combined.rs
+++ b/crates/cli/src/combined.rs
@@ -499,7 +499,7 @@ fn print_combined_json(
     health: Option<&HealthResult>,
     root: &std::path::Path,
     elapsed: std::time::Duration,
-    _explain: bool,
+    explain: bool,
     config_fixable: bool,
 ) -> ExitCode {
     // Build the envelope shell as a typed `CombinedOutput`, then convert
@@ -512,6 +512,7 @@ fn print_combined_json(
         schema_version: fallow_types::envelope::SchemaVersion(crate::report::SCHEMA_VERSION),
         version: fallow_types::envelope::ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
         elapsed_ms: fallow_types::envelope::ElapsedMs(elapsed.as_millis() as u64),
+        meta: None,
         check: None,
         dupes: None,
         health: None,
@@ -614,6 +615,12 @@ fn print_combined_json(
     }
 
     let mut output = serde_json::Value::Object(combined);
+    if explain && let serde_json::Value::Object(ref mut map) = output {
+        map.insert(
+            "_meta".to_string(),
+            crate::explain::combined_meta(check.is_some(), dupes.is_some(), health.is_some()),
+        );
+    }
     report::harmonize_multi_kind_suppress_line_actions(&mut output);
 
     match serde_json::to_string_pretty(&output) {

--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -718,6 +718,22 @@ pub fn check_meta() -> Value {
     })
 }
 
+/// Build the sectioned `_meta` object for bare `fallow --format json --explain`.
+#[must_use]
+pub fn combined_meta(include_check: bool, include_dupes: bool, include_health: bool) -> Value {
+    let mut sections = serde_json::Map::new();
+    if include_check {
+        sections.insert("check".to_string(), check_meta());
+    }
+    if include_dupes {
+        sections.insert("dupes".to_string(), dupes_meta());
+    }
+    if include_health {
+        sections.insert("health".to_string(), health_meta());
+    }
+    Value::Object(sections)
+}
+
 /// Build the `_meta` object for `fallow health --format json --explain`.
 #[must_use]
 #[expect(

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -324,6 +324,11 @@ pub struct CombinedOutput {
     pub version: ToolVersion,
     /// Analysis duration in milliseconds.
     pub elapsed_ms: ElapsedMs,
+    /// Sectioned `_meta` block emitted only when `--explain` is passed.
+    /// Contains `check`, `dupes`, and/or `health` keys matching the analyses
+    /// enabled for the combined run.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<CombinedMeta>,
     /// Dead-code analysis sub-envelope. Absent when `--skip check`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub check: Option<CheckOutput>,
@@ -337,6 +342,21 @@ pub struct CombinedOutput {
     /// `HealthOutput` envelope). Absent when `--skip health`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health: Option<HealthReport>,
+}
+
+/// Sectioned `_meta` block for the bare combined JSON envelope.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CombinedMeta {
+    /// Dead-code metadata from `crate::explain::check_meta()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check: Option<serde_json::Value>,
+    /// Duplication metadata from `crate::explain::dupes_meta()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dupes: Option<serde_json::Value>,
+    /// Health metadata from `crate::explain::health_meta()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health: Option<serde_json::Value>,
 }
 
 /// Singleton schema-version discriminator for [`CoverageAnalyzeOutput`].

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -170,6 +170,10 @@ fn insert_test_src_split<T>(lines: &mut Vec<String>, items: &[T], get_path: impl
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "human renderer entrypoint mirrors ReportContext fields without allocating a wrapper"
+)]
 pub(in crate::report) fn print_human(
     results: &AnalysisResults,
     root: &Path,
@@ -178,6 +182,7 @@ pub(in crate::report) fn print_human(
     quiet: bool,
     top: Option<usize>,
     show_explain_tip: bool,
+    explain: bool,
 ) {
     if !quiet {
         eprintln!();
@@ -189,7 +194,7 @@ pub(in crate::report) fn print_human(
     print_explain_tip_if_tty(show_explain_tip && total > 0, quiet);
 
     // Human output always includes section footers with doc links.
-    for line in build_human_lines(results, root, rules, top) {
+    for line in build_human_lines_with_explain(results, root, rules, top, explain) {
         println!("{line}");
     }
 
@@ -252,11 +257,22 @@ fn print_suppression_footer(results: &AnalysisResults) {
 ///
 /// Each section (unused files, exports, etc.) produces a header line followed by
 /// detail lines. Empty sections are omitted entirely.
+#[cfg(test)]
 pub(in crate::report) fn build_human_lines(
     results: &AnalysisResults,
     root: &Path,
     rules: &RulesConfig,
     top: Option<usize>,
+) -> Vec<String> {
+    build_human_lines_with_explain(results, root, rules, top, false)
+}
+
+fn build_human_lines_with_explain(
+    results: &AnalysisResults,
+    root: &Path,
+    rules: &RulesConfig,
+    top: Option<usize>,
+    explain: bool,
 ) -> Vec<String> {
     let max_items = top.unwrap_or(MAX_FLAT_ITEMS);
     let max_grouped_files = top.unwrap_or(MAX_GROUPED_FILES);
@@ -284,7 +300,73 @@ pub(in crate::report) fn build_human_lines(
     build_structure_section(&mut lines, results, root, rules, total_issues);
     build_maintenance_section(&mut lines, results, root, rules, total_issues);
 
-    lines
+    if explain {
+        inject_explain_blocks(lines)
+    } else {
+        lines
+    }
+}
+
+fn inject_explain_blocks(lines: Vec<String>) -> Vec<String> {
+    let mut out = Vec::with_capacity(lines.len());
+    for line in lines {
+        let explain = check_explain_for_header(&line);
+        out.push(line);
+        if let Some(rule) = explain {
+            out.push(format!(
+                "  {}",
+                format!("Description: {}", rule.full).dimmed()
+            ));
+        }
+    }
+    out
+}
+
+fn check_explain_for_header(line: &str) -> Option<&'static crate::explain::RuleDef> {
+    let mappings = [
+        ("Unused files", "fallow/unused-file"),
+        ("Unused exports", "fallow/unused-export"),
+        ("Unused type exports", "fallow/unused-type"),
+        ("Private type leaks", "fallow/private-type-leak"),
+        ("Unused dependencies", "fallow/unused-dependency"),
+        ("Unused devDependencies", "fallow/unused-dev-dependency"),
+        (
+            "Unused optionalDependencies",
+            "fallow/unused-optional-dependency",
+        ),
+        ("Type-only dependencies", "fallow/type-only-dependency"),
+        (
+            "Test-only production dependencies",
+            "fallow/test-only-dependency",
+        ),
+        ("Unused enum members", "fallow/unused-enum-member"),
+        ("Unused class members", "fallow/unused-class-member"),
+        ("Unresolved imports", "fallow/unresolved-import"),
+        ("Unlisted dependencies", "fallow/unlisted-dependency"),
+        ("Duplicate exports", "fallow/duplicate-export"),
+        ("Circular dependencies", "fallow/circular-dependency"),
+        ("Re-Export Cycles", "fallow/re-export-cycle"),
+        ("Boundary violations", "fallow/boundary-violation"),
+        ("Stale suppressions", "fallow/stale-suppression"),
+        ("Unused catalog entries", "fallow/unused-catalog-entry"),
+        ("Empty catalog groups", "fallow/empty-catalog-group"),
+        (
+            "Unresolved catalog references",
+            "fallow/unresolved-catalog-reference",
+        ),
+        (
+            "Unused dependency overrides",
+            "fallow/unused-dependency-override",
+        ),
+        (
+            "Misconfigured dependency overrides",
+            "fallow/misconfigured-dependency-override",
+        ),
+    ];
+    let (_, rule_id) = mappings
+        .iter()
+        .find(|(title, _)| line.contains(&format!("{title} (")))?;
+    crate::explain::rule_by_id(rule_id)
 }
 
 /// `── Label ───...` header followed by a blank line, dimmed.
@@ -1699,6 +1781,7 @@ pub(in crate::report) fn print_grouped_human(
     elapsed: Duration,
     quiet: bool,
     resolver: Option<&OwnershipResolver>,
+    explain: bool,
 ) {
     if !quiet {
         eprintln!();
@@ -1770,7 +1853,7 @@ pub(in crate::report) fn print_grouped_human(
         }
 
         // Build lines and dedup doc URL footers across groups
-        let lines = build_human_lines(&group.results, root, rules, None);
+        let lines = build_human_lines_with_explain(&group.results, root, rules, None, explain);
         for line in &lines {
             if line.contains("docs.fallow.tools") && !seen_footers.insert(line.clone()) {
                 continue;

--- a/crates/cli/src/report/human/dupes.rs
+++ b/crates/cli/src/report/human/dupes.rs
@@ -22,6 +22,7 @@ pub(in crate::report) fn print_duplication_human(
     elapsed: Duration,
     quiet: bool,
     show_explain_tip: bool,
+    explain: bool,
 ) {
     if !quiet {
         eprintln!();
@@ -44,7 +45,12 @@ pub(in crate::report) fn print_duplication_human(
 
     print_explain_tip_if_tty(show_explain_tip && !report.clone_groups.is_empty(), quiet);
 
-    for line in build_duplication_human_lines(report, root) {
+    let lines = if explain {
+        build_duplication_human_lines_with_explain(report, root, true)
+    } else {
+        build_duplication_human_lines(report, root)
+    };
+    for line in lines {
         println!("{line}");
     }
 
@@ -79,13 +85,21 @@ pub(in crate::report) fn print_duplication_human(
 }
 
 /// Build human-readable output lines for duplication report.
+pub(in crate::report) fn build_duplication_human_lines(
+    report: &DuplicationReport,
+    root: &Path,
+) -> Vec<String> {
+    build_duplication_human_lines_with_explain(report, root, false)
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "report builder with grouped output formatting"
 )]
-pub(in crate::report) fn build_duplication_human_lines(
+fn build_duplication_human_lines_with_explain(
     report: &DuplicationReport,
     root: &Path,
+    explain: bool,
 ) -> Vec<String> {
     let mut lines = Vec::new();
 
@@ -108,6 +122,12 @@ pub(in crate::report) fn build_duplication_human_lines(
             .cyan()
             .bold()
     ));
+    if explain && let Some(rule) = crate::explain::rule_by_id("fallow/code-duplication") {
+        lines.push(format!(
+            "  {}",
+            format!("Description: {}", rule.full).dimmed()
+        ));
+    }
     lines.push(String::new());
 
     for group in &sorted_groups[..shown] {

--- a/crates/cli/src/report/human/health.rs
+++ b/crates/cli/src/report/human/health.rs
@@ -18,6 +18,7 @@ pub(in crate::report) fn print_health_human(
     elapsed: Duration,
     quiet: bool,
     show_explain_tip: bool,
+    explain: bool,
 ) {
     if !quiet {
         eprintln!();
@@ -67,7 +68,12 @@ pub(in crate::report) fn print_health_human(
             .is_some_and(|coverage| !coverage.findings.is_empty());
     print_explain_tip_if_tty(show_explain_tip && has_findings, quiet);
 
-    for line in build_health_human_lines(report, root) {
+    let lines = if explain {
+        build_health_human_lines_with_explain(report, root, true)
+    } else {
+        build_health_human_lines(report, root)
+    };
+    for line in lines {
         println!("{line}");
     }
 
@@ -117,6 +123,14 @@ pub(in crate::report) fn build_health_human_lines(
     report: &crate::health_types::HealthReport,
     root: &Path,
 ) -> Vec<String> {
+    build_health_human_lines_with_explain(report, root, false)
+}
+
+fn build_health_human_lines_with_explain(
+    report: &crate::health_types::HealthReport,
+    root: &Path,
+    explain: bool,
+) -> Vec<String> {
     let mut lines = Vec::new();
     render_health_score(&mut lines, report);
     render_health_trend(&mut lines, report);
@@ -129,7 +143,67 @@ pub(in crate::report) fn build_health_human_lines(
     render_file_scores(&mut lines, report, root);
     render_hotspots(&mut lines, report, root);
     render_refactoring_targets(&mut lines, report, root);
-    lines
+    if explain {
+        inject_explain_blocks(lines)
+    } else {
+        lines
+    }
+}
+
+fn inject_explain_blocks(lines: Vec<String>) -> Vec<String> {
+    let mut out = Vec::with_capacity(lines.len());
+    for line in lines {
+        let explain = health_explain_for_header(&line);
+        out.push(line);
+        if let Some(text) = explain {
+            out.push(format!("  {}", format!("Description: {text}").dimmed()));
+        }
+    }
+    out
+}
+
+fn health_explain_for_header(line: &str) -> Option<String> {
+    if line.contains("Runtime coverage:") {
+        return rule_full("fallow/runtime-coverage");
+    }
+    if line.contains("Health score:") {
+        return Some(
+            "The 0-100 project health grade combines dead code, complexity, maintainability, duplication, dependency, hotspot, and coverage signals when available."
+                .to_string(),
+        );
+    }
+    if line.contains("Metrics:") {
+        return Some(
+            "Vital signs summarize the analyzed project before truncation: dead-code percentages, maintainability index, hotspot count, circular dependencies, unused dependencies, and duplication where available."
+                .to_string(),
+        );
+    }
+    if line.contains("Large functions (") {
+        return rule_full("fallow/high-cyclomatic-complexity");
+    }
+    if line.contains("High complexity functions (") {
+        return rule_full("fallow/high-complexity");
+    }
+    if line.contains("Coverage gaps (") {
+        return Some(
+            "Coverage gaps identify runtime-reachable files or exports with no static path from discovered test entry points."
+                .to_string(),
+        );
+    }
+    if line.contains("Hotspots (") {
+        return Some(
+            "Hotspots combine recent churn with complexity so frequently changed risky files surface before quieter debt."
+                .to_string(),
+        );
+    }
+    if line.contains("Refactoring targets (") {
+        return rule_full("fallow/refactoring-target");
+    }
+    None
+}
+
+fn rule_full(id: &str) -> Option<String> {
+    crate::explain::rule_by_id(id).map(|rule| rule.full.to_string())
 }
 
 fn render_runtime_coverage(

--- a/crates/cli/src/report/mod.rs
+++ b/crates/cli/src/report/mod.rs
@@ -199,6 +199,7 @@ pub fn print_results(
                     ctx.quiet,
                     ctx.top,
                     ctx.show_explain_tip,
+                    ctx.explain,
                 );
             }
             ExitCode::SUCCESS
@@ -267,6 +268,7 @@ fn print_grouped_results(
                 ctx.elapsed,
                 ctx.quiet,
                 Some(resolver),
+                ctx.explain,
             );
             ExitCode::SUCCESS
         }
@@ -346,6 +348,7 @@ pub fn print_duplication_report(
                     ctx.elapsed,
                     ctx.quiet,
                     ctx.show_explain_tip,
+                    ctx.explain,
                 );
             }
             ExitCode::SUCCESS
@@ -503,6 +506,7 @@ pub fn print_health_report(
                     ctx.elapsed,
                     ctx.quiet,
                     ctx.show_explain_tip,
+                    ctx.explain,
                 );
                 if let Some(grouping) = grouping {
                     human::print_health_grouping(grouping, ctx.root, ctx.quiet);

--- a/crates/cli/tests/exit_code_tests.rs
+++ b/crates/cli/tests/exit_code_tests.rs
@@ -57,6 +57,99 @@ fn combined_mode_runs_successfully() {
 }
 
 #[test]
+fn combined_json_explain_includes_sectioned_meta() {
+    let output = run_fallow_combined(
+        "basic-project",
+        &["--format", "json", "--quiet", "--explain"],
+    );
+    assert!(
+        output.code == 0 || output.code == 1,
+        "combined mode should not crash, got exit code {}",
+        output.code
+    );
+    let json = parse_json(&output);
+    assert!(
+        json.pointer("/_meta/check/rules/unused-export/description")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|text| text.contains("Named exports")),
+        "combined _meta should include dead-code rule descriptions"
+    );
+    assert!(
+        json.pointer("/_meta/dupes/metrics/duplication_percentage/description")
+            .and_then(serde_json::Value::as_str)
+            .is_some(),
+        "combined _meta should include duplication metric descriptions"
+    );
+    assert!(
+        json.pointer("/_meta/health/metrics/cyclomatic/description")
+            .and_then(serde_json::Value::as_str)
+            .is_some(),
+        "combined _meta should include health metric descriptions"
+    );
+}
+
+#[test]
+fn human_explain_adds_inline_descriptions_for_analysis_commands() {
+    let check = run_fallow("check", "basic-project", &["--quiet", "--explain"]);
+    assert!(
+        check
+            .stdout
+            .contains("Description: Named exports that are never imported"),
+        "check --explain should describe dead-code sections, stdout:\n{}",
+        check.stdout
+    );
+
+    let dupes = run_fallow("dupes", "duplicate-code", &["--quiet", "--explain"]);
+    assert!(
+        dupes.stdout.contains("Description: A block of code"),
+        "dupes --explain should describe duplicate sections, stdout:\n{}",
+        dupes.stdout
+    );
+
+    let health = run_fallow("health", "complexity-project", &["--quiet", "--explain"]);
+    assert!(
+        health
+            .stdout
+            .contains("Description: Function exceeds both cyclomatic and cognitive"),
+        "health --explain should describe health sections, stdout:\n{}",
+        health.stdout
+    );
+}
+
+#[test]
+fn combined_human_explain_renders_inline_descriptions() {
+    let combined = run_fallow_combined("basic-project", &["--quiet", "--explain"]);
+    assert!(
+        combined.code == 0 || combined.code == 1,
+        "combined --explain should not crash, got exit code {}",
+        combined.code
+    );
+    assert!(
+        combined
+            .stdout
+            .contains("Description: Named exports that are never imported"),
+        "combined --explain should render dead-code descriptions inline, stdout:\n{}",
+        combined.stdout
+    );
+}
+
+#[test]
+fn check_grouped_human_explain_renders_inline_descriptions() {
+    let output = run_fallow(
+        "check",
+        "basic-project",
+        &["--quiet", "--explain", "--group-by", "directory"],
+    );
+    assert!(
+        output
+            .stdout
+            .contains("Description: Named exports that are never imported"),
+        "check --group-by --explain should render dead-code descriptions inline, stdout:\n{}",
+        output.stdout
+    );
+}
+
+#[test]
 fn combined_mode_config_enabled_coverage_gaps_stays_out_of_health_section() {
     let dir = tempfile::tempdir().expect("create temp dir");
     let config_path = dir.path().join("fallow.json");

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -26,6 +26,17 @@
           "description": "Analysis duration in milliseconds.",
           "$ref": "#/definitions/ElapsedMs"
         },
+        "_meta": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CombinedMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Sectioned `_meta` block emitted only when `--explain` is passed.\nContains `check`, `dupes`, and/or `health` keys matching the analyses\nenabled for the combined run."
+        },
         "check": {
           "anyOf": [
             {
@@ -9296,6 +9307,21 @@
         }
       ],
       "description": "Discriminator for [`ReExportCycle`]: which structural shape was detected."
+    },
+    "CombinedMeta": {
+      "type": "object",
+      "properties": {
+        "check": {
+          "description": "Dead-code metadata from `crate::explain::check_meta()`."
+        },
+        "dupes": {
+          "description": "Duplication metadata from `crate::explain::dupes_meta()`."
+        },
+        "health": {
+          "description": "Health metadata from `crate::explain::health_meta()`."
+        }
+      },
+      "description": "Sectioned `_meta` block for the bare combined JSON envelope."
     }
   }
 }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -5480,6 +5480,12 @@ schema_version: SchemaVersion
 version: ToolVersion
 elapsed_ms: ElapsedMs
 /**
+ * Sectioned `_meta` block emitted only when `--explain` is passed.
+ * Contains `check`, `dupes`, and/or `health` keys matching the analyses
+ * enabled for the combined run.
+ */
+_meta?: (CombinedMeta | null)
+/**
  * Dead-code analysis sub-envelope. Absent when `--skip check`.
  */
 check?: (CheckOutput | null)
@@ -5495,6 +5501,29 @@ dupes?: (DupesReportPayload | null)
  * `HealthOutput` envelope). Absent when `--skip health`.
  */
 health?: (HealthReport | null)
+}
+/**
+ * Sectioned `_meta` block for the bare combined JSON envelope.
+ */
+export interface CombinedMeta {
+/**
+ * Dead-code metadata from `crate::explain::check_meta()`.
+ */
+check?: {
+[k: string]: unknown
+}
+/**
+ * Duplication metadata from `crate::explain::dupes_meta()`.
+ */
+dupes?: {
+[k: string]: unknown
+}
+/**
+ * Health metadata from `crate::explain::health_meta()`.
+ */
+health?: {
+[k: string]: unknown
+}
 }
 /**
  * Single CodeClimate-compatible issue inside [`CodeClimateOutput`].

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -5480,6 +5480,12 @@ schema_version: SchemaVersion
 version: ToolVersion
 elapsed_ms: ElapsedMs
 /**
+ * Sectioned `_meta` block emitted only when `--explain` is passed.
+ * Contains `check`, `dupes`, and/or `health` keys matching the analyses
+ * enabled for the combined run.
+ */
+_meta?: (CombinedMeta | null)
+/**
  * Dead-code analysis sub-envelope. Absent when `--skip check`.
  */
 check?: (CheckOutput | null)
@@ -5495,6 +5501,29 @@ dupes?: (DupesReportPayload | null)
  * `HealthOutput` envelope). Absent when `--skip health`.
  */
 health?: (HealthReport | null)
+}
+/**
+ * Sectioned `_meta` block for the bare combined JSON envelope.
+ */
+export interface CombinedMeta {
+/**
+ * Dead-code metadata from `crate::explain::check_meta()`.
+ */
+check?: {
+[k: string]: unknown
+}
+/**
+ * Duplication metadata from `crate::explain::dupes_meta()`.
+ */
+dupes?: {
+[k: string]: unknown
+}
+/**
+ * Health metadata from `crate::explain::health_meta()`.
+ */
+health?: {
+[k: string]: unknown
+}
 }
 /**
  * Single CodeClimate-compatible issue inside [`CodeClimateOutput`].


### PR DESCRIPTION
## Summary

- Human format: `--explain` now prints a `Description:` line under each section header for `check`, `dupes`, and `health`. Covers standalone, `--group-by`, and combined output.
- Combined JSON: `--explain` emits a sectioned `_meta` block keyed by `check` / `dupes` / `health`, so a single fetch covers every analysis the run produced.
- Companion `fallow-docs` and `fallow-skills` reference tables updated to describe the actual behavior; standalone `_meta` shapes are unchanged.

Fixes #559.

## Test plan

- [x] `cargo test --workspace --all-targets`: all suites pass, zero failures.
- [x] `cargo test -p fallow-cli --test exit_code_tests`: 31 pass, including new `combined_human_explain_renders_inline_descriptions`, `check_grouped_human_explain_renders_inline_descriptions`, and existing `combined_json_explain_includes_sectioned_meta`.
- [x] `cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit`: drift gate clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `node editors/vscode/scripts/codegen-types.mjs --check` clean (output-contract.d.ts pair in sync).
- [x] Smoke on `tests/fixtures/basic-project`: bare `fallow --explain` renders 6 `Description:` lines, `check --explain --group-by directory` renders 4 (was 0 before this PR).