### PR TITLE
feat(security): rank framework entry-point sources

### DIFF
--- a/crates/core/data/security_matchers.toml
+++ b/crates/core/data/security_matchers.toml
@@ -872,8 +872,11 @@ evidence_template = "Non-literal script bound to {callee} (runs in the embedded 
 # path_patterns are segment-aware (the same engine as callee_patterns): a
 # leading `*.` matches any object prefix, so `*.query` matches `req.query`,
 # `ctx.req.query` (Hono), and `request.query` (Fastify). Bare paths match
-# exactly. This is OUT of scope: inter-procedural flow, fetch()/response-body
-# call results (a call result is not a member-access binding), and aliasing.
+# exactly. Synthetic handler-parameter paths are emitted by the extract layer
+# for recognizable framework callback positions and are dependency-gated below.
+# This is OUT of scope: inter-procedural flow, fetch()/response-body call
+# results (a call result is not a member-access binding), decorator-injected
+# params such as NestJS `@Body()`, and aliasing.
 
 [[source]]
 id = "http-request-input"
@@ -882,6 +885,54 @@ title = "HTTP request input"
 # `*.params`, `*.body` cover `req.query`, `ctx.req.query`, `request.body`, etc.
 # `*.searchParams` covers `new URL(...).searchParams`-style bindings.
 path_patterns = ["*.query", "*.params", "*.body", "*.searchParams"]
+
+[[source]]
+id = "framework-handler-input"
+title = "Framework handler input"
+enabler = "express"
+path_patterns = ["framework.request"]
+
+[[source]]
+id = "framework-handler-input"
+title = "Framework handler input"
+enabler = "fastify"
+path_patterns = ["framework.request"]
+
+[[source]]
+id = "framework-handler-input"
+title = "Framework handler input"
+enabler = "koa"
+path_patterns = ["framework.request"]
+
+[[source]]
+id = "framework-handler-input"
+title = "Framework handler input"
+enabler = "hono"
+path_patterns = ["framework.request"]
+
+[[source]]
+id = "next-handler-input"
+title = "Next.js handler input"
+enabler = "next"
+path_patterns = ["next.request", "next.form-data"]
+
+[[source]]
+id = "queue-job-input"
+title = "Queue job input"
+enabler = "bullmq"
+path_patterns = ["queue.job"]
+
+[[source]]
+id = "queue-job-input"
+title = "Queue job input"
+enabler = "bull"
+path_patterns = ["queue.job"]
+
+[[source]]
+id = "mcp-tool-input"
+title = "MCP tool input"
+enabler = "@modelcontextprotocol/sdk"
+path_patterns = ["mcp.tool-input"]
 
 [[source]]
 id = "process-argv"

