### PR TITLE
fix(vscode): format audit status bar imports

### DIFF
--- a/editors/vscode/src/auditStatusBar.ts
+++ b/editors/vscode/src/auditStatusBar.ts
@@ -1,7 +1,11 @@
 // VS Code injects this module into the extension host at runtime.
 // fallow-ignore-next-line unlisted-dependency
 import * as vscode from "vscode";
-import { auditGatingSuffix, auditVerdictPresentation, buildAuditTooltipMarkdown } from "./audit-utils.js";
+import {
+  auditGatingSuffix,
+  auditVerdictPresentation,
+  buildAuditTooltipMarkdown,
+} from "./audit-utils.js";
 import { getChangedSince } from "./config.js";
 import type { AuditOutput } from "./types.js";
 


### PR DESCRIPTION
## Summary
- Format `editors/vscode/src/auditStatusBar.ts` so the root JS format check passes.

## Verification
- `npm run lint:js`
- `npm run fmt:js:check`
