### PR TITLE
fix(tests): normalize Contentlayer fixture paths

### DIFF
--- a/crates/core/tests/integration_test/issue_610_contentlayer_plugin.rs
+++ b/crates/core/tests/integration_test/issue_610_contentlayer_plugin.rs
@@ -3,13 +3,20 @@ use super::common::{create_config, fixture_path};
 #[test]
 fn contentlayer_plugin_marks_config_content_generated_output_and_processors_used() {
     let root = fixture_path("issue-610-contentlayer-plugin");
-    let config = create_config(root);
+    let config = create_config(root.clone());
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
 
     let unused_files: Vec<String> = results
         .unused_files
         .iter()
-        .map(|file| file.file.path.to_string_lossy().into_owned())
+        .map(|file| {
+            file.file
+                .path
+                .strip_prefix(&root)
+                .unwrap_or(&file.file.path)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
         .collect();
 
     for path in [


### PR DESCRIPTION
## Summary

- Normalize the Contentlayer integration test's unused-file paths relative to the fixture root.
- Convert path separators before suffix assertions so the Windows runner matches Unix behavior.
- Keep the regression focused on Contentlayer reachability while preserving the orphan-file control assertion.

## Test plan

- [x] `cargo test -p fallow-core --test integration_test issue_610_contentlayer_plugin -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `typos .`
- [x] `git diff --check`