### PR TITLE
fix(docs): avoid private rustdoc links in impact digest

### DIFF
--- a/crates/cli/src/impact.rs
+++ b/crates/cli/src/impact.rs
@@ -264,7 +264,7 @@ pub fn disable(root: &Path) -> bool {
 
 /// A due periodic value digest: the headline counters for "what has fallow
 /// done for you here". Returned by [`take_due_digest`] at most once per
-/// [`DIGEST_INTERVAL_SECS`] per project.
+/// `DIGEST_INTERVAL_SECS` per project.
 #[derive(Debug, Clone, Copy)]
 pub struct ImpactDigest {
     pub containment_count: usize,
@@ -275,7 +275,7 @@ pub struct ImpactDigest {
 const DIGEST_INTERVAL_SECS: u64 = 7 * 24 * 60 * 60;
 
 /// Return the periodic value digest when it is due, stamping the store so the
-/// next one is at least [`DIGEST_INTERVAL_SECS`] away. Due means: tracking is
+/// next one is at least `DIGEST_INTERVAL_SECS` away. Due means: tracking is
 /// enabled, there is non-zero value to report (anti-nag: a zero digest never
 /// surfaces), and the previous digest is older than the interval (or never
 /// happened). Best-effort like the rest of the store: a clean run that drops


### PR DESCRIPTION
The periodic impact digest docs linked to a private interval constant from public items, which fails rustdoc with private intra-doc links denied.

Keep the constant name visible as code text without making it an intra-doc link, so the documentation build passes under the workspace rustdoc gate.