### PR TITLE
feat: add opt-in hardcoded secret candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ fallow audit                 # Audit changed files (verdict: pass/warn/fail)
 fallow health                # Complexity + refactor targets
 fallow dupes                 # Repeated logic
 fallow dead-code             # Cleanup candidates
-fallow security              # Security candidates including secret leaks and dangerous sinks
+fallow security              # Security candidates, hardcoded-secret needs explicit category include
 fallow explain unused-export # Explain a rule without analyzing
 fallow watch                 # Re-analyze on file changes
 fallow fix --dry-run         # Preview automatic cleanup

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -962,7 +962,7 @@ enum Command {
 
     /// Surface local security candidates for downstream agent verification (opt-in).
     ///
-    /// Ships two complementary surfaces. (1) The graph-structural
+    /// Ships three complementary surfaces. (1) The graph-structural
     /// `client-server-leak` rule: a `"use client"` file that transitively imports
     /// a module reading a non-public env secret through `process.env` or
     /// `import.meta.env`. (2) The data-driven
@@ -973,8 +973,11 @@ enum Command {
     /// open-redirect, mass-assignment, weak-crypto, deprecated-cipher,
     /// insecure-randomness, unsafe-buffer-alloc, unsafe-deserialization,
     /// prototype-pollution, zip-slip, nosql-injection, ssti, xxe, xpath-injection,
-    /// and webview-injection. All findings are CANDIDATES for
-    /// verification, NOT verified vulnerabilities. This command is the only
+    /// and webview-injection. (3) `hardcoded-secret`, an include-required
+    /// category for provider-prefix literals and high-entropy literals assigned
+    /// to secret-shaped identifiers. It never runs from raw entropy alone. All
+    /// findings are CANDIDATES for verification, NOT verified vulnerabilities.
+    /// This command is the only
     /// surface for security findings; they never appear under bare `fallow` or
     /// the `audit` gate. Build-config and test files are excluded, and public
     /// env prefixes such as `NEXT_PUBLIC_` and `VITE_` are treated as public.

--- a/crates/config/src/config/mod.rs
+++ b/crates/config/src/config/mod.rs
@@ -218,19 +218,21 @@ pub struct FallowConfig {
     pub cache: CacheConfig,
 }
 
-/// Scopes the data-driven security matcher catalogue used by `fallow security`.
-/// An absent block (or both `include`/`exclude` unset) admits every category.
+/// Scopes the security categories used by `fallow security`. An absent block
+/// admits every catalogue category. `hardcoded-secret` is include-required and
+/// only runs when explicitly listed in `security.categories.include`.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SecurityConfig {
-    /// Include/exclude filter over catalogue category ids (e.g. `dangerous-html`).
+    /// Include/exclude filter over category ids (e.g. `dangerous-html`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub categories: Option<SecurityCategories>,
 }
 
-/// Include/exclude lists scoping the active security matcher categories. When
-/// `include` is set, only those categories are active; `exclude` removes
-/// categories from the admitted set. Both unset admits every category.
+/// Include/exclude lists scoping the active security categories. When `include`
+/// is set, only those categories are active; `exclude` removes categories from
+/// the admitted set. Both unset admits catalogue categories. `hardcoded-secret`
+/// still requires explicit inclusion.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SecurityCategories {

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -910,6 +910,16 @@ pub fn find_dead_code_full(
         );
         results.security_findings.extend(sink_findings);
         results.security_unresolved_callee_sites = sink_stats.sinks_skipped_dynamic_callee;
+        results
+            .security_findings
+            .extend(security::find_hardcoded_secret_candidates(
+                graph,
+                modules,
+                &suppressions,
+                &line_offsets_by_file,
+                &filter,
+                &config.root,
+            ));
     }
 
     // Reachability-weighted ranking (issue #860): order security candidates so

