### PR TITLE
fix(cli): gate scoped_child::tests module behind cfg(unix)

### DIFF
--- a/crates/cli/src/signal/scoped_child.rs
+++ b/crates/cli/src/signal/scoped_child.rs
@@ -141,7 +141,11 @@ pub fn output(command: &mut Command) -> io::Result<Output> {
     ScopedChild::spawn(command)?.wait_with_output()
 }
 
-#[cfg(test)]
+// Every test in this module exec's `/bin/sh` / `true` / `echo`, so the
+// entire suite is cfg(unix)-only. Gating at the module level keeps the
+// Windows `unused_imports` lint quiet on `use super::*;` (since the
+// module would otherwise be reduced to just the import line on Windows).
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
After #595 + v2.78.1's allow-fix on \`ScopedChild::id\`, every test inside \`scoped_child::tests\` is cfg(unix) (they all exec \`/bin/sh\` / \`true\` / \`echo\`). On Windows the module reduces to just \`use super::*;\`, which Rust 1.95's \`-D unused-imports\` flags as \`unused import: super::*\`.

Gate the module itself with \`#[cfg(all(test, unix))]\` so the whole suite (and its imports) only compile when the bodies have a chance to run. No Windows test loss because there were no Windows tests in this module to begin with.

Refs #561