### PR TITLE
fix(cli): clear test-only-dependency findings under single-type filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Issue-type filter flags no longer leak `test-only-dependency` findings.** `IssueFilters::apply()` clears every category that was not selected by a single-type filter flag, but the `--unused-deps` clear arm was missing `test_only_dependencies`, so a focused run like `fallow dead-code --unused-files` on a project with a production dependency imported only from test files reported that test-only finding alongside the requested issue type. `--unused-deps` now groups `test-only-dependency` with the other dependency kinds (matching how `type-only-dependency` is handled and how the `--file` scope already cleared all five categories), and the `fallow schema` capability manifest reports `--unused-deps` as the filter flag for the `test-only-dependency` row. (Closes [#1192](https://github.com/fallow-rs/fallow/issues/1192).)
+
 - **The GitLab CI template now runs Bash-only setup blocks through Bash explicitly.** GitLab Runner jobs on Alpine can start `before_script` entries with `/bin/sh`, but the fallow template validated versions, prepared MR scripts, and wrote the analysis runner with Bash-specific syntax. Those blocks now invoke `bash -eo pipefail` explicitly after the dependency-install block installs Bash, so the template no longer depends on the runner's default shell. Thanks [@KudrinOleg](https://github.com/KudrinOleg) for the report. (Closes [#1182](https://github.com/fallow-rs/fallow/issues/1182).)
 
 ## [2.92.1] - 2026-06-10

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -99,6 +99,7 @@ impl IssueFilters {
             results.unused_dev_dependencies.clear();
             results.unused_optional_dependencies.clear();
             results.type_only_dependencies.clear();
+            results.test_only_dependencies.clear();
         }
         if !self.unused_enum_members {
             results.unused_enum_members.clear();
@@ -769,6 +770,14 @@ mod tests {
                 line: 5,
                 used_in_workspaces: Vec::new(),
             }));
+        r.test_only_dependencies
+            .push(TestOnlyDependencyFinding::with_actions(
+                TestOnlyDependency {
+                    package_name: "msw".into(),
+                    path: PathBuf::from("/project/package.json"),
+                    line: 9,
+                },
+            ));
         r.unused_enum_members
             .push(UnusedEnumMemberFinding::with_actions(UnusedMember {
                 path: PathBuf::from("/project/src/d.ts"),
@@ -901,6 +910,7 @@ mod tests {
         assert!(results.unused_types.is_empty());
         assert!(results.unused_dependencies.is_empty());
         assert!(results.unused_dev_dependencies.is_empty());
+        assert!(results.test_only_dependencies.is_empty());
         assert!(results.unused_enum_members.is_empty());
         assert!(results.unused_class_members.is_empty());
         assert!(results.unresolved_imports.is_empty());
@@ -917,8 +927,28 @@ mod tests {
 
         assert_eq!(results.unused_dependencies.len(), 1);
         assert_eq!(results.unused_dev_dependencies.len(), 1);
+        assert_eq!(results.test_only_dependencies.len(), 1);
         assert!(results.unused_files.is_empty());
         assert!(results.unused_exports.is_empty());
+    }
+
+    #[test]
+    fn apply_single_type_filter_clears_test_only_dependencies() {
+        // Regression for #1192: a single-type filter that is not --unused-deps must clear
+        // test-only-dependency findings, matching every other dependency kind. Before the fix the
+        // --unused-deps clear arm omitted test_only_dependencies, so it leaked into the output of
+        // any single-type filter run (e.g. `fallow dead-code --unused-files`).
+        let mut results = make_results();
+        assert_eq!(results.test_only_dependencies.len(), 1);
+
+        let mut f = no_filters();
+        f.unused_files = true;
+        f.apply(&mut results);
+
+        assert!(
+            results.test_only_dependencies.is_empty(),
+            "test-only-dependency findings must be cleared when --unused-deps is not active"
+        );
     }
 
     #[test]

--- a/crates/cli/src/schema.rs
+++ b/crates/cli/src/schema.rs
@@ -177,7 +177,7 @@ fn dead_code_issue_meta(bare_id: &str) -> IssueTypeMeta {
             m.filter_flag = Some("--unused-deps");
             m.fixable = true;
             m.note = Some(
-                "--unused-deps controls unused-dependency, unused-dev-dependency, unused-optional-dependency, and type-only-dependency",
+                "--unused-deps controls unused-dependency, unused-dev-dependency, unused-optional-dependency, type-only-dependency, and test-only-dependency",
             );
         }
         "type-only-dependency" => {
@@ -187,7 +187,10 @@ fn dead_code_issue_meta(bare_id: &str) -> IssueTypeMeta {
             );
         }
         "test-only-dependency" => {
-            m.note = Some("Not reported in --production mode (test files are excluded there)");
+            m.filter_flag = Some("--unused-deps");
+            m.note = Some(
+                "Not reported in --production mode (test files are excluded there); --unused-deps scopes it together with the other dependency kinds",
+            );
         }
         "unused-enum-member" => {
             m.filter_flag = Some("--unused-enum-members");

--- a/npm/fallow/skills/fallow/SKILL.md
+++ b/npm/fallow/skills/fallow/SKILL.md
@@ -107,11 +107,11 @@ Run `fallow <command> --help` for the full flag list per command (see also refer
 | `unused-export` | `--unused-exports` | yes | `// fallow-ignore-next-line unused-export` | Symbols never imported elsewhere |
 | `unused-type` | `--unused-types` | - | `// fallow-ignore-next-line unused-type` | Type aliases and interfaces |
 | `private-type-leak` | `--private-type-leaks` | - | `// fallow-ignore-next-line private-type-leak` | Opt-in API hygiene check (default `off`) for exported signatures whose type references a same-file private type |
-| `unused-dependency` | `--unused-deps` | yes | - | Packages in `dependencies` never imported. In monorepos, internal workspace package names (e.g., `@repo/ui`) declared in another workspace's `package.json` but never imported are reported here too. `--unused-deps` also covers the dev/optional/type-only sibling rows below. |
+| `unused-dependency` | `--unused-deps` | yes | - | Packages in `dependencies` never imported. In monorepos, internal workspace package names (e.g., `@repo/ui`) declared in another workspace's `package.json` but never imported are reported here too. `--unused-deps` also covers the dev/optional/type-only/test-only sibling rows below. |
 | `unused-dev-dependency` | `--unused-deps` | yes | - | Packages in `devDependencies` never imported by test files, config files, or scripts |
 | `unused-optional-dependency` | `--unused-deps` | yes | - | Packages in `optionalDependencies` never imported (often platform-specific; verify before removing) |
 | `type-only-dependency` | `--unused-deps` | - | - | Production dependency only used via type-only imports; Only reported in --production mode; --unused-deps scopes it together with the other dependency kinds |
-| `test-only-dependency` | - | - | - | Production deps only imported from test files (should be devDependencies) |
+| `test-only-dependency` | `--unused-deps` | - | - | Production deps only imported from test files (should be devDependencies) |
 | `unused-enum-member` | `--unused-enum-members` | yes | `// fallow-ignore-next-line unused-enum-member` | Enum values never referenced |
 | `unused-class-member` | `--unused-class-members` | - | `// fallow-ignore-next-line unused-class-member` | Methods and properties |
 | `unresolved-import` | `--unresolved-imports` | - | `// fallow-ignore-next-line unresolved-import` | Imports that can't be resolved |


### PR DESCRIPTION
`IssueFilters::apply()` clears every issue category that was not selected by a single-type filter flag, but the `--unused-deps` clear arm omitted `test_only_dependencies`, so a focused run like `fallow dead-code --unused-files` on a project with a production dependency imported only from test files leaked that test-only finding alongside the requested issue type.

This groups `test-only-dependency` with the other dependency kinds under `--unused-deps` (matching how `type-only-dependency` is handled and how the `--file` scope already cleared all five categories), sets `filter_flag` to `--unused-deps` for the `test-only-dependency` row in the `fallow schema` capability manifest, regenerates the SKILL.md issue-types table, and adds a neuter-verified filter-parity regression test.

Fixes #1192.