### PR TITLE
refactor(core,lsp): unify plugin-result merging via field-exhaustive merge_into

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1196,10 +1196,6 @@ fn append_workspace_package_file_asset_patterns(
 }
 
 /// Run plugins for root project and all workspace packages.
-#[expect(
-    clippy::too_many_lines,
-    reason = "plugin orchestration keeps root and workspace merging in one flow"
-)]
 fn run_plugins(
     config: &ResolvedConfig,
     files: &[discover::DiscoveredFile],
@@ -1272,129 +1268,31 @@ fn run_plugins(
         })
         .collect();
 
-    // Merge workspace results sequentially (deterministic order via par_iter index stability)
-    // Track seen names for O(1) dedup instead of O(n) Vec::contains
-    let mut seen_plugins: rustc_hash::FxHashSet<String> =
-        result.active_plugins.iter().cloned().collect();
-    let mut seen_prefixes: rustc_hash::FxHashSet<String> =
-        result.virtual_module_prefixes.iter().cloned().collect();
-    let mut seen_generated: rustc_hash::FxHashSet<String> =
-        result.generated_import_patterns.iter().cloned().collect();
-    let mut seen_generated_type_prefixes: rustc_hash::FxHashSet<String> = result
-        .generated_type_import_prefixes
-        .iter()
-        .cloned()
-        .collect();
-    let mut seen_suffixes: rustc_hash::FxHashSet<String> =
-        result.virtual_package_suffixes.iter().cloned().collect();
-
-    fn extend_unique(
-        target: &mut Vec<String>,
-        seen: &mut rustc_hash::FxHashSet<String>,
-        items: Vec<String>,
-    ) {
-        for item in items {
-            if seen.insert(item.clone()) {
-                target.push(item);
-            }
-        }
-    }
-    for (ws_result, ws_prefix) in ws_results {
-        // Prefix helper: workspace-relative patterns need the workspace prefix
-        // to be matchable from the monorepo root. But patterns that are already
-        // project-root-relative (e.g., from angular.json which uses absolute paths
-        // like "apps/client/src/styles.css") should not be double-prefixed.
-        let prefix_if_needed = |pat: &str| -> String {
-            if pat.starts_with(ws_prefix.as_str()) || pat.starts_with('/') {
-                pat.to_string()
-            } else {
-                format!("{ws_prefix}/{pat}")
-            }
-        };
-
-        for (rule, pname) in &ws_result.entry_patterns {
-            result
-                .entry_patterns
-                .push((rule.prefixed(&ws_prefix), pname.clone()));
-        }
-        for (plugin_name, role) in ws_result.entry_point_roles {
-            result.entry_point_roles.entry(plugin_name).or_insert(role);
-        }
-        for (pat, pname) in &ws_result.always_used {
-            result
-                .always_used
-                .push((prefix_if_needed(pat), pname.clone()));
-        }
-        for (pat, pname) in &ws_result.discovered_always_used {
-            result
-                .discovered_always_used
-                .push((prefix_if_needed(pat), pname.clone()));
-        }
-        for (pat, pname) in &ws_result.fixture_patterns {
-            result
-                .fixture_patterns
-                .push((prefix_if_needed(pat), pname.clone()));
-        }
-        for rule in &ws_result.used_exports {
-            result.used_exports.push(rule.prefixed(&ws_prefix));
-        }
-        for rule in &ws_result.provided_dependencies {
-            result.provided_dependencies.push(rule.prefixed(&ws_prefix));
-        }
-        // Merge active plugin names (deduplicated via HashSet)
-        for plugin_name in ws_result.active_plugins {
-            if !seen_plugins.contains(&plugin_name) {
-                seen_plugins.insert(plugin_name.clone());
-                result.active_plugins.push(plugin_name);
-            }
-        }
-        // These don't need prefixing (absolute paths / package names)
-        result
-            .referenced_dependencies
-            .extend(ws_result.referenced_dependencies);
-        result.setup_files.extend(ws_result.setup_files);
-        result
-            .tooling_dependencies
-            .extend(ws_result.tooling_dependencies);
-        result
-            .static_dir_mappings
-            .extend(ws_result.static_dir_mappings);
-        // Virtual import boundaries — prefixes (e.g., Docusaurus `@theme/`),
-        // generated import patterns (e.g., SvelteKit `/$types`), generated type
-        // prefixes (e.g., React Router `./+types/`), and package-name suffixes
-        // (e.g., Vitest `/__mocks__`) — match against import specifiers or
-        // package names, never file paths, so no workspace prefix is applied.
-        extend_unique(
-            &mut result.virtual_module_prefixes,
-            &mut seen_prefixes,
-            ws_result.virtual_module_prefixes,
-        );
-        extend_unique(
-            &mut result.generated_import_patterns,
-            &mut seen_generated,
-            ws_result.generated_import_patterns,
-        );
-        extend_unique(
-            &mut result.generated_type_import_prefixes,
-            &mut seen_generated_type_prefixes,
-            ws_result.generated_type_import_prefixes,
-        );
-        extend_unique(
-            &mut result.virtual_package_suffixes,
-            &mut seen_suffixes,
-            ws_result.virtual_package_suffixes,
-        );
-        // Path aliases from workspace plugins (e.g., SvelteKit $lib/ → src/lib).
-        // Prefix the replacement directory so it resolves from the monorepo root.
-        for (prefix, replacement) in ws_result.path_aliases {
-            result
-                .path_aliases
-                .push((prefix, format!("{ws_prefix}/{replacement}")));
-        }
-        // Auto-import rules carry absolute `source` paths (built from the
-        // workspace package root), so they are already correct per-package and
-        // need no prefixing, just merging. See issue #704.
-        result.auto_imports.extend(ws_result.auto_imports);
+    // Merge workspace results sequentially (deterministic order via par_iter
+    // index stability). Each result is prefix-transformed for its workspace,
+    // then folded into the accumulator via the single field-exhaustive
+    // `merge_into` (issue #444): adding a field to `AggregatedPluginResult`
+    // becomes a compile error in `merge_into` rather than a silently-dropped
+    // field that would diverge the CLI from the LSP.
+    for (mut ws_result, ws_prefix) in ws_results {
+        ws_result.apply_workspace_prefix(&ws_prefix);
+        // Preserve pre-#444 behavior: the old workspace merge loop never
+        // folded these fields into the root aggregate. Clearing them on the
+        // incoming result keeps the merge byte-identical while `merge_into`
+        // stays a prefix-agnostic full union.
+        //   - `config_patterns`, `used_class_members`, `scss_include_paths`
+        //     ARE populated by `run_workspace_fast` and were dropped; whether
+        //     that drop is a latent bug is tracked in issue #772.
+        //   - `script_used_packages` is never populated by `run_workspace_fast`
+        //     (the root's script-used set is computed separately after this
+        //     function returns), so clearing it is a no-op today; it is cleared
+        //     anyway so a future change that starts populating it cannot
+        //     silently alter root script-credit behavior.
+        ws_result.config_patterns.clear();
+        ws_result.used_class_members.clear();
+        ws_result.scss_include_paths.clear();
+        ws_result.script_used_packages.clear();
+        result.merge_into(ws_result);
     }
 
     gate_auto_import_entry_patterns(&mut result, config, workspaces);

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -98,6 +98,141 @@ pub struct AggregatedPluginResult {
     pub provided_dependencies: Vec<ProvidedDependencyRule>,
 }
 
+/// Append `incoming` string items to `target`, skipping values already present
+/// in `target` or earlier in `incoming`. Matches the deduplication the
+/// workspace merge applied via per-field `seen` sets before #444 centralized
+/// it on [`AggregatedPluginResult::merge_into`].
+fn extend_unique(target: &mut Vec<String>, incoming: Vec<String>) {
+    let mut seen: FxHashSet<String> = target.iter().cloned().collect();
+    for item in incoming {
+        if seen.insert(item.clone()) {
+            target.push(item);
+        }
+    }
+}
+
+/// Prefix a workspace-relative pattern so it matches from the monorepo root,
+/// unless it is already workspace-prefixed or project-root-relative (leading
+/// `/`, e.g. an angular.json path). Mirrors the pre-#444 inline closure.
+fn prefix_if_needed(pat: &str, ws_prefix: &str) -> String {
+    if pat.starts_with(ws_prefix) || pat.starts_with('/') {
+        pat.to_string()
+    } else {
+        format!("{ws_prefix}/{pat}")
+    }
+}
+
+impl AggregatedPluginResult {
+    /// Apply a workspace prefix to every path-bearing field in place.
+    ///
+    /// Workspace-package results are collected with patterns relative to the
+    /// package root; to be matchable from the monorepo root they need the
+    /// package's prefix applied. This transform is call-site-specific (it
+    /// depends on `ws_prefix`), so it stays separate from [`Self::merge_into`],
+    /// which is a prefix-agnostic union. The root project's own result is
+    /// never prefixed.
+    ///
+    /// Fields that carry package names, absolute paths, or import-specifier
+    /// boundaries (referenced/tooling deps, setup files, static dir mappings,
+    /// auto-imports, virtual prefixes/suffixes, generated patterns) are left
+    /// untouched, matching the pre-#444 merge loop.
+    pub fn apply_workspace_prefix(&mut self, ws_prefix: &str) {
+        for (rule, _) in &mut self.entry_patterns {
+            *rule = rule.prefixed(ws_prefix);
+        }
+        for (pat, _) in &mut self.always_used {
+            *pat = prefix_if_needed(pat, ws_prefix);
+        }
+        for (pat, _) in &mut self.discovered_always_used {
+            *pat = prefix_if_needed(pat, ws_prefix);
+        }
+        for (pat, _) in &mut self.fixture_patterns {
+            *pat = prefix_if_needed(pat, ws_prefix);
+        }
+        for rule in &mut self.used_exports {
+            *rule = rule.prefixed(ws_prefix);
+        }
+        for rule in &mut self.provided_dependencies {
+            *rule = rule.prefixed(ws_prefix);
+        }
+        // Path aliases: the alias key (prefix) is unchanged, but the
+        // replacement directory is prefixed so it resolves from the root.
+        for (_, replacement) in &mut self.path_aliases {
+            *replacement = format!("{ws_prefix}/{replacement}");
+        }
+    }
+
+    /// Merge `other` into `self`, taking the union of every field.
+    ///
+    /// Exhaustively destructures `Self` so adding a field to
+    /// `AggregatedPluginResult` becomes a `missing field in pattern` compile
+    /// error here instead of a silently-dropped field. See issue #444.
+    ///
+    /// Callers that need the workspace prefix applied must call
+    /// [`Self::apply_workspace_prefix`] on `other` first; this method does not
+    /// transform any path. Dedup-bearing fields (`active_plugins`, the virtual
+    /// prefix/suffix and generated-pattern lists) deduplicate the incoming
+    /// values against the contents already in `self`, matching the pre-#444
+    /// `seen`-set behavior. `entry_point_roles` is first-writer-wins.
+    pub fn merge_into(&mut self, other: Self) {
+        let Self {
+            entry_patterns,
+            entry_point_roles,
+            config_patterns,
+            always_used,
+            used_exports,
+            used_class_members,
+            referenced_dependencies,
+            discovered_always_used,
+            setup_files,
+            tooling_dependencies,
+            script_used_packages,
+            virtual_module_prefixes,
+            virtual_package_suffixes,
+            generated_import_patterns,
+            generated_type_import_prefixes,
+            path_aliases,
+            auto_imports,
+            active_plugins,
+            fixture_patterns,
+            scss_include_paths,
+            static_dir_mappings,
+            provided_dependencies,
+        } = other;
+
+        self.entry_patterns.extend(entry_patterns);
+        for (plugin_name, role) in entry_point_roles {
+            self.entry_point_roles.entry(plugin_name).or_insert(role);
+        }
+        self.config_patterns.extend(config_patterns);
+        self.always_used.extend(always_used);
+        self.used_exports.extend(used_exports);
+        self.used_class_members.extend(used_class_members);
+        self.referenced_dependencies.extend(referenced_dependencies);
+        self.discovered_always_used.extend(discovered_always_used);
+        self.setup_files.extend(setup_files);
+        self.tooling_dependencies.extend(tooling_dependencies);
+        self.script_used_packages.extend(script_used_packages);
+        extend_unique(&mut self.virtual_module_prefixes, virtual_module_prefixes);
+        extend_unique(&mut self.virtual_package_suffixes, virtual_package_suffixes);
+        extend_unique(
+            &mut self.generated_import_patterns,
+            generated_import_patterns,
+        );
+        extend_unique(
+            &mut self.generated_type_import_prefixes,
+            generated_type_import_prefixes,
+        );
+        self.path_aliases.extend(path_aliases);
+        self.auto_imports.extend(auto_imports);
+        extend_unique(&mut self.active_plugins, active_plugins);
+        self.fixture_patterns.extend(fixture_patterns);
+        self.scss_include_paths.extend(scss_include_paths);
+        self.static_dir_mappings.extend(static_dir_mappings);
+        self.provided_dependencies.extend(provided_dependencies);
+    }
+}
+
 impl PluginRegistry {
     /// Create a registry with all built-in plugins and optional external plugins.
     #[must_use]

--- a/crates/core/src/results.rs
+++ b/crates/core/src/results.rs
@@ -11,11 +11,12 @@ pub use fallow_types::output_dead_code::{
 pub use fallow_types::results::{
     AnalysisResults, BoundaryViolation, CircularDependency, DependencyLocation,
     DependencyOverrideMisconfigReason, DependencyOverrideSource, DuplicateExport,
-    DuplicateLocation, EmptyCatalogGroup, EntryPointSummary, ExportUsage, ImportSite,
-    MisconfiguredDependencyOverride, PrivateTypeLeak, ReExportCycle, ReExportCycleKind,
-    ReferenceLocation, StaleSuppression, SuppressionOrigin, TestOnlyDependency, TypeOnlyDependency,
-    UnlistedDependency, UnresolvedCatalogReference, UnresolvedImport, UnusedCatalogEntry,
-    UnusedDependency, UnusedDependencyOverride, UnusedExport, UnusedFile, UnusedMember,
+    DuplicateLocation, EmptyCatalogGroup, EntryPointSummary, ExportUsage, FeatureFlag,
+    FlagConfidence, FlagKind, ImportSite, MisconfiguredDependencyOverride, PrivateTypeLeak,
+    ReExportCycle, ReExportCycleKind, ReferenceLocation, StaleSuppression, SuppressionOrigin,
+    TestOnlyDependency, TypeOnlyDependency, UnlistedDependency, UnresolvedCatalogReference,
+    UnresolvedImport, UnusedCatalogEntry, UnusedDependency, UnusedDependencyOverride, UnusedExport,
+    UnusedFile, UnusedMember,
 };
 
 #[cfg(test)]

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -1472,61 +1472,13 @@ fn dedup_results(target: &mut AnalysisResults) {
 }
 
 /// Merge analysis results from a sub-project into the accumulated results.
+///
+/// Thin wrapper over [`AnalysisResults::merge_into`], the single
+/// field-exhaustive union (issue #444). Cross-root duplicates this
+/// `.extend()`-based union accumulates are collapsed afterwards by
+/// [`dedup_results`].
 fn merge_results(target: &mut AnalysisResults, source: AnalysisResults) {
-    target.unused_files.extend(source.unused_files);
-    target.unused_exports.extend(source.unused_exports);
-    target.unused_types.extend(source.unused_types);
-    target.private_type_leaks.extend(source.private_type_leaks);
-    target
-        .unused_dependencies
-        .extend(source.unused_dependencies);
-    target
-        .unused_dev_dependencies
-        .extend(source.unused_dev_dependencies);
-    target
-        .unused_optional_dependencies
-        .extend(source.unused_optional_dependencies);
-    target
-        .unused_enum_members
-        .extend(source.unused_enum_members);
-    target
-        .unused_class_members
-        .extend(source.unused_class_members);
-    target.unresolved_imports.extend(source.unresolved_imports);
-    target
-        .unlisted_dependencies
-        .extend(source.unlisted_dependencies);
-    target.duplicate_exports.extend(source.duplicate_exports);
-    target
-        .type_only_dependencies
-        .extend(source.type_only_dependencies);
-    target
-        .circular_dependencies
-        .extend(source.circular_dependencies);
-    target.re_export_cycles.extend(source.re_export_cycles);
-    target
-        .test_only_dependencies
-        .extend(source.test_only_dependencies);
-    target
-        .boundary_violations
-        .extend(source.boundary_violations);
-    target.export_usages.extend(source.export_usages);
-    target.stale_suppressions.extend(source.stale_suppressions);
-    target
-        .unused_catalog_entries
-        .extend(source.unused_catalog_entries);
-    target
-        .empty_catalog_groups
-        .extend(source.empty_catalog_groups);
-    target
-        .unresolved_catalog_references
-        .extend(source.unresolved_catalog_references);
-    target
-        .unused_dependency_overrides
-        .extend(source.unused_dependency_overrides);
-    target
-        .misconfigured_dependency_overrides
-        .extend(source.misconfigured_dependency_overrides);
+    target.merge_into(source);
 }
 
 /// Merge duplication reports from a sub-project into the accumulated report.
@@ -1944,6 +1896,10 @@ mod tests {
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "intentionally names every AnalysisResults field (no ..Default::default()) so a new field is a compile error here; see #444"
+    )]
     fn merge_test_source_with_all_fields() -> AnalysisResults {
         AnalysisResults {
             unused_files: vec![UnusedFileFinding::with_actions(UnusedFile {
@@ -2048,7 +2004,115 @@ mod tests {
                 reference_count: 3,
                 reference_locations: vec![],
             }],
-            ..Default::default()
+            // Every remaining field is named explicitly (no `..Default::default()`)
+            // so adding a field to `AnalysisResults` is a compile error here, not a
+            // silently-unmerged field. This is the test-side half of the #444
+            // compile-time coverage; `AnalysisResults::merge_into`'s exhaustive
+            // destructure is the production-side half.
+            private_type_leaks: vec![fallow_core::results::PrivateTypeLeakFinding::with_actions(
+                fallow_core::results::PrivateTypeLeak {
+                    path: "/f.ts".into(),
+                    export_name: "pub_fn".to_string(),
+                    type_name: "Secret".to_string(),
+                    line: 14,
+                    col: 0,
+                    span_start: 0,
+                },
+            )],
+            re_export_cycles: vec![fallow_core::results::ReExportCycleFinding::with_actions(
+                fallow_core::results::ReExportCycle {
+                    files: vec!["/barrel.ts".into()],
+                    kind: fallow_core::results::ReExportCycleKind::SelfLoop,
+                },
+            )],
+            stale_suppressions: vec![fallow_core::results::StaleSuppression {
+                path: "/f.ts".into(),
+                line: 15,
+                col: 0,
+                origin: fallow_core::results::SuppressionOrigin::Comment {
+                    issue_kind: None,
+                    is_file_level: false,
+                    kind_known: true,
+                },
+            }],
+            unused_catalog_entries: vec![
+                fallow_core::results::UnusedCatalogEntryFinding::with_actions(
+                    fallow_core::results::UnusedCatalogEntry {
+                        entry_name: "react".to_string(),
+                        catalog_name: "default".to_string(),
+                        path: "/pnpm-workspace.yaml".into(),
+                        line: 16,
+                        hardcoded_consumers: vec![],
+                    },
+                ),
+            ],
+            empty_catalog_groups: vec![
+                fallow_core::results::EmptyCatalogGroupFinding::with_actions(
+                    fallow_core::results::EmptyCatalogGroup {
+                        catalog_name: "ui".to_string(),
+                        path: "/pnpm-workspace.yaml".into(),
+                        line: 17,
+                    },
+                ),
+            ],
+            unresolved_catalog_references: vec![
+                fallow_core::results::UnresolvedCatalogReferenceFinding::with_actions(
+                    fallow_core::results::UnresolvedCatalogReference {
+                        entry_name: "vue".to_string(),
+                        catalog_name: "default".to_string(),
+                        path: "/pkg.json".into(),
+                        line: 18,
+                        available_in_catalogs: vec![],
+                    },
+                ),
+            ],
+            unused_dependency_overrides: vec![
+                fallow_core::results::UnusedDependencyOverrideFinding::with_actions(
+                    fallow_core::results::UnusedDependencyOverride {
+                        raw_key: "react".to_string(),
+                        target_package: "react".to_string(),
+                        parent_package: None,
+                        version_constraint: None,
+                        version_range: "18".to_string(),
+                        source: fallow_core::results::DependencyOverrideSource::PnpmWorkspaceYaml,
+                        path: "/pnpm-workspace.yaml".into(),
+                        line: 19,
+                        hint: None,
+                    },
+                ),
+            ],
+            misconfigured_dependency_overrides: vec![
+                fallow_core::results::MisconfiguredDependencyOverrideFinding::with_actions(
+                    fallow_core::results::MisconfiguredDependencyOverride {
+                        raw_key: "bad>".to_string(),
+                        target_package: None,
+                        raw_value: String::new(),
+                        reason: fallow_core::results::DependencyOverrideMisconfigReason::EmptyValue,
+                        source: fallow_core::results::DependencyOverrideSource::PnpmPackageJson,
+                        path: "/pkg.json".into(),
+                        line: 20,
+                    },
+                ),
+            ],
+            suppression_count: 1,
+            feature_flags: vec![fallow_core::results::FeatureFlag {
+                path: "/f.ts".into(),
+                flag_name: "ENABLE_X".to_string(),
+                kind: fallow_core::results::FlagKind::EnvironmentVariable,
+                confidence: fallow_core::results::FlagConfidence::High,
+                line: 21,
+                col: 0,
+                guard_span_start: None,
+                guard_span_end: None,
+                sdk_name: None,
+                guard_line_start: None,
+                guard_line_end: None,
+                guarded_dead_exports: vec![],
+            }],
+            entry_point_summary: Some(fallow_core::results::EntryPointSummary {
+                total: 0,
+                by_source: vec![],
+            }),
         }
     }
 
@@ -2059,9 +2123,15 @@ mod tests {
 
         merge_results(&mut target, source);
 
+        // Every field the exhaustive fixture seeds with one element must
+        // survive the merge into an empty target (#444). If a new field is
+        // added to `AnalysisResults`, the fixture stops compiling (no
+        // `..Default::default()`) and `merge_into` flags the unmerged field;
+        // adding the assertion here keeps the union covered end to end.
         assert_eq!(target.unused_files.len(), 1);
         assert_eq!(target.unused_exports.len(), 1);
         assert_eq!(target.unused_types.len(), 1);
+        assert_eq!(target.private_type_leaks.len(), 1);
         assert_eq!(target.unused_dependencies.len(), 1);
         assert_eq!(target.unused_dev_dependencies.len(), 1);
         assert_eq!(target.unused_optional_dependencies.len(), 1);
@@ -2071,10 +2141,20 @@ mod tests {
         assert_eq!(target.unlisted_dependencies.len(), 1);
         assert_eq!(target.duplicate_exports.len(), 1);
         assert_eq!(target.type_only_dependencies.len(), 1);
-        assert_eq!(target.circular_dependencies.len(), 1);
         assert_eq!(target.test_only_dependencies.len(), 1);
+        assert_eq!(target.circular_dependencies.len(), 1);
+        assert_eq!(target.re_export_cycles.len(), 1);
         assert_eq!(target.boundary_violations.len(), 1);
+        assert_eq!(target.stale_suppressions.len(), 1);
+        assert_eq!(target.unused_catalog_entries.len(), 1);
+        assert_eq!(target.empty_catalog_groups.len(), 1);
+        assert_eq!(target.unresolved_catalog_references.len(), 1);
+        assert_eq!(target.unused_dependency_overrides.len(), 1);
+        assert_eq!(target.misconfigured_dependency_overrides.len(), 1);
         assert_eq!(target.export_usages.len(), 1);
+        assert_eq!(target.feature_flags.len(), 1);
+        assert_eq!(target.suppression_count, 1);
+        assert!(target.entry_point_summary.is_some());
     }
 
     #[test]

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -255,6 +255,84 @@ impl AnalysisResults {
         self.total_issues() > 0
     }
 
+    /// Merge `other` into `self`, taking the union of every field.
+    ///
+    /// This is the single canonical way to combine two [`AnalysisResults`]
+    /// (the LSP merges per-project-root results through it). The method
+    /// exhaustively destructures `Self`, so adding a field to the struct
+    /// becomes a compile error here instead of a silently-dropped field. See
+    /// issue #444.
+    ///
+    /// Every `Vec` field is appended (callers dedup downstream where needed,
+    /// e.g. the LSP's identity-keyed `dedup_results`). `suppression_count`
+    /// sums; `entry_point_summary` keeps `self`'s value when present and
+    /// otherwise adopts `other`'s.
+    pub fn merge_into(&mut self, other: Self) {
+        let Self {
+            unused_files,
+            unused_exports,
+            unused_types,
+            private_type_leaks,
+            unused_dependencies,
+            unused_dev_dependencies,
+            unused_optional_dependencies,
+            unused_enum_members,
+            unused_class_members,
+            unresolved_imports,
+            unlisted_dependencies,
+            duplicate_exports,
+            type_only_dependencies,
+            test_only_dependencies,
+            circular_dependencies,
+            re_export_cycles,
+            boundary_violations,
+            stale_suppressions,
+            unused_catalog_entries,
+            empty_catalog_groups,
+            unresolved_catalog_references,
+            unused_dependency_overrides,
+            misconfigured_dependency_overrides,
+            suppression_count,
+            feature_flags,
+            export_usages,
+            entry_point_summary,
+        } = other;
+
+        self.unused_files.extend(unused_files);
+        self.unused_exports.extend(unused_exports);
+        self.unused_types.extend(unused_types);
+        self.private_type_leaks.extend(private_type_leaks);
+        self.unused_dependencies.extend(unused_dependencies);
+        self.unused_dev_dependencies.extend(unused_dev_dependencies);
+        self.unused_optional_dependencies
+            .extend(unused_optional_dependencies);
+        self.unused_enum_members.extend(unused_enum_members);
+        self.unused_class_members.extend(unused_class_members);
+        self.unresolved_imports.extend(unresolved_imports);
+        self.unlisted_dependencies.extend(unlisted_dependencies);
+        self.duplicate_exports.extend(duplicate_exports);
+        self.type_only_dependencies.extend(type_only_dependencies);
+        self.test_only_dependencies.extend(test_only_dependencies);
+        self.circular_dependencies.extend(circular_dependencies);
+        self.re_export_cycles.extend(re_export_cycles);
+        self.boundary_violations.extend(boundary_violations);
+        self.stale_suppressions.extend(stale_suppressions);
+        self.unused_catalog_entries.extend(unused_catalog_entries);
+        self.empty_catalog_groups.extend(empty_catalog_groups);
+        self.unresolved_catalog_references
+            .extend(unresolved_catalog_references);
+        self.unused_dependency_overrides
+            .extend(unused_dependency_overrides);
+        self.misconfigured_dependency_overrides
+            .extend(misconfigured_dependency_overrides);
+        self.feature_flags.extend(feature_flags);
+        self.export_usages.extend(export_usages);
+        self.suppression_count += suppression_count;
+        if self.entry_point_summary.is_none() {
+            self.entry_point_summary = entry_point_summary;
+        }
+    }
+
     /// Sort all result arrays for deterministic output ordering.
     ///
     /// Parallel collection (rayon, `FxHashMap` iteration) does not guarantee


### PR DESCRIPTION
## Summary

- Replace the two hand-maintained field-by-field merge sites (`run_plugins`'s workspace merge loop in core and the LSP's `merge_results`) with `merge_into` methods that exhaustively destructure their own struct, so adding a field to `AggregatedPluginResult` or `AnalysisResults` is a compile error in the merge logic instead of a silent CLI/LSP divergence.
- `AggregatedPluginResult` gains `merge_into` (the prefix-agnostic union) plus `apply_workspace_prefix` (the call-site-specific path prefixing); the workspace loop now prefixes each result then folds it in via the single method.
- `AnalysisResults::merge_into` lives in fallow-types; the LSP `merge_results` becomes a thin wrapper delegating to it.
- Pre-refactor behavior is preserved exactly: workspace `config_patterns` / `used_class_members` / `scss_include_paths` (populated but historically dropped) stay dropped via clear-before-merge, and `script_used_packages` (never populated by `run_workspace_fast`) is cleared too so a future change cannot silently alter root script-credit. Whether the populated-field drops are latent bugs is tracked separately in #772.
- The LSP merge test fixture drops `..Default::default()` so it is a second compile-time field-coverage gate.

Fixes #444.

## Test plan

- [x] `cargo test --workspace --all-targets`: zero failures.
- [x] New end-to-end `merge_results_covers_all_fields` asserts every `AnalysisResults` field survives the merge; fixture is now exhaustive.
- [x] Negative compile-error check: injecting a dummy field into each struct breaks the build at the `merge_into` destructure (confirmed, then reverted).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` and `cargo doc --workspace --no-deps --document-private-items` clean.
- [x] OLD vs NEW byte-identical issue counts across all 10 real-world fixtures (incl. the vue-core / svelte / vite monorepos where the merge loop runs).