### PR TITLE
fix(security): propagate constant sink literals

### DIFF
--- a/crates/core/tests/integration_test/security_catalogue_categories.rs
+++ b/crates/core/tests/integration_test/security_catalogue_categories.rs
@@ -434,6 +434,10 @@ fn sql_injection_literal_does_not_fire() {
         !anchored_on(&results, "src/safe.ts"),
         "a literal SQL string must not be flagged"
     );
+    assert!(
+        !anchored_on(&results, "src/constant-safe.ts"),
+        "a constant-only raw SQL fragment must not be flagged"
+    );
 }
 
 #[test]

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -302,7 +302,11 @@ use crate::MemberKind;
 /// diagnostics for security sink-shaped callees that could not be flattened, so
 /// warm-cache `fallow security` runs can report the same blind-spot metadata as
 /// cold extraction.
-pub(super) const CACHE_VERSION: u32 = 142;
+///
+/// Bumped to 143 for issue #1138: JS/TS extraction now propagates simple
+/// module-scope literal constants into security sink argument metadata and
+/// filters public CI metadata env vars before source matching.
+pub(super) const CACHE_VERSION: u32 = 143;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -16,7 +16,8 @@ use crate::{
 };
 use fallow_types::extract::{
     ClassHeritageInfo, LocalTypeDeclaration, PublicSignatureTypeReference, SanitizedSinkArg,
-    SanitizerScope, SecurityControlSite, SinkSite, SkippedSecurityCalleeSite, TaintedBinding,
+    SanitizerScope, SecurityControlSite, SinkLiteralValue, SinkSite, SkippedSecurityCalleeSite,
+    TaintedBinding,
 };
 use helpers::LitCustomElementDecorator;
 
@@ -207,6 +208,9 @@ pub(crate) struct ModuleInfoExtractor {
     /// Module-scope literal-backed string allowlists. `false` means the name
     /// shadows an outer allowlist but is not trusted itself.
     pub(crate) module_literal_allowlist_bindings: FxHashMap<String, bool>,
+    /// Module-scope literal constants that can be propagated into security sink
+    /// argument classification.
+    pub(crate) module_static_sink_literals: FxHashMap<String, SinkLiteralValue>,
     /// Nested lexical literal allowlist bindings.
     pub(crate) literal_allowlist_binding_stack: Vec<FxHashMap<String, bool>>,
     /// Module-scope locals initialized from risky literal regex patterns.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -249,6 +249,32 @@ fn public_env_is_not_a_secret_source() {
 }
 
 #[test]
