### PR TITLE
fix: suppress DOMPurify-sanitized HTML security candidates

### DIFF
--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2542,7 +2542,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
         }
     }

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2542,6 +2542,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
         }
     }
 

--- a/crates/cli/src/health/scoring.rs
+++ b/crates/cli/src/health/scoring.rs
@@ -1795,6 +1795,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
         };
 
         let (cyc, cog, funcs, lines) = aggregate_complexity(&module);
@@ -1835,6 +1837,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
             line_offsets: vec![0, 10, 20, 30, 40], // 5 lines
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: "doStuff".into(),
@@ -1886,6 +1890,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
             line_offsets: vec![0, 10, 20], // 3 lines
             complexity: vec![
                 fallow_types::extract::FunctionComplexity {
@@ -2155,6 +2161,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
         }
     }
 

--- a/crates/cli/src/health/scoring.rs
+++ b/crates/cli/src/health/scoring.rs
@@ -1795,7 +1795,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
         };
 
@@ -1837,7 +1836,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
             line_offsets: vec![0, 10, 20, 30, 40], // 5 lines
             complexity: vec![fallow_types::extract::FunctionComplexity {
@@ -1890,7 +1888,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
             line_offsets: vec![0, 10, 20], // 3 lines
             complexity: vec![
@@ -2161,7 +2158,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
         }
     }

--- a/crates/cli/src/vital_signs.rs
+++ b/crates/cli/src/vital_signs.rs
@@ -978,7 +978,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: format!("fn_{id}"),

--- a/crates/cli/src/vital_signs.rs
+++ b/crates/cli/src/vital_signs.rs
@@ -978,6 +978,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: format!("fn_{id}"),
                 line: id + 1,

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -631,7 +631,6 @@ fn bench_cache_round_trip(c: &mut Criterion) {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -631,6 +631,8 @@ fn bench_cache_round_trip(c: &mut Criterion) {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     c.bench_function("cache_round_trip", |b| {

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -1378,6 +1378,8 @@ mod tests {
                 security_sinks: Vec::new(),
                 security_sinks_skipped: 0,
                 tainted_bindings: Vec::new(),
+                sanitized_bindings: Vec::new(),
+                sanitized_sink_args: Vec::new(),
             }];
 
             let rules = RulesConfig {

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -1378,7 +1378,6 @@ mod tests {
                 security_sinks: Vec::new(),
                 security_sinks_skipped: 0,
                 tainted_bindings: Vec::new(),
-                sanitized_bindings: Vec::new(),
                 sanitized_sink_args: Vec::new(),
             }];
 

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -14,7 +14,9 @@ use std::sync::OnceLock;
 
 use rustc_hash::FxHashMap;
 
-use fallow_types::extract::{ModuleInfo, SinkSite, TaintedBinding};
+use fallow_types::extract::{
+    ModuleInfo, SanitizedBinding, SanitizedSinkArg, SanitizerScope, SinkSite, TaintedBinding,
+};
 use fallow_types::output::{IssueAction, SuppressFileAction, SuppressFileKind};
 use fallow_types::results::{SecurityFinding, SecurityFindingKind, TraceHop, TraceHopRole};
 use fallow_types::suppress::IssueKind;
@@ -168,6 +170,31 @@ fn source_tainted_locals(bindings: &[TaintedBinding]) -> FxHashMap<&str, &'stati
     out
 }
 
+fn is_html_sanitizable_category(id: &str) -> bool {
+    matches!(id, "dangerous-html" | "dom-document-write" | "jquery-html")
+}
+
+fn has_direct_html_sanitizer(sink: &SinkSite, args: &[SanitizedSinkArg]) -> bool {
+    args.iter().any(|arg| {
+        arg.span_start == sink.span_start
+            && arg.arg_index == sink.arg_index
+            && arg.scope == SanitizerScope::Html
+    })
+}
+
+fn has_sanitized_html_binding(sink: &SinkSite, bindings: &[SanitizedBinding]) -> bool {
+    sink.arg_idents.iter().any(|name| {
+        bindings
+            .iter()
+            .any(|binding| binding.local == name.as_str() && binding.scope == SanitizerScope::Html)
+    })
+}
+
+fn sink_has_html_sanitizer(module: &ModuleInfo, sink: &SinkSite) -> bool {
+    has_direct_html_sanitizer(sink, &module.sanitized_sink_args)
+        || has_sanitized_html_binding(sink, &module.sanitized_bindings)
+}
+
 /// The matched source title if any of a sink's captured argument identifiers
 /// trace to a source-tainted local binding, else `None`. The intra-module,
 /// name-based back-trace from issue #859.
@@ -256,6 +283,10 @@ pub fn find_tainted_sinks(
             }) else {
                 continue;
             };
+
+            if is_html_sanitizable_category(&matcher.id) && sink_has_html_sanitizer(module, sink) {
+                continue;
+            }
 
             let (line, col) =
                 byte_offset_to_line_col(line_offsets_by_file, file_id, sink.span_start);

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 use rustc_hash::FxHashMap;
 
 use fallow_types::extract::{
-    ModuleInfo, SanitizedBinding, SanitizedSinkArg, SanitizerScope, SinkSite, TaintedBinding,
+    ModuleInfo, SanitizedSinkArg, SanitizerScope, SinkSite, TaintedBinding,
 };
 use fallow_types::output::{IssueAction, SuppressFileAction, SuppressFileKind};
 use fallow_types::results::{SecurityFinding, SecurityFindingKind, TraceHop, TraceHopRole};
@@ -182,17 +182,8 @@ fn has_direct_html_sanitizer(sink: &SinkSite, args: &[SanitizedSinkArg]) -> bool
     })
 }
 
-fn has_sanitized_html_binding(sink: &SinkSite, bindings: &[SanitizedBinding]) -> bool {
-    sink.arg_idents.iter().any(|name| {
-        bindings
-            .iter()
-            .any(|binding| binding.local == name.as_str() && binding.scope == SanitizerScope::Html)
-    })
-}
-
 fn sink_has_html_sanitizer(module: &ModuleInfo, sink: &SinkSite) -> bool {
     has_direct_html_sanitizer(sink, &module.sanitized_sink_args)
-        || has_sanitized_html_binding(sink, &module.sanitized_bindings)
 }
 
 /// The matched source title if any of a sink's captured argument identifiers

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -1848,6 +1848,8 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
+            sanitized_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
         }
     }
 

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -1848,7 +1848,6 @@ mod tests {
             security_sinks: Vec::new(),
             security_sinks_skipped: 0,
             tainted_bindings: Vec::new(),
-            sanitized_bindings: Vec::new(),
             sanitized_sink_args: Vec::new(),
         }
     }

