### PR TITLE
fix(unused-class-members): credit Playwright helper fixtures

### DIFF
--- a/crates/core/tests/integration_test/member_detection.rs
+++ b/crates/core/tests/integration_test/member_detection.rs
@@ -265,6 +265,36 @@ fn playwright_helper_function_fixture_pom_methods_are_credited() {
 }
 
 #[test]
+fn playwright_helper_function_with_local_setup_fixture_pom_methods_are_credited() {
+    let root = fixture_path("issue-586-playwright-helper-local-setup");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_class_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.member.parent_name, m.member.member_name))
+        .collect();
+
+    assert!(
+        !unused_class_members.contains(&"SidebarActionsLocal.openPatientsWithLocal".to_string()),
+        "SidebarActionsLocal.openPatientsWithLocal should be credited through a helper that has local setup before returning base.extend, found: {unused_class_members:?}"
+    );
+    assert!(
+        !unused_class_members.contains(&"SidebarActionsDirect.openPatientsDirect".to_string()),
+        "SidebarActionsDirect.openPatientsDirect should remain credited through the direct-return control helper, found: {unused_class_members:?}"
+    );
+    assert!(
+        unused_class_members.contains(&"SidebarActionsLocal.unusedLocalOnly".to_string()),
+        "genuinely unused local POM methods should still be reported, found: {unused_class_members:?}"
+    );
+    assert!(
+        unused_class_members.contains(&"SidebarActionsDirect.unusedDirectOnly".to_string()),
+        "genuinely unused direct POM methods should still be reported, found: {unused_class_members:?}"
+    );
+}
+
+#[test]
 fn playwright_fixture_teardown_credits_factory_getter_member_usage() {
     let root = fixture_path("issue-386-playwright-fixture-teardown");
     let config = create_config(root);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -40,7 +40,11 @@ use crate::MemberKind;
 /// `new URL(..., import.meta.url)`. Pre-fix entries carry empty
 /// `destructured_names` for the same source, so they would silently miss
 /// the named-export credit until the file is touched.
-pub(super) const CACHE_VERSION: u32 = 93;
+///
+/// Bumped to 94 for issue #586: Playwright helper fixture extraction recognizes
+/// helpers with local setup before the final `return base.extend<T>(...)`, so
+/// pre-fix entries can miss fixture definition sentinels.
+pub(super) const CACHE_VERSION: u32 = 94;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -1245,6 +1245,49 @@ fn playwright_helper_function_records_fixture_definitions() {
 }
 
 #[test]
+fn playwright_helper_function_with_local_setup_records_fixture_definitions() {
+    let info = parse(
+        r#"
+            import { test as base } from '@playwright/test';
+            import { LoginActions } from './login-actions';
+
+            type MyFixtures = {
+                appUi: {
+                    step: {
+                        login: LoginActions;
+                    };
+                };
+            };
+
+            type UserRole = "assistant" | "anonymous";
+
+            export function appTest(role: UserRole = "assistant") {
+                const storageState = role === "assistant" ? "assistant-auth.json" : undefined;
+
+                return base.extend<MyFixtures>({
+                    storageState: async ({}, use) => {
+                        await use(storageState);
+                    },
+                });
+            }
+        "#,
+    );
+
+    assert!(
+        info.member_accesses.iter().any(|a| {
+            a.object
+                == format!(
+                    "{}appTest:appUi.step.login",
+                    crate::PLAYWRIGHT_FIXTURE_DEF_SENTINEL
+                )
+                && a.member == "LoginActions"
+        }),
+        "helper-function Playwright fixture with local setup should record a def sentinel keyed by the function name, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
 fn playwright_helper_arrow_records_fixture_definitions() {
     let info = parse(
         r"

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -320,20 +320,18 @@ fn playwright_test_callee_name(expr: &Expression<'_>) -> Option<String> {
     }
 }
 
-/// Find the call expression that is the sole `return <call>` statement of a
-/// function body, or `None` if the body is empty, has more than one statement,
-/// or returns anything other than a call expression.
+/// Find the call expression from a function body's final `return <call>`
+/// statement, or `None` if the body is empty or returns anything other than a
+/// call expression.
 ///
 /// Used to detect helper-function Playwright fixtures such as
-/// `function appTest() { return base.extend<T>(...); }` and chained helpers
-/// `function appTest() { return setupTestFixture(); }`. See issue #491.
-fn extract_function_body_single_return_call<'a, 'b>(
+/// `function appTest() { return base.extend<T>(...); }`, helpers with local
+/// setup before the return, and chained helpers
+/// `function appTest() { return setupTestFixture(); }`. See issues #491/#586.
+fn extract_function_body_final_return_call<'a, 'b>(
     body: &'b oxc_ast::ast::FunctionBody<'a>,
 ) -> Option<&'b CallExpression<'a>> {
-    if body.statements.len() != 1 {
-        return None;
-    }
-    let Statement::ReturnStatement(ret) = body.statements.first()? else {
+    let Statement::ReturnStatement(ret) = body.statements.last()? else {
         return None;
     };
     let Expression::CallExpression(call) = ret.argument.as_ref()? else {
@@ -344,8 +342,8 @@ fn extract_function_body_single_return_call<'a, 'b>(
 
 /// Find the call expression that is the body of an arrow function, supporting
 /// both expression-body (`() => base.extend<T>(...)`) and block-body
-/// (`() => { return base.extend<T>(...); }`) shapes. See issue #491.
-fn extract_arrow_single_return_call<'a, 'b>(
+/// (`() => { return base.extend<T>(...); }`) shapes. See issues #491/#586.
+fn extract_arrow_return_call<'a, 'b>(
     arrow: &'b oxc_ast::ast::ArrowFunctionExpression<'a>,
 ) -> Option<&'b CallExpression<'a>> {
     if arrow.expression {
@@ -362,7 +360,7 @@ fn extract_arrow_single_return_call<'a, 'b>(
         };
         return Some(call.as_ref());
     }
-    extract_function_body_single_return_call(&arrow.body)
+    extract_function_body_final_return_call(&arrow.body)
 }
 
 fn collect_playwright_fixture_member_uses(
@@ -1104,8 +1102,8 @@ impl ModuleInfoExtractor {
             );
     }
 
-    /// Capture a helper-function Playwright fixture or alias from a body's
-    /// sole `return <call>` statement.
+    /// Capture a helper-function Playwright fixture or alias from the call
+    /// returned by the helper's final statement.
     ///
     /// Distinguishes two shapes:
     /// 1. `return base.extend<T>(...)`: collect type bindings now (mirrors
@@ -1118,7 +1116,7 @@ impl ModuleInfoExtractor {
     ///
     /// Non-matching shapes (member-call return, no callee identifier) are
     /// dropped silently: false matches would just produce inert def
-    /// sentinels with no use-side correlate. See issue #491.
+    /// sentinels with no use-side correlate. See issues #491 and #586.
     pub(super) fn try_capture_playwright_factory_helper(
         &mut self,
         test_name: &str,
@@ -1256,12 +1254,12 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                         let refs = Self::collect_function_signature_refs(function);
                         self.record_local_signature_refs(&id.name, refs);
 
-                        // `function appTest() { return base.extend<T>(...); }`
+                        // `function appTest() { const state = ...; return base.extend<T>(...); }`
                         // or `function appTest() { return setupTestFixture(); }`
                         // is a helper-function Playwright fixture consumed via
-                        // the curried `appTest()(...)` form. See issue #491.
+                        // the curried `appTest()(...)` form. See issues #491/#586.
                         if let Some(body) = function.body.as_deref()
-                            && let Some(call) = extract_function_body_single_return_call(body)
+                            && let Some(call) = extract_function_body_final_return_call(body)
                         {
                             self.try_capture_playwright_factory_helper(id.name.as_str(), call);
                         }
@@ -1640,19 +1638,17 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             }
 
             // `const appTest = () => base.extend<T>(...)` or
-            // `const appTest = () => { return base.extend<T>(...); }` or
+            // `const appTest = () => { const state = ...; return base.extend<T>(...); }` or
             // `const appTest = function () { return base.extend<T>(...); }`
             // are helper-function Playwright fixtures consumed via the curried
-            // `appTest()(...)` form. See issue #491.
+            // `appTest()(...)` form. See issues #491/#586.
             if let BindingPattern::BindingIdentifier(id) = &declarator.id {
                 let helper_call = match init {
-                    Expression::ArrowFunctionExpression(arrow) => {
-                        extract_arrow_single_return_call(arrow)
-                    }
+                    Expression::ArrowFunctionExpression(arrow) => extract_arrow_return_call(arrow),
                     Expression::FunctionExpression(func) => func
                         .body
                         .as_deref()
-                        .and_then(extract_function_body_single_return_call),
+                        .and_then(extract_function_body_final_return_call),
                     _ => None,
                 };
                 if let Some(call) = helper_call {

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/package.json
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "issue-586-playwright-helper-local-setup",
+  "devDependencies": {
+    "@playwright/test": "^1.0.0"
+  }
+}

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/playwright/fixture-direct.ts
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/playwright/fixture-direct.ts
@@ -1,0 +1,22 @@
+import { test as base } from '@playwright/test';
+import { SidebarActionsDirect } from '../src/pages/sidebar-actions-direct';
+
+type MyFixtures = {
+  appUi: {
+    step: {
+      sidebar: SidebarActionsDirect;
+    };
+  };
+};
+
+export function appTestDirectReturn() {
+  return base.extend<MyFixtures>({
+    appUi: async ({}, use) => {
+      await use({
+        step: {
+          sidebar: new SidebarActionsDirect(),
+        },
+      });
+    },
+  });
+}

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/playwright/fixture-with-local.ts
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/playwright/fixture-with-local.ts
@@ -1,0 +1,29 @@
+import { test as base } from '@playwright/test';
+import { SidebarActionsLocal } from '../src/pages/sidebar-actions-local';
+
+type MyFixtures = {
+  appUi: {
+    step: {
+      sidebar: SidebarActionsLocal;
+    };
+  };
+};
+
+type UserRole = 'assistant' | 'anonymous';
+
+export function appTestWithLocal(role: UserRole = 'assistant') {
+  const storageState = role === 'assistant' ? 'assistant-auth.json' : undefined;
+
+  return base.extend<MyFixtures>({
+    storageState: async ({}, use) => {
+      await use(storageState);
+    },
+    appUi: async ({}, use) => {
+      await use({
+        step: {
+          sidebar: new SidebarActionsLocal(),
+        },
+      });
+    },
+  });
+}

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/src/pages/sidebar-actions-direct.ts
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/src/pages/sidebar-actions-direct.ts
@@ -1,0 +1,9 @@
+export class SidebarActionsDirect {
+  async openPatientsDirect() {
+    return 'open patients directly';
+  }
+
+  async unusedDirectOnly() {
+    return 'unused';
+  }
+}

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/src/pages/sidebar-actions-local.ts
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/src/pages/sidebar-actions-local.ts
@@ -1,0 +1,9 @@
+export class SidebarActionsLocal {
+  async openPatientsWithLocal() {
+    return 'open patients with local setup';
+  }
+
+  async unusedLocalOnly() {
+    return 'unused';
+  }
+}

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/tests/direct-base-extend.spec.ts
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/tests/direct-base-extend.spec.ts
@@ -1,0 +1,5 @@
+import { appTestDirectReturn } from '../playwright/fixture-direct';
+
+appTestDirectReturn()('uses nested fixture member through direct return helper', async ({ appUi }) => {
+  await appUi.step.sidebar.openPatientsDirect();
+});

--- a/tests/fixtures/issue-586-playwright-helper-local-setup/tests/local-before-base-extend.spec.ts
+++ b/tests/fixtures/issue-586-playwright-helper-local-setup/tests/local-before-base-extend.spec.ts
@@ -1,0 +1,5 @@
+import { appTestWithLocal } from '../playwright/fixture-with-local';
+
+appTestWithLocal()('uses nested fixture member through helper with local setup', async ({ appUi }) => {
+  await appUi.step.sidebar.openPatientsWithLocal();
+});


### PR DESCRIPTION
## Summary

- Recognize Playwright helper functions whose final statement returns `base.extend<T>(...)` after local setup.
- Preserve existing direct-return and helper-alias fixture behavior.
- Bump the extraction cache to invalidate modules missing helper fixture definition sentinels.
- Add extractor and integration regression coverage for local-setup helper fixtures.

Fixes #586.

## Test plan

- [x] `cargo build --workspace`: finished successfully.
- [x] `cargo test --workspace --all-targets`: final suites reported zero failures.
- [x] `cargo test -p fallow-extract playwright_helper_function_with_local_setup_records_fixture_definitions`.
- [x] `cargo test -p fallow-core --test integration_test playwright_helper_function_with_local_setup_fixture_pom_methods_are_credited`.
- [x] CLI smoke on `tests/fixtures/issue-586-playwright-helper-local-setup`: used fixture methods are credited, genuinely unused methods remain reported.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo doc --workspace --no-deps --document-private-items` warning and error filter clean.
- [x] `typos` clean.
- [x] Real-world smoke on `zod`, `preact`, `vite`, `kookr`, and sparse `nova-spektr`: no crashes, deterministic where applicable; old and new binaries differed for the comparison run.