### PR TITLE
fix: credit package.json prettier string configs

### DIFF
--- a/crates/core/src/plugins/prettier.rs
+++ b/crates/core/src/plugins/prettier.rs
@@ -102,11 +102,21 @@ define_plugin! {
             }
         }
 
-        // Handle JSON configs (.prettierrc, .prettierrc.json)
+        // Handle JSON configs (.prettierrc, .prettierrc.json). Prettier also
+        // accepts a package name string in package.json: { "prettier": "pkg" }.
         let is_json = config_path.extension().is_some_and(|ext| ext == "json")
             || config_path
                 .file_name()
                 .is_some_and(|name| name == ".prettierrc");
+        if is_json
+            && let Ok(serde_json::Value::String(config_package)) =
+                serde_json::from_str::<serde_json::Value>(source)
+        {
+            result
+                .referenced_dependencies
+                .push(crate::resolve::extract_package_name(&config_package));
+            return result;
+        }
         let (parse_source, parse_path_buf) = if is_json {
             (format!("({source})"), config_path.with_extension("js"))
         } else {
@@ -179,6 +189,22 @@ mod tests {
         let result = plugin.resolve_config(Path::new(".prettierrc"), source, Path::new("/project"));
 
         assert!(result.referenced_dependencies.is_empty());
+    }
+
+    #[test]
+    fn resolve_package_json_string_config() {
+        let source = r#""@scope/prettier-config""#;
+        let plugin = PrettierPlugin;
+        let result = plugin.resolve_config(
+            Path::new("prettier.config.json"),
+            source,
+            Path::new("/project"),
+        );
+
+        assert_eq!(
+            result.referenced_dependencies,
+            vec!["@scope/prettier-config".to_string()]
+        );
     }
 
     #[test]

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -191,6 +191,8 @@ mod issue_635_scaffold_template_assets;
 mod issue_638_node_script_entrypoints;
 #[path = "integration_test/issue_754_eslint_meta_preset.rs"]
 mod issue_754_eslint_meta_preset;
+#[path = "integration_test/issue_818_prettier_pkg_json_string.rs"]
+mod issue_818_prettier_pkg_json_string;
 #[path = "integration_test/issue_820_vercel_ts_config.rs"]
 mod issue_820_vercel_ts_config;
 #[path = "integration_test/lexical_nodes.rs"]

--- a/crates/core/tests/integration_test/issue_818_prettier_pkg_json_string.rs
+++ b/crates/core/tests/integration_test/issue_818_prettier_pkg_json_string.rs
@@ -1,0 +1,31 @@
+//! Issue #818: package.json#prettier string configs reference external config packages.
+
+use super::common::{create_config, fixture_path};
+
+fn unused_dev_deps(fixture: &str) -> Vec<String> {
+    let root = fixture_path(fixture);
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    results
+        .unused_dev_dependencies
+        .iter()
+        .map(|dep| dep.dep.package_name.clone())
+        .collect()
+}
+
+#[test]
+fn package_json_string_config_credits_external_package() {
+    // Prettier treats package.json#prettier string values as an external config
+    // package or file. Fallow must credit the package instead of reporting the
+    // shared config as an unused dev dependency.
+    let unused = unused_dev_deps("issue-818-prettier-pkg-json-string");
+
+    assert!(
+        !unused.contains(&"@scope/prettier-config".to_string()),
+        "@scope/prettier-config is loaded from package.json#prettier and must be credited, got {unused:?}"
+    );
+    assert!(
+        unused.contains(&"unused-control".to_string()),
+        "unused-control should still be reported, got {unused:?}"
+    );
+}

--- a/tests/fixtures/issue-818-prettier-pkg-json-string/package.json
+++ b/tests/fixtures/issue-818-prettier-pkg-json-string/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "issue-818-prettier-pkg-json-string",
+  "version": "1.0.0",
+  "type": "module",
+  "prettier": "@scope/prettier-config",
+  "devDependencies": {
+    "@scope/prettier-config": "latest",
+    "prettier": "latest",
+    "unused-control": "latest"
+  }
+}

--- a/tests/fixtures/issue-818-prettier-pkg-json-string/src/main.ts
+++ b/tests/fixtures/issue-818-prettier-pkg-json-string/src/main.ts
@@ -1,0 +1,3 @@
+export const greeting = "hello";
+
+console.log(greeting);


### PR DESCRIPTION
## What

Credit package.json `"prettier": "<package>"` string configs as referenced dependencies in the Prettier plugin.

Also adds an issue #818 fixture and regression integration test.

## Why

Closes #818.

Prettier supports using the package.json `"prettier"` field as an external config package reference, for example:

```json
{
  "prettier": "@scope/prettier-config"
}
```

Fallow previously treated that shared config package as an unused dev dependency because the Prettier plugin only handled object-style configs and `plugins` arrays.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`