### PR TITLE
feat(security): rank sink candidates with runtime coverage

### DIFF
--- a/crates/cli/src/bin/schema_emit.rs
+++ b/crates/cli/src/bin/schema_emit.rs
@@ -97,11 +97,11 @@ use fallow_types::results::{
     FlagConfidence, FlagKind, ImportSite, MisconfiguredDependencyOverride, PrivateTypeLeak,
     ReferenceLocation, SecurityCandidate, SecurityCandidateBoundary, SecurityCandidateSink,
     SecurityDeadCodeContext, SecurityDeadCodeKind, SecurityFinding, SecurityFindingKind,
-    SecurityReachability, SecurityTaintFlow, SecurityZoneCrossing, StaleSuppression,
-    SuppressionOrigin, TaintEndpoint, TaintPath, TestOnlyDependency, TraceHop, TraceHopRole,
-    TypeOnlyDependency, UnlistedDependency, UnresolvedCatalogReference, UnresolvedImport,
-    UnusedCatalogEntry, UnusedDependency, UnusedDependencyOverride, UnusedExport, UnusedFile,
-    UnusedMember,
+    SecurityReachability, SecurityRuntimeContext, SecurityRuntimeState, SecurityTaintFlow,
+    SecurityZoneCrossing, StaleSuppression, SuppressionOrigin, TaintEndpoint, TaintPath,
+    TestOnlyDependency, TraceHop, TraceHopRole, TypeOnlyDependency, UnlistedDependency,
+    UnresolvedCatalogReference, UnresolvedImport, UnusedCatalogEntry, UnusedDependency,
+    UnusedDependencyOverride, UnusedExport, UnusedFile, UnusedMember,
 };
 
 /// Workspace-relative path to the committed schema.
@@ -529,6 +529,8 @@ fn derived_definitions() -> Map<String, Value> {
     let _ = generator.subschema_for::<TaintEndpoint>();
     let _ = generator.subschema_for::<TaintPath>();
     let _ = generator.subschema_for::<SecurityTaintFlow>();
+    let _ = generator.subschema_for::<SecurityRuntimeState>();
+    let _ = generator.subschema_for::<SecurityRuntimeContext>();
     let _ = generator.subschema_for::<SecurityFinding>();
     let _ = generator.subschema_for::<SecurityGateMode>();
     let _ = generator.subschema_for::<SecurityGateVerdict>();

--- a/crates/cli/src/bin/stub_sidecar.rs
+++ b/crates/cli/src/bin/stub_sidecar.rs
@@ -17,6 +17,7 @@
 //! - `"malformed-stdout"`: writes non-JSON bytes, exit 0
 //! - `"empty-stdout"`: writes nothing, exit 0
 //! - `"enforce-license-gate"`: mirrors the paid-shape sidecar gate for tests
+//! - `"security-hot"`: response with `src/sink.ts::render` as a hot path
 //! - `"capture-quality-short"`: clean response with a short-window
 //!   `capture_quality` (`lazy_parse_warning = true`), exit 0
 //! - `"capture-quality-long"`: clean response with a long-window
@@ -31,7 +32,7 @@ use std::io::{Read, Write};
 use std::process::ExitCode;
 
 use fallow_cov_protocol::{
-    CaptureQuality, PROTOCOL_VERSION, ReportVerdict, Request, Response, Summary,
+    CaptureQuality, HotPath, PROTOCOL_VERSION, ReportVerdict, Request, Response, Summary,
 };
 
 fn main() -> ExitCode {
@@ -61,6 +62,7 @@ fn main() -> ExitCode {
                 untracked_ratio_percent: 3.1,
             }),
         ),
+        "security-hot" => emit_security_hot_response(),
         "malformed-stdout" => emit_bytes(b"definitely not JSON\n"),
         "empty-stdout" => ExitCode::SUCCESS,
         "enforce-license-gate" => enforce_license_gate(parsed),
@@ -93,6 +95,54 @@ fn enforce_license_gate(request: Option<Request>) -> ExitCode {
         return ExitCode::from(3);
     }
     emit_clean_response(PROTOCOL_VERSION, None)
+}
+
+fn emit_security_hot_response() -> ExitCode {
+    let hot_path: HotPath = match serde_json::from_value(serde_json::json!({
+        "id": "fallow:hot:test",
+        "file": "src/sink.ts",
+        "function": "render",
+        "line": 2,
+        "end_line": 4,
+        "invocations": 250,
+        "percentile": 100,
+        "identity": null,
+    })) {
+        Ok(hot_path) => hot_path,
+        Err(err) => {
+            eprintln!("stub sidecar: failed to build hot path: {err}");
+            return ExitCode::from(6);
+        }
+    };
+    let response = Response {
+        protocol_version: PROTOCOL_VERSION.to_owned(),
+        verdict: ReportVerdict::HotPathTouched,
+        summary: Summary {
+            functions_tracked: 1,
+            functions_hit: 1,
+            functions_unhit: 0,
+            functions_untracked: 0,
+            coverage_percent: 100.0,
+            trace_count: 250,
+            period_days: 7,
+            deployments_seen: 1,
+            capture_quality: None,
+        },
+        findings: Vec::new(),
+        hot_paths: vec![hot_path],
+        blast_radius: Vec::new(),
+        importance: Vec::new(),
+        watermark: None,
+        errors: Vec::new(),
+        warnings: Vec::new(),
+    };
+    match serde_json::to_vec(&response) {
+        Ok(bytes) => emit_bytes(&bytes),
+        Err(err) => {
+            eprintln!("stub sidecar: failed to serialize response: {err}");
+            ExitCode::from(6)
+        }
+    }
 }
 
 fn emit_clean_response(

--- a/crates/cli/src/check/filtering.rs
+++ b/crates/cli/src/check/filtering.rs
@@ -1925,6 +1925,7 @@ mod tests {
             actions: Vec::new(),
             dead_code: None,
             reachability: None,
+            runtime: None,
         });
 
         filter_results_by_diff(&mut results, &diff, root);
@@ -1979,6 +1980,7 @@ mod tests {
                 blast_radius: 0,
                 crosses_boundary: false,
             }),
+            runtime: None,
         });
 
         filter_results_by_diff(&mut results, &diff, root);
@@ -2013,6 +2015,7 @@ mod tests {
             actions: Vec::new(),
             dead_code: None,
             reachability: None,
+            runtime: None,
         });
 
         retain_gate_new(&mut results, &diff, root);