--- a/crates/core/tests/integration_test/caching.rs
+++ b/crates/core/tests/integration_test/caching.rs
@@ -50,7 +50,6 @@ fn cache_roundtrip() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -196,7 +195,6 @@ fn incremental_cache_prune_stale_entries() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 

--- a/crates/core/tests/integration_test/caching.rs
+++ b/crates/core/tests/integration_test/caching.rs
@@ -50,6 +50,8 @@ fn cache_roundtrip() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     store.insert(std::path::Path::new("test.ts"), cached);
@@ -194,6 +196,8 @@ fn incremental_cache_prune_stale_entries() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     store.insert(std::path::Path::new("/project/existing.ts"), make_module());

--- a/crates/core/tests/integration_test/security_dangerous_html.rs
+++ b/crates/core/tests/integration_test/security_dangerous_html.rs
@@ -102,6 +102,15 @@ fn sanitizer_near_misses_still_fire() {
 }
 
 #[test]
+fn shadowed_sanitized_local_still_fires() {
+    let results = analyze_with_security_sink();
+    assert!(
+        anchored_on(&results, "src/shadowed-sanitized-local.ts"),
+        "a shadowing parameter must not inherit an outer sanitized binding"
+    );
+}
+
+#[test]
 fn dompurify_does_not_suppress_non_html_sinks() {
     let results = analyze_with_security_sink();
     let finding = results

--- a/crates/core/tests/integration_test/security_dangerous_html.rs
+++ b/crates/core/tests/integration_test/security_dangerous_html.rs
@@ -76,6 +76,48 @@ fn non_literal_dangerously_set_inner_html_fires() {
 }
 
 #[test]
+fn dompurify_sanitized_html_sinks_do_not_fire() {
+    let results = analyze_with_security_sink();
+    for suffix in [
+        "src/dompurify-default.ts",
+        "src/dompurify-namespace.ts",
+        "src/dompurify-require.ts",
+        "src/isomorphic-dompurify.ts",
+        "src/sanitized-component.tsx",
+    ] {
+        assert!(
+            !anchored_on(&results, suffix),
+            "{suffix} should be suppressed by DOMPurify provenance"
+        );
+    }
+}
+
+#[test]
+fn sanitizer_near_misses_still_fire() {
+    let results = analyze_with_security_sink();
+    assert!(
+        anchored_on(&results, "src/near-miss.ts"),
+        "local sanitize-like helpers must not suppress HTML sink candidates"
+    );
+}
+
+#[test]
+fn dompurify_does_not_suppress_non_html_sinks() {
+    let results = analyze_with_security_sink();
+    let finding = results
+        .security_findings
+        .iter()
+        .find(|f| {
+            f.path
+                .to_string_lossy()
+                .replace('\\', "/")
+                .ends_with("src/code-sink.ts")
+        })
+        .expect("eval with DOMPurify output must remain a code-injection candidate");
+    assert_eq!(finding.category.as_deref(), Some("code-injection"));
+}
+
+#[test]
 fn sink_in_test_or_config_file_does_not_fire() {
     // Build-config and test files are excluded from security candidate
     // generation (production-mode parity): an unsafe innerHTML sink inside a

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -247,6 +247,8 @@ pub fn cached_to_module_opts(
         security_sinks: cached.security_sinks.clone(),
         security_sinks_skipped: cached.security_sinks_skipped,
         tainted_bindings: cached.tainted_bindings.clone(),
+        sanitized_bindings: cached.sanitized_bindings.clone(),
+        sanitized_sink_args: cached.sanitized_sink_args.clone(),
     }
 }
 
@@ -436,5 +438,7 @@ pub fn module_to_cached(
         security_sinks: module.security_sinks.clone(),
         security_sinks_skipped: module.security_sinks_skipped,
         tainted_bindings: module.tainted_bindings.clone(),
+        sanitized_bindings: module.sanitized_bindings.clone(),
+        sanitized_sink_args: module.sanitized_sink_args.clone(),
     }
 }

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -247,7 +247,6 @@ pub fn cached_to_module_opts(
         security_sinks: cached.security_sinks.clone(),
         security_sinks_skipped: cached.security_sinks_skipped,
         tainted_bindings: cached.tainted_bindings.clone(),
-        sanitized_bindings: cached.sanitized_bindings.clone(),
         sanitized_sink_args: cached.sanitized_sink_args.clone(),
     }
 }
@@ -438,7 +437,6 @@ pub fn module_to_cached(
         security_sinks: module.security_sinks.clone(),
         security_sinks_skipped: module.security_sinks_skipped,
         tainted_bindings: module.tainted_bindings.clone(),
-        sanitized_bindings: module.sanitized_bindings.clone(),
         sanitized_sink_args: module.sanitized_sink_args.clone(),
     }
 }

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -58,7 +58,6 @@ fn cache_store_insert_and_get() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -103,7 +102,6 @@ fn cache_store_hash_mismatch_returns_none() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -152,7 +150,6 @@ fn cache_store_overwrite_entry() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     let m2 = CachedModule {
@@ -188,7 +185,6 @@ fn cache_store_overwrite_entry() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), m1);
@@ -240,7 +236,6 @@ fn module_to_cached_roundtrip_named_export() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -308,7 +303,6 @@ fn module_to_cached_roundtrip_side_effect_used_export() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -365,7 +359,6 @@ fn module_to_cached_roundtrip_default_export() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -445,7 +438,6 @@ fn module_to_cached_roundtrip_imports() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -509,7 +501,6 @@ fn module_to_cached_roundtrip_re_exports() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -570,7 +561,6 @@ fn module_to_cached_roundtrip_dynamic_imports() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -661,7 +651,6 @@ fn module_to_cached_roundtrip_members() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -731,7 +720,6 @@ fn cache_save_and_load_roundtrip() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -787,7 +775,6 @@ fn cache_version_mismatch_returns_none() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -848,7 +835,6 @@ fn module_to_cached_roundtrip_type_only_import() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -896,7 +882,6 @@ fn get_by_path_only_returns_entry_regardless_of_hash() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -955,7 +940,6 @@ fn retain_paths_removes_stale_entries() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1020,7 +1004,6 @@ fn retain_paths_with_empty_files_clears_cache() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("a.ts"), m);
@@ -1066,7 +1049,6 @@ fn get_by_metadata_returns_entry_on_match() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -1112,7 +1094,6 @@ fn get_by_metadata_returns_none_on_mtime_mismatch() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -1160,7 +1141,6 @@ fn get_by_metadata_returns_none_on_size_mismatch() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -1208,7 +1188,6 @@ fn get_by_metadata_returns_none_for_zero_mtime() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
@@ -1263,7 +1242,6 @@ fn module_to_cached_stores_mtime_and_size() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1306,7 +1284,6 @@ fn module_to_cached_roundtrip_line_offsets() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
     let cached = module_to_cached(&module, 0, 0);
