### PR TITLE
fix(security): keep source reachability diff matches

### DIFF
--- a/crates/cli/src/check/filtering.rs
+++ b/crates/cli/src/check/filtering.rs
@@ -358,6 +358,12 @@ pub fn filter_results_by_diff(
                     || (matches!(hop.role, fallow_core::results::TraceHopRole::SecretSource)
                         && touches_file(&hop.path))
             })
+            || f.reachability.as_ref().is_some_and(|reachability| {
+                reachability
+                    .untrusted_source_trace
+                    .iter()
+                    .any(|hop| line_in_diff(&hop.path, hop.line))
+            })
     });
 
     for unlisted in &mut results.unlisted_dependencies {
@@ -486,6 +492,7 @@ mod tests {
     use super::*;
     use fallow_core::extract::MemberKind;
     use fallow_core::results::*;
+    use fallow_types::results::SecurityReachability;
     use std::path::PathBuf;
 
     /// Test shim: single-workspace variant on top of `filter_to_workspaces`.
@@ -1860,6 +1867,57 @@ mod tests {
             actions: Vec::new(),
             dead_code: None,
             reachability: None,
+        });
+
+        filter_results_by_diff(&mut results, &diff, root);
+
+        assert_eq!(results.security_findings.len(), 1);
+    }
+
+    #[test]
+    fn filter_by_diff_keeps_security_finding_when_untrusted_source_trace_changed() {
+        let diff = build_diff(
+            "diff --git a/src/route.ts b/src/route.ts\n\
+             --- a/src/route.ts\n\
+             +++ b/src/route.ts\n\
+             @@ -3,0 +3,1 @@\n\
+             +import { run } from './runner';\n",
+        );
+        let root = Path::new("/project");
+        let mut results = AnalysisResults::default();
+        results.security_findings.push(SecurityFinding {
+            kind: SecurityFindingKind::TaintedSink,
+            category: Some("command-injection".into()),
+            cwe: Some(78),
+            path: PathBuf::from("/project/src/runner.ts"),
+            line: 10,
+            col: 0,
+            evidence: "candidate".into(),
+            source_backed: false,
+            trace: vec![],
+            actions: Vec::new(),
+            dead_code: None,
+            reachability: Some(SecurityReachability {
+                reachable_from_entry: false,
+                reachable_from_untrusted_source: true,
+                untrusted_source_hop_count: Some(1),
+                untrusted_source_trace: vec![
+                    TraceHop {
+                        path: PathBuf::from("/project/src/route.ts"),
+                        line: 3,
+                        col: 0,
+                        role: TraceHopRole::UntrustedSource,
+                    },
+                    TraceHop {
+                        path: PathBuf::from("/project/src/runner.ts"),
+                        line: 10,
+                        col: 0,
+                        role: TraceHopRole::Sink,
+                    },
+                ],
+                blast_radius: 0,
+                crosses_boundary: false,
+            }),
         });
 
         filter_results_by_diff(&mut results, &diff, root);

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -6,7 +6,8 @@
 //! verification, NOT verified vulnerabilities.
 //! This command is the ONLY surface for security findings: they never appear
 //! under bare `fallow` or the `audit` gate. There is no `confidence` or
-//! `signal_strength` field; the structural trace is the only honest signal.
+//! `signal_strength` field; structural traces and reachability context are the
+//! only honest signals.
 
 use crate::report::sink::outln;
 use std::path::{Path, PathBuf};
@@ -557,8 +558,8 @@ fn sarif_rule_def(rule_id: &str, finding: &SecurityFinding) -> serde_json::Value
 /// framing survives into the GitHub Security tab. Each finding's ruleId is
 /// per-category (`security/<category>` for tainted-sink, `security/client-server-leak`
 /// for the graph rule); the `rules` array carries one definition per distinct
-/// ruleId present, with the CWE tag for tainted-sink categories. Trace hops
-/// become `relatedLocations` of the result.
+/// ruleId present, with the CWE tag for tainted-sink categories. Detector trace
+/// hops and source-reachability hops become `relatedLocations` of the result.
 #[must_use]
 fn render_sarif(output: &SecurityOutput) -> String {
     let results: Vec<serde_json::Value> = output

--- a/crates/core/src/analyze/security/rank.rs
+++ b/crates/core/src/analyze/security/rank.rs
@@ -1,12 +1,10 @@
-//! Reachability-weighted ranking of security candidates (issue #860).
+//! Reachability-weighted ranking of security candidates (issues #860 and #885).
 //!
-//! Reuses the EXISTING module graph (runtime reachability + reverse-dependency
-//! fan-in) to rank `fallow security` candidates so a candidate reachable from a
-//! runtime/application entry point (route handlers, server entry, framework
-//! runtime roots) surfaces above an isolated helper or script. This is graph-side
-//! glue plus output ordering only: it touches neither the extract cache nor the
-//! finding enum, and adds no new BFS infrastructure beyond a bounded fan-in walk
-//! over the graph's reverse-dependency index.
+//! Reuses the existing module graph to rank `fallow security` candidates by
+//! runtime reachability, source-backed evidence, module-level untrusted-source
+//! reachability, reverse-dependency fan-in, boundary crossings, and dead-code
+//! context. This is graph-side glue plus output ordering only: it touches
+//! neither the extract cache nor detector semantics.
 //!
 //! The ranking is a relative-ordering signal, NOT proof of exploitability:
 //! candidates remain CANDIDATES for downstream agent verification.
@@ -173,9 +171,11 @@ fn prepend_dead_code_action(finding: &mut SecurityFinding) {
 /// architecture-boundary violation found in the same run (importing or imported
 /// side); a finding whose anchor is in that set is flagged `crosses_boundary`.
 ///
-/// Sort order (descending priority): reachable-from-entry first, then larger
-/// blast radius, then crosses-boundary, then the existing deterministic
-/// `(path, line, col, category)` tiebreak so output stays stable across runs.
+/// Sort order (descending priority): reachable-from-entry first, same-module
+/// source-backed sinks, module-level source-reachable sinks, larger blast
+/// radius, crosses-boundary, active-code over dead-code candidates, then the
+/// existing deterministic `(path, line, col, category)` tiebreak so output stays
+/// stable across runs.
 pub fn rank_security_findings(
     graph: &ModuleGraph,
     modules: &[ModuleInfo],

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -868,9 +868,10 @@ pub struct TraceHop {
 }
 
 /// Graph-derived reachability ranking signal for a security candidate. Computed
-/// from the EXISTING module graph (runtime reachability + reverse-dep fan-in)
-/// after detection, never proven exploitable. Used to surface candidates that
-/// sit on a request/runtime-reachable surface above isolated helpers or scripts.
+/// from the existing module graph after detection, never proven exploitable.
+/// Used to surface candidates that sit on a request/runtime-reachable surface,
+/// receive same-module source evidence, or are import-reachable from an
+/// untrusted-source module above isolated helpers or scripts.
 ///
 /// This is a relative-ordering signal, NOT a `confidence` or `signal_strength`
 /// score: fallow does not prove the path is exploitable.
@@ -987,10 +988,11 @@ pub struct SecurityFinding {
     /// the code instead of hardening the sink when deletion is safe.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dead_code: Option<SecurityDeadCodeContext>,
-    /// Graph-derived reachability ranking signal (issue #860). `None` until the
-    /// post-detection ranking pass fills it; additive on the wire (skipped when
-    /// absent). Drives the order findings are emitted in: candidates reachable
-    /// from a runtime entry point with a wider blast radius sort first.
+    /// Graph-derived reachability ranking signal (issues #860 and #885). `None`
+    /// until the post-detection ranking pass fills it; additive on the wire
+    /// (skipped when absent). Drives the order findings are emitted in:
+    /// runtime-reachable candidates sort first, followed by source-backed and
+    /// source-reachable candidates, then wider blast radius.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reachability: Option<SecurityReachability>,
 }

--- a/editors/vscode/src/securityTreeView.ts
+++ b/editors/vscode/src/securityTreeView.ts
@@ -160,9 +160,10 @@ class SecurityFindingItem extends vscode.TreeItem {
 /**
  * Renders local security CANDIDATES from `fallow security` into the Security
  * Candidates view. Findings are grouped by kind and CWE/category, then each
- * finding can expand into trace hops. Every node frames the finding as
- * unverified (#903): the view name, the tooltip prefix, and the toast wording
- * make clear these are candidates to verify, not confirmed vulnerabilities.
+ * finding can expand into detector trace hops, while source-reachability traces
+ * appear in the finding tooltip. Every node frames the finding as unverified
+ * (#903): the view name, the tooltip prefix, and the toast wording make clear
+ * these are candidates to verify, not confirmed vulnerabilities.
  */
 export class SecurityTreeProvider implements vscode.TreeDataProvider<SecurityItem> {
   private result: SecurityOutput | null = null;


### PR DESCRIPTION
Diff-scoped security runs now retain candidates when changed lines match the untrusted-source reachability trace, not only the sink anchor or detector trace.

This keeps MCP and CI diff filtering aligned with the source-reachability context added in #1050. The change also refreshes nearby comments so they describe the current ranking and SARIF behavior.

Follow-up to #1050.