### PR TITLE
docs(impact): fix stale store path and redundant intra-doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The MCP server also exposes `code_execute`, a bounded read-only Code Mode tool f
 
 For security review loops, see the [Security agent verification recipe](docs/security-agent-verification.md). It shows how to combine `fallow security --format json --surface`, candidate evidence, and MCP `security_candidates` output without adding model calls to fallow core.
 
-Run `fallow impact` to see what fallow has done for you: how many issues it is surfacing, the trend since your last recorded run, and how many commits its pre-commit gate caught before they shipped. It is opt-in (`fallow impact enable`) and entirely local: history lives in a gitignored `.fallow/impact.json` and is never uploaded.
+Run `fallow impact` to see what fallow has done for you: how many issues it is surfacing, the trend since your last recorded run, and how many commits its pre-commit gate caught before they shipped. Run `fallow impact --all` to roll every tracked project into one cross-repo view. It is opt-in (`fallow impact enable`) and entirely local: history lives in your user config directory (never written into the repo, so nothing to gitignore) and is never uploaded.
 
 Product telemetry for improving agent, CI, MCP, and editor workflows is off by default. Run `fallow telemetry inspect --example` to see the payload, or `FALLOW_TELEMETRY=inspect fallow audit --format json --quiet` to inspect a real run without sending it. Run `fallow telemetry enable` only when you want to help improve these integrations. See [Telemetry](docs/telemetry.md).
 

--- a/crates/core/src/analyze/mixed_barrel.rs
+++ b/crates/core/src/analyze/mixed_barrel.rs
@@ -8,8 +8,8 @@
 //!
 //! The trigger is deliberately precise to avoid false positives:
 //! - It requires a client origin AND a SERVER-ONLY origin (see the shared
-//!   [`is_server_only_module`](super::server_only::is_server_only_module)
-//!   predicate). A barrel re-exporting a `"use client"` component and an
+//!   [`is_server_only_module`] predicate). A barrel re-exporting a
+//!   `"use client"` component and an
 //!   ordinary undirected utility module is completely normal and MUST NOT flag.
 //! - Type-only re-exports (`export type { X } from './client'`) are erased and
 //!   carry no runtime directive context, so they are skipped when classifying an


### PR DESCRIPTION
Two small doc fixes:

- README's impact paragraph still described the store as a gitignored `.fallow/impact.json` in the repo. The store relocated to the user config directory (v2.96.0), so the wording is updated and a pointer to the new `fallow impact --all` cross-repo view is added.
- The mixed-barrel detection module docs had a redundant explicit target on the `is_server_only_module` intra-doc link, which tripped the `cargo doc -D warnings` Documentation CI check on main. Dropped the explicit target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)