@@ -2065,6 +2068,7 @@ mod tests {
             actions: Vec::new(),
             dead_code: None,
             reachability: None,
+            runtime: None,
         });
 
         // Advisory keeps it; the gate drops it.
@@ -2117,6 +2121,7 @@ mod tests {
                 blast_radius: 0,
                 crosses_boundary: false,
             }),
+            runtime: None,
         });
 
         retain_gate_new(&mut results, &diff, root);
@@ -2159,6 +2164,7 @@ mod tests {
             actions: Vec::new(),
             dead_code: None,
             reachability: None,
+            runtime: None,
         });
 
         retain_gate_new(&mut results, &diff, root);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1004,6 +1004,16 @@ enum Command {
     /// `--diff-stdin`, `--workspace`, `--changed-workspaces`, `--ci`,
     /// `--fail-on-issues`, `--sarif-file`, and `--summary`.
     Security {
+        /// Paid runtime-coverage sidecar input. Accepts a V8 directory, a
+        /// single V8 JSON file, or an Istanbul coverage map JSON. When set,
+        /// `fallow security` annotates tainted-sink candidates with production
+        /// runtime state and uses that state as an additive ranking signal.
+        #[arg(long, value_name = "PATH")]
+        runtime_coverage: Option<PathBuf>,
+        /// Threshold for hot-path classification, forwarded to the sidecar
+        /// when `--runtime-coverage` is set.
+        #[arg(long, default_value_t = 100)]
+        min_invocations_hot: u64,
         /// Only report security candidates in or reachable from the specified files.
         /// The full project graph is still built, but output is scoped to matching
         /// finding anchors or trace hops. Accepts multiple values.
@@ -2963,7 +2973,12 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
             },
         ),
         Command::Impact { subcommand } => dispatch_impact(root, quiet, output, subcommand),
-        Command::Security { file, gate } => {
+        Command::Security {
+            runtime_coverage,
+            min_invocations_hot,
+            file,
+            gate,
+        } => {
             let (output, quiet, fail_on_issues) = dispatch.ci_defaults();
             security::run(&security::SecurityOptions {
                 root,
@@ -2981,6 +2996,8 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
                 changed_workspaces: cli.changed_workspaces.as_deref(),
                 file: file.as_slice(),
                 gate,
+                runtime_coverage: runtime_coverage.as_deref(),
+                min_invocations_hot,
             })
         }
         Command::Schema => unreachable!("handled above"),

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -15,11 +15,18 @@ use std::process::ExitCode;
 
 use fallow_config::{OutputFormat, ProductionAnalysis, Severity};
 use fallow_core::results::{
-    SecurityDeadCodeKind, SecurityFinding, SecurityFindingKind, TraceHopRole,
+    AnalysisResults, SecurityDeadCodeKind, SecurityFinding, SecurityFindingKind, TraceHopRole,
 };
+use fallow_types::discover::DiscoveredFile;
+use fallow_types::extract::ModuleInfo;
+use fallow_types::results::{SecurityRuntimeContext, SecurityRuntimeState};
 use serde::Serialize;
 
 use crate::error::emit_error;
+use crate::health::{HealthOptions, SharedParseData, SortBy};
+use crate::health_types::{
+    RuntimeCoverageFinding, RuntimeCoverageHotPath, RuntimeCoverageReport, RuntimeCoverageVerdict,
+};
 use crate::load_config_for_analysis;
 
 /// The `fallow security --format json` schema version. Independently versioned
@@ -132,16 +139,16 @@ pub struct SecurityOptions<'a> {
     /// source (`--changed-since`, `--diff-file`, or `--diff-stdin`); reports only
     /// candidates introduced in the changed lines and exits 8 if any exist.
     pub gate: Option<SecurityGateMode>,
+    /// Paid local runtime-coverage sidecar input.
+    pub runtime_coverage: Option<&'a Path>,
+    /// Threshold for hot-path classification when `--runtime-coverage` is set.
+    pub min_invocations_hot: u64,
 }
 
 /// Run `fallow security`. Always exits 0 unless the user explicitly raised the
 /// `security-client-server-leak` rule to `error` AND findings exist (the rule
 /// defaults to `off` and the command forces it to `warn`, so the common case is
 /// advisory). Unsupported output formats exit 2.
-#[expect(
-    deprecated,
-    reason = "ADR-008 deprecates fallow_core::analyze externally; the CLI uses the workspace path dependency"
-)]
 pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
     if !matches!(
         opts.output,
@@ -180,9 +187,9 @@ pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
         config.rules.security_sink = Severity::Warn;
     }
 
-    let mut results = match fallow_core::analyze(&config) {
-        Ok(results) => results,
-        Err(err) => return emit_error(&format!("Analysis error: {err}"), 2, opts.output),
+    let mut analysis = match analyze_security_candidates(opts, &config) {
+        Ok(analysis) => analysis,
+        Err(code) => return code,
     };
 
     // Workspace scope (mutually exclusive flags resolved by the shared helper).
@@ -196,7 +203,7 @@ pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
         Err(code) => return code,
     };
     if let Some(ref roots) = ws_roots {
-        crate::check::filtering::filter_to_workspaces(&mut results, roots);
+        crate::check::filtering::filter_to_workspaces(&mut analysis.results, roots);
     }
 
     // Changed-since scope (canonical normalization via the core filter, which
@@ -204,66 +211,50 @@ pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
     if let Some(git_ref) = opts.changed_since
         && let Some(changed) = fallow_core::changed_files::get_changed_files(opts.root, git_ref)
     {
-        fallow_core::changed_files::filter_results_by_changed_files(&mut results, &changed);
+        fallow_core::changed_files::filter_results_by_changed_files(
+            &mut analysis.results,
+            &changed,
+        );
     }
     if opts.use_shared_diff_index
         && let Some(diff_index) = crate::report::ci::diff_filter::shared_diff_index()
     {
-        crate::check::filtering::filter_results_by_diff(&mut results, diff_index, opts.root);
+        crate::check::filtering::filter_results_by_diff(
+            &mut analysis.results,
+            diff_index,
+            opts.root,
+        );
     }
-    filter_to_files(&mut results, opts.root, opts.file, opts.quiet);
+    filter_to_files(&mut analysis.results, opts.root, opts.file, opts.quiet);
 
