### PR TITLE
fix(mcp): gate unix-only test helpers

### DIFF
--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -185,7 +185,7 @@ pub async fn run_tool(
     spawn_fallow(binary, args, timeout_duration(), Some(tool)).await
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub async fn run_fallow_with_timeout(
     binary: &str,
     args: &[String],
@@ -288,7 +288,7 @@ async fn spawn_fallow(
 /// Execute fallow and ensure successful JSON responses have a top-level
 /// `warnings` array for agent-facing runtime context tools. Untagged variant
 /// retained for tests; production goes through `run_tool_with_top_level_warnings`.
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub async fn run_fallow_with_top_level_warnings(
     binary: &str,
     args: &[String],


### PR DESCRIPTION
## Summary
- Compile Unix shell-based MCP test helpers only for Unix test builds so Windows Clippy does not flag them as unused.

## Verification
- cargo clippy -p fallow-mcp --all-targets -- -D warnings
- cargo test -p fallow-mcp --all-targets
- cargo fmt --all -- --check
- git diff --check