### PR TITLE
refactor: type plugin config parser paths

### DIFF
--- a/crates/core/src/plugins/config_parser.rs
+++ b/crates/core/src/plugins/config_parser.rs
@@ -186,15 +186,31 @@ pub(crate) fn array_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a Array
     }
 }
 
-/// Convert a path-like expression to zero or more statically recoverable path strings.
-pub(crate) fn expression_to_path_values(expr: &Expression<'_>) -> Vec<String> {
+/// Convert a config path string to a `PathBuf` with platform-independent
+/// separator handling.
+pub(crate) fn path_from_config_string(raw: &str) -> PathBuf {
+    PathBuf::from(raw.replace('\\', "/"))
+}
+
+/// Convert a config path to the forward-slash string form used in plugin output.
+pub(crate) fn path_to_config_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+/// Convert a path-like expression to a statically recoverable path.
+pub(crate) fn expression_to_path(expr: &Expression<'_>) -> Option<PathBuf> {
+    expression_to_path_string(expr).map(|path| path_from_config_string(&path))
+}
+
+/// Convert a path-like expression to zero or more statically recoverable paths.
+pub(crate) fn expression_to_path_values(expr: &Expression<'_>) -> Vec<PathBuf> {
     match expr {
         Expression::ArrayExpression(arr) => arr
             .elements
             .iter()
-            .filter_map(|element| element.as_expression().and_then(expression_to_path_string))
+            .filter_map(|element| element.as_expression().and_then(expression_to_path))
             .collect(),
-        _ => expression_to_path_string(expr).into_iter().collect(),
+        _ => expression_to_path(expr).into_iter().collect(),
     }
 }
 
@@ -251,13 +267,13 @@ pub fn extract_config_string_or_array(
     .unwrap_or_default()
 }
 
-/// Extract a statically recoverable path-like string from a property path.
+/// Extract a statically recoverable path-like value from a property path.
 #[must_use]
-pub fn extract_config_path_string(source: &str, path: &Path, prop_path: &[&str]) -> Option<String> {
+pub fn extract_config_path(source: &str, path: &Path, prop_path: &[&str]) -> Option<PathBuf> {
     extract_from_source(source, path, |program| {
         let obj = find_config_object(program)?;
         let expr = get_nested_expression(obj, prop_path)?;
-        expression_to_path_string(expr)
+        expression_to_path(expr)
     })
 }
 
@@ -370,6 +386,19 @@ pub fn extract_config_aliases(
     extract_config_aliases_kinded(source, path, prop_path)
         .into_iter()
         .map(|(find, replacement, _is_bare)| (find, replacement))
+        .collect()
+}
+
+/// Extract alias mappings where the replacement is a filesystem path value.
+#[must_use]
+pub fn extract_config_path_aliases(
+    source: &str,
+    path: &Path,
+    prop_path: &[&str],
+) -> Vec<(String, PathBuf)> {
+    extract_config_aliases_kinded(source, path, prop_path)
+        .into_iter()
+        .map(|(find, replacement, _is_bare)| (find, path_from_config_string(&replacement)))
         .collect()
 }
 
@@ -802,31 +831,44 @@ pub fn extract_vite_react_babel_dependencies(source: &str, path: &Path) -> Vec<S
     .unwrap_or_default()
 }
 
-/// Normalize a config-relative path string to a project-root-relative path.
+/// Normalize a config-relative path to a project-root-relative path.
 ///
 /// Handles values extracted from config files such as `"./src"`, `"src/lib"`,
 /// `"/src"`, or absolute filesystem paths under `root`.
 #[must_use]
-pub fn normalize_config_path(raw: &str, config_path: &Path, root: &Path) -> Option<String> {
-    if raw.is_empty() {
+pub fn normalize_config_path_buf(
+    raw: impl AsRef<Path>,
+    config_path: &Path,
+    root: &Path,
+) -> Option<PathBuf> {
+    let raw = raw.as_ref();
+    if raw.as_os_str().is_empty() {
         return None;
     }
 
-    let candidate = if let Some(stripped) = raw.strip_prefix('/') {
+    let raw_string = path_to_config_string(raw);
+    let raw_path = Path::new(&raw_string);
+    let candidate = if let Some(stripped) = raw_string.strip_prefix('/') {
         lexical_normalize(&root.join(stripped))
+    } else if raw_path.is_absolute() {
+        lexical_normalize(raw_path)
     } else {
-        let path = Path::new(raw);
-        if path.is_absolute() {
-            lexical_normalize(path)
-        } else {
-            let base = config_path.parent().unwrap_or(root);
-            lexical_normalize(&base.join(path))
-        }
+        let base = config_path.parent().unwrap_or(root);
+        lexical_normalize(&base.join(raw_path))
     };
 
     let relative = candidate.strip_prefix(root).ok()?;
-    let normalized = relative.to_string_lossy().replace('\\', "/");
-    (!normalized.is_empty()).then_some(normalized)
+    (!relative.as_os_str().is_empty()).then(|| relative.to_path_buf())
+}
+
+/// Normalize a config-relative path to a project-root-relative forward-slash string.
+#[must_use]
+pub fn normalize_config_path(
+    raw: impl AsRef<Path>,
+    config_path: &Path,
+    root: &Path,
+) -> Option<String> {
+    normalize_config_path_buf(raw, config_path, root).map(|path| path_to_config_string(&path))
 }
 
 /// Parse source and run an extraction function on the AST.
@@ -1329,7 +1371,10 @@ fn expression_to_alias_pairs(expr: &Expression) -> Vec<(String, String)> {
                     return None;
                 };
                 let find = property_key_to_string(&prop.key)?;
-                let replacement = expression_to_path_values(&prop.value).into_iter().next()?;
+                let replacement = expression_to_path_values(&prop.value)
+                    .into_iter()
+                    .next()
+                    .map(|path| path_to_config_string(&path))?;
                 Some((find, replacement))
             })
             .collect(),
@@ -1724,7 +1769,7 @@ fn array_from_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a ArrayExpres
     }
 }
 
