### PR TITLE
fix(corpus): remove unused script import

### DIFF
--- a/scripts/public-config-corpus.py
+++ b/scripts/public-config-corpus.py
@@ -7,7 +7,6 @@ import argparse
 import datetime as dt
 import hashlib
 import json
-import os
 import re
 import subprocess
 import sys


### PR DESCRIPTION
## Summary

- Removes the unused `os` import flagged by the automated review on #731.

Refs #731.

## Test plan

- [x] `python3 -m py_compile scripts/public-config-corpus.py`
- [x] `scripts/test-public-config-corpus.sh`
- [x] `cargo build --workspace`
- [x] pre-commit/pre-push fast guards: `cargo fmt`, `cargo clippy`, `typos`
