### PR TITLE
chore(napi): sync package.json / package-lock / index.js to v2.85.0

### DIFF
--- a/crates/napi/index.js
+++ b/crates/napi/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-android-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-android-arm-eabi')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-x64-gnu')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-x64-msvc')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@fallow-cli/fallow-node-darwin-universal')
       const bindingPackageVersion = require('@fallow-cli/fallow-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-darwin-x64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-darwin-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-freebsd-x64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-freebsd-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-x64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-x64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-loong64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-openharmony-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-openharmony-x64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-openharmony-arm')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.84.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.84.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.85.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.85.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/napi/package-lock.json
+++ b/crates/napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fallow-cli/fallow-node",
-  "version": "2.84.0",
+  "version": "2.85.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fallow-cli/fallow-node",
-      "version": "2.84.0",
+      "version": "2.85.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0"
@@ -15,14 +15,14 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@fallow-cli/fallow-node-darwin-arm64": "2.84.0",
-        "@fallow-cli/fallow-node-darwin-x64": "2.84.0",
-        "@fallow-cli/fallow-node-linux-arm64-gnu": "2.84.0",
-        "@fallow-cli/fallow-node-linux-arm64-musl": "2.84.0",
-        "@fallow-cli/fallow-node-linux-x64-gnu": "2.84.0",
-        "@fallow-cli/fallow-node-linux-x64-musl": "2.84.0",
-        "@fallow-cli/fallow-node-win32-arm64-msvc": "2.84.0",
-        "@fallow-cli/fallow-node-win32-x64-msvc": "2.84.0"
+        "@fallow-cli/fallow-node-darwin-arm64": "2.85.0",
+        "@fallow-cli/fallow-node-darwin-x64": "2.85.0",
+        "@fallow-cli/fallow-node-linux-arm64-gnu": "2.85.0",
+        "@fallow-cli/fallow-node-linux-arm64-musl": "2.85.0",
+        "@fallow-cli/fallow-node-linux-x64-gnu": "2.85.0",
+        "@fallow-cli/fallow-node-linux-x64-musl": "2.85.0",
+        "@fallow-cli/fallow-node-win32-arm64-msvc": "2.85.0",
+        "@fallow-cli/fallow-node-win32-x64-msvc": "2.85.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-darwin-arm64": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-darwin-arm64/-/fallow-node-darwin-arm64-2.84.0.tgz",
-      "integrity": "sha512-hehI6FQWpwtweCenlNN7/j6jU/mtxSNGpybD0W4e0YF238IgEtCP78tlLCBR2oYMOuWVScSSPten6IzoX3ZtTA==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-darwin-arm64/-/fallow-node-darwin-arm64-2.85.0.tgz",
+      "integrity": "sha512-6LzlW4AbTI5jnE/gxksJv/e0iQobFyQV8NAgbLiEv+gvo69K714LEbmJnotUThEfUxS/GPeSIYsEaAP4sMNy5Q==",
       "cpu": [
         "arm64"
       ],
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-darwin-x64": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-darwin-x64/-/fallow-node-darwin-x64-2.84.0.tgz",
-      "integrity": "sha512-c6Lz+AT9/d6zT+eZtTnsQPSVWGmKU32vkSbFx+9sCNQGEF5kj3VSe/sfvyENqCX/Kevuc7F9EHhpqqE1tVVSsA==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-darwin-x64/-/fallow-node-darwin-x64-2.85.0.tgz",
+      "integrity": "sha512-86rhuYf9RnKniQBLYGN6JMtpW46W38rmhGNWgSjADaruBO2xwKeCl5cYfEOoAd4tZTDf2zEtjTsqHgpkDS8L0Q==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-linux-arm64-gnu": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-arm64-gnu/-/fallow-node-linux-arm64-gnu-2.84.0.tgz",
-      "integrity": "sha512-uLVN//A3etcv22v+X7rvKDPVFBsXxQxj1zt6zRC7qY+zfSV20m7LWNEUyH/MzxC3AVAjbrc8atUTCSDiRy5m/w==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-arm64-gnu/-/fallow-node-linux-arm64-gnu-2.85.0.tgz",
+      "integrity": "sha512-pEQgFIO1k7FxaKPxzTiAj9tojxqTEIlp541zoZGlEP76Yz2wt15lNwNXfK1j1vLdSRjgHGFdeXL1Drc02SHZGA==",
       "cpu": [
         "arm64"
       ],
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-linux-arm64-musl": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-arm64-musl/-/fallow-node-linux-arm64-musl-2.84.0.tgz",
-      "integrity": "sha512-olLNUnPHM9PpgvrshlDZzmxBmfF0JuAQfG52iH7b768i1F+H1awc4WVpdcFd7wJc4wuYqQmzhaebbcjLZpS8/A==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-arm64-musl/-/fallow-node-linux-arm64-musl-2.85.0.tgz",
+      "integrity": "sha512-MGWMq5C9XKgEdZoDlAzouLTxqytZAugnrRd99N5bDH2fMXhccHHUsDVDjm2kqc4eAU/FaUjC0k54cUjqV4nFCg==",
       "cpu": [
         "arm64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-linux-x64-gnu": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-x64-gnu/-/fallow-node-linux-x64-gnu-2.84.0.tgz",
-      "integrity": "sha512-oyVdyhAu6peNZWGjyiR3OrpLqHWOus1Ro0lhyQ84WUHYbXUtLQqCZPrfg6AO3FCRASo+poC2bxsBTtGmlpmrXg==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-x64-gnu/-/fallow-node-linux-x64-gnu-2.85.0.tgz",
+      "integrity": "sha512-bp4dyDq5CKCIcTpisnmGKuI2iWLZ9ziljhroy5dIF+IVocs6PgMF/iDp/s6Zlu3VUJT+HBtPOlZrHG5Jl9Kfgw==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-linux-x64-musl": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-x64-musl/-/fallow-node-linux-x64-musl-2.84.0.tgz",
-      "integrity": "sha512-De2OS+otL8FqyFIgt5HQgY/HSVB3RRHP8o5aGcbi4WwEc+FSIbBFlH//tpDp3T3KNjq8aukGtdWD8xNGV10O6w==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-linux-x64-musl/-/fallow-node-linux-x64-musl-2.85.0.tgz",
+      "integrity": "sha512-Tmo/jbnZ0ntjJrlrUh1JQxefEqYg2/IfIUipwz/x1fFOZbLFyzYE/sZ3A+rBzvAHJwPKpnPosKqmpT5MpfEyrA==",
       "cpu": [
         "x64"
       ],
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-win32-arm64-msvc": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-win32-arm64-msvc/-/fallow-node-win32-arm64-msvc-2.84.0.tgz",
-      "integrity": "sha512-tQ8r+DWABAuVUlTZqejLENwjsJhonhgrDFMQVo8FGZ/J8hupcgTVxVdvHRt1O472iUpPQ0sJgps9K5je7dB6rw==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-win32-arm64-msvc/-/fallow-node-win32-arm64-msvc-2.85.0.tgz",
+      "integrity": "sha512-1zCqan+YFuXVvbHdQ/hxpUvGasLPbYm3Ol5xoJqBVKtQvU9wWFgz/OD0QPd+TDz/lvmzircqwY/w/XXovfUc8w==",
       "cpu": [
         "arm64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@fallow-cli/fallow-node-win32-x64-msvc": {
-      "version": "2.84.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-win32-x64-msvc/-/fallow-node-win32-x64-msvc-2.84.0.tgz",
-      "integrity": "sha512-NcIPeeBgFXPyqSeHnbzMKx7t/xHsLX5UTX0fAUEy0qeUVE7LQlYg+wxjUu08dSQuK3BIKW7JVGmd5DnH7JJupg==",
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/fallow-node-win32-x64-msvc/-/fallow-node-win32-x64-msvc-2.85.0.tgz",
+      "integrity": "sha512-JMCO0CcAzgQJaQ4g3PHFG5RBB8aPgs5qo7lmPUvA6ElpjELrcGhPDPF7rLSbjx89W/Q9QN20m2XhP0h9wfOwTA==",
       "cpu": [
         "x64"
       ],

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fallow-cli/fallow-node",
-  "version": "2.84.0",
+  "version": "2.85.0",
   "description": "Native Node.js bindings for fallow, codebase intelligence for TypeScript and JavaScript. Finds unused code, duplication, circular dependencies, complexity hotspots, and architecture drift. Optional runtime intelligence layer (Fallow Runtime) adds production execution evidence.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -64,13 +64,13 @@
     "@napi-rs/cli": "3.6.0"
   },
   "optionalDependencies": {
-    "@fallow-cli/fallow-node-darwin-arm64": "2.84.0",
-    "@fallow-cli/fallow-node-darwin-x64": "2.84.0",
-    "@fallow-cli/fallow-node-linux-arm64-gnu": "2.84.0",
-    "@fallow-cli/fallow-node-linux-arm64-musl": "2.84.0",
-    "@fallow-cli/fallow-node-linux-x64-gnu": "2.84.0",
-    "@fallow-cli/fallow-node-linux-x64-musl": "2.84.0",
-    "@fallow-cli/fallow-node-win32-arm64-msvc": "2.84.0",
-    "@fallow-cli/fallow-node-win32-x64-msvc": "2.84.0"
+    "@fallow-cli/fallow-node-darwin-arm64": "2.85.0",
+    "@fallow-cli/fallow-node-darwin-x64": "2.85.0",
+    "@fallow-cli/fallow-node-linux-arm64-gnu": "2.85.0",
+    "@fallow-cli/fallow-node-linux-arm64-musl": "2.85.0",
+    "@fallow-cli/fallow-node-linux-x64-gnu": "2.85.0",
+    "@fallow-cli/fallow-node-linux-x64-musl": "2.85.0",
+    "@fallow-cli/fallow-node-win32-arm64-msvc": "2.85.0",
+    "@fallow-cli/fallow-node-win32-x64-msvc": "2.85.0"
   }
 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -72,7 +72,7 @@ V1 events are workflow-level and coarse:
 {
   "schema_version": 1,
   "event": "workflow_completed",
-  "fallow_version": "2.84.0",
+  "fallow_version": "2.85.0",
   "workflow": "audit",
   "integration_surface": "cli_json",
   "invocation_context": "agent",


### PR DESCRIPTION
Post-release catch-up: bumps crates/napi to v2.85.0 now that the @fallow-cli/fallow-node-* platform packages exist on npm and the lockfile resolves. Standard step-12 napi sync.