### PR TITLE
chore(license): reflect team -> pro tier rename in claims doc and fixtures

### DIFF
--- a/crates/cli/src/license/mod.rs
+++ b/crates/cli/src/license/mod.rs
@@ -816,7 +816,7 @@ mod tests {
             sub: "org_1".to_owned(),
             tid: "tenant_1".to_owned(),
             seats: 5,
-            tier: "team".to_owned(),
+            tier: "pro".to_owned(),
             features: features.iter().map(|s| (*s).to_owned()).collect(),
             iat: 1_700_000_000,
             exp: 1_800_000_000,
@@ -946,7 +946,7 @@ mod tests {
         }
         assert_eq!(value["kind"], "license-status");
         assert_eq!(value["state"], "valid");
-        assert_eq!(value["tier"], "team");
+        assert_eq!(value["tier"], "pro");
         assert_eq!(value["seats"], 5);
         assert_eq!(value["days_until_expiry"], 12);
         assert!(value["days_since_expiry"].is_null());
@@ -993,7 +993,7 @@ mod tests {
         };
         let value = json_value(&status, LicenseKind::Status);
         assert_eq!(value["state"], "expired_warning");
-        assert_eq!(value["tier"], "team");
+        assert_eq!(value["tier"], "pro");
         assert_eq!(value["days_since_expiry"], 3);
         // Warning window still permits the feature.
         assert_eq!(value["runtime_coverage_enabled"], true);
@@ -1029,7 +1029,7 @@ mod tests {
         let value = json_value(&status, LicenseKind::Status);
 
         assert_eq!(value["state"], "expired_watermark");
-        assert_eq!(value["tier"], "team");
+        assert_eq!(value["tier"], "pro");
         assert_eq!(value["seats"], 5);
         assert_eq!(value["days_since_expiry"], 12);
         assert_eq!(value["runtime_coverage_enabled"], true);

--- a/crates/license/src/lib.rs
+++ b/crates/license/src/lib.rs
@@ -73,7 +73,10 @@ pub struct LicenseClaims {
     pub tid: String,
     /// Number of seats licensed.
     pub seats: u32,
-    /// Tier string: `team`, `enterprise`, `trial`, `founding`.
+    /// Tier string emitted by fallow-cloud: `pro`, `enterprise`, `trial`, `founding`.
+    /// (`team` is the legacy name for `pro`; the server now emits `pro`.) The
+    /// value is informational only: capability gating is on `features`, never on
+    /// this string, so any tier value is tolerated.
     pub tier: String,
     /// Feature flags. Modeled as strings on the wire for forward-compat;
     /// callers convert to [`Feature`] for matching.
@@ -613,7 +616,7 @@ mod tests {
             sub: "org_test".into(),
             tid: "tenant_test".into(),
             seats: 5,
-            tier: "team".into(),
+            tier: "pro".into(),
             features: vec!["runtime_coverage".into()],
             iat: 1_700_000_000,
             exp,
@@ -758,7 +761,7 @@ mod tests {
             "sub": "org_test",
             "tid": "tenant_test",
             "seats": 5,
-            "tier": "team",
+            "tier": "pro",
             "features": ["runtime_coverage"],
             "iat": 1_700_000_000,
             "exp": 2_000_000_000_i64,
@@ -773,7 +776,7 @@ mod tests {
             "sub": "org_test",
             "tid": "tenant_test",
             "seats": 5,
-            "tier": "team",
+            "tier": "pro",
             "features": ["runtime_coverage"],
             "iat": 1_700_000_000,
             "exp": 2_000_000_000_i64,
@@ -864,7 +867,7 @@ mod tests {
             sub: "org_test".into(),
             tid: "tenant_test".into(),
             seats: 5,
-            tier: "team".into(),
+            tier: "pro".into(),
             features: vec!["runtime_coverage".into()],
             iat,
             exp,


### PR DESCRIPTION
fallow-cloud renamed its paid subscription tier `team` -> `pro` (one per-seat tier for solo developers and teams). The license JWT `tier` claim now emits `pro`.

Update the `LicenseClaims.tier` doc comment and the `team`-tier test fixtures/assertions to match what the server now emits. Non-functional: `tier` is a free display `String` and capability gating is on the `features` array, so any tier value is tolerated (legacy `team` tokens still work).

- `crates/license/src/lib.rs`: doc comment + fixtures
- `crates/cli/src/license/mod.rs`: status-output fixture + assertions

`cargo test -p fallow-license` and the `fallow-cli` license tests pass; fmt + clippy clean.