### PR TITLE
fix: catch baseline drift on config-only PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitHub Action baseline checks now catch config-only baseline drift.** Before, pull request runs using the default `auto-changed-since: true` plus a generic dead-code baseline could hide baseline membership changes when the PR only changed fallow config, then fail later on the unscoped default-branch run. After, baseline-active dead-code/check action runs disable auto-derived PR scoping when a fallow config file changes, while preserving explicit `changed-since` and `diff-file` overrides. Saved generic baselines also keep pretty JSON and now end with a trailing newline. (Closes [#746](https://github.com/fallow-rs/fallow/issues/746).)
+
 ## [2.84.0] - 2026-05-28
 
 ### Fixed

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -30,6 +30,75 @@ artifact_path() {
   fi
 }
 
+is_dead_code_baseline_command() {
+  [ -n "${INPUT_BASELINE:-}" ] || return 1
+  case "${INPUT_COMMAND:-}" in
+    ""|dead-code|check) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_changed_path() {
+  local path=$1
+  local root="${INPUT_ROOT:-.}"
+
+  path="${path#./}"
+  root="${root#./}"
+
+  if [ "$root" != "." ] && [[ "$path" == "$root/"* ]]; then
+    path="${path#"$root/"}"
+  fi
+
+  printf '%s\n' "$path"
+}
+
+normalize_config_path() {
+  local path=$1
+  local root="${INPUT_ROOT:-.}"
+
+  path="${path#./}"
+  root="${root#./}"
+
+  if [[ "$path" = /* ]]; then
+    local abs_root
+    abs_root=$(cd "${INPUT_ROOT:-.}" 2>/dev/null && pwd -P)
+    if [ -n "$abs_root" ] && [[ "$path" == "$abs_root/"* ]]; then
+      path="${path#"$abs_root/"}"
+    fi
+  elif [ "$root" != "." ] && [[ "$path" == "$root/"* ]]; then
+    path="${path#"$root/"}"
+  fi
+
+  printf '%s\n' "$path"
+}
+
+find_changed_fallow_config() {
+  local changed_files=$1
+  local explicit_config=""
+
+  if [ -n "${INPUT_CONFIG:-}" ]; then
+    explicit_config=$(normalize_config_path "$INPUT_CONFIG")
+  fi
+
+  while IFS= read -r changed_file; do
+    [ -n "$changed_file" ] || continue
+    changed_file=$(normalize_changed_path "$changed_file")
+    case "$changed_file" in
+      .fallowrc.json|.fallowrc.jsonc|fallow.toml|.fallow.toml)
+        printf '%s\n' "$changed_file"
+        return 0
+        ;;
+    esac
+
+    if [ -n "$explicit_config" ] && [ "$changed_file" = "$explicit_config" ]; then
+      printf '%s\n' "$changed_file"
+      return 0
+    fi
+  done <<< "$changed_files"
+
+  return 1
+}
+
 # --- Shared argument building functions ---
 # Uses global ARGS array (avoids bash nameref compatibility issues)
 
@@ -249,15 +318,17 @@ fi
 
 # --- Auto-detect changed-since in PR context ---
 
+AUTO_CHANGED_SINCE=false
+USER_DIFF_FILE=false
+[ -n "${FALLOW_DIFF_FILE:-}" ] && USER_DIFF_FILE=true
+
 if [ -z "${INPUT_CHANGED_SINCE:-}" ] && [ "${INPUT_AUTO_CHANGED_SINCE:-}" = "true" ] && \
    { [ "${EVENT_NAME:-}" = "pull_request" ] || [ "${EVENT_NAME:-}" = "pull_request_target" ]; } && \
    [ -n "${PR_BASE_SHA:-}" ]; then
   INPUT_CHANGED_SINCE="$PR_BASE_SHA"
+  AUTO_CHANGED_SINCE=true
   echo "::notice::Auto-scoping analysis to files changed since PR base (${PR_BASE_SHA:0:7})"
 fi
-
-# Propagate the effective changed-since value so downstream steps can filter
-echo "changed_since=${INPUT_CHANGED_SINCE:-}" >> "$GITHUB_OUTPUT"
 
 # --- Pre-compute changed files list for downstream filtering ---
 # Downstream scripts (comment, summary, annotations, review) need the list of
@@ -270,7 +341,11 @@ echo "changed_since=${INPUT_CHANGED_SINCE:-}" >> "$GITHUB_OUTPUT"
 # requested. Without this, `if:` conditions using
 # `outputs.changed_files_unavailable == 'false'` as a positive signal see an
 # absent field instead of false when changed-since is not set.
-[ -n "${GITHUB_OUTPUT:-}" ] && echo "changed_files_unavailable=false" >> "$GITHUB_OUTPUT"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "changed_files_unavailable=false" >> "$GITHUB_OUTPUT"
+fi
+
+_CHANGED=""
 
 if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
   _ROOT="${INPUT_ROOT:-.}"
@@ -321,6 +396,29 @@ if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
   else
     echo "::warning::Could not determine changed files for --changed-since scoping. Use fetch-depth: 0 in actions/checkout for best results."
   fi
+fi
+
+if is_dead_code_baseline_command && [ -n "$_CHANGED" ]; then
+  CONFIG_SCOPE_TRIGGER=$(find_changed_fallow_config "$_CHANGED" || true)
+  if [ -n "$CONFIG_SCOPE_TRIGGER" ]; then
+    if [ "$AUTO_CHANGED_SINCE" = "true" ]; then
+      if [ "$USER_DIFF_FILE" = "true" ]; then
+        echo "::warning::fallow: '${CONFIG_SCOPE_TRIGGER}' changed, so auto changed-since scoping is disabled for dead-code baseline comparison. The explicit diff file remains active and may still hide baseline drift until an unscoped run." >&2
+      else
+        echo "::warning::fallow: dead-code baseline comparison is running unscoped because '${CONFIG_SCOPE_TRIGGER}' changed. Fallow config can change baseline membership; downstream PR filtering is disabled for this run." >&2
+      fi
+      INPUT_CHANGED_SINCE=""
+      rm -f "$CHANGED_FILES_FILE" "$AUTO_DIFF_FILE"
+    else
+      echo "::warning::fallow: '${CONFIG_SCOPE_TRIGGER}' changed while dead-code baseline comparison is explicitly scoped. Fallow config can change baseline membership, so baseline drift may stay hidden until an unscoped run." >&2
+    fi
+  fi
+fi
+
+# Propagate the effective changed-since value after config safety logic so
+# downstream steps do not reapply stale PR scope.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "changed_since=${INPUT_CHANGED_SINCE:-}" >> "$GITHUB_OUTPUT"
 fi
 
 # --- Pre-compute unified diff for line-level hot-path scoping ---

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -364,6 +364,137 @@ else
 fi
 assert_contains "$OUT" "dead-code-baseline" "analyze: baseline error points to audit baselines"
 
+cat > "$ANALYZE_TMP/bin/fallow" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"--help"*)
+    printf '%s\n' 'Usage: fallow dead-code --sarif-file <PATH>'
+    ;;
+  *)
+    printf '%s\n' '{"total_issues":0}'
+    ;;
+esac
+SH
+chmod +x "$ANALYZE_TMP/bin/fallow"
+
+cat > "$ANALYZE_TMP/bin/git" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  diff)
+    shift
+    for arg in "$@"; do
+      if [ "$arg" = "--name-only" ]; then
+        printf '%s\n' "${FAKE_CHANGED_FILES:-src/a.ts}"
+        exit 0
+      fi
+    done
+    printf '%s\n' 'diff --git a/src/a.ts b/src/a.ts'
+    printf '%s\n' '--- a/src/a.ts'
+    printf '%s\n' '+++ b/src/a.ts'
+    printf '%s\n' '@@ -0,0 +1 @@'
+    printf '%s\n' '+export const a = 1;'
+    ;;
+  cat-file)
+    exit 0
+    ;;
+  fetch)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$ANALYZE_TMP/bin/git"
+
+run_analyze_scope_case() {
+  local case_name=$1
+  local changed_files=$2
+  local baseline=$3
+  local changed_since=$4
+  local diff_file=$5
+  local root=${6:-.}
+  local config=${7:-}
+  local work="$ANALYZE_TMP/scope-$case_name"
+  mkdir -p "$work/$root"
+  rm -f "$ANALYZE_TMP/output-$case_name" "$ANALYZE_TMP/env-$case_name"
+  if [ -n "$diff_file" ]; then
+    printf '%s\n' 'diff --git a/src/a.ts b/src/a.ts' > "$diff_file"
+  fi
+
+  (
+    cd "$work" || exit 1
+    PATH="$ANALYZE_TMP/bin:$PATH" \
+      FAKE_CHANGED_FILES="$changed_files" \
+      GITHUB_OUTPUT="$ANALYZE_TMP/output-$case_name" \
+      GITHUB_ENV="$ANALYZE_TMP/env-$case_name" \
+      INPUT_ROOT="$root" \
+      INPUT_CONFIG="$config" \
+      INPUT_COMMAND="dead-code" \
+      INPUT_FORMAT="json" \
+      INPUT_AUTO_CHANGED_SINCE="true" \
+      INPUT_CHANGED_SINCE="$changed_since" \
+      EVENT_NAME="pull_request" \
+      PR_BASE_SHA="base1234" \
+      INPUT_BASELINE="$baseline" \
+      FALLOW_DIFF_FILE="$diff_file" \
+      bash "$DIR/../scripts/analyze.sh"
+  ) 2>&1
+}
+
+OUT=$(run_analyze_scope_case "config-baseline-auto" ".fallowrc.json" "baseline.json" "" "")
+ARGS=$(cat "$ANALYZE_TMP/scope-config-baseline-auto/fallow-analysis-args.sh")
+OUTPUTS=$(cat "$ANALYZE_TMP/output-config-baseline-auto")
+ENV_OUT=$(cat "$ANALYZE_TMP/env-config-baseline-auto")
+assert_not_contains "$ARGS" "--changed-since" "analyze: config baseline auto-scope removes changed-since"
+if grep -qx 'changed_since=' "$ANALYZE_TMP/output-config-baseline-auto"; then
+  pass "analyze: config baseline auto-scope clears changed_since output"
+else
+  fail "analyze: config baseline auto-scope clears changed_since output" "outputs were: $OUTPUTS"
+fi
+assert_not_contains "$ENV_OUT" "FALLOW_DIFF_FILE=" "analyze: config baseline auto-scope skips auto diff file"
+assert_contains "$OUT" "dead-code baseline comparison is running unscoped because '.fallowrc.json' changed" "analyze: config baseline auto-scope warns"
+
+OUT=$(run_analyze_scope_case "source-baseline-auto" "src/a.ts" "baseline.json" "" "")
+ARGS=$(cat "$ANALYZE_TMP/scope-source-baseline-auto/fallow-analysis-args.sh")
+OUTPUTS=$(cat "$ANALYZE_TMP/output-source-baseline-auto")
+ENV_OUT=$(cat "$ANALYZE_TMP/env-source-baseline-auto")
+assert_contains "$ARGS" "--changed-since base1234" "analyze: source baseline auto-scope keeps changed-since"
+assert_contains "$OUTPUTS" "changed_since=base1234" "analyze: source baseline auto-scope keeps changed_since output"
+assert_contains "$ENV_OUT" "FALLOW_DIFF_FILE=" "analyze: source baseline auto-scope writes auto diff file"
+
+OUT=$(run_analyze_scope_case "config-no-baseline" ".fallowrc.json" "" "" "")
+ARGS=$(cat "$ANALYZE_TMP/scope-config-no-baseline/fallow-analysis-args.sh")
+OUTPUTS=$(cat "$ANALYZE_TMP/output-config-no-baseline")
+assert_contains "$ARGS" "--changed-since base1234" "analyze: config without baseline keeps changed-since"
+assert_contains "$OUTPUTS" "changed_since=base1234" "analyze: config without baseline keeps changed_since output"
+
+OUT=$(run_analyze_scope_case "explicit-config-root-prefix" "packages/app/config/fallow.jsonc" "baseline.json" "" "" "packages/app" "config/fallow.jsonc")
+ARGS=$(cat "$ANALYZE_TMP/scope-explicit-config-root-prefix/fallow-analysis-args.sh")
+assert_not_contains "$ARGS" "--changed-since" "analyze: explicit config path with root prefix removes auto changed-since"
+assert_contains "$OUT" "because 'config/fallow.jsonc' changed" "analyze: explicit config path warning uses root-relative path"
+
+OUT=$(run_analyze_scope_case "config-explicit-changed-since" ".fallowrc.json" "baseline.json" "manual-base" "")
+ARGS=$(cat "$ANALYZE_TMP/scope-config-explicit-changed-since/fallow-analysis-args.sh")
+OUTPUTS=$(cat "$ANALYZE_TMP/output-config-explicit-changed-since")
+assert_contains "$ARGS" "--changed-since manual-base" "analyze: explicit changed-since is preserved"
+assert_contains "$OUTPUTS" "changed_since=manual-base" "analyze: explicit changed-since output is preserved"
+assert_contains "$OUT" "explicitly scoped" "analyze: explicit changed-since warns about baseline drift"
+
+EXPLICIT_DIFF="$ANALYZE_TMP/user.diff"
+OUT=$(run_analyze_scope_case "config-explicit-diff" ".fallowrc.json" "baseline.json" "" "$EXPLICIT_DIFF")
+ARGS=$(cat "$ANALYZE_TMP/scope-config-explicit-diff/fallow-analysis-args.sh")
+OUTPUTS=$(cat "$ANALYZE_TMP/output-config-explicit-diff")
+ENV_OUT=$(cat "$ANALYZE_TMP/env-config-explicit-diff")
+assert_not_contains "$ARGS" "--changed-since base1234" "analyze: explicit diff still clears auto changed-since"
+if grep -qx 'changed_since=' "$ANALYZE_TMP/output-config-explicit-diff"; then
+  pass "analyze: explicit diff clears auto changed_since output"
+else
+  fail "analyze: explicit diff clears auto changed_since output" "outputs were: $OUTPUTS"
+fi
+assert_contains "$ENV_OUT" "FALLOW_DIFF_FILE=$EXPLICIT_DIFF" "analyze: explicit diff file is preserved"
+assert_contains "$OUT" "explicit diff file remains active" "analyze: explicit diff warns about remaining scope"
+
 # Audit verdict + gate are emitted to GITHUB_OUTPUT for the Check threshold step.
 # Without this, the threshold step gates on raw introduced count, re-introducing
 # the issue #302 bug where warn-tier findings fail CI.

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -628,7 +628,8 @@ fn handle_baseline(
     if let Some(baseline_path) = save_path {
         let baseline_data = BaselineData::from_results(results, root);
         match serde_json::to_string_pretty(&baseline_data) {
-            Ok(json) => {
+            Ok(mut json) => {
+                json.push('\n');
                 if let Some(parent) = baseline_path.parent()
                     && !parent.as_os_str().is_empty()
                     && let Err(e) = std::fs::create_dir_all(parent)
@@ -843,6 +844,27 @@ mod tests {
                 ],
             }));
         r
+    }
+
+    #[test]
+    fn save_baseline_writes_trailing_newline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let baseline_path = dir.path().join("baseline.json");
+        let mut results = make_results();
+
+        handle_baseline(
+            &mut results,
+            Some(&baseline_path),
+            None,
+            std::path::Path::new("/project"),
+            true,
+            OutputFormat::Json,
+        )
+        .expect("baseline save succeeds");
+
+        let saved = std::fs::read_to_string(&baseline_path).expect("baseline is written");
+        assert!(saved.ends_with('\n'));
+        assert!(!saved.ends_with("\n\n"));
     }
 
     // ── IssueFilters::any_active ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Disable auto-derived GitHub Action PR scoping for baseline-active dead-code/check runs when fallow config changes can alter baseline membership.
- Preserve explicit `changed-since` and `diff-file` overrides, with warnings that explain the remaining risk.
- Add a trailing newline to saved generic baseline JSON.

Fixes #746.

## Test plan
- [x] `bash action/tests/run.sh`
- [x] `cargo check --workspace`
- [x] `cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings`
- [x] `cargo test -p fallow-cli -p fallow-mcp`
- [x] `cargo fmt --all -- --check`
- [x] `typos .`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `cargo test --workspace --all-targets`
- [x] CI-wrapper smoke against `benchmarks/fixtures/real-world/next.js`
