### PR TITLE
fix: preserve pnpm package source aliases

### DIFF
--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -197,6 +197,8 @@ mod issue_811_vite_alias_identifier_spread;
 mod issue_818_prettier_pkg_json_string;
 #[path = "integration_test/issue_820_vercel_ts_config.rs"]
 mod issue_820_vercel_ts_config;
+#[path = "integration_test/issue_823_pnpm_package_sources.rs"]
+mod issue_823_pnpm_package_sources;
 #[path = "integration_test/lexical_nodes.rs"]
 mod lexical_nodes;
 #[path = "integration_test/script_multiplexers.rs"]

--- a/crates/core/tests/integration_test/issue_823_pnpm_package_sources.rs
+++ b/crates/core/tests/integration_test/issue_823_pnpm_package_sources.rs
@@ -1,0 +1,120 @@
+//! Issue #823: pnpm package sources must preserve declared dependency names.
+
+use std::path::PathBuf;
+
+use super::common::{create_config, fixture_path};
+
+#[test]
+fn pnpm_package_source_catalog_entries_credit_declared_names() {
+    let root = fixture_path("issue-823-pnpm-package-sources");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_dependencies: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    for dep in [
+        "registry-pkg",
+        "jsr-pkg",
+        "workspace-pkg",
+        "local-dir-pkg",
+        "local-tarball-pkg",
+        "remote-tarball-pkg",
+        "git-url-pkg",
+        "git-shorthand-pkg",
+        "npm-alias-pkg",
+    ] {
+        assert!(
+            !unused_dependencies.contains(&dep),
+            "declared dependency {dep} should be credited, got {unused_dependencies:?}"
+        );
+    }
+    assert!(
+        unused_dependencies.contains(&"unused-control"),
+        "unused control dependency should still be reported, got {unused_dependencies:?}"
+    );
+
+    let unlisted_dependencies: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    for dep in [
+        "@jsr/scope__jsr-pkg",
+        "actual-npm-package",
+        "registry-pkg",
+        "jsr-pkg",
+        "workspace-pkg",
+        "local-dir-pkg",
+        "local-tarball-pkg",
+        "remote-tarball-pkg",
+        "git-url-pkg",
+        "git-shorthand-pkg",
+        "npm-alias-pkg",
+    ] {
+        assert!(
+            !unlisted_dependencies.contains(&dep),
+            "{dep} should not be reported as unlisted, got {unlisted_dependencies:?}"
+        );
+    }
+}
+
+#[test]
+fn pnpm_package_source_catalog_entries_are_not_reported_unused() {
+    let root = fixture_path("issue-823-pnpm-package-sources");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_catalog_entries: Vec<(&str, &str)> = results
+        .unused_catalog_entries
+        .iter()
+        .map(|finding| {
+            (
+                finding.entry.catalog_name.as_str(),
+                finding.entry.entry_name.as_str(),
+            )
+        })
+        .collect();
+    for dep in [
+        "registry-pkg",
+        "jsr-pkg",
+        "workspace-pkg",
+        "local-dir-pkg",
+        "local-tarball-pkg",
+        "remote-tarball-pkg",
+        "git-url-pkg",
+        "git-shorthand-pkg",
+        "npm-alias-pkg",
+    ] {
+        assert!(
+            !unused_catalog_entries.contains(&("default", dep)),
+            "catalog entry {dep} is consumed and should not be unused, got {unused_catalog_entries:?}"
+        );
+    }
+}
+
+#[test]
+fn fixture_uses_workspace_package_source_without_marking_workspace_unused() {
+    let root = fixture_path("issue-823-pnpm-package-sources");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_files: Vec<PathBuf> = results
+        .unused_files
+        .iter()
+        .map(|finding| {
+            finding
+                .file
+                .path
+                .strip_prefix(&root)
+                .unwrap_or(&finding.file.path)
+                .to_path_buf()
+        })
+        .collect();
+    assert!(
+        !unused_files.contains(&PathBuf::from("packages/workspace-pkg/src/index.ts")),
+        "workspace source package should be reachable, got {unused_files:?}"
+    );
+}

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -947,7 +947,7 @@ fn try_style_condition_package_resolution(
         return Some(ResolveResult::InternalModule(file_id));
     }
 
