### PR TITLE
feat(extract): recover SvelteKit page.data.<key> depth in templates

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -400,7 +400,13 @@ use crate::MemberKind;
 /// reads emit `data.<key>` member accesses. A warm cache from 162 lacks those
 /// template-side accesses, so the cross-file load-data-key join would miss keys
 /// consumed only in markup.
-pub(super) const CACHE_VERSION: u32 = 163;
+///
+/// Bumped to 164 for `unused-load-data-key` Primitive C: a SvelteKit global
+/// page-store read in a template (`{$page.data.KEY}` / `{page.data.KEY}`) now
+/// recovers the nested `page.data.<key>` member access (the template scanner
+/// previously dropped the key, keeping only `page.data`). A warm cache from 163
+/// lacks those project-wide global-store accesses.
+pub(super) const CACHE_VERSION: u32 = 164;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/template_usage.rs
+++ b/crates/extract/src/template_usage.rs
@@ -405,6 +405,23 @@ fn remap_object_name(
         }
         return Some(stripped.to_string());
     }
+    // unused-load-data-key Primitive C: the SvelteKit global page store read in a
+    // template, `$page.data.KEY` (Svelte 4 `$app/stores`) or `page.data.KEY`
+    // (Svelte 5 `$app/state`), arrives here as the dotted member object
+    // `$page.data` / `page.data` (the object of the outer `.KEY` access). The
+    // root-only logic above remaps `$page`/`page` but drops the `.data` suffix,
+    // so the consumed key is lost. Recover the canonical `page.data` object (the
+    // `$`-stripped form, matching how the root branch normalizes `$page` -> `page`)
+    // so the cross-file detector can see the project-wide `page.data.<key>`
+    // consumer channel. Scoped to the `page` store's `data` member only (gated on
+    // the Svelte dollar-ref path) to stay byte-identical for every other dotted
+    // template member object; `$page.url.pathname` etc. still map root-only.
+    if allow_dollar_prefixed_refs
+        && (name == "page.data" || name == "$page.data")
+        && unresolved_names.contains("page")
+    {
+        return Some("page.data".to_string());
+    }
     None
 }
 
@@ -537,5 +554,91 @@ mod tests {
         assert_eq!(usage.member_accesses.len(), 1);
         assert_eq!(usage.member_accesses[0].object, "page");
         assert_eq!(usage.member_accesses[0].member, "url");
+    }
+
+    // unused-load-data-key Primitive C: the SvelteKit global page store read in a
+    // template recovers the nested `page.data.<key>` member access.
+
+    #[test]
+    fn svelte4_page_store_data_key_recovers_nested_member() {
+        let usage = analyze_template_snippet(
+            "$page.data.user",
+            TemplateSnippetKind::Expression,
+            &bindings(&["page"]),
+            &[],
+            true,
+        );
+
+        assert!(
+            usage
+                .member_accesses
+                .iter()
+                .any(|a| a.object == "page.data" && a.member == "user"),
+            "`$page.data.user` should recover `page.data.user`, got: {:?}",
+            usage.member_accesses
+        );
+    }
+
+    #[test]
+    fn svelte5_page_state_data_key_recovers_nested_member() {
+        let usage = analyze_template_snippet(
+            "page.data.session",
+            TemplateSnippetKind::Expression,
+            &bindings(&["page"]),
+            &[],
+            true,
+        );
+
+        assert!(
+            usage
+                .member_accesses
+                .iter()
+                .any(|a| a.object == "page.data" && a.member == "session"),
+            "`page.data.session` should recover `page.data.session`, got: {:?}",
+            usage.member_accesses
+        );
+    }
+
+    #[test]
+    fn page_store_non_data_member_stays_root_only() {
+        // `$page.url.pathname` must keep mapping to root `page.url` -> `{page, url}`;
+        // only the `data` channel recovers the nested key. Regression guard for the
+        // existing store-ref behavior.
+        let usage = analyze_template_snippet(
+            "$page.url.pathname",
+            TemplateSnippetKind::Expression,
+            &bindings(&["page"]),
+            &[],
+            true,
+        );
+
+        assert!(
+            !usage.member_accesses.iter().any(|a| a.object == "page.url"),
+            "`$page.url` must not recover a nested member, got: {:?}",
+            usage.member_accesses
+        );
+    }
+
+    #[test]
+    fn page_data_nested_recovery_is_svelte_only() {
+        // Vue templates pass allow_dollar_prefixed_refs=false; the `page` store is
+        // SvelteKit-specific, so `page.data.x` must NOT recover the nested member
+        // in a Vue context (root `{page, data}` is still credited).
+        let usage = analyze_template_snippet(
+            "page.data.x",
+            TemplateSnippetKind::Expression,
+            &bindings(&["page"]),
+            &[],
+            false,
+        );
+
+        assert!(
+            !usage
+                .member_accesses
+                .iter()
+                .any(|a| a.object == "page.data"),
+            "Vue context must not recover `page.data`, got: {:?}",
+            usage.member_accesses
+        );
     }
 }

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -1608,3 +1608,38 @@ let { data } = $props();
         info.member_accesses
     );
 }
+
+#[test]
+fn sveltekit_page_store_data_key_recovered_in_script_and_template() {
+    // unused-load-data-key Primitive C cross-context contract: a SvelteKit global
+    // page-store `data` read recovers the nested `page.data.<key>` member access in
+    // BOTH the component `<script>` (Svelte 5 `$app/state`) and the markup
+    // (`{$page.data.X}` Svelte 4 store / `{page.data.X}` Svelte 5 rune). The script
+    // side already emitted the dotted object via the visitor's recursive
+    // member-name builder; this locks that contract and the template recovery.
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+import { page } from '$app/state';
+const id = page.data.session;
+</script>
+<h1>{page.data.title}</h1>
+"#,
+        "src/lib/Header.svelte",
+    );
+
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "page.data" && a.member == "session"),
+        "script `page.data.session` should be recorded, got: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "page.data" && a.member == "title"),
+        "template `page.data.title` should be recovered, got: {:?}",
+        info.member_accesses
+    );
+}


### PR DESCRIPTION
Primitive C for unused-load-data-key: a SvelteKit global page-store read in a template, `{$page.data.KEY}` (Svelte 4 `$app/stores`) or `{page.data.KEY}` (Svelte 5 `$app/state`), now recovers the nested `page.data.<key>` member access for the cross-file load-data-key detector's project-wide global-store consumer channel.

The template scanner's `remap_object_name` previously remapped only the root identifier (`$page` to `page`) and dropped the `.data` suffix, so the consumed key was lost. It now recovers the canonical `page.data` object, gated on the Svelte dollar-ref path (excludes Vue) and scoped to the page store's `data` member, so `$page.url.pathname` and every other dotted template member object still map root-only. The script context already emitted the dotted form via the visitor's recursive member-name builder (verified by probe), so no `visit_impl.rs` change was needed.

Internal extraction primitive with zero finding delta (the consuming detector lands later), so no CHANGELOG/detection.md entry, mirroring Primitives A (#1255) and B (#1257). CACHE_VERSION 164. Findings byte-identical on all 10 benchmark fixtures and 10 real SvelteKit corpus apps (grimoire/kener/wanderer heavily use `$page.data`); extract + core + full-workspace tests, clippy, fmt, and cargo doc all green.