### PR TITLE
feat(telemetry): add cache context to code quality review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Telemetry now separates admin workflow buckets.** Opt-in CLI telemetry now records coarse `project_inventory`, `setup`, and `license` workflow labels for admin and setup commands that previously collapsed into `unknown`. The payload remains allowlisted and still does not include raw commands, paths, config values, repository identifiers, or license identifiers. (Closes [#1061](https://github.com/fallow-rs/fallow/issues/1061).)
 - **Telemetry now describes parent-run follow-ups with safe dimensions.** Inspect-mode and uploaded workflow events use `has_parent_run`, `run_role`, and `followup_kind` instead of exposing raw parent-run tokens as event properties. Valid `--parent-run` values can still be used as private upload correlation metadata, while paths and free-form values are dropped. (Closes [#1078](https://github.com/fallow-rs/fallow/issues/1078).)
+- **Telemetry now segments code quality review duration by cache state.** Opt-in CLI telemetry for combined `code_quality_review` runs can now include an allowlisted `cache_state` value of `cold`, `warm`, `partial`, or `unknown`, so slow duration buckets can be interpreted without exact timings, raw cache counts, paths, repository identifiers, or cache directories. (Closes [#1062](https://github.com/fallow-rs/fallow/issues/1062).)
 
 ### Fixed
 

--- a/crates/cli/src/combined.rs
+++ b/crates/cli/src/combined.rs
@@ -155,6 +155,8 @@ pub fn run_combined(opts: &CombinedOptions<'_>) -> ExitCode {
         }
     }
 
+    record_combined_cache_state(opts, check_result.as_ref());
+
     if opts.performance
         && let Some(ref mut check) = check_result
         && let Some(ref mut timings) = check.timings
@@ -217,6 +219,20 @@ pub fn run_combined(opts: &CombinedOptions<'_>) -> ExitCode {
     );
 
     ExitCode::from(max_exit)
+}
+
+fn record_combined_cache_state(opts: &CombinedOptions<'_>, check_result: Option<&CheckResult>) {
+    if opts.no_cache {
+        crate::telemetry::note_cache_state_unknown();
+        return;
+    }
+
+    let Some(timings) = check_result.and_then(|check| check.timings.as_ref()) else {
+        crate::telemetry::note_cache_state_unknown();
+        return;
+    };
+
+    crate::telemetry::note_cache_state(timings.cache_hits, timings.cache_misses);
 }
 
 /// Whether this combined invocation is a true WHOLE-PROJECT run, the only shape

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -102,6 +102,7 @@ static FAILURE_REASON: AtomicU8 = AtomicU8::new(FAILURE_REASON_UNSET);
 static RESULT_COUNT_CAPPED: AtomicU16 = AtomicU16::new(RESULT_COUNT_UNSET);
 static REPORT_TRUNCATED: AtomicU8 = AtomicU8::new(REPORT_TRUNCATION_UNSET);
 static TRUNCATION_REASON: AtomicU8 = AtomicU8::new(TRUNCATION_REASON_UNSET);
+static CACHE_STATE: AtomicU8 = AtomicU8::new(CACHE_STATE_UNSET);
 
 const FINDINGS_UNSET: u8 = 0;
 const FINDINGS_CLEAN: u8 = 1;
@@ -128,6 +129,11 @@ const TRUNCATION_REASON_UNKNOWN: u8 = 1;
 const TRUNCATION_REASON_MAX_ITEMS: u8 = 2;
 const TRUNCATION_REASON_COMMENT_LIMIT: u8 = 3;
 const TRUNCATION_REASON_SIZE_LIMIT: u8 = 4;
+const CACHE_STATE_UNSET: u8 = 0;
+const CACHE_STATE_COLD: u8 = 1;
+const CACHE_STATE_WARM: u8 = 2;
+const CACHE_STATE_PARTIAL: u8 = 3;
+const CACHE_STATE_UNKNOWN: u8 = 4;
 
 /// Record whether the analysis that just completed surfaced any findings.
 ///
@@ -375,6 +381,47 @@ fn truncation_reason() -> Option<TruncationReason> {
     truncation_reason_from_state(TRUNCATION_REASON.load(Ordering::Relaxed))
         .or(Some(TruncationReason::Unknown))
 }
+
+/// Record a coarse cache state from aggregate cache counts.
+///
+/// Only the derived enum is serialized. Raw hit and miss counts remain local.
+pub fn note_cache_state(cache_hits: usize, cache_misses: usize) {
+    let value = match (cache_hits, cache_misses) {
+        (0, 0) => CACHE_STATE_UNKNOWN,
+        (0, _) => CACHE_STATE_COLD,
+        (_, 0) => CACHE_STATE_WARM,
+        (_, _) => CACHE_STATE_PARTIAL,
+    };
+    CACHE_STATE.store(value, Ordering::Relaxed);
+}
+
+pub fn note_cache_state_unknown() {
+    CACHE_STATE.store(CACHE_STATE_UNKNOWN, Ordering::Relaxed);
+}
+
+fn cache_state_from_state(state: u8) -> Option<CacheState> {
+    match state {
+        CACHE_STATE_COLD => Some(CacheState::Cold),
+        CACHE_STATE_WARM => Some(CacheState::Warm),
+        CACHE_STATE_PARTIAL => Some(CacheState::Partial),
+        CACHE_STATE_UNKNOWN => Some(CacheState::Unknown),
+        _ => None,
+    }
+}
+
+fn cache_state() -> Option<CacheState> {
+    cache_state_from_state(CACHE_STATE.load(Ordering::Relaxed))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CacheState {
+    Cold,
+    Warm,
+    Partial,
+    Unknown,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TelemetryCommand {
     Status,
@@ -565,6 +612,10 @@ struct TelemetryEvent {
     /// `report_truncated` is true.
     #[serde(skip_serializing_if = "Option::is_none")]
     truncation_reason: Option<TruncationReason>,
+    /// Coarse cache state for combined `code_quality_review` runs.
+    /// Derived from aggregate cache hits and misses, never raw counts or paths.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_state: Option<CacheState>,
     /// The MCP tool that triggered this run, when invoked through the MCP
     /// server. Allowlisted to the fixed set of tool names; absent otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -821,6 +872,7 @@ fn build_workflow_event(
         result_count_bucket: result_count_bucket(),
         report_truncated: report_truncated(),
         truncation_reason: truncation_reason(),
+        cache_state: cache_state(),
         mcp_tool: mcp_tool(),
         has_parent_run: parent_run.has_parent_run,
         run_role: parent_run.run_role,
@@ -871,6 +923,7 @@ fn status_changed_event(enabled: bool) -> TelemetryEvent {
         result_count_bucket: None,
         report_truncated: None,
         truncation_reason: None,
+        cache_state: None,
         mcp_tool: None,
         has_parent_run: false,
         run_role: RunRole::Root,
@@ -901,6 +954,7 @@ fn example_event() -> TelemetryEvent {
         result_count_bucket: Some(ResultCountBucket::OneToNine),
         report_truncated: Some(true),
         truncation_reason: Some(TruncationReason::CommentLimit),
+        cache_state: Some(CacheState::Warm),
         mcp_tool: Some("find_dupes"),
         has_parent_run: true,
         run_role: RunRole::Followup,
@@ -953,6 +1007,10 @@ fn field_purposes() -> Vec<(&'static str, &'static str)> {
         (
             "truncation_reason",
             "Why report/comment output was truncated: comment_limit, max_items, size_limit, or unknown.",
+        ),
+        (
+            "cache_state",
+            "Segments combined code-quality review durations into cold, warm, partial, or unknown cache states without uploading cache paths or raw counts.",
         ),
         (
             "mcp_tool",
@@ -2048,6 +2106,28 @@ mod tests {
             result_count_bucket_from_state(100),
             Some(ResultCountBucket::OneHundredPlus)
         );
+    }
+
+    #[test]
+    fn cache_state_maps_to_allowlisted_enum() {
+        assert_eq!(cache_state_from_state(CACHE_STATE_UNSET), None);
+        assert_eq!(
+            cache_state_from_state(CACHE_STATE_COLD),
+            Some(CacheState::Cold)
+        );
+        assert_eq!(
+            cache_state_from_state(CACHE_STATE_WARM),
+            Some(CacheState::Warm)
+        );
+        assert_eq!(
+            cache_state_from_state(CACHE_STATE_PARTIAL),
+            Some(CacheState::Partial)
+        );
+        assert_eq!(
+            cache_state_from_state(CACHE_STATE_UNKNOWN),
+            Some(CacheState::Unknown)
+        );
+        assert_eq!(cache_state_from_state(99), None);
     }
 
     #[test]

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -274,6 +274,26 @@ fn write_clean_project(dir: &Path) {
     fs::write(src.join("index.ts"), "export const value = 41 + 1;\n").expect("write source");
 }
 
+fn write_cache_project(dir: &Path) {
+    let src = dir.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        dir.join("package.json"),
+        "{\n  \"name\": \"cache-fixture\",\n  \"main\": \"src/index.ts\"\n}\n",
+    )
+    .expect("write package.json");
+    fs::write(
+        src.join("index.ts"),
+        "import { used } from './used';\nconsole.log(used());\n",
+    )
+    .expect("write index");
+    fs::write(
+        src.join("used.ts"),
+        "export const used = (): number => 42;\n",
+    )
+    .expect("write used");
+}
+
 fn write_many_unused_project(dir: &Path) {
     let src = dir.join("src");
     fs::create_dir_all(&src).expect("create src");
@@ -437,6 +457,60 @@ fn unsupported_format_failure_sets_failure_reason() {
 }
 
 #[test]
+fn code_quality_review_reports_cold_then_partial_cache_state() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_cache_project(dir.path());
+
+    let (first_event, first_output) =
+        inspect_event_output(dir.path(), &["--format", "json", "--quiet"], &[]);
+
+    assert_eq!(
+        first_output.code, 0,
+        "first combined run should exit 0: {}",
+        first_output.stderr
+    );
+    assert_eq!(
+        first_event["workflow"].as_str(),
+        Some("code_quality_review")
+    );
+    assert_eq!(first_event["cache_state"].as_str(), Some("cold"));
+
+    let (second_event, second_output) =
+        inspect_event_output(dir.path(), &["--format", "json", "--quiet"], &[]);
+
+    assert_eq!(
+        second_output.code, 0,
+        "second combined run should exit 0: {}",
+        second_output.stderr
+    );
+    assert_eq!(
+        second_event["workflow"].as_str(),
+        Some("code_quality_review")
+    );
+    assert_eq!(second_event["cache_state"].as_str(), Some("partial"));
+}
+
+#[test]
+fn code_quality_review_with_no_cache_reports_unknown_cache_state() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_cache_project(dir.path());
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &["--no-cache", "--format", "json", "--quiet"],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "combined run should exit 0: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("code_quality_review"));
+    assert_eq!(event["cache_state"].as_str(), Some("unknown"));
+}
+
+#[test]
 fn audit_with_findings_sets_findings_present_true() {
     let dir = tempfile::tempdir().expect("temp project");
     init_audit_repo(dir.path());
@@ -586,6 +660,10 @@ fn admin_command_emits_no_findings_present_key() {
     assert!(
         event.get("result_count_bucket").is_none(),
         "commands that run no analysis must omit result_count_bucket"
+    );
+    assert!(
+        event.get("cache_state").is_none(),
+        "commands that run no analysis must omit cache_state"
     );
 }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -90,6 +90,7 @@ V2 events are workflow-level and coarse:
   "result_count_bucket": "1-9",
   "report_truncated": true,
   "truncation_reason": "comment_limit",
+  "cache_state": "warm",
   "mcp_tool": "find_dupes",
   "has_parent_run": true,
   "run_role": "followup",
@@ -97,7 +98,7 @@ V2 events are workflow-level and coarse:
 }
 ```
 
-`agent_source`, `failure_reason`, `findings_present`, `result_count_bucket`, `report_truncated`, `truncation_reason`, and `mcp_tool` are optional. `agent_source` appears only on agent-driven runs. `failure_reason` appears only on failed workflow events and uses one of `validation`, `unsupported_format`, `config`, `analysis`, `diff`, `network`, `auth`, `gate`, `signal`, or `unknown`. `findings_present` and `result_count_bucket` are omitted by commands that run no analysis (and by older binaries). `report_truncated` appears only on report/comment output paths that can truncate output, and `truncation_reason` appears only when truncation happened. `mcp_tool` appears only when a run came through the MCP server. `has_parent_run`, `run_role`, and `followup_kind` are always safe, allowlisted values and never include the raw parent-run token.
+`agent_source`, `failure_reason`, `findings_present`, `result_count_bucket`, `report_truncated`, `truncation_reason`, `cache_state`, and `mcp_tool` are optional. `agent_source` appears only on agent-driven runs. `failure_reason` appears only on failed workflow events and uses one of `validation`, `unsupported_format`, `config`, `analysis`, `diff`, `network`, `auth`, `gate`, `signal`, or `unknown`. `findings_present` and `result_count_bucket` are omitted by commands that run no analysis (and by older binaries). `report_truncated` appears only on report/comment output paths that can truncate output, and `truncation_reason` appears only when truncation happened. `cache_state` appears on combined `code_quality_review` runs and is one of `cold`, `warm`, `partial`, or `unknown`; `unknown` covers disabled cache or missing cache signal. `mcp_tool` appears only when a run came through the MCP server. `has_parent_run`, `run_role`, and `followup_kind` are always safe, allowlisted values and never include the raw parent-run token.
 
 Field purposes:
 
@@ -114,6 +115,7 @@ Field purposes:
 | `findings_present` | Whether the analysis surfaced any findings, decoupled from the exit-code gate (so informational analyses like default-config `dupes`, which never exit non-zero, are still measurable). On the combined and audit workflows it is an OR across the sub-analyses; per-analysis find-rate is answerable on the standalone `dead_code`, `dupes`, `health`, and `security` workflows. |
 | `result_count_bucket` | Coarse result volume, one of `0`, `1-9`, `10-99`, `100+`, or `unknown`. Exact counts, paths, finding names, rule ids, and snippets are never uploaded. |
 | `report_truncated` / `truncation_reason` | Whether a report/comment output path was truncated and why. Reasons are `comment_limit`, `max_items`, `size_limit`, or `unknown`. |
+| `cache_state` | Segment combined code-quality review durations into cold, warm, partial, or unknown cache states without uploading cache paths, cache directories, raw counts, or exact timings. |
 | `mcp_tool` | Attribute MCP usage to a specific tool, from a fixed allowlist of tool names. |
 | `has_parent_run` | Segment explicit follow-up runs without exposing the parent-run token. |
 | `run_role` | Separate root runs, follow-up runs, and unknown parent-run state using the allowlist `root`, `followup`, `unknown`. |


### PR DESCRIPTION
## Summary

- Adds a privacy-safe `cache_state` telemetry dimension for code quality review runs.
- Keeps cache context bounded to `cold`, `warm`, `partial`, and `unknown`.
- Updates inspect-mode documentation and validation coverage for the emitted field.

Fixes #1062

## Validation

Post-rebase on current `origin/main`:

- `cargo fmt --all -- --check`
- `cargo test -p fallow-cli --test telemetry_tests cache_state`
- `cargo test -p fallow-cli cache_state_maps_to_allowlisted_enum`
- `cargo test -p fallow-cli --test telemetry_tests`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `cargo build --workspace`
- `typos .`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- Real inspect-mode run against this checkout with a shared cache dir: first run emitted `cache_state=cold`, repeat run emitted `cache_state=partial`.