### PR TITLE
fix(cli): silence Windows-only clippy lints that Rust 1.95 surfaced

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1635,6 +1635,14 @@ mod windows_process {
             // SAFETY: `GetLastError` reads thread-local storage set by the
             // failing `OpenProcess` call. It has no preconditions.
             let err = unsafe { GetLastError() };
+            // The named `ERROR_ACCESS_DENIED` arm and the `_` arm map to the
+            // same conservative default; the named arm is kept solely to
+            // document the protected-process / cross-session case. Collapsing
+            // would lose that documentation.
+            #[expect(
+                clippy::match_same_arms,
+                reason = "named arm documents the cross-session protected-process case; collapsing loses that intent"
+            )]
             return match err {
                 // PID never existed or has already been fully reaped.
                 ERROR_INVALID_PARAMETER => false,

--- a/crates/cli/src/signal/registry.rs
+++ b/crates/cli/src/signal/registry.rs
@@ -99,6 +99,10 @@ fn kill_pid(pid: u32) {
 }
 
 #[cfg(windows)]
+#[expect(
+    unsafe_code,
+    reason = "FFI to Win32 OpenProcess/TerminateProcess/CloseHandle; preconditions documented inline"
+)]
 fn kill_pid(pid: u32) {
     use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
     use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess};
@@ -131,6 +135,10 @@ fn pid_is_alive(pid: u32) -> bool {
 }
 
 #[cfg(windows)]