--- a/crates/core/src/analyze/security/catalogue.rs
+++ b/crates/core/src/analyze/security/catalogue.rs
@@ -34,6 +34,9 @@ struct RawCatalogue {
 struct RawSource {
     id: String,
     title: String,
+    /// Optional framework enabler, same semantics as matcher enablers.
+    #[serde(default)]
+    enabler: Option<String>,
     path_patterns: Vec<String>,
 }
 
@@ -239,6 +242,7 @@ pub struct Matcher {
 pub struct SourceMatcher {
     pub id: String,
     pub title: String,
+    pub enabler: Option<String>,
     pub path_patterns: Vec<CalleePattern>,
 }
 
@@ -248,6 +252,13 @@ impl SourceMatcher {
     #[must_use]
     pub fn matches(&self, source_path: &str) -> bool {
         self.path_patterns.iter().any(|p| p.matches(source_path))
+    }
+
+    /// Whether this source row's framework enabler is satisfied by the
+    /// project's declared dependency set. Unset means global.
+    #[must_use]
+    pub fn enabler_satisfied(&self, declared_deps: &rustc_hash::FxHashSet<String>) -> bool {
+        enabler_satisfied(self.enabler.as_deref(), declared_deps)
     }
 }
 
@@ -374,18 +385,22 @@ impl Matcher {
     /// activate on exactly the dependency universe the plugins do.
     #[must_use]
     pub fn enabler_satisfied(&self, declared_deps: &rustc_hash::FxHashSet<String>) -> bool {
-        let Some(enabler) = &self.enabler else {
-            return true;
-        };
-        if let Some(prefix) = enabler.strip_suffix('/') {
-            // Trailing-slash prefix match, e.g. `@fastify/` -> `@fastify/static`.
-            // Also admit the bare scope name itself (`@fastify`).
-            declared_deps
-                .iter()
-                .any(|d| d == prefix || d.starts_with(enabler))
-        } else {
-            declared_deps.contains(enabler)
-        }
+        enabler_satisfied(self.enabler.as_deref(), declared_deps)
+    }
+}
+
+fn enabler_satisfied(enabler: Option<&str>, declared_deps: &rustc_hash::FxHashSet<String>) -> bool {
+    let Some(enabler) = enabler else {
+        return true;
+    };
+    if let Some(prefix) = enabler.strip_suffix('/') {
+        // Trailing-slash prefix match, e.g. `@fastify/` -> `@fastify/static`.
+        // Also admit the bare scope name itself (`@fastify`).
+        declared_deps
+            .iter()
+            .any(|d| d == prefix || d.starts_with(enabler))
+    } else {
+        declared_deps.contains(enabler)
     }
 }
 
@@ -418,11 +433,26 @@ impl Catalogue {
 
     /// The id + human title of the first untrusted-source matcher whose pattern
     /// matches the given flattened member-access path, if any (issue #859).
+    #[cfg(test)]
     #[must_use]
     pub fn matching_source(&self, source_path: &str) -> Option<(&str, &str)> {
         self.sources
             .iter()
             .find(|s| s.matches(source_path))
+            .map(|s| (s.id.as_str(), s.title.as_str()))
+    }
+
+    /// The id + human title of the first untrusted-source matcher whose pattern
+    /// and optional framework enabler match the given source path.
+    #[must_use]
+    pub fn matching_source_for_deps(
+        &self,
+        source_path: &str,
+        declared_deps: &rustc_hash::FxHashSet<String>,
+    ) -> Option<(&str, &str)> {
+        self.sources
+            .iter()
+            .find(|s| s.enabler_satisfied(declared_deps) && s.matches(source_path))
             .map(|s| (s.id.as_str(), s.title.as_str()))
     }
 
@@ -642,9 +672,19 @@ fn parse_catalogue(src: &str) -> Result<Catalogue, String> {
             })?;
             path_patterns.push(parsed);
         }
+        let enabler = match entry.enabler {
+            Some(e) if e.trim().is_empty() => {
+                return Err(format!(
+                    "source {:?} has an empty / whitespace enabler; omit the key for a global row",
+                    entry.id
+                ));
+            }
+            other => other,
+        };
         sources.push(SourceMatcher {
             id: entry.id,
             title: entry.title,
+            enabler,
             path_patterns,
         });
     }
@@ -1163,6 +1203,33 @@ evidence_template = "x"
             .expect("http-request-input source present");
         assert!(http.matches("req.query"));
         assert!(!http.matches("process.argv"));
+    }
+
+    #[test]
+    fn source_enabler_gates_framework_param_sources() {
+        let cat = catalogue();
+        let source = cat
+            .sources()
+            .iter()
+            .find(|s| s.id == "framework-handler-input" && s.enabler.as_deref() == Some("express"))
+            .expect("express handler source present");
+        assert!(source.matches("framework.request"));
+
+        let empty = FxHashSet::default();
+        assert!(!source.enabler_satisfied(&empty));
+        assert!(
+            cat.matching_source_for_deps("framework.request", &empty)
+                .is_none(),
+            "framework handler params require an enabler"
+        );
+
+        let mut deps = FxHashSet::default();
+        deps.insert("express".to_string());
+        assert!(source.enabler_satisfied(&deps));
+        assert_eq!(
+            cat.matching_source_for_deps("framework.request", &deps),
+            Some(("framework-handler-input", "Framework handler input"))
+        );
     }
 
     #[test]

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -182,13 +182,16 @@ pub(super) fn is_low_value_anchor(path: &std::path::Path) -> bool {
 /// captured `tainted_binding.source_path` against the catalogue's `[[source]]`
 /// patterns. A sink whose argument references one of these names is
 /// "source-backed", and the matched source title names the input class.
-fn source_tainted_locals(bindings: &[TaintedBinding]) -> FxHashMap<&str, &'static str> {
+fn source_tainted_locals<'b>(
+    bindings: &'b [TaintedBinding],
+    declared_deps: &rustc_hash::FxHashSet<String>,
+) -> FxHashMap<&'b str, &'static str> {
     let cat = catalogue();
-    let mut out: FxHashMap<&str, &'static str> = FxHashMap::default();
+    let mut out: FxHashMap<&'b str, &'static str> = FxHashMap::default();
     for b in bindings {
-        // `matching_source` borrows from the `'static` catalogue, so the title
-        // outlives the per-module computation.
-        if let Some((_, title)) = cat.matching_source(&b.source_path) {
+        // `matching_source_for_deps` borrows from the `'static` catalogue, so
+        // the title outlives the per-module computation.
+        if let Some((_, title)) = cat.matching_source_for_deps(&b.source_path, declared_deps) {
             out.entry(b.local.as_str()).or_insert(title);
         }
     }
@@ -232,7 +235,11 @@ fn sink_has_html_sanitizer(module: &ModuleInfo, sink: &SinkSite) -> bool {
 /// The matched source title if any of a sink's captured argument identifiers
 /// trace to a source-tainted local binding, else `None`. The intra-module,
 /// name-based back-trace from issue #859.
-fn sink_source_title<'t>(sink: &SinkSite, tainted: &FxHashMap<&str, &'t str>) -> Option<&'t str> {
+fn sink_source_title<'t>(
+    sink: &SinkSite,
+    tainted: &FxHashMap<&str, &'t str>,
+    declared_deps: &rustc_hash::FxHashSet<String>,
+) -> Option<&'t str> {
     if !tainted.is_empty()
         && let Some(title) = sink
             .arg_idents
@@ -243,9 +250,10 @@ fn sink_source_title<'t>(sink: &SinkSite, tainted: &FxHashMap<&str, &'t str>) ->
     }
 
     let cat = catalogue();
