### PR TITLE
feat(telemetry): add coarse run context dimensions

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2461,8 +2461,13 @@ fn main() -> ExitCode {
         return code;
     }
     setup_tracing();
-    let telemetry_workflow = telemetry_workflow_for_command(cli.command.as_ref(), fmt.output);
-    let telemetry_start = std::time::Instant::now();
+    let telemetry_run = TelemetryRun {
+        workflow: telemetry_workflow_for_command(cli.command.as_ref(), fmt.output),
+        output: fmt.output,
+        quiet: fmt.quiet,
+        start: std::time::Instant::now(),
+        context: telemetry_context_for_command(&cli, cli.command.as_ref(), fmt.output),
+    };
 
     // Deliver any telemetry events the previous run spooled at exit. Detached and
     // gated on telemetry being enabled, so it overlaps the analysis work below and
@@ -2472,15 +2477,7 @@ fn main() -> ExitCode {
     let (root, threads) = match validate_inputs(&cli, fmt.output) {
         Ok(v) => v,
         Err(code) => {
-            return record_run_epilogue(
-                telemetry_workflow,
-                fmt.output,
-                fmt.quiet,
-                telemetry_start.elapsed(),
-                code,
-                None,
-                cli.parent_run.as_deref(),
-            );
+            return record_run_epilogue(telemetry_run, code, None, cli.parent_run.as_deref());
         }
     };
 
@@ -2499,10 +2496,7 @@ fn main() -> ExitCode {
         Err(msg) => {
             let code = emit_known_failure(&msg, 2, output, telemetry::FailureReason::Diff);
             return record_run_epilogue(
-                telemetry_workflow,
-                output,
-                quiet,
-                telemetry_start.elapsed(),
+                telemetry_run,
                 code,
                 Some(telemetry::FailureReason::Diff),
                 cli.parent_run.as_deref(),
@@ -2552,10 +2546,7 @@ fn main() -> ExitCode {
             telemetry::FailureReason::Validation,
         );
         return record_run_epilogue(
-            telemetry_workflow,
-            output,
-            quiet,
-            telemetry_start.elapsed(),
+            telemetry_run,
             code,
             Some(telemetry::FailureReason::Validation),
             cli.parent_run.as_deref(),
@@ -2570,10 +2561,7 @@ fn main() -> ExitCode {
             telemetry::FailureReason::Validation,
         );
         return record_run_epilogue(
-            telemetry_workflow,
-            output,
-            quiet,
-            telemetry_start.elapsed(),
+            telemetry_run,
             code,
             Some(telemetry::FailureReason::Validation),
             cli.parent_run.as_deref(),
@@ -2589,10 +2577,7 @@ fn main() -> ExitCode {
             telemetry::FailureReason::Validation,
         );
         return record_run_epilogue(
-            telemetry_workflow,
-            output,
-            quiet,
-            telemetry_start.elapsed(),
+            telemetry_run,
             code,
             Some(telemetry::FailureReason::Validation),
             cli.parent_run.as_deref(),
@@ -2606,10 +2591,7 @@ fn main() -> ExitCode {
             telemetry::FailureReason::Validation,
         );
         return record_run_epilogue(
-            telemetry_workflow,
-            output,
-            quiet,
-            telemetry_start.elapsed(),
+            telemetry_run,
             code,
             Some(telemetry::FailureReason::Validation),
             cli.parent_run.as_deref(),
@@ -2626,10 +2608,7 @@ fn main() -> ExitCode {
                 telemetry::FailureReason::Validation,
             );
             return record_run_epilogue(
-                telemetry_workflow,
-                output,
-                quiet,
-                telemetry_start.elapsed(),
+                telemetry_run,
                 code,
                 Some(telemetry::FailureReason::Validation),
                 cli.parent_run.as_deref(),
@@ -2675,41 +2654,162 @@ fn main() -> ExitCode {
     {
         return code;
     }
-    record_run_epilogue(
-        telemetry_workflow,
-        output,
-        quiet,
-        telemetry_start.elapsed(),
-        exit_code,
-        None,
-        cli.parent_run.as_deref(),
-    )
+    record_run_epilogue(telemetry_run, exit_code, None, cli.parent_run.as_deref())
+}
+
+#[derive(Clone, Copy)]
+struct TelemetryRun {
+    workflow: telemetry::Workflow,
+    output: fallow_config::OutputFormat,
+    quiet: bool,
+    start: std::time::Instant,
+    context: telemetry::WorkflowContext,
 }
 
 fn record_run_epilogue(
-    telemetry_workflow: telemetry::Workflow,
-    output: fallow_config::OutputFormat,
-    quiet: bool,
-    elapsed: std::time::Duration,
+    run: TelemetryRun,
     exit_code: ExitCode,
     failure_reason: Option<telemetry::FailureReason>,
     parent_run: Option<&str>,
 ) -> ExitCode {
     let cache_notice_printed = cache_notice::maybe_print_created_notice();
     telemetry::record_workflow(&telemetry::WorkflowRecord {
-        workflow: telemetry_workflow,
-        output,
-        quiet,
-        elapsed,
+        workflow: run.workflow,
+        output: run.output,
+        quiet: run.quiet,
+        elapsed: run.start.elapsed(),
         exit_code,
         failure_reason,
         parent_run,
+        context: run.context,
     });
     if exit_code == ExitCode::SUCCESS {
-        let note_printed = telemetry::maybe_print_opt_in_note(output, quiet);
-        update_check::maybe_nudge(output, quiet, note_printed || cache_notice_printed);
+        let note_printed = telemetry::maybe_print_opt_in_note(run.output, run.quiet);
+        update_check::maybe_nudge(run.output, run.quiet, note_printed || cache_notice_printed);
     }
     exit_code
+}
+
+fn telemetry_context_for_command(
+    cli: &Cli,
+    command: Option<&Command>,
+    output: fallow_config::OutputFormat,
+) -> telemetry::WorkflowContext {
+    telemetry::WorkflowContext {
+        run_scope: telemetry_run_scope_for_command(cli, command),
+        config_shape: telemetry_config_shape_for_cli(cli),
+        output_destination: telemetry_output_destination_for_command(cli, command, output),
+        analysis_mode: telemetry_analysis_mode_for_command(command),
+    }
+}
+
+fn telemetry_run_scope_for_command(cli: &Cli, command: Option<&Command>) -> telemetry::RunScope {
+    if command_is_file_scoped(command) {
+        return telemetry::RunScope::FileScoped;
+    }
+    if cli
+        .workspace
+        .as_ref()
+        .is_some_and(|workspaces| !workspaces.is_empty())
+        || cli.changed_workspaces.is_some()
+    {
+        return telemetry::RunScope::WorkspaceScoped;
+    }
+    if cli.changed_since.is_some()
+        || cli.diff_file.is_some()
+        || cli.diff_stdin
+        || matches!(command, Some(Command::Audit { .. }))
+    {
+        return telemetry::RunScope::ChangedOnly;
+    }
+    if command_runs_full_project_analysis(command) {
+        return telemetry::RunScope::FullProject;
+    }
+    telemetry::RunScope::Unknown
+}
+
+fn command_is_file_scoped(command: Option<&Command>) -> bool {
+    matches!(
+        command,
+        Some(Command::Check { file, .. } | Command::Security { file, .. }) if !file.is_empty()
+    )
+}
+
+fn command_runs_full_project_analysis(command: Option<&Command>) -> bool {
+    matches!(
+        command,
+        None | Some(
+            Command::Check { .. }
+                | Command::Dupes { .. }
+                | Command::Health { .. }
+                | Command::Flags { .. }
+                | Command::Security { .. }
+                | Command::Fix { .. }
+                | Command::Watch { .. },
+        )
+    )
+}
+
+fn telemetry_config_shape_for_cli(cli: &Cli) -> telemetry::ConfigShape {
+    if cli.config.is_some() {
+        telemetry::ConfigShape::CustomConfig
+    } else {
+        telemetry::ConfigShape::Unknown
+    }
+}
+
+fn telemetry_output_destination_for_command(
+    cli: &Cli,
+    command: Option<&Command>,
+    output: fallow_config::OutputFormat,
+) -> telemetry::OutputDestination {
+    if matches!(command, Some(Command::Ci { .. }))
+        || matches!(
+            output,
+            fallow_config::OutputFormat::PrCommentGithub
+                | fallow_config::OutputFormat::PrCommentGitlab
+                | fallow_config::OutputFormat::ReviewGithub
+                | fallow_config::OutputFormat::CodeClimate
+        )
+    {
+        return telemetry::OutputDestination::CiComment;
+    }
+    if cli.output_file.is_some() || cli.sarif_file.is_some() {
+        return telemetry::OutputDestination::File;
+    }
+    telemetry::OutputDestination::Stdout
+}
+
+fn telemetry_analysis_mode_for_command(command: Option<&Command>) -> telemetry::AnalysisMode {
+    match command {
+        Some(Command::Security { .. }) => telemetry::AnalysisMode::Security,
+        Some(Command::Fix { .. }) => telemetry::AnalysisMode::Fix,
+        Some(Command::Health {
+            runtime_coverage: Some(_),
+            ..
+        })
+        | Some(Command::Audit {
+            runtime_coverage: Some(_),
+            ..
+        })
+        | Some(Command::Coverage { .. }) => telemetry::AnalysisMode::ProductionCoverage,
+        Some(Command::Health {
+            coverage: Some(_), ..
+        })
+        | Some(Command::Audit {
+            coverage: Some(_), ..
+        }) => telemetry::AnalysisMode::RuntimeCoverage,
+        None
+        | Some(
+            Command::Check { .. }
+            | Command::Dupes { .. }
+            | Command::Health { .. }
+            | Command::Audit { .. }
+            | Command::Flags { .. }
+            | Command::Watch { .. },
+        ) => telemetry::AnalysisMode::Static,
+        _ => telemetry::AnalysisMode::Unknown,
+    }
 }
 
 fn handle_cli_parse_error(err: &clap::Error) -> ExitCode {

--- a/crates/cli/src/runtime_support.rs
+++ b/crates/cli/src/runtime_support.rs
@@ -2,7 +2,9 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::{LazyLock, Mutex};
 
-use fallow_config::{FallowConfig, OutputFormat, ProductionAnalysis, ResolvedConfig};
+use fallow_config::{
+    FallowConfig, OutputFormat, PartialRulesConfig, ProductionAnalysis, ResolvedConfig, RulesConfig,
+};
 use rustc_hash::FxHashSet;
 
 static CONFIG_LOADED_LOGGED: LazyLock<Mutex<FxHashSet<PathBuf>>> =
@@ -171,6 +173,7 @@ pub fn load_config_for_analysis(
         }
     };
 
+    let loaded_user_config = user_config.is_some();
     let final_config = match user_config {
         Some(mut config) => {
             let production =
@@ -183,6 +186,7 @@ pub fn load_config_for_analysis(
             ..FallowConfig::default()
         },
     };
+    crate::telemetry::note_config_shape(config_shape_for(&final_config, loaded_user_config));
 
     if let Err(errors) =
         fallow_config::discover_and_validate_external_plugins(root, &final_config.plugins)
@@ -242,6 +246,34 @@ pub fn load_config_for_analysis(
     }
 
     Ok(resolved)
+}
+
+fn config_shape_for(
+    config: &FallowConfig,
+    loaded_user_config: bool,
+) -> crate::telemetry::ConfigShape {
+    if !config.plugins.is_empty() || !config.framework.is_empty() {
+        return crate::telemetry::ConfigShape::PluginsEnabled;
+    }
+    if config.rules != RulesConfig::default()
+        || config
+            .overrides
+            .iter()
+            .any(|entry| partial_rules_config_has_values(&entry.rules))
+    {
+        return crate::telemetry::ConfigShape::CustomRules;
+    }
+    if loaded_user_config {
+        return crate::telemetry::ConfigShape::CustomConfig;
+    }
+    crate::telemetry::ConfigShape::Default
+}
+
+fn partial_rules_config_has_values(rules: &PartialRulesConfig) -> bool {
+    serde_json::to_value(rules)
+        .ok()
+        .and_then(|value| value.as_object().map(|object| !object.is_empty()))
+        .unwrap_or(false)
 }
 
 /// Read the workspace-discovery diagnostics produced by the most recent

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -103,6 +103,7 @@ static RESULT_COUNT_CAPPED: AtomicU16 = AtomicU16::new(RESULT_COUNT_UNSET);
 static REPORT_TRUNCATED: AtomicU8 = AtomicU8::new(REPORT_TRUNCATION_UNSET);
 static TRUNCATION_REASON: AtomicU8 = AtomicU8::new(TRUNCATION_REASON_UNSET);
 static CACHE_STATE: AtomicU8 = AtomicU8::new(CACHE_STATE_UNSET);
+static CONFIG_SHAPE: AtomicU8 = AtomicU8::new(CONFIG_SHAPE_UNSET);
 
 const FINDINGS_UNSET: u8 = 0;
 const FINDINGS_CLEAN: u8 = 1;
@@ -134,6 +135,12 @@ const CACHE_STATE_COLD: u8 = 1;
 const CACHE_STATE_WARM: u8 = 2;
 const CACHE_STATE_PARTIAL: u8 = 3;
 const CACHE_STATE_UNKNOWN: u8 = 4;
+const CONFIG_SHAPE_UNSET: u8 = 0;
+const CONFIG_SHAPE_UNKNOWN: u8 = 1;
+const CONFIG_SHAPE_DEFAULT: u8 = 2;
+const CONFIG_SHAPE_CUSTOM_CONFIG: u8 = 3;
+const CONFIG_SHAPE_CUSTOM_RULES: u8 = 4;
+const CONFIG_SHAPE_PLUGINS_ENABLED: u8 = 5;
 
 /// Record whether the analysis that just completed surfaced any findings.
 ///
@@ -224,6 +231,43 @@ fn findings_present_from_state(state: u8) -> Option<bool> {
 
 fn findings_present() -> Option<bool> {
     findings_present_from_state(FINDINGS_PRESENT.load(Ordering::Relaxed))
+}
+
+/// Record the coarse loaded configuration shape after config resolution.
+///
+/// The most specific shape wins. This stores only fixed enum buckets and never
+/// records config paths, rule names, plugin names, or config values.
+pub fn note_config_shape(shape: ConfigShape) {
+    CONFIG_SHAPE.fetch_max(config_shape_rank(shape), Ordering::Relaxed);
+}
+
+fn config_shape_rank(shape: ConfigShape) -> u8 {
+    match shape {
+        ConfigShape::Unknown => CONFIG_SHAPE_UNKNOWN,
+        ConfigShape::Default => CONFIG_SHAPE_DEFAULT,
+        ConfigShape::CustomConfig => CONFIG_SHAPE_CUSTOM_CONFIG,
+        ConfigShape::CustomRules => CONFIG_SHAPE_CUSTOM_RULES,
+        ConfigShape::PluginsEnabled => CONFIG_SHAPE_PLUGINS_ENABLED,
+    }
+}
+
+fn config_shape_from_state(state: u8) -> Option<ConfigShape> {
+    match state {
+        CONFIG_SHAPE_UNKNOWN => Some(ConfigShape::Unknown),
+        CONFIG_SHAPE_DEFAULT => Some(ConfigShape::Default),
+        CONFIG_SHAPE_CUSTOM_CONFIG => Some(ConfigShape::CustomConfig),
+        CONFIG_SHAPE_CUSTOM_RULES => Some(ConfigShape::CustomRules),
+        CONFIG_SHAPE_PLUGINS_ENABLED => Some(ConfigShape::PluginsEnabled),
+        _ => None,
+    }
+}
+
+fn noted_config_shape() -> Option<ConfigShape> {
+    config_shape_from_state(CONFIG_SHAPE.load(Ordering::Relaxed))
+}
+
+fn config_shape_for_record(record: &WorkflowRecord<'_>) -> ConfigShape {
+    noted_config_shape().unwrap_or(record.context.config_shape)
 }
 
 /// Coarse allowlisted reason for a failed workflow telemetry event.
@@ -489,6 +533,58 @@ pub enum InvocationContext {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+pub enum RunScope {
+    FullProject,
+    ChangedOnly,
+    WorkspaceScoped,
+    FileScoped,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigShape {
+    Default,
+    CustomConfig,
+    CustomRules,
+    PluginsEnabled,
+    Unknown,
+}
+
+#[expect(
+    dead_code,
+    reason = "telemetry schema reserves v1 destination values before every sink is wired"
+)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputDestination {
+    Stdout,
+    File,
+    CiComment,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnalysisMode {
+    Static,
+    RuntimeCoverage,
+    ProductionCoverage,
+    Security,
+    Fix,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WorkflowContext {
+    pub run_scope: RunScope,
+    pub config_shape: ConfigShape,
+    pub output_destination: OutputDestination,
+    pub analysis_mode: AnalysisMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AgentSource {
     None,
     Codex,
@@ -592,6 +688,22 @@ struct TelemetryEvent {
     /// events and never derived from raw error text.
     #[serde(skip_serializing_if = "Option::is_none")]
     failure_reason: Option<FailureReason>,
+    /// Coarse scope of the analyzed files. Never includes file, workspace,
+    /// branch, or ref names.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_scope: Option<RunScope>,
+    /// Coarse shape of the loaded configuration. Never includes paths, rule
+    /// names, plugin names, or config values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_shape: Option<ConfigShape>,
+    /// Coarse report destination bucket. Never includes destination paths,
+    /// URLs, or integration identifiers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_destination: Option<OutputDestination>,
+    /// Coarse analysis family. Never includes raw command lines or paths to
+    /// coverage artifacts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    analysis_mode: Option<AnalysisMode>,
     /// Whether the analysis surfaced any findings, independent of the exit-code
     /// `outcome` gate. Absent on commands that run no analysis (admin commands)
     /// and on older binaries. On the combined `code_quality_review` and `audit`
@@ -641,6 +753,7 @@ pub struct WorkflowRecord<'a> {
     pub exit_code: ExitCode,
     pub failure_reason: Option<FailureReason>,
     pub parent_run: Option<&'a str>,
+    pub context: WorkflowContext,
 }
 
 pub fn run(command: TelemetryCommand, output: OutputFormat) -> ExitCode {
@@ -868,6 +981,10 @@ fn build_workflow_event(
         outcome: outcome(record.exit_code),
         exit_code_bucket: exit_code_bucket(record.exit_code),
         failure_reason: failure_reason_for(record),
+        run_scope: Some(record.context.run_scope),
+        config_shape: Some(config_shape_for_record(record)),
+        output_destination: Some(record.context.output_destination),
+        analysis_mode: Some(record.context.analysis_mode),
         findings_present: findings_present(),
         result_count_bucket: result_count_bucket(),
         report_truncated: report_truncated(),
@@ -919,6 +1036,10 @@ fn status_changed_event(enabled: bool) -> TelemetryEvent {
         outcome: if enabled { "enabled" } else { "disabled" },
         exit_code_bucket: "0",
         failure_reason: None,
+        run_scope: None,
+        config_shape: None,
+        output_destination: None,
+        analysis_mode: None,
         findings_present: None,
         result_count_bucket: None,
         report_truncated: None,
@@ -950,6 +1071,10 @@ fn example_event() -> TelemetryEvent {
         outcome: "issues_found",
         exit_code_bucket: "1",
         failure_reason: None,
+        run_scope: Some(RunScope::ChangedOnly),
+        config_shape: Some(ConfigShape::CustomRules),
+        output_destination: Some(OutputDestination::Stdout),
+        analysis_mode: Some(AnalysisMode::Static),
         findings_present: Some(true),
         result_count_bucket: Some(ResultCountBucket::OneToNine),
         report_truncated: Some(true),
@@ -991,6 +1116,22 @@ fn field_purposes() -> Vec<(&'static str, &'static str)> {
         (
             "failure_reason",
             "Groups failed workflows into a fixed privacy-safe allowlist; unknown stays unknown instead of parsing raw error text.",
+        ),
+        (
+            "run_scope",
+            "Classifies the run as full-project, changed-only, workspace-scoped, or file-scoped without storing names or refs.",
+        ),
+        (
+            "config_shape",
+            "Classifies config as default, custom config, custom rules, or plugins enabled without storing paths, rules, plugin names, or values.",
+        ),
+        (
+            "output_destination",
+            "Classifies the report sink as stdout, file, or CI comment without storing paths or URLs.",
+        ),
+        (
+            "analysis_mode",
+            "Classifies static, runtime-coverage, production-coverage, security, and fix workflows without storing raw command lines.",
         ),
         (
             "findings_present",
@@ -1803,6 +1944,12 @@ mod tests {
             exit_code: ExitCode::from(1),
             failure_reason: None,
             parent_run: Some("tmp_123"),
+            context: WorkflowContext {
+                run_scope: RunScope::ChangedOnly,
+                config_shape: ConfigShape::CustomRules,
+                output_destination: OutputDestination::Stdout,
+                analysis_mode: AnalysisMode::Static,
+            },
         };
         let parent_run = parent_run_context(record.parent_run, record.workflow);
         let event = build_workflow_event(&record, &parent_run);
@@ -1811,6 +1958,10 @@ mod tests {
         assert_eq!(event.outcome, "issues_found");
         assert_eq!(event.exit_code_bucket, "1");
         assert_eq!(event.failure_reason, None);
+        assert_eq!(event.run_scope, Some(RunScope::ChangedOnly));
+        assert_eq!(event.config_shape, Some(ConfigShape::CustomRules));
+        assert_eq!(event.output_destination, Some(OutputDestination::Stdout));
+        assert_eq!(event.analysis_mode, Some(AnalysisMode::Static));
         assert_eq!(parent_run.token.as_deref(), Some("tmp_123"));
         assert!(event.has_parent_run);
         assert_eq!(event.run_role, RunRole::Followup);
@@ -1827,6 +1978,12 @@ mod tests {
             exit_code: ExitCode::from(2),
             failure_reason: None,
             parent_run: None,
+            context: WorkflowContext {
+                run_scope: RunScope::ChangedOnly,
+                config_shape: ConfigShape::Default,
+                output_destination: OutputDestination::Stdout,
+                analysis_mode: AnalysisMode::Static,
+            },
         };
         assert_eq!(
             failure_reason_for_value(&record, None),
@@ -1844,6 +2001,12 @@ mod tests {
             exit_code: ExitCode::from(2),
             failure_reason: Some(FailureReason::Diff),
             parent_run: None,
+            context: WorkflowContext {
+                run_scope: RunScope::ChangedOnly,
+                config_shape: ConfigShape::Default,
+                output_destination: OutputDestination::Stdout,
+                analysis_mode: AnalysisMode::Static,
+            },
         };
         assert_eq!(
             failure_reason_for_value(&record, Some(FailureReason::Validation)),
@@ -1917,6 +2080,12 @@ mod tests {
             exit_code: ExitCode::SUCCESS,
             failure_reason: None,
             parent_run: Some("tmp_abc-123"),
+            context: WorkflowContext {
+                run_scope: RunScope::FullProject,
+                config_shape: ConfigShape::Default,
+                output_destination: OutputDestination::Stdout,
+                analysis_mode: AnalysisMode::Static,
+            },
         };
         let parent_run = parent_run_context(record.parent_run, record.workflow);
         let event = build_workflow_event(&record, &parent_run);
@@ -2389,6 +2558,12 @@ mod tests {
             exit_code: ExitCode::from(0),
             failure_reason: None,
             parent_run: None,
+            context: WorkflowContext {
+                run_scope: RunScope::FullProject,
+                config_shape: ConfigShape::Default,
+                output_destination: OutputDestination::Stdout,
+                analysis_mode: AnalysisMode::Static,
+            },
         };
         let parent_run = parent_run_context(record.parent_run, record.workflow);
         let line =
@@ -2422,6 +2597,12 @@ mod tests {
             exit_code: ExitCode::SUCCESS,
             failure_reason: None,
             parent_run: Some("tmp_abc-123"),
+            context: WorkflowContext {
+                run_scope: RunScope::FullProject,
+                config_shape: ConfigShape::Default,
+                output_destination: OutputDestination::Stdout,
+                analysis_mode: AnalysisMode::Static,
+            },
         };
         let parent_run = parent_run_context(record.parent_run, record.workflow);
         let event = build_workflow_event(&record, &parent_run);

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -381,12 +381,65 @@ fn dupes_on_clean_project_sets_findings_present_false() {
         event.get("failure_reason").is_none(),
         "successful workflows must omit failure_reason"
     );
+    assert_eq!(event["run_scope"].as_str(), Some("full_project"));
+    assert_eq!(event["config_shape"].as_str(), Some("default"));
+    assert_eq!(event["output_destination"].as_str(), Some("stdout"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("static"));
     assert_eq!(
         event["findings_present"].as_bool(),
         Some(false),
         "a genuinely clean dupes run must report findings_present=false"
     );
     assert_eq!(event["result_count_bucket"].as_str(), Some("0"));
+}
+
+#[test]
+fn file_scoped_custom_rules_file_output_are_coarse_context_dimensions() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_clean_project(dir.path());
+    let config_path = dir.path().join(".fallowrc.json");
+    let output_path = dir.path().join("report.json");
+    fs::write(
+        &config_path,
+        "{\n  \"rules\": {\n    \"unused-files\": \"warn\"\n  }\n}\n",
+    )
+    .expect("write config");
+    let config_arg = config_path.to_string_lossy().to_string();
+    let output_arg = output_path.to_string_lossy().to_string();
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &[
+            "--config",
+            &config_arg,
+            "--output-file",
+            &output_arg,
+            "dead-code",
+            "--file",
+            "src/index.ts",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "file scoped run should pass: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("dead_code"));
+    assert_eq!(event["run_scope"].as_str(), Some("file_scoped"));
+    assert_eq!(event["config_shape"].as_str(), Some("custom_rules"));
+    assert_eq!(event["output_destination"].as_str(), Some("file"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("static"));
+    assert!(
+        !event
+            .to_string()
+            .contains(&dir.path().to_string_lossy().to_string()),
+        "telemetry event must not include raw project paths"
+    );
 }
 
 #[test]
@@ -534,6 +587,9 @@ fn audit_with_findings_sets_findings_present_true() {
     );
     assert_eq!(event["workflow"].as_str(), Some("audit"));
     assert_eq!(event["outcome"].as_str(), Some("issues_found"));
+    assert_eq!(event["run_scope"].as_str(), Some("changed_only"));
+    assert_eq!(event["output_destination"].as_str(), Some("stdout"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("static"));
     assert_eq!(event["findings_present"].as_bool(), Some(true));
     assert_eq!(event["result_count_bucket"].as_str(), Some("1-9"));
 }
@@ -598,8 +654,56 @@ fn security_with_findings_sets_findings_present_true() {
     assert_eq!(output.code, 0, "security should exit 0: {}", output.stderr);
     assert_eq!(event["workflow"].as_str(), Some("security"));
     assert_eq!(event["outcome"].as_str(), Some("success"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("security"));
     assert_eq!(event["findings_present"].as_bool(), Some(true));
     assert_eq!(event["result_count_bucket"].as_str(), Some("1-9"));
+}
+
+#[test]
+fn fix_dry_run_reports_fix_analysis_mode() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_clean_project(dir.path());
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &["fix", "--dry-run", "--format", "json", "--quiet"],
+        &[],
+    );
+
+    assert_eq!(output.code, 0, "fix dry-run should pass: {}", output.stderr);
+    assert_eq!(event["workflow"].as_str(), Some("fix"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("fix"));
+}
+
+#[test]
+fn health_coverage_flag_reports_runtime_coverage_mode_without_path() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_clean_project(dir.path());
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &[
+            "health",
+            "--coverage",
+            "missing-coverage.json",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 2,
+        "missing coverage should fail: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("health"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("runtime_coverage"));
+    assert!(
+        !event.to_string().contains("missing-coverage.json"),
+        "telemetry event must not include raw coverage paths"
+    );
 }
 
 #[test]

--- a/crates/config/src/config/rules.rs
+++ b/crates/config/src/config/rules.rs
@@ -60,7 +60,7 @@ impl std::str::FromStr for Severity {
 /// or are suppressed entirely. Most fields default to `Severity::Error`.
 ///
 /// Rule names use kebab-case in config files (e.g., `"unused-files": "error"`).
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct RulesConfig {
     #[serde(default, alias = "unused-file")]

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -86,6 +86,10 @@ V2 events are workflow-level and coarse:
   "duration_bucket_ms": "500-2000",
   "outcome": "issues_found",
   "exit_code_bucket": "1",
+  "run_scope": "changed_only",
+  "config_shape": "custom_rules",
+  "output_destination": "stdout",
+  "analysis_mode": "static",
   "findings_present": true,
   "result_count_bucket": "1-9",
   "report_truncated": true,
@@ -98,7 +102,7 @@ V2 events are workflow-level and coarse:
 }
 ```
 
-`agent_source`, `failure_reason`, `findings_present`, `result_count_bucket`, `report_truncated`, `truncation_reason`, `cache_state`, and `mcp_tool` are optional. `agent_source` appears only on agent-driven runs. `failure_reason` appears only on failed workflow events and uses one of `validation`, `unsupported_format`, `config`, `analysis`, `diff`, `network`, `auth`, `gate`, `signal`, or `unknown`. `findings_present` and `result_count_bucket` are omitted by commands that run no analysis (and by older binaries). `report_truncated` appears only on report/comment output paths that can truncate output, and `truncation_reason` appears only when truncation happened. `cache_state` appears on combined `code_quality_review` runs and is one of `cold`, `warm`, `partial`, or `unknown`; `unknown` covers disabled cache or missing cache signal. `mcp_tool` appears only when a run came through the MCP server. `has_parent_run`, `run_role`, and `followup_kind` are always safe, allowlisted values and never include the raw parent-run token.
+`agent_source`, `failure_reason`, `findings_present`, `result_count_bucket`, `report_truncated`, `truncation_reason`, `cache_state`, `mcp_tool`, `run_scope`, `config_shape`, `output_destination`, and `analysis_mode` are optional. `agent_source` appears only on agent-driven runs. `failure_reason` appears only on failed workflow events and uses one of `validation`, `unsupported_format`, `config`, `analysis`, `diff`, `network`, `auth`, `gate`, `signal`, or `unknown`. `findings_present` and `result_count_bucket` are omitted by commands that run no analysis (and by older binaries). `report_truncated` appears only on report/comment output paths that can truncate output, and `truncation_reason` appears only when truncation happened. `cache_state` appears on combined `code_quality_review` runs and is one of `cold`, `warm`, `partial`, or `unknown`; `unknown` covers disabled cache or missing cache signal. `mcp_tool` appears only when a run came through the MCP server. `run_scope`, `config_shape`, `output_destination`, and `analysis_mode` appear on workflow events and use fixed coarse buckets only. `has_parent_run`, `run_role`, and `followup_kind` are always safe, allowlisted values and never include the raw parent-run token. All are omitted otherwise.
 
 Field purposes:
 
@@ -112,6 +116,10 @@ Field purposes:
 | `duration_bucket_ms` | Find slow workflow classes without collecting exact timings. |
 | `outcome` / `exit_code_bucket` | Measure clean runs, findings, and failures without uploading raw error text. |
 | `failure_reason` | Group failed workflows by a fixed privacy-safe allowlist; unknown stays `unknown` instead of parsing raw error text. |
+| `run_scope` | Classify the run as `full_project`, `changed_only`, `workspace_scoped`, `file_scoped`, or `unknown` without uploading file, workspace, branch, or ref names. |
+| `config_shape` | Classify configuration as `default`, `custom_config`, `custom_rules`, `plugins_enabled`, or `unknown` without uploading config paths, rule names, plugin names, or values. |
+| `output_destination` | Classify the report sink as `stdout`, `file`, `ci_comment`, or `unknown` without uploading destination paths, URLs, or integration identifiers. |
+| `analysis_mode` | Classify analysis as `static`, `runtime_coverage`, `production_coverage`, `security`, `fix`, or `unknown` without uploading raw command lines or coverage artifact paths. |
 | `findings_present` | Whether the analysis surfaced any findings, decoupled from the exit-code gate (so informational analyses like default-config `dupes`, which never exit non-zero, are still measurable). On the combined and audit workflows it is an OR across the sub-analyses; per-analysis find-rate is answerable on the standalone `dead_code`, `dupes`, `health`, and `security` workflows. |
 | `result_count_bucket` | Coarse result volume, one of `0`, `1-9`, `10-99`, `100+`, or `unknown`. Exact counts, paths, finding names, rule ids, and snippets are never uploaded. |
 | `report_truncated` / `truncation_reason` | Whether a report/comment output path was truncated and why. Reasons are `comment_limit`, `max_items`, `size_limit`, or `unknown`. |


### PR DESCRIPTION
## Summary
- Add coarse telemetry context dimensions for run scope, config shape, output destination, and analysis mode.
- Keep values allowlisted and privacy-preserving, with no raw paths, config filenames, workspace names, command lines, package names, or repository identifiers.
- Update inspect-mode tests and telemetry docs for the new fields.

## Issue
Closes #1079

## Verification
- [x] cargo test -p fallow-cli --test telemetry_tests
- [x] real-project telemetry inspect smoke
- [x] cargo test --workspace --all-targets
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
- [x] fallow audit --base origin/main --format json --quiet