--- a/crates/core/src/analyze/security/hardcoded_secret.rs
+++ b/crates/core/src/analyze/security/hardcoded_secret.rs
@@ -1,0 +1,430 @@
+//! Opt-in hardcoded-secret candidate detector.
+//!
+//! This detector consumes extractor-captured static string literals and emits
+//! conservative first-party candidates only when a provider token shape matches,
+//! or high entropy is corroborated by a secret-shaped identifier.
+
+use rustc_hash::FxHashMap;
+
+use fallow_types::extract::{ModuleInfo, SinkLiteralValue, SinkShape};
+use fallow_types::results::{SecurityFinding, SecurityFindingKind, TraceHop, TraceHopRole};
+use fallow_types::suppress::IssueKind;
+
+use super::tainted_sink::{CategoryFilter, build_actions, is_low_value_anchor};
+use super::{LineOffsetsMap, byte_offset_to_line_col};
+use crate::discover::FileId;
+use crate::graph::ModuleGraph;
+use crate::suppress::SuppressionContext;
+
+pub const CATEGORY_ID: &str = "hardcoded-secret";
+pub const CATEGORY_TITLE: &str = "Hardcoded secret candidate";
+const CWE_ID: u32 = 798;
+const MIN_ENTROPY_LENGTH: usize = 20;
+const MIN_ENTROPY_BITS_PER_CHAR: f64 = 4.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretSignal {
+    Provider(&'static str),
+    EntropyWithIdentifier,
+}
+
+#[must_use]
+pub fn find_hardcoded_secret_candidates(
+    graph: &ModuleGraph,
+    modules: &[ModuleInfo],
+    suppressions: &SuppressionContext<'_>,
+    line_offsets_by_file: &LineOffsetsMap<'_>,
+    category_filter: &CategoryFilter,
+    root: &std::path::Path,
+) -> Vec<SecurityFinding> {
+    if !category_filter.explicitly_admits(CATEGORY_ID) {
+        return Vec::new();
+    }
+
+    let modules_by_id: FxHashMap<FileId, &ModuleInfo> =
+        modules.iter().map(|m| (m.file_id, m)).collect();
+
+    let mut findings = Vec::new();
+    for node in &graph.modules {
+        let Some(module) = modules_by_id.get(&node.file_id) else {
+            continue;
+        };
+        if module.security_sinks.is_empty() {
+            continue;
+        }
+        let rel_path = node.path.strip_prefix(root).unwrap_or(&node.path);
+        if is_low_value_anchor(rel_path) {
+            continue;
+        }
+        let file_id = node.file_id;
+        if suppressions.is_file_suppressed(file_id, IssueKind::SecuritySink) {
+            continue;
+        }
+
+        for sink in &module.security_sinks {
+            if sink.sink_shape != SinkShape::SecretLiteral {
+                continue;
+            }
+            let Some(SinkLiteralValue::String(value)) = sink.arg_literal.as_ref() else {
+                continue;
+            };
+            let Some(signal) = classify_secret_literal(&sink.callee_path, value) else {
+                continue;
+            };
+            let (line, col) =
+                byte_offset_to_line_col(line_offsets_by_file, file_id, sink.span_start);
+            if suppressions.is_suppressed(file_id, line, IssueKind::SecuritySink) {
+                continue;
+            }
+
+            let evidence = redacted_evidence(signal, &sink.callee_path);
+            let path = node.path.clone();
+            findings.push(SecurityFinding {
+                kind: SecurityFindingKind::TaintedSink,
+                category: Some(CATEGORY_ID.to_string()),
+                cwe: Some(CWE_ID),
+                path: path.clone(),
+                line,
+                col,
+                evidence,
+                source_backed: false,
+                trace: vec![TraceHop {
+                    path,
+                    line,
+                    col,
+                    role: TraceHopRole::Sink,
+                }],
+                actions: build_actions(),
+                reachability: None,
+                dead_code: None,
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then(a.line.cmp(&b.line))
+            .then(a.col.cmp(&b.col))
+            .then(a.category.cmp(&b.category))
+    });
+    findings
+}
+
+fn classify_secret_literal(context_name: &str, value: &str) -> Option<SecretSignal> {
+    if is_allowlisted_literal(value) {
+        return None;
+    }
+    if let Some(provider) = provider_secret_family(value) {
+        return Some(SecretSignal::Provider(provider));
+    }
+    if is_secret_shaped_identifier(context_name) && has_high_entropy(value) {
+        return Some(SecretSignal::EntropyWithIdentifier);
+    }
+    None
+}
+
+fn redacted_evidence(signal: SecretSignal, context_name: &str) -> String {
+    match signal {
+        SecretSignal::Provider(provider) => format!(
+            "Static string literal matches the {provider} credential shape. Verify whether this is a real secret, then rotate and move it to secret storage if needed."
+        ),
+        SecretSignal::EntropyWithIdentifier => format!(
+            "High-entropy static string literal assigned to secret-shaped identifier `{context_name}`. Verify whether this is a real secret, then rotate and move it to secret storage if needed."
+        ),
+    }
+}
+
+fn provider_secret_family(value: &str) -> Option<&'static str> {
+    if is_aws_access_key(value) {
+        return Some("AWS access key");
+    }
+    if is_github_token(value) {
+        return Some("GitHub token");
+    }
+    if matches_prefixed_len(value, "glpat-", 20) {
+        return Some("GitLab token");
+    }
+    if is_slack_token(value) {
+        return Some("Slack token");
+    }
+    if matches_prefixed_min_len(value, "sk_live_", 16)
+        || matches_prefixed_min_len(value, "rk_live_", 16)
+    {
+        return Some("Stripe key");
+    }
+    if matches_prefixed_min_len(value, "sk-ant-", 20) {
+        return Some("Anthropic key");
+    }
+    if matches_prefixed_min_len(value, "sk-proj-", 20) {
+        return Some("OpenAI project key");
+    }
+    if matches_prefixed_len(value, "AIza", 35) {
+        return Some("Google API key");
+    }
+    if is_sendgrid_key(value) {
+        return Some("SendGrid key");
+    }
+    if matches_prefixed_len(value, "npm_", 36) {
+        return Some("npm token");
+    }
+    if matches_prefixed_min_len(value, "pypi-AgEI", 60) {
+        return Some("PyPI token");
+    }
+    if matches_prefixed_min_len(value, "EAAA", 20) || matches_prefixed_min_len(value, "sq0atp-", 20)
+    {
+        return Some("Square token");
+    }
+    if ["shpat_", "shpss_", "shpca_", "shppa_"]
+        .iter()
+        .any(|prefix| matches_prefixed_min_len(value, prefix, 20))
+    {
+        return Some("Shopify token");
+    }
+    if matches_prefixed_min_len(value, "dp.pt.", 20) {
+        return Some("Doppler token");
+    }
+    if is_digitalocean_token(value) {
+        return Some("DigitalOcean token");
+    }
+    if matches_prefixed_min_len(value, "lin_api_", 20) {
+        return Some("Linear token");
+    }
+    if matches_prefixed_min_len(value, "PMAK-", 20) {
+        return Some("Postman key");
+    }
+    if matches_prefixed_min_len(value, "hf_", 20) {
+        return Some("Hugging Face token");
+    }
+    if matches_prefixed_min_len(value, "dapi", 20) {
+        return Some("Databricks token");
+    }
+    if is_telegram_bot_token(value) {
+        return Some("Telegram bot token");
+    }
+    if matches_prefixed_min_len(value, "AGE-SECRET-KEY-1", 30) {
+        return Some("age secret key");
+    }
+    if is_pem_private_key(value) {
+        return Some("PEM private key");
+    }
+    None
+}
+
+fn is_aws_access_key(value: &str) -> bool {
+    (value.starts_with("AKIA") || value.starts_with("ASIA"))
+        && value.len() == 20
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit())
+}
+
+fn is_github_token(value: &str) -> bool {
+    ["ghp_", "gho_", "ghu_", "ghs_", "ghr_"]
+        .iter()
+        .any(|prefix| matches_prefixed_len(value, prefix, 36))
+        || matches_prefixed_min_len(value, "github_pat_", 70)
+}
+
+fn is_slack_token(value: &str) -> bool {
+    ["xoxb-", "xoxp-", "xoxa-", "xoxr-", "xoxs-"]
+        .iter()
+        .any(|prefix| matches_prefixed_min_len(value, prefix, 16))
+}
+
+fn is_sendgrid_key(value: &str) -> bool {
+    let parts: Vec<&str> = value.split('.').collect();
+    parts.len() == 3 && parts[0] == "SG" && parts[1].len() >= 10 && parts[2].len() >= 10
+}
+
+fn is_digitalocean_token(value: &str) -> bool {
+    ["dop_v1_", "dor_v1_", "dot_v1_", "doo_v1_"]
+        .iter()
+        .any(|prefix| {
+            value.strip_prefix(prefix).is_some_and(|tail| {
+                tail.len() == 64 && tail.chars().all(|ch| ch.is_ascii_hexdigit())
+            })
+        })
+}
+
+fn is_telegram_bot_token(value: &str) -> bool {
+    let Some((id, token)) = value.split_once(':') else {
+        return false;
+    };
+    (8..=10).contains(&id.len())
+        && id.chars().all(|ch| ch.is_ascii_digit())
+        && token.starts_with("AA")
+        && token.len() >= 20
+}
+
+fn is_pem_private_key(value: &str) -> bool {
+    value.contains("-----BEGIN")
+        && value.contains("PRIVATE KEY-----")
+        && !value.contains("PUBLIC KEY-----")
+}
+
+fn matches_prefixed_len(value: &str, prefix: &str, tail_len: usize) -> bool {
+    value
+        .strip_prefix(prefix)
+        .is_some_and(|tail| tail.len() == tail_len && is_token_tail(tail))
+}
+
+fn matches_prefixed_min_len(value: &str, prefix: &str, min_tail_len: usize) -> bool {
+    value
+        .strip_prefix(prefix)
+        .is_some_and(|tail| tail.len() >= min_tail_len && is_token_tail(tail))
+}
+
+fn is_token_tail(value: &str) -> bool {
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+fn is_secret_shaped_identifier(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    [
+        "apikey",
+        "api_key",
+        "accesskey",
+        "access_key",
+        "privatekey",
+        "private_key",
+        "clientsecret",
+        "client_secret",
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "credential",
+        "jwt",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn has_high_entropy(value: &str) -> bool {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() < MIN_ENTROPY_LENGTH {
+        return false;
+    }
+    let mut counts: FxHashMap<char, usize> = FxHashMap::default();
+    for ch in &chars {
+        *counts.entry(*ch).or_default() += 1;
+    }
+    let len = chars.len() as f64;
+    let entropy = counts.values().fold(0.0, |acc, count| {
+        let p = *count as f64 / len;
+        p.mul_add(-p.log2(), acc)
+    });
+    entropy >= MIN_ENTROPY_BITS_PER_CHAR && has_mixed_secret_charset(value)
+}
+
+fn has_mixed_secret_charset(value: &str) -> bool {
+    let has_lower = value.chars().any(|ch| ch.is_ascii_lowercase());
+    let has_upper = value.chars().any(|ch| ch.is_ascii_uppercase());
+    let has_digit = value.chars().any(|ch| ch.is_ascii_digit());
+    let has_symbol = value
+        .chars()
+        .any(|ch| matches!(ch, '_' | '-' | '.' | '/' | '+' | '='));
+    [has_lower, has_upper, has_digit, has_symbol]
+        .into_iter()
+        .filter(|present| *present)
+        .count()
+        >= 3
+}
+
+fn is_allowlisted_literal(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if lower.contains("example")
+        || lower.contains("placeholder")
+        || lower.contains("changeme")
+        || lower.contains("dummy")
+        || lower.contains("fake")
+        || lower.starts_with("data:")
+        || lower.starts_with("sha256-")
+        || lower.starts_with("sha384-")
+        || lower.starts_with("sha512-")
+    {
+        return true;
+    }
+    is_uuid(value) || is_sha_like_hex(value) || is_jwt(value)
+}
+
+fn is_uuid(value: &str) -> bool {
+    let parts: Vec<&str> = value.split('-').collect();
+    parts.len() == 5
+        && [8, 4, 4, 4, 12]
+            .iter()
+            .zip(parts.iter())
+            .all(|(len, part)| part.len() == *len && part.chars().all(|ch| ch.is_ascii_hexdigit()))
+}
+
+fn is_sha_like_hex(value: &str) -> bool {
+    matches!(value.len(), 32 | 40 | 64 | 128) && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn is_jwt(value: &str) -> bool {
+    let parts: Vec<&str> = value.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| part.len() >= 8 && is_base64url(part))
+}
+
+fn is_base64url(value: &str) -> bool {
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_prefix_requires_full_shape() {
+        assert_eq!(
+            provider_secret_family("AKIA1234567890ABCDEF"),
+            Some("AWS access key")
+        );
+        assert_eq!(provider_secret_family("AKIAshort"), None);
+    }
+
+    #[test]
+    fn examples_and_hashes_are_allowlisted() {
+        assert!(is_allowlisted_literal("AKIAIOSFODNN7EXAMPLE"));
+        assert!(is_allowlisted_literal(
+            "0123456789abcdef0123456789abcdef01234567"
+        ));
+        assert!(is_allowlisted_literal(
+            "550e8400-e29b-41d4-a716-446655440000"
+        ));
+    }
+
+    #[test]
+    fn entropy_requires_secret_identifier() {
+        assert_eq!(
+            classify_secret_literal("cacheHash", "mF9a7Qp2Lx8Nz4Rv6Ts0"),
+            None
+        );
+        assert_eq!(
+            classify_secret_literal("WWW-Authenticate", "mF9a7Qp2Lx8Nz4Rv6Ts0"),
+            None
+        );
+        assert_eq!(
+            classify_secret_literal("apiKey", "mF9a7Qp2Lx8Nz4Rv6Ts0"),
+            Some(SecretSignal::EntropyWithIdentifier)
+        );
+    }
+
+    #[test]
+    fn evidence_does_not_include_literal_value() {
+        let value = "mF9a7Qp2Lx8Nz4Rv6Ts0";
+        let evidence = redacted_evidence(
+            classify_secret_literal("apiKey", value).expect("candidate"),
+            "apiKey",
+        );
+        assert!(!evidence.contains(value));
+    }
+}

--- a/crates/core/src/analyze/security/mod.rs
+++ b/crates/core/src/analyze/security/mod.rs
@@ -24,12 +24,22 @@ use crate::graph::ModuleGraph;
 use crate::suppress::SuppressionContext;
 
 mod catalogue;
+mod hardcoded_secret;
 mod rank;
 mod tainted_sink;
 
-pub use catalogue::catalogue_title;
+pub use hardcoded_secret::find_hardcoded_secret_candidates;
 pub use rank::{annotate_dead_code_cross_links, rank_security_findings};
 pub use tainted_sink::{CategoryFilter, find_tainted_sinks};
+
+#[must_use]
+pub fn catalogue_title(id: &str) -> Option<&'static str> {
+    if id == hardcoded_secret::CATEGORY_ID {
+        Some(hardcoded_secret::CATEGORY_TITLE)
+    } else {
+        catalogue::catalogue_title(id)
+    }
+}
 
 /// The inline suppression kind token for the client-server-leak rule.
 const SUPPRESS_KIND: &str = "security-client-server-leak";

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -29,7 +29,7 @@ use crate::suppress::SuppressionContext;
 
 /// The inline suppression kind token for the tainted-sink catalogue rule. ONE
 /// token covers every catalogue category.
-const SUPPRESS_KIND: &str = "security-sink";
+pub(super) const SUPPRESS_KIND: &str = "security-sink";
 
 /// Include/exclude scope over catalogue category ids. Built from
 /// `config.security.categories`; both unset admits every category.
@@ -62,6 +62,24 @@ impl CategoryFilter {
         }
         true
     }
+
+    /// Whether an include-required category is explicitly admitted. An absent
+    /// include list does not admit these categories.
+    #[must_use]
+    pub fn explicitly_admits(&self, id: &str) -> bool {
+        let Some(include) = &self.include else {
+            return false;
+        };
+        if !include.iter().any(|c| c == id) {
+            return false;
+        }
+        if let Some(exclude) = &self.exclude
+            && exclude.iter().any(|c| c == id)
+        {
+            return false;
+        }
+        true
+    }
 }
 
 /// In-band blind-spot accounting for the tainted-sink detector.
@@ -75,7 +93,7 @@ pub struct TaintedSinkStats {
 
 /// Build the machine-actionable file-level suppress hint emitted on every
 /// finding (`auto_fixable: false`: verifying the candidate is the agent's job).
-fn build_actions() -> Vec<IssueAction> {
+pub(super) fn build_actions() -> Vec<IssueAction> {
     vec![IssueAction::SuppressFile(SuppressFileAction {
         kind: SuppressFileKind::SuppressFile,
         auto_fixable: false,
@@ -153,7 +171,7 @@ fn production_exclude_globset() -> &'static globset::GlobSet {
 /// them. The match runs on the workspace-relative path (forward-slash
 /// normalized) so the `**/` globs anchor consistently across platforms; the
 /// config-file predicate is filename-only and is reused verbatim.
-fn is_low_value_anchor(path: &std::path::Path) -> bool {
+pub(super) fn is_low_value_anchor(path: &std::path::Path) -> bool {
     let normalized = path.to_string_lossy().replace('\\', "/");
     production_exclude_globset().is_match(&normalized)
         || crate::analyze::predicates::is_config_file(path)

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -112,6 +112,8 @@ mod security_dangerous_html;
 mod security_dead_code_cross_link;
 #[path = "integration_test/security_framework_sinks.rs"]
 mod security_framework_sinks;
+#[path = "integration_test/security_hardcoded_secret.rs"]
+mod security_hardcoded_secret;
 #[path = "integration_test/security_template_xss_sinks.rs"]
 mod security_template_xss_sinks;
 #[path = "integration_test/stale_suppressions.rs"]

--- a/crates/core/tests/integration_test/security_hardcoded_secret.rs
+++ b/crates/core/tests/integration_test/security_hardcoded_secret.rs
@@ -1,0 +1,91 @@
+//! Integration coverage for opt-in hardcoded-secret candidates.
+
+use fallow_config::{SecurityCategories, SecurityConfig, Severity};
+use fallow_core::results::{AnalysisResults, SecurityFindingKind};
+
+use super::common::{create_config_with_rules, fixture_path};
+
+const FIXTURE: &str = "security-hardcoded-secret-892";
+const CATEGORY: &str = "hardcoded-secret";
+
+fn analyze_with_category(include: bool, exclude: bool) -> AnalysisResults {
+    let root = fixture_path(FIXTURE);
+    let mut config = create_config_with_rules(root, |rules| {
+        rules.security_sink = Severity::Warn;
+    });
+    config.security = SecurityConfig {
+        categories: Some(SecurityCategories {
+            include: include.then(|| vec![CATEGORY.to_string()]),
+            exclude: exclude.then(|| vec![CATEGORY.to_string()]),
+        }),
+    };
+    fallow_core::analyze(&config).expect("analysis should succeed")
+}
+
+fn category_findings(results: &AnalysisResults) -> Vec<&fallow_core::results::SecurityFinding> {
+    results
+        .security_findings
+        .iter()
+        .filter(|finding| finding.category.as_deref() == Some(CATEGORY))
+        .collect()
+}
+
+fn anchored_on(results: &AnalysisResults, suffix: &str) -> bool {
+    results.security_findings.iter().any(|finding| {
+        finding
+            .path
+            .to_string_lossy()
+            .replace('\\', "/")
+            .ends_with(suffix)
+    })
+}
+
+#[test]
+fn hardcoded_secret_category_requires_explicit_include() {
+    let results = analyze_with_category(false, false);
+    assert!(category_findings(&results).is_empty());
+}
+
+#[test]
+fn hardcoded_secret_category_exclude_wins_over_include() {
+    let results = analyze_with_category(true, true);
+    assert!(category_findings(&results).is_empty());
+}
+
+#[test]
+fn hardcoded_secret_category_reports_conservative_candidates() {
+    let results = analyze_with_category(true, false);
+    let findings = category_findings(&results);
+
+    assert!(
+        findings
+            .iter()
+            .all(|finding| matches!(finding.kind, SecurityFindingKind::TaintedSink))
+    );
+    assert!(anchored_on(&results, "src/provider.ts"));
+    assert!(anchored_on(&results, "src/entropy.ts"));
+    assert!(anchored_on(&results, "src/object.ts"));
+    assert!(anchored_on(&results, "src/template.ts"));
+    assert!(anchored_on(&results, "src/assignment.ts"));
+    assert!(!anchored_on(&results, "src/safe.ts"));
+    assert!(!anchored_on(&results, "tests/provider.test.ts"));
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding.cwe == Some(798) && !finding.actions.is_empty())
+    );
+}
+
+#[test]
+fn hardcoded_secret_evidence_redacts_literal_values() {
+    let results = analyze_with_category(true, false);
+    let joined = category_findings(&results)
+        .iter()
+        .map(|finding| finding.evidence.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(!joined.contains("AKIA1234567890ABCDEF"));
+    assert!(!joined.contains("mF9a7Qp2Lx8Nz4Rv6Ts0"));
+    assert!(!joined.contains("n7Pq4Zx9Lm2Qa8Rt5Vb3"));
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -241,7 +241,12 @@ use crate::MemberKind;
 /// Bumped to 129 for issue #901: JS/TS extraction now captures cleartext
 /// request URL literals and `new WebSocket("ws://...")` as security sink sites.
 /// Pre-129 entries omit those sinks until the file is re-extracted.
-pub(super) const CACHE_VERSION: u32 = 129;
+///
+/// Bumped to 130 for issue #892: JS/TS extraction now captures static string
+/// literals assigned to secret-shaped identifiers or known provider credential
+/// prefixes as opt-in hardcoded-secret candidates.
+/// Pre-130 entries omit those candidates until the file is re-extracted.
+pub(super) const CACHE_VERSION: u32 = 130;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -309,6 +309,82 @@ fn security_zero_arg_member_call_capture_records_token_context() {
     assert_eq!(sink.arg_idents, vec!["sessionToken".to_string()]);
 }
 
+#[test]
+fn security_hardcoded_secret_capture_records_variable_literal() {
+    let info = parse(r#"const apiKey = "mF9a7Qp2Lx8Nz4Rv6Ts0";"#);
+    let sink = info
+        .security_sinks
+        .iter()
+        .find(|sink| sink.callee_path == "apiKey")
+        .expect("secret literal sink captured");
+
+    assert_eq!(sink.sink_shape, SinkShape::SecretLiteral);
+    assert_eq!(sink.arg_index, 0);
+    assert!(!sink.arg_is_non_literal);
+    assert_eq!(sink.arg_kind, SinkArgKind::Literal);
+    assert_eq!(
+        sink.arg_literal,
+        Some(SinkLiteralValue::String("mF9a7Qp2Lx8Nz4Rv6Ts0".to_string()))
+    );
+    assert_eq!(sink.arg_idents, vec!["apiKey".to_string()]);
+}
+
+#[test]
+fn security_hardcoded_secret_capture_records_template_literal() {
+    let info = parse("const accessToken = `R8vK2mP9qL4xZ7nT1sB6`;");
+    let sink = info
+        .security_sinks
+        .iter()
+        .find(|sink| sink.callee_path == "accessToken")
+        .expect("template secret literal sink captured");
+
+    assert_eq!(sink.sink_shape, SinkShape::SecretLiteral);
+    assert_eq!(
+        sink.arg_literal,
+        Some(SinkLiteralValue::String("R8vK2mP9qL4xZ7nT1sB6".to_string()))
+    );
+}
+
+#[test]
+fn security_hardcoded_secret_capture_records_object_property_literal() {
+    let info = parse(r#"const config = { clientSecret: "n7Pq4Zx9Lm2Qa8Rt5Vb3" };"#);
+    let sink = info
+        .security_sinks
+        .iter()
+        .find(|sink| sink.callee_path == "clientSecret")
+        .expect("object property secret literal sink captured");
+
+    assert_eq!(sink.sink_shape, SinkShape::SecretLiteral);
+    assert_eq!(
+        sink.arg_literal,
+        Some(SinkLiteralValue::String("n7Pq4Zx9Lm2Qa8Rt5Vb3".to_string()))
+    );
+}
+
+#[test]
+fn security_hardcoded_secret_capture_skips_entropy_only_context() {
+    let info = parse(r#"const cacheHash = "mF9a7Qp2Lx8Nz4Rv6Ts0";"#);
+
+    assert!(
+        !info
+            .security_sinks
+            .iter()
+            .any(|sink| sink.callee_path == "cacheHash")
+    );
+}
+
+#[test]
+fn security_hardcoded_secret_capture_skips_auth_header_context() {
+    let info = parse(r#"const headers = { "WWW-Authenticate": "mF9a7Qp2Lx8Nz4Rv6Ts0" };"#);
+
+    assert!(
+        !info
+            .security_sinks
+            .iter()
+            .any(|sink| sink.callee_path == "WWW-Authenticate")
+    );
+}
+
 fn jwt_verify_options_sink(source: &str) -> fallow_types::extract::SinkSite {
     let info = parse(source);
     info.security_sinks

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2504,6 +2504,10 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     self.binding_target_names.insert(call_key, query.type_arg);
                 }
             }
+
+            if let Some(value) = prop.value.as_ref() {
+                self.capture_hardcoded_secret_literal_sink(name.as_ref(), value, prop.span);
+            }
         }
 
         walk::walk_property_definition(self, prop);
@@ -3058,6 +3062,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             self.record_initialized_declarator_bindings(decl, declarator, init);
             if let BindingPattern::BindingIdentifier(id) = &declarator.id {
                 self.capture_math_random_context_sink(id.name.as_str(), init, declarator.span);
+                self.capture_hardcoded_secret_literal_sink(id.name.as_str(), init, declarator.span);
             }
 
             if let BindingPattern::ObjectPattern(obj_pat) = &declarator.id {
@@ -3181,6 +3186,10 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 is_speculative: false,
             });
             self.handled_import_spans.insert(import_expr.span);
+        }
+
+        if let Some(name) = prop.key.static_name() {
+            self.capture_hardcoded_secret_literal_sink(name.as_ref(), &prop.value, prop.span);
         }
 
         walk::walk_object_property(self, prop);
@@ -3428,6 +3437,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'a>) {
         if let Some(name) = assignment_target_security_context_name(&expr.left) {
             self.capture_math_random_context_sink(name.as_str(), &expr.right, expr.span);
+            self.capture_hardcoded_secret_literal_sink(name.as_str(), &expr.right, expr.span);
         }
 
         if let Some(name) = assignment_target_identifier_name(&expr.left) {
@@ -4005,6 +4015,86 @@ fn sink_literal_value(expr: &Expression<'_>) -> Option<SinkLiteralValue> {
     }
 }
 
+fn static_string_literal_value(expr: &Expression<'_>) -> Option<String> {
+    match unwrap_static_expr(expr) {
+        Expression::StringLiteral(lit) => Some(lit.value.to_string()),
+        Expression::TemplateLiteral(tpl) if tpl.expressions.is_empty() && tpl.quasis.len() == 1 => {
+            tpl.quasis
+                .first()
+                .and_then(|quasi| quasi.value.cooked.as_ref())
+                .map(ToString::to_string)
+        }
+        _ => None,
+    }
+}
+
+fn should_capture_hardcoded_secret_literal(context_name: &str, value: &str) -> bool {
+    is_secret_shaped_context_name(context_name) || has_provider_prefix_capture_hint(value)
+}
+
+fn is_secret_shaped_context_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    [
+        "apikey",
+        "api_key",
+        "accesskey",
+        "access_key",
+        "privatekey",
+        "private_key",
+        "clientsecret",
+        "client_secret",
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "credential",
+        "jwt",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn has_provider_prefix_capture_hint(value: &str) -> bool {
+    value.starts_with("AKIA")
+        || value.starts_with("ASIA")
+        || value.starts_with("ghp_")
+        || value.starts_with("gho_")
+        || value.starts_with("ghu_")
+        || value.starts_with("ghs_")
+        || value.starts_with("ghr_")
+        || value.starts_with("github_pat_")
+        || value.starts_with("glpat-")
+        || value.starts_with("xoxb-")
+        || value.starts_with("xoxp-")
+        || value.starts_with("xoxa-")
+        || value.starts_with("xoxr-")
+        || value.starts_with("xoxs-")
+        || value.starts_with("sk_live_")
+        || value.starts_with("rk_live_")
+        || value.starts_with("sk-ant-")
+        || value.starts_with("sk-proj-")
+        || value.starts_with("AIza")
+        || value.starts_with("SG.")
+        || value.starts_with("npm_")
+        || value.starts_with("pypi-")
+        || value.starts_with("sq0atp-")
+        || value.starts_with("shpat_")
+        || value.starts_with("shpss_")
+        || value.starts_with("shpca_")
+        || value.starts_with("shppa_")
+        || value.starts_with("dp.pt.")
+        || value.starts_with("doo_v1_")
+        || value.starts_with("dop_v1_")
+        || value.starts_with("dor_v1_")
+        || value.starts_with("dot_v1_")
+        || value.starts_with("dapi")
+        || value.starts_with("lin_api_")
+        || value.starts_with("PMAK-")
+        || value.starts_with("hf_")
+        || value.starts_with("AGE-SECRET-KEY-1")
+        || value.contains("-----BEGIN")
+}
+
 fn object_literal_properties(expr: &Expression<'_>) -> Vec<SinkObjectProperty> {
     let Expression::ObjectExpression(obj) = unwrap_static_expr(expr) else {
         return Vec::new();
@@ -4087,7 +4177,7 @@ fn should_capture_literal_sink_arg(
                 && callee_path == "process.env.NODE_TLS_REJECT_UNAUTHORIZED"
                 && value == "0"
         }
-        SinkShape::TaggedTemplate | SinkShape::JsxAttr => false,
+        SinkShape::TaggedTemplate | SinkShape::JsxAttr | SinkShape::SecretLiteral => false,
     }
 }
 
@@ -4942,6 +5032,35 @@ impl ModuleInfoExtractor {
             arg_is_non_literal: false,
             arg_kind: SinkArgKind::NoArg,
             arg_literal: None,
+            object_properties: Vec::new(),
+            object_property_keys: Vec::new(),
+            object_property_keys_complete: false,
+            arg_idents: vec![context_name.to_string()],
+            arg_source_paths: Vec::new(),
+            span_start: span.start,
+            span_end: span.end,
+        });
+    }
+
+    fn capture_hardcoded_secret_literal_sink(
+        &mut self,
+        context_name: &str,
+        expr: &Expression<'_>,
+        span: Span,
+    ) {
+        let Some(value) = static_string_literal_value(expr) else {
+            return;
+        };
+        if !should_capture_hardcoded_secret_literal(context_name, &value) {
+            return;
+        }
+        self.security_sinks.push(SinkSite {
+            sink_shape: SinkShape::SecretLiteral,
+            callee_path: context_name.to_string(),
+            arg_index: 0,
+            arg_is_non_literal: false,
+            arg_kind: SinkArgKind::Literal,
+            arg_literal: Some(SinkLiteralValue::String(value)),
             object_properties: Vec::new(),
             object_property_keys: Vec::new(),
             object_property_keys_complete: false,

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -186,6 +186,9 @@ pub enum SinkShape {
     JsxAttr,
     /// A constructor call (e.g. `new Function("return x")`).
     NewExpression,
+    /// A static string literal assigned to a secret-shaped identifier or known
+    /// provider credential prefix.
+    SecretLiteral,
 }
 
 /// The shape of the argument captured at a sink site. Category-blind like
@@ -870,6 +873,7 @@ mod tests {
             SinkShape::TaggedTemplate,
             SinkShape::JsxAttr,
             SinkShape::NewExpression,
+            SinkShape::SecretLiteral,
         ] {
             let encoded = bitcode::encode(&shape);
             let decoded: SinkShape = bitcode::decode(&encoded).expect("decode sink shape");

--- a/schema.json
+++ b/schema.json
@@ -1188,11 +1188,11 @@
       ]
     },
     "SecurityConfig": {
-      "description": "Scopes the data-driven security matcher catalogue used by `fallow security`.\nAn absent block (or both `include`/`exclude` unset) admits every category.",
+      "description": "Scopes the security categories used by `fallow security`. An absent block\nadmits every catalogue category. `hardcoded-secret` is include-required and\nonly runs when explicitly listed in `security.categories.include`.",
       "type": "object",
       "properties": {
         "categories": {
-          "description": "Include/exclude filter over catalogue category ids (e.g. `dangerous-html`).",
+          "description": "Include/exclude filter over category ids (e.g. `dangerous-html`).",
           "anyOf": [
             {
               "$ref": "#/$defs/SecurityCategories"
@@ -1206,7 +1206,7 @@
       "additionalProperties": false
     },
     "SecurityCategories": {
-      "description": "Include/exclude lists scoping the active security matcher categories. When\n`include` is set, only those categories are active; `exclude` removes\ncategories from the admitted set. Both unset admits every category.",
+      "description": "Include/exclude lists scoping the active security categories. When `include`\nis set, only those categories are active; `exclude` removes categories from\nthe admitted set. Both unset admits catalogue categories. `hardcoded-secret`\nstill requires explicit inclusion.",
       "type": "object",
       "properties": {
         "include": {

--- a/tests/fixtures/security-hardcoded-secret-892/package.json
+++ b/tests/fixtures/security-hardcoded-secret-892/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "security-hardcoded-secret-892-fixture",
+  "version": "0.0.0",
+  "private": true
+}

--- a/tests/fixtures/security-hardcoded-secret-892/src/assignment.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/src/assignment.ts
@@ -1,0 +1,2 @@
+export const settings: { privateKey?: string } = {};
+settings.privateKey = "Qz7Lm2Va9Tp4Nx8Rb5Sc";

--- a/tests/fixtures/security-hardcoded-secret-892/src/entropy.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/src/entropy.ts
@@ -1,0 +1,1 @@
+export const apiKey = "mF9a7Qp2Lx8Nz4Rv6Ts0";

--- a/tests/fixtures/security-hardcoded-secret-892/src/object.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/src/object.ts
@@ -1,0 +1,3 @@
+export const clientConfig = {
+  clientSecret: "n7Pq4Zx9Lm2Qa8Rt5Vb3",
+};

--- a/tests/fixtures/security-hardcoded-secret-892/src/provider.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/src/provider.ts
@@ -1,0 +1,1 @@
+export const publicIdentifier = "AKIA1234567890ABCDEF";

--- a/tests/fixtures/security-hardcoded-secret-892/src/safe.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/src/safe.ts
@@ -1,0 +1,7 @@
+export const cacheHash = "mF9a7Qp2Lx8Nz4Rv6Ts0";
+export const apiKey = "changeme";
+export const token = "550e8400-e29b-41d4-a716-446655440000";
+export const secret = "0123456789abcdef0123456789abcdef01234567";
+export const password = "sha256-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789";
+export const preview = "data:image/png;base64,ZmFrZQ==";
+export const sample = "AKIAIOSFODNN7EXAMPLE";

--- a/tests/fixtures/security-hardcoded-secret-892/src/template.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/src/template.ts
@@ -1,0 +1,1 @@
+export const accessToken = `R8vK2mP9qL4xZ7nT1sB6`;

--- a/tests/fixtures/security-hardcoded-secret-892/tests/provider.test.ts
+++ b/tests/fixtures/security-hardcoded-secret-892/tests/provider.test.ts
@@ -1,0 +1,1 @@
+export const testToken = "AKIA1234567890ABCDEF";

--- a/tests/fixtures/security-hardcoded-secret-892/tsconfig.json
+++ b/tests/fixtures/security-hardcoded-secret-892/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in `hardcoded-secret` security category for first-party static literals.
- Detects known provider credential shapes before entropy, and only uses entropy when the identifier or property name is secret-shaped.
- Keeps the category include-required, redacts literal values from evidence, and skips low-value anchors such as tests and tool config files.

## Issue
Closes #892

## Verification
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
- ./target/debug/fallow audit --format json --quiet
- ./target/debug/fallow security JSON, SARIF, and human smoke on the issue fixture
- Real-project smoke with a temporary `hardcoded-secret` opt-in config
