### PR TITLE
test(audit): characterize base-reuse predicate

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -3979,4 +3979,136 @@ export function App() {
                 .any(|instance| instance.file == changed_path)
         }));
     }
+
+    // ── Unit tests for js_ts_tokens_equivalent, is_analysis_input, is_non_behavioral_doc ──
+
+    #[test]
+    fn tokens_equivalent_whitespace_only() {
+        // Reformatting (indentation, blank lines) must not change token identity.
+        let a = "export const x = 1;\nexport const y = 2;\n";
+        let b = "export const x = 1;\n\n\nexport const y = 2;\n";
+        assert!(
+            js_ts_tokens_equivalent(Path::new("a.ts"), a, b),
+            "whitespace-only change must be treated as equivalent"
+        );
+    }
+
+    #[test]
+    fn tokens_equivalent_comment_only_change() {
+        // Comments do not produce tokens; adding or removing a comment should be
+        // treated as equivalent by the tokenizer.
+        let a = "export const x = 1;\n";
+        let b = "// note\nexport const x = 1;\n";
+        assert!(
+            js_ts_tokens_equivalent(Path::new("a.ts"), a, b),
+            "comment-only change must be treated as equivalent (comments emit no tokens)"
+        );
+    }
+
+    #[test]
+    fn tokens_equivalent_identifier_rename_is_not_equivalent() {
+        // Identifier carries its text payload; a rename must not be reusable.
+        let a = "export const a = 1;\n";
+        let b = "export const b = 1;\n";
+        assert!(
+            !js_ts_tokens_equivalent(Path::new("a.ts"), a, b),
+            "identifier rename must be treated as non-equivalent"
+        );
+    }
+
+    #[test]
+    fn tokens_equivalent_string_literal_change_is_not_equivalent() {
+        // StringLiteral carries its text payload; a changed import path must not be reusable.
+        let a = r#"import x from "./a";"#;
+        let b = r#"import x from "./b";"#;
+        assert!(
+            !js_ts_tokens_equivalent(Path::new("a.ts"), a, b),
+            "string-literal change must be treated as non-equivalent"
+        );
+    }
+
+    #[test]
+    fn tokens_equivalent_fallow_ignore_marker_forces_false() {
+        // The guard fires before tokenization; even identical content containing the
+        // marker must return false so suppression changes are never skipped.
+        let code = "// fallow-ignore-next-line unused-exports\nexport const x = 1;\n";
+        assert!(
+            !js_ts_tokens_equivalent(Path::new("a.ts"), code, code),
+            "fallow-ignore marker in either side must force false"
+        );
+    }
+
+    #[test]
+    fn tokens_equivalent_non_js_extension_is_false() {
+        // The extension check fires before tokenization; CSS content cannot be reused.
+        let a = ".foo { color: red; }\n";
+        let b = ".foo {\n  color: red;\n}\n";
+        assert!(
+            !js_ts_tokens_equivalent(Path::new("styles.css"), a, b),
+            "non-JS/TS extension must always return false"
+        );
+    }
+
+    /// KNOWN SOUNDNESS GAP: `TokenKind::TemplateLiteral` carries no payload
+    /// (see `crates/core/src/duplicates/token_types.rs`), so a change to the
+    /// content of a template literal is invisible to the tokenizer and is
+    /// treated as equivalent. This is safe for most template strings but
+    /// unsound for dynamic `import(\`...\`)` patterns where the quasi prefix
+    /// feeds module-resolution pattern edges. This test pins the current
+    /// behavior. A follow-up fix should give `TemplateLiteral` a payload to
+    /// close the gap.
+    #[test]
+    fn tokens_equivalent_template_literal_content_change_is_equivalent_known_gap() {
+        let a = "const p = import(`./pages/${x}`);\n";
+        let b = "const p = import(`./views/${x}`);\n";
+        // KNOWN GAP: changing the quasi string of a template literal is NOT
+        // detected as a behavioral change because TokenKind::TemplateLiteral
+        // has no payload. Expected: true (equivalent), which is incorrect for
+        // dynamic-import prefixes but documents the current reality.
+        assert!(
+            js_ts_tokens_equivalent(Path::new("a.ts"), a, b),
+            "template-literal content change is CURRENTLY treated as equivalent (known gap)"
+        );
+    }
+
+    /// Companion to the template-literal gap test: a regex-literal content
+    /// change is also invisible to the tokenizer.
+    #[test]
+    fn tokens_equivalent_regex_literal_content_change_is_equivalent_known_gap() {
+        let a = "const re = /^foo/;\n";
+        let b = "const re = /^bar/;\n";
+        // KNOWN GAP: TokenKind::RegExpLiteral has no payload.
+        assert!(
+            js_ts_tokens_equivalent(Path::new("a.ts"), a, b),
+            "regex-literal content change is CURRENTLY treated as equivalent (known gap)"
+        );
+    }
+
+    #[test]
+    fn analysis_input_and_doc_classification() {
+        // Analysis inputs: JS/TS variants and component formats are behavioral.
+        assert!(is_analysis_input(Path::new("src/app.ts")));
+        assert!(is_analysis_input(Path::new("src/app.tsx")));
+        assert!(is_analysis_input(Path::new("src/app.js")));
+        assert!(is_analysis_input(Path::new("src/app.jsx")));
+        assert!(is_analysis_input(Path::new("src/app.mts")));
+        assert!(is_analysis_input(Path::new("src/app.vue")));
+        assert!(is_analysis_input(Path::new("src/styles.css")));
+
+        // Non-analysis inputs.
+        assert!(!is_analysis_input(Path::new("README.md")));
+        assert!(!is_analysis_input(Path::new("package.json")));
+        assert!(!is_analysis_input(Path::new("image.png")));
+
+        // Non-behavioral docs.
+        assert!(is_non_behavioral_doc(Path::new("README.md")));
+        assert!(is_non_behavioral_doc(Path::new("CHANGELOG.txt")));
+        assert!(is_non_behavioral_doc(Path::new("docs/guide.rst")));
+        assert!(is_non_behavioral_doc(Path::new("docs/guide.adoc")));
+
+        // .json is neither an analysis input nor a non-behavioral doc, so the
+        // predicate treats it as behavioral (can_reuse returns false for it).
+        assert!(!is_analysis_input(Path::new("package.json")));
+        assert!(!is_non_behavioral_doc(Path::new("package.json")));
+    }
 }

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -1376,3 +1376,286 @@ fn audit_rejects_malformed_fallow_audit_base_env() {
         json["message"]
     );
 }