-    sink.arg_source_paths
-        .iter()
-        .find_map(|path| cat.matching_source(path).map(|(_, title)| title))
+    sink.arg_source_paths.iter().find_map(|path| {
+        cat.matching_source_for_deps(path, declared_deps)
+            .map(|(_, title)| title)
+    })
 }
 
 fn matcher_admits_sink(matcher: &Matcher, sink: &SinkSite, source_title: Option<&str>) -> bool {
@@ -327,10 +335,10 @@ pub fn find_tainted_sinks(
 
         // Source-tainted local names for this module (issue #859). Computed once
         // per module; empty for modules with no source-shaped bindings.
-        let tainted_locals = source_tainted_locals(&module.tainted_bindings);
+        let tainted_locals = source_tainted_locals(&module.tainted_bindings, declared_deps);
 
         for sink in &module.security_sinks {
-            let source_title = sink_source_title(sink, &tainted_locals);
+            let source_title = sink_source_title(sink, &tainted_locals, declared_deps);
             let Some(matcher) = active.iter().copied().find(|m| {
                 matcher_admits_sink(m, sink, source_title)
                     && provenance_satisfied(m, module, &sink.callee_path)
@@ -424,6 +432,7 @@ pub fn find_tainted_sinks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustc_hash::FxHashSet;
 
     #[test]
     fn category_filter_default_admits_all() {
@@ -487,7 +496,7 @@ mod tests {
         // `const id = req.query.id` is source-tainted; `const cfg = config.value`
         // is not (config.value is not an untrusted-source path).
         let bindings = vec![binding("id", "req.query"), binding("cfg", "config.value")];
-        let tainted = source_tainted_locals(&bindings);
+        let tainted = source_tainted_locals(&bindings, &FxHashSet::default());
         assert!(tainted.contains_key("id"));
         assert!(!tainted.contains_key("cfg"));
         // The matched local carries the source's human title.
@@ -497,35 +506,40 @@ mod tests {
     #[test]
     fn sink_is_source_backed_when_arg_traces_to_source() {
         let bindings = vec![binding("id", "req.query")];
-        let tainted = source_tainted_locals(&bindings);
+        let tainted = source_tainted_locals(&bindings, &FxHashSet::default());
         // `eval(id)` traces to the source-tainted `id`.
         assert_eq!(
-            sink_source_title(&sink_with_idents(&["id"]), &tainted),
+            sink_source_title(&sink_with_idents(&["id"]), &tainted, &FxHashSet::default()),
             Some("HTTP request input")
         );
         // `eval(other)` does not.
         assert_eq!(
-            sink_source_title(&sink_with_idents(&["other"]), &tainted),
+            sink_source_title(
+                &sink_with_idents(&["other"]),
+                &tainted,
+                &FxHashSet::default(),
+            ),
             None
         );
     }
 
     #[test]
     fn sink_not_source_backed_with_no_tainted_locals() {
-        let tainted = source_tainted_locals(&[]);
+        let tainted = source_tainted_locals(&[], &FxHashSet::default());
         assert_eq!(
-            sink_source_title(&sink_with_idents(&["id"]), &tainted),
+            sink_source_title(&sink_with_idents(&["id"]), &tainted, &FxHashSet::default()),
             None
         );
     }
 
     #[test]
     fn sink_is_source_backed_when_arg_source_path_matches_catalogue() {
-        let tainted = source_tainted_locals(&[]);
+        let tainted = source_tainted_locals(&[], &FxHashSet::default());
         assert_eq!(
             sink_source_title(
                 &sink_with_idents_and_sources(&["process"], &["process.env.SECRET", "process.env"]),
                 &tainted,
+                &FxHashSet::default(),
             ),
             Some("Environment secret")
         );

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -240,6 +240,14 @@ fn sink_source_title<'t>(
     tainted: &FxHashMap<&str, &'t str>,
     declared_deps: &rustc_hash::FxHashSet<String>,
 ) -> Option<&'t str> {
+    let cat = catalogue();
+    if let Some(title) = sink.arg_source_paths.iter().find_map(|path| {
+        cat.matching_source_for_deps(path, declared_deps)
+            .map(|(_, title)| title)
+    }) {
+        return Some(title);
+    }
+
     if !tainted.is_empty()
         && let Some(title) = sink
             .arg_idents
@@ -249,11 +257,7 @@ fn sink_source_title<'t>(
         return Some(title);
     }
 
-    let cat = catalogue();
-    sink.arg_source_paths.iter().find_map(|path| {
-        cat.matching_source_for_deps(path, declared_deps)
-            .map(|(_, title)| title)
-    })
+    None
 }
 
 fn matcher_admits_sink(matcher: &Matcher, sink: &SinkSite, source_title: Option<&str>) -> bool {
@@ -542,6 +546,23 @@ mod tests {
                 &FxHashSet::default(),
             ),
             Some("Environment secret")
+        );
+    }
+
+    #[test]
+    fn direct_source_path_precedes_broader_tainted_local_source() {
+        let bindings = vec![binding("req", "framework.request")];
+        let mut deps = FxHashSet::default();
+        deps.insert("express".to_string());
+        let tainted = source_tainted_locals(&bindings, &deps);
+
+        assert_eq!(
+            sink_source_title(
+                &sink_with_idents_and_sources(&["req"], &["req.body"]),
+                &tainted,
+                &deps,
+            ),
+            Some("HTTP request input")
         );
     }
 

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -110,6 +110,8 @@ mod security_client_server_leak;
 mod security_dangerous_html;
 #[path = "integration_test/security_dead_code_cross_link.rs"]
 mod security_dead_code_cross_link;
+#[path = "integration_test/security_framework_entry_sources.rs"]
+mod security_framework_entry_sources;
 #[path = "integration_test/security_framework_sinks.rs"]
 mod security_framework_sinks;
 #[path = "integration_test/security_hardcoded_secret.rs"]

--- a/crates/core/tests/integration_test/security_framework_entry_sources.rs
+++ b/crates/core/tests/integration_test/security_framework_entry_sources.rs
@@ -33,6 +33,14 @@ fn express_route_request_param_is_source_backed() {
         "evidence should name the matched framework source: {}",
         finding.evidence
     );
+
+    let accessor_finding = tainted_sink_at_line(&results, 6);
+    assert!(accessor_finding.source_backed);
+    assert!(
+        accessor_finding.evidence.contains("http request input"),
+        "evidence should prefer the specific request accessor source: {}",
+        accessor_finding.evidence
+    );
 }
 
 #[test]

--- a/crates/core/tests/integration_test/security_framework_entry_sources.rs
+++ b/crates/core/tests/integration_test/security_framework_entry_sources.rs
@@ -41,3 +41,27 @@ fn generic_route_callback_param_is_not_source_backed_without_enabler() {
     let finding = tainted_sink_at_line(&results, 5);
     assert!(!finding.source_backed);
 }
+
+#[test]
+fn bullmq_worker_job_param_is_source_backed() {
+    let results = analyze_fixture("security-framework-entry-sources-879-bullmq");
+    let finding = tainted_sink_at_line(&results, 4);
+    assert!(finding.source_backed);
+    assert!(
+        finding.evidence.contains("queue job input"),
+        "evidence should name the matched queue source: {}",
+        finding.evidence
+    );
+}
+
+#[test]
+fn mcp_tool_input_param_is_source_backed() {
+    let results = analyze_fixture("security-framework-entry-sources-879-mcp");
+    let finding = tainted_sink_at_line(&results, 6);
+    assert!(finding.source_backed);
+    assert!(
+        finding.evidence.contains("mcp tool input"),
+        "evidence should name the matched MCP source: {}",
+        finding.evidence
+    );
+}

--- a/crates/core/tests/integration_test/security_framework_entry_sources.rs
+++ b/crates/core/tests/integration_test/security_framework_entry_sources.rs
@@ -1,0 +1,43 @@
+//! Integration tests for framework entry-point sources (#879).
+
+use fallow_config::Severity;
+use fallow_core::results::{AnalysisResults, SecurityFinding, SecurityFindingKind};
+
+use super::common::{create_config_with_rules, fixture_path};
+
+fn analyze_fixture(name: &str) -> AnalysisResults {
+    let root = fixture_path(name);
+    let config = create_config_with_rules(root, |rules| {
+        rules.security_sink = Severity::Warn;
+    });
+    fallow_core::analyze(&config).expect("analysis should succeed")
+}
+
+fn tainted_sink_at_line(results: &AnalysisResults, line: u32) -> &SecurityFinding {
+    results
+        .security_findings
+        .iter()
+        .find(|finding| {
+            matches!(finding.kind, SecurityFindingKind::TaintedSink) && finding.line == line
+        })
+        .unwrap_or_else(|| panic!("tainted sink at line {line}"))
+}
+
+#[test]
+fn express_route_request_param_is_source_backed() {
+    let results = analyze_fixture("security-framework-entry-sources-879-express");
+    let finding = tainted_sink_at_line(&results, 5);
+    assert!(finding.source_backed);
+    assert!(
+        finding.evidence.contains("framework handler input"),
+        "evidence should name the matched framework source: {}",
+        finding.evidence
+    );
+}
+
+#[test]
+fn generic_route_callback_param_is_not_source_backed_without_enabler() {
+    let results = analyze_fixture("security-framework-entry-sources-879-plain");
+    let finding = tainted_sink_at_line(&results, 5);
+    assert!(!finding.source_backed);
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -246,7 +246,11 @@ use crate::MemberKind;
 /// literals assigned to secret-shaped identifiers or known provider credential
 /// prefixes as opt-in hardcoded-secret candidates.
 /// Pre-130 entries omit those candidates until the file is re-extracted.
-pub(super) const CACHE_VERSION: u32 = 130;
+///
+/// Bumped to 131 for issue #879: JS/TS extraction now records synthetic
+/// source bindings for recognizable framework handler parameters. Pre-131
+/// entries omit those bindings and cannot source-rank direct handler params.
+pub(super) const CACHE_VERSION: u32 = 131;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/security_sources.rs
+++ b/crates/extract/src/tests/js_ts/security_sources.rs
@@ -163,6 +163,17 @@ fn route_callback_param_records_framework_source() {
 }
 
 #[test]
+fn route_callback_destructured_param_records_framework_source() {
+    let info = parse_ts("app.post('/run', ({ body }) => { eval(body); });");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "body")
+        .expect("route callback destructured request param source");
+    assert_eq!(binding.source_path, "framework.request");
+}
+
+#[test]
 fn next_route_handler_param_records_next_request_source() {
     let info = parse_ts("export async function POST(request: Request) { eval(request); }");
     let binding = info
@@ -183,4 +194,37 @@ fn server_action_form_data_param_records_next_source() {
         .find(|b| b.local == "formData")
         .expect("server action FormData param source");
     assert_eq!(binding.source_path, "next.form-data");
+}
+
+#[test]
+fn queue_process_callback_param_records_job_source() {
+    let info = parse_ts("queue.process(async (job) => { eval(job); });");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "job")
+        .expect("queue process job param source");
+    assert_eq!(binding.source_path, "queue.job");
+}
+
+#[test]
+fn queue_worker_constructor_param_records_job_source() {
+    let info = parse_ts("new Worker('email', async ({ data }) => { eval(data); });");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "data")
+        .expect("BullMQ worker destructured job param source");
+    assert_eq!(binding.source_path, "queue.job");
+}
+
+#[test]
+fn mcp_tool_callback_param_records_input_source() {
+    let info = parse_ts("server.tool('lookup', schema, async ({ city }) => { eval(city); });");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "city")
+        .expect("MCP tool input param source");
+    assert_eq!(binding.source_path, "mcp.tool-input");
 }

--- a/crates/extract/src/tests/js_ts/security_sources.rs
+++ b/crates/extract/src/tests/js_ts/security_sources.rs
@@ -150,3 +150,37 @@ fn literal_init_records_no_source_binding() {
     let info = parse_ts("const x = 1;\nconst y = \"hello\";");
     assert!(info.tainted_bindings.is_empty());
 }
+
+#[test]
+fn route_callback_param_records_framework_source() {
+    let info = parse_ts("app.post('/run', (req) => { eval(req); });");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "req")
+        .expect("route callback request param source");
+    assert_eq!(binding.source_path, "framework.request");
+}
+
+#[test]
+fn next_route_handler_param_records_next_request_source() {
+    let info = parse_ts("export async function POST(request: Request) { eval(request); }");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "request")
+        .expect("Next route request param source");
+    assert_eq!(binding.source_path, "next.request");
+}
+
+#[test]
+fn server_action_form_data_param_records_next_source() {
+    let info =
+        parse_ts("const action = async (formData: FormData) => { 'use server'; eval(formData); };");
+    let binding = info
+        .tainted_bindings
+        .iter()
+        .find(|b| b.local == "formData")
+        .expect("server action FormData param source");
+    assert_eq!(binding.source_path, "next.form-data");
+}

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -1724,8 +1724,16 @@ impl ModuleInfoExtractor {
         let Some(param) = params.items.first() else {
             return;
         };
-        if let BindingPattern::BindingIdentifier(id) = &param.pattern {
-            self.record_tainted_param_binding(id.name.as_str(), source_path);
+        match &param.pattern {
+            BindingPattern::BindingIdentifier(id) => {
+                self.record_tainted_param_binding(id.name.as_str(), source_path);
+            }
+            BindingPattern::ObjectPattern(obj_pat) => {
+                for local in super::extract_destructured_names(obj_pat) {
+                    self.record_tainted_param_binding(&local, source_path);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -1786,6 +1794,18 @@ impl ModuleInfoExtractor {
             && let Some(params) = last_callback_params(&call.arguments)
         {
             self.record_first_param_source(params, MCP_TOOL_INPUT_SOURCE);
+        }
+    }
+
+    fn record_queue_worker_constructor_param_sources(&mut self, expr: &NewExpression<'_>) {
+        let Some(callee_path) = flatten_callee_path(&expr.callee) else {
+            return;
+        };
+        if callee_path.rsplit('.').next() != Some("Worker") {
+            return;
+        }
+        if let Some(params) = expr.arguments.iter().skip(1).find_map(callback_params) {
+            self.record_first_param_source(params, QUEUE_JOB_SOURCE);
         }
     }
 
@@ -3470,6 +3490,8 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_new_expression(&mut self, expr: &oxc_ast::ast::NewExpression<'a>) {
+        self.record_queue_worker_constructor_param_sources(expr);
+
         if let Some(source) = new_url_import_source(expr) {
             // A `new URL(specifier, import.meta.url)` whose specifier has no file
             // extension may refer to a directory rather than a module (e.g.

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -41,6 +41,11 @@ const PINO_FACTORY_EXPORT: &str = "pino";
 const PINO_TRANSPORT_KEY: &str = "transport";
 const PINO_TARGET_KEY: &str = "target";
 const PINO_TARGETS_KEY: &str = "targets";
+const FRAMEWORK_REQUEST_SOURCE: &str = "framework.request";
+const NEXT_REQUEST_SOURCE: &str = "next.request";
+const NEXT_FORM_DATA_SOURCE: &str = "next.form-data";
+const QUEUE_JOB_SOURCE: &str = "queue.job";
+const MCP_TOOL_INPUT_SOURCE: &str = "mcp.tool-input";
 
 type StaticPackageStringBindings = FxHashMap<String, Vec<String>>;
 type StaticPackageObjectBindings = FxHashMap<String, FxHashMap<String, Vec<String>>>;
@@ -1697,6 +1702,93 @@ impl ModuleInfoExtractor {
         }
     }
 
+    fn record_tainted_param_binding(&mut self, name: &str, source_path: &'static str) {
+        if self
+            .tainted_bindings
+            .iter()
+            .any(|b| b.local == name && b.source_path == source_path)
+        {
+            return;
+        }
+        self.tainted_bindings.push(TaintedBinding {
+            local: name.to_string(),
+            source_path: source_path.to_string(),
+        });
+    }
+
+    fn record_first_param_source(
+        &mut self,
+        params: &FormalParameters<'_>,
+        source_path: &'static str,
+    ) {
+        let Some(param) = params.items.first() else {
+            return;
+        };
+        if let BindingPattern::BindingIdentifier(id) = &param.pattern {
+            self.record_tainted_param_binding(id.name.as_str(), source_path);
+        }
+    }
+
+    fn record_named_param_source(
+        &mut self,
+        params: &FormalParameters<'_>,
+        names: &[&str],
+        source_path: &'static str,
+    ) {
+        for param in &params.items {
+            if let BindingPattern::BindingIdentifier(id) = &param.pattern
+                && names.iter().any(|name| *name == id.name.as_str())
+            {
+                self.record_tainted_param_binding(id.name.as_str(), source_path);
+            }
+        }
+    }
+
+    fn record_next_function_param_sources(&mut self, func: &Function<'_>) {
+        if func
+            .id
+            .as_ref()
+            .is_some_and(|id| is_http_route_handler_name(id.name.as_str()))
+        {
+            self.record_first_param_source(&func.params, NEXT_REQUEST_SOURCE);
+        }
+        if function_body_has_use_server(func.body.as_deref()) {
+            self.record_named_param_source(&func.params, &["formData"], NEXT_FORM_DATA_SOURCE);
+        }
+    }
+
+    fn record_next_arrow_param_sources(&mut self, expr: &ArrowFunctionExpression<'_>) {
+        if function_body_has_use_server(Some(&expr.body)) {
+            self.record_named_param_source(&expr.params, &["formData"], NEXT_FORM_DATA_SOURCE);
+        }
+    }
+
+    fn record_framework_callback_param_sources(&mut self, call: &CallExpression<'_>) {
+        let Some(callee_path) = flatten_callee_path(&call.callee) else {
+            return;
+        };
+        let Some((_, method)) = callee_path.rsplit_once('.') else {
+            return;
+        };
+        if is_route_registration_method(method) {
+            if let Some(params) = route_callback_params(&call.arguments, method) {
+                self.record_first_param_source(params, FRAMEWORK_REQUEST_SOURCE);
+            }
+            return;
+        }
+        if method == "process"
+            && let Some(params) = last_callback_params(&call.arguments)
+        {
+            self.record_first_param_source(params, QUEUE_JOB_SOURCE);
+            return;
+        }
+        if method == "tool"
+            && let Some(params) = last_callback_params(&call.arguments)
+        {
+            self.record_first_param_source(params, MCP_TOOL_INPUT_SOURCE);
+        }
+    }
+
     fn record_dompurify_import_binding(&mut self, source: &str, local: &str, is_type_only: bool) {
         if !is_type_only && self.is_module_scope() && is_dompurify_source(source) {
             self.dompurify_bindings.insert(local.to_string());
@@ -2679,6 +2771,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        self.record_next_function_param_sources(func);
         self.push_function_declaration_scope(&func.params);
         self.function_depth += 1;
         walk::walk_function(self, func, flags);
@@ -2687,6 +2780,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_arrow_function_expression(&mut self, expr: &ArrowFunctionExpression<'a>) {
+        self.record_next_arrow_param_sources(expr);
         self.push_function_declaration_scope(&expr.params);
         self.function_depth += 1;
         walk::walk_arrow_function_expression(self, expr);
@@ -3198,6 +3292,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
         self.record_structural_class_call_candidate(expr);
         self.clear_literal_allowlist_on_mutating_member_call(expr);
+        self.record_framework_callback_param_sources(expr);
 
         if let Some(test_name) = playwright_test_callee_name(&expr.callee) {
             self.member_accesses
@@ -4471,6 +4566,54 @@ fn collect_source_paths_into(expr: &Expression<'_>, out: &mut Vec<String>) {
         }
         _ => {}
     }
+}
+
+fn is_http_route_handler_name(name: &str) -> bool {
+    matches!(
+        name,
+        "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD"
+    )
+}
+
+fn is_route_registration_method(method: &str) -> bool {
+    matches!(
+        method,
+        "all" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "use"
+    )
+}
+
+fn function_body_has_use_server(body: Option<&FunctionBody<'_>>) -> bool {
+    body.is_some_and(|body| {
+        body.directives
+            .iter()
+            .any(|directive| directive.directive.as_str() == "use server")
+    })
+}
+
+fn callback_params<'a>(arg: &'a Argument<'a>) -> Option<&'a FormalParameters<'a>> {
+    match arg {
+        Argument::ArrowFunctionExpression(expr) => Some(&expr.params),
+        Argument::FunctionExpression(expr) => Some(&expr.params),
+        _ => arg.as_expression().and_then(|expr| match expr {
+            Expression::ArrowFunctionExpression(expr) => Some(&*expr.params),
+            Expression::FunctionExpression(expr) => Some(&*expr.params),
+            _ => None,
+        }),
+    }
+}
+
+fn last_callback_params<'a>(args: &'a [Argument<'a>]) -> Option<&'a FormalParameters<'a>> {
+    args.iter().rev().find_map(callback_params)
+}
+
+fn route_callback_params<'a>(
+    args: &'a [Argument<'a>],
+    method: &str,
+) -> Option<&'a FormalParameters<'a>> {
+    if method == "use" {
+        return last_callback_params(args);
+    }
+    args.iter().skip(1).find_map(callback_params)
 }
 
 fn collect_idents_into(expr: &Expression<'_>, out: &mut Vec<String>) {

--- a/tests/fixtures/security-framework-entry-sources-879-bullmq/package.json
+++ b/tests/fixtures/security-framework-entry-sources-879-bullmq/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "security-framework-entry-sources-879-bullmq",
+  "dependencies": {
+    "bullmq": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest"
+  }
+}

--- a/tests/fixtures/security-framework-entry-sources-879-bullmq/src/app.ts
+++ b/tests/fixtures/security-framework-entry-sources-879-bullmq/src/app.ts
@@ -1,0 +1,5 @@
+declare const Worker: new (name: string, handler: (job: { data: unknown }) => void) => unknown;
+
+new Worker("email", ({ data }) => {
+  eval(data);
+});

--- a/tests/fixtures/security-framework-entry-sources-879-bullmq/tsconfig.json
+++ b/tests/fixtures/security-framework-entry-sources-879-bullmq/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext"
+  },
+  "include": ["src"]
+}

--- a/tests/fixtures/security-framework-entry-sources-879-express/package.json
+++ b/tests/fixtures/security-framework-entry-sources-879-express/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "security-framework-entry-sources-879-express",
+  "dependencies": {
+    "express": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest"
+  }
+}

--- a/tests/fixtures/security-framework-entry-sources-879-express/src/app.ts
+++ b/tests/fixtures/security-framework-entry-sources-879-express/src/app.ts
@@ -1,0 +1,6 @@
+declare const app: {
+  post(path: string, handler: (req: unknown) => void): void;
+};
+app.post("/run", (req) => {
+  eval(req);
+});

--- a/tests/fixtures/security-framework-entry-sources-879-express/src/app.ts
+++ b/tests/fixtures/security-framework-entry-sources-879-express/src/app.ts
@@ -3,4 +3,5 @@ declare const app: {
 };
 app.post("/run", (req) => {
   eval(req);
+  eval(req.body);
 });

--- a/tests/fixtures/security-framework-entry-sources-879-express/tsconfig.json
+++ b/tests/fixtures/security-framework-entry-sources-879-express/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022"
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/security-framework-entry-sources-879-mcp/package.json
+++ b/tests/fixtures/security-framework-entry-sources-879-mcp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "security-framework-entry-sources-879-mcp",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest"
+  }
+}

