### PR TITLE
fix: bound retained parse payload memory

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -146,7 +146,8 @@ pub struct AnalysisOutput {
     pub timings: Option<PipelineTimings>,
     pub graph: Option<graph::ModuleGraph>,
     /// Parsed modules from the pipeline, available when `retain_modules` is true.
-    /// Used by the combined command to share a single parse across dead-code and health.
+    /// Used by combined and LSP flows to share downstream module data.
+    /// Graph-only extraction payloads are released after graph construction.
     pub modules: Option<Vec<extract::ModuleInfo>>,
     /// Discovered files from the pipeline, available when `retain_modules` is true.
     pub files: Option<Vec<discover::DiscoveredFile>>,
@@ -411,7 +412,8 @@ pub fn analyze_retaining_modules(
 /// This avoids re-parsing files when the caller already has a `ParseResult` (e.g., from
 /// `fallow_core::extract::parse_all_files`). Discovery, plugins, scripts, entry points,
 /// import resolution, graph construction, and dead code detection still run normally.
-/// The graph is always retained (needed for file scores).
+/// The graph is always retained (needed for file scores). Caller-owned modules
+/// are borrowed and are not compacted by this API.
 ///
 /// # Errors
 ///
@@ -733,7 +735,7 @@ fn analyze_full(
     };
 
     let parse_result = extract::parse_all_files(files, cache_store.as_ref(), need_complexity);
-    let modules = parse_result.modules;
+    let mut modules = parse_result.modules;
     let cache_hits = parse_result.cache_hits;
     let cache_misses = parse_result.cache_misses;
     let parse_cpu_ms = parse_result.parse_cpu_ms;
@@ -797,6 +799,9 @@ fn analyze_full(
     );
     credit_package_path_references(&mut graph, &modules);
     credit_workspace_package_usage(&mut graph, &resolved, workspaces);
+    for module in &mut modules {
+        module.release_resolution_payload();
+    }
     let graph_ms = t.elapsed().as_secs_f64() * 1000.0;
 
     let ep_summary = summarize_entry_points(&entry_points.all);

--- a/crates/core/tests/integration_test/caching.rs
+++ b/crates/core/tests/integration_test/caching.rs
@@ -90,6 +90,70 @@ fn incremental_no_cache_all_misses() {
 }
 
 #[test]
+fn retaining_modules_releases_graph_payload_after_analysis() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src")).expect("create src dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"payload-release-fixture","version":"1.0.0"}"#,
+    )
+    .expect("write package.json");
+    std::fs::write(root.join("src/lazy.ts"), "export const lazy = 1;\n")
+        .expect("write lazy module");
+    std::fs::write(root.join("src/required.ts"), "exports.value = 2;\n")
+        .expect("write required module");
+    std::fs::write(
+        root.join("src/index.ts"),
+        r#"
+export async function load(flag: boolean) {
+  const required = require("./required");
+  if (flag) {
+    return import("./lazy");
+  }
+  return required.value;
+}
+"#,
+    )
+    .expect("write index module");
+
+    let config = create_config(root.to_path_buf());
+    let files = fallow_core::discover::discover_files(&config);
+    let parsed = fallow_core::extract::parse_all_files(&files, None, true);
+    let parsed_index = parsed
+        .modules
+        .iter()
+        .find(|module| {
+            files
+                .get(module.file_id.0 as usize)
+                .is_some_and(|file| file.path.ends_with("src/index.ts"))
+        })
+        .expect("parsed index module should exist");
+    assert!(!parsed_index.dynamic_imports.is_empty());
+    assert!(!parsed_index.require_calls.is_empty());
+
+    let output =
+        fallow_core::analyze_retaining_modules(&config, true, false).expect("analysis succeeds");
+    let retained_modules = output.modules.expect("retained modules");
+    let retained_files = output.files.expect("retained files");
+    let retained_index = retained_modules
+        .iter()
+        .find(|module| {
+            retained_files
+                .get(module.file_id.0 as usize)
+                .is_some_and(|file| file.path.ends_with("src/index.ts"))
+        })
+        .expect("retained index module should exist");
+
+    assert!(retained_index.dynamic_imports.is_empty());
+    assert_eq!(retained_index.dynamic_imports.capacity(), 0);
+    assert!(retained_index.require_calls.is_empty());
+    assert_eq!(retained_index.require_calls.capacity(), 0);
+    assert!(!retained_index.line_offsets.is_empty());
+    assert!(!retained_index.complexity.is_empty());
+}
+
+#[test]
 fn incremental_with_cache_all_hits() {
     let root = fixture_path("basic-project");
     let config = create_config(root);

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -112,6 +112,29 @@ pub struct ModuleInfo {
     pub security_control_sites: Vec<SecurityControlSite>,
 }
 
+impl ModuleInfo {
+    /// Release extraction payload that resolution has already copied into the graph.
+    ///
+    /// This keeps fields needed by analysis, health, security, LSP, coverage,
+    /// and hash drift checks, while dropping vectors that otherwise duplicate
+    /// data owned by `ResolvedModule` or already credited into the module graph.
+    pub fn release_resolution_payload(&mut self) {
+        Self::release_vec(&mut self.dynamic_imports);
+        Self::release_vec(&mut self.require_calls);
+        Self::release_vec(&mut self.package_path_references);
+        Self::release_vec(&mut self.whole_object_uses);
+        Self::release_vec(&mut self.unused_import_bindings);
+        Self::release_vec(&mut self.type_referenced_import_bindings);
+        Self::release_vec(&mut self.value_referenced_import_bindings);
+        Self::release_vec(&mut self.namespace_object_aliases);
+        Self::release_vec(&mut self.auto_import_candidates);
+    }
+
+    fn release_vec<T>(values: &mut Vec<T>) {
+        *values = Vec::new();
+    }
+}
+
 /// Defensive control family detected on a source to sink path.
 #[derive(
     Debug,
@@ -952,9 +975,167 @@ pub struct ParseResult {
 mod tests {
     use super::*;
 
+    fn span() -> Span {
+        Span::new(0, 1)
+    }
+
+    macro_rules! assert_released {
+        ($values:expr) => {{
+            assert!($values.is_empty());
+            assert_eq!($values.capacity(), 0);
+        }};
+    }
+
     #[test]
     fn line_offsets_empty_string() {
         assert_eq!(compute_line_offsets(""), vec![0]);
+    }
+
+    #[test]
+    fn release_resolution_payload_drops_copied_vectors_only() {
+        let mut module = ModuleInfo {
+            file_id: FileId(7),
+            exports: vec![ExportInfo {
+                name: ExportName::Named("kept".to_string()),
+                local_name: None,
+                is_type_only: false,
+                is_side_effect_used: false,
+                visibility: VisibilityTag::None,
+                span: span(),
+                members: Vec::new(),
+                super_class: None,
+            }],
+            imports: vec![ImportInfo {
+                source: "node:child_process".to_string(),
+                imported_name: ImportedName::Default,
+                local_name: "childProcess".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: span(),
+                source_span: span(),
+            }],
+            re_exports: vec![ReExportInfo {
+                source: "./kept".to_string(),
+                imported_name: "kept".to_string(),
+                exported_name: "kept".to_string(),
+                is_type_only: false,
+                span: span(),
+            }],
+            dynamic_imports: vec![DynamicImportInfo {
+                source: "./dynamic".to_string(),
+                span: span(),
+                destructured_names: vec!["value".to_string()],
+                local_name: None,
+                is_speculative: false,
+            }],
+            dynamic_import_patterns: vec![DynamicImportPattern {
+                prefix: "./pages/".to_string(),
+                suffix: Some(".tsx".to_string()),
+                span: span(),
+            }],
+            require_calls: vec![RequireCallInfo {
+                source: "./required".to_string(),
+                span: span(),
+                source_span: span(),
+                destructured_names: Vec::new(),
+                local_name: Some("required".to_string()),
+            }],
+            package_path_references: vec!["react".to_string()],
+            member_accesses: vec![MemberAccess {
+                object: "Status".to_string(),
+                member: "Active".to_string(),
+            }],
+            whole_object_uses: vec!["Status".to_string()],
+            has_cjs_exports: true,
+            has_angular_component_template_url: true,
+            content_hash: 42,
+            suppressions: Vec::new(),
+            unknown_suppression_kinds: Vec::new(),
+            unused_import_bindings: vec!["unused".to_string()],
+            type_referenced_import_bindings: vec!["TypeOnly".to_string()],
+            value_referenced_import_bindings: vec!["Value".to_string()],
+            line_offsets: vec![0, 8],
+            complexity: vec![FunctionComplexity {
+                name: "work".to_string(),
+                line: 1,
+                col: 0,
+                cyclomatic: 2,
+                cognitive: 3,
+                line_count: 4,
+                param_count: 1,
+                source_hash: Some("hash".to_string()),
+                contributions: Vec::new(),
+            }],
+            flag_uses: vec![FlagUse {
+                flag_name: "FEATURE_X".to_string(),
+                kind: FlagUseKind::EnvVar,
+                line: 1,
+                col: 0,
+                guard_span_start: None,
+                guard_span_end: None,
+                sdk_name: None,
+            }],
+            class_heritage: vec![ClassHeritageInfo {
+                export_name: "Child".to_string(),
+                super_class: Some("Parent".to_string()),
+                implements: vec!["Contract".to_string()],
+                instance_bindings: Vec::new(),
+            }],
+            injection_tokens: vec![("TOKEN".to_string(), "Contract".to_string())],
+            local_type_declarations: vec![LocalTypeDeclaration {
+                name: "Contract".to_string(),
+                span: span(),
+            }],
+            public_signature_type_references: vec![PublicSignatureTypeReference {
+                export_name: "kept".to_string(),
+                type_name: "Contract".to_string(),
+                span: span(),
+            }],
+            namespace_object_aliases: vec![NamespaceObjectAlias {
+                via_export_name: "api".to_string(),
+                suffix: "read".to_string(),
+                namespace_local: "ns".to_string(),
+            }],
+            iconify_prefixes: vec!["hero".to_string()],
+            iconify_icon_names: vec!["hero-home".to_string()],
+            auto_import_candidates: vec!["useState".to_string()],
+            directives: vec!["use client".to_string()],
+            security_sinks: Vec::new(),
+            security_sinks_skipped: 1,
+            tainted_bindings: Vec::new(),
+            sanitized_sink_args: Vec::new(),
+            security_control_sites: Vec::new(),
+        };
+
+        module.release_resolution_payload();
+
+        assert_eq!(module.file_id, FileId(7));
+        assert_eq!(module.content_hash, 42);
+        assert_eq!(module.line_offsets, vec![0, 8]);
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.re_exports.len(), 1);
+        assert_eq!(module.dynamic_import_patterns.len(), 1);
+        assert_eq!(module.member_accesses.len(), 1);
+        assert_eq!(module.complexity.len(), 1);
+        assert_eq!(module.flag_uses.len(), 1);
+        assert_eq!(module.class_heritage.len(), 1);
+        assert_eq!(module.injection_tokens.len(), 1);
+        assert_eq!(module.local_type_declarations.len(), 1);
+        assert_eq!(module.public_signature_type_references.len(), 1);
+        assert_eq!(module.iconify_prefixes.len(), 1);
+        assert_eq!(module.iconify_icon_names.len(), 1);
+        assert_eq!(module.directives.len(), 1);
+        assert_eq!(module.security_sinks_skipped, 1);
+        assert_released!(module.dynamic_imports);
+        assert_released!(module.require_calls);
+        assert_released!(module.package_path_references);
+        assert_released!(module.whole_object_uses);
+        assert_released!(module.unused_import_bindings);
+        assert_released!(module.type_referenced_import_bindings);
+        assert_released!(module.value_referenced_import_bindings);
+        assert_released!(module.namespace_object_aliases);
+        assert_released!(module.auto_import_candidates);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Release graph-only extraction payload after module graph construction to reduce retained parse memory on large repositories.
- Keep downstream module data needed by analysis, health, security, LSP, coverage, and fix drift checks.
- Cover the compaction boundary with unit and integration regression tests.

## Issue
Closes #1104

## Verification
- [x] cargo check --workspace
- [x] cargo test --workspace --all-targets
- [x] cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo doc --workspace --no-deps --document-private-items
- [x] real-project JSON parity and RSS comparison on a large TypeScript project