+
+// Base-reuse predicate characterization tests
+//
+// These tests pin the behavior of `can_reuse_current_as_base` end-to-end
+// through the `fallow audit --gate new-only` path. Each test establishes a
+// committed base and a committed head, then asserts on the JSON attribution
+// fields `dead_code_introduced` and `dead_code_inherited` to confirm whether
+// the reuse predicate correctly skipped the base-snapshot rebuild.
+//
+// They serve as the safety net for refactors of the underlying helpers
+// (for example, batching the per-file `git show` calls).
+
+/// A whitespace-only reformat of a TS file must be treated as equivalent by
+/// the tokenizer and allow the base snapshot to be reused. The audit should
+/// report zero introduced dead-code findings.
+#[test]
+fn audit_whitespace_only_change_reports_no_introduced_findings() {
+    let dir = create_audit_fixture("reuse-whitespace");
+    let root = dir.path();
+    let base_sha = {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("git rev-parse should succeed");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+
+    // Reformat src/utils.ts with whitespace only (no semantic change).
+    fs::write(
+        root.join("src/utils.ts"),
+        "export const used = () => 42;\n\n\nexport const unused = () => 0;\n",
+    )
+    .unwrap();
+    commit_all(root, "reformat utils");
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root.to_str().unwrap(),
+        "--base",
+        &base_sha,
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+
+    assert!(
+        output.code == 0 || output.code == 1,
+        "audit should not crash on whitespace-only change. stderr: {}",
+        output.stderr
+    );
+    let json = parse_json(&output);
+    assert_eq!(
+        json["attribution"]["dead_code_introduced"].as_u64(),
+        Some(0),
+        "whitespace-only change must introduce zero dead-code findings. full json: {}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
+    );
+    // The pre-existing `unused` export should be inherited, not introduced.
+    assert!(
+        json["attribution"]["dead_code_inherited"]
+            .as_u64()
+            .is_some_and(|n| n >= 1),
+        "pre-existing unused export must appear as inherited"
+    );
+}
+
+/// Adding a genuinely new unused export must be classified as introduced.
+#[test]
+fn audit_semantic_change_reports_introduced_finding() {
+    let dir = create_audit_fixture("reuse-semantic");
+    let root = dir.path();
+    let base_sha = {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("git rev-parse should succeed");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+
+    // Add a new unused export.
+    fs::write(
+        root.join("src/utils.ts"),
+        "export const used = () => 42;\nexport const unused = () => 0;\nexport const extra = 1;\n",
+    )
+    .unwrap();
+    commit_all(root, "add extra unused export");
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root.to_str().unwrap(),
+        "--base",
+        &base_sha,
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+
+    assert!(
+        output.code == 0 || output.code == 1,
+        "audit should not crash. stderr: {}",
+        output.stderr
+    );
+    let json = parse_json(&output);
+    assert!(
+        json["attribution"]["dead_code_introduced"]
+            .as_u64()
+            .is_some_and(|n| n >= 1),
+        "new unused export must be attributed as introduced. full json: {}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
+    );
+}
+
+/// Changing only a Markdown README must not introduce dead-code findings.
+/// `is_non_behavioral_doc` classifies `.md` as non-behavioral, so the reuse
+/// predicate returns true for a doc-only diff.
+#[test]
+fn audit_doc_only_change_reports_no_introduced_findings() {
+    let dir = create_audit_fixture("reuse-doc");
+    let root = dir.path();
+    let base_sha = {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("git rev-parse should succeed");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+
+    fs::write(root.join("README.md"), "# My project\nUpdated docs.\n").unwrap();
+    commit_all(root, "update readme");
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root.to_str().unwrap(),
+        "--base",
+        &base_sha,
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+
+    assert!(
+        output.code == 0 || output.code == 1,
+        "audit should not crash on doc-only change. stderr: {}",
+        output.stderr
+    );
+    let json = parse_json(&output);
+    assert_eq!(
+        json["attribution"]["dead_code_introduced"].as_u64(),
+        Some(0),
+        "doc-only change must introduce zero dead-code findings. full json: {}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
+    );
+}
+
+/// Adding a brand-new TS file with an unused export forces a real base-snapshot
+/// computation (the file does not exist in base, so `git_show_file` returns
+/// None and the reuse predicate returns false). The new export should be
+/// attributed as introduced.
+#[test]
+fn audit_new_file_is_treated_as_behavioral() {
+    let dir = create_audit_fixture("reuse-newfile");
+    let root = dir.path();
+    let base_sha = {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("git rev-parse should succeed");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+
+    // Add a new file with an unused export; it has no counterpart in base.
+    fs::write(
+        root.join("src/new.ts"),
+        "export const brandNew = 'nobody uses me';\n",
+    )
+    .unwrap();
+    commit_all(root, "add new file with unused export");
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root.to_str().unwrap(),
+        "--base",
+        &base_sha,
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+
+    assert!(
+        output.code == 0 || output.code == 1,
+        "audit should complete successfully even when a new file forces a base-snapshot rebuild. stderr: {}",
+        output.stderr
+    );
+    let json = parse_json(&output);
+    assert!(
+        json["attribution"]["dead_code_introduced"]
+            .as_u64()
+            .is_some_and(|n| n >= 1),
+        "new unused export in a new file must be attributed as introduced. full json: {}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
+    );
+}
+
+/// Changing only `package.json` is neither an analysis-input file nor a
+/// non-behavioral doc (`.json` passes neither check), so the reuse predicate
+/// treats it as behavioral. The audit must complete and produce a coherent
+/// verdict; this test checks exit success rather than a specific attribution
+/// count because the JSON change may or may not affect dead-code counts.
+#[test]
+fn audit_json_only_change_is_behavioral() {
+    let dir = create_audit_fixture("reuse-json");
+    let root = dir.path();
+    let base_sha = {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .output()
+            .expect("git rev-parse should succeed");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+
+    // Remove the unused dependency from package.json: a plausible behavioral change.
+    fs::write(
+        root.join("package.json"),
+        r#"{"name": "audit-test", "main": "src/index.ts", "dependencies": {}}"#,
+    )
+    .unwrap();
+    commit_all(root, "remove unused dep from package.json");
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root.to_str().unwrap(),
+        "--base",
+        &base_sha,
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+
+    // The audit must complete and produce a parseable verdict; it may pass or
+    // fail depending on analysis results, but must not crash (exit 2+).
+    assert!(
+        output.code == 0 || output.code == 1,
+        "audit on a package.json-only change must complete without crashing. stderr: {}\nstdout: {}",
+        output.stderr,
+        output.stdout
+    );
+    let json = parse_json(&output);
+    assert!(
+        json.get("verdict").is_some(),
+        "audit must produce a verdict field in JSON output. full json: {}",
+        serde_json::to_string_pretty(&json).unwrap_or_default()
+    );
+    // The attribution block must be present.
+    assert!(
+        json.get("attribution").is_some(),
+        "audit must produce an attribution block even when package.json is the only change"
+    );
+}


### PR DESCRIPTION
Pin the behavior of the audit base-reuse predicate (can_reuse_current_as_base and js_ts_tokens_equivalent) before any refactor of its internals. The predicate decides whether fallow audit can skip the base snapshot analysis when every changed file is non-behavioral, so a wrong answer silently produces a wrong CI verdict.

Unit tests cover token equivalence across whitespace-only, comment-only, identifier-rename, string-literal, suppression-marker, and non-JS cases, plus the file classification helpers. Two tests pin a known soundness gap: TemplateLiteral and RegExpLiteral tokens carry no payload, so content changes inside template literals or regex literals are treated as equivalent today; the tests label the gap explicitly so a future fix flips them deliberately.

Integration tests assert end-to-end audit attribution across the reuse decision: whitespace-only and doc-only changes introduce zero findings, semantic changes and new files are attributed as introduced, and a package.json-only change is treated as behavioral.