### PR TITLE
fix: tighten security source matching

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -970,10 +970,13 @@ enum Command {
     /// catalogue (`security_matchers.toml`) spanning categories such as
     /// dangerous-html, template-escape-bypass, command-injection, code-injection,
     /// dynamic-regex, redos-regex, dynamic-module-load, sql-injection, ssrf,
-    /// path-traversal, header-injection, open-redirect, mass-assignment,
-    /// weak-crypto, deprecated-cipher, insecure-randomness, unsafe-buffer-alloc,
-    /// unsafe-deserialization, prototype-pollution, zip-slip, nosql-injection,
-    /// ssti, xxe, xpath-injection, and webview-injection. (3) `hardcoded-secret`,
+    /// path-traversal, header-injection, open-redirect, cleartext-transport,
+    /// electron-unsafe-webpreferences, world-writable-permission,
+    /// insecure-temp-file, mysql-multiple-statements, mass-assignment,
+    /// weak-crypto, deprecated-cipher, insecure-randomness,
+    /// unsafe-buffer-alloc, unsafe-deserialization, prototype-pollution,
+    /// zip-slip, nosql-injection, ssti, xxe, xpath-injection, and
+    /// webview-injection. (3) `hardcoded-secret`,
     /// an include-required
     /// category for provider-prefix literals and high-entropy literals assigned
     /// to secret-shaped identifiers. It never runs from raw entropy alone. All

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -140,10 +140,19 @@ fn provenance_satisfied(matcher: &Matcher, module: &ModuleInfo, callee_path: &st
 }
 
 /// Compare an import source against a provenance spec, tolerant of the `node:`
-/// prefix on either side (`node:child_process` matches `child_process`).
+/// prefix on either side (`node:child_process` matches `child_process`) and
+/// package subpath imports (`mysql2/promise` matches `mysql2`).
 fn import_source_matches(source: &str, spec: &str) -> bool {
-    let strip = |s: &str| s.strip_prefix("node:").unwrap_or(s).to_string();
-    strip(source) == strip(spec)
+    fn strip_node_prefix(value: &str) -> &str {
+        value.strip_prefix("node:").unwrap_or(value)
+    }
+
+    let source = strip_node_prefix(source);
+    let spec = strip_node_prefix(spec);
+    source == spec
+        || source
+            .strip_prefix(spec)
+            .is_some_and(|rest| rest.starts_with('/'))
 }
 
 /// Compiled glob set over [`PRODUCTION_EXCLUDE_PATTERNS`](crate::discover::PRODUCTION_EXCLUDE_PATTERNS),
@@ -472,6 +481,13 @@ mod tests {
         assert!(import_source_matches("node:child_process", "child_process"));
         assert!(import_source_matches("child_process", "node:child_process"));
         assert!(!import_source_matches("child_process", "node:vm"));
+    }
+
+    #[test]
+    fn import_source_matches_package_subpath() {
+        assert!(import_source_matches("mysql2/promise", "mysql2"));
+        assert!(import_source_matches("@scope/pkg/subpath", "@scope/pkg"));
+        assert!(!import_source_matches("mysql2-promise", "mysql2"));
     }
 
     fn binding(local: &str, source_path: &str) -> TaintedBinding {

--- a/crates/core/tests/integration_test/security_catalogue_categories.rs
+++ b/crates/core/tests/integration_test/security_catalogue_categories.rs
@@ -971,8 +971,8 @@ fn issue_901_literal_tier_rows_fire() {
     assert_candidate(&results, "src/mysql.ts", "mysql-multiple-statements", 89);
     assert_eq!(
         anchored_count(&results, "src/mysql.ts"),
-        2,
-        "mysql fixture should cover mysql and mysql2 provenances"
+        4,
+        "mysql fixture should cover mysql, mysql2, and mysql2 subpath provenances"
     );
 }
 

--- a/crates/core/tests/integration_test/security_framework_entry_sources.rs
+++ b/crates/core/tests/integration_test/security_framework_entry_sources.rs
@@ -26,7 +26,7 @@ fn tainted_sink_at_line(results: &AnalysisResults, line: u32) -> &SecurityFindin
 #[test]
 fn express_route_request_param_is_source_backed() {
     let results = analyze_fixture("security-framework-entry-sources-879-express");
-    let finding = tainted_sink_at_line(&results, 5);
+    let finding = tainted_sink_at_line(&results, 8);
     assert!(finding.source_backed);
     assert!(
         finding.evidence.contains("framework handler input"),
@@ -34,12 +34,24 @@ fn express_route_request_param_is_source_backed() {
         finding.evidence
     );
 
-    let accessor_finding = tainted_sink_at_line(&results, 6);
+    let accessor_finding = tainted_sink_at_line(&results, 9);
     assert!(accessor_finding.source_backed);
     assert!(
         accessor_finding.evidence.contains("http request input"),
         "evidence should prefer the specific request accessor source: {}",
         accessor_finding.evidence
+    );
+}
+
+#[test]
+fn express_enabled_non_route_get_callback_is_not_source_backed() {
+    let results = analyze_fixture("security-framework-entry-sources-879-express");
+    assert!(
+        results
+            .security_findings
+            .iter()
+            .all(|finding| finding.line != 12),
+        "ordinary cache.get callbacks must not be treated as framework request sources"
     );
 }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -1819,6 +1819,9 @@ impl ModuleInfoExtractor {
             return;
         };
         if is_route_registration_method(method) {
+            if !is_framework_route_receiver_path(&callee_path, method) {
+                return;
+            }
             if let Some(params) = route_callback_params(&call.arguments, method) {
                 self.record_first_param_source(params, FRAMEWORK_REQUEST_SOURCE);
             }
@@ -5141,6 +5144,23 @@ fn is_route_registration_method(method: &str) -> bool {
         method,
         "all" | "delete" | "get" | "head" | "options" | "patch" | "post" | "put" | "use"
     )
+}
+
+fn is_framework_route_receiver_path(callee_path: &str, method: &str) -> bool {
+    let Some(receiver_path) = callee_path.strip_suffix(&format!(".{method}")) else {
+        return false;
+    };
+    let Some(receiver) = receiver_path.rsplit('.').next() else {
+        return false;
+    };
+    let receiver = receiver.to_ascii_lowercase();
+    matches!(
+        receiver.as_str(),
+        "app" | "router" | "route" | "routes" | "server" | "fastify"
+    ) || receiver.ends_with("app")
+        || receiver.ends_with("router")
+        || receiver.ends_with("routes")
+        || receiver.ends_with("server")
 }
 
 fn function_body_has_use_server(body: Option<&FunctionBody<'_>>) -> bool {

--- a/tests/fixtures/security-framework-entry-sources-879-express/src/app.ts
+++ b/tests/fixtures/security-framework-entry-sources-879-express/src/app.ts
@@ -1,7 +1,13 @@
 declare const app: {
   post(path: string, handler: (req: unknown) => void): void;
 };
+declare const cache: {
+  get(key: string, handler: (value: string) => void): void;
+};
 app.post("/run", (req) => {
   eval(req);
   eval(req.body);
+});
+cache.get("token", (value) => {
+  /^(a+)+$/.test(value);
 });

--- a/tests/fixtures/security-literal-sinks-901/src/mysql.ts
+++ b/tests/fixtures/security-literal-sinks-901/src/mysql.ts
@@ -1,5 +1,7 @@
 import mysql from "mysql";
 import { createConnection } from "mysql2";
+import mysql2 from "mysql2/promise";
+import { createPool } from "mysql2/promise";
 
 export function connect(): void {
   mysql.createConnection({
@@ -8,6 +10,16 @@ export function connect(): void {
   });
 
   createConnection({
+    host: "localhost",
+    multipleStatements: true,
+  });
+
+  mysql2.createConnection({
+    host: "localhost",
+    multipleStatements: true,
+  });
+
+  createPool({
     host: "localhost",
     multipleStatements: true,
   });


### PR DESCRIPTION
Fixes two final-review gaps in the merged security catalogue work.

- Avoid treating ordinary `.get` callbacks as framework request handlers unless the receiver looks route-like.
- Match package subpath imports such as `mysql2/promise` for catalogue provenance.
- Update `fallow security --help` so the merged category examples include the new literal-aware categories.

Validation:
- `cargo test -p fallow-core --test integration_test security_framework_entry_sources -- --nocapture`
- `cargo test -p fallow-core --test integration_test issue_901 -- --nocapture`
- `cargo test -p fallow-core import_source_matches_package_subpath -- --nocapture`
- `cargo run --bin fallow -- security --root /Users/bartwaardenburg/Sites/acorn --format json --quiet`
- `cargo check --workspace`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos .`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`