### PR TITLE
fix: preserve security ranking within severity tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`fallow security --gate newly-reachable` now catches existing sinks newly exposed from entry points.** The gate compares head security candidates against a base-tree reachability snapshot from `--changed-since <ref>`, then exits 8 only when a matching candidate was not runtime-reachable in base but is runtime-reachable in head. Diff-only inputs still exit 2 because this mode needs a materialized base tree. JSON and SARIF reuse the existing additive `gate` block with `mode: "newly-reachable"`, and MCP `security_candidates` accepts the same gate value. (Closes [#1056](https://github.com/fallow-rs/fallow/issues/1056).)
 - **`fallow security` can extend HTTP request receiver detection from config.** `security.requestReceivers` now adds project-local request object names to the built-in `req` / `request` / `ctx` / `context` / `event` allowlist for `*.query`, `*.params`, and `*.body` source reads. Values are trimmed, case-normalized, and additive only, while ORM receivers remain excluded and `*.searchParams` stays ungated. (Closes [#1125](https://github.com/fallow-rs/fallow/issues/1125).)
 
+### Fixed
+
+- **`fallow security` now preserves source-backed ranking inside each severity tier.** The final CLI ordering still groups candidates by high, medium, then low severity, but same-tier ties now keep the existing runtime, arg-level/source-backed, module-level source reachability, blast-radius, boundary, and dead-code ranking signals before falling back to path order. This keeps stronger candidates ahead of weaker same-severity candidates without changing schema shape or treating any candidate as a proven vulnerability. (Closes [#1133](https://github.com/fallow-rs/fallow/issues/1133).)
+
 ## [2.91.0] - 2026-06-09
 
 ### Added

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -10,6 +10,7 @@
 //! only honest signals.
 
 use crate::report::sink::outln;
+use std::cmp::Ordering;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -23,7 +24,9 @@ use fallow_core::results::{
 use fallow_types::discover::DiscoveredFile;
 use fallow_types::envelope::Meta;
 use fallow_types::extract::ModuleInfo;
-use fallow_types::results::{SecurityRuntimeContext, SecurityRuntimeState, SecuritySeverity};
+use fallow_types::results::{
+    SecurityRuntimeContext, SecurityRuntimeState, SecuritySeverity, TaintConfidence,
+};
 use rustc_hash::FxHashSet;
 use serde::Serialize;
 use xxhash_rust::xxh3::xxh3_64;
@@ -972,14 +975,67 @@ fn apply_security_severity(findings: &mut [SecurityFinding]) {
 }
 
 fn sort_by_security_severity(findings: &mut [SecurityFinding]) {
-    findings.sort_by(|left, right| {
-        security_severity_rank(left.severity)
-            .cmp(&security_severity_rank(right.severity))
-            .then_with(|| left.path.cmp(&right.path))
-            .then_with(|| left.line.cmp(&right.line))
-            .then_with(|| left.col.cmp(&right.col))
-            .then_with(|| left.category.cmp(&right.category))
-    });
+    findings.sort_by(compare_security_priority);
+}
+
+fn compare_security_priority(left: &SecurityFinding, right: &SecurityFinding) -> Ordering {
+    security_severity_rank(left.severity)
+        .cmp(&security_severity_rank(right.severity))
+        .then_with(|| runtime_rank(left).cmp(&runtime_rank(right)))
+        .then_with(|| {
+            right
+                .reachability
+                .as_ref()
+                .is_some_and(|reach| reach.reachable_from_entry)
+                .cmp(
+                    &left
+                        .reachability
+                        .as_ref()
+                        .is_some_and(|reach| reach.reachable_from_entry),
+                )
+        })
+        .then_with(|| taint_rank(left).cmp(&taint_rank(right)))
+        .then_with(|| security_blast_radius(right).cmp(&security_blast_radius(left)))
+        .then_with(|| security_crosses_boundary(right).cmp(&security_crosses_boundary(left)))
+        .then_with(|| left.dead_code.is_some().cmp(&right.dead_code.is_some()))
+        .then_with(|| left.path.cmp(&right.path))
+        .then_with(|| left.line.cmp(&right.line))
+        .then_with(|| left.col.cmp(&right.col))
+        .then_with(|| left.category.cmp(&right.category))
+}
+
+fn taint_rank(finding: &SecurityFinding) -> u8 {
+    match finding
+        .reachability
+        .as_ref()
+        .and_then(|reach| reach.taint_confidence)
+    {
+        Some(TaintConfidence::ArgLevel) => 0,
+        Some(TaintConfidence::ModuleLevel) => 1,
+        None if finding.source_backed => 0,
+        None if finding
+            .reachability
+            .as_ref()
+            .is_some_and(|reach| reach.reachable_from_untrusted_source) =>
+        {
+            1
+        }
+        None => 2,
+    }
+}
+
+fn security_blast_radius(finding: &SecurityFinding) -> u32 {
+    finding
+        .reachability
+        .as_ref()
+        .map_or(0, |reach| reach.blast_radius)
+}
+
+fn security_crosses_boundary(finding: &SecurityFinding) -> bool {
+    finding
+        .reachability
+        .as_ref()
+        .is_some_and(|reach| reach.crosses_boundary)
 }
 
 const fn security_severity_rank(severity: SecuritySeverity) -> u8 {
@@ -1987,9 +2043,28 @@ mod tests {
         let mut medium_a = sample_finding(root);
         medium_a.path = root.join("a.ts");
         medium_a.severity = SecuritySeverity::Medium;
+        medium_a.reachability = Some(fallow_types::results::SecurityReachability {
+            reachable_from_entry: false,
+            reachable_from_untrusted_source: true,
+            taint_confidence: Some(TaintConfidence::ModuleLevel),
+            untrusted_source_hop_count: Some(1),
+            untrusted_source_trace: vec![],
+            blast_radius: 10,
+            crosses_boundary: false,
+        });
         let mut medium_b = sample_finding(root);
         medium_b.path = root.join("b.ts");
         medium_b.severity = SecuritySeverity::Medium;
+        medium_b.source_backed = true;
+        medium_b.reachability = Some(fallow_types::results::SecurityReachability {
+            reachable_from_entry: false,
+            reachable_from_untrusted_source: true,
+            taint_confidence: Some(TaintConfidence::ArgLevel),
+            untrusted_source_hop_count: Some(0),
+            untrusted_source_trace: vec![],
+            blast_radius: 1,
+            crosses_boundary: false,
+        });
         let mut findings = vec![low, medium_b, high, medium_a];
 
         sort_by_security_severity(&mut findings);
@@ -2001,8 +2076,8 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 (SecuritySeverity::High, std::ffi::OsStr::new("z.ts")),
-                (SecuritySeverity::Medium, std::ffi::OsStr::new("a.ts")),
                 (SecuritySeverity::Medium, std::ffi::OsStr::new("b.ts")),
+                (SecuritySeverity::Medium, std::ffi::OsStr::new("a.ts")),
                 (SecuritySeverity::Low, std::ffi::OsStr::new("a.ts")),
             ]
         );


### PR DESCRIPTION
## Summary
- Preserve `fallow security` severity grouping while keeping security-specific same-tier ranking signals.
- Same-tier sorting now considers runtime context, entry reachability, arg-level/source-backed evidence, module-level source reachability, blast radius, boundary crossings, and active-code status before location.
- No schema changes, no docs beyond the changelog entry.

## Issue
Closes #1133

## Plan
- Local plan: `.plans/issue-1133-security-ranking.md`

## Verification
- [x] `cargo test -p fallow-cli security::tests::severity_sort_orders_tiers_then_location`
- [x] `cargo check --workspace`
- [x] `cargo test -p fallow-cli`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `fallow audit --format json --quiet`
- [x] Real fixture smoke: `fallow security --format json --quiet --root tests/fixtures/security-taint-confidence-1093 --no-cache`