-    // Security gate (issue #886): narrow to the STRICT "new in changed lines"
-    // predicate and drive a dedicated exit code. The gate requires a diff
-    // source; a diff it cannot compute is a LOUD error (exit 2), never a green
-    // gate (a silent miss defeats a security gate).
-    let mut owned_gate_diff: Option<crate::report::ci::diff_filter::DiffIndex> = None;
-    let gate_mode = if let Some(mode) = opts.gate {
-        let gate_diff: &crate::report::ci::diff_filter::DiffIndex = if let Some(shared) =
-            crate::report::ci::diff_filter::shared_diff_index()
-        {
-            shared
-        } else if let Some(git_ref) = opts.changed_since {
-            match fallow_core::changed_files::try_get_changed_diff(opts.root, git_ref) {
-                Ok(text) => owned_gate_diff
-                    .insert(crate::report::ci::diff_filter::DiffIndex::from_unified_diff(&text)),
-                Err(err) => {
-                    return emit_error(
-                        &format!(
-                            "fallow security --gate could not compute the diff for '{git_ref}': {}",
-                            err.describe()
-                        ),
-                        2,
-                        opts.output,
-                    );
-                }
-            }
-        } else {
-            return emit_error(
-                "fallow security --gate requires a diff source: --changed-since <ref>, \
-                     --diff-file <path>, or --diff-stdin.",
-                2,
-                opts.output,
-            );
-        };
-        crate::check::filtering::retain_gate_new(&mut results, gate_diff, opts.root);
-        Some(mode)
-    } else {
-        None
+    let gate_mode = match apply_security_gate(opts, &mut analysis.results) {
+        Ok(mode) => mode,
+        Err(code) => return code,
     };
 
-    let unresolved_edge_files = results.security_unresolved_edge_files;
-    let unresolved_callee_sites = results.security_unresolved_callee_sites;
-    let findings: Vec<SecurityFinding> = std::mem::take(&mut results.security_findings)
-        .into_iter()
-        .map(|f| {
-            // Relativize first, then stamp the correlation id on the
-            // project-relative path so it matches the SARIF fingerprint.
-            let mut f = relativize_finding(f, &config.root);
-            f.finding_id = security_finding_id(&f);
-            f
-        })
-        .collect();
+    let unresolved_edge_files = analysis.results.security_unresolved_edge_files;
+    let unresolved_callee_sites = analysis.results.security_unresolved_callee_sites;
+    let runtime_report = match security_runtime_report(opts, &mut analysis) {
+        Ok(report) => report,
+        Err(code) => return code,
+    };
+    let mut findings: Vec<SecurityFinding> =
+        std::mem::take(&mut analysis.results.security_findings)
+            .into_iter()
+            .map(|f| relativize_finding(f, &config.root))
+            .collect();
+    if let (Some(report), Some(modules), Some(files)) = (
+        runtime_report.as_ref(),
+        analysis.modules.as_ref(),
+        analysis.files.as_ref(),
+    ) {
+        apply_runtime_context(&mut findings, modules, files, &config.root, report);
+    }
+    for finding in &mut findings {
+        // Stamp the correlation id on the project-relative path so it matches
+        // the SARIF fingerprint.
+        finding.finding_id = security_finding_id(finding);
+    }
 
     // In gate mode the displayed set IS the strict "new" set, so its length is
     // the new-candidate count. The gate block is emitted unconditionally when a
@@ -325,6 +316,378 @@ pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
     } else {
         ExitCode::SUCCESS
     }
