### PR TITLE
test(core): normalise path separators in glimmer-path-aliases test

### DIFF
--- a/crates/core/tests/integration_test/false_positive_fixes.rs
+++ b/crates/core/tests/integration_test/false_positive_fixes.rs
@@ -1585,10 +1585,14 @@ fn glimmer_typescript_imports_use_tsconfig_path_aliases() {
     let config = create_config(root);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
 
+    // Normalise to forward slashes so the `ends_with("app/services/...")`
+    // assertions below match on Windows too. The sibling
+    // `rootdirs_relative_imports_resolve_under_broken_extends_chain` test
+    // already does this; this one was missed.
     let unused_file_paths: Vec<String> = results
         .unused_files
         .iter()
-        .map(|file| file.file.path.to_string_lossy().to_string())
+        .map(|file| file.file.path.to_string_lossy().replace('\\', "/"))
         .collect();
 
     assert!(


### PR DESCRIPTION
Sixth fix in the #561 push-to-main Windows chain.

\`glimmer_typescript_imports_use_tsconfig_path_aliases\` collected unused file paths without the \`.replace('\\\\', \"/\")\` normalisation that the sibling \`rootdirs_relative_imports_resolve_under_broken_extends_chain\` test applies. On Windows the stored paths use backslash separators, so the \`path.ends_with(\"app/services/unused-service.ts\")\` check returned \`false\` even though the path was present, and the assertion panicked. Add the same normalisation.

Pure test fix; no production change.

Refs #561