### PR TITLE
fix(npm): embed SHA-256 digests in platform packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,51 @@ jobs:
             '
           done
 
+      # Embed each platform binary's SHA-256 digest into its platform
+      # package's package.json under the `fallowDigests` field. The npm
+      # postinstall script (`npm/fallow/scripts/verify-binary.js`) reads
+      # this field first and only falls back to the GitHub release API
+      # when it is absent. Without the embedded digest, shared-IP CI
+      # runners hit the 60 req/hr unauthenticated rate limit and the
+      # install aborts with `digest-unavailable`. PKG_PATH is set by the
+      # surrounding shell from a glob over npm/*/package.json, never from
+      # untrusted input. Refs #597.
+      - name: Embed SHA-256 digests into platform packages
+        run: |
+          for pkg in npm/*/package.json; do
+            PKG_PATH="$pkg" node -e '
+              const fs = require("fs");
+              const path = require("path");
+              const crypto = require("crypto");
+              const manifestPath = process.env.PKG_PATH;
+              const dir = path.dirname(manifestPath);
+              const pkg = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+              // Only platform packages (@fallow-cli/<platform>) ship binaries;
+              // the npm/fallow wrapper has no binaries to digest. Skip it
+              // silently so the same glob keeps working across both shapes.
+              if (typeof pkg.name !== "string" || !pkg.name.startsWith("@fallow-cli/")) {
+                process.exit(0);
+              }
+              const digests = {};
+              for (const entry of fs.readdirSync(dir)) {
+                if (entry.endsWith(".sig") || entry === "package.json" || entry === "README.md") {
+                  continue;
+                }
+                const full = path.join(dir, entry);
+                const stat = fs.statSync(full);
+                if (!stat.isFile()) continue;
+                digests[entry] = "sha256:" + crypto.createHash("sha256").update(fs.readFileSync(full)).digest("hex");
+              }
+              if (Object.keys(digests).length === 0) {
+                console.error("no binaries found in " + dir);
+                process.exit(1);
+              }
+              pkg.fallowDigests = digests;
+              fs.writeFileSync(manifestPath, JSON.stringify(pkg, null, 2) + "\n");
+              console.log(manifestPath + ": " + Object.keys(digests).join(", "));
+            '
+          done
+
       - name: Install NAPI package dependencies
         # Only safe here because this job has no publish tokens. The dev
         # dependency tree of @napi-rs/cli runs install scripts; keeping that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`npm install fallow` postinstall no longer fails on shared-IP CI runners with `digest-unavailable`.** Before, the postinstall verifier fetched each platform binary's expected SHA-256 from the unauthenticated GitHub release API (`api.github.com/repos/fallow-rs/fallow/releases/tags/v<version>`), so pooled CI IPs (Buildkite, GHA shared runners, internal build clusters) routinely exceeded the 60 req/hr unauthenticated limit and `pnpm install --frozen-lockfile` aborted with `fallow: binary verification failed ... (digest-unavailable): GitHub release API returned HTTP 403: API rate limit exceeded`. After, the release workflow's `npm-prep` job computes the SHA-256 of every binary inside each `@fallow-cli/<platform>` package and writes it into the platform package's `package.json` under `fallowDigests`. `verify-binary.js` reads that embedded value first and only falls back to the GitHub API for platform packages published before v2.78.1 that do not yet carry the field, so steady-state installs perform zero network calls during digest verification. The Ed25519 signature layer and the `FALLOW_SKIP_BINARY_VERIFY` escape hatch are unchanged. (Closes [#597](https://github.com/fallow-rs/fallow/issues/597).)
+
 ## [2.78.0] - 2026-05-22
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,9 +24,9 @@ On `fallow-rs/fallow`'s own GitHub Actions setup, the `approval_policy: first_ti
 
 ## Binary distribution and verification
 
-Every fallow release publishes per-platform CLI, LSP, and MCP binaries via three channels (the GitHub Release, the `@fallow-cli/*` npm platform packages, and the bundled `fallow-rs/fallow@v2` GitHub Action). At release time the `build` job in `.github/workflows/release.yml` signs each binary with the workflow's Ed25519 private key (`ED25519_BINARY_SIGNING_PRIVATE_KEY` repo secret), uploads the resulting `.sig` files alongside the binaries, and publishes npm tarballs with `npm publish --provenance --ignore-scripts`. GitHub records a SHA-256 `digest` field for every release asset; npm and Action installs compare platform-package bytes against that digest after signature verification succeeds.
+Every fallow release publishes per-platform CLI, LSP, and MCP binaries via three channels (the GitHub Release, the `@fallow-cli/*` npm platform packages, and the bundled `fallow-rs/fallow@v2` GitHub Action). At release time the `build` job in `.github/workflows/release.yml` signs each binary with the workflow's Ed25519 private key (`ED25519_BINARY_SIGNING_PRIVATE_KEY` repo secret), uploads the resulting `.sig` files alongside the binaries, and publishes npm tarballs with `npm publish --provenance --ignore-scripts`. The same workflow computes a SHA-256 digest of every platform binary and writes it into the platform package's `package.json` under a `fallowDigests` field, so npm and Action installs verify binary bytes locally without a network round-trip.
 
-The matching public key is `34 bytes of SPKI DER header + 32 raw bytes of Ed25519 public key`. The 32-byte raw key is hardcoded into every consumer (the VS Code extension at `editors/vscode/src/download.ts`, the npm wrapper at `npm/fallow/scripts/verify-binary.js`) so the Ed25519 layer of verification works fully offline and cannot be silently downgraded by network-path tampering. The SHA-256 layer reaches `https://api.github.com/repos/fallow-rs/fallow/releases/tags/v<version>` to pull the platform asset's `digest` field, providing a second factor that is rooted in GitHub's own integrity surface rather than the npm registry.
+The matching public key is `34 bytes of SPKI DER header + 32 raw bytes of Ed25519 public key`. The 32-byte raw key is hardcoded into every consumer (the VS Code extension at `editors/vscode/src/download.ts`, the npm wrapper at `npm/fallow/scripts/verify-binary.js`) so the Ed25519 layer of verification works fully offline and cannot be silently downgraded by network-path tampering. The SHA-256 layer reads the embedded `fallowDigests` field from the platform package's `package.json`. If the field is absent (older platform packages published before v2.78.1), the verifier falls back to fetching the platform asset's `digest` field from `https://api.github.com/repos/fallow-rs/fallow/releases/tags/v<version>`; this fallback can fail on shared-IP CI runners that exceed GitHub's 60 req/hr unauthenticated rate limit (issue #597), which is why steady-state verification uses the embedded path.
 
 **Public key fingerprint (raw 32-byte Ed25519, hex):**
 
@@ -41,7 +41,7 @@ You can copy this value out-of-band (a release blog post, this file at a tag you
 | Channel | When verification runs | What it verifies | Failure mode |
 |:--------|:-----------------------|:-----------------|:-------------|
 | VS Code extension | After downloading the binary from the GitHub Release | Ed25519 signature over the binary bytes; SHA-256 fallback when no `.sig` is present | Refuses to launch and deletes the partial download |
-| `npm install fallow` (postinstall) | After the platform package is resolved | Ed25519 signature over each of `fallow`, `fallow-lsp`, `fallow-mcp` in the resolved `@fallow-cli/<platform>` package, then SHA-256 of the binary bytes against the GitHub Release `asset.digest` field | Aborts the install with exit code 1 and a `fallow: binary verification failed: ...` message |
+| `npm install fallow` (postinstall) | After the platform package is resolved | Ed25519 signature over each of `fallow`, `fallow-lsp`, `fallow-mcp` in the resolved `@fallow-cli/<platform>` package, then SHA-256 of the binary bytes against the platform package's `fallowDigests` field (with the GitHub Release `asset.digest` field as a fallback for older packages) | Aborts the install with exit code 1 and a `fallow: binary verification failed: ...` message |
 | `fallow-rs/fallow@v2` GitHub Action installer | After `npm install -g --ignore-scripts fallow@<spec>` | Same as above, but the verifier code is loaded from the checked-out Action tree rather than the installed package so a tampered postinstall cannot self-validate | Aborts the action step with a `::error::` annotation |
 
 ### Out-of-band verification recipe
@@ -55,10 +55,16 @@ ED25519_BINARY_SIGNING_PUBLIC_KEY=g05v13Mz5u7fd5NHxxCstAPS2CNNVZ9e18h+VSreC9E= \
 
 The base64 form of the public key above (`g05v13Mz5u7fd5NHxxCstAPS2CNNVZ9e18h+VSreC9E=`) decodes to the same 32 bytes shown in the fingerprint section.
 
-For the SHA-256 half, compare the local binary hash with the GitHub Release asset digest:
+For the SHA-256 half, compare the local binary hash with the digest embedded in the matching `@fallow-cli/<platform>` package's `package.json`:
 
 ```sh
-shasum -a 256 fallow-aarch64-apple-darwin
+shasum -a 256 node_modules/@fallow-cli/linux-x64-gnu/fallow
+node -p 'require("@fallow-cli/linux-x64-gnu/package.json").fallowDigests.fallow'
+```
+
+Both lines should print the same hex digest (the second carries a `sha256:` prefix). For platform packages published before v2.78.1 that do not yet ship `fallowDigests`, compare against the GitHub Release asset digest instead:
+
+```sh
 gh release view v2.76.0 --repo fallow-rs/fallow --json assets \
   --jq '.assets[] | select(.name=="fallow-aarch64-apple-darwin") | .digest'
 ```

--- a/npm/fallow/scripts/verify-binary.js
+++ b/npm/fallow/scripts/verify-binary.js
@@ -2,18 +2,27 @@
 //
 // Verifies each platform binary against a .sig file shipped alongside it in
 // the @fallow-cli/<platform> package, then cross-checks the binary bytes
-// against the SHA-256 digest published by GitHub Releases for the matching
-// version/platform asset. The .sig is produced at release time by
-// `.github/scripts/sign-binary.mjs` using the workflow's
+// against an expected SHA-256 digest. The .sig is produced at release time
+// by `.github/scripts/sign-binary.mjs` using the workflow's
 // ED25519_BINARY_SIGNING_PRIVATE_KEY secret. The matching public key (32 raw
 // bytes) is embedded below and is identical to the value already trusted by
 // the VS Code extension at editors/vscode/src/download.ts:19-22.
+//
+// SHA-256 digest source (in order of preference, refs #465 and #597):
+//   1. `fallowDigests` field in the platform package's package.json, written
+//      at release time by the `npm-prep` job. This is the steady-state path:
+//      no network traffic, immune to GitHub API rate limits.
+//   2. Fallback: GitHub Release asset digest via the public REST API. Kept
+//      for backwards compatibility with platform packages published before
+//      #597 that lack the embedded field. Shared-IP CI runners (Buildkite,
+//      pooled GHA runners) can exceed the 60 req/hr unauthenticated limit;
+//      that failure mode is what motivated #597.
 //
 // Triggered from scripts/postinstall.js and from the GitHub Action installer
 // at action/scripts/install.sh. The escape hatch FALLOW_SKIP_BINARY_VERIFY=1
 // is documented in SECURITY.md.
 //
-// No external dependencies: uses node:crypto and node:fs only. Refs #465.
+// No external dependencies: uses node:crypto and node:fs only.
 
 const crypto = require('node:crypto');
 const fs = require('node:fs');
@@ -211,6 +220,31 @@ function platformPackageDir(pkg, resolveFrom) {
   return { dir: path.dirname(manifestPath), manifestPath };
 }
 
+// Read the SHA-256 digest for a binary embedded in the platform package's
+// package.json (written by the npm-prep job at release time as
+// `fallowDigests[<filename>]`). Returns the normalized digest hex or null
+// when the manifest does not exist, cannot be parsed, lacks the field, or
+// the value is malformed. Refs #597.
+function readEmbeddedDigest(manifestPath, binaryFileName) {
+  if (typeof manifestPath !== 'string' || manifestPath.length === 0) {
+    return null;
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (!manifest || typeof manifest !== 'object') {
+    return null;
+  }
+  const digests = manifest.fallowDigests;
+  if (!digests || typeof digests !== 'object') {
+    return null;
+  }
+  return normalizeDigest(digests[binaryFileName]);
+}
+
 function binaryTargetsForPlatform(platformId) {
   const isWindows = process.platform === 'win32';
   const ext = isWindows ? '.exe' : '';
@@ -265,6 +299,9 @@ async function verifyInstalled(options) {
     pkg = '<override>';
     version = opts.version || '0.0.0';
     platformId = opts.platformId || 'test-platform';
+    // Lets tests drop a package.json next to the binaries to exercise the
+    // embedded-digest path. readEmbeddedDigest returns null when missing.
+    manifestPath = path.join(dir, 'package.json');
   } else {
     if (process.platform !== 'linux') {
       pkg = getPlatformPackage(process.platform, process.arch);
@@ -308,22 +345,33 @@ async function verifyInstalled(options) {
     if (!result.ok) {
       return { ...result, binary: binaryPath, package: pkg };
     }
-    let expectedDigest;
-    try {
-      expectedDigest = await digestProvider({
-        assetName: target.asset,
-        binaryPath,
-        packageName: pkg,
-        version,
-      });
-    } catch (err) {
-      return {
-        ok: false,
-        code: 'digest-unavailable',
-        message: `cannot load SHA-256 digest for ${target.asset}: ${err.message}`,
-        binary: binaryPath,
-        package: pkg,
-      };
+    // Prefer the digest embedded in the platform package's package.json
+    // (written at release time by `npm-prep`). Falling back to the GitHub
+    // release API only when no embedded digest is present preserves
+    // backwards compatibility with platform packages published before #597.
+    // The shared-IP CI rate-limit failure mode that motivated #597 only
+    // affects the fallback path, so the steady-state install path is now
+    // fully offline.
+    let expectedDigest = manifestPath
+      ? readEmbeddedDigest(manifestPath, target.binary)
+      : null;
+    if (!expectedDigest) {
+      try {
+        expectedDigest = await digestProvider({
+          assetName: target.asset,
+          binaryPath,
+          packageName: pkg,
+          version,
+        });
+      } catch (err) {
+        return {
+          ok: false,
+          code: 'digest-unavailable',
+          message: `cannot load SHA-256 digest for ${target.asset}: ${err.message}`,
+          binary: binaryPath,
+          package: pkg,
+        };
+      }
     }
     const digestResult = verifyDigestAt(binaryPath, expectedDigest);
     if (!digestResult.ok) {
@@ -340,6 +388,7 @@ module.exports = {
   _verifyWithKey,
   fetchReleaseDigest,
   normalizeDigest,
+  readEmbeddedDigest,
   sha256Hex,
   EMBEDDED_PUBLIC_KEY,
   ED25519_SPKI_HEADER,

--- a/npm/fallow/scripts/verify-binary.test.js
+++ b/npm/fallow/scripts/verify-binary.test.js
@@ -12,6 +12,7 @@ const {
   verifyInstalled,
   sha256Hex,
   normalizeDigest,
+  readEmbeddedDigest,
   EMBEDDED_PUBLIC_KEY,
   ED25519_SPKI_HEADER,
   SKIP_ENV,
@@ -379,6 +380,141 @@ test('verifyInstalled honors FALLOW_SKIP_BINARY_VERIFY', async (t) => {
   const result = await verifyInstalled({ dirOverride: '/does/not/exist' });
   assert.equal(result.ok, true);
   assert.equal(result.skipped, true);
+});
+
+function computeDigestsForDir(dir) {
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const out = {};
+  for (const base of ['fallow', 'fallow-lsp', 'fallow-mcp']) {
+    const fileName = `${base}${ext}`;
+    const full = path.join(dir, fileName);
+    out[fileName] = 'sha256:' + crypto.createHash('sha256').update(fs.readFileSync(full)).digest('hex');
+  }
+  return out;
+}
+
+function writeManifest(dir, body) {
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(body));
+}
+
+test('readEmbeddedDigest returns null when manifest is missing', () => {
+  assert.equal(readEmbeddedDigest('/does/not/exist/package.json', 'fallow'), null);
+});
+
+test('readEmbeddedDigest returns null when fallowDigests field is absent', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallow-vbtest-emb-'));
+  t.after(() => cleanup(dir));
+  writeManifest(dir, { name: '@fallow-cli/x', version: '1.0.0' });
+  assert.equal(readEmbeddedDigest(path.join(dir, 'package.json'), 'fallow'), null);
+});
+
+test('readEmbeddedDigest returns null when the per-binary entry is malformed', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallow-vbtest-emb-'));
+  t.after(() => cleanup(dir));
+  writeManifest(dir, {
+    name: '@fallow-cli/x',
+    version: '1.0.0',
+    fallowDigests: { fallow: 'not-a-real-digest' },
+  });
+  assert.equal(readEmbeddedDigest(path.join(dir, 'package.json'), 'fallow'), null);
+});
+
+test('readEmbeddedDigest returns normalized hex for a valid sha256: prefixed entry', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallow-vbtest-emb-'));
+  t.after(() => cleanup(dir));
+  const hex = 'a'.repeat(64);
+  writeManifest(dir, {
+    name: '@fallow-cli/x',
+    version: '1.0.0',
+    fallowDigests: { fallow: 'sha256:' + hex },
+  });
+  assert.equal(readEmbeddedDigest(path.join(dir, 'package.json'), 'fallow'), hex);
+});
+
+test('verifyInstalled uses the embedded digest without calling the provider', async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const dir = makePlatformDir(privateKey);
+  t.after(() => cleanup(dir));
+  writeManifest(dir, {
+    name: '@fallow-cli/x',
+    version: '1.0.0',
+    fallowDigests: computeDigestsForDir(dir),
+  });
+  let providerCalls = 0;
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: () => {
+      providerCalls += 1;
+      return Promise.reject(new Error('provider should not be called'));
+    },
+  });
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(providerCalls, 0);
+});
+
+test('verifyInstalled falls back to the provider when the embedded digest is missing', async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const dir = makePlatformDir(privateKey);
+  t.after(() => cleanup(dir));
+  // No package.json at all; legacy platform package shape.
+  let providerCalls = 0;
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: ({ binaryPath }) => {
+      providerCalls += 1;
+      return Promise.resolve('sha256:' + crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex'));
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(providerCalls, 3);
+});
+
+test('verifyInstalled falls back to the provider when fallowDigests is partial / malformed', async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const dir = makePlatformDir(privateKey);
+  t.after(() => cleanup(dir));
+  writeManifest(dir, {
+    name: '@fallow-cli/x',
+    version: '1.0.0',
+    fallowDigests: { fallow: 'not-a-real-digest' },
+  });
+  let providerCalls = 0;
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: ({ binaryPath }) => {
+      providerCalls += 1;
+      return Promise.resolve('sha256:' + crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex'));
+    },
+  });
+  assert.equal(result.ok, true);
+  // One call per binary because all three entries fail to normalize.
+  assert.equal(providerCalls, 3);
+});
+
+test('verifyInstalled returns digest-mismatch when the embedded digest disagrees with the binary', async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const dir = makePlatformDir(privateKey);
+  t.after(() => cleanup(dir));
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  writeManifest(dir, {
+    name: '@fallow-cli/x',
+    version: '1.0.0',
+    fallowDigests: {
+      [`fallow${ext}`]: 'sha256:' + 'a'.repeat(64),
+      [`fallow-lsp${ext}`]: 'sha256:' + 'a'.repeat(64),
+      [`fallow-mcp${ext}`]: 'sha256:' + 'a'.repeat(64),
+    },
+  });
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: () => Promise.reject(new Error('should not be reached')),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'digest-mismatch');
 });
 
 test('verifyInstalled ignores skip env when allowSkipEnv is false', async (t) => {


### PR DESCRIPTION
## Summary

- Issue [#597](https://github.com/fallow-rs/fallow/issues/597): `npm install fallow`'s postinstall verifier fetches each platform binary's SHA-256 from the unauthenticated GitHub release API. Shared-IP CI runners (Buildkite, pooled GitHub Actions, internal build clusters) routinely exceed GitHub's 60 req/hr unauthenticated limit, and `pnpm install --frozen-lockfile` aborts with `fallow: binary verification failed ... (digest-unavailable): GitHub release API returned HTTP 403: API rate limit exceeded`.
- The release workflow's `npm-prep` job now computes the SHA-256 of every binary inside each `@fallow-cli/<platform>` package and writes it into the platform package's `package.json` under `fallowDigests`. `verify-binary.js` reads that embedded value first; the GitHub release API is only consulted as a fallback for older platform packages that do not ship `fallowDigests`. Steady-state installs perform zero network calls during digest verification.
- Ed25519 signature verification, the `FALLOW_SKIP_BINARY_VERIFY` escape hatch, and the action installer's verifier-resolution flow are unchanged.

## Backwards compatibility

- A v2.78.1+ wrapper installed alongside a v2.78.0 platform package falls through the embedded-digest miss and verifies via the existing GitHub API path, preserving the upgrade path until both packages are bumped.
- The platform package shape adds one optional `fallowDigests` field; older wrappers ignore it.

## Test plan

- [x] `node --test npm/fallow/scripts/*.test.js` (35 tests, +4 new covering embedded-present, missing, partial/malformed, digest-mismatch)
- [x] `actionlint .github/workflows/release.yml`
- [x] `bash action/tests/run.sh`
- [x] Local smoke of the inline embed step on a synthetic `npm/fallow` + `npm/linux-x64-gnu` tree: wrapper skipped, platform package gains correct `fallowDigests`.

Fixes #597