--- a/tests/fixtures/security-framework-entry-sources-879-mcp/src/app.ts
+++ b/tests/fixtures/security-framework-entry-sources-879-mcp/src/app.ts
@@ -1,0 +1,7 @@
+declare const server: {
+  tool(name: string, schema: unknown, handler: (input: { city: unknown }) => void): void;
+};
+
+server.tool("lookup", {}, ({ city }) => {
+  eval(city);
+});

--- a/tests/fixtures/security-framework-entry-sources-879-mcp/tsconfig.json
+++ b/tests/fixtures/security-framework-entry-sources-879-mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext"
+  },
+  "include": ["src"]
+}

--- a/tests/fixtures/security-framework-entry-sources-879-plain/package.json
+++ b/tests/fixtures/security-framework-entry-sources-879-plain/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "security-framework-entry-sources-879-plain",
+  "devDependencies": {
+    "typescript": "latest"
+  }
+}

--- a/tests/fixtures/security-framework-entry-sources-879-plain/src/app.ts
+++ b/tests/fixtures/security-framework-entry-sources-879-plain/src/app.ts
@@ -1,0 +1,6 @@
+declare const app: {
+  post(path: string, handler: (req: unknown) => void): void;
+};
+app.post("/run", (req) => {
+  eval(req);
+});

--- a/tests/fixtures/security-framework-entry-sources-879-plain/tsconfig.json
+++ b/tests/fixtures/security-framework-entry-sources-879-plain/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Add dependency-gated source rows for framework handler inputs, Next.js handlers and server actions, queue job payloads, and MCP tool inputs.
- Record recognizable framework callback parameters during extraction so existing security sink candidates can be ranked as source-backed.
- Keep NestJS decorator-injected params out of scope because they need decorator parameter capture rather than member-path matching.

## Issue
Fixes #879.

## Verification
- `cargo check --workspace`
- `cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings`
- `cargo clippy -p fallow-core -p fallow-extract --all-targets -- -D warnings`
- `cargo test -p fallow-cli -p fallow-mcp`
- `cargo test --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos .`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `fallow audit --format json --quiet`
- Minimal issue repro verified direct handler input and request accessor source ranking.
- Real MCP project smoke verified deterministic security JSON.