+fn public_ci_metadata_env_is_not_a_secret_source() {
+    let info = parse(
+        r"
+            const tagRef = process.env.TAG_REF;
+            const buildSha = import.meta.env.GITHUB_SHA;
+            console.error(tagRef);
+            console.warn(buildSha);
+        ",
+    );
+
+    assert!(
+        info.tainted_bindings
+            .iter()
+            .all(|binding| binding.source_path != "process.env"
+                && binding.source_path != "import.meta.env"),
+        "public CI metadata env reads must not create secret-source bindings"
+    );
+    assert!(
+        info.security_sinks
+            .iter()
+            .all(|sink| sink.arg_source_paths.is_empty()),
+        "public CI metadata env sink args must not record env source paths"
+    );
+}
+
+#[test]
 fn import_meta_env_secret_binds_as_a_source() {
     // Issue #890: a non-public `import.meta.env.X` (Vite) read is a secret source
     // like `process.env`, via the new flatten_member_path MetaProperty arm.
@@ -685,6 +711,70 @@ fn security_chmod_capture_records_integer_literal_argument() {
     assert!(!sink.arg_is_non_literal);
     assert_eq!(sink.arg_kind, SinkArgKind::Literal);
     assert_eq!(sink.arg_literal, Some(SinkLiteralValue::Integer(511)));
+}
+
+#[test]
+fn security_sink_constant_string_coercion_is_classified_as_literal() {
+    let info = parse(
+        r"
+            const MISSING_LINE_NUMBER_SENTINEL = -1;
+            sql.raw(String(MISSING_LINE_NUMBER_SENTINEL));
+        ",
+    );
+
+    assert!(
+        !info
+            .security_sinks
+            .iter()
+            .any(|sink| sink.callee_path == "sql.raw"),
+        "a numeric constant coerced through String() must not be captured as a non-literal raw SQL sink"
+    );
+}
+
+#[test]
+fn security_sink_constant_template_is_classified_as_literal() {
+    let info = parse(
+        r#"
+            const SCHEME = "http";
+            const HOST = "api.example.com";
+            const URL = `${SCHEME}://${HOST}/status`;
+            fetch(URL);
+        "#,
+    );
+    let sink = info
+        .security_sinks
+        .iter()
+        .find(|sink| sink.callee_path == "fetch" && sink.arg_index == 0)
+        .expect("cleartext fetch sink captured");
+
+    assert!(!sink.arg_is_non_literal);
+    assert_eq!(sink.arg_kind, SinkArgKind::Literal);
+    assert_eq!(
+        sink.arg_literal,
+        Some(SinkLiteralValue::String(
+            "http://api.example.com/status".to_string()
+        ))
+    );
+}
+
+#[test]
+fn security_sink_shadowed_constant_stays_dynamic() {
+    let info = parse(
+        r"
+            const MISSING_LINE_NUMBER_SENTINEL = -1;
+            function run(MISSING_LINE_NUMBER_SENTINEL: number): void {
+                sql.raw(String(MISSING_LINE_NUMBER_SENTINEL));
+            }
+        ",
+    );
+    let sink = info
+        .security_sinks
+        .iter()
+        .find(|sink| sink.callee_path == "sql.raw")
+        .expect("shadowed constant sink stays captured");
+
+    assert!(sink.arg_is_non_literal);
+    assert_eq!(sink.arg_kind, SinkArgKind::Call);
 }
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -92,6 +92,87 @@ impl ModuleInfoExtractor {
             .unwrap_or(false)
     }
 
+    fn record_static_sink_literal_binding(
+        &mut self,
+        decl: &VariableDeclaration<'_>,
+        declarator: &VariableDeclarator<'_>,
+        init: &Expression<'_>,
+    ) {
+        if !self.is_module_scope() {
+            return;
+        }
+        let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+            return;
+        };
+        if decl.kind != VariableDeclarationKind::Const {
+            self.module_static_sink_literals.remove(id.name.as_str());
+            return;
+        }
+        if let Some(value) = self.static_sink_literal_value(init) {
+            self.module_static_sink_literals
+                .insert(id.name.to_string(), value);
+        } else {
+            self.module_static_sink_literals.remove(id.name.as_str());
+        }
+    }
+
+    fn static_sink_literal_value(&self, expr: &Expression<'_>) -> Option<SinkLiteralValue> {
+        if let Some(value) = sink_literal_value(expr) {
+            return Some(value);
+        }
+        match unwrap_static_expr(expr) {
+            Expression::Identifier(ident) if !self.nested_scope_shadows(ident.name.as_str()) => {
+                self.module_static_sink_literals
+                    .get(ident.name.as_str())
+                    .cloned()
+            }
+            Expression::UnaryExpression(unary)
+                if unary.operator == UnaryOperator::UnaryNegation
+                    || unary.operator == UnaryOperator::UnaryPlus =>
+            {
+                let SinkLiteralValue::Integer(value) =
+                    self.static_sink_literal_value(&unary.argument)?
+                else {
+                    return None;
+                };
+                if unary.operator == UnaryOperator::UnaryNegation {
+                    value.checked_neg().map(SinkLiteralValue::Integer)
+                } else {
+                    Some(SinkLiteralValue::Integer(value))
+                }
+            }
+            Expression::CallExpression(call) => {
+                let Expression::Identifier(callee) = &call.callee else {
+                    return None;
+                };
+                if callee.name != "String"
+                    || call.arguments.len() != 1
+                    || self.nested_scope_shadows(callee.name.as_str())
+                    || self.local_declaration_names.contains(callee.name.as_str())
+                {
+                    return None;
+                }
+                let arg = call.arguments.first()?.as_expression()?;
+                Some(SinkLiteralValue::String(static_sink_literal_to_string(
+                    &self.static_sink_literal_value(arg)?,
+                )))
+            }
+            Expression::TemplateLiteral(template) => {
+                let mut value = String::new();
+                for (index, quasi) in template.quasis.iter().enumerate() {
+                    value.push_str(quasi.value.cooked.as_ref()?);
+                    if let Some(expression) = template.expressions.get(index) {
+                        value.push_str(&static_sink_literal_to_string(
+                            &self.static_sink_literal_value(expression)?,
+                        ));
+                    }
+                }
+                Some(SinkLiteralValue::String(value))
+            }
+            _ => None,
+        }
+    }
+
     fn record_risky_regex_binding(&mut self, name: &str, pattern: Option<String>) {
         if self.is_module_scope() {
             self.module_risky_regex_bindings
@@ -1929,6 +2010,7 @@ impl ModuleInfoExtractor {
                 self.record_static_package_values(id.name.as_str(), init);
             }
 
+            self.record_static_sink_literal_binding(decl, declarator, init);
             let sources = self.node_module_register_sources_from_expression(init);
             if !sources.is_empty() {
                 self.record_node_module_register_url_binding(id.name.to_string(), sources);
@@ -3986,6 +4068,15 @@ fn sink_literal_value(expr: &Expression<'_>) -> Option<SinkLiteralValue> {
     }
 }
 
+fn static_sink_literal_to_string(value: &SinkLiteralValue) -> String {
+    match value {
+        SinkLiteralValue::String(value) => value.clone(),
+        SinkLiteralValue::Integer(value) => value.to_string(),
+        SinkLiteralValue::Boolean(value) => value.to_string(),
+        SinkLiteralValue::Null => "null".to_string(),
+    }
+}
+
 fn static_string_literal_value(expr: &Expression<'_>) -> Option<String> {
     match unwrap_static_expr(expr) {
         Expression::StringLiteral(lit) => Some(lit.value.to_string()),
@@ -4351,15 +4442,12 @@ fn object_key_metadata(expr: &Expression<'_>) -> ObjectKeyMetadata {
     ObjectKeyMetadata { keys, complete }
 }
 
-fn should_capture_literal_sink_arg(
+fn should_capture_literal_sink_value(
     callee_path: &str,
     sink_shape: SinkShape,
     arg_index: u32,
-    expr: &Expression<'_>,
+    literal: &SinkLiteralValue,
 ) -> bool {
-    let Some(literal) = sink_literal_value(expr) else {
-        return false;
-    };
     match sink_shape {
         SinkShape::Call | SinkShape::MemberCall => match literal {
             SinkLiteralValue::String(value) => {
@@ -4369,10 +4457,10 @@ fn should_capture_literal_sink_arg(
                     || (arg_index == 0 && is_temp_file_literal_callee(callee_path))
                     || (arg_index == 0
                         && is_cleartext_transport_literal_callee(callee_path)
-                        && is_cleartext_transport_literal(&value))
+                        && is_cleartext_transport_literal(value))
                     || (arg_index == 0
                         && is_literal_metadata_url_callee(callee_path)
-                        && is_metadata_service_literal(&value))
+                        && is_metadata_service_literal(value))
             }
             SinkLiteralValue::Integer(_) => arg_index == 1 && is_chmod_literal_callee(callee_path),
             SinkLiteralValue::Boolean(_) | SinkLiteralValue::Null => false,
@@ -4381,7 +4469,7 @@ fn should_capture_literal_sink_arg(
             SinkLiteralValue::String(value) => {
                 arg_index == 0
                     && (callee_path == "Function"
-                        || (callee_path == "WebSocket" && is_cleartext_websocket_literal(&value)))
+                        || (callee_path == "WebSocket" && is_cleartext_websocket_literal(value)))
             }
             SinkLiteralValue::Integer(_)
             | SinkLiteralValue::Boolean(_)
@@ -5494,7 +5582,8 @@ impl ModuleInfoExtractor {
             let Ok(arg_index) = u32::try_from(index) else {
                 continue;
             };
-            let arg_is_non_literal = is_non_literal_arg(arg_expr);
+            let arg_literal = self.static_sink_literal_value(arg_expr);
+            let arg_is_non_literal = arg_literal.is_none() && is_non_literal_arg(arg_expr);
             if arg_is_non_literal
                 && should_skip_clamped_resource_amplification_arg(
                     &callee_path,
@@ -5506,7 +5595,9 @@ impl ModuleInfoExtractor {
                 continue;
             }
             if !arg_is_non_literal
-                && !should_capture_literal_sink_arg(&callee_path, sink_shape, arg_index, arg_expr)
+                && !arg_literal.as_ref().is_some_and(|literal| {
+                    should_capture_literal_sink_value(&callee_path, sink_shape, arg_index, literal)
+                })
             {
                 continue;
             }
@@ -5524,7 +5615,7 @@ impl ModuleInfoExtractor {
                 } else {
                     SinkArgKind::Literal
                 },
-                arg_literal: sink_literal_value(arg_expr),
+                arg_literal,
                 object_properties: object_literal_properties(arg_expr),
                 object_property_keys: object_keys.keys,
                 object_property_keys_complete: object_keys.complete,
@@ -5580,7 +5671,8 @@ impl ModuleInfoExtractor {
             let Ok(arg_index) = u32::try_from(index) else {
                 continue;
             };
-            let arg_is_non_literal = is_non_literal_arg(arg_expr);
+            let arg_literal = self.static_sink_literal_value(arg_expr);
+            let arg_is_non_literal = arg_literal.is_none() && is_non_literal_arg(arg_expr);
             if arg_is_non_literal
                 && should_skip_clamped_resource_amplification_arg(
                     &callee_path,
@@ -5592,12 +5684,14 @@ impl ModuleInfoExtractor {
                 continue;
             }
             if !arg_is_non_literal
-                && !should_capture_literal_sink_arg(
-                    &callee_path,
-                    SinkShape::NewExpression,
-                    arg_index,
-                    arg_expr,
-                )
+                && !arg_literal.as_ref().is_some_and(|literal| {
+                    should_capture_literal_sink_value(
+                        &callee_path,
+                        SinkShape::NewExpression,
+                        arg_index,
+                        literal,
+                    )
+                })
             {
                 continue;
             }
@@ -5612,7 +5706,7 @@ impl ModuleInfoExtractor {
                 } else {
                     SinkArgKind::Literal
                 },
-                arg_literal: sink_literal_value(arg_expr),
+                arg_literal,
                 object_properties: object_literal_properties(arg_expr),
                 object_property_keys: object_keys.keys,
                 object_property_keys_complete: object_keys.complete,
@@ -5711,14 +5805,12 @@ impl ModuleInfoExtractor {
             return;
         };
         let callee_path = format!("{}.{}", object_path, member.property.name);
-        let arg_is_non_literal = is_non_literal_arg(&expr.right);
+        let arg_literal = self.static_sink_literal_value(&expr.right);
+        let arg_is_non_literal = arg_literal.is_none() && is_non_literal_arg(&expr.right);
         if !arg_is_non_literal
-            && !should_capture_literal_sink_arg(
-                &callee_path,
-                SinkShape::MemberAssign,
-                0,
-                &expr.right,
-            )
+            && !arg_literal.as_ref().is_some_and(|literal| {
+                should_capture_literal_sink_value(&callee_path, SinkShape::MemberAssign, 0, literal)
+            })
         {
             return;
         }
@@ -5736,7 +5828,7 @@ impl ModuleInfoExtractor {
             } else {
                 SinkArgKind::Literal
             },
-            arg_literal: sink_literal_value(&expr.right),
+            arg_literal,
             object_properties: object_literal_properties(&expr.right),
             object_property_keys: object_keys.keys,
             object_property_keys_complete: object_keys.complete,

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -502,11 +502,40 @@ pub const PUBLIC_ENV_PREFIXES: &[&str] = &[
 /// Exact env var names that are public by convention (no prefix).
 pub const PUBLIC_ENV_EXACT: &[&str] = &["NODE_ENV"];
 
+/// Env var-name tokens that usually describe public build or deployment
+/// metadata rather than secrets. Secret-shaped names win over these tokens.
+pub const PUBLIC_ENV_METADATA_TOKENS: &[&str] =
+    &["BRANCH", "ENVIRONMENT", "MODE", "REF", "SHA", "TAG"];
+
+/// Env var-name tokens that should keep a variable source-backed even when the
+/// name also contains public metadata tokens such as `REF` or `SHA`.
+pub const SECRET_ENV_TOKENS: &[&str] = &[
+    "AUTH",
+    "CREDENTIAL",
+    "CREDENTIALS",
+    "KEY",
+    "PASS",
+    "PASSWORD",
+    "PRIVATE",
+    "SECRET",
+    "TOKEN",
+];
+
+fn env_name_has_token(name: &str, tokens: &[&str]) -> bool {
+    name.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .any(|part| tokens.contains(&part))
+}
+
 /// Whether an env var name is public-by-convention (build-inlined into the
 /// client bundle), and therefore not a secret.
 #[must_use]
 pub fn is_public_env_var(name: &str) -> bool {
-    PUBLIC_ENV_EXACT.contains(&name) || PUBLIC_ENV_PREFIXES.iter().any(|p| name.starts_with(p))
+    if PUBLIC_ENV_EXACT.contains(&name) || PUBLIC_ENV_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return true;
+    }
+    env_name_has_token(name, PUBLIC_ENV_METADATA_TOKENS)
+        && !env_name_has_token(name, SECRET_ENV_TOKENS)
 }
 
 /// Whether a flattened member path is a PUBLIC env-secret read
@@ -1065,6 +1094,23 @@ mod tests {
             assert!($values.is_empty());
             assert_eq!($values.capacity(), 0);
         }};
+    }
+
+    #[test]
+    fn public_env_var_includes_public_ci_metadata() {
+        for name in ["TAG_REF", "GITHUB_SHA", "CI_COMMIT_BRANCH", "APP_MODE"] {
+            assert!(is_public_env_var(name), "{name} should be public metadata");
+        }
+    }
+
+    #[test]
+    fn public_env_var_keeps_secret_shaped_names_source_backed() {
+        for name in ["GITHUB_TOKEN", "REFRESH_TOKEN", "API_KEY", "SECRET_SHA"] {
+            assert!(
+                !is_public_env_var(name),
+                "{name} should remain secret-shaped"
+            );
+        }
     }
 
     #[test]

--- a/tests/fixtures/security-secret-pii-log/src/safe.ts
+++ b/tests/fixtures/security-secret-pii-log/src/safe.ts
@@ -17,3 +17,8 @@ export function logsPublicEnv(): void {
   console.log(process.env.NEXT_PUBLIC_API_URL);
   console.info(import.meta.env.VITE_BUILD_ID);
 }
+
+export function logsPublicCiMetadata(): void {
+  const tagRef = process.env.TAG_REF;
+  console.error(`unexpected TAG_REF: ${tagRef}`);
+}

--- a/tests/fixtures/security-sql-injection/src/constant-safe.ts
+++ b/tests/fixtures/security-sql-injection/src/constant-safe.ts
@@ -1,0 +1,9 @@
+// Negative (constant): a numeric sentinel coerced through String() is static,
+// so sql.raw(...) must not be treated as attacker-controlled input.
+import { sql } from "drizzle-orm";
+
+const MISSING_LINE_NUMBER_SENTINEL = -1;
+
+export function missingLineSentinel(): unknown {
+  return sql.raw(String(MISSING_LINE_NUMBER_SENTINEL));
+}


### PR DESCRIPTION
## Summary
- Propagates simple module-scope constant sink literals before security catalogue matching.
- Treats public CI metadata env names as non-secret sources unless the name is secret-shaped.

## Issue
Closes #1138

## Verification
- [x] Focused extractor and security catalogue tests
- [x] Fixture-level `fallow security --format json --quiet` smoke
- [x] Real-project before/after validation for the reported SQL sentinel shape
- [x] `cargo check --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- [x] `typos .`
- [x] `fallow audit --format json --quiet`
