### PR TITLE
fix(ci): dogfood JS and TS surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       miri: ${{ steps.filter.outputs.miri }}
       ci-scripts: ${{ steps.filter.outputs.ci-scripts }}
       npm-package: ${{ steps.filter.outputs.npm-package }}
+      self-analyze: ${{ steps.filter.outputs.self-analyze }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -90,6 +91,10 @@ jobs:
               - 'npm/fallow/**'
               - 'schema.json'
               - '.github/workflows/ci.yml'
+            self-analyze:
+              - '.github/workflows/ci.yml'
+              - 'editors/vscode/**'
+              - 'npm/fallow/**'
 
   check:
     name: Check (${{ matrix.os }})
@@ -226,6 +231,30 @@ jobs:
             throw new Error(`npm package is missing expected files: ${missing.join(', ')}`);
           }
           NODE
+
+      - name: Run npm wrapper unit tests
+        run: |
+          cd npm/fallow
+          npm run test:platform
+          npm run test:verify
+
+  fallow-self-analyze:
+    name: Fallow Self Analysis
+    needs: changes
+    if: needs.changes.outputs.self-analyze == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-rust
+      - name: Build fallow binary
+        run: cargo build --bin fallow
+      - name: Analyze VS Code extension
+        run: ./target/debug/fallow dead-code --root editors/vscode --format json --quiet
+      - name: Analyze npm wrapper package
+        run: ./target/debug/fallow dead-code --root npm/fallow --format json --quiet
 
   vscode:
     name: VS Code Extension
@@ -437,7 +466,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, doc, typos, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri]
+    needs: [check, doc, typos, npm-package, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- **Fallow now dogfoods its shipped JavaScript and TypeScript surfaces in CI.** The main CI workflow builds the fallow binary and runs `fallow dead-code --format json --quiet` against `editors/vscode` and `npm/fallow` on relevant pull requests and every push to `main`. Per-surface configs mark VS Code's public generated type re-export surface and npm's platform-package wrapper shape explicitly, and the previously exported but unused `fetchReleaseDigest` helper is no longer part of the npm wrapper's CommonJS surface. The README now advertises that fallow self-analyzes its JS/TS code. (Closes [#483](https://github.com/fallow-rs/fallow/issues/483).)
+
 - **Extraction cache structs now fail loudly when their size changes without review.** `CachedModule`, its nested cache structs, and external extract element types persisted inside the cache have compile-time size assertions next to the cache type definitions. A future cache-shape edit that changes type sizes now fails the build until the contributor decides whether `CACHE_VERSION` must be bumped and updates the assertion values. (Closes [#443](https://github.com/fallow-rs/fallow/issues/443).)
 
 ## [2.80.0] - 2026-05-24

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <p align="center">
   <a href="https://github.com/fallow-rs/fallow/actions/workflows/ci.yml"><img src="https://github.com/fallow-rs/fallow/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/fallow-rs/fallow/actions/workflows/coverage.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/fallow-rs/fallow/badges/coverage.json" alt="Coverage"></a>
+  <a href="https://github.com/fallow-rs/fallow/actions/workflows/ci.yml"><img src="https://img.shields.io/badge/self--analyzed-fallow-brightgreen" alt="Self analyzed"></a>
   <a href="https://crates.io/crates/fallow-cli"><img src="https://img.shields.io/crates/v/fallow-cli.svg" alt="crates.io"></a>
   <a href="https://www.npmjs.com/package/fallow"><img src="https://img.shields.io/npm/v/fallow.svg" alt="npm"></a>
   <a href="https://github.com/fallow-rs/fallow/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
@@ -33,6 +34,8 @@ Fallow turns a JS/TS repository into a trusted quality report: health score, cha
 - What can be safely removed?
 
 Fallow is built for maintainers, CI pipelines, editors, and AI agents that need structured evidence instead of guesses. No AI inside the analyzer. Fallow produces deterministic findings, typed output contracts, and traceable explanations that downstream tools can trust.
+
+Fallow dogfoods its shipped JavaScript and TypeScript surfaces in CI: the VS Code extension and npm wrapper package are analyzed with fallow on every relevant change.
 
 ## Quick start
 

--- a/editors/vscode/.fallowrc.json
+++ b/editors/vscode/.fallowrc.json
@@ -1,7 +1,22 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "src/extension.ts",
+    "src/types.ts",
+    "src/generated/output-contract.d.ts"
+  ],
+  "ignorePatterns": [
+    "test/integration/fixtures/**"
+  ],
   "ignoreDependencies": ["@vscode/vsce"],
+  "ignoreExports": [
+    {
+      "file": "src/types.ts",
+      "exports": ["*"]
+    }
+  ],
   "rules": {
-    "unlisted-dependencies": "warn"
+    "unlisted-dependencies": "warn",
+    "unresolved-imports": "warn"
   }
 }

--- a/npm/fallow/.fallowrc.json
+++ b/npm/fallow/.fallowrc.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "bin/fallow",
+    "bin/fallow-lsp",
+    "bin/fallow-mcp",
+    "scripts/platform-package.js",
+    "scripts/postinstall.js",
+    "scripts/verify-binary.js"
+  ],
+  "ignorePatterns": [
+    "skills/**",
+    "types/**"
+  ]
+}

--- a/npm/fallow/scripts/verify-binary.js
+++ b/npm/fallow/scripts/verify-binary.js
@@ -386,7 +386,6 @@ module.exports = {
   verifyDigestAt,
   verifyInstalled,
   _verifyWithKey,
-  fetchReleaseDigest,
   normalizeDigest,
   readEmbeddedDigest,
   sha256Hex,


### PR DESCRIPTION
## Summary

- Add a `fallow-self-analyze` CI job that builds the local fallow binary and analyzes `editors/vscode` plus `npm/fallow` on relevant PRs and every push to `main`.
- Add per-surface fallow configs for the VS Code extension and npm wrapper package entry points, preserving intentional warn-level type/dependency surfaces.
- Wire `npm run test:platform` and `npm run test:verify` into the npm package CI job.
- Remove the unused `fetchReleaseDigest` CommonJS export from the npm wrapper and advertise self-analysis in the README.

Fixes #483.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace --all-targets`: all local test targets pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items`: no warnings or errors.
- [x] `./target/debug/fallow dead-code --root editors/vscode --format json --quiet`: exits 0 with configured warn-level generated type imports.
- [x] `./target/debug/fallow dead-code --root npm/fallow --format json --quiet`: exits 0 with configured warn-level package-shape findings and no unused exports.
- [x] Deliberate unused-file smoke in a temporary VS Code copy exits 1 and reports `src/dogfood-sentinel.ts`.
- [x] `npm run test:platform && npm run test:verify` in `npm/fallow`.
- [x] `actionlint .github/workflows/ci.yml`.
- [x] `zizmor --config .github/zizmor.yml --min-confidence medium --format plain .github/ action.yml`.
- [x] `typos .`.
- [x] `./target/debug/fallow audit --format json --quiet`: verdict `pass`.