@@ -1365,7 +1342,6 @@ fn module_to_cached_roundtrip_suppressions_with_kinds() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1427,7 +1403,6 @@ fn module_to_cached_roundtrip_unknown_suppression_kinds() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1488,7 +1463,6 @@ fn module_to_cached_roundtrip_visibility() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1540,7 +1514,6 @@ fn module_to_cached_roundtrip_visibility_internal() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1592,7 +1565,6 @@ fn module_to_cached_roundtrip_visibility_beta() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1644,7 +1616,6 @@ fn module_to_cached_roundtrip_visibility_alpha() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1698,7 +1669,6 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1750,7 +1720,6 @@ fn module_to_cached_roundtrip_unused_import_bindings() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1827,7 +1796,6 @@ fn module_to_cached_roundtrip_complexity() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1882,7 +1850,6 @@ fn module_to_cached_roundtrip_require_with_destructured() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1937,7 +1904,6 @@ fn module_to_cached_roundtrip_dynamic_import_with_local() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -1991,7 +1957,6 @@ fn module_to_cached_roundtrip_source_span() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -2052,7 +2017,6 @@ fn module_to_cached_roundtrip_member_decorators() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     };
 
@@ -2102,7 +2066,6 @@ fn synthetic_module(content_hash: u64, last_access_secs: u64, payload_kb: usize)
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     }
 }

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -58,6 +58,8 @@ fn cache_store_insert_and_get() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
     assert_eq!(store.len(), 1);
@@ -101,6 +103,8 @@ fn cache_store_hash_mismatch_returns_none() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
     assert!(store.get(Path::new("test.ts"), 99).is_none());
@@ -148,6 +152,8 @@ fn cache_store_overwrite_entry() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     let m2 = CachedModule {
         content_hash: 2,
@@ -182,6 +188,8 @@ fn cache_store_overwrite_entry() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), m1);
     store.insert(Path::new("test.ts"), m2);
@@ -232,6 +240,8 @@ fn module_to_cached_roundtrip_named_export() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -298,6 +308,8 @@ fn module_to_cached_roundtrip_side_effect_used_export() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -353,6 +365,8 @@ fn module_to_cached_roundtrip_default_export() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -431,6 +445,8 @@ fn module_to_cached_roundtrip_imports() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -493,6 +509,8 @@ fn module_to_cached_roundtrip_re_exports() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -552,6 +570,8 @@ fn module_to_cached_roundtrip_dynamic_imports() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -641,6 +661,8 @@ fn module_to_cached_roundtrip_members() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -709,6 +731,8 @@ fn cache_save_and_load_roundtrip() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
     store.save(&dir, 0, DEFAULT_CACHE_MAX_SIZE).unwrap();
@@ -763,6 +787,8 @@ fn cache_version_mismatch_returns_none() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
     store.save(&dir, 0, DEFAULT_CACHE_MAX_SIZE).unwrap();
@@ -822,6 +848,8 @@ fn module_to_cached_roundtrip_type_only_import() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -868,6 +896,8 @@ fn get_by_path_only_returns_entry_regardless_of_hash() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -925,6 +955,8 @@ fn retain_paths_removes_stale_entries() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     store.insert(Path::new("/project/a.ts"), m());
@@ -988,6 +1020,8 @@ fn retain_paths_with_empty_files_clears_cache() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("a.ts"), m);
     assert_eq!(store.len(), 1);
@@ -1032,6 +1066,8 @@ fn get_by_metadata_returns_entry_on_match() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -1076,6 +1112,8 @@ fn get_by_metadata_returns_none_on_mtime_mismatch() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -1122,6 +1160,8 @@ fn get_by_metadata_returns_none_on_size_mismatch() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -1168,6 +1208,8 @@ fn get_by_metadata_returns_none_for_zero_mtime() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -1221,6 +1263,8 @@ fn module_to_cached_stores_mtime_and_size() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 12345, 6789);
@@ -1262,6 +1306,8 @@ fn module_to_cached_roundtrip_line_offsets() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
     let cached = module_to_cached(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
@@ -1319,6 +1365,8 @@ fn module_to_cached_roundtrip_suppressions_with_kinds() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1379,6 +1427,8 @@ fn module_to_cached_roundtrip_unknown_suppression_kinds() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1438,6 +1488,8 @@ fn module_to_cached_roundtrip_visibility() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1488,6 +1540,8 @@ fn module_to_cached_roundtrip_visibility_internal() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1538,6 +1592,8 @@ fn module_to_cached_roundtrip_visibility_beta() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1588,6 +1644,8 @@ fn module_to_cached_roundtrip_visibility_alpha() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1640,6 +1698,8 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1690,6 +1750,8 @@ fn module_to_cached_roundtrip_unused_import_bindings() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1765,6 +1827,8 @@ fn module_to_cached_roundtrip_complexity() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1818,6 +1882,8 @@ fn module_to_cached_roundtrip_require_with_destructured() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1871,6 +1937,8 @@ fn module_to_cached_roundtrip_dynamic_import_with_local() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1923,6 +1991,8 @@ fn module_to_cached_roundtrip_source_span() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1982,6 +2052,8 @@ fn module_to_cached_roundtrip_member_decorators() {
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -2030,6 +2102,8 @@ fn synthetic_module(content_hash: u64, last_access_secs: u64, payload_kb: usize)
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     }
 }
 

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -146,7 +146,13 @@ use crate::MemberKind;
 /// `tainted_sink` detector can back-trace a sink argument to a known untrusted
 /// source. Pre-111 entries lack both, so source-to-sink association is unset
 /// until the file is re-extracted.
