### PR TITLE
fix(mcp): gate cfg(unix)-only run helpers behind cfg(unix) import

### DIFF
--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -3,7 +3,12 @@ use rmcp::model::*;
 #[cfg(unix)]
 use std::time::Duration;
 
-use crate::tools::{run_fallow, run_fallow_with_timeout, run_fallow_with_top_level_warnings};
+use crate::tools::run_fallow;
+// Both helpers are only exercised by the cfg(unix) /bin/sh-based tests
+// below; gating the imports keeps Windows clippy's `unused_imports` lint
+// quiet.
+#[cfg(unix)]
+use crate::tools::{run_fallow_with_timeout, run_fallow_with_top_level_warnings};
 
 use super::super::resolve_binary;
 


### PR DESCRIPTION
Tenth fix in the #561 push-to-main Windows chain. After PR #587 closed the cfg(windows)-only clippy errors, the Windows runner reached a different clippy fail: \`unused_imports\` on \`run_fallow_with_timeout\` and \`run_fallow_with_top_level_warnings\` in \`crates/mcp/src/server/tests/run.rs\`. Both helpers are only used by the cfg(unix) /bin/sh-based tests further down the file. On Windows the tests are excluded but the top-level \`use\` line still imported both helpers.

Gate those two behind a separate \`#[cfg(unix)]\` import while keeping \`run_fallow\` in the unconditional import (it is used by \`run_fallow_missing_binary\` which runs on all platforms). POSIX clippy and tests stay green.

Refs #561