### PR TITLE
feat(extract): credit SvelteKit route data prop as template-visible

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -393,7 +393,14 @@ use crate::MemberKind;
 /// member accesses (rest element records a whole-object use). A warm cache from
 /// 161 lacks those accesses, so the cross-file load-data-key join would miss the
 /// consumed keys.
-pub(super) const CACHE_VERSION: u32 = 162;
+///
+/// Bumped to 163 for `unused-load-data-key` Primitive B: a SvelteKit route
+/// component (`+page.svelte` / `+layout.svelte`) now credits the `data` prop as
+/// a template-visible root, so `{data.x}` / `{#each data.items as i}` markup
+/// reads emit `data.<key>` member accesses. A warm cache from 162 lacks those
+/// template-side accesses, so the cross-file load-data-key join would miss keys
+/// consumed only in markup.
+pub(super) const CACHE_VERSION: u32 = 163;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -363,6 +363,7 @@ pub(crate) fn parse_sfc_to_module(
         &template_visible_imports,
         &template_visible_bound_targets,
         props_return_binding.as_deref(),
+        kind == SfcKind::Svelte && is_sveltekit_route_data_component(path),
         &mut combined,
     );
 
@@ -406,6 +407,30 @@ fn sfc_kind(path: &Path) -> SfcKind {
     } else {
         SfcKind::Svelte
     }
