### PR TITLE
fix(action): upload SARIF on public repos (Code Scanning is free without GHAS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The GitHub Action now uploads SARIF on public repositories.** Setting `sarif: true` on a public repo previously skipped the upload with a warning that Code Scanning (GitHub Advanced Security) was not enabled. That was a false negative: public repositories get GitHub Code Scanning for free without Advanced Security, and the first SARIF upload is what initializes it. The action's availability check probed the `code-scanning/alerts` endpoint, which returns 404 on a public repo that has never run Code Scanning, so it concluded the feature was unavailable and never attempted the upload that would have enabled it. The check now treats a public repository (`visibility == "public"`) as available and attempts the upload directly; private and internal repositories still fall back to the alerts probe, since Code Scanning there genuinely requires Advanced Security (internal enterprise repos report `private: false` but still need it, so the check keys on `visibility`, not `private`). One consequence to note: on a public repo the upload step now runs unconditionally, so a workflow that set `sarif: true` without granting `permissions: security-events: write` will see the `github/codeql-action/upload-sarif` step fail rather than skip silently. Add that permission alongside `sarif: true`. Thanks [@cloud-walker](https://github.com/cloud-walker) for the detailed report. (Closes [#817](https://github.com/fallow-rs/fallow/issues/817).)
+
 ## [2.85.0] - 2026-05-30
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'sarif'
   sarif:
-    description: 'Upload SARIF to GitHub Code Scanning. Requires Code Scanning availability (public repo or a plan with GitHub Advanced Security).'
+    description: 'Upload SARIF to GitHub Code Scanning. Available on public repos (free) and private or internal repos with GitHub Advanced Security. Requires permissions: security-events: write.'
     required: false
     default: 'false'
   production:
@@ -442,13 +442,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         GH_REPO: ${{ github.repository }}
-      run: |
-        if gh api "repos/${GH_REPO}/code-scanning/alerts?per_page=1" > /dev/null 2>&1; then
-          echo "available=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "available=false" >> "$GITHUB_OUTPUT"
-          echo "::warning::SARIF upload skipped. Code Scanning (GitHub Advanced Security) is not enabled on this repository. To enable: Settings > Code security > Code scanning. The job summary and JSON output are still available. To suppress this warning, use format: json instead of sarif."
-        fi
+      run: bash ${{ github.action_path }}/action/scripts/check-code-scanning.sh
 
     - name: Upload SARIF
       if: >-

--- a/action/README.md
+++ b/action/README.md
@@ -2,7 +2,9 @@
 
 The action runs fallow in GitHub Actions and can publish job summaries, workflow annotations, sticky PR comments, inline review comments, and SARIF.
 
-SARIF upload uses GitHub Code Scanning. Code Scanning is available for public repositories and for private repositories with GitHub Advanced Security enabled. When Code Scanning is unavailable, the action warns and skips the SARIF upload; the job summary and primary fallow output still run.
+SARIF upload uses GitHub Code Scanning. Code Scanning is available for public repositories (free, no GitHub Advanced Security needed) and for private or internal repositories with GitHub Advanced Security enabled. On a public repository the action always attempts the upload (the first upload initializes Code Scanning); on a private or internal repository without Advanced Security it warns and skips, and the job summary and primary fallow output still run.
+
+The upload requires the job to grant `permissions: security-events: write`. Without it, `github/codeql-action/upload-sarif` fails the step. On public repositories this surfaces as a job failure rather than a silent skip, so add the permission alongside `sarif: true`.
 
 Inline review comments target the current PR file state (`side: RIGHT`). Findings on deleted lines are not modeled yet; fallow's diagnostics are current-state oriented in normal use.
 

--- a/action/scripts/check-code-scanning.sh
+++ b/action/scripts/check-code-scanning.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decide whether GitHub Code Scanning is available for a SARIF upload and write
+# `available=true|false` to $GITHUB_OUTPUT (consumed by the Upload SARIF step's
+# `if:` condition in action.yml).
+#
+# Required env: GH_REPO (owner/repo)
+# Optional env: GH_TOKEN (read by gh implicitly), GITHUB_OUTPUT (defaults to stdout)
+#
+# Public repositories get GitHub Code Scanning for free, without GitHub Advanced
+# Security (GHAS). The FIRST SARIF upload is what initializes Code Scanning, so
+# probing the code-scanning/alerts endpoint beforehand returns 404 on a public
+# repo that has never been set up. Gating on that probe wrongly skips the upload
+# on public repos (issue #817). Internal (enterprise) repos report
+# `private: false` + `visibility: "internal"` yet still require GHAS, so only
+# `visibility == "public"` short-circuits; private and internal repos fall back
+# to the alerts probe as a GHAS-availability proxy. If the visibility metadata
+# read fails (restricted token, transient error), fall back to the probe too,
+# preserving the historical behavior.
+
+GH_REPO="${GH_REPO:?GH_REPO required}"
+OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+visibility=$(gh api "repos/${GH_REPO}" --jq '.visibility' 2>/dev/null || echo "")
+
+if [ "$visibility" = "public" ]; then
+  echo "available=true" >> "$OUTPUT"
+else
+  if [ -z "$visibility" ]; then
+    echo "::debug::could not read repository visibility; falling back to the Code Scanning alerts probe"
+  fi
+  if gh api "repos/${GH_REPO}/code-scanning/alerts?per_page=1" > /dev/null 2>&1; then
+    echo "available=true" >> "$OUTPUT"
+  else
+    echo "available=false" >> "$OUTPUT"
+    echo "::warning::SARIF upload skipped. Code Scanning on a private or internal repository requires GitHub Advanced Security. The job summary and JSON output are still available. To suppress this warning, use format: json instead of sarif."
+  fi
+fi

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -1682,6 +1682,95 @@ assert_contains "$OUT" "::" "annotate.sh: custom artifacts path emits annotation
 
 rm -rf "$WORK_DIR"
 
+# --- Code Scanning availability gate (check-code-scanning.sh) ---
+
+echo ""
+echo "=== Code Scanning gate ==="
+
+CSCRIPT="$DIR/../scripts/check-code-scanning.sh"
+GATE_DIR=$(mktemp -d)
+GATE_BIN="$GATE_DIR/bin"
+mkdir -p "$GATE_BIN"
+
+# Parameterized gh mock. MOCK_VISIBILITY sets the repos/{repo} --jq .visibility
+# response; empty simulates a failed metadata read (gh exits non-zero).
+# MOCK_ALERTS_EXIT sets the code-scanning/alerts probe exit code (0 = available).
+cat > "$GATE_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"code-scanning/alerts"*)
+    exit "${MOCK_ALERTS_EXIT:-1}"
+    ;;
+  *"--jq"*".visibility"*)
+    if [ -n "${MOCK_VISIBILITY:-}" ]; then
+      printf '%s\n' "$MOCK_VISIBILITY"
+      exit 0
+    fi
+    exit 1
+    ;;
+esac
+exit 1
+SH
+chmod +x "$GATE_BIN/gh"
+
+GATE_OUT=""
+GATE_LOG=""
+run_gate() {
+  # $1 = visibility value (empty simulates read failure), $2 = alerts probe exit code
+  local out_file
+  out_file=$(mktemp)
+  GATE_LOG=$(PATH="$GATE_BIN:$PATH" GH_REPO="acme/web" GITHUB_OUTPUT="$out_file" \
+    MOCK_VISIBILITY="$1" MOCK_ALERTS_EXIT="$2" \
+    bash "$CSCRIPT" 2>&1)
+  GATE_OUT=$(cat "$out_file")
+  rm -f "$out_file"
+}
+
+# Case 1: public repo is available even when the alerts probe would fail
+# (the first upload initializes Code Scanning; this is the issue #817 fix).
+run_gate "public" 1
+assert_contains "$GATE_OUT" "available=true" "gate: public repo is available"
+assert_not_contains "$GATE_LOG" "::warning::" "gate: public repo emits no skip warning"
+
+# Case 2: private repo with GHAS (alerts probe succeeds) is available.
+run_gate "private" 0
+assert_contains "$GATE_OUT" "available=true" "gate: private repo with GHAS is available"
+assert_not_contains "$GATE_LOG" "::warning::" "gate: private repo with GHAS emits no warning"
+
+# Case 3: private repo without GHAS (alerts probe fails) skips with a warning.
+run_gate "private" 1
+assert_contains "$GATE_OUT" "available=false" "gate: private repo without GHAS is unavailable"
+assert_contains "$GATE_LOG" "::warning::" "gate: private repo without GHAS warns"
+assert_contains "$GATE_LOG" "private or internal repository" "gate: warning names private or internal repos"
+
+# Case 4: internal (enterprise) repo with GHAS is available via the probe.
+# This is the row the rejected `.private == false` approach would have broken.
+run_gate "internal" 0
+assert_contains "$GATE_OUT" "available=true" "gate: internal repo with GHAS is available"
+assert_not_contains "$GATE_LOG" "::warning::" "gate: internal repo with GHAS emits no warning"
+
+# Case 5: internal repo without GHAS skips with a warning; no fallback debug note
+# (visibility was read successfully, so this is the intended probe, not a fallback).
+run_gate "internal" 1
+assert_contains "$GATE_OUT" "available=false" "gate: internal repo without GHAS is unavailable"
+assert_contains "$GATE_LOG" "::warning::" "gate: internal repo without GHAS warns"
+assert_contains "$GATE_LOG" "private or internal repository" "gate: internal warning names private or internal repos"
+assert_not_contains "$GATE_LOG" "::debug::" "gate: internal repo emits no fallback debug note"
+
+# Case 6: visibility read fails (empty) but the probe succeeds -> available via fallback.
+run_gate "" 0
+assert_contains "$GATE_OUT" "available=true" "gate: unreadable visibility falls back to probe (available)"
+assert_contains "$GATE_LOG" "::debug::" "gate: unreadable visibility emits a fallback debug note"
+assert_not_contains "$GATE_LOG" "::warning::" "gate: unreadable visibility with probe success emits no warning"
+
+# Case 7: visibility read fails (empty) and the probe fails -> skip with warning + debug note.
+run_gate "" 1
+assert_contains "$GATE_OUT" "available=false" "gate: unreadable visibility with probe failure is unavailable"
+assert_contains "$GATE_LOG" "::warning::" "gate: unreadable visibility with probe failure warns"
+assert_contains "$GATE_LOG" "::debug::" "gate: unreadable visibility with probe failure emits a fallback debug note"
+
+rm -rf "$GATE_DIR"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- On a public repository, `sarif: true` previously skipped the upload with a warning that Code Scanning (GitHub Advanced Security) was not enabled. Public repos get GitHub Code Scanning for free without Advanced Security, and the first SARIF upload is what initializes it.
- Root cause: the availability check probed `code-scanning/alerts`, which returns 404 on a public repo that has never initialized Code Scanning, so it concluded the feature was unavailable and never attempted the upload that would have enabled it (chicken-and-egg).
- The check now treats `visibility == "public"` as available and attempts the upload directly. Private and internal repos fall back to the alerts probe, since Code Scanning there genuinely requires Advanced Security. The gate keys on `visibility` (not `private`) because internal enterprise repos report `private: false` yet still need Advanced Security.
- The inline `action.yml` step is extracted into a tested `action/scripts/check-code-scanning.sh`, with a 7-case mocked-`gh` block (public, private/internal with and without GHAS, and the unreadable-visibility fallback).
- Behavior note: on a public repo the upload step now runs unconditionally, so a workflow that set `sarif: true` without granting `permissions: security-events: write` will see the `github/codeql-action/upload-sarif` step fail rather than skip silently. Documented in the action README, the `sarif` input description, and the CHANGELOG.

Fixes #817.

## Test plan

- [x] `bash action/tests/run.sh`: full suite green, including the 7 new Code Scanning gate cases.
- [x] `shellcheck action/scripts/check-code-scanning.sh`: clean.
- [x] `action.yml` validates as YAML.
- [x] Mental-revert check: the old probe-only logic fails the public + alerts-fail case (the issue #817 regression).
- [ ] Not run locally: end-to-end smoke against a fresh public repo with `security-events: write` to confirm `upload-sarif` initializes Code Scanning. The unit tests prove the gate decision, not GitHub's downstream upload; worth one manual run before release.