### PR TITLE
docs(readme): mention mixed-barrel and misplaced-directive RSC checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Clone families and duplicated implementation patterns that increase maintenance 
 
 ### Architecture
 
-Circular dependencies, boundary violations across layers and modules, re-export chains, and other dependency-graph issues. Zero-config presets for bulletproof, layered, hexagonal, and feature-sliced architectures. Framework correctness checks catch Next.js `"use client"` files that export a server-only or route-segment config name (such as `metadata`, `revalidate`, or a route HTTP method) before the build does.
+Circular dependencies, boundary violations across layers and modules, re-export chains, and other dependency-graph issues. Zero-config presets for bulletproof, layered, hexagonal, and feature-sliced architectures. Framework correctness checks catch Next.js `"use client"` files that export a server-only or route-segment config name (such as `metadata`, `revalidate`, or a route HTTP method) before the build does. They also flag barrels that re-export both client and server-only modules, and `"use client"` / `"use server"` directives placed below an import where the bundler silently ignores them.
 
 ### Dependency hygiene
 


### PR DESCRIPTION
Extend the Architecture section's Next.js correctness blurb to also name the mixed-client-server-barrel and misplaced-directive checks that shipped alongside invalid-client-export.