### PR TITLE
fix(impact): gitignore the store on enable; reject unsupported formats

### DIFF
--- a/crates/cli/src/impact.rs
+++ b/crates/cli/src/impact.rs
@@ -162,6 +162,12 @@ fn save(store: &ImpactStore, root: &Path) {
 }
 
 /// Enable Impact tracking. Returns whether it was newly enabled (false if already on).
+///
+/// Also ensures `.fallow/` is gitignored so the store is not accidentally
+/// committed: the store is the feature's local-only promise, and `enable` is the
+/// moment it is first created, so it is the right place to make
+/// "gitignored, never uploaded" true even when the user never ran `fallow init`.
+/// Best-effort: a gitignore write failure must never fail enabling.
 pub fn enable(root: &Path) -> bool {
     let mut store = load(root);
     let was_enabled = store.enabled;
@@ -170,7 +176,31 @@ pub fn enable(root: &Path) -> bool {
         store.schema_version = IMPACT_SCHEMA_VERSION;
     }
     save(&store, root);
+    ensure_fallow_gitignored(root);
     !was_enabled
+}
+
+/// Best-effort: append `.fallow/` to the project's `.gitignore` if no line
+/// already ignores it. Idempotent, and a no-op when `fallow init` (which writes
+/// the same entry) already added it. Any IO error is swallowed: enabling Impact
+/// must never fail on a gitignore write. `impact` lives in the library crate
+/// while `setup_hooks::ensure_gitignore_entry` is binary-only, so this small
+/// helper is intentionally self-contained rather than shared.
+fn ensure_fallow_gitignored(root: &Path) {
+    let path = root.join(".gitignore");
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let already = existing
+        .lines()
+        .any(|line| matches!(line.trim(), ".fallow" | ".fallow/"));
+    if already {
+        return;
+    }
+    let mut contents = existing;
+    if !contents.is_empty() && !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push_str(".fallow/\n");
+    let _ = std::fs::write(&path, contents);
 }
 
 /// Disable Impact tracking. Retains existing history. Returns whether it was
@@ -571,6 +601,27 @@ mod tests {
         assert_eq!(
             store.first_recorded.as_deref(),
             Some("2026-05-29T10:00:00Z")
+        );
+    }
+
+    #[test]
+    fn enable_gitignores_the_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        enable(root);
+        let gitignore = std::fs::read_to_string(root.join(".gitignore")).unwrap();
+        assert!(
+            gitignore.lines().any(|l| l.trim() == ".fallow/"),
+            "enable must gitignore .fallow/, got: {gitignore:?}"
+        );
+        // Idempotent: a second enable does not duplicate the entry, and an
+        // existing entry (e.g. from `fallow init`) is left alone.
+        enable(root);
+        let gitignore = std::fs::read_to_string(root.join(".gitignore")).unwrap();
+        assert_eq!(
+            gitignore.lines().filter(|l| l.trim() == ".fallow/").count(),
+            1,
+            "re-enabling must not duplicate the .fallow/ entry"
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2781,7 +2781,21 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
                 let rendered = match output {
                     fallow_config::OutputFormat::Json => impact::render_json(&report),
                     fallow_config::OutputFormat::Markdown => impact::render_markdown(&report),
-                    _ => impact::render_human(&report),
+                    fallow_config::OutputFormat::Human => impact::render_human(&report),
+                    fallow_config::OutputFormat::Sarif
+                    | fallow_config::OutputFormat::Compact
+                    | fallow_config::OutputFormat::CodeClimate
+                    | fallow_config::OutputFormat::PrCommentGithub
+                    | fallow_config::OutputFormat::PrCommentGitlab
+                    | fallow_config::OutputFormat::ReviewGithub
+                    | fallow_config::OutputFormat::ReviewGitlab
+                    | fallow_config::OutputFormat::Badge => {
+                        return crate::error::emit_error(
+                            "impact supports human, json, and markdown output",
+                            2,
+                            output,
+                        );
+                    }
                 };
                 println!("{rendered}");
                 ExitCode::SUCCESS


### PR DESCRIPTION
## Summary

Two gaps found while smoke-testing `fallow impact` (still unreleased):

- **`enable` now gitignores the store.** `fallow impact enable` created `.fallow/impact.json` but did not ensure `.fallow/` was gitignored. In a project that had not run `fallow init` (which does add it), a routine `git add -A` would stage and push the store, contradicting the local-only / "never uploaded" promise the enable message prints. `enable` now appends `.fallow/` to `.gitignore` best-effort: idempotent, a no-op when the entry already exists, and never fails enabling on an IO error.
- **Unsupported formats are now rejected.** `fallow impact --format sarif|compact|codeclimate|badge|...` silently fell back to the human report, so a CI step asking for a machine format got human text it could not parse. The format dispatch is now exhaustive and returns exit 2 with a clear message, matching `fallow explain`. Supported set (human, json, markdown) is unchanged.

The gitignore helper is self-contained in `impact.rs` because that module is in the library crate while `setup_hooks::ensure_gitignore_entry` is binary-only.

## Test plan

- [x] New unit test `impact::tests::enable_gitignores_the_store`: enable writes `.fallow/`, idempotent on re-enable, pre-existing entry not duplicated.
- [x] `cargo test -p fallow-cli -- impact::tests` pass.
- [x] End-to-end: after `enable`, `git check-ignore .fallow/impact.json` confirms ignored and the store no longer appears in `git status`; a pre-existing `.fallow/` (from `fallow init`) is left untouched.
- [x] End-to-end: `--format sarif|compact|codeclimate|badge` exit 2 with "impact supports human, json, and markdown output"; `--format human|json|markdown` still exit 0.
- [x] `cargo clippy -p fallow-cli --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.