+}
+
+fn apply_security_gate(
+    opts: &SecurityOptions<'_>,
+    results: &mut AnalysisResults,
+) -> Result<Option<SecurityGateMode>, ExitCode> {
+    let Some(mode) = opts.gate else {
+        return Ok(None);
+    };
+
+    // Security gate (issue #886): narrow to the STRICT "new in changed lines"
+    // predicate and drive a dedicated exit code. The gate requires a diff
+    // source; a diff it cannot compute is a LOUD error (exit 2), never a green
+    // gate (a silent miss defeats a security gate).
+    let mut owned_gate_diff: Option<crate::report::ci::diff_filter::DiffIndex> = None;
+    let gate_diff: &crate::report::ci::diff_filter::DiffIndex =
+        if let Some(shared) = crate::report::ci::diff_filter::shared_diff_index() {
+            shared
+        } else if let Some(git_ref) = opts.changed_since {
+            match fallow_core::changed_files::try_get_changed_diff(opts.root, git_ref) {
+                Ok(text) => owned_gate_diff
+                    .insert(crate::report::ci::diff_filter::DiffIndex::from_unified_diff(&text)),
+                Err(err) => {
+                    return Err(emit_error(
+                        &format!(
+                            "fallow security --gate could not compute the diff for '{git_ref}': {}",
+                            err.describe()
+                        ),
+                        2,
+                        opts.output,
+                    ));
+                }
+            }
+        } else {
+            return Err(emit_error(
+                "fallow security --gate requires a diff source: --changed-since <ref>, \
+                     --diff-file <path>, or --diff-stdin.",
+                2,
+                opts.output,
+            ));
+        };
+    crate::check::filtering::retain_gate_new(results, gate_diff, opts.root);
+    Ok(Some(mode))
+}
+
+struct SecurityAnalysisState {
+    results: AnalysisResults,
+    modules: Option<Vec<ModuleInfo>>,
+    files: Option<Vec<DiscoveredFile>>,
+    analysis_output: Option<fallow_core::AnalysisOutput>,
+}
+
+#[expect(
+    deprecated,
+    reason = "ADR-008 deprecates fallow_core::analyze APIs externally; the CLI uses the workspace path dependency"
+)]
+fn analyze_security_candidates(
+    opts: &SecurityOptions<'_>,
+    config: &fallow_config::ResolvedConfig,
+) -> Result<SecurityAnalysisState, ExitCode> {
+    if opts.runtime_coverage.is_none() {
+        return fallow_core::analyze(config)
+            .map(|results| SecurityAnalysisState {
+                results,
+                modules: None,
+                files: None,
+                analysis_output: None,
+            })
+            .map_err(|err| emit_error(&format!("Analysis error: {err}"), 2, opts.output));
+    }
+
+    fallow_core::analyze_retaining_modules(config, true, true)
+        .map(|mut output| {
+            let modules = output.modules.take();
+            let files = output.files.take();
+            let results = output.results.clone();
+            SecurityAnalysisState {
+                results,
+                modules,
+                files,
+                analysis_output: Some(output),
+            }
+        })
+        .map_err(|err| emit_error(&format!("Analysis error: {err}"), 2, opts.output))
+}
+
+fn security_runtime_report(
+    opts: &SecurityOptions<'_>,
+    analysis: &mut SecurityAnalysisState,
+) -> Result<Option<RuntimeCoverageReport>, ExitCode> {
+    let Some(path) = opts.runtime_coverage else {
+        return Ok(None);
+    };
+    let (Some(modules), Some(files), Some(analysis_output)) = (
+        analysis.modules.as_ref(),
+        analysis.files.as_ref(),
+        analysis.analysis_output.take(),
+    ) else {
+        return Ok(None);
+    };
+    analyze_security_runtime(opts, path, modules.clone(), files.clone(), analysis_output)
+}
+
+fn analyze_security_runtime(
+    opts: &SecurityOptions<'_>,
+    path: &Path,
+    modules: Vec<ModuleInfo>,
+    files: Vec<DiscoveredFile>,
+    analysis_output: fallow_core::AnalysisOutput,
+) -> Result<Option<RuntimeCoverageReport>, ExitCode> {
+    let runtime_coverage = crate::health::coverage::prepare_options(
+        path,
+        opts.min_invocations_hot,
+        None,
+        None,
+        opts.output,
+    )?;
+    let result = crate::health::execute_health_with_shared_parse(
+        &HealthOptions {
+            root: opts.root,
+            config_path: opts.config_path,
+            output: opts.output,
+            no_cache: opts.no_cache,
+            threads: opts.threads,
+            quiet: opts.quiet,
+            max_cyclomatic: None,
+            max_cognitive: None,
+            max_crap: None,
+            top: None,
+            sort: SortBy::Cyclomatic,
+            production: true,
+            production_override: Some(true),
+            changed_since: opts.changed_since,
+            diff_index: None,
+            use_shared_diff_index: opts.use_shared_diff_index,
+            workspace: opts.workspace,
+            changed_workspaces: opts.changed_workspaces,
+            baseline: None,
+            save_baseline: None,
+            complexity: false,
+            complexity_breakdown: false,
+            file_scores: false,
+            coverage_gaps: false,
+            config_activates_coverage_gaps: false,
+            hotspots: false,
+            ownership: false,
+            ownership_emails: None,
+            targets: false,
+            force_full: false,
+            score_only_output: false,
+            enforce_coverage_gap_gate: false,
+            effort: None,
+            score: false,
+            min_score: None,
+            since: None,
+            min_commits: None,
+            explain: false,
+            summary: false,
+            save_snapshot: None,
+            trend: false,
+            group_by: None,
+            coverage: None,
+            coverage_root: None,
+            performance: false,
+            min_severity: None,
+            report_only: false,
+            runtime_coverage: Some(runtime_coverage),
+            churn_file: None,
+        },
+        SharedParseData {
+            files,
+            modules,
+            analysis_output: Some(analysis_output),
+        },
+    )?;
+    Ok(result.report.runtime_coverage)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RuntimeFunctionKey {
+    path: String,
+    function: String,
+    line: u32,
+}
+
+#[derive(Debug, Clone)]
+struct FunctionSpan {
+    key: RuntimeFunctionKey,
+    end_line: u32,
+}
+
+fn apply_runtime_context(
+    findings: &mut Vec<SecurityFinding>,
+    modules: &[ModuleInfo],
+    files: &[fallow_types::discover::DiscoveredFile],
+    root: &Path,
+    report: &RuntimeCoverageReport,
+) {
+    let spans = function_spans(modules, files, root);
+    let runtime = SecurityRuntimeIndex::new(report);
+    let mut indexed = findings.drain(..).enumerate().collect::<Vec<_>>();
+    for (_, finding) in &mut indexed {
+        if !matches!(finding.kind, SecurityFindingKind::TaintedSink) {
+            continue;
+        }
+        finding.runtime = runtime_context_for_finding(finding, &spans, &runtime);
+    }
+    indexed.sort_by(|(left_index, left), (right_index, right)| {
+        runtime_rank(left)
+            .cmp(&runtime_rank(right))
+            .then_with(|| left_index.cmp(right_index))
+    });
+    findings.extend(indexed.into_iter().map(|(_, finding)| finding));
+}
+
+fn function_spans(
+    modules: &[ModuleInfo],
+    files: &[fallow_types::discover::DiscoveredFile],
+    root: &Path,
+) -> Vec<FunctionSpan> {
+    let paths_by_id = files
+        .iter()
+        .map(|file| (file.id, &file.path))
+        .collect::<rustc_hash::FxHashMap<_, _>>();
+    let mut spans = Vec::new();
+    for module in modules {
+        let Some(path) = paths_by_id.get(&module.file_id) else {
+            continue;
+        };
+        let path = relative_key(path, root);
+        for function in &module.complexity {
+            spans.push(FunctionSpan {
+                key: RuntimeFunctionKey {
+                    path: path.clone(),
+                    function: function.name.clone(),
+                    line: function.line,
+                },
+                end_line: function.line.saturating_add(function.line_count),
+            });
+        }
+    }
+    spans
+}
+
+struct SecurityRuntimeIndex {
+    hot_paths: Vec<(RuntimeFunctionKey, u32, SecurityRuntimeContext)>,
+    findings: rustc_hash::FxHashMap<RuntimeFunctionKey, SecurityRuntimeContext>,
+}
+
+impl SecurityRuntimeIndex {
+    fn new(report: &RuntimeCoverageReport) -> Self {
+        let hot_paths = report
+            .hot_paths
+            .iter()
+            .map(|hot| {
+                (
+                    runtime_hot_key(hot),
+                    hot.end_line.max(hot.line),
+                    SecurityRuntimeContext {
+                        state: SecurityRuntimeState::RuntimeHot,
+                        function: hot.function.clone(),
+                        line: hot.line,
+                        invocations: Some(hot.invocations),
+                        stable_id: hot.stable_id.clone(),
+                        evidence: Some(format!(
+                            "production hot path observed with {} invocation{}",
+                            hot.invocations,
+                            crate::report::plural(hot.invocations as usize)
+                        )),
+                    },
+                )
+            })
+            .collect();
+        let findings = report
+            .findings
+            .iter()
+            .map(runtime_finding_context)
+            .collect();
+        Self {
+            hot_paths,
+            findings,
+        }
+    }
+}
+
+fn runtime_context_for_finding(
+    finding: &SecurityFinding,
+    spans: &[FunctionSpan],
+    runtime: &SecurityRuntimeIndex,
+) -> Option<SecurityRuntimeContext> {
+    let path = path_key(&finding.path);
+    let span = spans
+        .iter()
+        .filter(|span| {
+            span.key.path == path && span.key.line <= finding.line && finding.line <= span.end_line
+        })
+        .min_by_key(|span| span.end_line.saturating_sub(span.key.line))?;
+    if let Some((_, _, context)) = runtime.hot_paths.iter().find(|(key, end_line, _)| {
+        key == &span.key && key.line <= finding.line && finding.line <= *end_line
+    }) {
+        return Some(context.clone());
+    }
+    runtime.findings.get(&span.key).cloned().or_else(|| {
+        Some(SecurityRuntimeContext {
+            state: SecurityRuntimeState::RuntimeUnknown,
+            function: span.key.function.clone(),
+            line: span.key.line,
+            invocations: None,
+            stable_id: None,
+            evidence: Some("runtime coverage carried no matching function evidence".to_owned()),
+        })
+    })
+}
+
+fn runtime_rank(finding: &SecurityFinding) -> u8 {
+    match finding.runtime.as_ref().map(|runtime| runtime.state) {
+        Some(SecurityRuntimeState::RuntimeHot) => 0,
+        Some(SecurityRuntimeState::LowTraffic) => 1,
+        None | Some(SecurityRuntimeState::RuntimeUnknown) => 2,
+        Some(SecurityRuntimeState::CoverageUnavailable) => 3,
+        Some(SecurityRuntimeState::RuntimeCold) => 4,
+        Some(SecurityRuntimeState::NeverExecuted) => 5,
+    }
+}
+
+fn runtime_hot_key(hot: &RuntimeCoverageHotPath) -> RuntimeFunctionKey {
+    RuntimeFunctionKey {
+        path: path_key(&hot.path),
+        function: hot.function.clone(),
+        line: hot.line,
+    }
+}
+
+fn runtime_finding_context(
+    finding: &RuntimeCoverageFinding,
+) -> (RuntimeFunctionKey, SecurityRuntimeContext) {
+    let state = match finding.verdict {
+        RuntimeCoverageVerdict::SafeToDelete => SecurityRuntimeState::NeverExecuted,
+        RuntimeCoverageVerdict::ReviewRequired if finding.invocations.unwrap_or(0) == 0 => {
+            SecurityRuntimeState::RuntimeCold
+        }
+        RuntimeCoverageVerdict::LowTraffic => SecurityRuntimeState::LowTraffic,
+        RuntimeCoverageVerdict::CoverageUnavailable | RuntimeCoverageVerdict::Unknown => {
+            SecurityRuntimeState::CoverageUnavailable
+        }
+        RuntimeCoverageVerdict::ReviewRequired | RuntimeCoverageVerdict::Active => {
+            SecurityRuntimeState::RuntimeUnknown
+        }
+    };
+    (
+        RuntimeFunctionKey {
+            path: path_key(&finding.path),
+            function: finding.function.clone(),
+            line: finding.line,
+        },
+        SecurityRuntimeContext {
+            state,
+            function: finding.function.clone(),
+            line: finding.line,
+            invocations: finding.invocations,
+            stable_id: finding.stable_id.clone(),
+            evidence: Some(format!("runtime coverage verdict: {}", finding.verdict)),
+        },
+    )
+}
+
+fn relative_key(path: &Path, root: &Path) -> String {
+    path_key(path.strip_prefix(root).unwrap_or(path))
+}
+
+fn path_key(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 fn filter_to_files(
@@ -500,6 +863,9 @@ pub fn render_human(output: &SecurityOutput) -> String {
             if let Some(hint) = dead_code_hint(finding) {
                 out.push_str(&format!("    dead-code: {hint}\n"));
             }
+            if let Some(runtime) = finding.runtime.as_ref() {
+                out.push_str(&format!("    runtime: {}\n", runtime_hint_text(runtime)));
+            }
             if let Some(reach) = finding.reachability.as_ref() {
                 let entry = if reach.reachable_from_entry {
                     "reachable from a runtime entry point"
@@ -651,6 +1017,41 @@ fn source_reachability_hint(finding: &SecurityFinding) -> Option<&'static str> {
         })
 }
 
+fn runtime_hint_text(runtime: &SecurityRuntimeContext) -> String {
+    use std::fmt::Write as _;
+
+    let mut text = format!(
+        "{} in {}:{}",
+        runtime_state_label(runtime.state),
+        runtime.function,
+        runtime.line
+    );
+    if let Some(invocations) = runtime.invocations {
+        let _ = write!(
+            text,
+            " ({} invocation{})",
+            invocations,
+            crate::report::plural(invocations as usize)
+        );
+    }
+    if let Some(evidence) = runtime.evidence.as_deref() {
+        text.push_str("; ");
+        text.push_str(evidence);
+    }
+    text
+}
+
+const fn runtime_state_label(state: SecurityRuntimeState) -> &'static str {
+    match state {
+        SecurityRuntimeState::RuntimeHot => "runtime-hot",
+        SecurityRuntimeState::RuntimeCold => "runtime-cold",
+        SecurityRuntimeState::NeverExecuted => "never-executed",
+        SecurityRuntimeState::LowTraffic => "low-traffic",
+        SecurityRuntimeState::CoverageUnavailable => "coverage-unavailable",
+        SecurityRuntimeState::RuntimeUnknown => "runtime-unknown",
+    }
+}
+
 /// The SARIF ruleId for a finding. `client-server-leak` keeps its bespoke id;
 /// each `TaintedSink` category gets `security/<category>` so the GitHub Security
 /// tab groups and labels candidates per CWE class instead of collapsing every
@@ -730,6 +1131,11 @@ fn render_sarif(output: &SecurityOutput) -> String {
             if let Some(hint) = source_reachability_hint(finding) {
                 message.push(' ');
                 message.push_str(hint);
+            }
+            if let Some(runtime) = finding.runtime.as_ref() {
+                message.push_str(" Runtime context: ");
+                message.push_str(&runtime_hint_text(runtime));
+                message.push('.');
             }
             let mut related: Vec<serde_json::Value> = finding
                 .trace
@@ -894,6 +1300,7 @@ mod tests {
                 },
             },
             taint_flow: None,
+            runtime: None,
         }
     }
 