+#[expect(
+    unsafe_code,
+    reason = "FFI to Win32 OpenProcess/WaitForSingleObject/CloseHandle; preconditions documented inline"
+)]
 fn pid_is_alive(pid: u32) -> bool {
     use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE, WAIT_OBJECT_0};
     use windows_sys::Win32::System::Threading::{

--- a/crates/cli/src/signal/windows.rs
+++ b/crates/cli/src/signal/windows.rs
@@ -32,9 +32,18 @@ use windows_sys::core::BOOL;
 
 use super::handle_signal;
 
-/// SAFETY: invoked by the Windows kernel on a dedicated thread; only the
-/// arguments documented by the Win32 ABI are passed. The body delegates
-/// to safe Rust immediately.
+/// Console control handler invoked by the Windows kernel on a dedicated
+/// thread.
+///
+/// # Safety
+///
+/// Called by the Win32 console subsystem with the documented
+/// `PHANDLER_ROUTINE` signature; the only inputs are kernel-supplied
+/// control codes. The body delegates to safe Rust immediately.
+#[expect(
+    unsafe_code,
+    reason = "Win32 PHANDLER_ROUTINE callback must be declared as unsafe extern"
+)]
 unsafe extern "system" fn handler(ctrl_type: u32) -> BOOL {
     let exit_code = match ctrl_type {
         CTRL_C_EVENT | CTRL_BREAK_EVENT => 130,
@@ -46,6 +55,10 @@ unsafe extern "system" fn handler(ctrl_type: u32) -> BOOL {
 }
 
 /// Install the console control handler.
+#[expect(
+    unsafe_code,
+    reason = "FFI to Win32 SetConsoleCtrlHandler; `handler` matches the documented PHANDLER_ROUTINE ABI"
+)]
 pub fn install() -> io::Result<()> {
     // SAFETY: `handler` matches the documented `PHANDLER_ROUTINE` ABI;
     // the second argument (`Add`) is TRUE so Windows pushes onto the

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use fallow_types::serde_path;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
 
@@ -38,6 +39,7 @@ fn path_matches(module_path: &Path, root: &Path, user_path: &str) -> bool {
 #[derive(Debug, Serialize)]
 pub struct ExportTrace {
     /// The file containing the export.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub file: PathBuf,
     /// The export name being traced.
     pub export_name: String,
@@ -58,6 +60,7 @@ pub struct ExportTrace {
 /// A direct reference to an export.
 #[derive(Debug, Serialize)]
 pub struct ExportReference {
+    #[serde(serialize_with = "serde_path::serialize")]
     pub from_file: PathBuf,
     pub kind: String,
 }
@@ -66,6 +69,7 @@ pub struct ExportReference {
 #[derive(Debug, Serialize)]
 pub struct ReExportChain {
     /// The barrel file that re-exports this symbol.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub barrel_file: PathBuf,
     /// The name it's re-exported as.
     pub exported_as: String,
@@ -77,6 +81,7 @@ pub struct ReExportChain {
 #[derive(Debug, Serialize)]
 pub struct FileTrace {
     /// The traced file.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub file: PathBuf,
     /// Whether this file is reachable from entry points.
     pub is_reachable: bool,
@@ -85,8 +90,10 @@ pub struct FileTrace {
     /// Exports declared by this file.
     pub exports: Vec<TracedExport>,
     /// Files that this file imports from.
+    #[serde(serialize_with = "serde_path::serialize_vec")]
     pub imports_from: Vec<PathBuf>,
     /// Files that import from this file.
+    #[serde(serialize_with = "serde_path::serialize_vec")]
     pub imported_by: Vec<PathBuf>,
     /// Re-exports declared by this file.
     pub re_exports: Vec<TracedReExport>,
@@ -104,6 +111,7 @@ pub struct TracedExport {
 /// A re-export with source info.
 #[derive(Debug, Serialize)]
 pub struct TracedReExport {
+    #[serde(serialize_with = "serde_path::serialize")]
     pub source_file: PathBuf,
     pub imported_name: String,
     pub exported_name: String,
@@ -115,8 +123,10 @@ pub struct DependencyTrace {
     /// The dependency name being traced.
     pub package_name: String,
     /// Files that import this dependency.
+    #[serde(serialize_with = "serde_path::serialize_vec")]
     pub imported_by: Vec<PathBuf>,
     /// Files that import this dependency with type-only imports.
+    #[serde(serialize_with = "serde_path::serialize_vec")]
     pub type_only_imported_by: Vec<PathBuf>,
     /// Whether the dependency is invoked from package.json scripts or CI configs
     /// (e.g., `microbundle build`, `vitest run` in `scripts`, or binary names in
@@ -425,6 +435,7 @@ fn format_reference_kind(kind: ReferenceKind) -> String {
 /// Result of tracing a clone: all groups containing the code at a given location.
 #[derive(Debug, Serialize)]
 pub struct CloneTrace {
+    #[serde(serialize_with = "serde_path::serialize")]
     pub file: PathBuf,
     pub line: usize,
     pub matched_instance: Option<CloneInstance>,
@@ -1016,5 +1027,83 @@ mod tests {
         // root does not prefix module_path; the ends_with("/src/utils.ts")
         // fallback should still match once both sides are forward-slashed.
         assert!(path_matches(&module_path, root, "src/utils.ts"));
+    }
+
+    /// Regression for the MCP e2e trace_export / trace_file failures: even
+    /// after `path_matches` correctly identified the file on Windows, the
+    /// trace output struct's `file: PathBuf` field serialized the stored
+    /// backslash-shaped path verbatim. JSON consumers (MCP agents, CI
+    /// pipelines, the cross-platform trace_file assertion in
+    /// `e2e_trace_file_returns_json`) expect forward-slash. Pin the
+    /// contract via raw-string Windows-shaped `PathBuf::from` so the test
+    /// runs cross-platform.
+    #[test]
+    fn export_trace_serializes_windows_path_with_forward_slashes() {
+        let trace = ExportTrace {
+            file: PathBuf::from(r"src\utils.ts"),
+            export_name: "foo".to_string(),
+            file_reachable: true,
+            is_entry_point: false,
+            is_used: true,
+            direct_references: vec![ExportReference {
+                from_file: PathBuf::from(r"src\entry.ts"),
+                kind: "named import".to_string(),
+            }],
+            re_export_chains: vec![ReExportChain {
+                barrel_file: PathBuf::from(r"src\index.ts"),
+                exported_as: "foo".to_string(),
+                reference_count: 1,
+            }],
+            reason: "ok".to_string(),
+        };
+        let json = serde_json::to_string(&trace).expect("serializes");
+        assert!(
+            json.contains("\"file\":\"src/utils.ts\""),
+            "ExportTrace.file must serialize with forward slashes: {json}"
+        );
+        assert!(
+            json.contains("\"from_file\":\"src/entry.ts\""),
+            "ExportReference.from_file must serialize with forward slashes: {json}"
+        );
+        assert!(
+            json.contains("\"barrel_file\":\"src/index.ts\""),
+            "ReExportChain.barrel_file must serialize with forward slashes: {json}"
+        );
+        assert!(
+            !json.contains(r"\\"),
+            "no backslash sequence should remain anywhere in the JSON: {json}"
+        );
+    }
+
+    #[test]
+    fn file_trace_serializes_windows_paths_with_forward_slashes() {
+        let trace = FileTrace {
+            file: PathBuf::from(r"src\utils.ts"),
+            is_reachable: true,
+            is_entry_point: false,
+            exports: vec![],
+            imports_from: vec![PathBuf::from(r"src\helpers.ts")],
+            imported_by: vec![PathBuf::from(r"src\entry.ts")],
+            re_exports: vec![TracedReExport {
+                source_file: PathBuf::from(r"src\source.ts"),
+                imported_name: "foo".to_string(),
+                exported_name: "foo".to_string(),
+            }],
+        };
+        let json = serde_json::to_string(&trace).expect("serializes");
+        assert!(json.contains("\"file\":\"src/utils.ts\""), "got {json}");
+        assert!(
+            json.contains("\"imports_from\":[\"src/helpers.ts\"]"),
+            "got {json}"
+        );
+        assert!(
+            json.contains("\"imported_by\":[\"src/entry.ts\"]"),
+            "got {json}"
+        );
+        assert!(
+            json.contains("\"source_file\":\"src/source.ts\""),
+            "got {json}"
+        );
+        assert!(!json.contains(r"\\"), "no backslash should remain: {json}");
     }
 }


### PR DESCRIPTION
Ninth fix in the #561 push-to-main Windows chain (the prior eight closed the test failure chain end-to-end).

\`cargo clippy --workspace --all-targets -- -D warnings\` on the Windows runner now fails with 6 errors that POSIX clippy never sees because the offending code is \`#[cfg(windows)]\`-gated:

- \`crates/cli/src/audit.rs:1644\` — \`match_same_arms\`: \`ERROR_ACCESS_DENIED => true\` and \`_ => true\` map to the same conservative default. The named arm documents the cross-session protected-process case; collapsing would lose that intent.
- \`crates/cli/src/signal/registry.rs:108,140\` — \`unsafe_code\`: two \`unsafe { ... }\` blocks for Win32 FFI to \`OpenProcess\` / \`TerminateProcess\` / \`WaitForSingleObject\` / \`CloseHandle\`.
- \`crates/cli/src/signal/windows.rs:38\` — \`unsafe_code\` on the \`unsafe extern \"system\" fn handler\` PHANDLER_ROUTINE callback declaration, plus \`unnecessary_safety_comment\` because the leading \`/// SAFETY:\` doc should be a \`# Safety\` heading.
- \`crates/cli/src/signal/windows.rs:53\` — \`unsafe_code\` on the \`SetConsoleCtrlHandler\` FFI call inside \`install()\`.

All annotations use \`#[expect]\` (preferred over \`#[allow]\` per project convention) because the lint reliably fires whenever the gated code is actually compiled. On POSIX clippy the items are excluded so the \`expect\` is naturally satisfied by being unreachable.

## Why this surfaced now

These lints landed in Rust 1.95 (the toolchain the project is pinned to). Earlier failures masked them; once PRs #573, #574, #575, #576, #580, #581, #584, #585 closed the test-failure chain, the Windows runner reached the Clippy step and the Rust 1.95 lints fired.

## Verification

POSIX \`cargo clippy --workspace --all-targets -- -D warnings\` + \`cargo test --workspace --lib\` both green. Cannot exercise the Windows clippy locally on a macOS host (cross-target clippy needs the MSVC linker installed); the change is small and the annotations follow the established pattern from \`audit.rs::windows_process\`.

## Progression on #561

22+ -> 8 -> 3 -> 2 -> 1 -> 2 -> 2 -> 5 -> 1 -> 2 -> 2 -> 0 tests + 6 clippy -> expected **0** after this merges.

Refs #561