### PR TITLE
chore(security): re-bless agent-file baseline for cli-crate rule

### DIFF
--- a/scripts/agent-files.sha256
+++ b/scripts/agent-files.sha256
@@ -9,7 +9,7 @@ a01291344648084dadb8206b7df6797ca821c291d949eb3fc4f3800b873ac364  .claude/agents
 194f53e3def2eac97a06c81b76bd9531bdd6a677e53b6a38ef31b65f5584cab2  .claude/agents/rust-reviewer.md
 63a663fb2a80b04d2e7700732fee84935a691320a9123483c7dd54c6bf985495  .claude/agents/user-panel.md
 b40014209809c5a25ce8d4f8b434a77a1fb6d9deb78b9059badd098d39062c13  .claude/agents/vscode-reviewer.md
-c3324afb651c67e141757fddd17b9d0b15ac9a3dbc4b49224af3ccb6c6f81269  .claude/rules/cli-crate.md
+5c8c6c0ef39c393e49b2e97c17b14502dff5a035aabf985cdcedb6a1adb9c75d  .claude/rules/cli-crate.md
 ba291bbb73bed92aa102c43eb6360f1107e1d86af443d3249b800f4292900c07  .claude/rules/code-quality.md
 80d9fea77af6652946d6eefe4f30ed35c1df8dcbabeb9d8f47f4308019caddc6  .claude/rules/core-crate.md
 9486f78c0432d19df6044d15ad67f859a5177975962460088bd7b2a885d33aab  .claude/rules/detection.md


### PR DESCRIPTION
The `.claude/rules/cli-crate.md` health-gate documentation edit from #790 changed the file's content hash without refreshing the blessed manifest in `scripts/agent-files.sha256`. The SessionStart agent-file guard flags this as drift on every new session.

Re-blesses the baseline so the committed content matches the manifest. Only the `cli-crate.md` hash changes; no content edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)