### PR TITLE
feat(extract): track SvelteKit data-prop destructure as member accesses

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -388,14 +388,12 @@ use crate::MemberKind;
 /// `has_emit_whole_object_use` abstain flags, so a warm cache from 159 would
 /// report zero unused-component-emit findings.
 ///
-/// Bumped to 161 for the `unused-server-action` detector: the suppression token
-/// `unused-server-action` is now a known `IssueKind` (discriminant 40). A warm
-/// cache from 160 stored that marker in `unknown_suppression_kinds` (it was an
-/// unrecognized token then), so reading it would leave a suppressed action
-/// unsuppressed (false `unused-server-action` finding) AND report the consumed
-/// marker as a stale suppression. Invalidating the cache forces a re-parse that
-/// routes the token to `suppressions` with the now-known discriminant.
-pub(super) const CACHE_VERSION: u32 = 161;
+/// Bumped to 162 for `unused-load-data-key` Primitive A: a destructure off the
+/// SvelteKit `data` prop local (`const { user } = data`) now emits `data.<key>`
+/// member accesses (rest element records a whole-object use). A warm cache from
+/// 161 lacks those accesses, so the cross-file load-data-key join would miss the
+/// consumed keys.
+pub(super) const CACHE_VERSION: u32 = 162;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -4975,6 +4975,34 @@ fn namespace_import_destructuring_with_rest_marks_whole() {
 }
 
 #[test]
+fn data_prop_destructuring_emits_member_accesses() {
+    // Primitive A (unused-load-data-key): `const { user, posts } = data` off the
+    // SvelteKit `data` prop emits `data.<key>` member accesses for the detector.
+    let info = parse("const { user, posts } = data;");
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "data" && a.member == "user")
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "data" && a.member == "posts")
+    );
+}
+
+#[test]
+fn data_prop_destructuring_with_rest_marks_whole() {
+    // A rest element consumes the whole `data` object opaquely: abstain.
+    let info = parse("const { user, ...rest } = data;");
+    assert!(info.whole_object_uses.contains(&"data".to_string()));
+    assert!(
+        !info.member_accesses.iter().any(|a| a.object == "data"),
+        "rest destructure must not emit per-key accesses"
+    );
+}
+
+#[test]
 fn require_namespace_destructuring() {
     let info = parse("const mod = require('./mod');\nconst { x, y } = mod;");
     assert!(

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -3480,6 +3480,22 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 continue;
             }
 
+            // Primitive A (unused-load-data-key): a destructure off the SvelteKit
+            // `data` prop local (`const { user } = data` / `let { user } = data`)
+            // emits `data.<key>` member accesses so the cross-file detector can
+            // see the consumed load-return keys. Rooted on the `data` local (not
+            // an import); a rest element (`const { a, ...rest } = data`) records a
+            // whole-object use of `data` (abstain). Crediting a member against a
+            // binding named `data` is inert for every other detector unless a
+            // tracked export / instance is also named `data`; the load-data-key
+            // join is the only consumer of `data.<key>`.
+            if let Expression::Identifier(ident) = init
+                && ident.name == "data"
+            {
+                self.handle_namespace_destructuring(declarator, &ident.name);
+                continue;
+            }
+
             let Some((import_expr, source)) = try_extract_dynamic_import(init) else {
                 continue;
             };


### PR DESCRIPTION
Primitive A for the planned `unused-load-data-key` SvelteKit detector. A destructure off the `data` prop local (`const { user } = data` / `let { user } = data`) now emits `data.<key>` member accesses (rest element records a whole-object use of `data` so the downstream detector abstains), rooted on the `data` local, mirroring the namespace-destructure path.

Crediting a member against a binding named `data` is inert for every existing detector unless a tracked export / instance is also named `data`; the load-data-key join (a later change) is the only intended consumer. CACHE_VERSION 162.

Verified findings-byte-identical (OLD vs NEW) on all 10 real-world benchmark fixtures (vite, typescript, next.js, svelte, astro, vue-core, preact, query, fastify, zod); only `elapsed_ms` and `analysis_run_id` differ (both volatile). Full workspace test + clippy `-D warnings` green.