### PR TITLE
test(core): canonicalise init_repo via dunce so test fixtures match production toplevel

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -114,7 +114,10 @@ fallow-cov-protocol = "0.5"
 serde_yaml_ng = { workspace = true }
 
 [package.metadata.cargo-shear]
-ignored = ["miette"] # feature-only dep: activates fancy rendering for fallow-config's miette::Report
+ignored = [
+    "miette",       # feature-only dep: activates fancy rendering for fallow-config's miette::Report
+    "proc-macro2",  # feature-only dep: activates `span-locations` so syn-returned `.span().start().line` reports real source positions in the schema-drift gate (crates/cli/tests/schema_tests.rs); no explicit import
+]
 
 [lints]
 workspace = true

--- a/crates/core/src/changed_files.rs
+++ b/crates/core/src/changed_files.rs
@@ -944,6 +944,15 @@ mod tests {
 
     /// Initialize a temp git repo with a single committed file plus a tag
     /// at HEAD. Returns the canonical repo root.
+    ///
+    /// Uses `dunce::canonicalize` rather than `std::fs::canonicalize` so the
+    /// returned path agrees with what `resolve_git_toplevel` produces in
+    /// production (PR #566 swapped that helper to `dunce::canonicalize` to
+    /// strip the Windows `\\?\` verbatim prefix). `std::fs::canonicalize`
+    /// still produces verbatim on Windows, so the prior shape diverged from
+    /// the production helper and downstream `changed.contains(&expected)`
+    /// assertions silently failed because one side was verbatim and the
+    /// other was not. POSIX behaviour is identical to `std::fs::canonicalize`.
     fn init_repo(repo: &Path) -> PathBuf {
         run_git(repo, &["init", "--quiet", "--initial-branch=main"]);
         run_git(repo, &["config", "user.email", "test@example.com"]);
@@ -953,7 +962,7 @@ mod tests {
         run_git(repo, &["add", "seed.txt"]);
         run_git(repo, &["commit", "--quiet", "-m", "initial"]);
         run_git(repo, &["tag", "fallow-baseline"]);
-        repo.canonicalize().unwrap()
+        dunce::canonicalize(repo).unwrap()
     }
 
     fn run_git(cwd: &Path, args: &[&str]) {
@@ -1092,9 +1101,14 @@ mod tests {
 
         let toplevel = resolve_git_toplevel(&frontend).unwrap();
         assert_eq!(toplevel, repo, "toplevel should equal canonical repo root");
+        // Use `dunce::canonicalize` rather than `std::fs::canonicalize` on
+        // the RHS so the assertion stays self-consistent on Windows.
+        // Production `resolve_git_toplevel` runs `dunce::canonicalize` (PR
+        // #566); `std::fs::canonicalize` on Windows would re-add the `\\?\`
+        // verbatim prefix and diverge from `toplevel`. POSIX is identical.
         assert_eq!(
             toplevel,
-            toplevel.canonicalize().unwrap(),
+            dunce::canonicalize(&toplevel).unwrap(),
             "resolved toplevel should already be canonical"
         );
     }


### PR DESCRIPTION
## Summary

Fifth fix in the #561 push-to-main Windows chain. After PRs #573, #574, #575, #576 closed every production-side trap that #561 surfaced, the rerun showed 5 test-side failures in \`crates/core/src/changed_files.rs\`:

- \`resolve_git_toplevel_returns_canonical_path\`
- \`try_get_changed_files_workspace_at_repo_root\`
- \`try_get_changed_files_workspace_in_subdirectory\`
- \`try_get_changed_files_includes_committed_sibling_changes\`
- \`try_get_changed_files_includes_modified_tracked_file\`

All five share a stale test fixture: \`init_repo\` returned \`repo.canonicalize().unwrap()\` (i.e. \`std::fs::canonicalize\`), which on Windows produces the \`\\\\?\\\` verbatim form. Production \`resolve_git_toplevel\` was swapped to \`dunce::canonicalize\` in PR #566 so it strips that prefix. The test-side verbatim path then diverged from the production-side non-verbatim path and every \`changed.contains(&expected)\` assertion silently failed.

Swap the two test-side call sites (\`init_repo\` + the self-canonicalize assertion inside \`resolve_git_toplevel_returns_canonical_path\`) to \`dunce::canonicalize\` so test fixtures land in the same shape production emits. POSIX is identical to \`std::fs::canonicalize\`, so no POSIX behaviour change.

## Scope

Test-side only. No production code path changes. The production-side normalisations already shipped in PR #573 onwards.

## Progression on #561

22+ -> 8 -> 3 -> 2 -> 1 -> 2 -> 2 -> 5 (stale test fixtures surfaced after every production trap closed) -> expected **0** on Windows after this merges.

Refs #561