@@ -919,6 +1326,84 @@ mod tests {
             unresolved_edge_files: 0,
             unresolved_callee_sites: 0,
         }
+    }
+
+    fn tainted_with_runtime(root: &Path, state: Option<SecurityRuntimeState>) -> SecurityFinding {
+        let mut finding = sample_finding(root);
+        finding.kind = SecurityFindingKind::TaintedSink;
+        finding.category = Some("dangerous-html".to_owned());
+        finding.cwe = Some(79);
+        finding.runtime = state.map(|state| SecurityRuntimeContext {
+            state,
+            function: "render".to_owned(),
+            line: 10,
+            invocations: Some(123),
+            stable_id: Some("fallow:fn:test".to_owned()),
+            evidence: Some("production runtime evidence".to_owned()),
+        });
+        finding
+    }
+
+    #[test]
+    fn runtime_rank_promotes_hot_and_demotes_never_executed() {
+        let root = Path::new("/proj/root");
+        let mut findings = [
+            tainted_with_runtime(root, Some(SecurityRuntimeState::NeverExecuted)),
+            tainted_with_runtime(root, None),
+            tainted_with_runtime(root, Some(SecurityRuntimeState::RuntimeHot)),
+            tainted_with_runtime(root, Some(SecurityRuntimeState::CoverageUnavailable)),
+        ];
+
+        findings.sort_by_key(runtime_rank);
+
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| finding.runtime.as_ref().map(|runtime| runtime.state))
+                .collect::<Vec<_>>(),
+            vec![
+                Some(SecurityRuntimeState::RuntimeHot),
+                None,
+                Some(SecurityRuntimeState::CoverageUnavailable),
+                Some(SecurityRuntimeState::NeverExecuted),
+            ]
+        );
+    }
+
+    #[test]
+    fn human_render_includes_runtime_context_line() {
+        let root = Path::new("/proj/root");
+        let finding = relativize_finding(
+            tainted_with_runtime(root, Some(SecurityRuntimeState::RuntimeHot)),
+            root,
+        );
+        let out = render_human(&output_with(vec![finding], 0));
+
+        assert!(
+            out.contains("runtime: runtime-hot in render:10"),
+            "got: {out}"
+        );
+        assert!(out.contains("production runtime evidence"), "got: {out}");
+    }
+
+    #[test]
+    fn sarif_render_includes_runtime_context_in_message() {
+        let root = Path::new("/proj/root");
+        let finding = relativize_finding(
+            tainted_with_runtime(root, Some(SecurityRuntimeState::RuntimeHot)),
+            root,
+        );
+        let rendered = render_sarif(&output_with(vec![finding], 0));
+        let sarif: serde_json::Value = serde_json::from_str(&rendered).expect("valid SARIF JSON");
+        let message = sarif["runs"][0]["results"][0]["message"]["text"]
+            .as_str()
+            .expect("message text");
+
+        assert!(message.contains("Runtime context"), "got: {message}");
+        assert!(
+            message.contains("runtime-hot in render:10"),
+            "got: {message}"
+        );
     }
 
     #[test]
