### PR TITLE
perf(cli): avoid CI renderer JSON roundtrip

### DIFF
--- a/crates/cli/src/combined.rs
+++ b/crates/cli/src/combined.rs
@@ -346,44 +346,48 @@ fn print_combined_report(
             }
         }
         OutputFormat::PrCommentGithub => {
-            let value = build_combined_codeclimate(check_result, dupes_result, health_result);
-            let code = report::ci::pr_comment::print_pr_comment(
+            let issues =
+                build_combined_codeclimate_issues(check_result, dupes_result, health_result);
+            let code = report::ci::pr_comment::print_pr_comment_from_codeclimate_issues(
                 "combined",
                 report::ci::pr_comment::Provider::Github,
-                &value,
+                &issues,
             );
             if code != ExitCode::SUCCESS {
                 return Err(code);
             }
         }
         OutputFormat::PrCommentGitlab => {
-            let value = build_combined_codeclimate(check_result, dupes_result, health_result);
-            let code = report::ci::pr_comment::print_pr_comment(
+            let issues =
+                build_combined_codeclimate_issues(check_result, dupes_result, health_result);
+            let code = report::ci::pr_comment::print_pr_comment_from_codeclimate_issues(
                 "combined",
                 report::ci::pr_comment::Provider::Gitlab,
-                &value,
+                &issues,
             );
             if code != ExitCode::SUCCESS {
                 return Err(code);
             }
         }
         OutputFormat::ReviewGithub => {
-            let value = build_combined_codeclimate(check_result, dupes_result, health_result);
-            let code = report::ci::review::print_review_envelope(
+            let issues =
+                build_combined_codeclimate_issues(check_result, dupes_result, health_result);
+            let code = report::ci::review::print_review_envelope_from_codeclimate_issues(
                 "combined",
                 report::ci::pr_comment::Provider::Github,
-                &value,
+                &issues,
             );
             if code != ExitCode::SUCCESS {
                 return Err(code);
             }
         }
         OutputFormat::ReviewGitlab => {
-            let value = build_combined_codeclimate(check_result, dupes_result, health_result);
-            let code = report::ci::review::print_review_envelope(
+            let issues =
+                build_combined_codeclimate_issues(check_result, dupes_result, health_result);
+            let code = report::ci::review::print_review_envelope_from_codeclimate_issues(
                 "combined",
                 report::ci::pr_comment::Provider::Gitlab,
-                &value,
+                &issues,
             );
             if code != ExitCode::SUCCESS {
                 return Err(code);
@@ -807,6 +811,15 @@ fn build_combined_codeclimate(
     dupes: Option<&DupesResult>,
     health: Option<&HealthResult>,
 ) -> serde_json::Value {
+    let all_issues = build_combined_codeclimate_issues(check, dupes, health);
+    serde_json::to_value(&all_issues).expect("CodeClimateIssue serializes infallibly")
+}
+
+fn build_combined_codeclimate_issues(
+    check: Option<&CheckResult>,
+    dupes: Option<&DupesResult>,
+    health: Option<&HealthResult>,
+) -> Vec<crate::output_envelope::CodeClimateIssue> {
     let mut all_issues: Vec<crate::output_envelope::CodeClimateIssue> = Vec::new();
     if let Some(result) = check {
         all_issues.extend(report::build_codeclimate(
@@ -830,7 +843,7 @@ fn build_combined_codeclimate(
         ));
     }
 
-    serde_json::to_value(&all_issues).expect("CodeClimateIssue serializes infallibly")
+    all_issues
 }
 
 /// Build the dupes options and dispatch to either `execute_dupes` or

--- a/crates/cli/src/report/ci/pr_comment.rs
+++ b/crates/cli/src/report/ci/pr_comment.rs
@@ -4,6 +4,8 @@ use std::sync::OnceLock;
 
 use serde_json::Value;
 
+use crate::output_envelope::{CodeClimateIssue, CodeClimateSeverity};
+
 /// Workspace name, set once by `main()` when the binary is invoked with
 /// `--workspace <name>`. Read by `sticky_marker_id` to auto-suffix the
 /// sticky-comment marker per workspace, which keeps parallel per-workspace
@@ -91,8 +93,17 @@ pub fn issues_from_codeclimate(value: &Value) -> Vec<CiIssue> {
         .flatten()
         .filter_map(issue_from_codeclimate)
         .collect::<Vec<_>>();
+    sort_ci_issues(&mut issues);
     issues
-        .sort_by(|a, b| (&a.path, a.line, &a.fingerprint).cmp(&(&b.path, b.line, &b.fingerprint)));
+}
+
+#[must_use]
+pub fn issues_from_codeclimate_issues(issues: &[CodeClimateIssue]) -> Vec<CiIssue> {
+    let mut issues = issues
+        .iter()
+        .map(issue_from_codeclimate_issue)
+        .collect::<Vec<_>>();
+    sort_ci_issues(&mut issues);
     issues
 }
 
@@ -128,6 +139,32 @@ fn issue_from_codeclimate(value: &Value) -> Option<CiIssue> {
     })
 }
 
+fn issue_from_codeclimate_issue(issue: &CodeClimateIssue) -> CiIssue {
+    CiIssue {
+        rule_id: issue.check_name.clone(),
+        description: issue.description.clone(),
+        severity: codeclimate_severity_label(issue.severity).to_owned(),
+        path: issue.location.path.clone(),
+        line: u64::from(issue.location.lines.begin),
+        fingerprint: issue.fingerprint.clone(),
+    }
+}
+
+const fn codeclimate_severity_label(severity: CodeClimateSeverity) -> &'static str {
+    match severity {
+        CodeClimateSeverity::Info => "info",
+        CodeClimateSeverity::Minor => "minor",
+        CodeClimateSeverity::Major => "major",
+        CodeClimateSeverity::Critical => "critical",
+        CodeClimateSeverity::Blocker => "blocker",
+    }
+}
+
+fn sort_ci_issues(issues: &mut [CiIssue]) {
+    issues
+        .sort_by(|a, b| (&a.path, a.line, &a.fingerprint).cmp(&(&b.path, b.line, &b.fingerprint)));
+}
+
 #[must_use]
 #[expect(clippy::expect_used, reason = "formatting into String is infallible")]
 pub fn render_pr_comment(command: &str, provider: Provider, issues: &[CiIssue]) -> String {
@@ -152,8 +189,8 @@ pub fn render_pr_comment(command: &str, provider: Provider, issues: &[CiIssue]) 
     } else {
         write!(&mut out, "Found **{count}** {noun}.\n\n").expect("write to string");
         let groups = group_by_category(issues);
-        if groups.len() == 1 {
-            render_findings_table(&mut out, issues, max, "Details");
+        if let [(_, group_issues)] = groups.as_slice() {
+            render_findings_table(&mut out, group_issues, max, "Details");
         } else {
             for (category, group_issues) in &groups {
                 let summary_label = summary_label(category, group_issues.len(), max);
@@ -179,7 +216,7 @@ fn summary_label(category: &str, total: usize, max: usize) -> String {
 }
 
 #[expect(clippy::expect_used, reason = "formatting into String is infallible")]
-fn render_findings_table(out: &mut String, issues: &[CiIssue], max: usize, summary: &str) {
+fn render_findings_table(out: &mut String, issues: &[&CiIssue], max: usize, summary: &str) {
     writeln!(out, "<details>\n<summary>{summary}</summary>\n").expect("write to string");
     out.push_str("| Severity | Rule | Location | Description |\n");
     out.push_str("| --- | --- | --- | --- |\n");
@@ -263,14 +300,14 @@ const CATEGORY_ORDER: [&str; 6] = [
     "Suppressions",
 ];
 
-fn group_by_category(issues: &[CiIssue]) -> Vec<(&'static str, Vec<CiIssue>)> {
-    let mut buckets: std::collections::BTreeMap<&'static str, Vec<CiIssue>> =
+fn group_by_category(issues: &[CiIssue]) -> Vec<(&'static str, Vec<&CiIssue>)> {
+    let mut buckets: std::collections::BTreeMap<&'static str, Vec<&CiIssue>> =
         std::collections::BTreeMap::new();
     for issue in issues {
         let category = category_for_rule(&issue.rule_id);
-        buckets.entry(category).or_default().push(issue.clone());
+        buckets.entry(category).or_default().push(issue);
     }
-    let mut ordered: Vec<(&'static str, Vec<CiIssue>)> = Vec::with_capacity(buckets.len());
+    let mut ordered: Vec<(&'static str, Vec<&CiIssue>)> = Vec::with_capacity(buckets.len());
     for category in CATEGORY_ORDER {
         if let Some(items) = buckets.remove(category) {
             ordered.push((category, items));
@@ -341,7 +378,27 @@ fn sanitize_marker_segment(value: &str) -> String {
 pub fn print_pr_comment(command: &str, provider: Provider, codeclimate: &Value) -> ExitCode {
     let issues =
         super::diff_filter::filter_issues_for_summary(issues_from_codeclimate(codeclimate));
-    println!("{}", render_pr_comment(command, provider, &issues));
+    print_pr_comment_from_ci_issues(command, provider, &issues)
+}
+
+#[must_use]
+pub fn print_pr_comment_from_codeclimate_issues(
+    command: &str,
+    provider: Provider,
+    codeclimate: &[CodeClimateIssue],
+) -> ExitCode {
+    let issues =
+        super::diff_filter::filter_issues_for_summary(issues_from_codeclimate_issues(codeclimate));
+    print_pr_comment_from_ci_issues(command, provider, &issues)
+}
+
+#[must_use]
+fn print_pr_comment_from_ci_issues(
+    command: &str,
+    provider: Provider,
+    issues: &[CiIssue],
+) -> ExitCode {
+    println!("{}", render_pr_comment(command, provider, issues));
     ExitCode::SUCCESS
 }
 
@@ -428,6 +485,50 @@ mod tests {
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].path, "src/a.ts");
         assert_eq!(issues[0].line, 7);
+    }
+
+    #[test]
+    fn typed_codeclimate_issues_extract_like_json_codeclimate() {
+        let severities = [
+            (CodeClimateSeverity::Info, "info"),
+            (CodeClimateSeverity::Minor, "minor"),
+            (CodeClimateSeverity::Major, "major"),
+            (CodeClimateSeverity::Critical, "critical"),
+            (CodeClimateSeverity::Blocker, "blocker"),
+        ];
+        let typed = severities
+            .iter()
+            .enumerate()
+            .map(|(index, (severity, _))| CodeClimateIssue {
+                kind: crate::output_envelope::CodeClimateIssueKind::Issue,
+                check_name: format!("fallow/rule-{index}"),
+                description: format!("Finding {index}"),
+                categories: vec!["Complexity".to_owned()],
+                severity: *severity,
+                fingerprint: format!("fp-{index}"),
+                location: crate::output_envelope::CodeClimateLocation {
+                    path: format!("src/{index}.ts"),
+                    lines: crate::output_envelope::CodeClimateLines {
+                        begin: u32::try_from(index + 1).expect("small fixture index"),
+                    },
+                },
+            })
+            .collect::<Vec<_>>();
+        let value = serde_json::to_value(&typed).expect("typed fixture serializes");
+
+        assert_eq!(
+            issues_from_codeclimate_issues(&typed),
+            issues_from_codeclimate(&value)
+        );
+        let typed_labels = issues_from_codeclimate_issues(&typed)
+            .into_iter()
+            .map(|issue| issue.severity)
+            .collect::<Vec<_>>();
+        let expected_labels = severities
+            .iter()
+            .map(|(_, label)| (*label).to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(typed_labels, expected_labels);
     }
 
     #[test]

--- a/crates/cli/src/report/ci/review.rs
+++ b/crates/cli/src/report/ci/review.rs
@@ -4,13 +4,15 @@ use serde_json::Value;
 
 use super::diff_filter::DiffIndex;
 use super::fingerprint::{composite_fingerprint, summary_fingerprint};
-use super::pr_comment::{CiIssue, Provider, command_title, escape_md};
+use super::pr_comment::{
+    CiIssue, Provider, command_title, escape_md, issues_from_codeclimate_issues,
+};
 use super::severity;
 use crate::output_envelope::{
-    GitHubReviewComment, GitHubReviewSide, GitLabReviewComment, GitLabReviewPosition,
-    GitLabReviewPositionType, ReviewCheckConclusion, ReviewComment, ReviewEnvelopeEvent,
-    ReviewEnvelopeMeta, ReviewEnvelopeOutput, ReviewEnvelopeSchema, ReviewEnvelopeSummary,
-    ReviewProvider, default_marker_regex, default_marker_regex_flags,
+    CodeClimateIssue, GitHubReviewComment, GitHubReviewSide, GitLabReviewComment,
+    GitLabReviewPosition, GitLabReviewPositionType, ReviewCheckConclusion, ReviewComment,
+    ReviewEnvelopeEvent, ReviewEnvelopeMeta, ReviewEnvelopeOutput, ReviewEnvelopeSchema,
+    ReviewEnvelopeSummary, ReviewProvider, default_marker_regex, default_marker_regex_flags,
 };
 use crate::report::emit_json;
 
@@ -81,11 +83,10 @@ pub fn render_review_envelope_with_diff(
         .flatten();
     let include_guidance = review_guidance_enabled();
 
-    let merged_groups = group_by_path_line(issues);
+    let merged_groups = group_by_path_line(issues, max);
 
     let comments: Vec<ReviewComment> = merged_groups
         .iter()
-        .take(max)
         .map(|group| {
             render_merged_comment(
                 provider,
@@ -143,15 +144,35 @@ pub fn render_review_envelope_with_diff(
 }
 
 #[must_use]
-#[expect(
-    clippy::expect_used,
-    reason = "review envelope contains only infallibly serializable fields"
-)]
 pub fn print_review_envelope(command: &str, provider: Provider, codeclimate: &Value) -> ExitCode {
     let issues = super::diff_filter::filter_issues_from_env(
         super::pr_comment::issues_from_codeclimate(codeclimate),
     );
-    let envelope = render_review_envelope(command, provider, &issues);
+    print_review_envelope_from_ci_issues(command, provider, &issues)
+}
+
+#[must_use]
+pub fn print_review_envelope_from_codeclimate_issues(
+    command: &str,
+    provider: Provider,
+    codeclimate: &[CodeClimateIssue],
+) -> ExitCode {
+    let issues =
+        super::diff_filter::filter_issues_from_env(issues_from_codeclimate_issues(codeclimate));
+    print_review_envelope_from_ci_issues(command, provider, &issues)
+}
+
+#[must_use]
+#[expect(
+    clippy::expect_used,
+    reason = "review envelope contains only infallibly serializable fields"
+)]
+fn print_review_envelope_from_ci_issues(
+    command: &str,
+    provider: Provider,
+    issues: &[CiIssue],
+) -> ExitCode {
+    let envelope = render_review_envelope(command, provider, issues);
     let value = crate::output_envelope::serialize_root_output(
         crate::output_envelope::FallowOutput::ReviewEnvelope(envelope),
     )
@@ -202,8 +223,11 @@ fn env_truthy(value: &str) -> bool {
 
 /// Group consecutive same-(path, line) issues. Input is already sorted by
 /// `(path, line, fingerprint)` so a single linear pass collects runs.
-fn group_by_path_line(issues: &[CiIssue]) -> Vec<Vec<&CiIssue>> {
-    let mut groups: Vec<Vec<&CiIssue>> = Vec::new();
+fn group_by_path_line(issues: &[CiIssue], max_groups: usize) -> Vec<Vec<&CiIssue>> {
+    if max_groups == 0 {
+        return Vec::new();
+    }
+    let mut groups: Vec<Vec<&CiIssue>> = Vec::with_capacity(max_groups.min(issues.len()));
     let mut current: Vec<&CiIssue> = Vec::new();
     let mut current_key: Option<(&str, u64)> = None;
     for issue in issues {
@@ -211,12 +235,15 @@ fn group_by_path_line(issues: &[CiIssue]) -> Vec<Vec<&CiIssue>> {
         if Some(key) != current_key {
             if !current.is_empty() {
                 groups.push(std::mem::take(&mut current));
+                if groups.len() == max_groups {
+                    return groups;
+                }
             }
             current_key = Some(key);
         }
         current.push(issue);
     }
-    if !current.is_empty() {
+    if !current.is_empty() && groups.len() < max_groups {
         groups.push(current);
     }
     groups
@@ -612,6 +639,34 @@ mod tests {
         assert!(
             merged.get("constituent_fingerprints").is_none(),
             "v2 hashed-composite design does not emit constituent_fingerprints"
+        );
+    }
+
+    #[test]
+    fn group_by_path_line_respects_max_groups_without_splitting_same_line_findings() {
+        let a = issue("fallow/unused-export", "minor", "src/foo.ts", 42, "fp_a");
+        let b = issue("fallow/duplicate-export", "minor", "src/foo.ts", 42, "fp_b");
+        let c = issue("fallow/unused-type", "minor", "src/z.ts", 7, "fp_c");
+        let issues = vec![a, b, c];
+
+        assert!(group_by_path_line(&issues, 0).is_empty());
+
+        let max_one = group_by_path_line(&issues, 1);
+        assert_eq!(max_one.len(), 1);
+        assert_eq!(max_one[0].len(), 2);
+        assert_eq!(max_one[0][0].path, "src/foo.ts");
+        assert_eq!(max_one[0][0].line, 42);
+
+        let max_two = group_by_path_line(&issues, 2);
+        assert_eq!(max_two.len(), 2);
+        assert_eq!(max_two[0].len(), 2);
+        assert_eq!(max_two[1].len(), 1);
+        assert_eq!(
+            max_two[0]
+                .iter()
+                .map(|issue| issue.fingerprint.as_str())
+                .collect::<Vec<_>>(),
+            ["fp_a", "fp_b"]
         );
     }
 


### PR DESCRIPTION
Keep combined CodeClimate output as the same serialized array, but let the PR comment and review-envelope paths consume the typed CodeClimate issues directly. This removes the serialize-then-parse hop from combined CI renderers while preserving existing diff filtering and ordering.

The review envelope grouping now applies the comment cap during grouping so large reports stop building unused groups. Regression coverage pins typed severity parity and max-comment behavior, including zero comments and same-line merged findings.