-pub(super) const CACHE_VERSION: u32 = 111;
+///
+/// Bumped to 112 for issue #863 (sanitizer-aware security sinks):
+/// `ModuleInfo`/`CachedModule` now carry recognized sanitizer bindings and
+/// direct sanitized sink arguments, so the security `tainted_sink` detector can
+/// suppress high-confidence DOMPurify-backed HTML sink candidates. Pre-112
+/// entries lack sanitizer metadata until the file is re-extracted.
+pub(super) const CACHE_VERSION: u32 = 112;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.
@@ -189,7 +195,7 @@ macro_rules! assert_cached_type_size {
     };
 }
 
-assert_cached_type_size!(CachedModule, 640);
+assert_cached_type_size!(CachedModule, 688);
 assert_cached_type_size!(CachedNamespaceObjectAlias, 72);
 assert_cached_type_size!(CachedLocalTypeDeclaration, 32);
 assert_cached_type_size!(CachedPublicSignatureTypeReference, 56);
@@ -294,6 +300,10 @@ pub struct CachedModule {
     /// Round-trips so the security `tainted_sink` source-to-sink association
     /// sees source-tainted bindings on warm-cache loads.
     pub tainted_bindings: Vec<fallow_types::extract::TaintedBinding>,
+    /// Local bindings initialized from recognized sanitizer calls.
+    pub sanitized_bindings: Vec<fallow_types::extract::SanitizedBinding>,
+    /// Direct sink arguments recognized as sanitizer calls.
+    pub sanitized_sink_args: Vec<fallow_types::extract::SanitizedSinkArg>,
 }
 
 /// Cached namespace-object alias.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -148,10 +148,10 @@ use crate::MemberKind;
 /// until the file is re-extracted.
 ///
 /// Bumped to 112 for issue #863 (sanitizer-aware security sinks):
-/// `ModuleInfo`/`CachedModule` now carry recognized sanitizer bindings and
-/// direct sanitized sink arguments, so the security `tainted_sink` detector can
-/// suppress high-confidence DOMPurify-backed HTML sink candidates. Pre-112
-/// entries lack sanitizer metadata until the file is re-extracted.
+/// `ModuleInfo`/`CachedModule` now carry direct sanitized sink arguments, so
+/// the security `tainted_sink` detector can suppress high-confidence
+/// DOMPurify-backed HTML sink candidates. Pre-112 entries lack sanitizer
+/// metadata until the file is re-extracted.
 pub(super) const CACHE_VERSION: u32 = 112;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
@@ -195,7 +195,7 @@ macro_rules! assert_cached_type_size {
     };
 }
 
-assert_cached_type_size!(CachedModule, 688);
+assert_cached_type_size!(CachedModule, 664);
 assert_cached_type_size!(CachedNamespaceObjectAlias, 72);
 assert_cached_type_size!(CachedLocalTypeDeclaration, 32);
 assert_cached_type_size!(CachedPublicSignatureTypeReference, 56);
@@ -300,8 +300,6 @@ pub struct CachedModule {
     /// Round-trips so the security `tainted_sink` source-to-sink association
     /// sees source-tainted bindings on warm-cache loads.
     pub tainted_bindings: Vec<fallow_types::extract::TaintedBinding>,
-    /// Local bindings initialized from recognized sanitizer calls.
-    pub sanitized_bindings: Vec<fallow_types::extract::SanitizedBinding>,
     /// Direct sink arguments recognized as sanitizer calls.
     pub sanitized_sink_args: Vec<fallow_types::extract::SanitizedSinkArg>,
 }

--- a/crates/extract/src/css.rs
+++ b/crates/extract/src/css.rs
@@ -409,6 +409,8 @@ pub(crate) fn parse_css_to_module(
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     }
 }
 

--- a/crates/extract/src/css.rs
+++ b/crates/extract/src/css.rs
@@ -409,7 +409,6 @@ pub(crate) fn parse_css_to_module(
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     }
 }

--- a/crates/extract/src/graphql.rs
+++ b/crates/extract/src/graphql.rs
@@ -104,6 +104,8 @@ pub(crate) fn parse_graphql_to_module(
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     }
 }
 

--- a/crates/extract/src/graphql.rs
+++ b/crates/extract/src/graphql.rs
@@ -104,7 +104,6 @@ pub(crate) fn parse_graphql_to_module(
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     }
 }

--- a/crates/extract/src/html.rs
+++ b/crates/extract/src/html.rs
@@ -198,6 +198,8 @@ pub(crate) fn parse_html_to_module_with_complexity(
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     }
 }
 

--- a/crates/extract/src/html.rs
+++ b/crates/extract/src/html.rs
@@ -198,7 +198,6 @@ pub(crate) fn parse_html_to_module_with_complexity(
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     }
 }

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -329,6 +329,8 @@ fn empty_sfc_module(file_id: FileId, source: &str, content_hash: u64) -> ModuleI
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
+        sanitized_bindings: Vec::new(),
+        sanitized_sink_args: Vec::new(),
     }
 }
 

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -329,7 +329,6 @@ fn empty_sfc_module(file_id: FileId, source: &str, content_hash: u64) -> ModuleI
         security_sinks: Vec::new(),
         security_sinks_skipped: 0,
         tainted_bindings: Vec::new(),