@@ -1400,6 +1885,8 @@ mod tests {
             changed_workspaces: None,
             file: &[],
             gate: None,
+            runtime_coverage: None,
+            min_invocations_hot: 100,
         }
     }
 

--- a/crates/cli/tests/runtime_coverage_tests.rs
+++ b/crates/cli/tests/runtime_coverage_tests.rs
@@ -108,6 +108,20 @@ mod gated {
             ]
         }
 
+        fn security_args(&self) -> Vec<String> {
+            let fixture = fixture_path("security-dangerous-html");
+            vec![
+                "security".to_owned(),
+                "--root".to_owned(),
+                fixture.to_string_lossy().into_owned(),
+                "--runtime-coverage".to_owned(),
+                self.coverage_file.to_string_lossy().into_owned(),
+                "--format".to_owned(),
+                "json".to_owned(),
+                "--quiet".to_owned(),
+            ]
+        }
+
         fn multi_capture_dir(&self) -> PathBuf {
             let dir = self.tmp.path().join("multi-capture");
             fs::create_dir_all(&dir).expect("create multi-capture dir");
@@ -241,6 +255,42 @@ mod gated {
             json.pointer("/runtime_coverage/schema_version"),
             Some(&serde_json::Value::String("1".to_owned())),
             "runtime_coverage schema_version must be stable for agent consumers"
+        );
+    }
+
+    #[test]
+    fn security_runtime_coverage_marks_hot_sink_candidate() {
+        let harness = Harness::new();
+        let mut cmd = harness.fallow();
+        cmd.env("FALLOW_LICENSE", sign::mint_runtime_coverage_jwt());
+        cmd.env("FALLOW_STUB_MODE", "security-hot");
+        for arg in harness.security_args() {
+            cmd.arg(arg);
+        }
+        let (stdout, stderr, code) = run_with(cmd);
+        assert_eq!(
+            code,
+            0,
+            "security runtime coverage must exit 0; stderr={stderr}; stdout head={}",
+            &stdout.chars().take(400).collect::<String>()
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("security output should be JSON");
+        let first = json
+            .pointer("/security_findings/0")
+            .expect("first security finding");
+
+        assert_eq!(
+            first.pointer("/path"),
+            Some(&serde_json::Value::String("src/sink.ts".to_owned()))
+        );
+        assert_eq!(
+            first.pointer("/runtime/state"),
+            Some(&serde_json::Value::String("runtime-hot".to_owned()))
+        );
+        assert_eq!(
+            first.pointer("/runtime/invocations"),
+            Some(&serde_json::Value::Number(250.into()))
         );
     }
 

--- a/crates/core/src/analyze/security/hardcoded_secret.rs
+++ b/crates/core/src/analyze/security/hardcoded_secret.rs
@@ -117,6 +117,7 @@ pub fn find_hardcoded_secret_candidates(
                 dead_code: None,
                 candidate,
                 taint_flow: None,
+                runtime: None,
             });
         }
     }

--- a/crates/core/src/analyze/security/mod.rs
+++ b/crates/core/src/analyze/security/mod.rs
@@ -350,6 +350,7 @@ fn build_leak_finding(
         reachability: None,
         candidate,
         taint_flow: None,
+        runtime: None,
     }
 }
 
@@ -412,6 +413,7 @@ fn build_direct_finding(
         reachability: None,
         candidate,
         taint_flow: None,
+        runtime: None,
     }
 }
 

