### PR TITLE
chore(ci): only comment benchmark results on alert threshold breach

### DIFF
--- a/.github/actions/store-benchmark/action.yml
+++ b/.github/actions/store-benchmark/action.yml
@@ -36,7 +36,7 @@ runs:
         github-token: ${{ inputs.github-token }}
         auto-push: ${{ github.event_name != 'pull_request' }}
         comment-on-alert: true
-        comment-always: ${{ github.event_name == 'pull_request' }}
+        comment-always: false
         alert-threshold: ${{ inputs.alert-threshold }}
         fail-on-alert: false
         max-items-in-chart: 100


### PR DESCRIPTION
## Summary

- `store-benchmark` composite action now sets `comment-always: false` so PR benchmark comments only fire on a real `alert-threshold` breach
- Affects all seven benchmark workflows: bench, bench-real-world, bloat, allocs, conformance, coverage, coupling
- Step summary in the Actions tab still renders the full ratio table; `auto-push` and `save-data-file` remain gated on non-PR runs so gh-pages data is unchanged

## Test plan

- [x] YAML diff is a single-line flip on `comment-always`; no other inputs or steps changed
- [x] `comment-on-alert: true` retained, so a regression past `alert-threshold` (default 110%, coupling 150%) still posts a comment
- [x] `auto-push` and `save-data-file` still gated on `github.event_name != 'pull_request'` so non-PR runs continue to persist data on gh-pages