-        sanitized_bindings: Vec::new(),
         sanitized_sink_args: Vec::new(),
     }
 }

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -15,8 +15,8 @@ use crate::{
     MemberAccess, MemberInfo, MemberKind, ModuleInfo, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
 use fallow_types::extract::{
-    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedBinding,
-    SanitizedSinkArg, SinkSite, TaintedBinding,
+    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedSinkArg,
+    SanitizerScope, SinkSite, TaintedBinding,
 };
 use helpers::LitCustomElementDecorator;
 
@@ -143,13 +143,16 @@ pub(crate) struct ModuleInfoExtractor {
     /// (e.g. `const id = req.query.id`). Feeds the security `tainted_sink`
     /// source-to-sink association in the analyze layer.
     pub(crate) tainted_bindings: Vec<TaintedBinding>,
-    /// Local bindings initialized from recognized sanitizer calls.
-    pub(crate) sanitized_bindings: Vec<SanitizedBinding>,
     /// Direct sink arguments recognized as sanitizer calls.
     pub(crate) sanitized_sink_args: Vec<SanitizedSinkArg>,
     /// Module-scope default, namespace, or require bindings imported from
     /// DOMPurify-compatible packages.
     pub(crate) dompurify_bindings: FxHashSet<String>,
+    /// Module-scope local sanitizer bindings. `None` means the name is declared
+    /// but not sanitizer-backed, shadowing any outer match.
+    pub(crate) module_sanitizer_bindings: FxHashMap<String, Option<SanitizerScope>>,
+    /// Nested lexical sanitizer binding stack for functions and blocks.
+    pub(crate) sanitizer_binding_stack: Vec<FxHashMap<String, Option<SanitizerScope>>>,
 }
 
 impl ModuleInfoExtractor {
@@ -742,7 +745,6 @@ impl ModuleInfoExtractor {
             security_sinks: self.security_sinks,
             security_sinks_skipped: self.security_sinks_skipped,
             tainted_bindings: self.tainted_bindings,
-            sanitized_bindings: self.sanitized_bindings,
             sanitized_sink_args: self.sanitized_sink_args,
         }
     }
@@ -788,7 +790,6 @@ impl ModuleInfoExtractor {
         info.security_sinks.extend(self.security_sinks);
         info.security_sinks_skipped += self.security_sinks_skipped;
         info.tainted_bindings.extend(self.tainted_bindings);
-        info.sanitized_bindings.extend(self.sanitized_bindings);
         info.sanitized_sink_args.extend(self.sanitized_sink_args);
     }
 }

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -15,7 +15,8 @@ use crate::{
     MemberAccess, MemberInfo, MemberKind, ModuleInfo, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
 use fallow_types::extract::{
-    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SinkSite, TaintedBinding,
+    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedBinding,
+    SanitizedSinkArg, SinkSite, TaintedBinding,
 };
 use helpers::LitCustomElementDecorator;
 
@@ -142,6 +143,13 @@ pub(crate) struct ModuleInfoExtractor {
     /// (e.g. `const id = req.query.id`). Feeds the security `tainted_sink`
     /// source-to-sink association in the analyze layer.
     pub(crate) tainted_bindings: Vec<TaintedBinding>,
+    /// Local bindings initialized from recognized sanitizer calls.
+    pub(crate) sanitized_bindings: Vec<SanitizedBinding>,
+    /// Direct sink arguments recognized as sanitizer calls.
+    pub(crate) sanitized_sink_args: Vec<SanitizedSinkArg>,
+    /// Module-scope default, namespace, or require bindings imported from
+    /// DOMPurify-compatible packages.
+    pub(crate) dompurify_bindings: FxHashSet<String>,
 }
 
 impl ModuleInfoExtractor {
@@ -734,6 +742,8 @@ impl ModuleInfoExtractor {
             security_sinks: self.security_sinks,
             security_sinks_skipped: self.security_sinks_skipped,
             tainted_bindings: self.tainted_bindings,
+            sanitized_bindings: self.sanitized_bindings,
+            sanitized_sink_args: self.sanitized_sink_args,
         }
     }
 
@@ -778,6 +788,8 @@ impl ModuleInfoExtractor {
         info.security_sinks.extend(self.security_sinks);
         info.security_sinks_skipped += self.security_sinks_skipped;
         info.tainted_bindings.extend(self.tainted_bindings);
+        info.sanitized_bindings.extend(self.sanitized_bindings);
+        info.sanitized_sink_args.extend(self.sanitized_sink_args);
     }
 }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -14,8 +14,8 @@ use crate::{
     MemberAccess, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
 use fallow_types::extract::{
-    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SinkArgKind, SinkShape,
-    SinkSite, TaintedBinding,
+    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedBinding,
+    SanitizedSinkArg, SanitizerScope, SinkArgKind, SinkShape, SinkSite, TaintedBinding,
 };
 
 use crate::asset_url::normalize_asset_url;
@@ -112,6 +112,10 @@ fn vitest_auto_mock_source(source: &str) -> Option<String> {
     }
 
     Some(format!("{dir}/__mocks__/{file_name}"))
+}
+
+fn is_dompurify_source(source: &str) -> bool {
+    matches!(source, "dompurify" | "isomorphic-dompurify")
 }
 
 /// Detect whether `vi.mock(specifier, factory, ...)` passes a factory.
@@ -1173,6 +1177,88 @@ impl ModuleInfoExtractor {
         }
     }
 
+    fn record_sanitized_binding(&mut self, name: &str, expr: &Expression<'_>) {
+        let Some(scope) = self.sanitizer_scope_for_expr(expr) else {
+            return;
+        };
+        self.sanitized_bindings.push(SanitizedBinding {
+            local: name.to_string(),
+            scope,
+        });
+    }
+
+    fn record_dompurify_import_binding(&mut self, source: &str, local: &str, is_type_only: bool) {
+        if !is_type_only && self.is_module_scope() && is_dompurify_source(source) {
+            self.dompurify_bindings.insert(local.to_string());
+        }
+    }
+
+    fn record_dompurify_require_binding(
+        &mut self,
+        declarator: &VariableDeclarator<'_>,
+        source: &str,
+    ) {
+        if !self.is_module_scope() || !is_dompurify_source(source) {
+            return;
+        }
+        if let BindingPattern::BindingIdentifier(id) = &declarator.id {
+            self.dompurify_bindings.insert(id.name.to_string());
+        }
+    }
+
+    fn sanitizer_scope_for_expr(&self, expr: &Expression<'_>) -> Option<SanitizerScope> {
+        match unwrap_parens(expr) {
+            Expression::AwaitExpression(await_expr) => {
+                self.sanitizer_scope_for_expr(&await_expr.argument)
+            }
+            Expression::CallExpression(call) if self.is_dompurify_sanitize_call(call) => {
+                Some(SanitizerScope::Html)
+            }
+            Expression::ObjectExpression(obj) => self.sanitizer_scope_for_object(obj),
+            _ => None,
+        }
+    }
+
+    fn sanitizer_scope_for_object(&self, obj: &ObjectExpression<'_>) -> Option<SanitizerScope> {
+        obj.properties.iter().find_map(|prop| {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                return None;
+            };
+            if prop.key.static_name().is_none_or(|name| name != "__html") {
+                return None;
+            }
+            self.sanitizer_scope_for_expr(&prop.value)
+        })
+    }
+
+    fn is_dompurify_sanitize_call(&self, call: &CallExpression<'_>) -> bool {
+        let Some(callee_path) = flatten_callee_path(&call.callee) else {
+            return false;
+        };
+        let Some((object, method)) = callee_path.rsplit_once('.') else {
+            return false;
+        };
+        method == "sanitize"
+            && self.dompurify_bindings.contains(object)
+            && !self.nested_scope_shadows(object)
+    }
+
+    fn record_sanitized_sink_arg(
+        &mut self,
+        span_start: u32,
+        arg_index: u32,
+        expr: &Expression<'_>,
+    ) {
+        let Some(scope) = self.sanitizer_scope_for_expr(expr) else {
+            return;
+        };
+        self.sanitized_sink_args.push(SanitizedSinkArg {
+            span_start,
+            arg_index,
+            scope,
+        });
+    }
+
     /// Record tainted-source bindings for `const { a, b } = <object>.<prop>`,
     /// where the destructured initializer is a member-access chain (or bare
     /// identifier root). Each bound local maps to the FULL flattened init path:
@@ -1749,6 +1835,11 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                         });
                     }
                     ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
+                        self.record_dompurify_import_binding(
+                            &source,
+                            s.local.name.as_str(),
+                            is_type_only,
+                        );
                         if self.is_module_scope() && is_node_path_source(&source) {
                             self.node_path_namespace_bindings
                                 .insert(s.local.name.to_string());
@@ -1765,6 +1856,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     }
                     ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
                         let local = s.local.name.to_string();
+                        self.record_dompurify_import_binding(&source, &local, is_type_only);
                         if self.is_module_scope() && is_child_process_source(&source) {
                             self.child_process_namespace_bindings.insert(local.clone());
                         }
@@ -2060,6 +2152,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 self.record_current_module_file_path_binding(id.name.as_str(), init);
                 self.record_child_process_fork_target_binding(id.name.as_str(), init);
                 self.record_tainted_source_binding(id.name.as_str(), init);
+                self.record_sanitized_binding(id.name.as_str(), init);
             }
 
             if let BindingPattern::ObjectPattern(obj_pat) = &declarator.id {
@@ -2093,6 +2186,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             }
 
             if let Some((call, source)) = try_extract_require(init) {
+                self.record_dompurify_require_binding(declarator, source);
                 self.record_child_process_require_binding(declarator, source);
                 self.handle_require_declaration(declarator, call, source);
                 continue;
@@ -2896,6 +2990,13 @@ fn collect_idents_into(expr: &Expression<'_>, out: &mut Vec<String>) {
                 }
             }
         }