--- a/crates/core/src/analyze/security/rank.rs
+++ b/crates/core/src/analyze/security/rank.rs
@@ -759,6 +759,7 @@ mod tests {
                 boundary: SecurityCandidateBoundary::default(),
             },
             taint_flow: None,
+            runtime: None,
         }
     }
 

--- a/crates/core/src/analyze/security/tainted_sink.rs
+++ b/crates/core/src/analyze/security/tainted_sink.rs
@@ -460,6 +460,7 @@ pub fn find_tainted_sinks(
                 reachability: None,
                 candidate,
                 taint_flow: None,
+                runtime: None,
             });
         }
     }

--- a/crates/core/src/changed_files.rs
+++ b/crates/core/src/changed_files.rs
@@ -813,6 +813,7 @@ mod tests {
             actions: Vec::new(),
             dead_code: None,
             reachability: None,
+            runtime: None,
         });
 
         let mut changed: FxHashSet<PathBuf> = FxHashSet::default();
@@ -862,6 +863,7 @@ mod tests {
                 blast_radius: 0,
                 crosses_boundary: false,
             }),
+            runtime: None,
         });
 
         let mut changed: FxHashSet<PathBuf> = FxHashSet::default();

--- a/crates/lsp/src/code_actions/suppress.rs
+++ b/crates/lsp/src/code_actions/suppress.rs
@@ -167,6 +167,7 @@ mod tests {
             actions: vec![],
             dead_code: None,
             reachability: None,
+            runtime: None,
         }
     }
 
@@ -187,6 +188,7 @@ mod tests {
             actions: vec![],
             dead_code: None,
             reachability: None,
+            runtime: None,
         }
     }
 

--- a/crates/lsp/src/diagnostics/mod.rs
+++ b/crates/lsp/src/diagnostics/mod.rs
@@ -214,6 +214,7 @@ mod tests {
                 actions: vec![],
                 dead_code: None,
                 reachability: None,
+                runtime: None,
             });
 
         let duplication = empty_duplication();

--- a/crates/lsp/src/diagnostics/security.rs
+++ b/crates/lsp/src/diagnostics/security.rs
@@ -173,6 +173,7 @@ mod tests {
                 blast_radius: 3,
                 crosses_boundary: true,
             }),
+            runtime: None,
         }
     }
 
@@ -193,6 +194,7 @@ mod tests {
             actions: vec![],
             dead_code: None,
             reachability: None,
+            runtime: None,
         }
     }
 

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -1528,6 +1528,7 @@ mod tests {
                 blast_radius: 4,
                 crosses_boundary: false,
             }),
+            runtime: None,
         }
     }
 

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -2545,6 +2545,7 @@ export function choose(value: number): string {
                 actions: vec![],
                 dead_code: None,
                 reachability: None,
+                runtime: None,
             }],
             security_unresolved_edge_files: 2,
             security_unresolved_callee_sites: 0,
@@ -3357,6 +3358,7 @@ export function choose(value: number): string {
             actions: vec![],
             dead_code: None,
             reachability: None,
+            runtime: None,
         };
         let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
         diags_by_file.insert(

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -1075,6 +1075,51 @@ pub struct SecurityTaintFlow {
     pub path: TaintPath,
 }
 
+/// Runtime coverage state for the function enclosing a security sink.
+/// This is production-observation evidence, not an exploitability verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum SecurityRuntimeState {
+    /// The sink sits inside a runtime hot path.
+    RuntimeHot,
+    /// The sink sits inside a tracked function with zero production invocations.
+    RuntimeCold,
+    /// The sink sits inside a tracked function the runtime layer marked as safe
+    /// to delete because it was never executed.
+    NeverExecuted,
+    /// The sink sits inside a function that executed, but below the low-traffic
+    /// threshold.
+    LowTraffic,
+    /// Runtime coverage could not classify the enclosing function.
+    CoverageUnavailable,
+    /// A static enclosing function was found, but the runtime report carried no
+    /// matching evidence for it.
+    RuntimeUnknown,
+}
+
+/// Runtime coverage context attached to a security candidate when
+/// `fallow security --runtime-coverage` is supplied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SecurityRuntimeContext {
+    /// Runtime state for the enclosing function.
+    pub state: SecurityRuntimeState,
+    /// Enclosing function name from static extraction.
+    pub function: String,
+    /// 1-based line where the enclosing function starts.
+    pub line: u32,
+    /// Observed invocation count when the runtime report provides it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocations: Option<u64>,
+    /// Runtime coverage stable function id, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_id: Option<String>,
+    /// Short candidate-framed explanation of the runtime evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
+}
+
 /// A local security CANDIDATE for downstream agent verification, NOT a verified
 /// vulnerability. Emitted only by `fallow security`, never under bare `fallow`
 /// or the `audit` gate. There is deliberately no `confidence` or
@@ -1149,6 +1194,11 @@ pub struct SecurityFinding {
     /// is import-reachable to this sink. Absent (skipped) otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub taint_flow: Option<SecurityTaintFlow>,
+    /// Production runtime coverage context for the function enclosing this
+    /// security sink. Present only when `fallow security --runtime-coverage`
+    /// runs and the candidate is a `tainted-sink`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<SecurityRuntimeContext>,
 }
 
 /// A pnpm catalog entry declared in pnpm-workspace.yaml that no workspace package

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -9974,6 +9974,17 @@
             }
           ],
           "description": "Source-to-sink taint-flow triple, present only when an untrusted source\nis import-reachable to this sink. Absent (skipped) otherwise."
+        },
+        "runtime": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecurityRuntimeContext"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Production runtime coverage context for the function enclosing this\nsecurity sink. Present only when `fallow security --runtime-coverage`\nruns and the candidate is a `tainted-sink`."
         }
       },
       "required": [
@@ -10606,6 +10617,85 @@
         "cross_module_hops"
       ],
       "description": "Compact taint-flow path shape. The ordered per-hop trace is NOT duplicated\nhere: it lives on [`SecurityReachability::untrusted_source_trace`]. This\ncarries only the flow's structural summary (intra-module flow plus the\ncross-module hop count) so consumers do not parse two copies of the hops."
