### PR TITLE
chore(npm): remove unused freshEnv test helper

### DIFF
--- a/npm/fallow/scripts/lazy-verify.test.js
+++ b/npm/fallow/scripts/lazy-verify.test.js
@@ -67,10 +67,6 @@ function cleanup(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-function freshEnv(extra) {
-  return { ...extra };
-}
-
 function captureStderr(t) {
   const lines = [];
   const original = process.stderr.write.bind(process.stderr);


### PR DESCRIPTION
## Summary

- Remove the unused `freshEnv` helper from `npm/fallow/scripts/lazy-verify.test.js`.

CodeQL flagged this as dead code: the function is defined at line 70 with zero callsites. Net change: three lines deleted, no functional impact.

## Test plan

- [x] `node --test npm/fallow/scripts/*.test.js`: 76 pass + 1 skip (unchanged from #683).