### PR TITLE
fix: guard CachedModule cache shape

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -15,7 +15,7 @@ paths:
 - All suppressions use `#[expect(clippy::..., reason = "...")]` — warns when unnecessary, preventing dead annotations. Every `#[allow]` and `#[expect]` must include a `reason` attribute. Use `#[allow]` only for pedantic-only or target-dependent lints where `#[expect]` would be unfulfilled.
 
 ## Size assertions
-`ModuleNode` (96 bytes), `ModuleInfo` (400 bytes), `ExportInfo` (112 bytes), `ImportInfo` (96 bytes), `Edge` (32 bytes), `MemberAccess` (48 bytes), `ImportedName` / `ExportName` (24 bytes each), prevents accidental struct bloat. Source of truth is `const _: () = assert!(...)` in `crates/types/src/extract.rs`; this doc is informational and may lag the code.
+`ModuleNode` (96 bytes), `ModuleInfo` (496 bytes), `ExportInfo` (112 bytes), `ImportInfo` (96 bytes), `Edge` (32 bytes), `MemberAccess` (48 bytes), `ImportedName` / `ExportName` (24 bytes each), prevents accidental struct bloat. `CachedModule` (520 bytes), nested cache structs, and external extract element types persisted inside the cache are also pinned in `crates/extract/src/cache/types.rs`; assertion failures there are the review point for whether `CACHE_VERSION` needs a bump. Source of truth is `const _: () = assert!(...)` in the relevant Rust files; this doc is informational and may lag the code.
 
 ## Formatting
 `.rustfmt.toml` with `style_edition = "2024"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Re-export source edges now participate in resolver dependency diagnostics.** Before, unresolved `export { x } from "./missing"` and `export * from "./missing"` sources were skipped by `unresolved-import`, and package re-exports such as `export { default as pad } from "left-pad"` could fall back to `package.json:1` style locations in unlisted-dependency reporting. After, re-export sources share the same resolved source-edge path as static and literal dynamic imports, so missing re-export sources report as unresolved imports and package re-exports report their actual source line. Package `imports` / `exports` array targets also preserve fallback order, and package `imports` entries that target external packages credit the target dependency. Thanks [@M-Hassan-Raza](https://github.com/M-Hassan-Raza) for the patch. (PR [#666](https://github.com/fallow-rs/fallow/pull/666).)
 
+### Internal
+
+- **Extraction cache structs now fail loudly when their size changes without review.** `CachedModule`, its nested cache structs, and external extract element types persisted inside the cache have compile-time size assertions next to the cache type definitions. A future cache-shape edit that changes type sizes now fails the build until the contributor decides whether `CACHE_VERSION` must be bumped and updates the assertion values. (Closes [#443](https://github.com/fallow-rs/fallow/issues/443).)
 
 ## [2.80.0] - 2026-05-24
 

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -96,6 +96,36 @@ pub(super) const IMPORT_KIND_DEFAULT: u8 = 1;
 pub(super) const IMPORT_KIND_NAMESPACE: u8 = 2;
 pub(super) const IMPORT_KIND_SIDE_EFFECT: u8 = 3;
 
+macro_rules! assert_cached_type_size {
+    ($ty:ty, $size:expr) => {
+        const _: () = assert!(
+            std::mem::size_of::<$ty>() == $size,
+            concat!(
+                stringify!($ty),
+                " size changed; bump CACHE_VERSION if the cached wire shape or extraction semantics changed, then update this assertion"
+            )
+        );
+    };
+}
+
+assert_cached_type_size!(CachedModule, 520);
+assert_cached_type_size!(CachedNamespaceObjectAlias, 72);
+assert_cached_type_size!(CachedLocalTypeDeclaration, 32);
+assert_cached_type_size!(CachedPublicSignatureTypeReference, 56);
+assert_cached_type_size!(CachedSuppression, 12);
+assert_cached_type_size!(CachedUnknownSuppressionKind, 32);
+assert_cached_type_size!(CachedExport, 112);
+assert_cached_type_size!(CachedImport, 96);
+assert_cached_type_size!(CachedDynamicImport, 88);
+assert_cached_type_size!(CachedRequireCall, 80);
+assert_cached_type_size!(CachedReExport, 88);
+assert_cached_type_size!(CachedMember, 64);
+assert_cached_type_size!(CachedDynamicImportPattern, 56);
+assert_cached_type_size!(crate::MemberAccess, 48);
+assert_cached_type_size!(fallow_types::extract::FunctionComplexity, 48);
+assert_cached_type_size!(fallow_types::extract::FlagUse, 80);
+assert_cached_type_size!(fallow_types::extract::ClassHeritageInfo, 96);
+
 /// Cached data for a single module.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct CachedModule {


### PR DESCRIPTION
## Summary
- Add compile-time size assertions for `CachedModule`, nested cache structs, and external extract element types persisted in the incremental cache.
- Keep the guard scoped to size-changing cache-shape edits; same-size structural changes remain covered by normal cache review and `CACHE_VERSION` judgment.
- Document the new cache-size guard in the code-quality rule and changelog.

## Issue
Closes #443

## Verification
- [x] `cargo build -p fallow-extract`
- [x] dummy-field compile-fail smoke, `CachedModule size changed; bump CACHE_VERSION ...`
- [x] `cargo test -p fallow-extract --all-targets`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `typos .`
- [x] `./target/debug/fallow audit --format json --quiet` (`verdict: pass`)
- [x] real-world cache smoke on `zod`, `preact`, and `vite`, two deterministic JSON runs each

## Review
- Pre-ship review: SHIP.