+    },
+    "SecurityRuntimeState": {
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "runtime-hot",
+          "description": "The sink sits inside a runtime hot path."
+        },
+        {
+          "type": "string",
+          "const": "runtime-cold",
+          "description": "The sink sits inside a tracked function with zero production invocations."
+        },
+        {
+          "type": "string",
+          "const": "never-executed",
+          "description": "The sink sits inside a tracked function the runtime layer marked as safe\nto delete because it was never executed."
+        },
+        {
+          "type": "string",
+          "const": "low-traffic",
+          "description": "The sink sits inside a function that executed, but below the low-traffic\nthreshold."
+        },
+        {
+          "type": "string",
+          "const": "coverage-unavailable",
+          "description": "Runtime coverage could not classify the enclosing function."
+        },
+        {
+          "type": "string",
+          "const": "runtime-unknown",
+          "description": "A static enclosing function was found, but the runtime report carried no\nmatching evidence for it."
+        }
+      ],
+      "description": "Runtime coverage state for the function enclosing a security sink.\nThis is production-observation evidence, not an exploitability verdict."
+    },
+    "SecurityRuntimeContext": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "Runtime state for the enclosing function.",
+          "$ref": "#/definitions/SecurityRuntimeState"
+        },
+        "function": {
+          "type": "string",
+          "description": "Enclosing function name from static extraction."
+        },
+        "line": {
+          "type": "integer",
+          "description": "1-based line where the enclosing function starts."
+        },
+        "invocations": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Observed invocation count when the runtime report provides it."
+        },
+        "stable_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Runtime coverage stable function id, when available."
+        },
+        "evidence": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Short candidate-framed explanation of the runtime evidence."
+        }
+      },
+      "required": [
+        "state",
+        "function",
+        "line"
+      ],
+      "description": "Runtime coverage context attached to a security candidate when\n`fallow security --runtime-coverage` is supplied."
     }
   }
 }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -626,6 +626,11 @@ export type TraceHopRole = ("client-boundary" | "untrusted-source" | "intermedia
  */
 export type SecurityDeadCodeKind = ("unused-file" | "unused-export")
 /**
+ * Runtime coverage state for the function enclosing a security sink.
+ * This is production-observation evidence, not an exploitability verdict.
+ */
+export type SecurityRuntimeState = ("runtime-hot" | "runtime-cold" | "never-executed" | "low-traffic" | "coverage-unavailable" | "runtime-unknown")
+/**
  * Discriminator value for [`CodeClimateIssue::kind`].
  */
 export type CodeClimateIssueKind = "issue"
@@ -4979,6 +4984,12 @@ candidate: SecurityCandidate
  * is import-reachable to this sink. Absent (skipped) otherwise.
  */
 taint_flow?: (SecurityTaintFlow | null)
+/**
+ * Production runtime coverage context for the function enclosing this
+ * security sink. Present only when `fallow security --runtime-coverage`
+ * runs and the candidate is a `tainted-sink`.
+ */
+runtime?: (SecurityRuntimeContext | null)
 }
 /**
  * One hop in a security finding's structural trace. Stored as an absolute path
@@ -5221,6 +5232,33 @@ intra_module: boolean
  * module. Zero for an intra-module flow.
  */
 cross_module_hops: number
+}
+/**
+ * Runtime coverage context attached to a security candidate when
+ * `fallow security --runtime-coverage` is supplied.
+ */
+export interface SecurityRuntimeContext {
+state: SecurityRuntimeState
+/**
+ * Enclosing function name from static extraction.
+ */
+function: string
+/**
+ * 1-based line where the enclosing function starts.
+ */
+line: number
+/**
+ * Observed invocation count when the runtime report provides it.
+ */
+invocations?: (number | null)
+/**
+ * Runtime coverage stable function id, when available.
+ */
+stable_id?: (string | null)
+/**
+ * Short candidate-framed explanation of the runtime evidence.
+ */
+evidence?: (string | null)
 }
 /**
  * Bare `fallow --format json` envelope.

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -626,6 +626,11 @@ export type TraceHopRole = ("client-boundary" | "untrusted-source" | "intermedia
  */
 export type SecurityDeadCodeKind = ("unused-file" | "unused-export")
 /**
+ * Runtime coverage state for the function enclosing a security sink.
+ * This is production-observation evidence, not an exploitability verdict.
+ */
+export type SecurityRuntimeState = ("runtime-hot" | "runtime-cold" | "never-executed" | "low-traffic" | "coverage-unavailable" | "runtime-unknown")
+/**
  * Discriminator value for [`CodeClimateIssue::kind`].
  */
 export type CodeClimateIssueKind = "issue"
@@ -4979,6 +4984,12 @@ candidate: SecurityCandidate
  * is import-reachable to this sink. Absent (skipped) otherwise.
  */
 taint_flow?: (SecurityTaintFlow | null)
+/**
+ * Production runtime coverage context for the function enclosing this
+ * security sink. Present only when `fallow security --runtime-coverage`
+ * runs and the candidate is a `tainted-sink`.
+ */
+runtime?: (SecurityRuntimeContext | null)
 }
 /**
  * One hop in a security finding's structural trace. Stored as an absolute path
@@ -5221,6 +5232,33 @@ intra_module: boolean
  * module. Zero for an intra-module flow.
  */
 cross_module_hops: number
+}
+/**
+ * Runtime coverage context attached to a security candidate when
+ * `fallow security --runtime-coverage` is supplied.
+ */
+export interface SecurityRuntimeContext {
+state: SecurityRuntimeState
+/**
+ * Enclosing function name from static extraction.
+ */
+function: string
+/**
+ * 1-based line where the enclosing function starts.
+ */
+line: number
+/**
+ * Observed invocation count when the runtime report provides it.
+ */
+invocations?: (number | null)
+/**
+ * Runtime coverage stable function id, when available.
+ */
+stable_id?: (string | null)
+/**
+ * Short candidate-framed explanation of the runtime evidence.
+ */
+evidence?: (string | null)
 }
 /**
  * Bare `fallow --format json` envelope.


### PR DESCRIPTION
Closes #887.

## Summary
- Add opt-in runtime coverage enrichment to `fallow security` for tainted-sink candidates.
- Annotate candidates with production runtime state when runtime evidence is supplied.
- Promote runtime-hot sink candidates while demoting cold or never-executed candidates.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `cd editors/vscode && pnpm run check:codegen`
- `cd editors/vscode && pnpm run check:dist`
- `npm run lint:js`
- `npm run fmt:js:check`
- `cd editors/vscode && pnpm lint`
- `fallow audit --format json --quiet`
