### PR TITLE
test(cli): snapshot coverage-intelligence render + drop stale dead_code allow

### DIFF
--- a/crates/cli/src/health_types/scores.rs
+++ b/crates/cli/src/health_types/scores.rs
@@ -430,16 +430,7 @@ impl ExceededThreshold {
     }
 
     /// True when the CRAP threshold contributed to the finding.
-    ///
-    /// Exercised by the `exceeded_threshold_includes_helpers` unit test below;
-    /// the binary target has no direct caller today, so the lint is allowed
-    /// rather than expected (`#[expect]` would be unfulfilled on the lib side
-    /// which does reach the tests).
     #[must_use]
-    #[allow(
-        dead_code,
-        reason = "symmetry with includes_cyclomatic/cognitive; consumed by tests and intended for report format extensions"
-    )]
     pub const fn includes_crap(self) -> bool {
         matches!(
             self,

--- a/crates/cli/tests/snapshot_tests.rs
+++ b/crates/cli/tests/snapshot_tests.rs
@@ -2462,6 +2462,138 @@ fn health_report_with_runtime_coverage(root: &Path) -> HealthReport {
     report
 }
 
+/// Health report carrying a populated `coverage_intelligence` block alongside
+/// runtime coverage, so the public format renderers exercise the live combined
+/// surface (not just the per-format helper unit tests). Mirrors the shape the
+/// `build_coverage_intelligence` builder emits for a risky changed hot path plus
+/// a high-confidence delete candidate, with one ambiguous match skipped.
+fn health_report_with_coverage_intelligence(root: &Path) -> HealthReport {
+    let mut report = health_report_with_runtime_coverage(root);
+    report.coverage_intelligence = Some(CoverageIntelligenceReport {
+        schema_version: CoverageIntelligenceSchemaVersion::default(),
+        verdict: CoverageIntelligenceVerdict::RiskyChangeDetected,
+        summary: CoverageIntelligenceSummary {
+            findings: 2,
+            risky_changes: 1,
+            high_confidence_deletes: 1,
+            review_required: 0,
+            refactor_carefully: 0,
+            skipped_ambiguous_matches: 1,
+        },
+        findings: vec![
+            CoverageIntelligenceFinding {
+                id: "fallow:coverage-intel:0badc0de".to_string(),
+                path: root.join("src/hot.ts"),
+                identity: Some("handler".to_string()),
+                line: 10,
+                verdict: CoverageIntelligenceVerdict::RiskyChangeDetected,
+                signals: vec![
+                    CoverageIntelligenceSignal::Changed,
+                    CoverageIntelligenceSignal::HotPath,
+                    CoverageIntelligenceSignal::LowTestCoverage,
+                    CoverageIntelligenceSignal::HighCrap,
+                ],
+                recommendation: CoverageIntelligenceRecommendation::AddTestOrSplitBeforeMerge,
+                confidence: CoverageIntelligenceConfidence::High,
+                related_ids: vec!["fallow:hot:cafebabe".to_string()],
+                evidence: CoverageIntelligenceEvidence {
+                    coverage_pct: Some(20.0),
+                    crap: Some(45.0),
+                    runtime_verdict: Some("hot_path_touched".to_string()),
+                    invocations: Some(250),
+                    static_status: Some("used".to_string()),
+                    test_coverage: Some("partially_covered".to_string()),
+                    changed: true,
+                    ownership_state: None,
+                    match_confidence: CoverageIntelligenceMatchConfidence::PathFunctionLine,
+                },
+                actions: vec![CoverageIntelligenceAction {
+                    kind: "add-tests".to_string(),
+                    description:
+                        "Add tests or split before merge: this changed hot path is undertested."
+                            .to_string(),
+                    auto_fixable: false,
+                }],
+            },
+            CoverageIntelligenceFinding {
+                id: "fallow:coverage-intel:1deadfa1".to_string(),
+                path: root.join("src/dead.ts"),
+                identity: Some("deadPath".to_string()),
+                line: 4,
+                verdict: CoverageIntelligenceVerdict::HighConfidenceDelete,
+                signals: vec![
+                    CoverageIntelligenceSignal::StaticUnused,
+                    CoverageIntelligenceSignal::RuntimeCold,
+                    CoverageIntelligenceSignal::NoTestPath,
+                ],
+                recommendation: CoverageIntelligenceRecommendation::DeleteAfterConfirmingOwner,
+                confidence: CoverageIntelligenceConfidence::High,
+                related_ids: vec!["fallow:prod:deadbeef".to_string()],
+                evidence: CoverageIntelligenceEvidence {
+                    coverage_pct: Some(0.0),
+                    crap: None,
+                    runtime_verdict: Some("safe_to_delete".to_string()),
+                    invocations: Some(0),
+                    static_status: Some("unused".to_string()),
+                    test_coverage: Some("not_covered".to_string()),
+                    changed: false,
+                    ownership_state: None,
+                    match_confidence: CoverageIntelligenceMatchConfidence::PathLine,
+                },
+                actions: vec![CoverageIntelligenceAction {
+                    kind: "delete-after-confirm".to_string(),
+                    description:
+                        "Delete after confirming with the owner: unused, cold, and untested."
+                            .to_string(),
+                    auto_fixable: false,
+                }],
+            },
+        ],
+    });
+    report
+}
+
+#[test]
+fn json_health_with_coverage_intelligence_snapshot() {
+    let root = PathBuf::from("/project");
+    let report = health_report_with_coverage_intelligence(&root);
+    let value = build_health_json(&report, &root, Duration::ZERO, false)
+        .expect("health JSON build should succeed");
+    let json_str = serde_json::to_string_pretty(&value).expect("should serialize");
+    insta::assert_snapshot!(
+        "json_health_with_coverage_intelligence",
+        redact_version(&json_str)
+    );
+}
+
+#[test]
+fn markdown_health_with_coverage_intelligence_snapshot() {
+    let root = PathBuf::from("/project");
+    let report = health_report_with_coverage_intelligence(&root);
+    let output = build_health_markdown(&report, &root);
+    insta::assert_snapshot!("markdown_health_with_coverage_intelligence", output);
+}
+
+#[test]
+fn sarif_health_with_coverage_intelligence_snapshot() {
+    let root = PathBuf::from("/project");
+    let report = health_report_with_coverage_intelligence(&root);
+    let json_str = serde_json::to_string_pretty(&build_health_sarif(&report, &root)).unwrap();
+    insta::assert_snapshot!(
+        "sarif_health_with_coverage_intelligence",
+        redact_sarif_version(&json_str)
+    );
+}
+
+#[test]
+fn codeclimate_health_with_coverage_intelligence_snapshot() {
+    let root = PathBuf::from("/project");
+    let report = health_report_with_coverage_intelligence(&root);
+    let cc = codeclimate_issues_to_value(&build_health_codeclimate(&report, &root));
+    let json_str = serde_json::to_string_pretty(&cc).expect("should serialize");
+    insta::assert_snapshot!("codeclimate_health_with_coverage_intelligence", json_str);
+}
+
 /// Build an empty health report (no findings).
 const fn empty_health_report() -> HealthReport {
     HealthReport {

--- a/crates/cli/tests/snapshots/snapshot_tests__codeclimate_health_with_coverage_intelligence.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__codeclimate_health_with_coverage_intelligence.snap
@@ -1,0 +1,86 @@
+---
+source: crates/cli/tests/snapshot_tests.rs
+expression: json_str
+---
+[
+  {
+    "type": "issue",
+    "check_name": "fallow/high-complexity",
+    "description": "'processData' has cyclomatic complexity 25 (threshold: 20) and cognitive complexity 30 (threshold: 15)",
+    "categories": [
+      "Complexity"
+    ],
+    "severity": "major",
+    "fingerprint": "d4ee093a5fdb5d49",
+    "location": {
+      "path": "src/complex.ts",
+      "lines": {
+        "begin": 42
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "check_name": "fallow/runtime-review-required",
+    "description": "'coldPath' runtime coverage verdict: review required (0 invocations)",
+    "categories": [
+      "Bug Risk"
+    ],
+    "severity": "major",
+    "fingerprint": "8ad72b7a0b4f6fb2",
+    "location": {
+      "path": "src/cold.ts",
+      "lines": {
+        "begin": 14
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "check_name": "fallow/runtime-coverage-unavailable",
+    "description": "'lateBound' runtime coverage verdict: coverage unavailable (untracked)",
+    "categories": [
+      "Bug Risk"
+    ],
+    "severity": "minor",
+    "fingerprint": "a4bc61bb1ba59529",
+    "location": {
+      "path": "src/unknown.ts",
+      "lines": {
+        "begin": 8
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "check_name": "fallow/coverage-intelligence-risky-change",
+    "description": "'handler' coverage intelligence verdict: risky-change-detected (add-test-or-split-before-merge)",
+    "categories": [
+      "Bug Risk"
+    ],
+    "severity": "major",
+    "fingerprint": "a60e4e21a3776e01",
+    "location": {
+      "path": "src/hot.ts",
+      "lines": {
+        "begin": 10
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "check_name": "fallow/coverage-intelligence-delete",
+    "description": "'deadPath' coverage intelligence verdict: high-confidence-delete (delete-after-confirming-owner)",
+    "categories": [
+      "Bug Risk"
+    ],
+    "severity": "major",
+    "fingerprint": "d597d8564a9ed362",
+    "location": {
+      "path": "src/dead.ts",
+      "lines": {
+        "begin": 4
+      }
+    }
+  }
+]

--- a/crates/cli/tests/snapshots/snapshot_tests__json_health_with_coverage_intelligence.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_health_with_coverage_intelligence.snap
@@ -1,0 +1,216 @@
+---
+source: crates/cli/tests/snapshot_tests.rs
+expression: redact_version(&json_str)
+---
+{
+  "schema_version": 6,
+  "version": "[VERSION]",
+  "elapsed_ms": 0,
+  "findings": [
+    {
+      "path": "src/complex.ts",
+      "name": "processData",
+      "line": 42,
+      "col": 0,
+      "cyclomatic": 25,
+      "cognitive": 30,
+      "line_count": 120,
+      "param_count": 0,
+      "exceeded": "both",
+      "severity": "high",
+      "actions": [
+        {
+          "type": "refactor-function",
+          "auto_fixable": false,
+          "description": "Refactor `processData` to reduce complexity (extract helper functions, simplify branching)",
+          "note": "Consider splitting into smaller functions with single responsibilities"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the function declaration",
+          "comment": "// fallow-ignore-next-line complexity",
+          "placement": "above-function-declaration"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "files_analyzed": 50,
+    "functions_analyzed": 200,
+    "functions_above_threshold": 1,
+    "max_cyclomatic_threshold": 20,
+    "max_cognitive_threshold": 15,
+    "max_crap_threshold": 30.0,
+    "severity_critical_count": 0,
+    "severity_high_count": 1,
+    "severity_moderate_count": 0
+  },
+  "runtime_coverage": {
+    "schema_version": "1",
+    "verdict": "cold-code-detected",
+    "summary": {
+      "data_source": "local",
+      "last_received_at": null,
+      "functions_tracked": 6,
+      "functions_hit": 3,
+      "functions_unhit": 2,
+      "functions_untracked": 1,
+      "coverage_percent": 50.0,
+      "trace_count": 2847291,
+      "period_days": 30,
+      "deployments_seen": 14
+    },
+    "findings": [
+      {
+        "id": "fallow:prod:deadbeef",
+        "stable_id": "fallow:fn:00000001",
+        "path": "src/cold.ts",
+        "function": "coldPath",
+        "line": 14,
+        "verdict": "review_required",
+        "invocations": 0,
+        "confidence": "medium",
+        "evidence": {
+          "static_status": "used",
+          "test_coverage": "not_covered",
+          "v8_tracking": "tracked",
+          "observation_days": 30,
+          "deployments_observed": 14
+        },
+        "actions": [
+          {
+            "type": "review-deletion",
+            "description": "Tracked in runtime coverage with zero invocations.",
+            "auto_fixable": false
+          }
+        ]
+      },
+      {
+        "id": "fallow:prod:feedface",
+        "path": "src/unknown.ts",
+        "function": "lateBound",
+        "line": 8,
+        "verdict": "coverage_unavailable",
+        "confidence": "none",
+        "evidence": {
+          "static_status": "used",
+          "test_coverage": "not_covered",
+          "v8_tracking": "untracked",
+          "untracked_reason": "lazy_parsed",
+          "observation_days": 30,
+          "deployments_observed": 14
+        },
+        "actions": [
+          {
+            "type": "collect-runtime-coverage",
+            "description": "Collect a broader production dump.",
+            "auto_fixable": false
+          }
+        ]
+      }
+    ],
+    "hot_paths": [
+      {
+        "id": "fallow:hot:cafebabe",
+        "stable_id": "fallow:fn:00000002",
+        "path": "src/hot.ts",
+        "function": "hotPath",
+        "line": 3,
+        "end_line": 9,
+        "invocations": 250,
+        "percentile": 99
+      }
+    ],
+    "blast_radius": [],
+    "importance": [],
+    "watermark": "license-expired-grace",
+    "warnings": [
+      {
+        "code": "partial-input",
+        "message": "One dump was incomplete."
+      }
+    ]
+  },
+  "coverage_intelligence": {
+    "schema_version": "1",
+    "verdict": "risky-change-detected",
+    "summary": {
+      "findings": 2,
+      "risky_changes": 1,
+      "high_confidence_deletes": 1,
+      "review_required": 0,
+      "refactor_carefully": 0,
+      "skipped_ambiguous_matches": 1
+    },
+    "findings": [
+      {
+        "id": "fallow:coverage-intel:0badc0de",
+        "path": "src/hot.ts",
+        "identity": "handler",
+        "line": 10,
+        "verdict": "risky-change-detected",
+        "signals": [
+          "changed",
+          "hot_path",
+          "low_test_coverage",
+          "high_crap"
+        ],
+        "recommendation": "add-test-or-split-before-merge",
+        "confidence": "high",
+        "related_ids": [
+          "fallow:hot:cafebabe"
+        ],
+        "evidence": {
+          "coverage_pct": 20.0,
+          "crap": 45.0,
+          "runtime_verdict": "hot_path_touched",
+          "invocations": 250,
+          "static_status": "used",
+          "test_coverage": "partially_covered",
+          "changed": true,
+          "match_confidence": "path-function-line"
+        },
+        "actions": [
+          {
+            "type": "add-tests",
+            "description": "Add tests or split before merge: this changed hot path is undertested.",
+            "auto_fixable": false
+          }
+        ]
+      },
+      {
+        "id": "fallow:coverage-intel:1deadfa1",
+        "path": "src/dead.ts",
+        "identity": "deadPath",
+        "line": 4,
+        "verdict": "high-confidence-delete",
+        "signals": [
+          "static_unused",
+          "runtime_cold",
+          "no_test_path"
+        ],
+        "recommendation": "delete-after-confirming-owner",
+        "confidence": "high",
+        "related_ids": [
+          "fallow:prod:deadbeef"
+        ],
+        "evidence": {
+          "coverage_pct": 0.0,
+          "runtime_verdict": "safe_to_delete",
+          "invocations": 0,
+          "static_status": "unused",
+          "test_coverage": "not_covered",
+          "match_confidence": "path-line"
+        },
+        "actions": [
+          {
+            "type": "delete-after-confirm",
+            "description": "Delete after confirming with the owner: unused, cold, and untested.",
+            "auto_fixable": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/crates/cli/tests/snapshots/snapshot_tests__markdown_health_with_coverage_intelligence.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__markdown_health_with_coverage_intelligence.snap
@@ -1,0 +1,44 @@
+---
+source: crates/cli/tests/snapshot_tests.rs
+expression: output
+---
+## Fallow: 1 high complexity function
+
+| File | Function | Severity | Cyclomatic | Cognitive | CRAP | Lines |
+|:-----|:---------|:---------|:-----------|:----------|:-----|:------|
+| `src/complex.ts:42` | `processData` | high | 25 **!** | 30 **!** | - | 120 |
+
+**50** files, **200** functions analyzed (thresholds: cyclomatic > 20, cognitive > 15, CRAP >= 30.0)
+
+## Runtime Coverage
+
+- Verdict: cold-code-detected
+- Functions tracked: 6
+- Hit: 3
+- Unhit: 2
+- Untracked: 1
+- Coverage: 50.0%
+- Traces observed: 2847291
+- Period: 30 day(s), 14 deployment(s)
+
+- Watermark: license-expired-grace
+
+| ID | Path | Function | Verdict | Invocations | Confidence |
+|:---|:-----|:---------|:--------|------------:|:-----------|
+| `fallow:prod:deadbeef` | `src/cold.ts`:14 | `coldPath` | review_required | 0 | medium |
+| `fallow:prod:feedface` | `src/unknown.ts`:8 | `lateBound` | coverage_unavailable | - | none |
+
+| ID | Hot path | Function | Invocations | Percentile |
+|:---|:---------|:---------|------------:|-----------:|
+| `fallow:hot:cafebabe` | `src/hot.ts`:3 | `hotPath` | 250 | 99 |
+
+## Coverage Intelligence
+
+- Verdict: risky-change-detected
+- Findings: 2
+- Ambiguous matches skipped: 1
+
+| ID | Path | Identity | Verdict | Recommendation | Confidence | Signals |
+|:---|:-----|:---------|:--------|:---------------|:-----------|:--------|
+| `fallow:coverage-intel:0badc0de` | `src/hot.ts`:10 | `handler` | risky-change-detected | add-test-or-split-before-merge | high | changed, hot_path, low_test_coverage, high_crap |
+| `fallow:coverage-intel:1deadfa1` | `src/dead.ts`:4 | `deadPath` | high-confidence-delete | delete-after-confirming-owner | high | static_unused, runtime_cold, no_test_path |

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_health_with_coverage_intelligence.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_health_with_coverage_intelligence.snap
@@ -1,0 +1,380 @@
+---
+source: crates/cli/tests/snapshot_tests.rs
+expression: redact_sarif_version(&json_str)
+---
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "fallow",
+          "version": "[VERSION]",
+          "informationUri": "https://github.com/fallow-rs/fallow",
+          "rules": [
+            {
+              "id": "fallow/high-cyclomatic-complexity",
+              "shortDescription": {
+                "text": "Function has high cyclomatic complexity"
+              },
+              "fullDescription": {
+                "text": "McCabe cyclomatic complexity exceeds the configured threshold. Cyclomatic complexity counts the number of independent paths through a function (1 + decision points: if/else, switch cases, loops, ternary, logical operators). High values indicate functions that are hard to test exhaustively. fallow also emits this rule on synthetic `<template>` findings (Angular .html templates and inline `@Component({ template: ... })` literals), counting template control-flow blocks (`@if`, `@else if`, `@for`, `@case`, `@defer (when ...)`, legacy `*ngIf`/`*ngFor`) plus ternary and logical operators inside bound attributes and `{{ }}` interpolations; and on synthetic `<component>` rollup findings whose `cyclomatic` is the worst class method's score plus the template's. Ranking and `--targets` use the rollup total; JSON exposes the per-half breakdown under `component_rollup`."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#cyclomatic-complexity",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "fallow/high-cognitive-complexity",
+              "shortDescription": {
+                "text": "Function has high cognitive complexity"
+              },
+              "fullDescription": {
+                "text": "SonarSource cognitive complexity exceeds the configured threshold. Unlike cyclomatic complexity, cognitive complexity penalizes nesting depth and non-linear control flow (breaks, continues, early returns). It measures how hard a function is to understand when reading sequentially. fallow also emits this rule on synthetic `<template>` findings (Angular .html templates and inline `@Component({ template: ... })` literals), where nesting penalties accumulate on stacked `@if`/`@for`/`@switch` blocks; and on synthetic `<component>` rollup findings whose `cognitive` is the worst class method's score plus the template's. Ranking and `--targets` use the rollup total; JSON exposes the per-half breakdown under `component_rollup`."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#cognitive-complexity",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "fallow/high-complexity",
+              "shortDescription": {
+                "text": "Function exceeds both complexity thresholds"
+              },
+              "fullDescription": {
+                "text": "Function exceeds both cyclomatic and cognitive complexity thresholds. This is the strongest signal that a function needs refactoring, it has many paths AND is hard to understand. The same rule fires on synthetic `<template>` findings (Angular .html templates and inline `@Component({ template: ... })` literals) when both metrics exceed their thresholds, and on synthetic `<component>` rollup findings whose totals are the worst class method's score plus the template's. Ranking and `--targets` use the rollup totals; JSON exposes the per-half breakdown under `component_rollup`."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#complexity-metrics",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "fallow/high-crap-score",
+              "shortDescription": {
+                "text": "Function has a high CRAP score (complexity combined with low coverage)"
+              },
+              "fullDescription": {
+                "text": "The function's CRAP (Change Risk Anti-Patterns) score meets or exceeds the configured threshold. CRAP combines cyclomatic complexity with test coverage using the Savoia and Evans (2007) formula: `CC^2 * (1 - coverage/100)^3 + CC`. High CRAP indicates changes to this function carry high risk because it is complex AND poorly tested. Pair with `--coverage` for accurate per-function scoring; without it fallow estimates coverage from the module graph."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#crap-score",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/refactoring-target",
+              "shortDescription": {
+                "text": "File identified as a high-priority refactoring candidate"
+              },
+              "fullDescription": {
+                "text": "File identified as a refactoring candidate based on a weighted combination of complexity density, churn velocity, dead code ratio, fan-in (blast radius), and fan-out (coupling). Categories: urgent churn+complexity, break circular dependency, split high-impact file, remove dead code, extract complex functions, reduce coupling."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#refactoring-targets",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/untested-file",
+              "shortDescription": {
+                "text": "Runtime-reachable file has no test dependency path"
+              },
+              "fullDescription": {
+                "text": "A file is reachable from runtime entry points but not from any discovered test entry point. This indicates production code that no test imports, directly or transitively, according to the static module graph."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#coverage-gaps",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/untested-export",
+              "shortDescription": {
+                "text": "Runtime-reachable export has no test dependency path"
+              },
+              "fullDescription": {
+                "text": "A value export is reachable from runtime entry points but no test-reachable module references it. This is a static test dependency gap rather than line coverage, and highlights exports exercised only through production entry paths."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#coverage-gaps",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/runtime-safe-to-delete",
+              "shortDescription": {
+                "text": "Statically unused AND never invoked in production with V8 tracking"
+              },
+              "fullDescription": {
+                "text": "The function is both statically unreachable in the module graph and was never invoked during the observed runtime coverage window. This is the highest-confidence delete signal fallow emits."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#runtime-coverage",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/runtime-review-required",
+              "shortDescription": {
+                "text": "Statically used but never invoked in production"
+              },
+              "fullDescription": {
+                "text": "The function is reachable in the module graph (or exercised by tests / untracked call sites) but was not invoked during the observed runtime coverage window. Needs a human look: may be seasonal, error-path only, or legitimately unused."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#runtime-coverage",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/runtime-low-traffic",
+              "shortDescription": {
+                "text": "Function was invoked below the low-traffic threshold"
+              },
+              "fullDescription": {
+                "text": "The function was invoked in production but below the configured `--low-traffic-threshold` fraction of total trace count (spec default 0.1%). Effectively dead for the current period."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#runtime-coverage",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "fallow/runtime-coverage-unavailable",
+              "shortDescription": {
+                "text": "Runtime coverage could not be resolved for this function"
+              },
+              "fullDescription": {
+                "text": "The function could not be matched to a V8-tracked coverage entry. Common causes: the function lives in a worker thread (separate V8 isolate), it is lazy-parsed and never reached the JIT tier, or its source map did not resolve to the expected source path. This is advisory, not a dead-code signal."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#runtime-coverage",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "fallow/runtime-coverage",
+              "shortDescription": {
+                "text": "Runtime coverage finding"
+              },
+              "fullDescription": {
+                "text": "Generic runtime-coverage finding for verdicts not covered by a more specific rule. Covers the forward-compat `unknown` sentinel; the CLI filters `active` entries out of `runtime_coverage.findings` so the surfaced list stays actionable."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#runtime-coverage",
+              "defaultConfiguration": {
+                "level": "note"
+              }
+            },
+            {
+              "id": "fallow/coverage-intelligence-risky-change",
+              "shortDescription": {
+                "text": "Changed hot path combines high CRAP and low test coverage"
+              },
+              "fullDescription": {
+                "text": "Coverage intelligence combined change scope, runtime hot-path evidence, low test coverage, and high CRAP into a risky-change finding. Add focused tests or split the change before merging."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#coverage-intelligence",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/coverage-intelligence-delete",
+              "shortDescription": {
+                "text": "Static and runtime evidence indicate code can be deleted"
+              },
+              "fullDescription": {
+                "text": "Coverage intelligence combined static unused status, runtime cold evidence, and lack of test reachability into a high-confidence delete recommendation."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#coverage-intelligence",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/coverage-intelligence-review",
+              "shortDescription": {
+                "text": "Cold reachable uncovered code needs owner review"
+              },
+              "fullDescription": {
+                "text": "Coverage intelligence found code that is statically reachable but cold in runtime evidence, uncovered by tests, and ownership-risky. Route it to an owner before changing or deleting it."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#coverage-intelligence",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/coverage-intelligence-refactor",
+              "shortDescription": {
+                "text": "Hot covered code has high CRAP and should be refactored carefully"
+              },
+              "fullDescription": {
+                "text": "Coverage intelligence found hot production code that is covered by tests but still has high CRAP. Refactor carefully while preserving behavior."
+              },
+              "helpUri": "https://docs.fallow.tools/explanations/health#coverage-intelligence",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "fallow/high-complexity",
+          "level": "warning",
+          "message": {
+            "text": "'processData' has cyclomatic complexity 25 (threshold: 20) and cognitive complexity 30 (threshold: 15)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/complex.ts"
+                },
+                "region": {
+                  "startLine": 42,
+                  "startColumn": 1
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "tools.fallow.fingerprint/v1": "c3976b43718b2197",
+            "primaryLocationLineHash/v1": "c3976b43718b2197"
+          }
+        },
+        {
+          "ruleId": "fallow/runtime-review-required",
+          "level": "warning",
+          "message": {
+            "text": "'coldPath' runtime coverage verdict: review required (0 invocations)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/cold.ts"
+                },
+                "region": {
+                  "startLine": 14,
+                  "startColumn": 1
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "tools.fallow.fingerprint/v1": "50be8b87d2e2ba94",
+            "primaryLocationLineHash/v1": "50be8b87d2e2ba94"
+          }
+        },
+        {
+          "ruleId": "fallow/runtime-coverage-unavailable",
+          "level": "note",
+          "message": {
+            "text": "'lateBound' runtime coverage verdict: coverage unavailable (untracked)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/unknown.ts"
+                },
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 1
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "tools.fallow.fingerprint/v1": "2d109423d5abfa94",
+            "primaryLocationLineHash/v1": "2d109423d5abfa94"
+          }
+        },
+        {
+          "ruleId": "fallow/coverage-intelligence-risky-change",
+          "level": "warning",
+          "message": {
+            "text": "'handler' coverage intelligence verdict: risky-change-detected (add-test-or-split-before-merge, signals: changed, hot_path, low_test_coverage, high_crap)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/hot.ts"
+                },
+                "region": {
+                  "startLine": 10,
+                  "startColumn": 1
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "tools.fallow.fingerprint/v1": "51d70fbdfc758d28",
+            "primaryLocationLineHash/v1": "51d70fbdfc758d28"
+          },
+          "properties": {
+            "coverage_intelligence_id": "fallow:coverage-intel:0badc0de",
+            "verdict": "risky-change-detected",
+            "recommendation": "add-test-or-split-before-merge",
+            "confidence": "high",
+            "signals": [
+              "changed",
+              "hot_path",
+              "low_test_coverage",
+              "high_crap"
+            ],
+            "related_ids": [
+              "fallow:hot:cafebabe"
+            ]
+          }
+        },
+        {
+          "ruleId": "fallow/coverage-intelligence-delete",
+          "level": "warning",
+          "message": {
+            "text": "'deadPath' coverage intelligence verdict: high-confidence-delete (delete-after-confirming-owner, signals: static_unused, runtime_cold, no_test_path)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/dead.ts"
+                },
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 1
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "tools.fallow.fingerprint/v1": "3a98b15b50d82422",
+            "primaryLocationLineHash/v1": "3a98b15b50d82422"
+          },
+          "properties": {
+            "coverage_intelligence_id": "fallow:coverage-intel:1deadfa1",
+            "verdict": "high-confidence-delete",
+            "recommendation": "delete-after-confirming-owner",
+            "confidence": "high",
+            "signals": [
+              "static_unused",
+              "runtime_cold",
+              "no_test_path"
+            ],
+            "related_ids": [
+              "fallow:prod:deadbeef"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a `HealthReport` fixture carrying a populated `coverage_intelligence` block (risky changed hot path + high-confidence delete candidate, with one ambiguous match skipped) alongside runtime coverage, and snapshot it through the public `build_health_json` / `build_health_markdown` / `build_health_sarif` / `build_health_codeclimate` renderers. Previously the coverage-intelligence rendering was covered only by per-format helper unit tests; these committed snapshots lock the live combined wire format across all four string-returning formats.
- Drop the stale `#[allow(dead_code)]` on `ExceededThreshold::includes_crap`. Its doc comment claimed "the binary target has no direct caller today", but `baseline.rs`, `finding.rs`, `health/mod.rs`, and `coverage_intelligence.rs` all call it on the binary side, so the lint cannot fire. The doc comment now matches its `includes_cyclomatic` / `includes_cognitive` siblings.

Follow-up polish on the coverage-intelligence verdict shipped in #768. The compact path keeps its existing dedicated unit test (it prints to stdout rather than returning a string).

## Test plan

- [x] `cargo test -p fallow-cli --test snapshot_tests`: passes, zero failures (4 new coverage-intelligence snapshots).
- [x] `cargo test -p fallow-cli --lib exceeded_threshold_includes_helpers`: passes after removing the attribute.
- [x] `cargo clippy -p fallow-cli --all-targets -- -D warnings`: clean (confirms the function is genuinely live).
- [x] `cargo fmt --all -- --check`: clean.