### PR TITLE
fix(graph): keep tsconfig aliases out of dependency reports

### DIFF
--- a/crates/core/tests/integration_test/false_positive_fixes.rs
+++ b/crates/core/tests/integration_test/false_positive_fixes.rs
@@ -211,6 +211,79 @@ fn broken_tsconfig_path_alias_is_not_misclassified_as_unlisted_dependency() {
 }
 
 #[test]
+fn unresolved_tsconfig_path_alias_is_not_misclassified_as_unlisted_dependency() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("src")).expect("src dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+            "name": "alias-unlisted-regression",
+            "private": true,
+            "main": "src/index.ts",
+            "dependencies": {
+                "react": "18.0.0"
+            }
+        }"#,
+    )
+    .expect("package json");
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+            "compilerOptions": {
+                "baseUrl": ".",
+                "paths": {
+                    "@app/*": ["src/app/*"]
+                }
+            }
+        }"#,
+    )
+    .expect("tsconfig");
+    std::fs::write(
+        root.join("src/index.ts"),
+        r#"import { missing } from "@app/missing";
+import { external } from "@scope/pkg";
+import React from "react";
+
+console.log(missing, external, React);
+"#,
+    )
+    .expect("index");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unlisted_names: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|dep| dep.dep.package_name.as_str())
+        .collect();
+    let unresolved_specifiers: Vec<&str> = results
+        .unresolved_imports
+        .iter()
+        .map(|import| import.import.specifier.as_str())
+        .collect();
+
+    assert!(
+        !unlisted_names.contains(&"@app/missing"),
+        "declared tsconfig path aliases should not be treated as unlisted dependencies: {unlisted_names:?}"
+    );
+    assert!(
+        !unlisted_names.contains(&"react"),
+        "real listed packages should still receive dependency credit: {unlisted_names:?}"
+    );
+    assert!(
+        unlisted_names.contains(&"@scope/pkg"),
+        "real unlisted scoped packages should still be reported in a tsconfig path project: {unlisted_names:?}"
+    );
+    assert!(
+        unresolved_specifiers.contains(&"@app/missing"),
+        "missing local alias targets should stay unresolved instead of becoming package deps: {unresolved_specifiers:?}"
+    );
+}
+
+#[test]
 fn bun_bare_runtime_module_is_not_unlisted() {
     let root = fixture_path("issue-642-bun-builtin");
     let config = create_config(root);

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -1356,17 +1356,14 @@ pub(super) fn resolve_specifier(
                 return result;
             }
 
-            if used_tsconfig_fallback
+            if (used_tsconfig_fallback || is_bare || is_alias || matches_plugin_alias)
                 && let Some(result) = try_nearest_tsconfig_path_alias(ctx, from_file, specifier)
             {
                 return result;
             }
 
-            if used_tsconfig_fallback
-                && matches_nearest_tsconfig_path_alias(ctx.root, from_file, specifier)
-            {
-                return ResolveResult::Unresolvable(specifier.to_string());
-            }
+            let matches_tsconfig_path_alias =
+                matches_nearest_tsconfig_path_alias(ctx.root, from_file, specifier);
 
             if let Some(result) = try_package_imports_fallback(ctx, from_file, specifier) {
                 return result;
@@ -1388,6 +1385,9 @@ pub(super) fn resolve_specifier(
                 {
                     return result;
                 }
+                if matches_tsconfig_path_alias {
+                    return ResolveResult::Unresolvable(specifier.to_string());
+                }
                 ResolveResult::Unresolvable(specifier.to_string())
             } else if let Some(result) =
                 try_css_relative_subpath_fallback(ctx, from_file, specifier, from_style)
@@ -1398,6 +1398,9 @@ pub(super) fn resolve_specifier(
             } else if is_bare && is_valid_package_name(specifier) {
                 if let Some(result) = try_workspace_package_fallback(ctx, specifier) {
                     return result;
+                }
+                if matches_tsconfig_path_alias {
+                    return ResolveResult::Unresolvable(specifier.to_string());
                 }
                 let pkg_name = extract_package_name(specifier);
                 if ctx.workspace_roots.contains_key(pkg_name.as_str())


### PR DESCRIPTION
## Summary
- Keep imports that match local tsconfig path aliases out of unlisted dependency reports when the alias target is missing.
- Preserve workspace package fallback before marking a matched alias unresolved.
- Add regression coverage for the alias false positive, listed dependency credit, and real unlisted scoped packages.

## Verification
- cargo build --workspace
- cargo test --workspace --all-targets
- cargo test -p fallow-core --test integration_test unresolved_tsconfig_path_alias_is_not_misclassified_as_unlisted_dependency
- cargo fmt --all -- --check
- git diff --check
