### PR TITLE
ci: add codspeed benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,12 +30,9 @@ env:
 
 jobs:
   benchmark:
-    name: Performance regression check
+    name: CodSpeed performance check
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -43,44 +40,18 @@ jobs:
         with:
           cache-key: bench
 
-      - name: Run benchmarks
-        # Only run the `analysis` bench target (not `large_analysis` which
-        # contains 5000+ file benchmarks that take 5+ minutes each).
-        run: cargo bench --bench analysis -- --output-format bencher | tee bench-output.txt
-
-      - name: Store benchmark result
-        uses: ./.github/actions/store-benchmark
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
         with:
-          name: Fallow Benchmarks
-          tool: cargo
-          output-file-path: bench-output.txt
-          data-dir: bench
-          alert-threshold: '150%'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          continue-on-error: ${{ github.event_name == 'pull_request' }}
+          tool: cargo-codspeed
 
-      - name: Deploy dashboard
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          # Save the dashboard page before switching branches
-          cp .github/pages/index.html /tmp/dashboard-index.html
+      - name: Build benchmark
+        # Only run the analysis bench target. large_analysis contains larger
+        # synthetic project benchmarks that exceed the fast PR feedback budget.
+        run: cargo codspeed build -p fallow-core --bench analysis
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Fetch latest gh-pages (benchmark-action may have just pushed)
-          git fetch origin gh-pages
-
-          # Use worktree to avoid losing the main checkout
-          git worktree add /tmp/gh-pages origin/gh-pages
-          cd /tmp/gh-pages
-
-          cp /tmp/dashboard-index.html index.html
-          git add index.html
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update dashboard index.html"
-            git push origin HEAD:gh-pages
-          fi
-
-          cd "$GITHUB_WORKSPACE"
-          git worktree remove /tmp/gh-pages
+      - name: Run benchmark
+        uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5
+        with:
+          mode: simulation
+          run: cargo codspeed run -p fallow-core --bench analysis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,15 +40,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,12 +53,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -124,6 +109,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arrayvec"
@@ -298,12 +292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,33 +332,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -387,6 +354,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -417,10 +385,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57af92d1db7f6871b7e82c79cd87f2501db66f36b0eab924be6ea83dd6b2f3f3"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored 2.2.0",
+ "getrandom 0.2.17",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-divan-compat"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ea79fd0b1f2128cfac6308369013dba92df47baf4a4f66b57d8158224a361d"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-divan-compat-macros",
+ "codspeed-divan-compat-walltime",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-divan-compat-macros"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70e4ddd6beedefeb48f59d5f85fc21365a66e7976408c3d39f6cbbc4f03e08c"
+dependencies = [
+ "divan-macros",
+ "itertools 0.14.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "codspeed-divan-compat-walltime"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490c04f6076be6eacfafb496b8b237f3efbbed93838f2689115cc6f35fcf81c9"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "codspeed",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "colored"
@@ -444,6 +482,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
@@ -576,41 +620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,12 +643,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -848,6 +851,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,7 +975,7 @@ dependencies = [
  "base64",
  "bitcode",
  "clap",
- "colored",
+ "colored 3.1.1",
  "dunce",
  "ed25519-dalek",
  "fallow-config",
@@ -1033,7 +1047,7 @@ name = "fallow-core"
 version = "2.97.0"
 dependencies = [
  "bitcode",
- "criterion",
+ "codspeed-divan-compat",
  "dhat",
  "dunce",
  "fallow-config",
@@ -1465,17 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "halfbrown"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,15 +1797,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1885,9 +1879,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2114,6 +2108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodejs-built-in-modules"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,12 +2227,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "outref"
@@ -2675,16 +2675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "papaya"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,34 +2868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +2923,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -3157,6 +3128,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -3715,6 +3692,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "str_indices"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,16 +3887,6 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4396,16 +4373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4425,22 +4392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,12 +4399,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-st
 notify = "8"
 
 # Testing
-criterion = { version = "0.8", features = ["html_reports"] }
+divan = { package = "codspeed-divan-compat", version = "4.7" }
 dhat = "0.3"
 insta = { version = "1", features = ["yaml"] }
 proptest = "1"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <p align="center">
   <a href="https://github.com/fallow-rs/fallow/actions/workflows/ci.yml"><img src="https://github.com/fallow-rs/fallow/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/fallow-rs/fallow/actions/workflows/coverage.yml"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/fallow-rs/fallow/badges/coverage.json" alt="Coverage"></a>
+  <a href="https://app.codspeed.io/fallow-rs/fallow?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"></a>
   <a href="https://github.com/fallow-rs/fallow/stargazers"><img src="https://img.shields.io/github/stars/fallow-rs/fallow?style=flat&label=stars&color=blue" alt="GitHub stars"></a>
   <a href="https://www.npmjs.com/package/fallow"><img src="https://img.shields.io/npm/v/fallow.svg" alt="npm"></a>
   <a href="https://www.npmjs.com/package/fallow"><img src="https://img.shields.io/npm/dm/fallow.svg" alt="npm downloads"></a>

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -69,7 +69,7 @@ schemars = { workspace = true, optional = true }
 schema = ["dep:schemars", "fallow-types/schema"]
 
 [dev-dependencies]
-criterion = { workspace = true }
+divan = { workspace = true }
 proptest = { workspace = true }
 dhat = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/core/benches/allocations.rs
+++ b/crates/core/benches/allocations.rs
@@ -7,8 +7,8 @@
 //! Allocation tracking benchmark using dhat.
 //!
 //! This benchmark measures heap allocation statistics for the fallow analysis
-//! pipeline. It cannot be a Criterion benchmark because dhat requires being
-//! the global allocator.
+//! pipeline. It uses a dedicated harness because dhat requires being the global
+//! allocator.
 //!
 //! Run with: `cargo bench --bench allocations`
 //!

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -10,13 +10,40 @@
 
 use std::path::PathBuf;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use divan::Bencher;
 use rustc_hash::FxHashSet;
 
 mod helpers;
 
-fn bench_parse_file(c: &mut Criterion) {
+fn main() {
+    divan::main();
+}
+
+struct ParseFileInput {
+    temp_dir: PathBuf,
+    file: fallow_core::discover::DiscoveredFile,
+}
+
+impl Drop for ParseFileInput {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.temp_dir);
+    }
+}
+
+struct ConfigInput {
+    temp_dir: PathBuf,
+    config: fallow_config::ResolvedConfig,
+}
+
+impl Drop for ConfigInput {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.temp_dir);
+    }
+}
+
+fn create_parse_file_input() -> ParseFileInput {
     let temp_dir = std::env::temp_dir().join("fallow-bench");
+    let _ = std::fs::remove_dir_all(&temp_dir);
     std::fs::create_dir_all(&temp_dir).unwrap();
 
     let test_file = temp_dir.join("bench.ts");
@@ -103,16 +130,17 @@ export default function App({ name, age }: Props) {
         size_bytes: std::fs::metadata(&test_file).unwrap().len(),
     };
 
-    c.bench_function("parse_single_file", |b| {
-        b.iter(|| {
-            let _ = fallow_core::extract::parse_single_file(&file);
-        });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
+    ParseFileInput { temp_dir, file }
 }
 
-fn bench_full_pipeline(c: &mut Criterion) {
+#[divan::bench]
+fn parse_single_file(bencher: Bencher) {
+    bencher
+        .with_inputs(create_parse_file_input)
+        .bench_refs(|input| fallow_core::extract::parse_single_file(&input.file));
+}
+
+fn create_full_pipeline_input() -> ConfigInput {
     let temp_dir = std::env::temp_dir().join("fallow-bench-project");
     let _ = std::fs::remove_dir_all(&temp_dir);
     std::fs::create_dir_all(temp_dir.join("src")).unwrap();
@@ -146,37 +174,39 @@ export type Type{i} = {{ value: number }};
 
     let config = helpers::create_test_config(temp_dir.clone());
 
-    c.bench_function("full_pipeline_10_files", |b| {
-        b.iter(|| {
-            let _ = fallow_core::analyze(&config);
-        });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
+    ConfigInput { temp_dir, config }
 }
 
-fn bench_full_pipeline_100(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_synthetic_project("100", 100);
-
-    c.bench_function("full_pipeline_100_files", |b| {
-        b.iter(|| {
-            let _ = fallow_core::analyze(&config);
-        });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
+#[divan::bench]
+fn full_pipeline_10_files(bencher: Bencher) {
+    bencher
+        .with_inputs(create_full_pipeline_input)
+        .bench_refs(|input| fallow_core::analyze(&input.config));
 }
 
-fn bench_full_pipeline_1000(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_synthetic_project("1000", 1000);
+fn create_synthetic_config_input(name: &str, file_count: usize) -> ConfigInput {
+    let (temp_dir, config) = helpers::create_synthetic_project(name, file_count);
+    ConfigInput { temp_dir, config }
+}
 
-    c.bench_function("full_pipeline_1000_files", |b| {
-        b.iter(|| {
-            let _ = fallow_core::analyze(&config);
-        });
-    });
+#[divan::bench]
+fn full_pipeline_100_files(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_synthetic_config_input("100", 100))
+        .bench_refs(|input| fallow_core::analyze(&input.config));
+}
 
-    let _ = std::fs::remove_dir_all(&temp_dir);
+#[divan::bench]
+fn full_pipeline_1000_files(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_synthetic_config_input("1000", 1000))
+        .bench_refs(|input| fallow_core::analyze(&input.config));
+}
+
+struct ReExportInput {
+    files: Vec<fallow_core::discover::DiscoveredFile>,
+    resolved_modules: Vec<fallow_core::resolve::ResolvedModule>,
+    entry_points: Vec<fallow_core::discover::EntryPoint>,
 }
 
 #[expect(
@@ -187,7 +217,7 @@ fn bench_full_pipeline_1000(c: &mut Criterion) {
     clippy::too_many_lines,
     reason = "benchmark with extensive fixture setup"
 )]
-fn bench_resolve_re_export_chains(c: &mut Criterion) {
+fn create_re_export_input() -> ReExportInput {
     use fallow_core::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
     use fallow_core::extract::{
         ExportInfo, ExportName, ImportInfo, ImportedName, ReExportInfo, VisibilityTag,
@@ -380,26 +410,38 @@ fn bench_resolve_re_export_chains(c: &mut Criterion) {
         source: EntryPointSource::PackageJsonMain,
     }];
 
-    c.bench_function("resolve_re_export_chains", |b| {
-        b.iter(|| {
-            fallow_core::graph::ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    ReExportInput {
+        files,
+        resolved_modules,
+        entry_points,
+    }
+}
+
+#[divan::bench]
+fn resolve_re_export_chains(bencher: Bencher) {
+    bencher
+        .with_inputs(create_re_export_input)
+        .bench_refs(|input| {
+            fallow_core::graph::ModuleGraph::build(
+                &input.resolved_modules,
+                &input.entry_points,
+                &input.files,
+            );
         });
-    });
 }
 
 #[expect(
     clippy::too_many_lines,
     reason = "benchmark with extensive fixture setup"
 )]
-fn bench_cache_round_trip(c: &mut Criterion) {
-    use fallow_core::cache::{cached_to_module, module_to_cached};
+fn create_cache_round_trip_input() -> fallow_core::extract::ModuleInfo {
     use fallow_core::discover::FileId;
     use fallow_core::extract::{
         DynamicImportInfo, ExportInfo, ExportName, ImportInfo, ImportedName, MemberAccess,
         MemberInfo, MemberKind, ModuleInfo, ReExportInfo, RequireCallInfo, VisibilityTag,
     };
 
-    let module = ModuleInfo {
+    ModuleInfo {
         file_id: FileId(0),
         exports: vec![
             ExportInfo {
@@ -671,14 +713,20 @@ fn bench_cache_round_trip(c: &mut Criterion) {
         angular_entry_component_refs: Vec::new(),
         has_dynamic_component_render: false,
         has_dynamic_dispatch: false,
-    };
+    }
+}
 
-    c.bench_function("cache_round_trip", |b| {
-        b.iter(|| {
-            let cached = module_to_cached(&module, 0, 0);
-            let _restored = cached_to_module(&cached, FileId(0));
+#[divan::bench]
+fn cache_round_trip(bencher: Bencher) {
+    use fallow_core::cache::{cached_to_module, module_to_cached};
+    use fallow_core::discover::FileId;
+
+    bencher
+        .with_inputs(create_cache_round_trip_input)
+        .bench_refs(|module| {
+            let cached = module_to_cached(module, 0, 0);
+            let _ = cached_to_module(&cached, FileId(0));
         });
-    });
 }
 
 fn make_hashed_tokens(hashes: &[u64]) -> Vec<fallow_core::duplicates::normalize::HashedToken> {
@@ -760,55 +808,44 @@ fn make_diverse_files(n: usize, tokens_per_file: usize) -> DupeInput {
         .collect()
 }
 
-fn bench_dupe_detect_2x500(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_2x500_identical(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 500);
-    c.bench_function("dupe_detect_2x500_identical", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect(d),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
 }
 
-fn bench_dupe_detect_2x2000(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_2x2000_identical(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 2000);
-    c.bench_function("dupe_detect_2x2000_identical", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect(d),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
 }
 
-fn bench_dupe_detect_10x500(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_10x500_identical(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(10, 500);
-    c.bench_function("dupe_detect_10x500_identical", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect(d),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
 }
 
-fn bench_dupe_detect_50x200_diverse(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_50x200_diverse(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_diverse_files(50, 200);
-    c.bench_function("dupe_detect_50x200_diverse", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect(d),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
 }
 
-fn bench_dupe_detect_100x200_mixed(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_100x200_mixed(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     let hashes: Vec<u64> = (1..=200).collect();
     let data: DupeInput = (0..100)
@@ -828,16 +865,13 @@ fn bench_dupe_detect_100x200_mixed(c: &mut Criterion) {
         })
         .collect();
 
-    c.bench_function("dupe_detect_100x200_mixed", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect(d),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
 }
 
-fn bench_dupe_detect_100x200_mixed_focused(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_100x200_mixed_focused(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     use rustc_hash::FxHashSet;
 
@@ -860,46 +894,16 @@ fn bench_dupe_detect_100x200_mixed_focused(c: &mut Criterion) {
         .collect();
     let focus: FxHashSet<PathBuf> = std::iter::once(PathBuf::from("dir0/file0.ts")).collect();
 
-    c.bench_function("dupe_detect_100x200_mixed_focused", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect_touching_files(d, &focus),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect_touching_files(d, &focus));
 }
 
-fn bench_dupe_suffix_array_only(c: &mut Criterion) {
+#[divan::bench]
+fn dupe_detect_2x5000_identical(bencher: Bencher) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 5000);
-    c.bench_function("dupe_detect_2x5000_identical", |b| {
-        b.iter_batched(
-            || data.clone(),
-            |d| CloneDetector::new(30, 5, false).detect(d),
-            criterion::BatchSize::SmallInput,
-        );
-    });
+    bencher
+        .with_inputs(|| data.clone())
+        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
 }
-
-criterion_group!(
-    benches,
-    bench_parse_file,
-    bench_full_pipeline,
-    bench_full_pipeline_100,
-    bench_full_pipeline_1000,
-    bench_resolve_re_export_chains,
-    bench_cache_round_trip,
-);
-
-criterion_group!(
-    dupe_benches,
-    bench_dupe_detect_2x500,
-    bench_dupe_detect_2x2000,
-    bench_dupe_detect_10x500,
-    bench_dupe_detect_50x200_diverse,
-    bench_dupe_detect_100x200_mixed,
-    bench_dupe_detect_100x200_mixed_focused,
-    bench_dupe_suffix_array_only,
-);
-
-criterion_main!(benches, dupe_benches);

--- a/crates/core/benches/helpers.rs
+++ b/crates/core/benches/helpers.rs
@@ -59,6 +59,10 @@ pub fn make_config(root: PathBuf, no_cache: bool) -> fallow_config::ResolvedConf
 /// Generate a synthetic project with `file_count` source files.
 /// Half of the exports are consumed by the entry point, the other half are "dead".
 #[must_use]
+#[allow(
+    dead_code,
+    reason = "shared helper is used by analysis but not every bench target"
+)]
 pub fn create_synthetic_project(
     name: &str,
     file_count: usize,

--- a/crates/core/benches/large_analysis.rs
+++ b/crates/core/benches/large_analysis.rs
@@ -8,92 +8,96 @@
     reason = "ADR-008: benchmark exercises the workspace path-dep fallow_core::analyze surface"
 )]
 
-use std::time::Duration;
-
-use criterion::{Criterion, criterion_group, criterion_main};
+use divan::Bencher;
 
 mod helpers;
 
-fn bench_full_pipeline_5000(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_synthetic_project("5000", 5000);
+fn main() {
+    divan::main();
+}
 
-    c.bench_function("full_pipeline_5000_files", |b| {
-        b.iter(|| {
-            let _ = fallow_core::analyze(&config);
+struct ConfigInput {
+    temp_dir: std::path::PathBuf,
+    config: fallow_config::ResolvedConfig,
+}
+
+impl Drop for ConfigInput {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.temp_dir);
+    }
+}
+
+struct DupesInput {
+    temp_dir: std::path::PathBuf,
+    root: std::path::PathBuf,
+    files: Vec<fallow_core::discover::DiscoveredFile>,
+    config: fallow_config::DuplicatesConfig,
+}
+
+impl Drop for DupesInput {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.temp_dir);
+    }
+}
+
+fn create_config_input(name: &str, file_count: usize, no_cache: bool) -> ConfigInput {
+    let (temp_dir, config) =
+        helpers::create_synthetic_project_with_cache(name, file_count, no_cache);
+    ConfigInput { temp_dir, config }
+}
+
+fn create_warm_config_input(name: &str, file_count: usize) -> ConfigInput {
+    let input = create_config_input(name, file_count, false);
+    let _ = fallow_core::analyze(&input.config);
+    input
+}
+
+fn create_dupes_input(name: &str, file_count: usize) -> DupesInput {
+    let (temp_dir, resolved_config) = helpers::create_dupe_project(name, file_count);
+    let files = fallow_core::discover::discover_files(&resolved_config);
+    DupesInput {
+        temp_dir,
+        root: resolved_config.root,
+        files,
+        config: fallow_config::DuplicatesConfig::default(),
+    }
+}
+
+#[divan::bench]
+fn full_pipeline_5000_files(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_config_input("5000", 5000, true))
+        .bench_refs(|input| fallow_core::analyze(&input.config));
+}
+
+#[divan::bench]
+fn full_pipeline_1000_files_warm_cache(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_warm_config_input("1000-warm", 1000))
+        .bench_refs(|input| fallow_core::analyze(&input.config));
+}
+
+#[divan::bench]
+fn full_pipeline_5000_files_warm_cache(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_warm_config_input("5000-warm", 5000))
+        .bench_refs(|input| fallow_core::analyze(&input.config));
+}
+
+#[divan::bench]
+fn dupes_full_pipeline_1000_files(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_dupes_input("1000", 1000))
+        .bench_refs(|input| {
+            fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
         });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
 }
 
-fn bench_full_pipeline_1000_warm(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_synthetic_project_with_cache("1000-warm", 1000, false);
-
-    let _ = fallow_core::analyze(&config);
-
-    c.bench_function("full_pipeline_1000_files_warm_cache", |b| {
-        b.iter(|| {
-            let _ = fallow_core::analyze(&config);
+#[divan::bench]
+fn dupes_full_pipeline_5000_files(bencher: Bencher) {
+    bencher
+        .with_inputs(|| create_dupes_input("5000", 5000))
+        .bench_refs(|input| {
+            fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
         });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
 }
-
-fn bench_full_pipeline_5000_warm(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_synthetic_project_with_cache("5000-warm", 5000, false);
-
-    let _ = fallow_core::analyze(&config);
-
-    c.bench_function("full_pipeline_5000_files_warm_cache", |b| {
-        b.iter(|| {
-            let _ = fallow_core::analyze(&config);
-        });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
-}
-
-fn bench_dupes_full_1000(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_dupe_project("1000", 1000);
-    let files = fallow_core::discover::discover_files(&config);
-    let dupes_config = fallow_config::DuplicatesConfig::default();
-
-    c.bench_function("dupes_full_pipeline_1000_files", |b| {
-        b.iter(|| {
-            fallow_core::duplicates::find_duplicates(&config.root, &files, &dupes_config);
-        });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
-}
-
-fn bench_dupes_full_5000(c: &mut Criterion) {
-    let (temp_dir, config) = helpers::create_dupe_project("5000", 5000);
-    let files = fallow_core::discover::discover_files(&config);
-    let dupes_config = fallow_config::DuplicatesConfig::default();
-
-    c.bench_function("dupes_full_pipeline_5000_files", |b| {
-        b.iter(|| {
-            fallow_core::duplicates::find_duplicates(&config.root, &files, &dupes_config);
-        });
-    });
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
-}
-
-criterion_group! {
-    name = large_scale_benches;
-    config = Criterion::default()
-        .sample_size(10)
-        .measurement_time(Duration::from_mins(1))
-        .warm_up_time(Duration::from_secs(5));
-    targets =
-        bench_full_pipeline_5000,
-        bench_full_pipeline_1000_warm,
-        bench_full_pipeline_5000_warm,
-        bench_dupes_full_1000,
-        bench_dupes_full_5000,
-}
-
-criterion_main!(large_scale_benches);


### PR DESCRIPTION
## Summary
- Replaces the current Criterion benchmark-action flow with CodSpeed for the `fallow-core` analysis benchmark.
- Switches the Rust benchmark harnesses from Criterion to Divan through `codspeed-divan-compat`.
- Uses tokenless CodSpeed upload for this public repository by omitting job-level OIDC permissions.
- Uses `taiki-e/install-action` to install `cargo-codspeed`, matching the CodSpeed bot PR setup style.
- Adds the CodSpeed badge to the README.
- Keeps the shared GitHub Pages benchmark helper for the other metric workflows that still use it.

## Plan
- Local plan: `.plans/codspeed-integration.md`

## Verification
- [x] `cargo bench -p fallow-core --bench analysis --no-run`
- [x] `cargo bench -p fallow-core --bench large_analysis --no-run`
- [x] `cargo codspeed build -p fallow-core --bench analysis`
- [x] `cargo codspeed run -p fallow-core --bench analysis`
- [x] `cargo check --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p fallow-core --bench analysis --bench large_analysis -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo deny check`
- [x] `actionlint .github/workflows/bench.yml`
- [x] `git diff --check`

## Note
- Compared with CodSpeed bot PR #1295. This PR keeps the requested Divan migration and replacement of the existing benchmark workflow, while folding in the useful badge and installer-action pieces from #1295.
