### PR TITLE
feat(cli): accept -v as a version flag alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **The duplication `minOccurrences` threshold is now reachable from the bare `fallow` command and the VS Code extension.** Raising the rule-of-three threshold previously required editing the config file or running the standalone `fallow dupes` subcommand. A new global `--dupes-min-occurrences N` flag now applies in combined mode (validated `>= 2`, falling back to the config value), and the VS Code extension gains a `fallow.duplication.minOccurrences` setting that forwards it. The neighbouring `fallow.duplication.threshold` extension setting was also mislabeled: it is a duplication-percentage failure cap where `0` means no limit, not a minimum line count, and it defaulted to `5`. Its description is corrected and its default aligned to `0` to match the CLI. (Closes [#894](https://github.com/fallow-rs/fallow/issues/894). Thanks [@rbalet](https://github.com/rbalet) for the report.)
+- **Lowercase `-v` now prints the version.** `fallow -v`, `fallow -V`, and `fallow --version` all print the version string. Previously only `-V` and `--version` worked (clap's default). Lowercase `-v` is what every tool in the TS/JS toolchain uses for the version (node, npm, pnpm, yarn, bun, tsc, eslint, prettier), so it is now the primary short form; `-V` is kept for back-compat (matching knip, oxlint, and biome). (Closes [#916](https://github.com/fallow-rs/fallow/issues/916). Thanks [@rbalet](https://github.com/rbalet) for the report.)
 
 ### Fixed
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -116,12 +116,24 @@ Use --only/--skip to select specific analyses.";
     name = "fallow",
     about = "Codebase analyzer for TypeScript/JavaScript: unused code, circular dependencies, code duplication, complexity hotspots, and architecture boundary violations",
     version,
+    disable_version_flag = true,
     help_template = TOP_LEVEL_HELP_TEMPLATE,
     after_help = TOP_LEVEL_AFTER_HELP
 )]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
+
+    /// Print version.
+    /// Accepts `-v`, `-V`, and `--version`; TS/JS tooling (node, npm, pnpm,
+    /// yarn, bun, tsc) uses `-v`, while `-V` matches knip/oxlint/biome.
+    #[arg(
+        short = 'v',
+        visible_short_alias = 'V',
+        long = "version",
+        action = clap::ArgAction::Version
+    )]
+    version: Option<bool>,
 
     /// Project root directory
     #[arg(short, long, global = true)]
@@ -3572,6 +3584,25 @@ mod tests {
     fn cli_definition_has_no_flag_collisions() {
         use clap::CommandFactory;
         Cli::command().debug_assert();
+    }
+
+    /// `-v`, `-V`, and `--version` must all trigger clap's Version action so
+    /// the version prints regardless of which spelling the user reaches for
+    /// (issue #916). clap surfaces a Version action from `try_get_matches_from`
+    /// as the `DisplayVersion` error kind.
+    #[test]
+    fn version_flag_accepts_lower_v_upper_v_and_long() {
+        use clap::CommandFactory;
+        for argv in [["fallow", "-v"], ["fallow", "-V"], ["fallow", "--version"]] {
+            let err = Cli::command()
+                .try_get_matches_from(argv)
+                .expect_err("version flag should short-circuit parsing");
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::DisplayVersion,
+                "{argv:?} should trigger the Version action"
+            );
+        }
     }
 
     /// Guard against deferred-work wording leaking into clap-rendered help.


### PR DESCRIPTION
Makes `-v`, `-V`, and `--version` all print the version. Today only `-V` / `--version` work (clap's default).

## Why

Lowercase `-v` is the version flag across the TS/JS toolchain fallow's users actually run:

| tool | version flag |
|------|--------------|
| node, npm, pnpm, yarn, bun, tsc | `-v` |
| eslint, prettier | `-v` |
| knip, oxlint, biome | `-V` |

The category is split, so both spellings are supported: `-v` becomes the primary short form (matching the package managers, runtimes, and JS-native linters), and `-V` is kept for back-compat (matching the Rust-built analyzers). `--version` is unchanged.

## How

Disables clap's auto-generated version flag (`disable_version_flag = true`) while keeping the version string set via the `version` directive, then adds a custom arg with `short = 'v'`, `visible_short_alias = 'V'`, `long = "version"`, and `ArgAction::Version`.

## Verification

- All three spellings print `fallow <version>` and exit 0.
- New unit test asserts each of `-v`, `-V`, `--version` triggers the Version action.
- `Cli::command().debug_assert()` passes (no flag collision).
- clippy `-D warnings`, fmt, `cargo doc`, full `fallow-cli` suite, and `fallow audit` all clean.

Closes #916