+        Expression::ObjectExpression(obj) => {
+            for prop in &obj.properties {
+                if let ObjectPropertyKind::ObjectProperty(prop) = prop {
+                    collect_idents_into(&prop.value, out);
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -2985,6 +3086,7 @@ impl ModuleInfoExtractor {
             let Ok(arg_index) = u32::try_from(index) else {
                 continue;
             };
+            self.record_sanitized_sink_arg(expr.span.start, arg_index, arg_expr);
             self.security_sinks.push(SinkSite {
                 sink_shape,
                 callee_path: callee_path.clone(),
@@ -3012,6 +3114,7 @@ impl ModuleInfoExtractor {
             self.security_sinks_skipped += 1;
             return;
         };
+        self.record_sanitized_sink_arg(expr.span.start, 0, &expr.right);
         self.security_sinks.push(SinkSite {
             sink_shape: SinkShape::MemberAssign,
             callee_path: format!("{}.{}", object_path, member.property.name),
@@ -3068,6 +3171,7 @@ impl ModuleInfoExtractor {
         if !is_non_literal_arg(value_expr) {
             return;
         }
+        self.record_sanitized_sink_arg(attr.span.start, 0, value_expr);
         self.security_sinks.push(SinkSite {
             sink_shape: SinkShape::JsxAttr,
             callee_path: name.name.to_string(),

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -14,8 +14,8 @@ use crate::{
     MemberAccess, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
 use fallow_types::extract::{
-    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedBinding,
-    SanitizedSinkArg, SanitizerScope, SinkArgKind, SinkShape, SinkSite, TaintedBinding,
+    ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedSinkArg,
+    SanitizerScope, SinkArgKind, SinkShape, SinkSite, TaintedBinding,
 };
 
 use crate::asset_url::normalize_asset_url;
@@ -568,6 +568,28 @@ impl ModuleInfoExtractor {
             .any(|scope| scope.contains(name))
     }
 
+    fn record_sanitizer_binding(&mut self, name: &str, scope: Option<SanitizerScope>) {
+        if self.is_module_scope() {
+            self.module_sanitizer_bindings
+                .insert(name.to_string(), scope);
+            return;
+        }
+        if let Some(bindings) = self.sanitizer_binding_stack.last_mut() {
+            bindings.insert(name.to_string(), scope);
+        }
+    }
+
+    fn sanitizer_scope_for_identifier(&self, name: &str) -> Option<SanitizerScope> {
+        for bindings in self.sanitizer_binding_stack.iter().rev() {
+            if let Some(scope) = bindings.get(name) {
+                return *scope;
+            }
+        }
+        self.module_sanitizer_bindings
+            .get(name)
+            .and_then(|scope| *scope)
+    }
+
     fn record_nested_declaration_names<'a>(
         &mut self,
         declarations: impl IntoIterator<Item = &'a BindingIdentifier<'a>>,
@@ -596,12 +618,18 @@ impl ModuleInfoExtractor {
                     .map(|id| id.name.to_string()),
             );
         }
+        let sanitizer_scope = scope
+            .iter()
+            .map(|name| (name.clone(), None))
+            .collect::<FxHashMap<_, _>>();
         self.nested_declaration_stack.push(scope);
+        self.sanitizer_binding_stack.push(sanitizer_scope);
     }
 
     fn pop_function_declaration_scope(&mut self) {
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.pop();
+            self.sanitizer_binding_stack.pop();
         }
     }
 
@@ -1177,16 +1205,6 @@ impl ModuleInfoExtractor {
         }
     }
 
-    fn record_sanitized_binding(&mut self, name: &str, expr: &Expression<'_>) {
-        let Some(scope) = self.sanitizer_scope_for_expr(expr) else {
-            return;
-        };
-        self.sanitized_bindings.push(SanitizedBinding {
-            local: name.to_string(),
-            scope,
-        });
-    }
-
     fn record_dompurify_import_binding(&mut self, source: &str, local: &str, is_type_only: bool) {
         if !is_type_only && self.is_module_scope() && is_dompurify_source(source) {
             self.dompurify_bindings.insert(local.to_string());
@@ -1208,6 +1226,7 @@ impl ModuleInfoExtractor {
 
     fn sanitizer_scope_for_expr(&self, expr: &Expression<'_>) -> Option<SanitizerScope> {
         match unwrap_parens(expr) {
+            Expression::Identifier(ident) => self.sanitizer_scope_for_identifier(&ident.name),
             Expression::AwaitExpression(await_expr) => {
                 self.sanitizer_scope_for_expr(&await_expr.argument)
             }
@@ -1672,10 +1691,12 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.block_depth += 1;
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.push(FxHashSet::default());
+            self.sanitizer_binding_stack.push(FxHashMap::default());
         }
         walk::walk_block_statement(self, stmt);
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.pop();
+            self.sanitizer_binding_stack.pop();
         }
         self.block_depth -= 1;
     }
@@ -1693,6 +1714,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 Declaration::ClassDeclaration(class) => {
                     if let Some(id) = class.id.as_ref() {
                         self.record_local_declaration_name(&id.name);
+                        self.record_sanitizer_binding(id.name.as_str(), None);
                         self.record_local_type_declaration(&id.name, id.span);
                         let is_angular = has_angular_class_decorator(class);
                         let instance_bindings =
@@ -1711,6 +1733,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 Declaration::FunctionDeclaration(function) => {
                     if let Some(id) = function.id.as_ref() {
                         self.record_local_declaration_name(&id.name);
+                        self.record_sanitizer_binding(id.name.as_str(), None);
                         let refs = Self::collect_function_signature_refs(function);
                         self.record_local_signature_refs(&id.name, refs);
 
@@ -1770,11 +1793,13 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 Declaration::ClassDeclaration(class) => {
                     if let Some(id) = class.id.as_ref() {
                         self.record_nested_declaration_names(std::iter::once(id));
+                        self.record_sanitizer_binding(id.name.as_str(), None);
                     }
                 }
                 Declaration::FunctionDeclaration(function) => {
                     if let Some(id) = function.id.as_ref() {
                         self.record_nested_declaration_names(std::iter::once(id));
+                        self.record_sanitizer_binding(id.name.as_str(), None);
                     }
                 }
                 _ => {}
@@ -2141,6 +2166,9 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             }
 
             let Some(init) = &declarator.init else {
+                for id in declarator.id.get_binding_identifiers() {
+                    self.record_sanitizer_binding(id.name.as_str(), None);
+                }
                 continue;
             };
 
@@ -2152,7 +2180,12 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 self.record_current_module_file_path_binding(id.name.as_str(), init);
                 self.record_child_process_fork_target_binding(id.name.as_str(), init);
                 self.record_tainted_source_binding(id.name.as_str(), init);
-                self.record_sanitized_binding(id.name.as_str(), init);
+                let sanitizer_scope = self.sanitizer_scope_for_expr(init);
+                self.record_sanitizer_binding(id.name.as_str(), sanitizer_scope);
+            } else {
+                for id in declarator.id.get_binding_identifiers() {
+                    self.record_sanitizer_binding(id.name.as_str(), None);
+                }
             }
 
             if let BindingPattern::ObjectPattern(obj_pat) = &declarator.id {

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -90,10 +90,6 @@ pub struct ModuleInfo {
     /// matching `local` names as source-tainted. Intra-module and name-based
     /// (no scope analysis); a conservative association, never a taint proof.
     pub tainted_bindings: Vec<TaintedBinding>,
-    /// Local bindings whose initializer is a recognized sanitizer call.
-    /// Consumed by the security `tainted_sink` detector to suppress high
-    /// confidence sanitizer-backed HTML sink candidates.
-    pub sanitized_bindings: Vec<SanitizedBinding>,
     /// Sink arguments that were recognized as sanitizer calls at extraction
     /// time. Used for direct sink calls such as
     /// `el.innerHTML = DOMPurify.sanitize(input)`.
@@ -116,15 +112,6 @@ pub struct ModuleInfo {
 pub enum SanitizerScope {
     /// HTML markup sanitized by DOMPurify-compatible APIs.
     Html,
-}
-
-/// A local binding initialized from a recognized sanitizer call.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bitcode::Encode, bitcode::Decode)]
-pub struct SanitizedBinding {
-    /// The local binding name introduced by the declarator.
-    pub local: String,
-    /// The sanitizer output domain for this binding.
-    pub scope: SanitizerScope,
 }
 
 /// A captured sink argument that is itself a recognized sanitizer call.
@@ -628,7 +615,7 @@ const _: () = assert!(std::mem::size_of::<MemberAccess>() == 48);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<SinkSite>() == 64);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<ModuleInfo>() == 672);
+const _: () = assert!(std::mem::size_of::<ModuleInfo>() == 648);
 
 /// A re-export declaration.
 #[derive(Debug, Clone)]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -90,6 +90,52 @@ pub struct ModuleInfo {
     /// matching `local` names as source-tainted. Intra-module and name-based
     /// (no scope analysis); a conservative association, never a taint proof.
     pub tainted_bindings: Vec<TaintedBinding>,
+    /// Local bindings whose initializer is a recognized sanitizer call.
+    /// Consumed by the security `tainted_sink` detector to suppress high
+    /// confidence sanitizer-backed HTML sink candidates.
+    pub sanitized_bindings: Vec<SanitizedBinding>,
+    /// Sink arguments that were recognized as sanitizer calls at extraction
+    /// time. Used for direct sink calls such as
+    /// `el.innerHTML = DOMPurify.sanitize(input)`.
+    pub sanitized_sink_args: Vec<SanitizedSinkArg>,
+}
+
+/// Sanitizer output domain. Kept intentionally narrow so a sanitizer for one
+/// domain cannot suppress a different sink family.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    bitcode::Encode,
+    bitcode::Decode,
+)]
+pub enum SanitizerScope {
+    /// HTML markup sanitized by DOMPurify-compatible APIs.
+    Html,
+}
+
+/// A local binding initialized from a recognized sanitizer call.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bitcode::Encode, bitcode::Decode)]
+pub struct SanitizedBinding {
+    /// The local binding name introduced by the declarator.
+    pub local: String,
+    /// The sanitizer output domain for this binding.
+    pub scope: SanitizerScope,
+}
+
+/// A captured sink argument that is itself a recognized sanitizer call.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bitcode::Encode, bitcode::Decode)]
+pub struct SanitizedSinkArg {
+    /// Byte offset of the owning sink span start.
+    pub span_start: u32,
+    /// The positional argument index on the owning sink.
+    pub arg_index: u32,
+    /// The sanitizer output domain for this argument.
+    pub scope: SanitizerScope,
 }
 
 /// A local binding tied to the flattened member-access path it was initialized
@@ -582,7 +628,7 @@ const _: () = assert!(std::mem::size_of::<MemberAccess>() == 48);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<SinkSite>() == 64);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<ModuleInfo>() == 624);
+const _: () = assert!(std::mem::size_of::<ModuleInfo>() == 672);
 
 /// A re-export declaration.
 #[derive(Debug, Clone)]

--- a/tests/fixtures/security-dangerous-html/package.json
+++ b/tests/fixtures/security-dangerous-html/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "dompurify": "3.2.6",
+    "isomorphic-dompurify": "2.25.0",
     "react": "19.0.0"
   }
 }

--- a/tests/fixtures/security-dangerous-html/src/code-sink.ts
+++ b/tests/fixtures/security-dangerous-html/src/code-sink.ts
@@ -1,0 +1,6 @@
+import DOMPurify from "dompurify";
+
+// Positive: HTML sanitization must not suppress non-HTML sink families.
+export function runCode(userInput: string): void {
+  eval(DOMPurify.sanitize(userInput));
+}

--- a/tests/fixtures/security-dangerous-html/src/dompurify-default.ts
+++ b/tests/fixtures/security-dangerous-html/src/dompurify-default.ts
@@ -1,0 +1,6 @@
+import DOMPurify from "dompurify";
+
+// Negative: a direct DOMPurify sanitizer call suppresses the HTML sink candidate.
+export function renderDefault(el: HTMLElement, userInput: string): void {
+  el.innerHTML = DOMPurify.sanitize(userInput);
+}

--- a/tests/fixtures/security-dangerous-html/src/dompurify-namespace.ts
+++ b/tests/fixtures/security-dangerous-html/src/dompurify-namespace.ts
@@ -1,0 +1,7 @@
+import * as DOMPurify from "dompurify";
+
+// Negative: namespace imports from DOMPurify are recognized sanitizer provenance.
+export function renderNamespace(el: HTMLElement, userInput: string): void {
+  const html = DOMPurify.sanitize(userInput);
+  document.write(html);
+}

--- a/tests/fixtures/security-dangerous-html/src/dompurify-require.ts
+++ b/tests/fixtures/security-dangerous-html/src/dompurify-require.ts
@@ -1,0 +1,7 @@
+const DOMPurify = require("dompurify");
+
+// Negative: CommonJS require bindings from DOMPurify are recognized too.
+export function renderRequire(el: HTMLElement, userInput: string): void {
+  const html = DOMPurify.sanitize(userInput);
+  el.insertAdjacentHTML("beforeend", html);
+}

--- a/tests/fixtures/security-dangerous-html/src/isomorphic-dompurify.ts
+++ b/tests/fixtures/security-dangerous-html/src/isomorphic-dompurify.ts
@@ -1,0 +1,6 @@
+import DOMPurify from "isomorphic-dompurify";
+
+// Negative: the isomorphic DOMPurify package has the same trusted API shape.
+export function renderIsomorphic(el: HTMLElement, userInput: string): void {
+  el.innerHTML = DOMPurify.sanitize(userInput);
+}

--- a/tests/fixtures/security-dangerous-html/src/near-miss.ts
+++ b/tests/fixtures/security-dangerous-html/src/near-miss.ts
@@ -1,0 +1,13 @@
+// Positive: local helpers named like sanitizers have no package provenance.
+const DOMPurifyLike = {
+  sanitize(value: string): string {
+    return value;
+  },
+};
+
+const sanitize = (value: string): string => value;
+
+export function renderNearMisses(el: HTMLElement, userInput: string): void {
+  el.innerHTML = DOMPurifyLike.sanitize(userInput);
+  document.write(sanitize(userInput));
+}

--- a/tests/fixtures/security-dangerous-html/src/sanitized-component.tsx
+++ b/tests/fixtures/security-dangerous-html/src/sanitized-component.tsx
@@ -1,0 +1,6 @@
+import DOMPurify from "dompurify";
+
+// Negative: React's usual __html object shape is recognized when its value is sanitized.
+export function SanitizedMarkup(props: { html: string }): JSX.Element {
+  return <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(props.html) }} />;
+}

--- a/tests/fixtures/security-dangerous-html/src/shadowed-sanitized-local.ts
+++ b/tests/fixtures/security-dangerous-html/src/shadowed-sanitized-local.ts
@@ -1,0 +1,13 @@
+import DOMPurify from "dompurify";
+
+// Positive: a shadowing parameter must not inherit the outer sanitized binding.
+export function renderShadowed(el: HTMLElement, userInput: string): void {
+  const html = DOMPurify.sanitize(userInput);
+
+  function write(html: string): void {
+    el.innerHTML = html;
+  }
+
+  write(userInput);
+  void html;
+}


### PR DESCRIPTION
## Summary
- Suppress high-confidence HTML security candidates when the exact sink argument comes from package-backed `DOMPurify.sanitize()`, including visible sanitized locals resolved during extraction.
- Recognize default and namespace imports plus CommonJS require from `dompurify` and `isomorphic-dompurify`.
- Keep redirect, path containment, broad sanitizer families, shadowed locals, and non-HTML sinks reporting.

## Review notes
- Review found and fixed a module-wide local-name false negative: a sanitized `html` local could suppress a later shadowing parameter named `html`. Sanitized locals are now resolved lexically during extraction and persisted only as exact sanitized sink arguments.

## Validation
- `cargo test -p fallow-core --test integration_test security_dangerous_html`: passed
- `cargo check --workspace`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo test --workspace`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check origin/main...HEAD`: passed
- `typos .`: passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`: passed
- Old-vs-new real consumer smoke on a local DOMPurify project: reviewed binary removed one `dangerous-html` candidate and left other categories unchanged
- Real-world fixture smoke on zod, preact, and vite: passed and deterministic
- DOMPurify consumer cache round-trip: deterministic

Refs #863