### PR TITLE
test: cover Vite array aliases

### DIFF
--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -896,6 +896,44 @@ fn vite_aliases_from_config_resolve_internal_modules() {
 }
 
 #[test]
+fn vite_array_aliases_from_config_resolve_internal_modules() {
+    let root = fixture_path("vite-array-alias-project");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unresolved_specs: Vec<&str> = results
+        .unresolved_imports
+        .iter()
+        .map(|u| u.import.specifier.as_str())
+        .collect();
+    assert!(
+        !unresolved_specs.contains(&"@/auth.js"),
+        "vite array alias import should resolve, found unresolved: {unresolved_specs:?}"
+    );
+
+    let unused_file_paths: Vec<String> = results
+        .unused_files
+        .iter()
+        .filter_map(|f| f.file.path.strip_prefix(&root).ok())
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    assert!(
+        !unused_file_paths.contains(&"src/auth.js".to_string()),
+        "src/auth.js should be reachable via vite array alias import: {unused_file_paths:?}"
+    );
+
+    let unused_export_names: Vec<&str> = results
+        .unused_exports
+        .iter()
+        .map(|e| e.export.export_name.as_str())
+        .collect();
+    assert!(
+        unused_export_names.contains(&"unusedAuthHelper"),
+        "reachable aliased module should still report unused exports: {unused_export_names:?}"
+    );
+}
+
+#[test]
 fn webpack_aliases_from_config_resolve_internal_modules() {
     let root = fixture_path("webpack-alias-project");
     let config = create_config(root);

--- a/tests/fixtures/vite-array-alias-project/package.json
+++ b/tests/fixtures/vite-array-alias-project/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "vite-array-alias-project",
+  "dependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/tests/fixtures/vite-array-alias-project/src/auth.js
+++ b/tests/fixtures/vite-array-alias-project/src/auth.js
@@ -1,0 +1,5 @@
+const Auth = 'ok';
+
+export default Auth;
+
+export const unusedAuthHelper = () => 'unused';

--- a/tests/fixtures/vite-array-alias-project/src/main.js
+++ b/tests/fixtures/vite-array-alias-project/src/main.js
@@ -1,0 +1,3 @@
+import Auth from '@/auth.js';
+
+console.log(Auth);

--- a/tests/fixtures/vite-array-alias-project/test/support.js
+++ b/tests/fixtures/vite-array-alias-project/test/support.js
@@ -1,0 +1,1 @@
+export const support = 'unused';

--- a/tests/fixtures/vite-array-alias-project/vite.config.js
+++ b/tests/fixtures/vite-array-alias-project/vite.config.js
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: '@', replacement: path.resolve(__dirname, 'src') },
+      { find: 'test', replacement: path.resolve(__dirname, 'test') }
+    ]
+  }
+});


### PR DESCRIPTION
## Summary
- Adds regression coverage for the Vite `resolve.alias` array shape reported in #915.
- Keeps the existing Vite object-alias fixture coverage intact.

## Issue
Refs #915

## Verification
- [x] `cargo check --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `fallow audit --format json --quiet`
- [x] `cargo test -p fallow-core --test integration_test vite_aliases_from_config_resolve_internal_modules --`
- [x] `cargo test -p fallow-core --test integration_test vite_array_aliases_from_config_resolve_internal_modules --`
- [x] Vite array-alias fixture smoke
- [x] Real-world Vite benchmark smoke
