### PR TITLE
test: enforce serde_path on serialized paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Serialized `PathBuf` fields are now covered by a drift gate and normalized consistently.** A new schema test walks CLI/core/types `Serialize` structs and enum struct variants to require `serde_path` serializers for `PathBuf`, `Option<PathBuf>`, and `Vec<PathBuf>` fields, with support for skipped serde fields and custom scalar/option serializers. Existing health/runtime-coverage/setup path fields now use those serializers, including optional component-inherited coverage paths, so Windows paths stay slash-normalized in JSON output. (Closes [#615](https://github.com/fallow-rs/fallow/issues/615).)
+
 ## [2.82.0] - 2026-05-26
 
 ### Fixed

--- a/crates/cli/src/coverage/mod.rs
+++ b/crates/cli/src/coverage/mod.rs
@@ -22,6 +22,7 @@ use std::process::{Command, ExitCode};
 use fallow_config::{OutputFormat, PackageJson, WorkspaceInfo, atomic_write, discover_workspaces};
 use fallow_core::git_env::clear_ambient_git_env;
 use fallow_license::{DEFAULT_HARD_FAIL_DAYS, LicenseStatus};
+use fallow_types::serde_path;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -219,6 +220,7 @@ struct SetupLicenseState {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct SetupSidecarState {
+    #[serde(serialize_with = "serde_path::serialize")]
     path: PathBuf,
     checksum: String,
     updated_at: i64,
@@ -226,6 +228,7 @@ struct SetupSidecarState {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct SetupRecipeState {
+    #[serde(serialize_with = "serde_path::serialize")]
     path: PathBuf,
     checksum: String,
     context_fingerprint: String,

--- a/crates/cli/src/health_types/coverage.rs
+++ b/crates/cli/src/health_types/coverage.rs
@@ -3,12 +3,14 @@ use std::path::{Path, PathBuf};
 use fallow_types::output_health::{
     UntestedExportAction, UntestedExportActionType, UntestedFileAction, UntestedFileActionType,
 };
+use fallow_types::serde_path;
 
 /// Runtime code that no test dependency path reaches.
 #[derive(Debug, Clone, serde::Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct UntestedFile {
     /// Absolute file path.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub path: PathBuf,
     /// Number of value exports declared by the file.
     pub value_export_count: usize,
@@ -19,6 +21,7 @@ pub struct UntestedFile {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct UntestedExport {
     /// Absolute file path.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub path: PathBuf,
     /// Export name.
     pub export_name: String,

--- a/crates/cli/src/health_types/runtime_coverage.rs
+++ b/crates/cli/src/health_types/runtime_coverage.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use fallow_types::serde_path;
+
 /// Runtime coverage JSON contract version. This is scoped to the
 /// `runtime_coverage` block and is independent of the top-level fallow
 /// JSON `schema_version`.
@@ -332,6 +334,7 @@ pub struct RuntimeCoverageFinding {
     /// is the first 8 hex characters of SHA-256(file + function + line + 'prod').
     pub id: String,
     /// File path relative to the project root.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub path: PathBuf,
     /// Static function name as reported in the merged coverage result.
     pub function: String,
@@ -356,6 +359,7 @@ pub struct RuntimeCoverageHotPath {
     /// Stable content-hash ID of the form `fallow:hot:<hash>`.
     pub id: String,
     /// File path relative to the project root.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub path: PathBuf,
     /// Function name for the hot path.
     pub function: String,
@@ -414,6 +418,7 @@ pub struct RuntimeCoverageBlastRadiusEntry {
     /// Stable content-hash ID of the form `fallow:blast:<hash>`.
     pub id: String,
     /// File path relative to the project root.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub file: PathBuf,
     /// Function name for the blast-radius entry.
     pub function: String,
@@ -436,6 +441,7 @@ pub struct RuntimeCoverageImportanceEntry {
     /// Stable content-hash ID of the form `fallow:importance:<hash>`.
     pub id: String,
     /// File path relative to the project root.
+    #[serde(serialize_with = "serde_path::serialize")]
     pub file: PathBuf,
     /// Function name for the importance entry.
     pub function: String,

--- a/crates/cli/src/health_types/scores.rs
+++ b/crates/cli/src/health_types/scores.rs
@@ -246,6 +246,7 @@ pub enum CoverageSource {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ComplexityViolation {
     /// Absolute file path.
+    #[serde(serialize_with = "fallow_types::serde_path::serialize")]
     pub path: std::path::PathBuf,
     /// Function name, `"<anonymous>"` for unnamed functions/arrows, or
     /// `"<template>"` for synthetic Angular template findings.
@@ -302,7 +303,11 @@ pub struct ComplexityViolation {
     /// to project-relative form just like other path fields. Lets human and
     /// AI consumers explain "the template scored partial because the
     /// component it belongs to is tested" without re-deriving the link.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        serialize_with = "fallow_types::serde_path::serialize_option",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub inherited_from: Option<std::path::PathBuf>,
     /// Breakdown of a synthetic `<component>` rollup finding into its
     /// worst-class-function and template contributions. Present only on
@@ -515,6 +520,7 @@ pub fn compute_finding_severity(
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct LargeFunctionEntry {
     /// Absolute file path.
+    #[serde(serialize_with = "fallow_types::serde_path::serialize")]
     pub path: std::path::PathBuf,
     /// Function name, or `"<anonymous>"` for unnamed functions/arrows.
     pub name: String,
@@ -626,6 +632,7 @@ impl Default for HealthSummary {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct FileHealthScore {
     /// File path (absolute; stripped to relative in output).
+    #[serde(serialize_with = "fallow_types::serde_path::serialize")]
     pub path: std::path::PathBuf,
     /// Number of files that import this file.
     pub fan_in: usize,
@@ -696,6 +703,7 @@ pub enum CoverageModel {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct HotspotEntry {
     /// File path (absolute; stripped to relative in output).
+    #[serde(serialize_with = "fallow_types::serde_path::serialize")]
     pub path: std::path::PathBuf,
     /// Hotspot score (0–100). Higher means more risk.
     pub score: f64,

--- a/crates/cli/src/health_types/targets.rs
+++ b/crates/cli/src/health_types/targets.rs
@@ -203,6 +203,7 @@ pub struct EvidenceFunction {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RefactoringTarget {
     /// Absolute file path (stripped to relative in output).
+    #[serde(serialize_with = "fallow_types::serde_path::serialize")]
     pub path: std::path::PathBuf,
     /// Priority score (0–100, higher = more urgent).
     pub priority: f64,

--- a/crates/cli/tests/schema_tests.rs
+++ b/crates/cli/tests/schema_tests.rs
@@ -216,6 +216,169 @@ struct Example {
     assert!(offenders.is_empty());
 }
 
+#[test]
+fn path_fields_use_serde_path_serializer() {
+    let root = workspace_root();
+    let mut offenders = Vec::new();
+
+    for source_root in [
+        root.join("crates/types/src"),
+        root.join("crates/core/src"),
+        root.join("crates/cli/src"),
+    ] {
+        let mut files = Vec::new();
+        collect_rs_files(&source_root, &mut files);
+
+        for file in files {
+            let source = fs::read_to_string(&file)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", file.display()));
+            let syntax = syn::parse_file(&source)
+                .unwrap_or_else(|err| panic!("failed to parse {}: {err}", file.display()));
+            collect_path_field_offenders(&root, &file, &syntax.items, &mut offenders);
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "Serialize-deriving PathBuf fields must use serde_path serializers for cross-platform JSON paths.\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn path_field_gate_reports_missing_scalar_option_and_vec_serializers() {
+    let source = r"#[derive(Serialize)]
+struct Example {
+    file: PathBuf,
+    maybe: Option<PathBuf>,
+    files: Vec<PathBuf>,
+}";
+    let syntax = syn::parse_file(source).expect("synthetic path struct should parse");
+    let root = Path::new("/workspace");
+    let file = root.join("crates/fake/src/lib.rs");
+    let mut offenders = Vec::new();
+
+    collect_path_field_offenders(root, &file, &syntax.items, &mut offenders);
+
+    assert_eq!(
+        offenders,
+        vec![
+            "crates/fake/src/lib.rs:3: Example.file is PathBuf and derives Serialize without a path serializer; use #[serde(serialize_with = \"serde_path::serialize\")]",
+            "crates/fake/src/lib.rs:4: Example.maybe is Option<PathBuf> and derives Serialize without a path serializer; use #[serde(serialize_with = \"serde_path::serialize_option\")]",
+            "crates/fake/src/lib.rs:5: Example.files is Vec<PathBuf> and derives Serialize without a path serializer; use #[serde(serialize_with = \"serde_path::serialize_vec\")]",
+        ]
+    );
+}
+
+#[test]
+fn path_field_gate_handles_fully_qualified_types() {
+    let source = r"#[derive(serde::Serialize)]
+struct Example {
+    file: std::path::PathBuf,
+    maybe: std::option::Option<std::path::PathBuf>,
+    files: std::vec::Vec<std::path::PathBuf>,
+}";
+    let syntax = syn::parse_file(source).expect("synthetic path struct should parse");
+    let root = Path::new("/workspace");
+    let file = root.join("crates/fake/src/lib.rs");
+    let mut offenders = Vec::new();
+
+    collect_path_field_offenders(root, &file, &syntax.items, &mut offenders);
+
+    assert_eq!(offenders.len(), 3);
+    assert!(offenders[0].contains("Example.file is PathBuf"));
+    assert!(offenders[1].contains("Example.maybe is Option<PathBuf>"));
+    assert!(offenders[2].contains("Example.files is Vec<PathBuf>"));
+}
+
+#[test]
+fn path_field_gate_accepts_cfg_attr_serialize_derives() {
+    let source = r#"#[cfg_attr(feature = "schema", derive(Debug, serde::Serialize))]
+struct Example {
+    file: PathBuf,
+}"#;
+    let syntax = syn::parse_file(source).expect("synthetic path struct should parse");
+    let root = Path::new("/workspace");
+    let file = root.join("crates/fake/src/lib.rs");
+    let mut offenders = Vec::new();
+
+    collect_path_field_offenders(root, &file, &syntax.items, &mut offenders);
+
+    assert_eq!(offenders.len(), 1);
+    assert!(offenders[0].contains("Example.file is PathBuf"));
+}
+
+#[test]
+fn path_field_gate_walks_and_skips_enum_struct_variants() {
+    let source = r"#[derive(Serialize)]
+enum Example {
+    Visible {
+        file: PathBuf,
+    },
+    #[serde(skip)]
+    Hidden {
+        file: PathBuf,
+    },
+}";
+    let syntax = syn::parse_file(source).expect("synthetic path enum should parse");
+    let root = Path::new("/workspace");
+    let file = root.join("crates/fake/src/lib.rs");
+    let mut offenders = Vec::new();
+
+    collect_path_field_offenders(root, &file, &syntax.items, &mut offenders);
+
+    assert_eq!(offenders.len(), 1);
+    assert!(offenders[0].contains("Example::Visible.file is PathBuf"));
+}
+
+#[test]
+fn path_field_gate_accepts_skipped_fields_and_custom_scalar_option_serializers() {
+    let source = r#"#[derive(Serialize)]
+struct Example {
+    #[serde(skip)]
+    skipped: PathBuf,
+    #[serde(skip_serializing)]
+    skipped_serializing: PathBuf,
+    #[serde(serialize_with = "custom_path")]
+    file: PathBuf,
+    #[serde(serialize_with = "custom_option_path")]
+    maybe: Option<PathBuf>,
+}"#;
+    let syntax = syn::parse_file(source).expect("synthetic path struct should parse");
+    let root = Path::new("/workspace");
+    let file = root.join("crates/fake/src/lib.rs");
+    let mut offenders = Vec::new();
+
+    collect_path_field_offenders(root, &file, &syntax.items, &mut offenders);
+
+    assert!(offenders.is_empty());
+}
+
+#[test]
+fn path_field_gate_requires_serialize_vec_for_vec_paths() {
+    let source = r#"#[derive(Serialize)]
+struct Example {
+    #[serde(serialize_with = "custom_vec")]
+    custom: Vec<PathBuf>,
+    #[serde(serialize_with = "serde_path::serialize_vec")]
+    local: Vec<PathBuf>,
+    #[serde(serialize_with = "crate::serde_path::serialize_vec")]
+    crate_path: Vec<PathBuf>,
+    #[serde(serialize_with = "fallow_types::serde_path::serialize_vec")]
+    external_path: Vec<PathBuf>,
+}"#;
+    let syntax = syn::parse_file(source).expect("synthetic path struct should parse");
+    let root = Path::new("/workspace");
+    let file = root.join("crates/fake/src/lib.rs");
+    let mut offenders = Vec::new();
+
+    collect_path_field_offenders(root, &file, &syntax.items, &mut offenders);
+
+    assert_eq!(offenders.len(), 1);
+    assert!(offenders[0].contains("Example.custom is Vec<PathBuf>"));
+    assert!(offenders[0].contains("serde_path::serialize_vec"));
+}
+
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -271,6 +434,172 @@ fn collect_schema_default_offenders(
             _ => {}
         }
     }
+}
+
+fn collect_path_field_offenders(
+    root: &Path,
+    file: &Path,
+    items: &[syn::Item],
+    offenders: &mut Vec<String>,
+) {
+    for item in items {
+        match item {
+            syn::Item::Struct(item_struct) if derives_serialize(&item_struct.attrs) => {
+                collect_path_fields_offenders(
+                    root,
+                    file,
+                    &item_struct.fields,
+                    &item_struct.ident.to_string(),
+                    offenders,
+                );
+            }
+            syn::Item::Enum(item_enum) if derives_serialize(&item_enum.attrs) => {
+                for variant in &item_enum.variants {
+                    if matches!(variant.fields, syn::Fields::Named(_))
+                        && !serde_skips_serialization(&variant.attrs)
+                    {
+                        let owner = format!("{}::{}", item_enum.ident, variant.ident);
+                        collect_path_fields_offenders(
+                            root,
+                            file,
+                            &variant.fields,
+                            &owner,
+                            offenders,
+                        );
+                    }
+                }
+            }
+            syn::Item::Mod(item_mod) => {
+                if let Some((_, nested_items)) = &item_mod.content {
+                    collect_path_field_offenders(root, file, nested_items, offenders);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_path_fields_offenders(
+    root: &Path,
+    file: &Path,
+    fields: &syn::Fields,
+    owner: &str,
+    offenders: &mut Vec<String>,
+) {
+    for (index, field) in fields.iter().enumerate() {
+        let Some(kind) = path_field_kind(&field.ty) else {
+            continue;
+        };
+        if serde_skips_serialization(&field.attrs)
+            || path_field_has_valid_serializer(&field.attrs, kind)
+        {
+            continue;
+        }
+
+        let field_name = field
+            .ident
+            .as_ref()
+            .map_or_else(|| index.to_string(), ToString::to_string);
+        let relative = file.strip_prefix(root).unwrap_or(file);
+        let line = field.ident.as_ref().map_or_else(
+            || field.span().start().line,
+            |ident| ident.span().start().line,
+        );
+        offenders.push(format!(
+            "{}:{line}: {owner}.{field_name} is {} and derives Serialize without a path serializer; use {}",
+            relative.display(),
+            kind.label(),
+            kind.fix_hint()
+        ));
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PathFieldKind {
+    Scalar,
+    Option,
+    Vec,
+}
+
+impl PathFieldKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Scalar => "PathBuf",
+            Self::Option => "Option<PathBuf>",
+            Self::Vec => "Vec<PathBuf>",
+        }
+    }
+
+    fn fix_hint(self) -> &'static str {
+        match self {
+            Self::Scalar => "#[serde(serialize_with = \"serde_path::serialize\")]",
+            Self::Option => "#[serde(serialize_with = \"serde_path::serialize_option\")]",
+            Self::Vec => "#[serde(serialize_with = \"serde_path::serialize_vec\")]",
+        }
+    }
+}
+
+fn path_field_kind(ty: &syn::Type) -> Option<PathFieldKind> {
+    if is_pathbuf_type(ty) {
+        return Some(PathFieldKind::Scalar);
+    }
+
+    let syn::Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    let inner = first_angle_bracket_type(segment)?;
+    if !is_pathbuf_type(inner) {
+        return None;
+    }
+    if segment.ident == "Option" {
+        Some(PathFieldKind::Option)
+    } else if segment.ident == "Vec" {
+        Some(PathFieldKind::Vec)
+    } else {
+        None
+    }
+}
+
+fn is_pathbuf_type(ty: &syn::Type) -> bool {
+    let syn::Type::Path(type_path) = ty else {
+        return false;
+    };
+    type_path
+        .path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "PathBuf")
+}
+
+fn first_angle_bracket_type(segment: &syn::PathSegment) -> Option<&syn::Type> {
+    let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        syn::GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    })
+}
+
+fn path_field_has_valid_serializer(attrs: &[syn::Attribute], kind: PathFieldKind) -> bool {
+    let Some(serializer) = serde_serialize_with(attrs) else {
+        return false;
+    };
+    match kind {
+        PathFieldKind::Scalar | PathFieldKind::Option => true,
+        PathFieldKind::Vec => serializer
+            .rsplit("::")
+            .next()
+            .is_some_and(|segment| segment == "serialize_vec"),
+    }
+}
+
+fn derives_serialize(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("derive") && attr_tokens_contain(attr, "Serialize")
+            || attr.path().is_ident("cfg_attr") && attr_tokens_contain(attr, "Serialize")
+    })
 }
 
 fn collect_fields_offenders(
@@ -359,6 +688,41 @@ fn serde_has_default(attrs: &[syn::Attribute]) -> bool {
             Ok(())
         });
         has_default
+    })
+}
+
+fn serde_skips_serialization(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("serde") {
+            return false;
+        }
+        let mut skips = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("skip") || meta.path.is_ident("skip_serializing") {
+                skips = true;
+            }
+            if meta.input.peek(syn::Token![=]) {
+                let _value: syn::Expr = meta.value()?.parse()?;
+            }
+            Ok(())
+        });
+        skips
+    })
+}
+
+fn serde_serialize_with(attrs: &[syn::Attribute]) -> Option<String> {
+    attrs.iter().find_map(|attr| {
+        if !attr.path().is_ident("serde") {
+            return None;
+        }
+        let mut serializer = None;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("serialize_with") {
+                serializer = Some(meta.value()?.parse::<syn::LitStr>()?.value());
+            }
+            Ok(())
+        });
+        serializer
     })
 }
 

--- a/crates/types/src/serde_path.rs
+++ b/crates/types/src/serde_path.rs
@@ -1,4 +1,4 @@
-//! Custom serde serializers for `PathBuf` and `Vec<PathBuf>` that always
+//! Custom serde serializers for `PathBuf`, `Option<PathBuf>`, and `Vec<PathBuf>` that always
 //! output forward slashes, regardless of platform. This ensures consistent
 //! JSON/SARIF output on Windows.
 
@@ -13,6 +13,18 @@ use serde::Serializer;
 /// Returns any serializer error produced while writing the normalized path string.
 pub fn serialize<S: Serializer>(path: &Path, s: S) -> Result<S::Ok, S::Error> {
     s.serialize_str(&path.to_string_lossy().replace('\\', "/"))
+}
+
+/// Serialize an `Option<PathBuf>` with forward slashes for cross-platform consistency.
+///
+/// # Errors
+///
+/// Returns any serializer error produced while writing the normalized optional path.
+pub fn serialize_option<S: Serializer>(path: &Option<PathBuf>, s: S) -> Result<S::Ok, S::Error> {
+    match path {
+        Some(path) => s.serialize_some(&path.to_string_lossy().replace('\\', "/")),
+        None => s.serialize_none(),
+    }
 }
 
 /// Serialize a `Vec<PathBuf>` with forward slashes for cross-platform consistency.
@@ -103,7 +115,8 @@ mod tests {
         assert_eq!(path.replace('\\', "/"), "src/deep/nested/file.ts");
     }
 
-    /// Property tests that drive the real `serialize` / `serialize_vec`
+    /// Property tests that drive the real `serialize` / `serialize_option` /
+    /// `serialize_vec`
     /// functions through `serde_json`, rather than the `normalize` proxy the
     /// example tests above use. The forward-slash output is a load-bearing
     /// cross-platform invariant for JSON/SARIF, and the input space (arbitrary
@@ -118,6 +131,13 @@ mod tests {
         struct ScalarPath {
             #[serde(serialize_with = "crate::serde_path::serialize")]
             path: PathBuf,
+        }
+
+        /// Wrapper that routes its field through the real option serializer.
+        #[derive(Serialize)]
+        struct OptionalPath {
+            #[serde(serialize_with = "crate::serde_path::serialize_option")]
+            path: Option<PathBuf>,
         }
 
         /// Wrapper that routes its field through the real vec serializer.
@@ -145,6 +165,14 @@ mod tests {
             })
             .expect("scalar wrapper serializes");
             value["path"].as_str().expect("path is a string").to_owned()
+        }
+
+        /// Serialize one optional path through `OptionalPath`.
+        fn option_json(path: Option<&str>) -> serde_json::Value {
+            serde_json::to_value(OptionalPath {
+                path: path.map(PathBuf::from),
+            })
+            .expect("option wrapper serializes")
         }
 
         proptest! {
@@ -176,6 +204,22 @@ mod tests {
                 let once = scalar_json(&path);
                 let twice = scalar_json(&once);
                 prop_assert_eq!(once, twice);
+            }
+
+            /// The option serializer keeps `None` as null and normalizes `Some`.
+            #[test]
+            fn serialize_option_normalizes_some(path in path_like()) {
+                let value = option_json(Some(&path));
+                let out = value["path"].as_str().expect("path is a string");
+                prop_assert!(!out.contains('\\'), "output {out:?} still contains a backslash");
+                prop_assert_eq!(out, path.replace('\\', "/"));
+            }
+
+            /// None remains a JSON null rather than a string sentinel.
+            #[test]
+            fn serialize_option_none_is_null(_path in path_like()) {
+                let value = option_json(None);
+                prop_assert!(value["path"].is_null());
             }
 
             /// The vec serializer agrees element-for-element with the scalar


### PR DESCRIPTION
## Summary
- Adds a syn-based schema drift gate that scans CLI/core/types `Serialize` structs and enum struct variants for `PathBuf`, `Option<PathBuf>`, and `Vec<PathBuf>` fields without path serializers.
- Adds `serde_path::serialize_option` and property coverage for optional paths.
- Annotates existing health, runtime coverage, refactoring target, and coverage setup path fields so serialized paths stay slash-normalized.
- Adds an Unreleased changelog note.

## Issue
Closes #615

## Verification
- [x] `cargo check --workspace`
- [x] `cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings`
- [x] `cargo test -p fallow-cli -p fallow-mcp`
- [x] `cargo fmt --all -- --check`
- [x] `typos .`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `cargo run --bin fallow-schema-emit --features schema-emit > /tmp/issue-615-output-schema.json && diff -q /tmp/issue-615-output-schema.json docs/output-schema.json`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] Real-world deterministic health smoke on `zod`, `preact`, and `vite`; no non-finite JSON values.
- [x] `fallow audit --format json --quiet | jq ...` (command succeeded; current repo verdict remains `fail`: complexity_findings=2, max_cyclomatic=167, dup=7, dead_code_issues=66)
