### PR TITLE
feat(telemetry): add outcome buckets

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1090,10 +1090,8 @@ pub fn execute_audit(opts: &AuditOptions<'_>) -> Result<AuditResult, ExitCode> {
         dupes_result.as_ref(),
         health_result.as_ref(),
     );
-    crate::telemetry::note_findings_present(
-        summary.dead_code_issues > 0
-            || summary.complexity_findings > 0
-            || summary.duplication_clone_groups > 0,
+    crate::telemetry::note_final_result_count(
+        summary.dead_code_issues + summary.complexity_findings + summary.duplication_clone_groups,
     );
 
     Ok(AuditResult {
@@ -1139,7 +1137,7 @@ fn resolve_base_ref(opts: &AuditOptions<'_>) -> Result<String, ExitCode> {
 
 /// Build an empty pass result when no files have changed.
 fn empty_audit_result(base_ref: String, opts: &AuditOptions<'_>, elapsed: Duration) -> AuditResult {
-    crate::telemetry::note_findings_present(false);
+    crate::telemetry::note_final_result_count(0);
 
     AuditResult {
         verdict: AuditVerdict::Pass,

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -452,9 +452,9 @@ pub fn execute_check(opts: &CheckOptions<'_>) -> Result<CheckResult, ExitCode> {
 
     let config_fixable = crate::fix::is_config_fixable(opts.root, opts.config_path.as_ref());
 
-    // Report findings presence to telemetry from the real result, independent of
-    // the exit-code gate. See `telemetry::note_findings_present`.
-    crate::telemetry::note_findings_present(results.total_issues() > 0);
+    // Report result volume to telemetry from the real result, independent of
+    // the exit-code gate. Exact counts are bucketed before serialization.
+    crate::telemetry::note_result_count(results.total_issues());
 
     Ok(CheckResult {
         results,

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -413,10 +413,10 @@ fn execute_dupes_inner(
 
     let elapsed = start.elapsed();
 
-    // Report findings presence to telemetry from the real result, independent of
-    // the duplication threshold gate (which exits 0 by default even at 100%
-    // duplication). See `telemetry::note_findings_present`.
-    crate::telemetry::note_findings_present(!report.clone_groups.is_empty());
+    // Report result volume to telemetry from the real result, independent of
+    // the duplication threshold gate. Exact counts are bucketed before
+    // serialization.
+    crate::telemetry::note_result_count(report.clone_groups.len());
 
     Ok(DupesResult {
         report,

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -667,12 +667,15 @@ fn execute_health_inner(
         None
     };
 
-    // Report findings presence to telemetry from the real result (complexity
-    // findings or coverage gaps), independent of the exit-code gate. See
-    // `telemetry::note_findings_present`.
-    crate::telemetry::note_findings_present(
-        !report.findings.is_empty() || coverage_gaps_has_findings,
-    );
+    // Report result volume to telemetry from the real result, independent of
+    // the exit-code gate. Coverage gaps are a section-level signal today, so
+    // they mark an unknown non-empty bucket until that report carries a stable
+    // finding count.
+    if coverage_gaps_has_findings && report.findings.is_empty() {
+        crate::telemetry::note_findings_present(true);
+    } else {
+        crate::telemetry::note_result_count(report.findings.len());
+    }
 
     Ok(HealthResult {
         report,

--- a/crates/cli/src/report/ci/review.rs
+++ b/crates/cli/src/report/ci/review.rs
@@ -83,9 +83,10 @@ pub fn render_review_envelope_with_diff(
         .flatten();
     let include_guidance = review_guidance_enabled();
 
-    let merged_groups = group_by_path_line(issues, max);
+    let grouped = group_by_path_line(issues, max);
 
-    let comments: Vec<ReviewComment> = merged_groups
+    let comments: Vec<ReviewComment> = grouped
+        .groups
         .iter()
         .map(|group| {
             render_merged_comment(
@@ -97,6 +98,23 @@ pub fn render_review_envelope_with_diff(
             )
         })
         .collect();
+    let body_truncated = comments.iter().any(review_comment_truncated);
+    if body_truncated {
+        crate::telemetry::note_report_truncation(
+            true,
+            crate::telemetry::TruncationReason::SizeLimit,
+        );
+    } else if grouped.truncated {
+        crate::telemetry::note_report_truncation(
+            true,
+            crate::telemetry::TruncationReason::CommentLimit,
+        );
+    } else {
+        crate::telemetry::note_report_truncation(
+            false,
+            crate::telemetry::TruncationReason::Unknown,
+        );
+    }
 
     let summary_text = format!(
         "### Fallow {}\n\n{} inline finding{} selected for {} review.\n\n<!-- fallow-review -->",
@@ -221,11 +239,20 @@ fn env_truthy(value: &str) -> bool {
     )
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct GroupedReviewIssues<'a> {
+    groups: Vec<Vec<&'a CiIssue>>,
+    truncated: bool,
+}
+
 /// Group consecutive same-(path, line) issues. Input is already sorted by
 /// `(path, line, fingerprint)` so a single linear pass collects runs.
-fn group_by_path_line(issues: &[CiIssue], max_groups: usize) -> Vec<Vec<&CiIssue>> {
+fn group_by_path_line(issues: &[CiIssue], max_groups: usize) -> GroupedReviewIssues<'_> {
     if max_groups == 0 {
-        return Vec::new();
+        return GroupedReviewIssues {
+            groups: Vec::new(),
+            truncated: !issues.is_empty(),
+        };
     }
     let mut groups: Vec<Vec<&CiIssue>> = Vec::with_capacity(max_groups.min(issues.len()));
     let mut current: Vec<&CiIssue> = Vec::new();
@@ -236,7 +263,10 @@ fn group_by_path_line(issues: &[CiIssue], max_groups: usize) -> Vec<Vec<&CiIssue
             if !current.is_empty() {
                 groups.push(std::mem::take(&mut current));
                 if groups.len() == max_groups {
-                    return groups;
+                    return GroupedReviewIssues {
+                        groups,
+                        truncated: true,
+                    };
                 }
             }
             current_key = Some(key);
@@ -246,7 +276,17 @@ fn group_by_path_line(issues: &[CiIssue], max_groups: usize) -> Vec<Vec<&CiIssue
     if !current.is_empty() && groups.len() < max_groups {
         groups.push(current);
     }
-    groups
+    GroupedReviewIssues {
+        groups,
+        truncated: false,
+    }
+}
+
+fn review_comment_truncated(comment: &ReviewComment) -> bool {
+    match comment {
+        ReviewComment::GitHub(comment) => comment.truncated,
+        ReviewComment::GitLab(comment) => comment.truncated,
+    }
 }
 
 /// Render one comment from a group of 1+ issues that share the same
@@ -649,20 +689,24 @@ mod tests {
         let c = issue("fallow/unused-type", "minor", "src/z.ts", 7, "fp_c");
         let issues = vec![a, b, c];
 
-        assert!(group_by_path_line(&issues, 0).is_empty());
+        let max_zero = group_by_path_line(&issues, 0);
+        assert!(max_zero.groups.is_empty());
+        assert!(max_zero.truncated);
 
         let max_one = group_by_path_line(&issues, 1);
-        assert_eq!(max_one.len(), 1);
-        assert_eq!(max_one[0].len(), 2);
-        assert_eq!(max_one[0][0].path, "src/foo.ts");
-        assert_eq!(max_one[0][0].line, 42);
+        assert_eq!(max_one.groups.len(), 1);
+        assert!(max_one.truncated);
+        assert_eq!(max_one.groups[0].len(), 2);
+        assert_eq!(max_one.groups[0][0].path, "src/foo.ts");
+        assert_eq!(max_one.groups[0][0].line, 42);
 
         let max_two = group_by_path_line(&issues, 2);
-        assert_eq!(max_two.len(), 2);
-        assert_eq!(max_two[0].len(), 2);
-        assert_eq!(max_two[1].len(), 1);
+        assert_eq!(max_two.groups.len(), 2);
+        assert!(!max_two.truncated);
+        assert_eq!(max_two.groups[0].len(), 2);
+        assert_eq!(max_two.groups[1].len(), 1);
         assert_eq!(
-            max_two[0]
+            max_two.groups[0]
                 .iter()
                 .map(|issue| issue.fingerprint.as_str())
                 .collect::<Vec<_>>(),

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -294,7 +294,7 @@ pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
         unresolved_edge_files,
         unresolved_callee_sites,
     };
-    crate::telemetry::note_findings_present(!output.security_findings.is_empty());
+    crate::telemetry::note_result_count(output.security_findings.len());
 
     if let Some(path) = opts.sarif_file
         && let Err(message) = write_sarif_file(&output, path)

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::io::{IsTerminal, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU16, Ordering};
 use std::time::Duration;
 
 use fallow_config::OutputFormat;
@@ -98,6 +98,9 @@ const MCP_TOOLS: &[&str] = &[
 /// would see the bit stick at the max across all of them.
 static FINDINGS_PRESENT: AtomicU8 = AtomicU8::new(FINDINGS_UNSET);
 static FAILURE_REASON: AtomicU8 = AtomicU8::new(FAILURE_REASON_UNSET);
+static RESULT_COUNT_CAPPED: AtomicU16 = AtomicU16::new(RESULT_COUNT_UNSET);
+static REPORT_TRUNCATED: AtomicU8 = AtomicU8::new(REPORT_TRUNCATION_UNSET);
+static TRUNCATION_REASON: AtomicU8 = AtomicU8::new(TRUNCATION_REASON_UNSET);
 
 const FINDINGS_UNSET: u8 = 0;
 const FINDINGS_CLEAN: u8 = 1;
@@ -113,6 +116,17 @@ const FAILURE_REASON_NETWORK: u8 = 7;
 const FAILURE_REASON_AUTH: u8 = 8;
 const FAILURE_REASON_GATE: u8 = 9;
 const FAILURE_REASON_SIGNAL: u8 = 10;
+const RESULT_COUNT_MAX: usize = 100;
+const RESULT_COUNT_UNSET: u16 = u16::MAX;
+const RESULT_COUNT_UNKNOWN: u16 = u16::MAX - 1;
+const REPORT_TRUNCATION_UNSET: u8 = 0;
+const REPORT_TRUNCATION_FALSE: u8 = 1;
+const REPORT_TRUNCATION_TRUE: u8 = 2;
+const TRUNCATION_REASON_UNSET: u8 = 0;
+const TRUNCATION_REASON_UNKNOWN: u8 = 1;
+const TRUNCATION_REASON_MAX_ITEMS: u8 = 2;
+const TRUNCATION_REASON_COMMENT_LIMIT: u8 = 3;
+const TRUNCATION_REASON_SIZE_LIMIT: u8 = 4;
 
 /// Record whether the analysis that just completed surfaced any findings.
 ///
@@ -127,6 +141,68 @@ pub fn note_findings_present(present: bool) {
         FINDINGS_CLEAN
     };
     FINDINGS_PRESENT.fetch_max(value, Ordering::Relaxed);
+    if present {
+        mark_result_count_unknown();
+    } else {
+        note_result_count(0);
+    }
+}
+
+/// Record the number of findings in the analysis batch that just completed.
+///
+/// The exact count is used only in-process to combine sub-analyses from a
+/// single CLI invocation. The event serializes only the coarse bucket.
+pub fn note_result_count(count: usize) {
+    let value = if count > 0 {
+        FINDINGS_FOUND
+    } else {
+        FINDINGS_CLEAN
+    };
+    FINDINGS_PRESENT.fetch_max(value, Ordering::Relaxed);
+
+    let capped = count.min(RESULT_COUNT_MAX) as u16;
+    let _ = RESULT_COUNT_CAPPED.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        let next = match current {
+            RESULT_COUNT_UNSET => capped,
+            RESULT_COUNT_UNKNOWN => RESULT_COUNT_UNKNOWN,
+            value => value.saturating_add(capped).min(RESULT_COUNT_MAX as u16),
+        };
+        Some(next)
+    });
+}
+
+/// Record a final command-level count after nested analysis helpers ran.
+pub fn note_final_result_count(count: usize) {
+    let value = if count > 0 {
+        FINDINGS_FOUND
+    } else {
+        FINDINGS_CLEAN
+    };
+    FINDINGS_PRESENT.fetch_max(value, Ordering::Relaxed);
+    RESULT_COUNT_CAPPED.store(count.min(RESULT_COUNT_MAX) as u16, Ordering::Relaxed);
+}
+
+fn mark_result_count_unknown() {
+    RESULT_COUNT_CAPPED.store(RESULT_COUNT_UNKNOWN, Ordering::Relaxed);
+}
+
+/// Record whether a report/comment style output path was truncated.
+pub fn note_report_truncation(truncated: bool, reason: TruncationReason) {
+    if truncated {
+        REPORT_TRUNCATED.store(REPORT_TRUNCATION_TRUE, Ordering::Relaxed);
+        let reason_state = truncation_reason_to_state(reason);
+        let _ = TRUNCATION_REASON.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.max(reason_state))
+        });
+    } else {
+        let _ = REPORT_TRUNCATED.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            if current == REPORT_TRUNCATION_UNSET {
+                Some(REPORT_TRUNCATION_FALSE)
+            } else {
+                Some(current)
+            }
+        });
+    }
 }
 
 /// Map the accumulator state to the optional payload field. Pure so it can be
@@ -222,6 +298,82 @@ fn failure_reason() -> Option<FailureReason> {
     failure_reason_from_state(FAILURE_REASON.load(Ordering::Relaxed))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub enum ResultCountBucket {
+    #[serde(rename = "0")]
+    Zero,
+    #[serde(rename = "1-9")]
+    OneToNine,
+    #[serde(rename = "10-99")]
+    TenToNinetyNine,
+    #[serde(rename = "100+")]
+    OneHundredPlus,
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+fn result_count_bucket_from_state(state: u16) -> Option<ResultCountBucket> {
+    match state {
+        RESULT_COUNT_UNSET => None,
+        RESULT_COUNT_UNKNOWN => Some(ResultCountBucket::Unknown),
+        0 => Some(ResultCountBucket::Zero),
+        1..=9 => Some(ResultCountBucket::OneToNine),
+        10..=99 => Some(ResultCountBucket::TenToNinetyNine),
+        _ => Some(ResultCountBucket::OneHundredPlus),
+    }
+}
+
+fn result_count_bucket() -> Option<ResultCountBucket> {
+    result_count_bucket_from_state(RESULT_COUNT_CAPPED.load(Ordering::Relaxed))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TruncationReason {
+    CommentLimit,
+    MaxItems,
+    SizeLimit,
+    Unknown,
+}
+
+fn truncation_reason_to_state(reason: TruncationReason) -> u8 {
+    match reason {
+        TruncationReason::Unknown => TRUNCATION_REASON_UNKNOWN,
+        TruncationReason::MaxItems => TRUNCATION_REASON_MAX_ITEMS,
+        TruncationReason::CommentLimit => TRUNCATION_REASON_COMMENT_LIMIT,
+        TruncationReason::SizeLimit => TRUNCATION_REASON_SIZE_LIMIT,
+    }
+}
+
+fn truncation_reason_from_state(state: u8) -> Option<TruncationReason> {
+    match state {
+        TRUNCATION_REASON_UNKNOWN => Some(TruncationReason::Unknown),
+        TRUNCATION_REASON_MAX_ITEMS => Some(TruncationReason::MaxItems),
+        TRUNCATION_REASON_COMMENT_LIMIT => Some(TruncationReason::CommentLimit),
+        TRUNCATION_REASON_SIZE_LIMIT => Some(TruncationReason::SizeLimit),
+        _ => None,
+    }
+}
+
+fn report_truncated_from_state(state: u8) -> Option<bool> {
+    match state {
+        REPORT_TRUNCATION_FALSE => Some(false),
+        REPORT_TRUNCATION_TRUE => Some(true),
+        _ => None,
+    }
+}
+
+fn report_truncated() -> Option<bool> {
+    report_truncated_from_state(REPORT_TRUNCATED.load(Ordering::Relaxed))
+}
+
+fn truncation_reason() -> Option<TruncationReason> {
+    if report_truncated() != Some(true) {
+        return None;
+    }
+    truncation_reason_from_state(TRUNCATION_REASON.load(Ordering::Relaxed))
+        .or(Some(TruncationReason::Unknown))
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TelemetryCommand {
     Status,
@@ -379,6 +531,18 @@ struct TelemetryEvent {
     /// workflows.
     #[serde(skip_serializing_if = "Option::is_none")]
     findings_present: Option<bool>,
+    /// Coarse bucket of the rendered analysis result count. Never serializes
+    /// exact counts, paths, finding names, rule ids, or snippets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result_count_bucket: Option<ResultCountBucket>,
+    /// Whether a report/comment style output path was truncated. Absent on
+    /// output formats that have no truncation-aware reporting path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    report_truncated: Option<bool>,
+    /// Why a report/comment style output path was truncated. Only present when
+    /// `report_truncated` is true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncation_reason: Option<TruncationReason>,
     /// The MCP tool that triggered this run, when invoked through the MCP
     /// server. Allowlisted to the fixed set of tool names; absent otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -618,6 +782,9 @@ fn build_workflow_event(record: &WorkflowRecord<'_>) -> TelemetryEvent {
         exit_code_bucket: exit_code_bucket(record.exit_code),
         failure_reason: failure_reason_for(record),
         findings_present: findings_present(),
+        result_count_bucket: result_count_bucket(),
+        report_truncated: report_truncated(),
+        truncation_reason: truncation_reason(),
         mcp_tool: mcp_tool(),
         parent_run: record.parent_run.and_then(sanitize_parent_run),
     }
@@ -663,6 +830,9 @@ fn status_changed_event(enabled: bool) -> TelemetryEvent {
         exit_code_bucket: "0",
         failure_reason: None,
         findings_present: None,
+        result_count_bucket: None,
+        report_truncated: None,
+        truncation_reason: None,
         mcp_tool: None,
         parent_run: None,
     }
@@ -688,6 +858,9 @@ fn example_event() -> TelemetryEvent {
         exit_code_bucket: "1",
         failure_reason: None,
         findings_present: Some(true),
+        result_count_bucket: Some(ResultCountBucket::OneToNine),
+        report_truncated: Some(true),
+        truncation_reason: Some(TruncationReason::CommentLimit),
         mcp_tool: Some("find_dupes"),
         parent_run: Some("tmp_8x7p4k".to_owned()),
     }
@@ -730,6 +903,18 @@ fn field_purposes() -> Vec<(&'static str, &'static str)> {
         (
             "findings_present",
             "Whether the analysis surfaced any findings, decoupled from the exit-code gate. On combined and audit workflows it is an OR across sub-analyses; per-analysis find-rate is answerable only on standalone dead_code, dupes, and health.",
+        ),
+        (
+            "result_count_bucket",
+            "Coarse analysis result volume: 0, 1-9, 10-99, 100+, or unknown. Exact counts, paths, finding names, rule ids, and snippets are never sent.",
+        ),
+        (
+            "report_truncated",
+            "Whether a report/comment output path was truncated before delivery.",
+        ),
+        (
+            "truncation_reason",
+            "Why report/comment output was truncated: comment_limit, max_items, size_limit, or unknown.",
         ),
         (
             "mcp_tool",
@@ -1667,6 +1852,56 @@ mod tests {
         assert_eq!(findings_present_from_state(FINDINGS_FOUND), Some(true));
         // Any unexpected value is treated as unset, never a misleading false.
         assert_eq!(findings_present_from_state(99), None);
+    }
+
+    #[test]
+    fn result_count_state_maps_to_buckets() {
+        assert_eq!(result_count_bucket_from_state(RESULT_COUNT_UNSET), None);
+        assert_eq!(
+            result_count_bucket_from_state(RESULT_COUNT_UNKNOWN),
+            Some(ResultCountBucket::Unknown)
+        );
+        assert_eq!(
+            result_count_bucket_from_state(0),
+            Some(ResultCountBucket::Zero)
+        );
+        assert_eq!(
+            result_count_bucket_from_state(9),
+            Some(ResultCountBucket::OneToNine)
+        );
+        assert_eq!(
+            result_count_bucket_from_state(10),
+            Some(ResultCountBucket::TenToNinetyNine)
+        );
+        assert_eq!(
+            result_count_bucket_from_state(99),
+            Some(ResultCountBucket::TenToNinetyNine)
+        );
+        assert_eq!(
+            result_count_bucket_from_state(100),
+            Some(ResultCountBucket::OneHundredPlus)
+        );
+    }
+
+    #[test]
+    fn report_truncation_state_maps_to_payload_fields() {
+        assert_eq!(report_truncated_from_state(REPORT_TRUNCATION_UNSET), None);
+        assert_eq!(
+            report_truncated_from_state(REPORT_TRUNCATION_FALSE),
+            Some(false)
+        );
+        assert_eq!(
+            report_truncated_from_state(REPORT_TRUNCATION_TRUE),
+            Some(true)
+        );
+        assert_eq!(
+            truncation_reason_from_state(TRUNCATION_REASON_COMMENT_LIMIT),
+            Some(TruncationReason::CommentLimit)
+        );
+        assert_eq!(
+            truncation_reason_from_state(TRUNCATION_REASON_SIZE_LIMIT),
+            Some(TruncationReason::SizeLimit)
+        );
     }
 
     #[test]

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -237,6 +237,24 @@ fn write_clean_project(dir: &Path) {
     fs::write(src.join("index.ts"), "export const value = 41 + 1;\n").expect("write source");
 }
 
+fn write_many_unused_project(dir: &Path) {
+    let src = dir.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        dir.join("package.json"),
+        "{\n  \"name\": \"many-unused\",\n  \"main\": \"src/index.ts\"\n}\n",
+    )
+    .expect("write package.json");
+    fs::write(src.join("index.ts"), "console.log('entry');\n").expect("write index");
+    for index in 0..12 {
+        fs::write(
+            src.join(format!("unused-{index}.ts")),
+            format!("export const unused{index} = {index};\n"),
+        )
+        .expect("write unused source");
+    }
+}
+
 fn write_audit_base_project(dir: &Path) {
     let src = dir.join("src");
     fs::create_dir_all(&src).expect("create src");
@@ -293,6 +311,7 @@ fn dupes_with_duplication_sets_findings_present_despite_success_outcome() {
         Some(true),
         "dupes with real duplication must report findings_present=true"
     );
+    assert_eq!(event["result_count_bucket"].as_str(), Some("1-9"));
 }
 
 #[test]
@@ -310,6 +329,7 @@ fn dupes_on_clean_project_sets_findings_present_false() {
         Some(false),
         "a genuinely clean dupes run must report findings_present=false"
     );
+    assert_eq!(event["result_count_bucket"].as_str(), Some("0"));
 }
 
 #[test]
@@ -404,6 +424,7 @@ fn audit_with_findings_sets_findings_present_true() {
     assert_eq!(event["workflow"].as_str(), Some("audit"));
     assert_eq!(event["outcome"].as_str(), Some("issues_found"));
     assert_eq!(event["findings_present"].as_bool(), Some(true));
+    assert_eq!(event["result_count_bucket"].as_str(), Some("1-9"));
 }
 
 #[test]
@@ -427,6 +448,7 @@ fn audit_on_clean_changed_files_sets_findings_present_false() {
     assert_eq!(event["workflow"].as_str(), Some("audit"));
     assert_eq!(event["outcome"].as_str(), Some("success"));
     assert_eq!(event["findings_present"].as_bool(), Some(false));
+    assert_eq!(event["result_count_bucket"].as_str(), Some("0"));
 }
 
 #[test]
@@ -448,6 +470,7 @@ fn audit_with_no_changed_files_sets_findings_present_false() {
     assert_eq!(event["workflow"].as_str(), Some("audit"));
     assert_eq!(event["outcome"].as_str(), Some("success"));
     assert_eq!(event["findings_present"].as_bool(), Some(false));
+    assert_eq!(event["result_count_bucket"].as_str(), Some("0"));
 }
 
 #[test]
@@ -465,6 +488,7 @@ fn security_with_findings_sets_findings_present_true() {
     assert_eq!(event["workflow"].as_str(), Some("security"));
     assert_eq!(event["outcome"].as_str(), Some("success"));
     assert_eq!(event["findings_present"].as_bool(), Some(true));
+    assert_eq!(event["result_count_bucket"].as_str(), Some("1-9"));
 }
 
 #[test]
@@ -482,6 +506,31 @@ fn security_on_clean_project_sets_findings_present_false() {
     assert_eq!(event["workflow"].as_str(), Some("security"));
     assert_eq!(event["outcome"].as_str(), Some("success"));
     assert_eq!(event["findings_present"].as_bool(), Some(false));
+    assert_eq!(event["result_count_bucket"].as_str(), Some("0"));
+}
+
+#[test]
+fn review_output_reports_comment_limit_truncation() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_many_unused_project(dir.path());
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &["dead-code", "--format", "review-github", "--quiet"],
+        &[("FALLOW_MAX_COMMENTS", "1")],
+    );
+
+    assert_eq!(
+        output.code, 1,
+        "dead-code with findings should exit 1: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("dead_code"));
+    assert_eq!(event["output_format"].as_str(), Some("review_github"));
+    assert_eq!(event["findings_present"].as_bool(), Some(true));
+    assert_eq!(event["result_count_bucket"].as_str(), Some("10-99"));
+    assert_eq!(event["report_truncated"].as_bool(), Some(true));
+    assert_eq!(event["truncation_reason"].as_str(), Some("comment_limit"));
 }
 
 #[test]
@@ -496,6 +545,10 @@ fn admin_command_emits_no_findings_present_key() {
     assert!(
         event.get("findings_present").is_none(),
         "commands that run no analysis must omit findings_present"
+    );
+    assert!(
+        event.get("result_count_bucket").is_none(),
+        "commands that run no analysis must omit result_count_bucket"
     );
 }
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -87,12 +87,15 @@ V1 events are workflow-level and coarse:
   "outcome": "issues_found",
   "exit_code_bucket": "1",
   "findings_present": true,
+  "result_count_bucket": "1-9",
+  "report_truncated": true,
+  "truncation_reason": "comment_limit",
   "mcp_tool": "find_dupes",
   "parent_run": "tmp_8x7p4k"
 }
 ```
 
-`agent_source`, `failure_reason`, `findings_present`, `mcp_tool`, and `parent_run` are optional. `agent_source` appears only on agent-driven runs. `failure_reason` appears only on failed workflow events and uses one of `validation`, `unsupported_format`, `config`, `analysis`, `diff`, `network`, `auth`, `gate`, `signal`, or `unknown`. `findings_present` is omitted by commands that run no analysis (and by older binaries). `mcp_tool` appears only when a run came through the MCP server. `parent_run` appears only when a run is explicitly correlated to a previous one. All are omitted otherwise.
+`agent_source`, `failure_reason`, `findings_present`, `result_count_bucket`, `report_truncated`, `truncation_reason`, `mcp_tool`, and `parent_run` are optional. `agent_source` appears only on agent-driven runs. `failure_reason` appears only on failed workflow events and uses one of `validation`, `unsupported_format`, `config`, `analysis`, `diff`, `network`, `auth`, `gate`, `signal`, or `unknown`. `findings_present` and `result_count_bucket` are omitted by commands that run no analysis (and by older binaries). `report_truncated` appears only on report/comment output paths that can truncate output, and `truncation_reason` appears only when truncation happened. `mcp_tool` appears only when a run came through the MCP server. `parent_run` appears only when a run is explicitly correlated to a previous one. All are omitted otherwise.
 
 Field purposes:
 
@@ -107,6 +110,8 @@ Field purposes:
 | `outcome` / `exit_code_bucket` | Measure clean runs, findings, and failures without uploading raw error text. |
 | `failure_reason` | Group failed workflows by a fixed privacy-safe allowlist; unknown stays `unknown` instead of parsing raw error text. |
 | `findings_present` | Whether the analysis surfaced any findings, decoupled from the exit-code gate (so informational analyses like default-config `dupes`, which never exit non-zero, are still measurable). On the combined and audit workflows it is an OR across the sub-analyses; per-analysis find-rate is answerable on the standalone `dead_code`, `dupes`, `health`, and `security` workflows. |
+| `result_count_bucket` | Coarse result volume, one of `0`, `1-9`, `10-99`, `100+`, or `unknown`. Exact counts, paths, finding names, rule ids, and snippets are never uploaded. |
+| `report_truncated` / `truncation_reason` | Whether a report/comment output path was truncated and why. Reasons are `comment_limit`, `max_items`, `size_limit`, or `unknown`. |
 | `mcp_tool` | Attribute MCP usage to a specific tool, from a fixed allowlist of tool names. |
 | `parent_run` | Link explicit agent follow-up runs using a short allowlisted token, never a path or free-form string. |
 
@@ -153,6 +158,7 @@ Fallow telemetry must not include:
 - file paths, import specifiers, source snippets, or stack traces
 - package, dependency, workspace, or framework package names
 - raw command-line arguments
+- exact result counts or per-rule result counts
 - config contents or config values
 - environment variable names or values
 - raw errors, logs, or serialized exceptions


### PR DESCRIPTION
## Summary
- Add privacy-safe result count buckets to telemetry workflow events.
- Add report truncation telemetry for review/comment output.
- Update telemetry docs and CLI tests.

## Issue
Closes #1080

## Verification
- cargo check --workspace
- cargo test --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- typos .
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
- ./target/debug/fallow audit --format json --quiet
- FALLOW_TELEMETRY=inspect ./target/debug/fallow --root <real-js-ts-project> audit --format json --quiet

## Companion
- Cloud telemetry ingestion/storage was updated for the new fields.