+}
+
+/// SvelteKit route components receive a `data` prop populated by the route's
+/// `load()` return object. This predicate gates the `data`-as-template-root
+/// credit (unused-load-data-key Primitive B) to exactly those files. It matches
+/// `+page.svelte` / `+layout.svelte` AND their layout-reset variants
+/// (`+page@.svelte`, `+page@named.svelte`, `+page@(group).svelte`, and the
+/// `+layout@...` forms), all of which still receive the `data` prop. `+error.svelte`
+/// is excluded (it receives `$page.error`, not the `load()` `data` prop), and a
+/// non-route file like `+pageHelper.svelte` is excluded by the grammar (the part
+/// after `+page` must be empty or start with `@`). The leading `+` is a
+/// SvelteKit-only filename convention, so no ordinary `.svelte` component matches.
+fn is_sveltekit_route_data_component(path: &Path) -> bool {
+    let Some(stem) = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_suffix(".svelte"))
+    else {
+        return false;
+    };
+    ["+page", "+layout"].iter().any(|prefix| {
+        stem.strip_prefix(prefix)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('@'))
+    })
 }
 
 fn empty_sfc_module(file_id: FileId, source: &str, content_hash: u64) -> ModuleInfo {
@@ -727,6 +752,7 @@ fn apply_template_usage(
     template_visible_imports: &FxHashSet<String>,
     template_visible_bound_targets: &FxHashMap<String, String>,
     props_return_binding: Option<&str>,
+    credit_load_data: bool,
     combined: &mut ModuleInfo,
 ) {
     // Props are NOT imports, so the template scanner does not credit them by
@@ -735,24 +761,36 @@ fn apply_template_usage(
     // additional credited set alongside `template_visible_imports`. Crediting a
     // prop name against an import is inert (no import binding shares the name),
     // so the unused-import retain is unaffected.
-    let credited: FxHashSet<String> = if combined.component_props.is_empty() {
-        template_visible_imports.clone()
-    } else {
-        let mut set = template_visible_imports.clone();
+    let mut credited: FxHashSet<String> = template_visible_imports.clone();
+    // unused-load-data-key Primitive B: a SvelteKit route component
+    // (`+page.svelte` / `+layout.svelte`) receives a `data` prop populated by
+    // the route's `load()` return object. The prop is template-visible
+    // (`{data.x}`, `{#each data.items as i}`) but is neither an import nor a
+    // tracked binding, so the member-access scanner gates it out by default.
+    // Credit `data` as a recognized root so its template member accesses
+    // (`data.<key>`) are emitted for the cross-file load-data-key join. Gated to
+    // route components only (`credit_load_data`): a non-route component's
+    // `let { data } = $props()` is a different, parent-passed `data`, so
+    // crediting it as load data would be semantically wrong. Inert for every
+    // other detector unless a tracked export/instance is named `data` (mirrors
+    // Primitive A); the load-data-key join is the only consumer of `data.<key>`.
+    if credit_load_data {
+        credited.insert("data".to_string());
+    }
+    if !combined.component_props.is_empty() {
         for prop in &combined.component_props {
             // Credit both the declared name (Vue exposes props by name in the
             // template) and the destructure local (a renamed prop is used via it).
-            set.insert(prop.name.clone());
-            set.insert(prop.local.clone());
+            credited.insert(prop.name.clone());
+            credited.insert(prop.local.clone());
         }
         // Vue's implicit `$props` whole-props object is always available in a
         // template; credit `$props.<name>` member accesses too.
-        set.insert("$props".to_string());
+        credited.insert("$props".to_string());
         if let Some(binding) = props_return_binding {
-            set.insert(binding.to_string());
+            credited.insert(binding.to_string());
         }
-        set
-    };
+    }
 
     let template_usage = collect_template_usage_with_bound_targets(
         kind,

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -1450,3 +1450,161 @@ type Local = UseTypeOnly;
             .contains(&"localOnly".to_string())
     );
 }
+
+// unused-load-data-key Primitive B: SvelteKit route components credit the `data`
+// prop as a template-visible root so `{data.x}` / `{#each data.items as i}`
+// markup reads emit `data.<key>` member accesses for the cross-file join.
+
+#[test]
+fn sveltekit_data_prop_template_member_access_in_page_svelte() {
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+export let data;
+</script>
+<h1>{data.title}</h1>
+<p>{data.user.name}</p>
+"#,
+        "src/routes/+page.svelte",
+    );
+
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "data" && access.member == "title"),
+        "template `data.title` should be recorded, got: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "data" && access.member == "user"),
+        "template `data.user` (nested) should record the first member, got: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn sveltekit_data_prop_each_block_member_access_in_page_svelte() {
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+export let data;
+</script>
+{#each data.items as item}
+  <li>{item}</li>
+{/each}
+"#,
+        "src/routes/blog/+page.svelte",
+    );
+
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "data" && access.member == "items"),
+        "`{{#each data.items as item}}` should record `data.items`, got: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn sveltekit_data_prop_credited_in_layout_svelte() {
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+export let data;
+</script>
+<nav>{data.menu}</nav>
+"#,
+        "src/routes/+layout.svelte",
+    );
+
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "data" && access.member == "menu"),
+        "`+layout.svelte` should credit `data.menu`, got: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn sveltekit_data_prop_credited_in_layout_reset_page() {
+    // Layout-reset route components (`+page@.svelte`, `+page@named.svelte`,
+    // `+page@(group).svelte`, `+layout@named.svelte`) still receive the `load()`
+    // `data` prop, so they must be credited too.
+    for filename in [
+        "src/routes/marketing/+page@.svelte",
+        "src/routes/marketing/+layout@named.svelte",
+        "src/routes/promo/+page@(checkout).svelte",
+    ] {
+        let info = parse_sfc(
+            r#"
+<script lang="ts">
+export let data;
+</script>
+<h1>{data.title}</h1>
+"#,
+            filename,
+        );
+
+        assert!(
+            info.member_accesses
+                .iter()
+                .any(|access| access.object == "data" && access.member == "title"),
+            "layout-reset route `{filename}` should credit `data.title`, got: {:?}",
+            info.member_accesses
+        );
+    }
+}
+
+#[test]
+fn sveltekit_data_credit_excludes_error_and_non_route_plus_files() {
+    // `+error.svelte` receives `$page.error`, not the `load()` `data` prop, and a
+    // `+pageHelper.svelte` is not a SvelteKit route file, so neither is credited.
+    for filename in ["src/routes/+error.svelte", "src/routes/+pageHelper.svelte"] {
+        let info = parse_sfc(
+            r#"
+<script lang="ts">
+export let data;
+</script>
+<h1>{data.title}</h1>
+"#,
+            filename,
+        );
+
+        assert!(
+            !info
+                .member_accesses
+                .iter()
+                .any(|access| access.object == "data"),
+            "`{filename}` must not credit `data.*`, got: {:?}",
+            info.member_accesses
+        );
+    }
+}
+
+#[test]
+fn sveltekit_data_prop_not_credited_in_non_route_svelte() {
+    // A non-route component's `data` is a parent-passed prop, NOT load() data, so
+    // crediting it as load data would be semantically wrong. Route-narrowing keeps
+    // the credit off ordinary `.svelte` files.
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+let { data } = $props();
+</script>
+<h1>{data.title}</h1>
+"#,
+        "src/lib/Card.svelte",
+    );
+
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "data"),
+        "non-route `Card.svelte` must not credit `data.*`, got: {:?}",
+        info.member_accesses
+    );
+}


### PR DESCRIPTION
Primitive B for unused-load-data-key: a SvelteKit route component now credits the `data` prop as a template-visible root, so `{data.x}` and `{#each data.items as i}` markup reads emit `data.<key>` member accesses for the cross-file load-data-key join.

Route-narrowed (not all `.svelte`): a non-route component's parent-passed `data` is a different binding, so crediting it as load data would be semantically wrong. The predicate matches `+page.svelte` / `+layout.svelte` AND their layout-reset variants (`+page@.svelte`, `+page@named.svelte`, `+page@(group).svelte`, `+layout@named.svelte`), all of which still receive the `load()` data prop; `+error.svelte` (gets `$page.error`) and non-route `+pageHelper.svelte` are excluded by the grammar.

Internal extraction primitive with zero finding delta (the consuming detector lands later), so no CHANGELOG/detection.md entry, mirroring Primitive A (#1255). CACHE_VERSION 162 to 163. Findings byte-identical (deep payload compare) on all 10 benchmark fixtures and 10 real SvelteKit apps; extract + core + full-workspace tests, clippy -D warnings, fmt, and cargo doc all green.