### PR TITLE
chore(release): pass --ignore-scripts on release-pipeline dev installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
 
       - name: Install NAPI package dependencies
-        run: cd crates/napi && npm ci --omit=optional
+        run: cd crates/napi && npm ci --omit=optional --ignore-scripts
 
       - name: Build NAPI addon
         run: cd crates/napi && npx napi build --platform --release --target ${{ matrix.target }}
@@ -454,7 +454,7 @@ jobs:
           cache-dependency-path: editors/vscode/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: cd editors/vscode && pnpm install --frozen-lockfile
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Verify generated TypeScript matches docs/output-schema.json
         run: cd editors/vscode && pnpm run check:codegen
@@ -580,10 +580,12 @@ jobs:
           done
 
       - name: Install NAPI package dependencies
-        # Only safe here because this job has no publish tokens. The dev
-        # dependency tree of @napi-rs/cli runs install scripts; keeping that
-        # off the npm-publish job is the whole point of the split.
-        run: cd crates/napi && npm ci --omit=optional
+        # --ignore-scripts blocks dependency-tree install scripts here too, on
+        # top of the prep/publish split. The split (keeping dependency installs
+        # off the token-holding npm-publish job) is the primary guard; this is
+        # belt-and-suspenders. napi build does not need install scripts to
+        # produce the native addon, so disabling them is safe.
+        run: cd crates/napi && npm ci --omit=optional --ignore-scripts
 
       - name: Update NAPI package version
         env:
@@ -875,7 +877,7 @@ jobs:
           cache-dependency-path: editors/vscode/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: cd editors/vscode && pnpm install --frozen-lockfile
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Update extension version
         env:


### PR DESCRIPTION
## Summary

- Extends the `--ignore-scripts` posture from #775 (ci.yml) to `release.yml`'s four dependency installs: NAPI `npm ci` in the build matrix + npm-prep jobs, and editors/vscode `pnpm install` in the vscode-prep + vscode-publish-prep jobs. All four run in prep jobs that hold no publish tokens (the prep/publish split is the primary supply-chain guard); `--ignore-scripts` is belt-and-suspenders. Also reconciles the npm-prep comment that wrongly claimed `@napi-rs/cli` needs its install scripts.

## Why this is safe

- **Empirically verified the consuming builds work with scripts disabled.** Full release-shape NAPI build: `npm ci --omit=optional --ignore-scripts` then `napi build --release --platform` produced the 9.6M native addon (exit 0). editors/vscode `pnpm install --ignore-scripts` + rolldown build also verified (during #775).
- **`--ignore-scripts` only blocks install-time lifecycle hooks, not explicit `npm run`/`pnpm run` steps.** So `publish:prepare`, `create-npm-dirs`, `prebuild`, and `prepackage` all still fire on their explicit invocations.
- **Cross-platform:** `--omit=optional` already excludes the platform addon packages, leaving only `@napi-rs/cli` (a pure CLI, no load-bearing postinstall); `napi build` compiles via cargo, not a lifecycle hook. Verified on darwin-arm64; behavior is platform-independent.
- **No `release-workflow.md` hard rule touched** (prep/publish split, two-step npm bootstrap, `--no-verify`, pinned npm all unchanged).

## Caveat

`release.yml` is only fully exercised at tag-push time, and tags are permanent tombstones. The risk is mitigated because ci.yml already carries the same flag, so any future dependency needing install scripts fails on PR CI before a release runs, but the literal release.yml jobs do not execute on this PR.

## Test plan

- [x] Local: release-shape NAPI build + editors/vscode build both succeed with `--ignore-scripts`.
- [x] `actionlint` clean; `zizmor` introduces zero new findings vs origin/main (87=87 total).
- [x] yaml parses; all 4 install sites covered; no em-dashes.
- [x] github-action-reviewer: APPROVE.