-    if let Some(pkg_name) = extract_package_name_from_node_modules_path(resolved_path)
+    if let Some(pkg_name) = package_usage_name_for_resolved_package(specifier, resolved_path)
         && !ctx.workspace_roots.contains_key(pkg_name.as_str())
     {
         return Some(ResolveResult::NpmPackage(pkg_name));
@@ -970,7 +970,7 @@ fn try_style_condition_package_resolution(
         {
             return Some(ResolveResult::InternalModule(file_id));
         }
-        if let Some(pkg_name) = extract_package_name_from_node_modules_path(&canonical)
+        if let Some(pkg_name) = package_usage_name_for_resolved_package(specifier, &canonical)
             && !ctx.workspace_roots.contains_key(pkg_name.as_str())
         {
             return Some(ResolveResult::NpmPackage(pkg_name));
@@ -978,9 +978,21 @@ fn try_style_condition_package_resolution(
         return Some(ResolveResult::ExternalFile(canonical));
     }
 
-    extract_package_name_from_node_modules_path(resolved_path)
+    package_usage_name_for_resolved_package(specifier, resolved_path)
         .map(ResolveResult::NpmPackage)
         .or_else(|| Some(ResolveResult::ExternalFile(resolved_path.to_path_buf())))
+}
+
+fn package_usage_name_for_resolved_package(
+    specifier: &str,
+    resolved_path: &Path,
+) -> Option<String> {
+    let resolved_package = extract_package_name_from_node_modules_path(resolved_path)?;
+    if is_bare_specifier(specifier) {
+        Some(extract_package_name(specifier))
+    } else {
+        Some(resolved_package)
+    }
 }
 
 /// Resolve a single import specifier to a target.
@@ -1136,7 +1148,8 @@ pub(super) fn resolve_specifier(
                     .as_encoded_bytes()
                     .windows(7)
                     .any(|w| w == b"/.pnpm/" || w == b"\\.pnpm\\")
-                && let Some(pkg_name) = extract_package_name_from_node_modules_path(resolved_path)
+                && let Some(pkg_name) =
+                    package_usage_name_for_resolved_package(specifier, resolved_path)
                 && !ctx.workspace_roots.contains_key(pkg_name.as_str())
             {
                 return if should_preserve_node_modules_style_file(
@@ -1165,7 +1178,7 @@ pub(super) fn resolve_specifier(
                     {
                         ResolveResult::InternalModule(file_id)
                     } else if let Some(pkg_name) =
-                        extract_package_name_from_node_modules_path(&canonical)
+                        package_usage_name_for_resolved_package(specifier, &canonical)
                     {
                         if ctx.workspace_roots.contains_key(pkg_name.as_str())
                             && let Some(result) = try_workspace_package_fallback(ctx, specifier)
@@ -1192,7 +1205,7 @@ pub(super) fn resolve_specifier(
                     ) {
                         ResolveResult::InternalModule(file_id)
                     } else if let Some(pkg_name) =
-                        extract_package_name_from_node_modules_path(resolved_path)
+                        package_usage_name_for_resolved_package(specifier, resolved_path)
                     {
                         if ctx.workspace_roots.contains_key(pkg_name.as_str())
                             && let Some(result) = try_workspace_package_fallback(ctx, specifier)

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -983,12 +983,23 @@ fn try_style_condition_package_resolution(
         .or_else(|| Some(ResolveResult::ExternalFile(resolved_path.to_path_buf())))
 }
 
-fn package_usage_name_for_resolved_package(
+/// Package-usage key for an import that resolved into `node_modules`.
+///
+/// pnpm can install a package under a declared name (e.g. `unstorage`) symlinked
+/// to a `.pnpm` store whose inner package has a different "source" name (e.g.
+/// `unstorage-nightly`). For a plain bare specifier we credit the declared import
+/// name so `unused-dependency` / `unlisted-dependency` accounting matches what the
+/// user wrote in `package.json`, not the on-disk source package. Path aliases that
+/// happen to be bare (Node.js `#imports`, `~/`, `@/`, PascalCase scopes) are
+/// excluded: they can map to an external package whose real name is only recoverable
+/// from the resolved path, so they keep the resolved-package name. Returns `None`
+/// when the path is not inside a `node_modules` directory.
+pub(super) fn package_usage_name_for_resolved_package(
     specifier: &str,
     resolved_path: &Path,
 ) -> Option<String> {
     let resolved_package = extract_package_name_from_node_modules_path(resolved_path)?;
-    if is_bare_specifier(specifier) {
+    if is_bare_specifier(specifier) && !is_path_alias(specifier) {
         Some(extract_package_name(specifier))
     } else {
         Some(resolved_package)

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -1332,6 +1332,121 @@ fn specifier_bare_npm_scheme_returns_external_file() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
+fn pnpm_package_source_alias_preserves_declared_import_name() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let root = dir.path();
+
+    let source_pkg = root
+        .join("node_modules/.pnpm/unstorage-nightly@2.0.0-alpha.5/node_modules/unstorage-nightly");
+    std::fs::create_dir_all(&source_pkg).unwrap();
+    std::fs::write(
+        source_pkg.join("index.js"),
+        "export const createStorage = () => ({});",
+    )
+    .unwrap();
+    std::fs::write(
+        source_pkg.join("package.json"),
+        r#"{"name":"unstorage-nightly","exports":"./index.js"}"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&source_pkg, root.join("node_modules/unstorage")).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&source_pkg, root.join("node_modules/unstorage")).unwrap();
+
+    let resolver = specifier::create_resolver(&[], &[]);
+    let style_resolver = specifier::create_resolver(&[], &["style".to_string()]);
+    let extensions = react_native::build_extensions(&[]);
+    let path_to_id = FxHashMap::default();
+    let raw_path_to_id = FxHashMap::default();
+    let workspace_roots = FxHashMap::default();
+    let package_manifests = Vec::new();
+    let condition_names = react_native::build_condition_names(&[], &[]);
+    let tsconfig_warned = std::sync::Mutex::new(FxHashSet::default());
+    let ctx = ResolveContext {
+        resolver: &resolver,
+        style_resolver: &style_resolver,
+        extensions: &extensions,
+        path_to_id: &path_to_id,
+        raw_path_to_id: &raw_path_to_id,
+        workspace_roots: &workspace_roots,
+        package_manifests: &package_manifests,
+        condition_names: &condition_names,
+        path_aliases: &[],
+        scss_include_paths: &[],
+        static_dir_mappings: &[],
+        root,
+        canonical_fallback: None,
+        tsconfig_warned: &tsconfig_warned,
+    };
+
+    let result = specifier::resolve_specifier(&ctx, &root.join("app.ts"), "unstorage", false);
+    assert!(
+        matches!(result, ResolveResult::NpmPackage(ref name) if name == "unstorage"),
+        "expected package usage to preserve declared import name, got {result:?}"
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn pnpm_jsr_package_source_alias_preserves_declared_import_name() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let root = dir.path();
+
+    let source_pkg = root.join("node_modules/.pnpm/@jsr+std__csv@1.0.6/node_modules/@jsr/std__csv");
+    std::fs::create_dir_all(&source_pkg).unwrap();
+    std::fs::write(
+        source_pkg.join("stringify.js"),
+        "export const stringify = () => '';",
+    )
+    .unwrap();
+    std::fs::write(
+        source_pkg.join("package.json"),
+        r#"{"name":"@jsr/std__csv","exports":{"./stringify":"./stringify.js"}}"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(root.join("node_modules/@std")).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&source_pkg, root.join("node_modules/@std/csv")).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&source_pkg, root.join("node_modules/@std/csv")).unwrap();
+
+    let resolver = specifier::create_resolver(&[], &[]);
+    let style_resolver = specifier::create_resolver(&[], &["style".to_string()]);
+    let extensions = react_native::build_extensions(&[]);
+    let path_to_id = FxHashMap::default();
+    let raw_path_to_id = FxHashMap::default();
+    let workspace_roots = FxHashMap::default();
+    let package_manifests = Vec::new();
+    let condition_names = react_native::build_condition_names(&[], &[]);
+    let tsconfig_warned = std::sync::Mutex::new(FxHashSet::default());
+    let ctx = ResolveContext {
+        resolver: &resolver,
+        style_resolver: &style_resolver,
+        extensions: &extensions,
+        path_to_id: &path_to_id,
+        raw_path_to_id: &raw_path_to_id,
+        workspace_roots: &workspace_roots,
+        package_manifests: &package_manifests,
+        condition_names: &condition_names,
+        path_aliases: &[],
+        scss_include_paths: &[],
+        static_dir_mappings: &[],
+        root,
+        canonical_fallback: None,
+        tsconfig_warned: &tsconfig_warned,
+    };
+
+    let result =
+        specifier::resolve_specifier(&ctx, &root.join("app.ts"), "@std/csv/stringify", false);
+    assert!(
+        matches!(result, ResolveResult::NpmPackage(ref name) if name == "@std/csv"),
+        "expected package usage to preserve declared import name, got {result:?}"
+    );
+}
+
+#[test]
 fn specifier_html_root_relative_unresolvable() {
     with_empty_ctx(|ctx| {
         let file = Path::new("/project/public/index.html");

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -1447,6 +1447,48 @@ fn pnpm_jsr_package_source_alias_preserves_declared_import_name() {
 }
 
 #[test]
+fn package_usage_name_prefers_declared_name_for_bare_specifiers() {
+    // pnpm source alias: declared `unstorage` resolved into a `.pnpm` store dir
+    // whose inner package is `unstorage-nightly`. Credit the declared name.
+    let resolved =
+        Path::new("/p/node_modules/.pnpm/unstorage-nightly@2.0.0/node_modules/unstorage-nightly");
+    assert_eq!(
+        specifier::package_usage_name_for_resolved_package("unstorage", resolved),
+        Some("unstorage".to_string()),
+    );
+
+    // Scoped subpath bare specifier reduces to the package name.
+    let resolved_scoped =
+        Path::new("/p/node_modules/.pnpm/@jsr+std__csv@1.0.6/node_modules/@jsr/std__csv");
+    assert_eq!(
+        specifier::package_usage_name_for_resolved_package("@std/csv/stringify", resolved_scoped),
+        Some("@std/csv".to_string()),
+    );
+
+    // Common case (declared name == source name) is unchanged.
+    let resolved_plain = Path::new("/p/node_modules/lodash");
+    assert_eq!(
+        specifier::package_usage_name_for_resolved_package("lodash", resolved_plain),
+        Some("lodash".to_string()),
+    );
+
+    // Path aliases that are bare (Node.js `#imports`) must NOT be credited as the
+    // package name: they can map to an external package whose real name is only on
+    // the resolved path. Keep the resolved-package name instead.
+    let resolved_import_map = Path::new("/p/node_modules/polyfill-pkg/index.js");
+    assert_eq!(
+        specifier::package_usage_name_for_resolved_package("#polyfill", resolved_import_map),
+        Some("polyfill-pkg".to_string()),
+    );
+
+    // Not under node_modules: no package-usage credit.
+    assert_eq!(
+        specifier::package_usage_name_for_resolved_package("unstorage", Path::new("/p/src/x.ts")),
+        None,
+    );
+}
+
+#[test]
 fn specifier_html_root_relative_unresolvable() {
     with_empty_ctx(|ctx| {
         let file = Path::new("/project/public/index.html");

--- a/tests/fixtures/issue-823-pnpm-package-sources/apps/app/package.json
+++ b/tests/fixtures/issue-823-pnpm-package-sources/apps/app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "registry-pkg": "catalog:",
+    "jsr-pkg": "catalog:",
+    "workspace-pkg": "catalog:",
+    "local-dir-pkg": "catalog:",
+    "local-tarball-pkg": "catalog:",
+    "remote-tarball-pkg": "catalog:",
+    "git-url-pkg": "catalog:",
+    "git-shorthand-pkg": "catalog:",
+    "npm-alias-pkg": "catalog:",
+    "unused-control": "catalog:"
+  }
+}

--- a/tests/fixtures/issue-823-pnpm-package-sources/apps/app/src/index.ts
+++ b/tests/fixtures/issue-823-pnpm-package-sources/apps/app/src/index.ts
@@ -1,0 +1,21 @@
+import { registryValue } from "registry-pkg";
+import { jsrValue } from "jsr-pkg";
+import { workspaceValue } from "workspace-pkg";
+import { localDirValue } from "local-dir-pkg";
+import { localTarballValue } from "local-tarball-pkg";
+import { remoteTarballValue } from "remote-tarball-pkg";
+import { gitUrlValue } from "git-url-pkg";
+import { gitShorthandValue } from "git-shorthand-pkg";
+import { npmAliasValue } from "npm-alias-pkg";
+
+console.log(
+  registryValue,
+  jsrValue,
+  workspaceValue,
+  localDirValue,
+  localTarballValue,
+  remoteTarballValue,
+  gitUrlValue,
+  gitShorthandValue,
+  npmAliasValue,
+);

--- a/tests/fixtures/issue-823-pnpm-package-sources/package.json
+++ b/tests/fixtures/issue-823-pnpm-package-sources/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "issue-823-pnpm-package-sources",
+  "private": true,
+  "version": "0.0.0",
+  "workspaces": ["apps/*", "packages/*"]
+}

--- a/tests/fixtures/issue-823-pnpm-package-sources/packages/local-dir-pkg/index.js
+++ b/tests/fixtures/issue-823-pnpm-package-sources/packages/local-dir-pkg/index.js
@@ -1,0 +1,1 @@
+export const localDirValue = "local-dir";

--- a/tests/fixtures/issue-823-pnpm-package-sources/packages/local-dir-pkg/package.json
+++ b/tests/fixtures/issue-823-pnpm-package-sources/packages/local-dir-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "local-dir-pkg",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/tests/fixtures/issue-823-pnpm-package-sources/packages/workspace-pkg/package.json
+++ b/tests/fixtures/issue-823-pnpm-package-sources/packages/workspace-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-pkg",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/issue-823-pnpm-package-sources/packages/workspace-pkg/src/index.ts
+++ b/tests/fixtures/issue-823-pnpm-package-sources/packages/workspace-pkg/src/index.ts
@@ -1,0 +1,1 @@
+export const workspaceValue = "workspace";

--- a/tests/fixtures/issue-823-pnpm-package-sources/pnpm-workspace.yaml
+++ b/tests/fixtures/issue-823-pnpm-package-sources/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+
+catalog:
+  registry-pkg: ^1.0.0
+  jsr-pkg: jsr:@scope/jsr-pkg@1.0.0
+  workspace-pkg: workspace:*
+  local-dir-pkg: ./packages/local-dir-pkg
+  local-tarball-pkg: ./vendor/local-tarball-pkg-1.0.0.tgz
+  remote-tarball-pkg: https://example.com/remote-tarball-pkg-1.0.0.tgz
+  git-url-pkg: git+https://github.com/example/git-url-pkg.git#v1.0.0
+  git-shorthand-pkg: github:example/git-shorthand-pkg#v1.0.0
+  npm-alias-pkg: npm:actual-npm-package@1.0.0
+  unused-control: ^1.0.0


### PR DESCRIPTION
## What

Preserves declared import/package names when pnpm package sources resolve to a differently named package in `.pnpm`.

Adds regression coverage for pnpm package source forms from the [pnpm docs](https://pnpm.io/package-sources):

- npm registry/range
- JSR
- workspace
- local directory
- local tarball
- remote tarball
- git URL
- hosted git shorthand
- `npm:<actual>@<version>` alias

## Why

Closes #823.

pnpm package sources can map a declared dependency name to a different resolved source package, e.g. `jsr:` or `npm:<actual>@<version>`.

Fallow should credit the declared/imported package name for unused/unlisted dependency analysis, rather than reporting the declared dependency as unused and the resolved source package as unlisted.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`