-fn lexical_normalize(path: &Path) -> PathBuf {
+pub(crate) fn lexical_normalize(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
 
     for component in path.components() {
@@ -2847,6 +2892,28 @@ mod tests {
     }
 
     #[test]
+    fn normalize_config_path_mixed_separators_and_parent_dirs() {
+        let config_path = PathBuf::from("/project/config/vite.config.ts");
+        let root = PathBuf::from("/project");
+
+        assert_eq!(
+            normalize_config_path(".\\src\\..\\app\\lib", &config_path, &root),
+            Some("config/app/lib".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_config_path_leading_slash_stays_project_relative() {
+        let config_path = PathBuf::from("/project/vite.config.ts");
+        let root = PathBuf::from("/project");
+
+        assert_eq!(
+            normalize_config_path("/src\\lib", &config_path, &root),
+            Some("src/lib".to_string())
+        );
+    }
+
+    #[test]
     fn json_wrapped_in_parens_string() {
         let source = r#"({"extends": "@tsconfig/node18/tsconfig.json"})"#;
         let val = extract_config_string(source, &js_path(), &["extends"]);
@@ -3675,6 +3742,32 @@ mod tests {
             });
         "#;
         let mut got = extract_config_aliases_kinded(source, &js_path(), &["resolve", "alias"]);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("@".to_string(), "./src".to_string(), false),
+                ("lodash-es".to_string(), "lodash".to_string(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn aliases_kinded_preserves_is_bare_through_imported_spread() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("aliases.js"),
+            r#"export const packageAliases = [{ find: "lodash-es", replacement: "lodash" }];"#,
+        )
+        .unwrap();
+        let config = dir.path().join("vite.config.js");
+        let source = r#"
+            import { packageAliases } from "./aliases.js";
+            export default defineConfig({
+                resolve: { alias: [...packageAliases, { find: "@", replacement: "./src" }] }
+            });
+        "#;
+        let mut got = extract_config_aliases_kinded(source, &config, &["resolve", "alias"]);
         got.sort();
         assert_eq!(
             got,

--- a/crates/core/src/plugins/docusaurus.rs
+++ b/crates/core/src/plugins/docusaurus.rs
@@ -727,7 +727,11 @@ fn normalize_local_module_path(raw: &str, config_path: &Path, root: &Path) -> Op
         .flatten()
 }
 
-fn normalize_project_path(raw: &str, config_path: &Path, root: &Path) -> Option<String> {
+fn normalize_project_path(
+    raw: impl AsRef<Path>,
+    config_path: &Path,
+    root: &Path,
+) -> Option<String> {
     config_parser::normalize_config_path(raw, config_path, root)
 }
 
@@ -747,7 +751,7 @@ fn resolve_site_asset_paths(
             .filter_map(|directory| {
                 let candidate = join_project_relative_path(directory, site_relative);
                 let normalized = config_parser::normalize_config_path(
-                    &format!("/{candidate}"),
+                    format!("/{candidate}"),
                     config_path,
                     root,
                 )?;
@@ -789,11 +793,11 @@ fn property_project_path(
     root: &Path,
 ) -> Option<String> {
     config_parser::property_expr(obj, key)
-        .and_then(config_parser::expression_to_path_string)
-        .and_then(|raw| normalize_project_path(&raw, config_path, root))
+        .and_then(config_parser::expression_to_path)
+        .and_then(|raw| normalize_project_path(raw, config_path, root))
 }
 
-fn property_path_values(obj: &ObjectExpression<'_>, key: &str) -> Vec<String> {
+fn property_path_values(obj: &ObjectExpression<'_>, key: &str) -> Vec<PathBuf> {
     config_parser::property_expr(obj, key)
         .map(config_parser::expression_to_path_values)
         .unwrap_or_default()

--- a/crates/core/src/plugins/nuxt.rs
+++ b/crates/core/src/plugins/nuxt.rs
@@ -277,7 +277,7 @@ impl Plugin for NuxtPlugin {
             .unwrap_or_else(|| default_src_dir.clone());
 
         if let Some(configured_src_dir) = configured_src_dir.as_deref()
-            && configured_src_dir != default_src_dir.as_str()
+            && configured_src_dir != default_src_dir.as_path()
         {
             add_src_dir_support(&mut result, configured_src_dir);
         }
@@ -342,8 +342,9 @@ impl Plugin for NuxtPlugin {
         }
 
         for (find, replacement) in
-            config_parser::extract_config_aliases(source, config_path, &["alias"])
+            config_parser::extract_config_path_aliases(source, config_path, &["alias"])
         {
+            let replacement = config_parser::path_to_config_string(&replacement);
             if let Some(normalized) = normalize_nuxt_path(&replacement, config_path, root, &src_dir)
             {
                 result.path_aliases.push((find, normalized));
@@ -447,11 +448,11 @@ fn add_module_runtime_patterns(result: &mut PluginResult, root: &Path) {
     }
 }
 
-fn default_nuxt_src_dir(root: &Path) -> String {
+fn default_nuxt_src_dir(root: &Path) -> PathBuf {
     if root.join("app").is_dir() {
-        "app".to_string()
+        PathBuf::from("app")
     } else {
-        String::new()
+        PathBuf::new()
     }
 }
 
@@ -464,28 +465,32 @@ fn is_local_css_path(entry: &str) -> bool {
         || entry.starts_with('/')
 }
 
-fn extract_nuxt_src_dir(source: &str, config_path: &Path, root: &Path) -> Option<String> {
-    let raw = config_parser::extract_config_string(source, config_path, &["srcDir"])?;
+fn extract_nuxt_src_dir(source: &str, config_path: &Path, root: &Path) -> Option<PathBuf> {
+    let raw = config_parser::extract_config_path(source, config_path, &["srcDir"])?;
     normalize_nuxt_src_dir(&raw, config_path, root)
 }
 
-fn normalize_nuxt_src_dir(raw: &str, config_path: &Path, root: &Path) -> Option<String> {
-    let trimmed = raw.trim().trim_end_matches('/');
+fn normalize_nuxt_src_dir(raw: &Path, config_path: &Path, root: &Path) -> Option<PathBuf> {
+    let raw_string = config_parser::path_to_config_string(raw);
+    let trimmed = raw_string.trim().trim_end_matches('/');
     if trimmed.is_empty() || trimmed == "." {
-        return Some(String::new());
+        return Some(PathBuf::new());
     }
-    config_parser::normalize_config_path(trimmed, config_path, root)
+    config_parser::normalize_config_path_buf(
+        config_parser::path_from_config_string(trimmed),
+        config_path,
+        root,
+    )
 }
 
-fn add_src_dir_support(result: &mut PluginResult, src_dir: &str) {
+fn add_src_dir_support(result: &mut PluginResult, src_dir: &Path) {
+    let src_dir_string = config_parser::path_to_config_string(src_dir);
     result
         .path_aliases
-        .push(("~/".to_string(), src_dir.to_string()));
-    result
-        .path_aliases
-        .push(("@/".to_string(), src_dir.to_string()));
+        .push(("~/".to_string(), src_dir_string.clone()));
+    result.path_aliases.push(("@/".to_string(), src_dir_string));
 
-    if src_dir.is_empty() {
+    if src_dir.as_os_str().is_empty() {
         return;
     }
 
@@ -507,13 +512,13 @@ fn add_default_used_export(result: &mut PluginResult, pattern: impl Into<String>
     result.push_used_export_rule(pattern, ["default"]);
 }
 
-fn add_prefixed_default_used_exports(result: &mut PluginResult, prefix: &str, patterns: &[&str]) {
+fn add_prefixed_default_used_exports(result: &mut PluginResult, prefix: &Path, patterns: &[&str]) {
     for pattern in patterns {
         add_default_used_export(result, prefix_with_src_dir(prefix, pattern));
     }
 }
 
-fn extend_prefixed_patterns(target: &mut Vec<String>, prefix: &str, patterns: &[&str]) {
+fn extend_prefixed_patterns(target: &mut Vec<String>, prefix: &Path, patterns: &[&str]) {
     target.extend(
         patterns
             .iter()
@@ -553,14 +558,16 @@ fn normalize_nuxt_path(
     raw: &str,
     config_path: &Path,
     root: &Path,
-    src_dir: &str,
+    src_dir: &Path,
 ) -> Option<String> {
     if let Some(stripped) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("@/")) {
         return Some(prefix_with_src_dir(src_dir, stripped));
     }
 
     if let Some(stripped) = raw.strip_prefix("~~/").or_else(|| raw.strip_prefix("@@/")) {
-        return Some(stripped.to_string());
+        return Some(config_parser::path_to_config_string(
+            &config_parser::path_from_config_string(stripped),
+        ));
     }
 
     config_parser::normalize_config_path(raw, config_path, root)
@@ -570,7 +577,7 @@ fn normalize_imports_dir_pattern(
     raw: &str,
     config_path: &Path,
     root: &Path,
-    src_dir: &str,
+    src_dir: &Path,
 ) -> Option<String> {
     let normalized = normalize_nuxt_path(raw, config_path, root, src_dir)?;
     Some(imports_dir_pattern(&normalized))
@@ -604,11 +611,13 @@ fn path_looks_like_file_pattern(pattern: &str) -> bool {
         .is_some_and(|segment| segment.contains('.'))
 }
 
-fn prefix_with_src_dir(src_dir: &str, path: &str) -> String {
-    if src_dir.is_empty() {
-        path.to_string()
+fn prefix_with_src_dir(src_dir: &Path, path: &str) -> String {
+    let path = config_parser::path_from_config_string(path);
+    if src_dir.as_os_str().is_empty() {
+        config_parser::path_to_config_string(&path)
     } else {
-        format!("{src_dir}/{path}")
+        let normalized = config_parser::lexical_normalize(&src_dir.join(path));
+        config_parser::path_to_config_string(&normalized)
     }
 }
 
@@ -1484,6 +1493,79 @@ mod tests {
                 .always_used_files
                 .contains(&"src/error.vue".to_string()),
             "srcDir should add error.vue under the configured source root"
+        );
+    }
+
+    #[test]
+    fn resolve_config_src_dir_leading_slash_is_project_relative() {
+        let source = r#"
+            export default defineNuxtConfig({
+                srcDir: "/src",
+                imports: {
+                    dirs: ["~/custom/composables"]
+                }
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
+
+        assert!(
+            result
+                .path_aliases
+                .contains(&("~/".to_string(), "src".to_string())),
+            "leading-slash srcDir should remap ~/ under the project root"
+        );
+        assert!(has_entry_pattern(
+            &result,
+            "src/custom/composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"
+        ));
+    }
+
+    #[test]
+    fn resolve_config_src_dir_normalizes_backslash_config_values() {
+        let source = r#"
+            export default defineNuxtConfig({
+                srcDir: path.resolve(__dirname, "src\\\\app/"),
+                imports: {
+                    dirs: ["~/custom\\\\composables"]
+                },
+                components: [
+                    { path: "@/feature\\\\components" }
+                ]
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
+
+        assert!(
+            result
+                .path_aliases
+                .contains(&("~/".to_string(), "src/app".to_string())),
+            "srcDir should be normalized in aliases"
+        );
+        assert!(has_entry_pattern(
+            &result,
+            "src/app/custom/composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"
+        ));
+        assert!(has_entry_pattern(
+            &result,
+            "src/app/feature/components/**/*.{vue,ts,tsx,js,jsx}"
+        ));
+        assert!(
+            result
+                .entry_patterns
+                .iter()
+                .all(|entry| !entry.contains('\\')),
+            "entry patterns should use forward slashes: {:?}",
+            result.entry_patterns
         );
     }
 

--- a/crates/core/src/plugins/sveltekit.rs
+++ b/crates/core/src/plugins/sveltekit.rs
@@ -164,7 +164,7 @@ impl Plugin for SvelteKitPlugin {
         }
 
         for (find, replacement) in
-            config_parser::extract_config_aliases(source, config_path, &["kit", "alias"])
+            config_parser::extract_config_path_aliases(source, config_path, &["kit", "alias"])
         {
             if let Some(normalized) =
                 config_parser::normalize_config_path(&replacement, config_path, root)

--- a/crates/core/src/plugins/typescript.rs
+++ b/crates/core/src/plugins/typescript.rs
@@ -78,7 +78,7 @@ define_plugin!(
             result.referenced_dependencies.push(jsx_source);
         }
 
-        for (find, replacement) in config_parser::extract_config_aliases(
+        for (find, replacement) in config_parser::extract_config_path_aliases(
             &parse_source,
             parse_path,
             &["compilerOptions", "paths"],
@@ -103,7 +103,7 @@ define_plugin!(
 
 fn normalize_tsconfig_path_alias(
     find: &str,
-    replacement: &str,
+    replacement: &Path,
     config_path: &Path,
     root: &Path,
 ) -> Option<(String, String)> {
@@ -111,10 +111,11 @@ fn normalize_tsconfig_path_alias(
     if normalized_find.is_empty() {
         return None;
     }
+    let replacement = config_parser::path_to_config_string(replacement);
     let normalized_replacement = replacement
         .strip_suffix("/*")
         .or_else(|| replacement.strip_suffix('*'))
-        .unwrap_or(replacement);
+        .unwrap_or(&replacement);
     let normalized_replacement =
         config_parser::normalize_config_path(normalized_replacement, config_path, root)?;
 

--- a/crates/core/src/plugins/vite.rs
+++ b/crates/core/src/plugins/vite.rs
@@ -112,7 +112,7 @@ define_plugin!(
         ));
 
         for (find, replacement) in
-            config_parser::extract_config_aliases(source, config_path, &["resolve", "alias"])
+            config_parser::extract_config_path_aliases(source, config_path, &["resolve", "alias"])
         {
             if let Some(normalized) =
                 config_parser::normalize_config_path(&replacement, config_path, root)

--- a/crates/core/src/plugins/webpack.rs
+++ b/crates/core/src/plugins/webpack.rs
@@ -4,7 +4,7 @@
 //! Parses webpack config to extract entry points, plugin dependencies, loader
 //! packages from module.rules, and external dependencies.
 
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use super::config_parser;
 use super::{Plugin, PluginResult};
@@ -38,17 +38,17 @@ define_plugin!(
 
         let entries =
             config_parser::extract_config_string_or_array(source, config_path, &["entry"]);
-        let context = config_parser::extract_config_path_string(source, config_path, &["context"])
-            .and_then(|raw| config_parser::normalize_config_path(&raw, config_path, root));
+        let context = config_parser::extract_config_path(source, config_path, &["context"])
+            .and_then(|raw| config_parser::normalize_config_path_buf(&raw, config_path, root));
         result.extend_entry_patterns(entries.into_iter().map(|entry| {
             context
-                .as_deref()
+                .as_ref()
                 .map(|context| normalize_context_entry(&entry, context, config_path, root))
                 .unwrap_or(entry)
         }));
 
         for (find, replacement) in
-            config_parser::extract_config_aliases(source, config_path, &["resolve", "alias"])
+            config_parser::extract_config_path_aliases(source, config_path, &["resolve", "alias"])
         {
             if let Some(normalized) =
                 config_parser::normalize_config_path(&replacement, config_path, root)
@@ -203,34 +203,27 @@ fn walk_rule(rule: &oxc_ast::ast::ObjectExpression, result: &mut PluginResult) {
     }
 }
 
-fn normalize_context_entry(entry: &str, context: &str, config_path: &Path, root: &Path) -> String {
-    if entry.starts_with('/') || Path::new(entry).is_absolute() {
+fn normalize_context_entry(entry: &str, context: &Path, config_path: &Path, root: &Path) -> String {
+    let entry_path = config_parser::path_from_config_string(entry);
+    if entry.starts_with('/') || entry_path.is_absolute() {
         return config_parser::normalize_config_path(entry, config_path, root)
             .unwrap_or_else(|| entry.to_string());
     }
 
-    if entry.starts_with("./") || entry.starts_with("../") {
-        return normalize_project_relative_join(context, entry);
+    if entry.starts_with("./")
+        || entry.starts_with("../")
+        || entry.starts_with(".\\")
+        || entry.starts_with("..\\")
+    {
+        return normalize_project_relative_join(context, &entry_path);
     }
 
     entry.to_string()
 }
 
-fn normalize_project_relative_join(base: &str, child: &str) -> String {
-    let path = PathBuf::from(base).join(child);
-
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
-            Component::Normal(segment) => normalized.push(segment),
-        }
-    }
-
-    normalized.to_string_lossy().replace('\\', "/")
+fn normalize_project_relative_join(base: &Path, child: &Path) -> String {
+    let normalized = config_parser::lexical_normalize(&base.join(child));
+    config_parser::path_to_config_string(&normalized)
 }
 
 #[cfg(test)]
@@ -307,6 +300,37 @@ mod tests {
                 "react",
                 "react-dom",
             ]
+        );
+    }
+
+    #[test]
+    fn resolve_config_context_normalizes_mixed_separator_entries() {
+        let source = r#"
+            module.exports = {
+                context: "./app/features",
+                entry: {
+                    main: ".\\dashboard\\main.ts",
+                    shared: "../shared/index.ts",
+                },
+            };
+        "#;
+        let plugin = WebpackPlugin;
+        let result = plugin.resolve_config(
+            std::path::Path::new("/project/webpack.config.js"),
+            source,
+            std::path::Path::new("/project"),
+        );
+        assert_eq!(
+            result.entry_patterns,
+            vec!["app/features/dashboard/main.ts", "app/shared/index.ts"]
+        );
+        assert!(
+            result
+                .entry_patterns
+                .iter()
+                .all(|entry| !entry.contains('\\')),
+            "entry patterns should use forward slashes: {:?}",
+            result.entry_patterns
         );
     }
 

--- a/crates/core/src/plugins/wrangler.rs
+++ b/crates/core/src/plugins/wrangler.rs
@@ -70,18 +70,24 @@ fn extract_main_entries(config_path: &Path, source: &str, root: &Path) -> Vec<St
 }
 
 fn extract_js_main_entries(config_path: &Path, source: &str, root: &Path) -> Vec<String> {
-    let top_level = config_parser::extract_config_path_string(source, config_path, &["main"]);
+    let mut entries = Vec::new();
+    if let Some(raw) = config_parser::extract_config_path(source, config_path, &["main"])
+        && let Some(path) = config_parser::normalize_config_path(&raw, config_path, root)
+    {
+        entries.push(path);
+    }
     let env_entries = config_parser::extract_config_object_nested_strings(
         source,
         config_path,
         &["env"],
         &["main"],
     );
-    top_level
-        .into_iter()
-        .chain(env_entries)
-        .filter_map(|raw| config_parser::normalize_config_path(&raw, config_path, root))
-        .collect()
+    entries.extend(
+        env_entries
+            .into_iter()
+            .filter_map(|raw| config_parser::normalize_config_path(raw, config_path, root)),
+    );
+    entries
 }
 
 fn extract_toml_main_entries(config_path: &Path, source: &str, root: &Path) -> Vec<String> {


### PR DESCRIPTION
## Summary
- Refactors path-shaped config parser helpers to return `PathBuf` and adds explicit conversion helpers for forward-slash plugin output.
- Migrates webpack, Nuxt, Vite, SvelteKit, TypeScript, Wrangler, and Docusaurus path call sites to typed path handling where they consume filesystem paths.
- Adds regression coverage for mixed separators, project-root-style leading slashes, imported/spread alias kind preservation, webpack context entries, and Nuxt `srcDir`/alias normalization.

## Issue
Closes #448

## Verification
- [x] `cargo check -p fallow-core`
- [x] `cargo test -p fallow-core --lib plugins::config_parser -- --nocapture`
- [x] `cargo test -p fallow-core --lib plugins::webpack -- --nocapture`
- [x] `cargo test -p fallow-core --lib plugins::nuxt -- --nocapture`
- [x] `cargo test -p fallow-core --lib plugins::test_alias -- --nocapture`
- [x] `cargo test -p fallow-core --lib plugins::vite -- --nocapture`
- [x] `cargo test -p fallow-core --lib plugins::sveltekit -- --nocapture`
- [x] `cargo test -p fallow-core --lib plugins::typescript -- --nocapture`
- [x] `cargo test -p fallow-graph --test cross_platform`
- [x] `cargo check --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items` (no warnings/errors)
- [x] `fallow audit --format json --quiet` (pass, 0 introduced findings)