### PR TITLE
chore(hooks): gate oxlint + oxfmt --check on staged JS/TS

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,3 +11,27 @@ if command -v typos &> /dev/null; then
   echo "Running typos check..."
   typos
 fi
+
+# Run oxlint + oxfmt --check only when this commit touches a JS/TS file
+# inside one of the lintable scopes. Keeps pure-Rust commits fast.
+#
+# The lintable scopes mirror the root `npm run lint:js` / `fmt:js:check`
+# script targets in package.json. Update both when adding a new tree.
+js_ts_changed=$(
+  git diff --cached --name-only --diff-filter=ACMR | \
+    grep -E '^(npm/|benchmarks/|crates/napi/|\.github/scripts/|editors/vscode/src/|commitlint\.config\.mjs$)' | \
+    grep -E '\.(js|ts|mjs|cjs|jsx|tsx)$' || true
+)
+
+if [ -n "$js_ts_changed" ]; then
+  if [ ! -d node_modules ]; then
+    echo "JS/TS files staged but node_modules is missing. Run \`npm install\` first." >&2
+    exit 1
+  fi
+
+  echo "Running oxlint..."
+  npm run --silent lint:js
+
+  echo "Running oxfmt --check..."
+  npm run --silent fmt:js:check
+fi


### PR DESCRIPTION
## Summary

- Extends `.githooks/pre-commit` with a JS/TS branch: when this commit touches a `.js|.ts|.mjs|.cjs|.jsx|.tsx` file inside one of the lintable scopes (`npm/`, `benchmarks/`, `crates/napi/`, `.github/scripts/`, `editors/vscode/src/`, `commitlint.config.mjs`), it runs `npm run lint:js` and `npm run fmt:js:check`. Pure-Rust commits skip the JS gate so the hook stays fast.
- Mirrors the CI `JS Lint and Format` job locally so `freshEnv`-style dead code, quote drift, and `.sort()` misuse get caught one step earlier than CodeQL's post-merge sweep.
- Aborts with an `npm install` hint when `node_modules/` is missing rather than skipping silently.

## Test plan

- [x] `git diff --cached --name-only --diff-filter=ACMR | grep -E '^(npm/|benchmarks/|crates/napi/|\.github/scripts/|editors/vscode/src/|commitlint\.config\.mjs$)' | grep -E '\.(js|ts|mjs|cjs|jsx|tsx)$'` returns empty when only `.githooks/pre-commit` is staged (this PR): JS branch is skipped, only `cargo fmt` + `cargo clippy` + `typos` run.
- [x] Same grep returns `npm/fallow/scripts/lazy-verify.js` when that file is staged: JS branch fires, runs `npm run lint:js` and `npm run fmt:js:check`.
- [x] Activated locally via `git config core.hooksPath .githooks` (already documented in CLAUDE.md).