### PR TITLE
feat(telemetry): split admin workflow buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Telemetry now separates admin workflow buckets.** Opt-in CLI telemetry now records coarse `project_inventory`, `setup`, and `license` workflow labels for admin and setup commands that previously collapsed into `unknown`. The payload remains allowlisted and still does not include raw commands, paths, config values, repository identifiers, or license identifiers. (Closes [#1061](https://github.com/fallow-rs/fallow/issues/1061).)
+
 ## [2.90.0] - 2026-06-08
 
 ### Added

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3122,7 +3122,9 @@ fn telemetry_workflow_for_command(
     output: fallow_config::OutputFormat,
 ) -> telemetry::Workflow {
     match command {
-        None | Some(Command::Flags { .. }) => telemetry::Workflow::CodeQualityReview,
+        None | Some(Command::Flags { .. } | Command::Watch { .. }) => {
+            telemetry::Workflow::CodeQualityReview
+        }
         Some(Command::Check { .. }) => telemetry::Workflow::DeadCode,
         Some(Command::Dupes { .. }) => telemetry::Workflow::Dupes,
         Some(Command::Health { .. }) => telemetry::Workflow::Health,
@@ -3138,22 +3140,21 @@ fn telemetry_workflow_for_command(
         Some(Command::Security { .. }) => telemetry::Workflow::Security,
         Some(Command::Fix { .. }) => telemetry::Workflow::Fix,
         Some(Command::Explain { .. }) => telemetry::Workflow::Explain,
+        Some(Command::List { .. } | Command::Workspaces | Command::Schema) => {
+            telemetry::Workflow::ProjectInventory
+        }
+        Some(Command::License { .. }) => telemetry::Workflow::License,
         Some(
-            Command::List { .. }
-            | Command::Workspaces
-            | Command::Watch { .. }
-            | Command::Init { .. }
+            Command::Init { .. }
             | Command::Hooks { .. }
             | Command::ConfigSchema
             | Command::PluginSchema
             | Command::Config { .. }
-            | Command::Schema
             | Command::CiTemplate { .. }
             | Command::Migrate { .. }
-            | Command::License { .. }
             | Command::Telemetry { .. }
             | Command::SetupHooks { .. },
-        ) => telemetry::Workflow::Unknown,
+        ) => telemetry::Workflow::Setup,
     }
 }
 
@@ -3940,9 +3941,9 @@ mod tests {
         Cli::command().debug_assert();
     }
 
-    /// The high-value commands each get their own telemetry workflow instead of
-    /// the `Unknown` catch-all, so "is anyone using `fallow impact`?" is
-    /// answerable. Admin / low-signal commands stay `Unknown`.
+    /// The high-value and coarse admin commands each get a distinct telemetry
+    /// workflow instead of the `Unknown` catch-all, so command families stay
+    /// answerable without uploading raw command lines.
     #[test]
     fn high_value_commands_route_to_distinct_workflows() {
         use clap::Parser;
@@ -3956,6 +3957,44 @@ mod tests {
                 vec!["fallow", "explain", "unused-exports"],
                 telemetry::Workflow::Explain,
             ),
+            (
+                vec!["fallow", "watch"],
+                telemetry::Workflow::CodeQualityReview,
+            ),
+            (
+                vec!["fallow", "list"],
+                telemetry::Workflow::ProjectInventory,
+            ),
+            (
+                vec!["fallow", "workspaces"],
+                telemetry::Workflow::ProjectInventory,
+            ),
+            (
+                vec!["fallow", "schema"],
+                telemetry::Workflow::ProjectInventory,
+            ),
+            (vec!["fallow", "init"], telemetry::Workflow::Setup),
+            (
+                vec!["fallow", "hooks", "install", "--target", "git"],
+                telemetry::Workflow::Setup,
+            ),
+            (vec!["fallow", "config-schema"], telemetry::Workflow::Setup),
+            (vec!["fallow", "plugin-schema"], telemetry::Workflow::Setup),
+            (vec!["fallow", "config"], telemetry::Workflow::Setup),
+            (
+                vec!["fallow", "ci-template", "gitlab"],
+                telemetry::Workflow::Setup,
+            ),
+            (vec!["fallow", "migrate"], telemetry::Workflow::Setup),
+            (
+                vec!["fallow", "telemetry", "status"],
+                telemetry::Workflow::Setup,
+            ),
+            (vec!["fallow", "setup-hooks"], telemetry::Workflow::Setup),
+            (
+                vec!["fallow", "license", "status"],
+                telemetry::Workflow::License,
+            ),
         ];
         for (argv, expected) in distinct {
             let cli = Cli::try_parse_from(&argv).expect("argv parses");
@@ -3963,19 +4002,6 @@ mod tests {
                 telemetry_workflow_for_command(cli.command.as_ref(), OutputFormat::Json),
                 expected,
                 "{argv:?} should map to {expected:?}"
-            );
-        }
-
-        for argv in [
-            vec!["fallow", "list"],
-            vec!["fallow", "config"],
-            vec!["fallow", "schema"],
-        ] {
-            let cli = Cli::try_parse_from(&argv).expect("argv parses");
-            assert_eq!(
-                telemetry_workflow_for_command(cli.command.as_ref(), OutputFormat::Json),
-                telemetry::Workflow::Unknown,
-                "{argv:?} should stay Unknown"
             );
         }
     }

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -146,6 +146,9 @@ pub enum Workflow {
     Security,
     Fix,
     Explain,
+    ProjectInventory,
+    Setup,
+    License,
     Unknown,
 }
 

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -429,6 +429,59 @@ fn admin_command_emits_no_findings_present_key() {
 }
 
 #[test]
+fn project_inventory_command_routes_to_project_inventory_without_findings_present() {
+    let dir = tempfile::tempdir().expect("temp project");
+    std::fs::write(dir.path().join("package.json"), "{\n  \"name\": \"x\"\n}\n")
+        .expect("write package.json");
+
+    let (event, output) = inspect_event_output(dir.path(), &["list"], &[]);
+
+    assert_eq!(output.code, 0, "list should exit 0: {}", output.stderr);
+    assert_eq!(event["workflow"].as_str(), Some("project_inventory"));
+    assert!(
+        event.get("findings_present").is_none(),
+        "project-inventory commands must omit findings_present"
+    );
+}
+
+#[test]
+fn setup_command_routes_to_setup_without_findings_present() {
+    let dir = tempfile::tempdir().expect("temp project");
+    std::fs::write(dir.path().join("package.json"), "{\n  \"name\": \"x\"\n}\n")
+        .expect("write package.json");
+
+    let (event, output) = inspect_event_output(dir.path(), &["init"], &[]);
+
+    assert_eq!(output.code, 0, "init should exit 0: {}", output.stderr);
+    assert_eq!(event["workflow"].as_str(), Some("setup"));
+    assert!(
+        event.get("findings_present").is_none(),
+        "setup commands must omit findings_present"
+    );
+}
+
+#[test]
+fn license_command_routes_to_license_without_findings_present() {
+    let dir = tempfile::tempdir().expect("temp project");
+    std::fs::write(dir.path().join("package.json"), "{\n  \"name\": \"x\"\n}\n")
+        .expect("write package.json");
+
+    let (event, output) = inspect_event_output(dir.path(), &["license", "status"], &[]);
+
+    assert_eq!(
+        output.code, 3,
+        "license status should exit 3 when no local license exists: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("license"));
+    assert_eq!(event["outcome"].as_str(), Some("failed"));
+    assert!(
+        event.get("findings_present").is_none(),
+        "license commands must omit findings_present"
+    );
+}
+
+#[test]
 fn mcp_surface_override_tags_event_with_tool() {
     let dir = tempfile::tempdir().expect("temp project");
     std::fs::write(dir.path().join("package.json"), "{\n  \"name\": \"x\"\n}\n")

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -98,7 +98,7 @@ Field purposes:
 
 | Field | Purpose |
 | --- | --- |
-| `workflow` | Prioritize the audit, dead-code, health, duplication, CI, runtime-coverage setup, impact, security, fix, and explain workflows. |
+| `workflow` | Prioritize the audit, dead-code, health, duplication, CI, runtime-coverage setup, impact, security, fix, explain, project-inventory, setup, and license workflows. Project-inventory, setup, and license are coarse buckets and do not expose raw commands, config values, repository identifiers, or license identifiers. |
 | `integration_surface` | Understand whether Fallow is used through human CLI, CLI JSON, MCP, CI, editor, or programmatic surfaces. |
 | `invocation_context` | Separate human, CI, editor, and agent-driven use without uploading detection evidence. |
 | `agent_source` | Improve compatibility with specific agent integrations using a documented allowlist. |


### PR DESCRIPTION
## Summary
- Split admin and setup telemetry commands into coarse workflow buckets.
- Keep non-analysis commands free of findings_present metadata.
- Document the allowlisted workflow labels.

## Issue
Closes #1061

## Verification
- [x] cargo check --workspace
- [x] cargo build --workspace
- [x] cargo test -p fallow-cli --test telemetry_tests
- [x] cargo test --workspace --all-targets
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] real-project inspect smoke for project_inventory, setup, and license workflows