### PR TITLE
test: improve coverage across CLI output helpers

### DIFF
--- a/crates/cli/src/audit_output.rs
+++ b/crates/cli/src/audit_output.rs
@@ -581,11 +581,47 @@ fn build_audit_codeclimate(result: &AuditResult) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use crate::audit::AuditSummary;
+    use std::process::ExitCode;
+    use std::time::Duration;
+
+    use fallow_config::{AuditGate, OutputFormat};
+
+    use crate::audit::{AuditAttribution, AuditResult, AuditSummary, AuditVerdict};
 
     use super::{
-        build_status_parts, build_vital_sign_parts, format_scope_line_parts, short_base_ref,
+        build_audit_codeclimate, build_status_parts, build_vital_sign_parts,
+        format_scope_line_parts, print_audit_result, short_base_ref,
     };
+
+    fn audit_result(verdict: AuditVerdict, output: OutputFormat) -> AuditResult {
+        AuditResult {
+            verdict,
+            summary: AuditSummary {
+                dead_code_issues: 0,
+                dead_code_has_errors: false,
+                complexity_findings: 0,
+                max_cyclomatic: None,
+                duplication_clone_groups: 0,
+            },
+            attribution: AuditAttribution {
+                gate: AuditGate::NewOnly,
+                ..AuditAttribution::default()
+            },
+            base_snapshot: None,
+            base_snapshot_skipped: false,
+            changed_files_count: 0,
+            changed_files: Vec::new(),
+            base_ref: "origin/main".to_string(),
+            base_description: None,
+            head_sha: None,
+            output,
+            performance: false,
+            check: None,
+            dupes: None,
+            health: None,
+            elapsed: Duration::ZERO,
+        }
+    }
 
     #[test]
     fn short_base_ref_abbreviates_full_sha() {
@@ -693,5 +729,26 @@ mod tests {
                 "duplication 0".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn build_audit_codeclimate_returns_empty_issue_list_without_findings() {
+        let result = audit_result(AuditVerdict::Pass, OutputFormat::CodeClimate);
+
+        assert_eq!(build_audit_codeclimate(&result), serde_json::json!([]));
+    }
+
+    #[test]
+    fn print_audit_result_rejects_badge_format() {
+        let result = audit_result(AuditVerdict::Pass, OutputFormat::Badge);
+
+        assert_eq!(print_audit_result(&result, true, false), ExitCode::from(2));
+    }
+
+    #[test]
+    fn print_audit_result_maps_fail_verdict_to_error_exit() {
+        let result = audit_result(AuditVerdict::Fail, OutputFormat::Human);
+
+        assert_eq!(print_audit_result(&result, true, false), ExitCode::from(1));
     }
 }

--- a/crates/cli/src/cache_notice.rs
+++ b/crates/cli/src/cache_notice.rs
@@ -131,6 +131,12 @@ fn env_truthy(name: &str) -> bool {
 mod tests {
     use super::*;
 
+    static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn clear_candidate() {
+        *CACHE_NOTICE.lock().expect("cache notice lock") = None;
+    }
+
     #[test]
     fn notice_requires_human_non_quiet_tty_and_enabled_env() {
         let active = CacheNoticeContext {
@@ -175,5 +181,66 @@ mod tests {
             display_cache_dir(root, Path::new("/tmp/fallow-cache")),
             "/tmp/fallow-cache/"
         );
+    }
+
+    #[test]
+    fn maybe_print_created_notice_returns_false_without_candidate() {
+        let _guard = TEST_LOCK.lock().expect("test lock");
+        clear_candidate();
+
+        assert!(!maybe_print_created_notice());
+    }
+
+    #[test]
+    fn maybe_print_created_notice_returns_false_for_existing_cache() {
+        let _guard = TEST_LOCK.lock().expect("test lock");
+        clear_candidate();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache_dir = dir.path().join(".fallow");
+        std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+        *CACHE_NOTICE.lock().expect("cache notice lock") = Some(CacheNoticeCandidate {
+            root: dir.path().to_path_buf(),
+            cache_dir,
+            existed_before: true,
+        });
+
+        assert!(!maybe_print_created_notice());
+        clear_candidate();
+    }
+
+    #[test]
+    fn maybe_print_created_notice_returns_false_when_cache_was_not_created() {
+        let _guard = TEST_LOCK.lock().expect("test lock");
+        clear_candidate();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        *CACHE_NOTICE.lock().expect("cache notice lock") = Some(CacheNoticeCandidate {
+            root: dir.path().to_path_buf(),
+            cache_dir: dir.path().join(".fallow"),
+            existed_before: false,
+        });
+
+        assert!(!maybe_print_created_notice());
+        clear_candidate();
+    }
+
+    #[test]
+    fn maybe_print_created_notice_reports_new_cache_once() {
+        let _guard = TEST_LOCK.lock().expect("test lock");
+        clear_candidate();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache_dir = dir.path().join(".fallow");
+        std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+        *CACHE_NOTICE.lock().expect("cache notice lock") = Some(CacheNoticeCandidate {
+            root: dir.path().to_path_buf(),
+            cache_dir,
+            existed_before: false,
+        });
+
+        assert!(maybe_print_created_notice());
+        assert!(!maybe_print_created_notice());
+        clear_candidate();
     }
 }

--- a/crates/cli/src/combined/output.rs
+++ b/crates/cli/src/combined/output.rs
@@ -772,3 +772,88 @@ fn build_combined_codeclimate_issues(
 pub(super) fn exit_code_to_u8(code: ExitCode) -> u8 {
     u8::from(code != ExitCode::SUCCESS)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::process::ExitCode;
+    use std::time::Duration;
+
+    use super::{
+        build_combined_codeclimate, combined_json_root, combined_machine_success,
+        emit_combined_json_output, exit_code_to_u8, insert_combined_dupes_json,
+        insert_combined_health_json, print_combined_codeclimate, print_combined_sarif,
+    };
+
+    #[test]
+    fn combined_machine_success_maps_success_to_zero_exit() {
+        assert_eq!(combined_machine_success(ExitCode::SUCCESS), Ok(Some(0)));
+    }
+
+    #[test]
+    fn combined_machine_success_preserves_output_error() {
+        let code = ExitCode::from(2);
+
+        assert_eq!(combined_machine_success(code), Err(code));
+    }
+
+    #[test]
+    fn exit_code_to_u8_collapses_non_success_codes() {
+        assert_eq!(exit_code_to_u8(ExitCode::SUCCESS), 0);
+        assert_eq!(exit_code_to_u8(ExitCode::from(1)), 1);
+        assert_eq!(exit_code_to_u8(ExitCode::from(2)), 1);
+    }
+
+    #[test]
+    fn combined_json_root_contains_stable_envelope_fields() {
+        let root = combined_json_root(Duration::from_millis(42)).expect("combined JSON root");
+
+        assert_eq!(
+            root.get("kind").and_then(serde_json::Value::as_str),
+            Some("combined")
+        );
+        assert_eq!(
+            root.get("elapsed_ms").and_then(serde_json::Value::as_u64),
+            Some(42)
+        );
+        assert!(root.get("schema_version").is_some());
+        assert!(root.get("version").is_some());
+    }
+
+    #[test]
+    fn empty_combined_codeclimate_output_is_an_empty_issue_list() {
+        assert_eq!(
+            build_combined_codeclimate(None, None, None),
+            serde_json::json!([])
+        );
+    }
+
+    #[test]
+    fn empty_combined_machine_printers_succeed() {
+        assert_eq!(print_combined_sarif(None, None, None), ExitCode::SUCCESS);
+        assert_eq!(
+            print_combined_codeclimate(None, None, None),
+            ExitCode::SUCCESS
+        );
+    }
+
+    #[test]
+    fn insert_empty_optional_sections_leaves_combined_map_unchanged() {
+        let mut combined = serde_json::Map::new();
+        insert_combined_dupes_json(&mut combined, None, std::path::Path::new("."))
+            .expect("empty dupes section should serialize");
+        insert_combined_health_json(&mut combined, None, ".")
+            .expect("empty health section should serialize");
+
+        assert!(combined.is_empty());
+    }
+
+    #[test]
+    fn emit_combined_json_output_can_attach_empty_meta() {
+        let combined = combined_json_root(Duration::ZERO).expect("combined JSON root");
+
+        assert_eq!(
+            emit_combined_json_output(combined, None, None, None, true),
+            ExitCode::SUCCESS
+        );
+    }
+}

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -3302,6 +3302,62 @@ mod tests {
     }
 
     #[test]
+    fn truncation_hint_suggests_scoping_for_large_sections_or_totals() {
+        assert!(truncation_hint(10, 10).contains("--format json"));
+        assert!(truncation_hint(SCOPING_HINT_THRESHOLD + 1, 10).contains("--workspace"));
+        assert!(truncation_hint(10, SCOPING_HINT_THRESHOLD + 1).contains("--changed-since"));
+    }
+
+    #[test]
+    fn insert_test_src_split_only_reports_meaningful_mixed_sections() {
+        let src_a = PathBuf::from("src/a.ts");
+        let src_b = PathBuf::from("src/b.ts");
+        let src_c = PathBuf::from("src/c.ts");
+        let src_d = PathBuf::from("src/d.ts");
+        let test_a = PathBuf::from("tests/a.test.ts");
+        let test_b = PathBuf::from("tests/b.test.ts");
+        let fixture = PathBuf::from("__fixtures__/sample.ts");
+
+        let mut small = vec!["section".to_string(), String::new()];
+        insert_test_src_split(
+            &mut small,
+            &[src_a.clone(), test_a.clone()],
+            PathBuf::as_path,
+        );
+        assert_eq!(small, vec!["section".to_string(), String::new()]);
+
+        let mut mostly_src = vec!["section".to_string(), String::new()];
+        insert_test_src_split(
+            &mut mostly_src,
+            &[src_a.clone(), src_b.clone(), src_c, src_d, test_a.clone()],
+            PathBuf::as_path,
+        );
+        assert_eq!(mostly_src, vec!["section".to_string(), String::new()]);
+
+        let mut all_tests = vec!["section".to_string(), String::new()];
+        insert_test_src_split(
+            &mut all_tests,
+            &[
+                test_a.clone(),
+                test_b.clone(),
+                fixture.clone(),
+                test_a.clone(),
+                test_b.clone(),
+            ],
+            PathBuf::as_path,
+        );
+        assert_eq!(all_tests, vec!["section".to_string(), String::new()]);
+
+        let mut mixed = vec!["section".to_string()];
+        insert_test_src_split(
+            &mut mixed,
+            &[src_a, src_b, test_a, test_b, fixture],
+            PathBuf::as_path,
+        );
+        assert!(plain(&mixed).contains("2 in src, 3 in test directories"));
+    }
+
+    #[test]
     fn collect_matching_rules_routes_mixed_client_server_barrels() {
         // A file whose ONLY finding is a mixed-client-server-barrel must still
         // surface its CODEOWNERS rule in the `--group-by owner` "matched by"


### PR DESCRIPTION
Adds focused coverage for CLI audit output, combined output helpers, cache notice lifecycle, and human report helper behavior.

The branch keeps production code unchanged and stops the coverage loop once the remaining gains became marginal.