### PR TITLE
refactor: reduce SIG unit interfacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,10 +645,8 @@ jobs:
       - name: fallow-graph
         run: cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-graph --lib --tests -- --skip proptests
 
-      # Only suppress, css, and visitor/helpers run under Miri (pure data logic).
-      # Parser-heavy modules (visitor::tests, sfc_template, html, template_usage,
-      # sfc_css, template_complexity) have no unsafe code and are too slow under
-      # Miri interpretation.
+      # Only suppress, CSS helpers, and visitor helpers run under Miri (pure data logic).
+      # Parser-heavy modules have no unsafe code and are too slow under Miri interpretation.
       #
       # Tree Borrows for this crate only: the css analytics path parses via
       # lightningcss (alpha), whose @layer string handling reconstructs a &str
@@ -659,13 +657,12 @@ jobs:
       - name: fallow-extract
         env:
           MIRIFLAGS: -Zmiri-tree-borrows
-        # `react` skips the React JSX extraction tests (react_structural + the
-        # complexity React-fold tests): pure-safe AST/parse tests with no unsafe
-        # for Miri to check, so a low-value speed-skip, same rationale as the
-        # visitor::tests / sfc_template / html entries above. `sfc_css` and
-        # `template_complexity` are also parser-heavy and exceeded the
-        # 60-minute CI budget under Miri.
-        run: cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-extract --lib --tests -- --skip cache --skip visitor::tests --skip sfc_template --skip html --skip template_usage --skip react --skip sfc_css --skip template_complexity
+        run: |
+          cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-extract --lib --tests css:: -- --skip sfc_css::
+          cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-extract --lib --tests css_classes::
+          cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-extract --lib --tests css_metrics::
+          cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-extract --lib --tests suppress::
+          cargo +"$MIRI_TOOLCHAIN" miri test -p fallow-extract --lib --tests visitor::helpers::
 
   ci-ok:
     name: CI

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -827,15 +827,15 @@ fn apply_gitlab_reconcile(
     }
 
     for (index, operation) in operations.iter().enumerate() {
-        if let Err(failure) = apply_gitlab_operation(
+        if let Err(failure) = apply_gitlab_operation(GitlabOperationInput {
             operation,
-            &agent,
-            &encoded_project,
+            agent: &agent,
+            encoded_project: &encoded_project,
             mr,
-            &token,
-            &api,
-            &mut result,
-        ) {
+            token: &token,
+            api: &api,
+            result: &mut result,
+        }) {
             result.record_failure(
                 failure,
                 operations[index..]
@@ -948,16 +948,18 @@ fn preflight_gitlab_operations(
     Ok(())
 }
 
-fn apply_gitlab_operation(
-    operation: &GitlabApplyOperation,
-    agent: &ureq::Agent,
-    encoded_project: &str,
-    mr: &str,
-    token: &str,
-    api: &str,
-    result: &mut ApplyResult,
-) -> Result<(), ApplyFailure> {
-    match operation {
+struct GitlabOperationInput<'a> {
+    operation: &'a GitlabApplyOperation,
+    agent: &'a ureq::Agent,
+    encoded_project: &'a str,
+    mr: &'a str,
+    token: &'a str,
+    api: &'a str,
+    result: &'a mut ApplyResult,
+}
+
+fn apply_gitlab_operation(input: GitlabOperationInput<'_>) -> Result<(), ApplyFailure> {
+    match input.operation {
         GitlabApplyOperation::Note {
             fingerprint,
             discussion_id,
@@ -965,15 +967,16 @@ fn apply_gitlab_operation(
         } => {
             let payload = serde_json::json!({ "body": body });
             let url = format!(
-                "{api}/projects/{encoded_project}/merge_requests/{mr}/discussions/{discussion_id}/notes"
+                "{}/projects/{}/merge_requests/{}/discussions/{discussion_id}/notes",
+                input.api, input.encoded_project, input.mr
             );
-            gitlab_post_json(agent, &url, token, &payload).map_err(|err| {
+            gitlab_post_json(input.agent, &url, input.token, &payload).map_err(|err| {
                 ApplyFailure::new(
                     fingerprint.clone(),
                     format!("GitLab failed to post resolution note for {fingerprint}: {err}"),
                 )
             })?;
-            result.resolution_comments_posted += 1;
+            input.result.resolution_comments_posted += 1;
         }
         GitlabApplyOperation::ResolveDiscussion {
             fingerprint,
@@ -981,15 +984,16 @@ fn apply_gitlab_operation(
         } => {
             let payload = serde_json::json!({ "resolved": true });
             let url = format!(
-                "{api}/projects/{encoded_project}/merge_requests/{mr}/discussions/{discussion_id}"
+                "{}/projects/{}/merge_requests/{}/discussions/{discussion_id}",
+                input.api, input.encoded_project, input.mr
             );
-            gitlab_put_json(agent, &url, token, &payload).map_err(|err| {
+            gitlab_put_json(input.agent, &url, input.token, &payload).map_err(|err| {
                 ApplyFailure::new(
                     fingerprint.clone(),
                     format!("GitLab failed to resolve discussion {discussion_id}: {err}"),
                 )
             })?;
-            result.threads_resolved += 1;
+            input.result.threads_resolved += 1;
         }
     }
     Ok(())

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -498,7 +498,7 @@ fn apply_github_reconcile(
     }
 
     for (index, operation) in operations.iter().enumerate() {
-        if let Err(failure) = apply_github_operation(GithubOperationInput {
+        if let Err(failure) = apply_github_operation(&mut GithubOperationInput {
             operation,
             agent: &agent,
             repo: &repo,
@@ -661,7 +661,7 @@ struct GithubOperationInput<'a> {
     result: &'a mut ApplyResult,
 }
 
-fn apply_github_operation(input: GithubOperationInput<'_>) -> Result<(), ApplyFailure> {
+fn apply_github_operation(input: &mut GithubOperationInput<'_>) -> Result<(), ApplyFailure> {
     match input.operation {
         GithubApplyOperation::Reply {
             fingerprint,
@@ -827,7 +827,7 @@ fn apply_gitlab_reconcile(
     }
 
     for (index, operation) in operations.iter().enumerate() {
-        if let Err(failure) = apply_gitlab_operation(GitlabOperationInput {
+        if let Err(failure) = apply_gitlab_operation(&mut GitlabOperationInput {
             operation,
             agent: &agent,
             encoded_project: &encoded_project,
@@ -958,7 +958,7 @@ struct GitlabOperationInput<'a> {
     result: &'a mut ApplyResult,
 }
 
-fn apply_gitlab_operation(input: GitlabOperationInput<'_>) -> Result<(), ApplyFailure> {
+fn apply_gitlab_operation(input: &mut GitlabOperationInput<'_>) -> Result<(), ApplyFailure> {
     match input.operation {
         GitlabApplyOperation::Note {
             fingerprint,

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -498,9 +498,15 @@ fn apply_github_reconcile(
     }
 
     for (index, operation) in operations.iter().enumerate() {
-        if let Err(failure) =
-            apply_github_operation(operation, &agent, &repo, pr, &token, api, &mut result)
-        {
+        if let Err(failure) = apply_github_operation(GithubOperationInput {
+            operation,
+            agent: &agent,
+            repo: &repo,
+            pr,
+            token: &token,
+            api,
+            result: &mut result,
+        }) {
             result.record_failure(
                 failure,
                 operations[index..]
@@ -645,30 +651,35 @@ fn preflight_github_operations(
     Ok(())
 }
 
-fn apply_github_operation(
-    operation: &GithubApplyOperation,
-    agent: &ureq::Agent,
-    repo: &str,
-    pr: &str,
-    token: &str,
-    api: &str,
-    result: &mut ApplyResult,
-) -> Result<(), ApplyFailure> {
-    match operation {
+struct GithubOperationInput<'a> {
+    operation: &'a GithubApplyOperation,
+    agent: &'a ureq::Agent,
+    repo: &'a str,
+    pr: &'a str,
+    token: &'a str,
+    api: &'a str,
+    result: &'a mut ApplyResult,
+}
+
+fn apply_github_operation(input: GithubOperationInput<'_>) -> Result<(), ApplyFailure> {
+    match input.operation {
         GithubApplyOperation::Reply {
             fingerprint,
             comment_id,
             body,
         } => {
             let payload = serde_json::json!({ "body": body });
-            let url = format!("{api}/repos/{repo}/pulls/{pr}/comments/{comment_id}/replies");
-            github_post_json(agent, &url, token, &payload).map_err(|err| {
+            let url = format!(
+                "{}/repos/{}/pulls/{}/comments/{comment_id}/replies",
+                input.api, input.repo, input.pr
+            );
+            github_post_json(input.agent, &url, input.token, &payload).map_err(|err| {
                 ApplyFailure::new(
                     fingerprint.clone(),
                     format!("GitHub failed to post resolution reply for {fingerprint}: {err}"),
                 )
             })?;
-            result.resolution_comments_posted += 1;
+            input.result.resolution_comments_posted += 1;
         }
         GithubApplyOperation::ResolveThread {
             fingerprint,
@@ -678,20 +689,25 @@ fn apply_github_operation(
                 "query": "mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}",
                 "variables": { "threadId": thread_id },
             });
-            let value = github_post_json(agent, &format!("{api}/graphql"), token, &payload)
-                .map_err(|err| {
-                    ApplyFailure::new(
-                        fingerprint.clone(),
-                        format!("GitHub failed to resolve review thread {thread_id}: {err}"),
-                    )
-                })?;
+            let value = github_post_json(
+                input.agent,
+                &format!("{}/graphql", input.api),
+                input.token,
+                &payload,
+            )
+            .map_err(|err| {
+                ApplyFailure::new(
+                    fingerprint.clone(),
+                    format!("GitHub failed to resolve review thread {thread_id}: {err}"),
+                )
+            })?;
             if value.get("errors").is_some() {
                 return Err(ApplyFailure::new(
                     fingerprint.clone(),
                     format!("GitHub resolveReviewThread failed for {fingerprint}: {value}"),
                 ));
             }
-            result.threads_resolved += 1;
+            input.result.threads_resolved += 1;
         }
     }
     Ok(())

--- a/crates/cli/src/combined/output.rs
+++ b/crates/cli/src/combined/output.rs
@@ -408,6 +408,7 @@ fn print_failure_summary(
 }
 
 /// Print combined JSON output wrapping check, dupes, and health results.
+#[derive(Clone, Copy)]
 struct CombinedJsonPrintInput<'a> {
     check_result: Option<&'a CheckResult>,
     dupes_result: Option<&'a DupesResult>,

--- a/crates/cli/src/combined/output.rs
+++ b/crates/cli/src/combined/output.rs
@@ -60,16 +60,16 @@ fn print_machine_combined_report(
 ) -> Result<Option<u8>, ExitCode> {
     match opts.output {
         OutputFormat::Json => {
-            let code = print_combined_json(
+            let code = print_combined_json(CombinedJsonPrintInput {
                 check_result,
                 dupes_result,
                 health_result,
-                opts.root,
-                total_elapsed,
-                opts.explain,
-                opts.config_path.is_some()
+                root: opts.root,
+                elapsed: total_elapsed,
+                explain: opts.explain,
+                config_fixable: opts.config_path.is_some()
                     || fallow_config::FallowConfig::find_config_path(opts.root).is_some(),
-            );
+            });
             combined_machine_success(code)
         }
         OutputFormat::Sarif => {
@@ -408,42 +408,57 @@ fn print_failure_summary(
 }
 
 /// Print combined JSON output wrapping check, dupes, and health results.
-fn print_combined_json(
-    check: Option<&CheckResult>,
-    dupes: Option<&DupesResult>,
-    health: Option<&HealthResult>,
-    root: &std::path::Path,
+struct CombinedJsonPrintInput<'a> {
+    check_result: Option<&'a CheckResult>,
+    dupes_result: Option<&'a DupesResult>,
+    health_result: Option<&'a HealthResult>,
+    root: &'a std::path::Path,
     elapsed: std::time::Duration,
     explain: bool,
     config_fixable: bool,
-) -> ExitCode {
-    let mut combined = match combined_json_root(elapsed) {
+}
+
+fn print_combined_json(input: CombinedJsonPrintInput<'_>) -> ExitCode {
+    let mut combined = match combined_json_root(input.elapsed) {
         Ok(combined) => combined,
         Err(code) => return code,
     };
-    let root_prefix = format!("{}/", root.display());
+    let root_prefix = format!("{}/", input.root.display());
 
-    if let Some(result) = check
-        && let Err(code) = insert_combined_check_json(&mut combined, result, config_fixable)
+    if let Some(result) = input.check_result
+        && let Err(code) = insert_combined_check_json(&mut combined, result, input.config_fixable)
     {
         return code;
     }
 
-    let dupes_payload =
-        dupes.map(|result| crate::output_dupes::DupesReportPayload::from_report(&result.report));
-    if let Err(code) = insert_combined_dupes_json(&mut combined, dupes_payload.as_ref(), root) {
-        return code;
-    }
-    if let Err(code) = insert_combined_health_json(&mut combined, health, &root_prefix) {
-        return code;
-    }
-    if let Err(code) =
-        insert_combined_next_steps(&mut combined, check, dupes_payload.as_ref(), health, root)
+    let dupes_payload = input
+        .dupes_result
+        .map(|result| crate::output_dupes::DupesReportPayload::from_report(&result.report));
+    if let Err(code) = insert_combined_dupes_json(&mut combined, dupes_payload.as_ref(), input.root)
     {
         return code;
     }
+    if let Err(code) = insert_combined_health_json(&mut combined, input.health_result, &root_prefix)
+    {
+        return code;
+    }
+    if let Err(code) = insert_combined_next_steps(
+        &mut combined,
+        input.check_result,
+        dupes_payload.as_ref(),
+        input.health_result,
+        input.root,
+    ) {
+        return code;
+    }
 
-    emit_combined_json_output(combined, check, dupes, health, explain)
+    emit_combined_json_output(
+        combined,
+        input.check_result,
+        input.dupes_result,
+        input.health_result,
+        input.explain,
+    )
 }
 
 #[expect(

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -643,15 +643,15 @@ pub fn run_dupes(opts: &DupesOptions<'_>) -> ExitCode {
         Ok(r) => r,
         Err(code) => return code,
     };
-    print_dupes_result_with_grouping(
-        &result,
-        opts.quiet,
-        opts.explain,
-        resolver,
-        opts.summary,
-        true,
-        true,
-    )
+    print_dupes_result_with_grouping(DupesResultGroupingInput {
+        result: &result,
+        quiet: opts.quiet,
+        explain: opts.explain,
+        group_by: resolver,
+        summary: opts.summary,
+        summary_heading: true,
+        show_explain_tip: true,
+    })
 }
 
 /// Emit a stderr timing panel for `fallow dupes --performance`. Stays out of
@@ -710,33 +710,36 @@ fn print_dupes_performance(result: &DupesResult, output: OutputFormat) {
     }
 }
 
-fn print_dupes_result_with_grouping(
-    result: &DupesResult,
+struct DupesResultGroupingInput<'a> {
+    result: &'a DupesResult,
     quiet: bool,
     explain: bool,
     group_by: Option<report::OwnershipResolver>,
     summary: bool,
     summary_heading: bool,
     show_explain_tip: bool,
-) -> ExitCode {
+}
+
+fn print_dupes_result_with_grouping(input: DupesResultGroupingInput<'_>) -> ExitCode {
+    let result = input.result;
     let ctx = report::ReportContext {
         root: &result.config.root,
         rules: &result.config.rules,
         elapsed: result.elapsed,
-        quiet,
-        explain,
-        group_by,
+        quiet: input.quiet,
+        explain: input.explain,
+        group_by: input.group_by,
         top: None,
-        summary,
-        summary_heading,
-        show_explain_tip,
+        summary: input.summary,
+        summary_heading: input.summary_heading,
+        show_explain_tip: input.show_explain_tip,
         baseline_matched: None,
         config_fixable: false,
         skip_score_and_trend: false,
     };
-    print_default_ignore_note(result, quiet);
-    print_min_occurrences_note(result, quiet);
-    print_ignore_imports_note(result, quiet);
+    print_default_ignore_note(result, input.quiet);
+    print_min_occurrences_note(result, input.quiet);
+    print_ignore_imports_note(result, input.quiet);
     report::print_duplication_report(&result.report, &ctx, result.config.output)
 }
 

--- a/crates/cli/src/fix/catalog.rs
+++ b/crates/cli/src/fix/catalog.rs
@@ -87,15 +87,15 @@ pub(super) fn apply_catalog_entry_fixes(
 
         let lines: Vec<&str> = content.split(meta.line_ending).collect();
 
-        let to_remove = collect_catalog_entry_removals(
-            &file_entries,
-            &lines,
+        let to_remove = collect_catalog_entry_removals(CatalogEntryRemovalInput {
+            file_entries: &file_entries,
+            lines: &lines,
             preceding_comment_policy,
-            &mut summary,
+            summary: &mut summary,
             fixes,
             output,
             relative_path,
-        );
+        });
 
         if to_remove.is_empty() {
             continue;
@@ -151,29 +151,46 @@ pub(super) fn apply_catalog_entry_fixes(
     summary
 }
 
-fn collect_catalog_entry_removals<'a>(
-    file_entries: &[&'a UnusedCatalogEntry],
-    lines: &[&str],
+struct CatalogEntryRemovalInput<'a, 'b> {
+    file_entries: &'b [&'a UnusedCatalogEntry],
+    lines: &'b [&'b str],
     preceding_comment_policy: CatalogPrecedingCommentPolicy,
-    summary: &mut CatalogFixSummary,
-    fixes: &mut Vec<serde_json::Value>,
+    summary: &'b mut CatalogFixSummary,
+    fixes: &'b mut Vec<serde_json::Value>,
     output: OutputFormat,
-    relative_path: &Path,
+    relative_path: &'b Path,
+}
+
+fn collect_catalog_entry_removals<'a>(
+    input: CatalogEntryRemovalInput<'a, '_>,
 ) -> Vec<CatalogRemoval<'a>> {
     let mut to_remove = Vec::new();
-    for entry in file_entries {
+    for entry in input.file_entries {
         if !entry.hardcoded_consumers.is_empty() {
-            skip_hardcoded_catalog_consumers(entry, summary, fixes, output, relative_path);
+            skip_hardcoded_catalog_consumers(
+                entry,
+                input.summary,
+                input.fixes,
+                input.output,
+                input.relative_path,
+            );
             continue;
         }
 
         let line_idx = entry.line.saturating_sub(1) as usize;
-        if line_idx >= lines.len() {
-            skip_out_of_range_catalog_entry(entry, summary, fixes, output, relative_path);
+        if line_idx >= input.lines.len() {
+            skip_out_of_range_catalog_entry(
+                entry,
+                input.summary,
+                input.fixes,
+                input.output,
+                input.relative_path,
+            );
             continue;
         }
 
-        let range = compute_deletion_range(lines, line_idx, entry, preceding_comment_policy);
+        let range =
+            compute_deletion_range(input.lines, line_idx, entry, input.preceding_comment_policy);
         to_remove.push((range, *entry));
     }
     to_remove

--- a/crates/cli/src/fix/catalog.rs
+++ b/crates/cli/src/fix/catalog.rs
@@ -87,7 +87,7 @@ pub(super) fn apply_catalog_entry_fixes(
 
         let lines: Vec<&str> = content.split(meta.line_ending).collect();
 
-        let to_remove = collect_catalog_entry_removals(CatalogEntryRemovalInput {
+        let to_remove = collect_catalog_entry_removals(&mut CatalogEntryRemovalInput {
             file_entries: &file_entries,
             lines: &lines,
             preceding_comment_policy,
@@ -162,7 +162,7 @@ struct CatalogEntryRemovalInput<'a, 'b> {
 }
 
 fn collect_catalog_entry_removals<'a>(
-    input: CatalogEntryRemovalInput<'a, '_>,
+    input: &mut CatalogEntryRemovalInput<'a, '_>,
 ) -> Vec<CatalogRemoval<'a>> {
     let mut to_remove = Vec::new();
     for entry in input.file_entries {

--- a/crates/cli/src/fix/deps.rs
+++ b/crates/cli/src/fix/deps.rs
@@ -20,7 +20,7 @@ pub(super) struct DependencyFixInput<'a> {
     pub(super) fixes: &'a mut Vec<serde_json::Value>,
 }
 
-pub(super) fn apply_dependency_fixes(input: DependencyFixInput<'_>) {
+pub(super) fn apply_dependency_fixes(input: &mut DependencyFixInput<'_>) {
     let _ = input.hashes; // see doc above
 
     if input.results.unused_dependencies.is_empty()
@@ -133,7 +133,7 @@ mod tests {
     ) -> bool {
         let mut plan = FixPlan::new();
         let hashes = CapturedHashes::default();
-        apply_dependency_fixes(DependencyFixInput {
+        apply_dependency_fixes(&mut DependencyFixInput {
             root,
             results,
             hashes: &hashes,

--- a/crates/cli/src/fix/deps.rs
+++ b/crates/cli/src/fix/deps.rs
@@ -10,36 +10,38 @@ use super::plan::{CapturedHashes, FixPlan};
 ///
 /// `hashes` is accepted for signature uniformity; `package.json` files are
 /// re-read and reparsed here, so the hash check is a no-op.
-pub(super) fn apply_dependency_fixes(
-    root: &Path,
-    results: &fallow_core::results::AnalysisResults,
-    hashes: &CapturedHashes,
-    plan: &mut FixPlan,
-    output: OutputFormat,
-    dry_run: bool,
-    fixes: &mut Vec<serde_json::Value>,
-) {
-    let _ = hashes; // see doc above
+pub(super) struct DependencyFixInput<'a> {
+    pub(super) root: &'a Path,
+    pub(super) results: &'a fallow_core::results::AnalysisResults,
+    pub(super) hashes: &'a CapturedHashes,
+    pub(super) plan: &'a mut FixPlan,
+    pub(super) output: OutputFormat,
+    pub(super) dry_run: bool,
+    pub(super) fixes: &'a mut Vec<serde_json::Value>,
+}
 
-    if results.unused_dependencies.is_empty()
-        && results.unused_dev_dependencies.is_empty()
-        && results.unused_optional_dependencies.is_empty()
+pub(super) fn apply_dependency_fixes(input: DependencyFixInput<'_>) {
+    let _ = input.hashes; // see doc above
+
+    if input.results.unused_dependencies.is_empty()
+        && input.results.unused_dev_dependencies.is_empty()
+        && input.results.unused_optional_dependencies.is_empty()
     {
         return;
     }
 
     let mut deps_by_pkg: FxHashMap<&Path, Vec<(&str, &str)>> = FxHashMap::default();
-    for dep in &results.unused_dependencies {
+    for dep in &input.results.unused_dependencies {
         queue_dependency_removal(&mut deps_by_pkg, &dep.dep, "dependencies");
     }
-    for dep in &results.unused_dev_dependencies {
+    for dep in &input.results.unused_dev_dependencies {
         queue_dependency_removal(&mut deps_by_pkg, &dep.dep, "devDependencies");
     }
-    for dep in &results.unused_optional_dependencies {
+    for dep in &input.results.unused_optional_dependencies {
         queue_dependency_removal(&mut deps_by_pkg, &dep.dep, "optionalDependencies");
     }
 
-    let _ = root; // root was previously used to construct the path; now deps carry their own path
+    let _ = input.root; // root was previously used to construct the path; now deps carry their own path
 
     for (pkg_path, removals) in &deps_by_pkg {
         if let Ok(content) = std::fs::read_to_string(pkg_path)
@@ -52,14 +54,14 @@ pub(super) fn apply_dependency_fixes(
                     && let Some(obj) = deps.as_object_mut()
                     && obj.remove(package_name).is_some()
                 {
-                    if dry_run {
-                        if !matches!(output, OutputFormat::Json) {
+                    if input.dry_run {
+                        if !matches!(input.output, OutputFormat::Json) {
                             eprintln!(
                                 "Would remove `{package_name}` from {location} in {}",
                                 pkg_path.display()
                             );
                         }
-                        fixes.push(serde_json::json!({
+                        input.fixes.push(serde_json::json!({
                             "type": "remove_dependency",
                             "package": package_name,
                             "location": location,
@@ -67,7 +69,7 @@ pub(super) fn apply_dependency_fixes(
                         }));
                     } else {
                         changed = true;
-                        fixes.push(serde_json::json!({
+                        input.fixes.push(serde_json::json!({
                             "type": "remove_dependency",
                             "package": package_name,
                             "location": location,
@@ -79,15 +81,17 @@ pub(super) fn apply_dependency_fixes(
                 }
             }
 
-            if changed && !dry_run {
+            if changed && !input.dry_run {
                 match serde_json::to_string_pretty(&pkg_value) {
                     Ok(new_json) => {
                         let pkg_content = new_json + "\n";
-                        plan.stage(pkg_path.to_path_buf(), pkg_content.into_bytes());
+                        input
+                            .plan
+                            .stage(pkg_path.to_path_buf(), pkg_content.into_bytes());
                     }
                     Err(e) => {
                         eprintln!("Error: failed to serialize {}: {e}", pkg_path.display());
-                        for entry in fixes.iter_mut() {
+                        for entry in input.fixes.iter_mut() {
                             let matches = entry
                                 .get("__target")
                                 .and_then(|v| v.as_str())
@@ -129,7 +133,15 @@ mod tests {
     ) -> bool {
         let mut plan = FixPlan::new();
         let hashes = CapturedHashes::default();
-        apply_dependency_fixes(root, results, &hashes, &mut plan, output, dry_run, fixes);
+        apply_dependency_fixes(DependencyFixInput {
+            root,
+            results,
+            hashes: &hashes,
+            plan: &mut plan,
+            output,
+            dry_run,
+            fixes,
+        });
         if dry_run {
             return false;
         }

--- a/crates/cli/src/fix/enum_members.rs
+++ b/crates/cli/src/fix/enum_members.rs
@@ -271,7 +271,7 @@ fn apply_enum_member_file_fixes(
         new_lines.remove(idx);
     }
 
-    record_applied_enum_member_fixes(AppliedEnumMemberRecordInput {
+    record_applied_enum_member_fixes(&mut AppliedEnumMemberRecordInput {
         member_fixes,
         folded,
         folded_parents,
@@ -313,7 +313,7 @@ struct AppliedEnumMemberRecordInput<'a> {
     fixes: &'a mut Vec<serde_json::Value>,
 }
 
-fn record_applied_enum_member_fixes(input: AppliedEnumMemberRecordInput<'_>) {
+fn record_applied_enum_member_fixes(input: &mut AppliedEnumMemberRecordInput<'_>) {
     let target = input.path.display().to_string();
     for fix in input.member_fixes {
         if input.folded_parents.contains(fix.parent_name.as_str()) {

--- a/crates/cli/src/fix/enum_members.rs
+++ b/crates/cli/src/fix/enum_members.rs
@@ -271,15 +271,15 @@ fn apply_enum_member_file_fixes(
         new_lines.remove(idx);
     }
 
-    record_applied_enum_member_fixes(
+    record_applied_enum_member_fixes(AppliedEnumMemberRecordInput {
         member_fixes,
         folded,
         folded_parents,
-        ctx.path,
-        ctx.relative,
-        ctx.output,
-        ctx.fixes,
-    );
+        path: ctx.path,
+        relative: ctx.relative,
+        output: ctx.output,
+        fixes: ctx.fixes,
+    });
 }
 
 fn enum_member_lines_to_delete(
@@ -303,23 +303,25 @@ fn enum_member_lines_to_delete(
     lines_to_delete
 }
 
-fn record_applied_enum_member_fixes(
-    member_fixes: &[EnumMemberFix],
-    folded: &[FoldedEnum],
-    folded_parents: &rustc_hash::FxHashSet<&str>,
-    path: &Path,
-    relative: &Path,
+struct AppliedEnumMemberRecordInput<'a> {
+    member_fixes: &'a [EnumMemberFix],
+    folded: &'a [FoldedEnum],
+    folded_parents: &'a rustc_hash::FxHashSet<&'a str>,
+    path: &'a Path,
+    relative: &'a Path,
     output: OutputFormat,
-    fixes: &mut Vec<serde_json::Value>,
-) {
-    let target = path.display().to_string();
-    for fix in member_fixes {
-        if folded_parents.contains(fix.parent_name.as_str()) {
+    fixes: &'a mut Vec<serde_json::Value>,
+}
+
+fn record_applied_enum_member_fixes(input: AppliedEnumMemberRecordInput<'_>) {
+    let target = input.path.display().to_string();
+    for fix in input.member_fixes {
+        if input.folded_parents.contains(fix.parent_name.as_str()) {
             continue;
         }
-        fixes.push(serde_json::json!({
+        input.fixes.push(serde_json::json!({
             "type": "remove_enum_member",
-            "path": relative.display().to_string(),
+            "path": input.relative.display().to_string(),
             "line": fix.line_idx + 1,
             "parent": fix.parent_name,
             "name": fix.member_name,
@@ -327,17 +329,17 @@ fn record_applied_enum_member_fixes(
             "__target": target,
         }));
     }
-    for fold in folded {
-        if !matches!(output, OutputFormat::Json) {
+    for fold in input.folded {
+        if !matches!(input.output, OutputFormat::Json) {
             eprintln!(
                 "Removed unused enum `{}` from {}; importers in other files will need cleanup, run your TypeScript build to find them.",
                 fold.parent_name,
-                relative.display(),
+                input.relative.display(),
             );
         }
-        fixes.push(serde_json::json!({
+        input.fixes.push(serde_json::json!({
             "type": "remove_export",
-            "path": relative.display().to_string(),
+            "path": input.relative.display().to_string(),
             "line": fold.decl_line + 1,
             "name": fold.parent_name,
             "applied": true,

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -80,15 +80,15 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
     let mut fixes: Vec<serde_json::Value> = Vec::new();
     let mut plan = FixPlan::new();
 
-    apply_unused_export_fixes(
-        opts.root,
-        &results,
-        &file_hashes,
-        &mut plan,
-        opts.output,
-        opts.dry_run,
-        &mut fixes,
-    );
+    apply_unused_export_fixes(FixApplicationInput {
+        root: opts.root,
+        results: &results,
+        file_hashes: &file_hashes,
+        plan: &mut plan,
+        output: opts.output,
+        dry_run: opts.dry_run,
+        fixes: &mut fixes,
+    });
 
     deps::apply_dependency_fixes(
         opts.root,
@@ -198,37 +198,40 @@ fn emit_empty_fix_output(opts: &FixOptions<'_>) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn apply_unused_export_fixes(
-    root: &Path,
-    results: &fallow_core::results::AnalysisResults,
-    file_hashes: &CapturedHashes,
-    plan: &mut FixPlan,
+struct FixApplicationInput<'a> {
+    root: &'a Path,
+    results: &'a fallow_core::results::AnalysisResults,
+    file_hashes: &'a CapturedHashes,
+    plan: &'a mut FixPlan,
     output: OutputFormat,
     dry_run: bool,
-    fixes: &mut Vec<serde_json::Value>,
-) {
+    fixes: &'a mut Vec<serde_json::Value>,
+}
+
+fn apply_unused_export_fixes(input: FixApplicationInput<'_>) {
     let mut exports_by_file: FxHashMap<PathBuf, Vec<&fallow_core::results::UnusedExport>> =
         FxHashMap::default();
-    for finding in &results.unused_exports {
+    for finding in &input.results.unused_exports {
         exports_by_file
             .entry(finding.export.path.clone())
             .or_default()
             .push(&finding.export);
     }
-    let unresolved_import_files: FxHashSet<PathBuf> = results
+    let unresolved_import_files: FxHashSet<PathBuf> = input
+        .results
         .unresolved_imports
         .iter()
         .map(|finding| finding.import.path.clone())
         .collect();
     exports::apply_export_fixes(
-        root,
+        input.root,
         &exports_by_file,
-        file_hashes,
+        input.file_hashes,
         &unresolved_import_files,
-        plan,
-        output,
-        dry_run,
-        fixes,
+        input.plan,
+        input.output,
+        input.dry_run,
+        input.fixes,
     );
 }
 

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -90,15 +90,15 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
         fixes: &mut fixes,
     });
 
-    deps::apply_dependency_fixes(
-        opts.root,
-        &results,
-        &file_hashes,
-        &mut plan,
-        opts.output,
-        opts.dry_run,
-        &mut fixes,
-    );
+    deps::apply_dependency_fixes(deps::DependencyFixInput {
+        root: opts.root,
+        results: &results,
+        hashes: &file_hashes,
+        plan: &mut plan,
+        output: opts.output,
+        dry_run: opts.dry_run,
+        fixes: &mut fixes,
+    });
 
     let mut had_write_error = config::apply_config_fixes(
         opts.root,

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -80,7 +80,7 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
     let mut fixes: Vec<serde_json::Value> = Vec::new();
     let mut plan = FixPlan::new();
 
-    apply_unused_export_fixes(FixApplicationInput {
+    apply_unused_export_fixes(&mut FixApplicationInput {
         root: opts.root,
         results: &results,
         file_hashes: &file_hashes,
@@ -90,7 +90,7 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
         fixes: &mut fixes,
     });
 
-    deps::apply_dependency_fixes(deps::DependencyFixInput {
+    deps::apply_dependency_fixes(&mut deps::DependencyFixInput {
         root: opts.root,
         results: &results,
         hashes: &file_hashes,
@@ -110,7 +110,7 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
         &mut fixes,
     );
 
-    apply_unused_enum_member_fixes(FixApplicationInput {
+    apply_unused_enum_member_fixes(&mut FixApplicationInput {
         root: opts.root,
         results: &results,
         file_hashes: &file_hashes,
@@ -208,7 +208,7 @@ struct FixApplicationInput<'a> {
     fixes: &'a mut Vec<serde_json::Value>,
 }
 
-fn apply_unused_export_fixes(input: FixApplicationInput<'_>) {
+fn apply_unused_export_fixes(input: &mut FixApplicationInput<'_>) {
     let mut exports_by_file: FxHashMap<PathBuf, Vec<&fallow_core::results::UnusedExport>> =
         FxHashMap::default();
     for finding in &input.results.unused_exports {
@@ -235,7 +235,7 @@ fn apply_unused_export_fixes(input: FixApplicationInput<'_>) {
     );
 }
 
-fn apply_unused_enum_member_fixes(input: FixApplicationInput<'_>) {
+fn apply_unused_enum_member_fixes(input: &mut FixApplicationInput<'_>) {
     if input.results.unused_enum_members.is_empty() {
         return;
     }

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -110,15 +110,15 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
         &mut fixes,
     );
 
-    apply_unused_enum_member_fixes(
-        opts.root,
-        &results,
-        &file_hashes,
-        &mut plan,
-        opts.output,
-        opts.dry_run,
-        &mut fixes,
-    );
+    apply_unused_enum_member_fixes(FixApplicationInput {
+        root: opts.root,
+        results: &results,
+        file_hashes: &file_hashes,
+        plan: &mut plan,
+        output: opts.output,
+        dry_run: opts.dry_run,
+        fixes: &mut fixes,
+    });
 
     let mut catalog_request = CatalogFixRequest {
         root: opts.root,
@@ -235,34 +235,26 @@ fn apply_unused_export_fixes(input: FixApplicationInput<'_>) {
     );
 }
 
-fn apply_unused_enum_member_fixes(
-    root: &Path,
-    results: &fallow_core::results::AnalysisResults,
-    file_hashes: &CapturedHashes,
-    plan: &mut FixPlan,
-    output: OutputFormat,
-    dry_run: bool,
-    fixes: &mut Vec<serde_json::Value>,
-) {
-    if results.unused_enum_members.is_empty() {
+fn apply_unused_enum_member_fixes(input: FixApplicationInput<'_>) {
+    if input.results.unused_enum_members.is_empty() {
         return;
     }
     let mut enum_members_by_file: FxHashMap<PathBuf, Vec<&fallow_core::results::UnusedMember>> =
         FxHashMap::default();
-    for finding in &results.unused_enum_members {
+    for finding in &input.results.unused_enum_members {
         enum_members_by_file
             .entry(finding.member.path.clone())
             .or_default()
             .push(&finding.member);
     }
     enum_members::apply_enum_member_fixes(
-        root,
+        input.root,
         &enum_members_by_file,
-        file_hashes,
-        plan,
-        output,
-        dry_run,
-        fixes,
+        input.file_hashes,
+        input.plan,
+        input.output,
+        input.dry_run,
+        input.fixes,
     );
 }
 

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2070,33 +2070,37 @@ fn project_uses_tailwind_plugin(any_plugin_directive: bool, root: &std::path::Pa
 ///
 /// The usage test is false-negative-leaning by design: every check CREDITS usage,
 /// so a genuinely-dead token is missed before a live one is flagged.
+struct UnusedThemeTokenScanInput<'a> {
+    tokens: &'a CssTokenSets,
+    files: &'a [fallow_types::discover::DiscoveredFile],
+    config: &'a ResolvedConfig,
+    ignore_set: &'a globset::GlobSet,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+    summary: &'a mut crate::health_types::CssAnalyticsSummary,
+}
+
 fn scan_unused_theme_tokens(
-    tokens: &CssTokenSets,
-    files: &[fallow_types::discover::DiscoveredFile],
-    config: &ResolvedConfig,
-    ignore_set: &globset::GlobSet,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
-    summary: &mut crate::health_types::CssAnalyticsSummary,
+    input: UnusedThemeTokenScanInput<'_>,
 ) -> Vec<crate::health_types::UnusedThemeToken> {
     use crate::health_types::{CssCandidateAction, UnusedThemeToken};
 
     // Partial scope cannot prove a token dead.
-    if changed_files.is_some() || ws_roots.is_some() {
+    if input.changed_files.is_some() || input.ws_roots.is_some() {
         return Vec::new();
     }
     // v4 gate: a Tailwind dependency AND at least one @theme token present.
-    if tokens.theme_token_definers.is_empty() || !project_uses_tailwind(&config.root) {
+    if input.tokens.theme_token_definers.is_empty() || !project_uses_tailwind(&input.config.root) {
         return Vec::new();
     }
     // Tailwind-plugin abstain (DI blind spot).
-    if project_uses_tailwind_plugin(tokens.any_plugin_directive, &config.root) {
+    if project_uses_tailwind_plugin(input.tokens.any_plugin_directive, &input.config.root) {
         return Vec::new();
     }
 
     // Classify candidate tokens; drop variant namespaces, published-library
     // stylesheets, and anything that does not match a known namespace.
-    let published = published_css_paths(config);
+    let published = published_css_paths(input.config);
     struct Candidate {
         token: String,
         namespace: String,
@@ -2105,7 +2109,7 @@ fn scan_unused_theme_tokens(
         line: u32,
     }
     let mut candidates: Vec<Candidate> = Vec::new();
-    for (raw, (path, line)) in &tokens.theme_token_definers {
+    for (raw, (path, line)) in &input.tokens.theme_token_definers {
         if published.contains(path) {
             continue;
         }
@@ -2124,7 +2128,7 @@ fn scan_unused_theme_tokens(
         });
     }
     if candidates.is_empty() {
-        summary.unused_theme_tokens = 0;
+        input.summary.unused_theme_tokens = 0;
         return Vec::new();
     }
 
@@ -2132,17 +2136,17 @@ fn scan_unused_theme_tokens(
     // and from non-CSS source (markup class attributes, `clsx` args, CSS-in-JS),
     // plus the `var()` reads (CSS-side, including `@theme` interiors).
     let mut utility_tokens: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
-    for apply in &tokens.apply_tokens {
+    for apply in &input.tokens.apply_tokens {
         collect_class_shaped_tokens(apply, &mut utility_tokens);
     }
-    for file in files {
+    for file in input.files {
         let path = &file.path;
         let extension = path.extension().and_then(|ext| ext.to_str());
         if !extension.is_some_and(|ext| THEME_USAGE_SOURCE_EXTS.contains(&ext)) {
             continue;
         }
-        let relative = path.strip_prefix(&config.root).unwrap_or(path);
-        if ignore_set.is_match(relative) {
+        let relative = path.strip_prefix(&input.config.root).unwrap_or(path);
+        if input.ignore_set.is_match(relative) {
             continue;
         }
         if let Ok(source) = std::fs::read_to_string(path) {
@@ -2150,8 +2154,8 @@ fn scan_unused_theme_tokens(
         }
     }
 
-    let mut var_reads: rustc_hash::FxHashSet<String> = tokens.theme_var_reads.clone();
-    for referenced in &tokens.referenced_custom_props {
+    let mut var_reads: rustc_hash::FxHashSet<String> = input.tokens.theme_var_reads.clone();
+    for referenced in &input.tokens.referenced_custom_props {
         var_reads.insert(referenced.trim_start_matches('-').to_owned());
     }
 
@@ -2185,7 +2189,7 @@ fn scan_unused_theme_tokens(
             .then_with(|| a.line.cmp(&b.line))
             .then_with(|| a.token.cmp(&b.token))
     });
-    summary.unused_theme_tokens = saturate_len(out.len());
+    input.summary.unused_theme_tokens = saturate_len(out.len());
     out
 }
 
@@ -2243,15 +2247,15 @@ fn scan_markup_css_candidates(input: MarkupCssCandidateInput<'_>) -> MarkupCssCa
         ),
         // Tailwind v4 @theme design tokens used by no utility / var() / @apply
         // anywhere (heavily gated: v4 + non-plugin + non-published + whole-scope).
-        unused_theme_tokens: scan_unused_theme_tokens(
-            input.tokens,
-            input.files,
-            input.config,
-            input.ignore_set,
-            input.changed_files,
-            input.ws_roots,
-            input.summary,
-        ),
+        unused_theme_tokens: scan_unused_theme_tokens(UnusedThemeTokenScanInput {
+            tokens: input.tokens,
+            files: input.files,
+            config: input.config,
+            ignore_set: input.ignore_set,
+            changed_files: input.changed_files,
+            ws_roots: input.ws_roots,
+            summary: input.summary,
+        }),
     }
 }
 

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2081,7 +2081,7 @@ struct UnusedThemeTokenScanInput<'a> {
 }
 
 fn scan_unused_theme_tokens(
-    input: UnusedThemeTokenScanInput<'_>,
+    input: &mut UnusedThemeTokenScanInput<'_>,
 ) -> Vec<crate::health_types::UnusedThemeToken> {
     use crate::health_types::{CssCandidateAction, UnusedThemeToken};
 
@@ -2216,7 +2216,7 @@ struct MarkupCssCandidateInput<'a> {
     summary: &'a mut crate::health_types::CssAnalyticsSummary,
 }
 
-fn scan_markup_css_candidates(input: MarkupCssCandidateInput<'_>) -> MarkupCssCandidates {
+fn scan_markup_css_candidates(input: &mut MarkupCssCandidateInput<'_>) -> MarkupCssCandidates {
     MarkupCssCandidates {
         // Markup arbitrary-value scan (gated on the project using Tailwind).
         tailwind_arbitrary_values: scan_markup_tailwind_arbitrary_values(
@@ -2247,7 +2247,7 @@ fn scan_markup_css_candidates(input: MarkupCssCandidateInput<'_>) -> MarkupCssCa
         ),
         // Tailwind v4 @theme design tokens used by no utility / var() / @apply
         // anywhere (heavily gated: v4 + non-plugin + non-published + whole-scope).
-        unused_theme_tokens: scan_unused_theme_tokens(UnusedThemeTokenScanInput {
+        unused_theme_tokens: scan_unused_theme_tokens(&mut UnusedThemeTokenScanInput {
             tokens: input.tokens,
             files: input.files,
             config: input.config,
@@ -2428,7 +2428,7 @@ fn compute_css_analytics_report(
         unresolved_class_references,
         unreferenced_css_classes,
         unused_theme_tokens,
-    } = scan_markup_css_candidates(MarkupCssCandidateInput {
+    } = scan_markup_css_candidates(&mut MarkupCssCandidateInput {
         tokens: &tokens,
         files,
         config,
@@ -2593,6 +2593,7 @@ fn build_health_output_parts(
     }
 }
 
+#[derive(Clone, Copy)]
 struct HealthSupportingPartsInput<'a> {
     opts: &'a HealthOptions<'a>,
     build: &'a HealthOutputBuildInput<'a>,
@@ -3047,6 +3048,7 @@ struct ThresholdOverrideStateInput {
     dimension: ThresholdOverrideDimension,
 }
 
+#[derive(Clone, Copy)]
 struct HealthGroupingContextInput<'a> {
     opts: &'a HealthOptions<'a>,
     config: &'a ResolvedConfig,
@@ -3285,6 +3287,7 @@ fn build_health_result(input: HealthResultInput) -> HealthResult {
     }
 }
 
+#[derive(Clone, Copy)]
 struct HealthFindingsInput<'a> {
     opts: &'a HealthOptions<'a>,
     config: &'a ResolvedConfig,
@@ -3701,6 +3704,7 @@ fn prepare_shared_analysis_output(
         .map_err(|e| emit_error(&format!("analysis failed: {e}"), 2, opts.output))
 }
 
+#[derive(Clone, Copy)]
 struct RuntimeCoverageAnalysisScope<'a> {
     opts: &'a HealthOptions<'a>,
     config: &'a ResolvedConfig,
@@ -3938,6 +3942,7 @@ fn prepare_health_analysis_data(
 
 type FileScoresAndChurn = (FileScoreResult, f64, Option<hotspots::ChurnFetchResult>);
 
+#[derive(Clone, Copy)]
 struct FileScoresAndChurnInput<'a> {
     opts: &'a HealthOptions<'a>,
     config: &'a ResolvedConfig,
@@ -4095,6 +4100,7 @@ fn compute_filtered_hotspots(
     )
 }
 
+#[derive(Clone, Copy)]
 struct FilteredTargetInput<'a> {
     opts: &'a HealthOptions<'a>,
     score_output: Option<&'a scoring::FileScoreOutput>,
@@ -4417,6 +4423,7 @@ fn compute_health_score_metrics(
         .then(|| vital_signs::compute_health_score(vital_signs, total_files_scoped))
 }
 
+#[derive(Clone, Copy)]
 struct FilteredLargeFunctionInput<'a> {
     vital_signs: &'a crate::health_types::VitalSigns,
     modules: &'a [fallow_core::extract::ModuleInfo],

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -4110,15 +4110,7 @@ fn compute_filtered_targets(
     input: FilteredTargetInput<'_>,
 ) -> (Vec<RefactoringTarget>, Option<TargetThresholds>, f64) {
     let t = Instant::now();
-    let (mut targets, target_thresholds) = compute_targets(
-        input.opts,
-        input.score_output,
-        input.file_scores_slice,
-        input.hotspots,
-        input.loaded_baseline,
-        &input.config.root,
-        input.dupes_report,
-    );
+    let (mut targets, target_thresholds) = compute_targets(&input);
     if let Some(diff_index) = input.diff_index {
         filter_refactoring_targets_by_diff(&mut targets, diff_index, &input.config.root);
     }
@@ -4689,33 +4681,29 @@ fn compute_filtered_file_scores(input: FileScoreInput<'_>) -> Result<FileScoreRe
 
 /// Compute refactoring targets when requested, applying baseline and top filters.
 fn compute_targets(
-    opts: &HealthOptions<'_>,
-    score_output: Option<&scoring::FileScoreOutput>,
-    file_scores_slice: &[FileHealthScore],
-    hotspots: &[HotspotEntry],
-    loaded_baseline: Option<&HealthBaselineData>,
-    config_root: &std::path::Path,
-    dupes_report: Option<&fallow_core::duplicates::DuplicationReport>,
+    input: &FilteredTargetInput<'_>,
 ) -> (Vec<RefactoringTarget>, Option<TargetThresholds>) {
-    if !opts.targets {
+    if !input.opts.targets {
         return (Vec::new(), None);
     }
-    let Some(output) = score_output else {
+    let Some(output) = input.score_output else {
         return (Vec::new(), None);
     };
-    let clone_siblings = dupes_report.map_or_else(rustc_hash::FxHashMap::default, |report| {
-        targets::build_clone_sibling_evidence(report)
-    });
+    let clone_siblings = input
+        .dupes_report
+        .map_or_else(rustc_hash::FxHashMap::default, |report| {
+            targets::build_clone_sibling_evidence(report)
+        });
     let target_aux = TargetAuxData::from_output(output, &clone_siblings);
     let (mut tgts, thresholds) =
-        compute_refactoring_targets(file_scores_slice, &target_aux, hotspots);
-    if let Some(baseline) = loaded_baseline {
-        tgts = filter_new_health_targets(tgts, baseline, config_root);
+        compute_refactoring_targets(input.file_scores_slice, &target_aux, input.hotspots);
+    if let Some(baseline) = input.loaded_baseline {
+        tgts = filter_new_health_targets(tgts, baseline, &input.config.root);
     }
-    if let Some(ref effort) = opts.effort {
+    if let Some(ref effort) = input.opts.effort {
         tgts.retain(|t| t.effort == *effort);
     }
-    if let Some(top) = opts.top {
+    if let Some(top) = input.opts.top {
         tgts.truncate(top);
     }
     (tgts, Some(thresholds))

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2202,53 +2202,55 @@ struct MarkupCssCandidates {
 /// likely class typos, unreferenced global classes, unused `@theme` tokens),
 /// each honoring the same ignore / changed / workspace filters and setting its
 /// own summary counts.
-fn scan_markup_css_candidates(
-    tokens: &CssTokenSets,
-    files: &[fallow_types::discover::DiscoveredFile],
-    config: &ResolvedConfig,
-    ignore_set: &globset::GlobSet,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
-    summary: &mut crate::health_types::CssAnalyticsSummary,
-) -> MarkupCssCandidates {
+struct MarkupCssCandidateInput<'a> {
+    tokens: &'a CssTokenSets,
+    files: &'a [fallow_types::discover::DiscoveredFile],
+    config: &'a ResolvedConfig,
+    ignore_set: &'a globset::GlobSet,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+    summary: &'a mut crate::health_types::CssAnalyticsSummary,
+}
+
+fn scan_markup_css_candidates(input: MarkupCssCandidateInput<'_>) -> MarkupCssCandidates {
     MarkupCssCandidates {
         // Markup arbitrary-value scan (gated on the project using Tailwind).
         tailwind_arbitrary_values: scan_markup_tailwind_arbitrary_values(
-            files,
-            config,
-            ignore_set,
-            changed_files,
-            ws_roots,
-            summary,
+            input.files,
+            input.config,
+            input.ignore_set,
+            input.changed_files,
+            input.ws_roots,
+            input.summary,
         ),
         // Static markup class tokens one edit from a defined class (likely typos).
         unresolved_class_references: scan_unresolved_class_references(
-            files,
-            config,
-            ignore_set,
-            changed_files,
-            ws_roots,
-            summary,
+            input.files,
+            input.config,
+            input.ignore_set,
+            input.changed_files,
+            input.ws_roots,
+            input.summary,
         ),
         // Global classes referenced by no in-project markup (heavily gated).
         unreferenced_css_classes: scan_unreferenced_css_classes(
-            files,
-            config,
-            ignore_set,
-            changed_files,
-            ws_roots,
-            summary,
+            input.files,
+            input.config,
+            input.ignore_set,
+            input.changed_files,
+            input.ws_roots,
+            input.summary,
         ),
         // Tailwind v4 @theme design tokens used by no utility / var() / @apply
         // anywhere (heavily gated: v4 + non-plugin + non-published + whole-scope).
         unused_theme_tokens: scan_unused_theme_tokens(
-            tokens,
-            files,
-            config,
-            ignore_set,
-            changed_files,
-            ws_roots,
-            summary,
+            input.tokens,
+            input.files,
+            input.config,
+            input.ignore_set,
+            input.changed_files,
+            input.ws_roots,
+            input.summary,
         ),
     }
 }
@@ -2422,15 +2424,15 @@ fn compute_css_analytics_report(
         unresolved_class_references,
         unreferenced_css_classes,
         unused_theme_tokens,
-    } = scan_markup_css_candidates(
-        &tokens,
+    } = scan_markup_css_candidates(MarkupCssCandidateInput {
+        tokens: &tokens,
         files,
         config,
         ignore_set,
         changed_files,
         ws_roots,
-        &mut summary,
-    );
+        summary: &mut summary,
+    });
 
     if summary.files_analyzed == 0
         && scoped_unused.is_empty()

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -344,18 +344,18 @@ fn execute_health_inner(
         enforce_coverage_gaps,
         scope.enforce_crap,
     );
-    let analysis_data = prepare_health_analysis_data(
+    let analysis_data = prepare_health_analysis_data(HealthAnalysisDataInput {
         opts,
-        &config,
-        &modules,
-        &scope.file_paths,
-        &scope.ignore_set,
-        scope.changed_files.as_ref(),
-        scope.ws_roots.as_deref(),
-        istanbul_coverage.as_ref(),
+        config: &config,
+        modules: &modules,
+        file_paths: &scope.file_paths,
+        ignore_set: &scope.ignore_set,
+        changed_files: scope.changed_files.as_ref(),
+        ws_roots: scope.ws_roots.as_deref(),
+        istanbul_coverage: istanbul_coverage.as_ref(),
         pre_computed_analysis,
         needs_file_scores,
-    )?;
+    })?;
 
     let findings_data = prepare_health_findings(HealthFindingsInput {
         opts,
@@ -3857,28 +3857,28 @@ fn prepare_health_vital_data_from_sections(
     })
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "health analysis preparation shares the active scope across runtime coverage and file scores"
-)]
-fn prepare_health_analysis_data(
-    opts: &HealthOptions<'_>,
-    config: &ResolvedConfig,
-    modules: &[fallow_core::extract::ModuleInfo],
-    file_paths: &rustc_hash::FxHashMap<fallow_core::discover::FileId, &std::path::PathBuf>,
-    ignore_set: &globset::GlobSet,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
-    istanbul_coverage: Option<&scoring::IstanbulCoverage>,
+struct HealthAnalysisDataInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    config: &'a ResolvedConfig,
+    modules: &'a [fallow_core::extract::ModuleInfo],
+    file_paths: &'a rustc_hash::FxHashMap<fallow_core::discover::FileId, &'a std::path::PathBuf>,
+    ignore_set: &'a globset::GlobSet,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+    istanbul_coverage: Option<&'a scoring::IstanbulCoverage>,
     pre_computed_analysis: Option<fallow_core::AnalysisOutput>,
     needs_file_scores: bool,
+}
+
+fn prepare_health_analysis_data(
+    input: HealthAnalysisDataInput<'_>,
 ) -> Result<HealthAnalysisData, ExitCode> {
-    let needs_analysis_output = needs_file_scores || opts.runtime_coverage.is_some();
+    let needs_analysis_output = input.needs_file_scores || input.opts.runtime_coverage.is_some();
     let mut shared_analysis_output = prepare_shared_analysis_output(
-        opts,
-        config,
-        modules,
-        pre_computed_analysis,
+        input.opts,
+        input.config,
+        input.modules,
+        input.pre_computed_analysis,
         needs_analysis_output,
     )?;
     if let Some(graph) = shared_analysis_output
@@ -3889,33 +3889,33 @@ fn prepare_health_analysis_data(
     }
 
     let runtime_coverage = analyze_runtime_coverage(
-        opts,
-        config,
-        modules,
+        input.opts,
+        input.config,
+        input.modules,
         shared_analysis_output.as_ref(),
-        istanbul_coverage,
-        file_paths,
-        ignore_set,
-        changed_files,
-        ws_roots,
+        input.istanbul_coverage,
+        input.file_paths,
+        input.ignore_set,
+        input.changed_files,
+        input.ws_roots,
     )?;
 
-    let precomputed_for_scores = if needs_file_scores {
+    let precomputed_for_scores = if input.needs_file_scores {
         shared_analysis_output.take()
     } else {
         None
     };
 
     let (file_score_result, file_scores_ms, churn_fetch) = compute_file_scores_and_churn(
-        opts,
-        config,
-        modules,
-        file_paths,
-        changed_files,
-        ws_roots,
-        ignore_set,
-        istanbul_coverage,
-        needs_file_scores,
+        input.opts,
+        input.config,
+        input.modules,
+        input.file_paths,
+        input.changed_files,
+        input.ws_roots,
+        input.ignore_set,
+        input.istanbul_coverage,
+        input.needs_file_scores,
         precomputed_for_scores,
     )?;
     let (git_churn_ms, git_churn_cache_hit) = churn_fetch
@@ -3923,7 +3923,7 @@ fn prepare_health_analysis_data(
         .map_or((0.0, false), |cf| (cf.git_log_ms, cf.cache_hit));
     let (score_output, files_scored, average_maintainability) = file_score_result;
 
-    print_slow_churn_note(opts, churn_fetch.as_ref());
+    print_slow_churn_note(input.opts, churn_fetch.as_ref());
 
     Ok(HealthAnalysisData {
         runtime_coverage,

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2548,15 +2548,16 @@ fn build_health_output_parts(
         build.max_crap,
     );
 
-    let HealthOutputSupportingParts { grouping, timings } = build_health_supporting_parts(
-        opts,
-        build,
-        &analysis_data,
-        &derived_sections,
-        &vital_data,
-        &findings,
-        &action_ctx,
-    );
+    let HealthOutputSupportingParts { grouping, timings } =
+        build_health_supporting_parts(HealthSupportingPartsInput {
+            opts,
+            build,
+            analysis_data: &analysis_data,
+            derived_sections: &derived_sections,
+            vital_data: &vital_data,
+            findings: &findings,
+            action_ctx: &action_ctx,
+        });
 
     let report = build_health_report_from_pipeline(
         opts,
@@ -2592,30 +2593,34 @@ fn build_health_output_parts(
     }
 }
 
+struct HealthSupportingPartsInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    build: &'a HealthOutputBuildInput<'a>,
+    analysis_data: &'a HealthAnalysisData,
+    derived_sections: &'a HealthDerivedSections,
+    vital_data: &'a HealthVitalData,
+    findings: &'a [ComplexityViolation],
+    action_ctx: &'a crate::health_types::HealthActionContext,
+}
+
 fn build_health_supporting_parts(
-    opts: &HealthOptions<'_>,
-    build: &HealthOutputBuildInput<'_>,
-    analysis_data: &HealthAnalysisData,
-    derived_sections: &HealthDerivedSections,
-    vital_data: &HealthVitalData,
-    findings: &[ComplexityViolation],
-    action_ctx: &crate::health_types::HealthActionContext,
+    input: HealthSupportingPartsInput<'_>,
 ) -> HealthOutputSupportingParts {
     let grouping = build_health_output_grouping(
-        opts,
-        build,
-        analysis_data,
-        derived_sections,
-        vital_data,
-        findings,
-        action_ctx,
+        input.opts,
+        input.build,
+        input.analysis_data,
+        input.derived_sections,
+        input.vital_data,
+        input.findings,
+        input.action_ctx,
     );
     let timings = build_health_timings_from_pipeline(
-        opts,
-        build.start,
-        analysis_data,
-        derived_sections,
-        &build.timing_base,
+        input.opts,
+        input.build.start,
+        input.analysis_data,
+        input.derived_sections,
+        &input.build.timing_base,
     );
 
     HealthOutputSupportingParts { grouping, timings }

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -3217,16 +3217,16 @@ fn prepare_health_section_targets(
     opts: &HealthOptions<'_>,
     input: &HealthTargetSectionInput<'_>,
 ) -> (Vec<RefactoringTarget>, Option<TargetThresholds>, f64) {
-    compute_filtered_targets(
+    compute_filtered_targets(FilteredTargetInput {
         opts,
-        input.score_output,
-        input.file_scores,
-        input.hotspots,
-        input.loaded_baseline,
-        input.config,
-        input.diff_index,
-        input.dupes_report,
-    )
+        score_output: input.score_output,
+        file_scores_slice: input.file_scores,
+        hotspots: input.hotspots,
+        loaded_baseline: input.loaded_baseline,
+        config: input.config,
+        diff_index: input.diff_index,
+        dupes_report: input.dupes_report,
+    })
 }
 
 struct HealthTimingInput {
@@ -4094,32 +4094,32 @@ fn compute_filtered_hotspots(
     )
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "target filtering coordinates independent health scope inputs"
-)]
+struct FilteredTargetInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    score_output: Option<&'a scoring::FileScoreOutput>,
+    file_scores_slice: &'a [FileHealthScore],
+    hotspots: &'a [HotspotEntry],
+    loaded_baseline: Option<&'a HealthBaselineData>,
+    config: &'a ResolvedConfig,
+    diff_index: Option<&'a crate::report::ci::diff_filter::DiffIndex>,
+    dupes_report: Option<&'a fallow_core::duplicates::DuplicationReport>,
+}
+
 fn compute_filtered_targets(
-    opts: &HealthOptions<'_>,
-    score_output: Option<&scoring::FileScoreOutput>,
-    file_scores_slice: &[FileHealthScore],
-    hotspots: &[HotspotEntry],
-    loaded_baseline: Option<&HealthBaselineData>,
-    config: &ResolvedConfig,
-    diff_index: Option<&crate::report::ci::diff_filter::DiffIndex>,
-    dupes_report: Option<&fallow_core::duplicates::DuplicationReport>,
+    input: FilteredTargetInput<'_>,
 ) -> (Vec<RefactoringTarget>, Option<TargetThresholds>, f64) {
     let t = Instant::now();
     let (mut targets, target_thresholds) = compute_targets(
-        opts,
-        score_output,
-        file_scores_slice,
-        hotspots,
-        loaded_baseline,
-        &config.root,
-        dupes_report,
+        input.opts,
+        input.score_output,
+        input.file_scores_slice,
+        input.hotspots,
+        input.loaded_baseline,
+        &input.config.root,
+        input.dupes_report,
     );
-    if let Some(diff_index) = diff_index {
-        filter_refactoring_targets_by_diff(&mut targets, diff_index, &config.root);
+    if let Some(diff_index) = input.diff_index {
+        filter_refactoring_targets_by_diff(&mut targets, diff_index, &input.config.root);
     }
     (
         targets,

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2625,23 +2625,23 @@ fn build_health_output_grouping(
     action_ctx: &crate::health_types::HealthActionContext,
 ) -> Option<crate::health_types::HealthGrouping> {
     let file_scores = health_file_scores_slice(analysis_data.score_output.as_ref());
-    build_health_grouping_from_context(
+    build_health_grouping_from_context(HealthGroupingContextInput {
         opts,
-        build.config,
-        build.group_resolver,
-        &derived_sections.candidate_paths,
-        build.files,
-        build.modules,
-        build.file_paths,
-        analysis_data.score_output.as_ref(),
+        config: build.config,
+        group_resolver: build.group_resolver,
+        candidate_paths: &derived_sections.candidate_paths,
+        files: build.files,
+        modules: build.modules,
+        file_paths: build.file_paths,
+        score_output: analysis_data.score_output.as_ref(),
         file_scores,
         findings,
-        &derived_sections.hotspots,
+        hotspots: &derived_sections.hotspots,
         vital_data,
-        &derived_sections.targets,
-        build.needs_file_scores,
+        targets: &derived_sections.targets,
+        needs_file_scores: build.needs_file_scores,
         action_ctx,
-    )
+    })
 }
 
 struct HealthDerivedSectionInput<'a> {
@@ -3050,47 +3050,47 @@ struct ThresholdOverrideStateInput {
     dimension: ThresholdOverrideDimension,
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "grouping bridges the assembled health pipeline context into the grouping module"
-)]
-fn build_health_grouping_from_context(
-    opts: &HealthOptions<'_>,
-    config: &ResolvedConfig,
-    group_resolver: Option<&crate::report::OwnershipResolver>,
-    candidate_paths: &rustc_hash::FxHashSet<std::path::PathBuf>,
-    files: &[fallow_types::discover::DiscoveredFile],
-    modules: &[fallow_core::extract::ModuleInfo],
-    file_paths: &rustc_hash::FxHashMap<fallow_core::discover::FileId, &std::path::PathBuf>,
-    score_output: Option<&scoring::FileScoreOutput>,
-    file_scores: &[FileHealthScore],
-    findings: &[ComplexityViolation],
-    hotspots: &[HotspotEntry],
-    vital_data: &HealthVitalData,
-    targets: &[RefactoringTarget],
+struct HealthGroupingContextInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    config: &'a ResolvedConfig,
+    group_resolver: Option<&'a crate::report::OwnershipResolver>,
+    candidate_paths: &'a rustc_hash::FxHashSet<std::path::PathBuf>,
+    files: &'a [fallow_types::discover::DiscoveredFile],
+    modules: &'a [fallow_core::extract::ModuleInfo],
+    file_paths: &'a rustc_hash::FxHashMap<fallow_core::discover::FileId, &'a std::path::PathBuf>,
+    score_output: Option<&'a scoring::FileScoreOutput>,
+    file_scores: &'a [FileHealthScore],
+    findings: &'a [ComplexityViolation],
+    hotspots: &'a [HotspotEntry],
+    vital_data: &'a HealthVitalData,
+    targets: &'a [RefactoringTarget],
     needs_file_scores: bool,
-    action_ctx: &crate::health_types::HealthActionContext,
+    action_ctx: &'a crate::health_types::HealthActionContext,
+}
+
+fn build_health_grouping_from_context(
+    input: HealthGroupingContextInput<'_>,
 ) -> Option<crate::health_types::HealthGrouping> {
     build_optional_health_grouping_opt(
-        group_resolver,
-        &config.root,
-        candidate_paths,
+        input.group_resolver,
+        &input.config.root,
+        input.candidate_paths,
         &grouping::HealthGroupingInput {
-            files,
-            modules,
-            file_paths,
-            score_output,
-            file_scores,
-            findings,
-            hotspots,
-            large_functions: &vital_data.large_functions,
-            targets,
-            score_requested: opts.score,
-            duplicates_config: opts.score.then_some(&config.duplicates),
-            needs_file_scores,
-            needs_hotspots: opts.hotspots || opts.targets,
-            show_vital_signs: !opts.score_only_output,
-            action_ctx,
+            files: input.files,
+            modules: input.modules,
+            file_paths: input.file_paths,
+            score_output: input.score_output,
+            file_scores: input.file_scores,
+            findings: input.findings,
+            hotspots: input.hotspots,
+            large_functions: &input.vital_data.large_functions,
+            targets: input.targets,
+            score_requested: input.opts.score,
+            duplicates_config: input.opts.score.then_some(&input.config.duplicates),
+            needs_file_scores: input.needs_file_scores,
+            needs_hotspots: input.opts.hotspots || input.opts.targets,
+            show_vital_signs: !input.opts.score_only_output,
+            action_ctx: input.action_ctx,
         },
     )
 }

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -3907,15 +3907,17 @@ fn prepare_health_analysis_data(
     };
 
     let (file_score_result, file_scores_ms, churn_fetch) = compute_file_scores_and_churn(
-        input.opts,
-        input.config,
-        input.modules,
-        input.file_paths,
-        input.changed_files,
-        input.ws_roots,
-        input.ignore_set,
-        input.istanbul_coverage,
-        input.needs_file_scores,
+        FileScoresAndChurnInput {
+            opts: input.opts,
+            config: input.config,
+            modules: input.modules,
+            file_paths: input.file_paths,
+            changed_files: input.changed_files,
+            ws_roots: input.ws_roots,
+            ignore_set: input.ignore_set,
+            istanbul_coverage: input.istanbul_coverage,
+            needs_file_scores: input.needs_file_scores,
+        },
         precomputed_for_scores,
     )?;
     let (git_churn_ms, git_churn_cache_hit) = churn_fetch
@@ -3939,57 +3941,58 @@ fn prepare_health_analysis_data(
 
 type FileScoresAndChurn = (FileScoreResult, f64, Option<hotspots::ChurnFetchResult>);
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "file-score filtering needs the active health scope and optional precomputed analysis"
-)]
-fn compute_file_scores_and_churn(
-    opts: &HealthOptions<'_>,
-    config: &ResolvedConfig,
-    modules: &[fallow_core::extract::ModuleInfo],
-    file_paths: &rustc_hash::FxHashMap<fallow_core::discover::FileId, &std::path::PathBuf>,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
-    ignore_set: &globset::GlobSet,
-    istanbul_coverage: Option<&scoring::IstanbulCoverage>,
+struct FileScoresAndChurnInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    config: &'a ResolvedConfig,
+    modules: &'a [fallow_core::extract::ModuleInfo],
+    file_paths: &'a rustc_hash::FxHashMap<fallow_core::discover::FileId, &'a std::path::PathBuf>,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+    ignore_set: &'a globset::GlobSet,
+    istanbul_coverage: Option<&'a scoring::IstanbulCoverage>,
     needs_file_scores: bool,
+}
+
+fn compute_file_scores_and_churn(
+    input: FileScoresAndChurnInput<'_>,
     precomputed_for_scores: Option<fallow_core::AnalysisOutput>,
 ) -> Result<FileScoresAndChurn, ExitCode> {
-    let needs_churn = opts.hotspots || opts.targets;
-    if needs_file_scores && needs_churn {
+    let needs_churn = input.opts.hotspots || input.opts.targets;
+    if input.needs_file_scores && needs_churn {
         return std::thread::scope(|s| {
-            let churn_handle = s.spawn(|| hotspots::fetch_churn_data(opts, &config.cache_dir));
+            let churn_handle =
+                s.spawn(|| hotspots::fetch_churn_data(input.opts, &input.config.cache_dir));
             let t = Instant::now();
             let score_result = compute_filtered_file_scores(FileScoreInput {
-                config,
-                modules,
-                file_paths,
-                changed_files,
-                ws_roots,
-                ignore_set,
-                output: opts.output,
-                istanbul_coverage,
+                config: input.config,
+                modules: input.modules,
+                file_paths: input.file_paths,
+                changed_files: input.changed_files,
+                ws_roots: input.ws_roots,
+                ignore_set: input.ignore_set,
+                output: input.opts.output,
+                istanbul_coverage: input.istanbul_coverage,
                 pre_computed: precomputed_for_scores,
             })?;
             let fs_ms = t.elapsed().as_secs_f64() * 1000.0;
             let churn = churn_handle
                 .join()
-                .map_err(|_| emit_error("churn thread panicked", 2, opts.output))?;
+                .map_err(|_| emit_error("churn thread panicked", 2, input.opts.output))?;
             Ok((score_result, fs_ms, churn))
         });
     }
 
     let t = Instant::now();
-    let score_result = if needs_file_scores {
+    let score_result = if input.needs_file_scores {
         compute_filtered_file_scores(FileScoreInput {
-            config,
-            modules,
-            file_paths,
-            changed_files,
-            ws_roots,
-            ignore_set,
-            output: opts.output,
-            istanbul_coverage,
+            config: input.config,
+            modules: input.modules,
+            file_paths: input.file_paths,
+            changed_files: input.changed_files,
+            ws_roots: input.ws_roots,
+            ignore_set: input.ignore_set,
+            output: input.opts.output,
+            istanbul_coverage: input.istanbul_coverage,
             pre_computed: precomputed_for_scores,
         })?
     } else {
@@ -3997,7 +4000,7 @@ fn compute_file_scores_and_churn(
     };
     let fs_ms = t.elapsed().as_secs_f64() * 1000.0;
     let churn = if needs_churn {
-        hotspots::fetch_churn_data(opts, &config.cache_dir)
+        hotspots::fetch_churn_data(input.opts, &input.config.cache_dir)
     } else {
         None
     };

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -3704,46 +3704,46 @@ fn prepare_shared_analysis_output(
         .map_err(|e| emit_error(&format!("analysis failed: {e}"), 2, opts.output))
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "runtime coverage analysis needs the same filtered health context as scoring"
-)]
+struct RuntimeCoverageAnalysisScope<'a> {
+    opts: &'a HealthOptions<'a>,
+    config: &'a ResolvedConfig,
+    modules: &'a [fallow_core::extract::ModuleInfo],
+    shared_analysis_output: Option<&'a fallow_core::AnalysisOutput>,
+    istanbul_coverage: Option<&'a scoring::IstanbulCoverage>,
+    file_paths: &'a rustc_hash::FxHashMap<fallow_core::discover::FileId, &'a std::path::PathBuf>,
+    ignore_set: &'a globset::GlobSet,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+}
+
 fn analyze_runtime_coverage(
-    opts: &HealthOptions<'_>,
-    config: &ResolvedConfig,
-    modules: &[fallow_core::extract::ModuleInfo],
-    shared_analysis_output: Option<&fallow_core::AnalysisOutput>,
-    istanbul_coverage: Option<&scoring::IstanbulCoverage>,
-    file_paths: &rustc_hash::FxHashMap<fallow_core::discover::FileId, &std::path::PathBuf>,
-    ignore_set: &globset::GlobSet,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
+    input: RuntimeCoverageAnalysisScope<'_>,
 ) -> Result<Option<crate::health_types::RuntimeCoverageReport>, ExitCode> {
-    let Some(ref production_options) = opts.runtime_coverage else {
+    let Some(ref production_options) = input.opts.runtime_coverage else {
         return Ok(None);
     };
-    let Some(analysis_output) = shared_analysis_output else {
+    let Some(analysis_output) = input.shared_analysis_output else {
         return Err(emit_error(
             "runtime coverage requires analysis output",
             2,
-            opts.output,
+            input.opts.output,
         ));
     };
     coverage::analyze(
         production_options,
         &coverage::RuntimeCoverageAnalysisInput {
-            root: &config.root,
-            modules,
+            root: &input.config.root,
+            modules: input.modules,
             analysis_output,
-            istanbul_coverage,
-            file_paths,
-            ignore_set,
-            changed_files,
-            ws_roots,
-            top: opts.top,
-            codeowners_path: config.codeowners.as_deref(),
-            quiet: opts.quiet,
-            output: opts.output,
+            istanbul_coverage: input.istanbul_coverage,
+            file_paths: input.file_paths,
+            ignore_set: input.ignore_set,
+            changed_files: input.changed_files,
+            ws_roots: input.ws_roots,
+            top: input.opts.top,
+            codeowners_path: input.config.codeowners.as_deref(),
+            quiet: input.opts.quiet,
+            output: input.opts.output,
         },
     )
     .map(Some)
@@ -3888,17 +3888,17 @@ fn prepare_health_analysis_data(
         crate::telemetry::note_graph_structure(graph);
     }
 
-    let runtime_coverage = analyze_runtime_coverage(
-        input.opts,
-        input.config,
-        input.modules,
-        shared_analysis_output.as_ref(),
-        input.istanbul_coverage,
-        input.file_paths,
-        input.ignore_set,
-        input.changed_files,
-        input.ws_roots,
-    )?;
+    let runtime_coverage = analyze_runtime_coverage(RuntimeCoverageAnalysisScope {
+        opts: input.opts,
+        config: input.config,
+        modules: input.modules,
+        shared_analysis_output: shared_analysis_output.as_ref(),
+        istanbul_coverage: input.istanbul_coverage,
+        file_paths: input.file_paths,
+        ignore_set: input.ignore_set,
+        changed_files: input.changed_files,
+        ws_roots: input.ws_roots,
+    })?;
 
     let precomputed_for_scores = if input.needs_file_scores {
         shared_analysis_output.take()

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -2606,15 +2606,7 @@ struct HealthSupportingPartsInput<'a> {
 fn build_health_supporting_parts(
     input: HealthSupportingPartsInput<'_>,
 ) -> HealthOutputSupportingParts {
-    let grouping = build_health_output_grouping(
-        input.opts,
-        input.build,
-        input.analysis_data,
-        input.derived_sections,
-        input.vital_data,
-        input.findings,
-        input.action_ctx,
-    );
+    let grouping = build_health_output_grouping(&input);
     let timings = build_health_timings_from_pipeline(
         input.opts,
         input.build.start,
@@ -2627,31 +2619,25 @@ fn build_health_supporting_parts(
 }
 
 fn build_health_output_grouping(
-    opts: &HealthOptions<'_>,
-    build: &HealthOutputBuildInput<'_>,
-    analysis_data: &HealthAnalysisData,
-    derived_sections: &HealthDerivedSections,
-    vital_data: &HealthVitalData,
-    findings: &[ComplexityViolation],
-    action_ctx: &crate::health_types::HealthActionContext,
+    input: &HealthSupportingPartsInput<'_>,
 ) -> Option<crate::health_types::HealthGrouping> {
-    let file_scores = health_file_scores_slice(analysis_data.score_output.as_ref());
+    let file_scores = health_file_scores_slice(input.analysis_data.score_output.as_ref());
     build_health_grouping_from_context(HealthGroupingContextInput {
-        opts,
-        config: build.config,
-        group_resolver: build.group_resolver,
-        candidate_paths: &derived_sections.candidate_paths,
-        files: build.files,
-        modules: build.modules,
-        file_paths: build.file_paths,
-        score_output: analysis_data.score_output.as_ref(),
+        opts: input.opts,
+        config: input.build.config,
+        group_resolver: input.build.group_resolver,
+        candidate_paths: &input.derived_sections.candidate_paths,
+        files: input.build.files,
+        modules: input.build.modules,
+        file_paths: input.build.file_paths,
+        score_output: input.analysis_data.score_output.as_ref(),
         file_scores,
-        findings,
-        hotspots: &derived_sections.hotspots,
-        vital_data,
-        targets: &derived_sections.targets,
-        needs_file_scores: build.needs_file_scores,
-        action_ctx,
+        findings: input.findings,
+        hotspots: &input.derived_sections.hotspots,
+        vital_data: input.vital_data,
+        targets: &input.derived_sections.targets,
+        needs_file_scores: input.build.needs_file_scores,
+        action_ctx: input.action_ctx,
     })
 }
 

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -3189,15 +3189,15 @@ fn prepare_health_section_hotspots(
     opts: &HealthOptions<'_>,
     input: HealthHotspotSectionInput<'_>,
 ) -> (Vec<HotspotEntry>, Option<HotspotSummary>, f64) {
-    compute_filtered_hotspots(
+    compute_filtered_hotspots(FilteredHotspotInput {
         opts,
-        input.config,
-        input.file_scores,
-        input.ignore_set,
-        input.ws_roots,
-        input.churn_fetch,
-        input.diff_index,
-    )
+        config: input.config,
+        file_scores_slice: input.file_scores,
+        ignore_set: input.ignore_set,
+        ws_roots: input.ws_roots,
+        churn_fetch: input.churn_fetch,
+        diff_index: input.diff_index,
+    })
 }
 
 struct HealthTargetSectionInput<'a> {
@@ -4059,30 +4059,34 @@ fn apply_health_baseline_and_top(
     Ok(loaded_baseline)
 }
 
-fn compute_filtered_hotspots(
-    opts: &HealthOptions<'_>,
-    config: &ResolvedConfig,
-    file_scores_slice: &[FileHealthScore],
-    ignore_set: &globset::GlobSet,
-    ws_roots: Option<&[std::path::PathBuf]>,
+struct FilteredHotspotInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    config: &'a ResolvedConfig,
+    file_scores_slice: &'a [FileHealthScore],
+    ignore_set: &'a globset::GlobSet,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
     churn_fetch: Option<hotspots::ChurnFetchResult>,
-    diff_index: Option<&crate::report::ci::diff_filter::DiffIndex>,
+    diff_index: Option<&'a crate::report::ci::diff_filter::DiffIndex>,
+}
+
+fn compute_filtered_hotspots(
+    input: FilteredHotspotInput<'_>,
 ) -> (Vec<HotspotEntry>, Option<HotspotSummary>, f64) {
     let t = Instant::now();
-    let (mut hotspots, hotspot_summary) = if let Some(churn_data) = churn_fetch {
+    let (mut hotspots, hotspot_summary) = if let Some(churn_data) = input.churn_fetch {
         compute_hotspots(
-            opts,
-            config,
-            file_scores_slice,
-            ignore_set,
-            ws_roots,
+            input.opts,
+            input.config,
+            input.file_scores_slice,
+            input.ignore_set,
+            input.ws_roots,
             churn_data,
         )
     } else {
         (Vec::new(), None)
     };
-    if let Some(diff_index) = diff_index {
-        filter_hotspots_by_diff(&mut hotspots, diff_index, &config.root);
+    if let Some(diff_index) = input.diff_index {
+        filter_hotspots_by_diff(&mut hotspots, diff_index, &input.config.root);
     }
     (
         hotspots,

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -357,21 +357,21 @@ fn execute_health_inner(
         needs_file_scores,
     )?;
 
-    let findings_data = prepare_health_findings(
+    let findings_data = prepare_health_findings(HealthFindingsInput {
         opts,
-        &config,
-        &modules,
-        &scope.file_paths,
-        &scope.ignore_set,
-        scope.changed_files.as_ref(),
-        scope.ws_roots.as_deref(),
-        scope.diff_index,
-        scope.max_cyclomatic,
-        scope.max_cognitive,
-        scope.max_crap,
-        scope.enforce_crap,
-        analysis_data.score_output.as_ref(),
-    )?;
+        config: &config,
+        modules: &modules,
+        file_paths: &scope.file_paths,
+        ignore_set: &scope.ignore_set,
+        changed_files: scope.changed_files.as_ref(),
+        ws_roots: scope.ws_roots.as_deref(),
+        diff_index: scope.diff_index,
+        max_cyclomatic: scope.max_cyclomatic,
+        max_cognitive: scope.max_cognitive,
+        max_crap: scope.max_crap,
+        enforce_crap: scope.enforce_crap,
+        score_output: analysis_data.score_output.as_ref(),
+    })?;
 
     let HealthRuntimeSections {
         analysis_data,
@@ -3288,69 +3288,72 @@ fn build_health_result(input: HealthResultInput) -> HealthResult {
     }
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "finding preparation applies the active health scope and optional scoring data"
-)]
-fn prepare_health_findings(
-    opts: &HealthOptions<'_>,
-    config: &ResolvedConfig,
-    modules: &[fallow_core::extract::ModuleInfo],
-    file_paths: &rustc_hash::FxHashMap<fallow_core::discover::FileId, &std::path::PathBuf>,
-    ignore_set: &globset::GlobSet,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
-    diff_index: Option<&crate::report::ci::diff_filter::DiffIndex>,
+struct HealthFindingsInput<'a> {
+    opts: &'a HealthOptions<'a>,
+    config: &'a ResolvedConfig,
+    modules: &'a [fallow_core::extract::ModuleInfo],
+    file_paths: &'a rustc_hash::FxHashMap<fallow_core::discover::FileId, &'a std::path::PathBuf>,
+    ignore_set: &'a globset::GlobSet,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+    diff_index: Option<&'a crate::report::ci::diff_filter::DiffIndex>,
     max_cyclomatic: u16,
     max_cognitive: u16,
     max_crap: f64,
     enforce_crap: bool,
-    score_output: Option<&scoring::FileScoreOutput>,
-) -> Result<HealthFindingsData, ExitCode> {
+    score_output: Option<&'a scoring::FileScoreOutput>,
+}
+
+fn prepare_health_findings(input: HealthFindingsInput<'_>) -> Result<HealthFindingsData, ExitCode> {
     let t = Instant::now();
     let global_thresholds = GlobalHealthThresholds {
-        cyclomatic: max_cyclomatic,
-        cognitive: max_cognitive,
-        crap: max_crap,
+        cyclomatic: input.max_cyclomatic,
+        cognitive: input.max_cognitive,
+        crap: input.max_crap,
     };
     let threshold_resolver =
-        ThresholdOverrideResolver::new(&config.health.threshold_overrides, global_thresholds);
+        ThresholdOverrideResolver::new(&input.config.health.threshold_overrides, global_thresholds);
     let mut threshold_state_tracker = ThresholdOverrideStateTracker::default();
     let mut collect_input = CollectFindingsInput {
-        modules,
-        file_paths,
-        config_root: &config.root,
-        ignore_set,
-        changed_files,
-        ws_roots,
+        modules: input.modules,
+        file_paths: input.file_paths,
+        config_root: &input.config.root,
+        ignore_set: input.ignore_set,
+        changed_files: input.changed_files,
+        ws_roots: input.ws_roots,
         threshold_resolver: &threshold_resolver,
         threshold_state_tracker: &mut threshold_state_tracker,
-        complexity_breakdown: opts.complexity_breakdown,
+        complexity_breakdown: input.opts.complexity_breakdown,
     };
     let (mut findings, files_analyzed, total_functions) =
         collect_findings_with_resolver(&mut collect_input);
     let complexity_ms = t.elapsed().as_secs_f64() * 1000.0;
 
     let mut crap_ctx = HealthCrapMergeContext {
-        modules,
-        file_paths,
-        ignore_set,
-        changed_files,
-        ws_roots,
-        max_cyclomatic,
-        max_cognitive,
-        enforce_crap,
-        score_output,
-        config_root: &config.root,
+        modules: input.modules,
+        file_paths: input.file_paths,
+        ignore_set: input.ignore_set,
+        changed_files: input.changed_files,
+        ws_roots: input.ws_roots,
+        max_cyclomatic: input.max_cyclomatic,
+        max_cognitive: input.max_cognitive,
+        enforce_crap: input.enforce_crap,
+        score_output: input.score_output,
+        config_root: &input.config.root,
         threshold_resolver: &threshold_resolver,
         threshold_state_tracker: &mut threshold_state_tracker,
     };
-    apply_optional_crap_findings(opts, &mut findings, &mut crap_ctx);
+    apply_optional_crap_findings(input.opts, &mut findings, &mut crap_ctx);
     let (total_above_threshold, sev_critical, sev_high, sev_moderate, loaded_baseline) =
-        finalize_health_findings(opts, config, &mut findings, diff_index)?;
+        finalize_health_findings(input.opts, input.config, &mut findings, input.diff_index)?;
     threshold_state_tracker.record_no_match_entries(
         &threshold_resolver,
-        should_emit_no_match_threshold_overrides(opts, changed_files, ws_roots, diff_index),
+        should_emit_no_match_threshold_overrides(
+            input.opts,
+            input.changed_files,
+            input.ws_roots,
+            input.diff_index,
+        ),
     );
 
     Ok(HealthFindingsData {

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -4376,16 +4376,16 @@ fn prepare_health_vital_data(
         &mut counts,
         total_files_scoped,
     );
-    let large_functions = collect_filtered_large_functions(
-        &vital_signs,
-        input.modules,
-        input.file_paths,
-        input.config,
-        input.ignore_set,
-        input.changed_files,
-        input.ws_roots,
-        input.diff_index,
-    );
+    let large_functions = collect_filtered_large_functions(FilteredLargeFunctionInput {
+        vital_signs: &vital_signs,
+        modules: input.modules,
+        file_paths: input.file_paths,
+        config: input.config,
+        ignore_set: input.ignore_set,
+        changed_files: input.changed_files,
+        ws_roots: input.ws_roots,
+        diff_index: input.diff_index,
+    });
     if let Some(ref snapshot_path) = input.opts.save_snapshot {
         save_snapshot(SnapshotInput {
             opts: input.opts,
@@ -4424,32 +4424,32 @@ fn compute_health_score_metrics(
         .then(|| vital_signs::compute_health_score(vital_signs, total_files_scoped))
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "large-function filtering needs vital signs plus the active health scope"
-)]
+struct FilteredLargeFunctionInput<'a> {
+    vital_signs: &'a crate::health_types::VitalSigns,
+    modules: &'a [fallow_core::extract::ModuleInfo],
+    file_paths: &'a rustc_hash::FxHashMap<fallow_core::discover::FileId, &'a std::path::PathBuf>,
+    config: &'a ResolvedConfig,
+    ignore_set: &'a globset::GlobSet,
+    changed_files: Option<&'a rustc_hash::FxHashSet<std::path::PathBuf>>,
+    ws_roots: Option<&'a [std::path::PathBuf]>,
+    diff_index: Option<&'a crate::report::ci::diff_filter::DiffIndex>,
+}
+
 fn collect_filtered_large_functions(
-    vital_signs: &crate::health_types::VitalSigns,
-    modules: &[fallow_core::extract::ModuleInfo],
-    file_paths: &rustc_hash::FxHashMap<fallow_core::discover::FileId, &std::path::PathBuf>,
-    config: &ResolvedConfig,
-    ignore_set: &globset::GlobSet,
-    changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
-    ws_roots: Option<&[std::path::PathBuf]>,
-    diff_index: Option<&crate::report::ci::diff_filter::DiffIndex>,
+    input: FilteredLargeFunctionInput<'_>,
 ) -> Vec<crate::health_types::LargeFunctionEntry> {
-    let input = LargeFunctionInput {
-        vital_signs,
-        modules,
-        file_paths,
-        config_root: &config.root,
-        ignore_set,
-        changed_files,
-        ws_roots,
+    let large_input = LargeFunctionInput {
+        vital_signs: input.vital_signs,
+        modules: input.modules,
+        file_paths: input.file_paths,
+        config_root: &input.config.root,
+        ignore_set: input.ignore_set,
+        changed_files: input.changed_files,
+        ws_roots: input.ws_roots,
     };
-    let mut large_functions = collect_large_functions(&input);
-    if let Some(diff_index) = diff_index {
-        filter_large_functions_by_diff(&mut large_functions, diff_index, &config.root);
+    let mut large_functions = collect_large_functions(&large_input);
+    if let Some(diff_index) = input.diff_index {
+        filter_large_functions_by_diff(&mut large_functions, diff_index, &input.config.root);
     }
     large_functions
 }

--- a/crates/cli/src/health/scoring.rs
+++ b/crates/cli/src/health/scoring.rs
@@ -1262,20 +1262,20 @@ pub(super) fn compute_file_scores(
         istanbul_total += crap.istanbul_total;
         record_per_function_crap(&mut per_function_crap, &path_owned, crap.per_function);
 
-        scores.push(build_file_health_score(
-            path_owned,
+        scores.push(FileHealthScore {
+            path: path_owned,
             fan_in,
             fan_out,
-            dead_code_ratio_rounded,
-            complexity_density_rounded,
-            maintainability_index,
+            dead_code_ratio: dead_code_ratio_rounded,
+            complexity_density: complexity_density_rounded,
+            maintainability_index: (maintainability_index * 10.0).round() / 10.0,
             total_cyclomatic,
             total_cognitive,
             function_count,
             lines,
-            crap.max,
-            crap.above_threshold,
-        ));
+            crap_max: crap.max,
+            crap_above_threshold: crap.above_threshold,
+        });
     }
 
     if let Some(changed) = changed_files {
@@ -1515,40 +1515,6 @@ fn record_per_function_crap(
 ) {
     if !per_function.is_empty() {
         per_function_crap.insert(path.to_path_buf(), per_function);
-    }
-}
-
-#[expect(
-    clippy::too_many_arguments,
-    reason = "constructs a typed score row from already named per-file metrics"
-)]
-fn build_file_health_score(
-    path: std::path::PathBuf,
-    fan_in: usize,
-    fan_out: usize,
-    dead_code_ratio: f64,
-    complexity_density: f64,
-    maintainability_index: f64,
-    total_cyclomatic: u32,
-    total_cognitive: u32,
-    function_count: usize,
-    lines: u32,
-    crap_max: f64,
-    crap_above_threshold: usize,
-) -> FileHealthScore {
-    FileHealthScore {
-        path,
-        fan_in,
-        fan_out,
-        dead_code_ratio,
-        complexity_density,
-        maintainability_index: (maintainability_index * 10.0).round() / 10.0,
-        total_cyclomatic,
-        total_cognitive,
-        function_count,
-        lines,
-        crap_max,
-        crap_above_threshold,
     }
 }
 

--- a/crates/cli/src/health_types/finding.rs
+++ b/crates/cli/src/health_types/finding.rs
@@ -173,6 +173,7 @@ pub fn build_health_finding_actions(
     actions
 }
 
+#[derive(Clone, Copy)]
 struct RefactorActionDecision<'a> {
     crap_only: bool,
     full_coverage_can_clear_crap: bool,

--- a/crates/cli/src/health_types/finding.rs
+++ b/crates/cli/src/health_types/finding.rs
@@ -149,7 +149,7 @@ pub fn build_health_finding_actions(
 
     let is_template = name == "<template>";
     let is_component = name == "<component>";
-    if should_add_refactor_action(
+    if should_add_refactor_action(RefactorActionDecision {
         crap_only,
         full_coverage_can_clear_crap,
         cyclomatic,
@@ -157,7 +157,7 @@ pub fn build_health_finding_actions(
         max_cyclomatic_threshold,
         max_cognitive_threshold,
         ctx,
-    ) {
+    }) {
         actions.push(build_refactor_action(
             violation,
             name,
@@ -173,22 +173,28 @@ pub fn build_health_finding_actions(
     actions
 }
 
-fn should_add_refactor_action(
+struct RefactorActionDecision<'a> {
     crap_only: bool,
     full_coverage_can_clear_crap: bool,
     cyclomatic: u16,
     cognitive: u16,
     max_cyclomatic_threshold: u16,
     max_cognitive_threshold: u16,
-    ctx: &HealthActionContext,
-) -> bool {
-    let crap_only_needs_complexity_reduction = crap_only && !full_coverage_can_clear_crap;
-    let cognitive_floor = max_cognitive_threshold / 2;
-    let near_cyclomatic_threshold = crap_only
-        && cyclomatic > 0
-        && cyclomatic >= max_cyclomatic_threshold.saturating_sub(ctx.crap_refactor_band)
-        && cognitive >= cognitive_floor;
-    !crap_only || crap_only_needs_complexity_reduction || near_cyclomatic_threshold
+    ctx: &'a HealthActionContext,
+}
+
+fn should_add_refactor_action(input: RefactorActionDecision<'_>) -> bool {
+    let crap_only_needs_complexity_reduction =
+        input.crap_only && !input.full_coverage_can_clear_crap;
+    let cognitive_floor = input.max_cognitive_threshold / 2;
+    let near_cyclomatic_threshold = input.crap_only
+        && input.cyclomatic > 0
+        && input.cyclomatic
+            >= input
+                .max_cyclomatic_threshold
+                .saturating_sub(input.ctx.crap_refactor_band)
+        && input.cognitive >= cognitive_floor;
+    !input.crap_only || crap_only_needs_complexity_reduction || near_cyclomatic_threshold
 }
 
 fn build_refactor_action(

--- a/crates/cli/src/report/codeclimate.rs
+++ b/crates/cli/src/report/codeclimate.rs
@@ -388,29 +388,32 @@ fn push_unused_file_issues(
 /// `direct_label` / `re_export_label` let the same helper produce the right
 /// prose for both `unused-export` (Export / Re-export) and `unused-type`
 /// (Type export / Type re-export) rule ids.
-fn push_unused_export_issues<'a, I>(
-    issues: &mut Vec<CodeClimateIssue>,
+struct UnusedExportIssuesInput<'a, I> {
+    issues: &'a mut Vec<CodeClimateIssue>,
     exports: I,
-    root: &Path,
-    rule_id: &str,
-    direct_label: &str,
-    re_export_label: &str,
+    root: &'a Path,
+    rule_id: &'a str,
+    direct_label: &'a str,
+    re_export_label: &'a str,
     severity: Severity,
-) where
+}
+
+fn push_unused_export_issues<'a, I>(input: UnusedExportIssuesInput<'a, I>)
+where
     I: IntoIterator<Item = &'a fallow_core::results::UnusedExport>,
 {
-    for export in exports {
-        let level = severity_to_codeclimate(severity);
-        let path = cc_path(&export.path, root);
+    let level = severity_to_codeclimate(input.severity);
+    for export in input.exports {
+        let path = cc_path(&export.path, input.root);
         let kind = if export.is_re_export {
-            re_export_label
+            input.re_export_label
         } else {
-            direct_label
+            input.direct_label
         };
         let line_str = export.line.to_string();
-        let fp = fingerprint_hash(&[rule_id, &path, &line_str, &export.export_name]);
-        issues.push(cc_issue(
-            rule_id,
+        let fp = fingerprint_hash(&[input.rule_id, &path, &line_str, &export.export_name]);
+        input.issues.push(cc_issue(
+            input.rule_id,
             &format!(
                 "{kind} '{}' is never imported by other modules",
                 export.export_name
@@ -1669,24 +1672,24 @@ impl CodeClimateBuilder<'_> {
             self.root,
             self.rules.unused_files,
         );
-        push_unused_export_issues(
-            &mut self.issues,
-            self.results.unused_exports.iter().map(|e| &e.export),
-            self.root,
-            "fallow/unused-export",
-            "Export",
-            "Re-export",
-            self.rules.unused_exports,
-        );
-        push_unused_export_issues(
-            &mut self.issues,
-            self.results.unused_types.iter().map(|e| &e.export),
-            self.root,
-            "fallow/unused-type",
-            "Type export",
-            "Type re-export",
-            self.rules.unused_types,
-        );
+        push_unused_export_issues(UnusedExportIssuesInput {
+            issues: &mut self.issues,
+            exports: self.results.unused_exports.iter().map(|e| &e.export),
+            root: self.root,
+            rule_id: "fallow/unused-export",
+            direct_label: "Export",
+            re_export_label: "Re-export",
+            severity: self.rules.unused_exports,
+        });
+        push_unused_export_issues(UnusedExportIssuesInput {
+            issues: &mut self.issues,
+            exports: self.results.unused_types.iter().map(|e| &e.export),
+            root: self.root,
+            rule_id: "fallow/unused-type",
+            direct_label: "Type export",
+            re_export_label: "Type re-export",
+            severity: self.rules.unused_types,
+        });
     }
 
     fn push_private_type_leak_issues(&mut self) {

--- a/crates/cli/src/report/codeclimate.rs
+++ b/crates/cli/src/report/codeclimate.rs
@@ -402,8 +402,8 @@ fn push_unused_export_issues<'a, I>(input: UnusedExportIssuesInput<'a, I>)
 where
     I: IntoIterator<Item = &'a fallow_core::results::UnusedExport>,
 {
-    let level = severity_to_codeclimate(input.severity);
     for export in input.exports {
+        let level = severity_to_codeclimate(input.severity);
         let path = cc_path(&export.path, input.root);
         let kind = if export.is_re_export {
             input.re_export_label

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -285,15 +285,15 @@ fn build_human_lines_with_explain(
     let total_issues = results.total_issues();
     let mut lines = Vec::new();
 
-    build_unused_code_section(
-        &mut lines,
+    build_unused_code_section(UnusedCodeSectionInput {
+        lines: &mut lines,
         results,
         root,
         rules,
         max_items,
         max_grouped_files,
         total_issues,
-    );
+    });
     build_dependencies_section(DependencySectionInput {
         lines: &mut lines,
         results,
@@ -608,102 +608,121 @@ fn push_human_pkg_dep_section<T: NamedPkgDep>(
     );
 }
 
-fn build_unused_code_section(
-    lines: &mut Vec<String>,
-    results: &AnalysisResults,
-    root: &Path,
-    rules: &RulesConfig,
+struct UnusedCodeSectionInput<'a> {
+    lines: &'a mut Vec<String>,
+    results: &'a AnalysisResults,
+    root: &'a Path,
+    rules: &'a RulesConfig,
     max_items: usize,
     max_grouped_files: usize,
     total_issues: usize,
-) {
-    let unused_file_set: FxHashSet<&Path> = results
+}
+
+fn build_unused_code_section(input: UnusedCodeSectionInput<'_>) {
+    let unused_file_set: FxHashSet<&Path> = input
+        .results
         .unused_files
         .iter()
         .map(|f| f.file.path.as_path())
         .collect();
-    let filtered_exports: Vec<UnusedExportFinding> = results
+    let filtered_exports: Vec<UnusedExportFinding> = input
+        .results
         .unused_exports
         .iter()
         .filter(|e| !unused_file_set.contains(e.export.path.as_path()))
         .cloned()
         .collect();
-    let filtered_types: Vec<UnusedTypeFinding> = results
+    let filtered_types: Vec<UnusedTypeFinding> = input
+        .results
         .unused_types
         .iter()
         .filter(|e| !unused_file_set.contains(e.export.path.as_path()))
         .cloned()
         .collect();
-    let suppressed_exports = results.unused_exports.len() - filtered_exports.len();
-    let suppressed_types = results.unused_types.len() - filtered_types.len();
+    let suppressed_exports = input.results.unused_exports.len() - filtered_exports.len();
+    let suppressed_types = input.results.unused_types.len() - filtered_types.len();
 
-    let has_unused_code = !results.unused_files.is_empty()
+    let has_unused_code = !input.results.unused_files.is_empty()
         || !filtered_exports.is_empty()
         || !filtered_types.is_empty()
-        || !results.private_type_leaks.is_empty()
-        || !results.unused_enum_members.is_empty()
-        || !results.unused_class_members.is_empty()
-        || !results.unused_store_members.is_empty();
+        || !input.results.private_type_leaks.is_empty()
+        || !input.results.unused_enum_members.is_empty()
+        || !input.results.unused_class_members.is_empty()
+        || !input.results.unused_store_members.is_empty();
     if !has_unused_code {
         return;
     }
-    push_category_header(lines, "Unused Code");
+    push_category_header(input.lines, "Unused Code");
 
-    if results.unused_files.len() > DIR_ROLLUP_THRESHOLD {
-        build_dir_rollup_section(lines, &results.unused_files, root, rules, total_issues);
+    if input.results.unused_files.len() > DIR_ROLLUP_THRESHOLD {
+        build_dir_rollup_section(
+            input.lines,
+            &input.results.unused_files,
+            input.root,
+            input.rules,
+            input.total_issues,
+        );
     } else {
         build_human_section_ex(
-            lines,
-            &results.unused_files,
+            input.lines,
+            &input.results.unused_files,
             "Unused files",
-            severity_to_level(rules.unused_files),
-            max_items,
-            total_issues,
+            severity_to_level(input.rules.unused_files),
+            input.max_items,
+            input.total_issues,
             |file| {
-                let path_str = relative_path(&file.file.path, root).display().to_string();
+                let path_str = relative_path(&file.file.path, input.root)
+                    .display()
+                    .to_string();
                 vec![format!("  {}", format_path(&path_str))]
             },
         );
     }
-    insert_test_src_split(lines, &results.unused_files, |f| &f.file.path);
+    insert_test_src_split(input.lines, &input.results.unused_files, |f| &f.file.path);
 
     build_human_grouped_section(GroupedSectionInput {
-        lines,
+        lines: input.lines,
         items: &filtered_exports,
         title: "Unused exports",
-        level: severity_to_level(rules.unused_exports),
-        root,
-        max_files: max_grouped_files,
+        level: severity_to_level(input.rules.unused_exports),
+        root: input.root,
+        max_files: input.max_grouped_files,
         get_path: |e| e.export.path.as_path(),
         format_detail: &|e: &UnusedExportFinding| format_unused_export(&e.export),
     });
-    push_suppressed_count_note(lines, suppressed_exports);
-    insert_test_src_split(lines, &filtered_exports, |e| &e.export.path);
+    push_suppressed_count_note(input.lines, suppressed_exports);
+    insert_test_src_split(input.lines, &filtered_exports, |e| &e.export.path);
 
     build_human_grouped_section(GroupedSectionInput {
-        lines,
+        lines: input.lines,
         items: &filtered_types,
         title: "Unused type exports",
-        level: severity_to_level(rules.unused_types),
-        root,
-        max_files: max_grouped_files,
+        level: severity_to_level(input.rules.unused_types),
+        root: input.root,
+        max_files: input.max_grouped_files,
         get_path: |e| e.export.path.as_path(),
         format_detail: &|e: &UnusedTypeFinding| format_unused_export(&e.export),
     });
-    push_suppressed_count_note(lines, suppressed_types);
+    push_suppressed_count_note(input.lines, suppressed_types);
 
     build_human_grouped_section(GroupedSectionInput {
-        lines,
-        items: &results.private_type_leaks,
+        lines: input.lines,
+        items: &input.results.private_type_leaks,
         title: "Private type leaks",
-        level: severity_to_level(rules.private_type_leaks),
-        root,
-        max_files: max_grouped_files,
+        level: severity_to_level(input.rules.private_type_leaks),
+        root: input.root,
+        max_files: input.max_grouped_files,
         get_path: |e| e.leak.path.as_path(),
         format_detail: &format_private_type_leak,
     });
 
-    build_unused_member_sections(lines, results, root, rules, max_grouped_files);
+    build_unused_member_sections(
+        input.lines,
+        input.results,
+        input.root,
+        input.rules,
+        input.max_grouped_files,
+    );
 }
 
 fn build_unused_member_sections(

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -294,15 +294,15 @@ fn build_human_lines_with_explain(
         max_grouped_files,
         total_issues,
     );
-    build_dependencies_section(
-        &mut lines,
+    build_dependencies_section(DependencySectionInput {
+        lines: &mut lines,
         results,
         root,
         rules,
         max_items,
         max_grouped_files,
         total_issues,
-    );
+    });
     build_structure_section(&mut lines, results, root, rules, total_issues);
     build_policy_section(&mut lines, results, root, rules, total_issues);
     build_maintenance_section(&mut lines, results, root, rules, total_issues);
@@ -747,32 +747,55 @@ fn build_unused_member_sections(
     });
 }
 
-fn build_dependencies_section(
-    lines: &mut Vec<String>,
-    results: &AnalysisResults,
-    root: &Path,
-    rules: &RulesConfig,
+struct DependencySectionInput<'a> {
+    lines: &'a mut Vec<String>,
+    results: &'a AnalysisResults,
+    root: &'a Path,
+    rules: &'a RulesConfig,
     max_items: usize,
     max_grouped_files: usize,
     total_issues: usize,
-) {
-    if !has_dependency_findings(results) {
+}
+
+fn build_dependencies_section(input: DependencySectionInput<'_>) {
+    if !has_dependency_findings(input.results) {
         return;
     }
-    push_category_header(lines, "Dependencies");
+    push_category_header(input.lines, "Dependencies");
 
-    push_package_dependency_sections(lines, results, root, rules, max_items, total_issues);
+    push_package_dependency_sections(
+        input.lines,
+        input.results,
+        input.root,
+        input.rules,
+        input.max_items,
+        input.total_issues,
+    );
     push_import_dependency_sections(ImportDependencySectionInput {
-        lines,
-        results,
-        root,
-        rules,
-        max_items,
-        max_grouped_files,
-        total_issues,
+        lines: input.lines,
+        results: input.results,
+        root: input.root,
+        rules: input.rules,
+        max_items: input.max_items,
+        max_grouped_files: input.max_grouped_files,
+        total_issues: input.total_issues,
     });
-    push_catalog_dependency_sections(lines, results, root, rules, max_items, total_issues);
-    push_dependency_override_sections(lines, results, root, rules, max_items, total_issues);
+    push_catalog_dependency_sections(
+        input.lines,
+        input.results,
+        input.root,
+        input.rules,
+        input.max_items,
+        input.total_issues,
+    );
+    push_dependency_override_sections(
+        input.lines,
+        input.results,
+        input.root,
+        input.rules,
+        input.max_items,
+        input.total_issues,
+    );
 }
 
 fn has_dependency_findings(results: &AnalysisResults) -> bool {

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -578,22 +578,24 @@ impl NamedPkgDep for TestOnlyDependencyFinding {
     }
 }
 
-fn push_human_pkg_dep_section<T: NamedPkgDep>(
-    lines: &mut Vec<String>,
-    items: &[T],
+struct HumanPkgDepSectionInput<'a, T> {
+    lines: &'a mut Vec<String>,
+    items: &'a [T],
     title: &'static str,
     severity: Severity,
     max_items: usize,
     total_issues: usize,
-    root: &Path,
-) {
+    root: &'a Path,
+}
+
+fn push_human_pkg_dep_section<T: NamedPkgDep>(input: HumanPkgDepSectionInput<'_, T>) {
     build_human_section_ex(
-        lines,
-        items,
-        title,
-        severity_to_level(severity),
-        max_items,
-        total_issues,
+        input.lines,
+        input.items,
+        input.title,
+        severity_to_level(input.severity),
+        input.max_items,
+        input.total_issues,
         |dep| {
             vec![format!(
                 "  {}",
@@ -601,7 +603,7 @@ fn push_human_pkg_dep_section<T: NamedPkgDep>(
                     dep.pkg_name(),
                     dep.pkg_path(),
                     dep.used_in_workspaces(),
-                    root
+                    input.root
                 )
             )]
         },
@@ -840,33 +842,33 @@ fn push_package_dependency_sections(
     max_items: usize,
     total_issues: usize,
 ) {
-    push_human_pkg_dep_section(
+    push_human_pkg_dep_section(HumanPkgDepSectionInput {
         lines,
-        &results.unused_dependencies,
-        "Unused dependencies",
-        rules.unused_dependencies,
+        items: &results.unused_dependencies,
+        title: "Unused dependencies",
+        severity: rules.unused_dependencies,
         max_items,
         total_issues,
         root,
-    );
-    push_human_pkg_dep_section(
+    });
+    push_human_pkg_dep_section(HumanPkgDepSectionInput {
         lines,
-        &results.unused_dev_dependencies,
-        "Unused devDependencies",
-        rules.unused_dev_dependencies,
+        items: &results.unused_dev_dependencies,
+        title: "Unused devDependencies",
+        severity: rules.unused_dev_dependencies,
         max_items,
         total_issues,
         root,
-    );
-    push_human_pkg_dep_section(
+    });
+    push_human_pkg_dep_section(HumanPkgDepSectionInput {
         lines,
-        &results.unused_optional_dependencies,
-        "Unused optionalDependencies",
-        rules.unused_optional_dependencies,
+        items: &results.unused_optional_dependencies,
+        title: "Unused optionalDependencies",
+        severity: rules.unused_optional_dependencies,
         max_items,
         total_issues,
         root,
-    );
+    });
 }
 
 struct ImportDependencySectionInput<'a> {
@@ -915,24 +917,24 @@ fn push_import_dependency_sections(input: ImportDependencySectionInput<'_>) {
         total_issues,
         |dep| vec![format!("  {}", dep.dep.package_name.bold())],
     );
-    push_human_pkg_dep_section(
+    push_human_pkg_dep_section(HumanPkgDepSectionInput {
         lines,
-        &results.type_only_dependencies,
-        "Type-only dependencies (consider moving to devDependencies)",
-        rules.type_only_dependencies,
+        items: &results.type_only_dependencies,
+        title: "Type-only dependencies (consider moving to devDependencies)",
+        severity: rules.type_only_dependencies,
         max_items,
         total_issues,
         root,
-    );
-    push_human_pkg_dep_section(
+    });
+    push_human_pkg_dep_section(HumanPkgDepSectionInput {
         lines,
-        &results.test_only_dependencies,
-        "Test-only production dependencies (consider moving to devDependencies)",
-        rules.test_only_dependencies,
+        items: &results.test_only_dependencies,
+        title: "Test-only production dependencies (consider moving to devDependencies)",
+        severity: rules.test_only_dependencies,
         max_items,
         total_issues,
         root,
-    );
+    });
 }
 
 fn push_catalog_dependency_sections(

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -285,7 +285,7 @@ fn build_human_lines_with_explain(
     let total_issues = results.total_issues();
     let mut lines = Vec::new();
 
-    build_unused_code_section(UnusedCodeSectionInput {
+    build_unused_code_section(&mut UnusedCodeSectionInput {
         lines: &mut lines,
         results,
         root,
@@ -294,7 +294,7 @@ fn build_human_lines_with_explain(
         max_grouped_files,
         total_issues,
     });
-    build_dependencies_section(DependencySectionInput {
+    build_dependencies_section(&mut DependencySectionInput {
         lines: &mut lines,
         results,
         root,
@@ -588,7 +588,7 @@ struct HumanPkgDepSectionInput<'a, T> {
     root: &'a Path,
 }
 
-fn push_human_pkg_dep_section<T: NamedPkgDep>(input: HumanPkgDepSectionInput<'_, T>) {
+fn push_human_pkg_dep_section<T: NamedPkgDep>(input: &mut HumanPkgDepSectionInput<'_, T>) {
     build_human_section_ex(
         input.lines,
         input.items,
@@ -620,7 +620,7 @@ struct UnusedCodeSectionInput<'a> {
     total_issues: usize,
 }
 
-fn build_unused_code_section(input: UnusedCodeSectionInput<'_>) {
+fn build_unused_code_section(input: &mut UnusedCodeSectionInput<'_>) {
     let unused_file_set: FxHashSet<&Path> = input
         .results
         .unused_files
@@ -778,7 +778,7 @@ struct DependencySectionInput<'a> {
     total_issues: usize,
 }
 
-fn build_dependencies_section(input: DependencySectionInput<'_>) {
+fn build_dependencies_section(input: &mut DependencySectionInput<'_>) {
     if !has_dependency_findings(input.results) {
         return;
     }
@@ -842,7 +842,7 @@ fn push_package_dependency_sections(
     max_items: usize,
     total_issues: usize,
 ) {
-    push_human_pkg_dep_section(HumanPkgDepSectionInput {
+    push_human_pkg_dep_section(&mut HumanPkgDepSectionInput {
         lines,
         items: &results.unused_dependencies,
         title: "Unused dependencies",
@@ -851,7 +851,7 @@ fn push_package_dependency_sections(
         total_issues,
         root,
     });
-    push_human_pkg_dep_section(HumanPkgDepSectionInput {
+    push_human_pkg_dep_section(&mut HumanPkgDepSectionInput {
         lines,
         items: &results.unused_dev_dependencies,
         title: "Unused devDependencies",
@@ -860,7 +860,7 @@ fn push_package_dependency_sections(
         total_issues,
         root,
     });
-    push_human_pkg_dep_section(HumanPkgDepSectionInput {
+    push_human_pkg_dep_section(&mut HumanPkgDepSectionInput {
         lines,
         items: &results.unused_optional_dependencies,
         title: "Unused optionalDependencies",
@@ -917,7 +917,7 @@ fn push_import_dependency_sections(input: ImportDependencySectionInput<'_>) {
         total_issues,
         |dep| vec![format!("  {}", dep.dep.package_name.bold())],
     );
-    push_human_pkg_dep_section(HumanPkgDepSectionInput {
+    push_human_pkg_dep_section(&mut HumanPkgDepSectionInput {
         lines,
         items: &results.type_only_dependencies,
         title: "Type-only dependencies (consider moving to devDependencies)",
@@ -926,7 +926,7 @@ fn push_import_dependency_sections(input: ImportDependencySectionInput<'_>) {
         total_issues,
         root,
     });
-    push_human_pkg_dep_section(HumanPkgDepSectionInput {
+    push_human_pkg_dep_section(&mut HumanPkgDepSectionInput {
         lines,
         items: &results.test_only_dependencies,
         title: "Test-only production dependencies (consider moving to devDependencies)",

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -470,15 +470,15 @@ fn resolve_extends_file(
     let mut merged = serde_json::Value::Object(serde_json::Map::new());
 
     for extend_path_str in &extends {
-        let base = resolve_extends_file_entry(
+        let base = resolve_extends_file_entry(ExtendsFileEntryInput {
             path,
             config_dir,
-            extend_path_str,
+            entry: extend_path_str,
             sealed,
-            sealed_dir_canonical.as_deref(),
+            sealed_dir_canonical: sealed_dir_canonical.as_deref(),
             visited,
             depth,
-        )?;
+        })?;
         deep_merge_json(&mut merged, base);
     }
 
@@ -520,39 +520,43 @@ fn sealed_config_dir(config_dir: &Path, sealed: bool) -> Result<Option<PathBuf>,
     })
 }
 
-fn resolve_extends_file_entry(
-    path: &Path,
-    config_dir: &Path,
-    entry: &str,
+struct ExtendsFileEntryInput<'a> {
+    path: &'a Path,
+    config_dir: &'a Path,
+    entry: &'a str,
     sealed: bool,
-    sealed_dir_canonical: Option<&Path>,
-    visited: &mut FxHashSet<String>,
+    sealed_dir_canonical: Option<&'a Path>,
+    visited: &'a mut FxHashSet<String>,
     depth: usize,
+}
+
+fn resolve_extends_file_entry(
+    input: ExtendsFileEntryInput<'_>,
 ) -> Result<serde_json::Value, miette::Report> {
-    if entry.starts_with(HTTPS_PREFIX) {
-        reject_sealed_remote_extends(path, entry, sealed, "URL")?;
-        return resolve_url_extends(entry, visited, depth + 1);
+    if input.entry.starts_with(HTTPS_PREFIX) {
+        reject_sealed_remote_extends(input.path, input.entry, input.sealed, "URL")?;
+        return resolve_url_extends(input.entry, input.visited, input.depth + 1);
     }
-    if entry.starts_with(HTTP_PREFIX) {
+    if input.entry.starts_with(HTTP_PREFIX) {
         return Err(miette::miette!(
             "URL extends must use https://, got http:// URL '{}' (in {}). \
              Change the URL to use https:// instead",
-            entry,
-            path.display()
+            input.entry,
+            input.path.display()
         ));
     }
-    if let Some(npm_specifier) = entry.strip_prefix(NPM_PREFIX) {
-        reject_sealed_remote_extends(path, entry, sealed, "npm")?;
-        let npm_path = resolve_npm_package(config_dir, npm_specifier, path)?;
-        return resolve_extends_file(&npm_path, visited, depth + 1);
+    if let Some(npm_specifier) = input.entry.strip_prefix(NPM_PREFIX) {
+        reject_sealed_remote_extends(input.path, input.entry, input.sealed, "npm")?;
+        let npm_path = resolve_npm_package(input.config_dir, npm_specifier, input.path)?;
+        return resolve_extends_file(&npm_path, input.visited, input.depth + 1);
     }
     resolve_relative_extends_file(
-        path,
-        config_dir,
-        entry,
-        sealed_dir_canonical,
-        visited,
-        depth,
+        input.path,
+        input.config_dir,
+        input.entry,
+        input.sealed_dir_canonical,
+        input.visited,
+        input.depth,
     )
 }
 

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -470,7 +470,7 @@ fn resolve_extends_file(
     let mut merged = serde_json::Value::Object(serde_json::Map::new());
 
     for extend_path_str in &extends {
-        let base = resolve_extends_file_entry(ExtendsFileEntryInput {
+        let base = resolve_extends_file_entry(&mut ExtendsFileEntryInput {
             path,
             config_dir,
             entry: extend_path_str,
@@ -531,7 +531,7 @@ struct ExtendsFileEntryInput<'a> {
 }
 
 fn resolve_extends_file_entry(
-    input: ExtendsFileEntryInput<'_>,
+    input: &mut ExtendsFileEntryInput<'_>,
 ) -> Result<serde_json::Value, miette::Report> {
     if input.entry.starts_with(HTTPS_PREFIX) {
         reject_sealed_remote_extends(input.path, input.entry, input.sealed, "URL")?;

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -1547,15 +1547,15 @@ fn run_member_and_dependency_detectors(
             })
         },
         || {
-            run_dependency_detectors(
-                input.graph,
-                input.pkg,
-                input.config,
-                input.plugin_result,
-                input.workspaces,
-                input.resolved_modules,
-                input.line_offsets_by_file,
-            )
+            run_dependency_detectors(DependencyDetectorInput {
+                graph: input.graph,
+                pkg: input.pkg,
+                config: input.config,
+                plugin_result: input.plugin_result,
+                workspaces: input.workspaces,
+                resolved_modules: input.resolved_modules,
+                line_offsets_by_file: input.line_offsets_by_file,
+            })
         },
     )
 }
@@ -2072,43 +2072,50 @@ fn run_member_detectors(input: MemberDetectorInput<'_>) -> AnalysisResults {
     results
 }
 
+struct DependencyDetectorInput<'a> {
+    graph: &'a ModuleGraph,
+    pkg: Option<&'a PackageJson>,
+    config: &'a ResolvedConfig,
+    plugin_result: Option<&'a crate::plugins::AggregatedPluginResult>,
+    workspaces: &'a [fallow_config::WorkspaceInfo],
+    resolved_modules: &'a [ResolvedModule],
+    line_offsets_by_file: &'a LineOffsetsMap<'a>,
+}
+
 #[expect(
     deprecated,
     reason = "ADR-008 deprecates detector helpers for external callers; core orchestration still calls them internally"
 )]
-fn run_dependency_detectors(
-    graph: &ModuleGraph,
-    pkg: Option<&PackageJson>,
-    config: &ResolvedConfig,
-    plugin_result: Option<&crate::plugins::AggregatedPluginResult>,
-    workspaces: &[fallow_config::WorkspaceInfo],
-    resolved_modules: &[ResolvedModule],
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-) -> AnalysisResults {
+fn run_dependency_detectors(input: DependencyDetectorInput<'_>) -> AnalysisResults {
     let mut results = AnalysisResults::default();
-    let Some(pkg) = pkg else {
+    let Some(pkg) = input.pkg else {
         return results;
     };
 
-    if config.rules.unused_dependencies != Severity::Off
-        || config.rules.unused_dev_dependencies != Severity::Off
-        || config.rules.unused_optional_dependencies != Severity::Off
+    if input.config.rules.unused_dependencies != Severity::Off
+        || input.config.rules.unused_dev_dependencies != Severity::Off
+        || input.config.rules.unused_optional_dependencies != Severity::Off
     {
-        let (deps, dev_deps, optional_deps) =
-            find_unused_dependencies(graph, pkg, config, plugin_result, workspaces);
-        if config.rules.unused_dependencies != Severity::Off {
+        let (deps, dev_deps, optional_deps) = find_unused_dependencies(
+            input.graph,
+            pkg,
+            input.config,
+            input.plugin_result,
+            input.workspaces,
+        );
+        if input.config.rules.unused_dependencies != Severity::Off {
             results.unused_dependencies = deps
                 .into_iter()
                 .map(UnusedDependencyFinding::with_actions)
                 .collect();
         }
-        if config.rules.unused_dev_dependencies != Severity::Off {
+        if input.config.rules.unused_dev_dependencies != Severity::Off {
             results.unused_dev_dependencies = dev_deps
                 .into_iter()
                 .map(UnusedDevDependencyFinding::with_actions)
                 .collect();
         }
-        if config.rules.unused_optional_dependencies != Severity::Off {
+        if input.config.rules.unused_optional_dependencies != Severity::Off {
             results.unused_optional_dependencies = optional_deps
                 .into_iter()
                 .map(UnusedOptionalDependencyFinding::with_actions)
@@ -2116,32 +2123,32 @@ fn run_dependency_detectors(
         }
     }
 
-    if config.rules.unlisted_dependencies != Severity::Off {
+    if input.config.rules.unlisted_dependencies != Severity::Off {
         results.unlisted_dependencies = find_unlisted_dependencies(
-            graph,
+            input.graph,
             pkg,
-            config,
-            workspaces,
-            plugin_result,
-            resolved_modules,
-            line_offsets_by_file,
+            input.config,
+            input.workspaces,
+            input.plugin_result,
+            input.resolved_modules,
+            input.line_offsets_by_file,
         )
         .into_iter()
         .map(UnlistedDependencyFinding::with_actions)
         .collect();
     }
 
-    if config.production {
+    if input.config.production {
         results.type_only_dependencies =
-            find_type_only_dependencies(graph, pkg, config, workspaces)
+            find_type_only_dependencies(input.graph, pkg, input.config, input.workspaces)
                 .into_iter()
                 .map(TypeOnlyDependencyFinding::with_actions)
                 .collect();
     }
 
-    if !config.production && config.rules.test_only_dependencies != Severity::Off {
+    if !input.config.production && input.config.rules.test_only_dependencies != Severity::Off {
         results.test_only_dependencies =
-            find_test_only_dependencies(graph, pkg, config, workspaces)
+            find_test_only_dependencies(input.graph, pkg, input.config, input.workspaces)
                 .into_iter()
                 .map(TestOnlyDependencyFinding::with_actions)
                 .collect();

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -812,15 +812,7 @@ fn populate_framework_specific_findings(input: &mut FrameworkSpecificFindingsInp
     populate_misplaced_directive_findings(input);
     populate_unprovided_inject_findings(input);
     populate_unrendered_component_findings(input);
-    populate_unused_component_prop_findings(
-        input.graph,
-        input.modules,
-        input.config,
-        input.declared_deps,
-        input.line_offsets_by_file,
-        input.suppressions,
-        input.results,
-    );
+    populate_unused_component_prop_findings(input);
     populate_unused_component_emit_findings(
         input.graph,
         input.modules,
@@ -1049,28 +1041,29 @@ fn populate_unrendered_component_findings(input: &mut FrameworkSpecificFindingsI
 /// Populate `unused_component_props` when the rule is enabled. Gated on the
 /// project declaring `vue` / `@vue/runtime-core` / `nuxt` inside the detector
 /// (see [`find_unused_component_props`]).
-fn populate_unused_component_prop_findings(
-    graph: &ModuleGraph,
-    modules: &[ModuleInfo],
-    config: &ResolvedConfig,
-    declared_deps: &FxHashSet<String>,
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-    suppressions: &SuppressionContext<'_>,
-    results: &mut AnalysisResults,
-) {
-    if config.rules.unused_component_props == Severity::Off {
+fn populate_unused_component_prop_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
+    if input.config.rules.unused_component_props == Severity::Off {
         return;
     }
     // Vue arm: one component per `.vue` SFC, flagged from `component_props`.
-    results.unused_component_props =
-        find_unused_component_props(graph, modules, declared_deps, line_offsets_by_file)
-            .into_iter()
-            .map(UnusedComponentPropFinding::with_actions)
-            .collect();
+    input.results.unused_component_props = find_unused_component_props(
+        input.graph,
+        input.modules,
+        input.declared_deps,
+        input.line_offsets_by_file,
+    )
+    .into_iter()
+    .map(UnusedComponentPropFinding::with_actions)
+    .collect();
     // React/Preact arm: another producer of the SAME finding kind, emitting into
     // the same vector. Gated on `react` / `react-dom` / `next` / `preact` inside
     // the producer.
-    let react = find_unused_react_props(graph, modules, declared_deps, line_offsets_by_file);
+    let react = find_unused_react_props(
+        input.graph,
+        input.modules,
+        input.declared_deps,
+        input.line_offsets_by_file,
+    );
     if react.components_scanned > 0 {
         // Observability: make a silent dep-gate or silent abstain visible (a
         // scanned-but-zero-finding run is a clean bill, not a no-op). Surfaced at
@@ -1082,7 +1075,7 @@ fn populate_unused_component_prop_findings(
             react.components_scanned
         );
     }
-    results.unused_component_props.extend(
+    input.results.unused_component_props.extend(
         react
             .findings
             .into_iter()
@@ -1094,18 +1087,23 @@ fn populate_unused_component_prop_findings(
     // `// fallow-ignore-file unused-component-prop`) drops the finding. The
     // finding's `path` is the absolute graph node path, so it maps directly to a
     // FileId for the line-anchored suppression check.
-    let path_to_id: FxHashMap<&std::path::Path, FileId> = graph
+    let path_to_id: FxHashMap<&std::path::Path, FileId> = input
+        .graph
         .modules
         .iter()
         .map(|node| (node.path.as_path(), node.file_id))
         .collect();
-    results.unused_component_props.retain(|finding| {
+    input.results.unused_component_props.retain(|finding| {
         let Some(&file_id) = path_to_id.get(finding.prop.path.as_path()) else {
             return true;
         };
-        let suppressed =
-            suppressions.is_suppressed(file_id, finding.prop.line, IssueKind::UnusedComponentProp)
-                || suppressions.is_file_suppressed(file_id, IssueKind::UnusedComponentProp);
+        let suppressed = input.suppressions.is_suppressed(
+            file_id,
+            finding.prop.line,
+            IssueKind::UnusedComponentProp,
+        ) || input
+            .suppressions
+            .is_file_suppressed(file_id, IssueKind::UnusedComponentProp);
         !suppressed
     });
 }

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -1565,15 +1565,15 @@ fn run_import_and_duplicate_detectors(
 ) -> (Vec<UnresolvedImportFinding>, Vec<DuplicateExportFinding>) {
     rayon::join(
         || {
-            run_unresolved_import_detector(
-                input.resolved_modules,
-                input.config,
-                input.suppressions,
-                input.virtual_prefixes,
-                input.generated_patterns,
-                input.generated_type_prefixes,
-                input.line_offsets_by_file,
-            )
+            run_unresolved_import_detector(UnresolvedImportDetectorInput {
+                resolved_modules: input.resolved_modules,
+                config: input.config,
+                suppressions: input.suppressions,
+                virtual_prefixes: input.virtual_prefixes,
+                generated_patterns: input.generated_patterns,
+                generated_type_prefixes: input.generated_type_prefixes,
+                line_offsets_by_file: input.line_offsets_by_file,
+            })
         },
         || {
             run_duplicate_export_detector(
@@ -2156,26 +2156,30 @@ fn run_dependency_detectors(input: DependencyDetectorInput<'_>) -> AnalysisResul
     results
 }
 
+struct UnresolvedImportDetectorInput<'a> {
+    resolved_modules: &'a [ResolvedModule],
+    config: &'a ResolvedConfig,
+    suppressions: &'a crate::suppress::SuppressionContext<'a>,
+    virtual_prefixes: &'a [&'a str],
+    generated_patterns: &'a [&'a str],
+    generated_type_prefixes: &'a [&'a str],
+    line_offsets_by_file: &'a LineOffsetsMap<'a>,
+}
+
 fn run_unresolved_import_detector(
-    resolved_modules: &[ResolvedModule],
-    config: &ResolvedConfig,
-    suppressions: &crate::suppress::SuppressionContext<'_>,
-    virtual_prefixes: &[&str],
-    generated_patterns: &[&str],
-    generated_type_prefixes: &[&str],
-    line_offsets_by_file: &LineOffsetsMap<'_>,
+    input: UnresolvedImportDetectorInput<'_>,
 ) -> Vec<UnresolvedImportFinding> {
-    if config.rules.unresolved_imports == Severity::Off || resolved_modules.is_empty() {
+    if input.config.rules.unresolved_imports == Severity::Off || input.resolved_modules.is_empty() {
         return Vec::new();
     }
     find_unresolved_imports(
-        resolved_modules,
-        config,
-        suppressions,
-        virtual_prefixes,
-        generated_patterns,
-        generated_type_prefixes,
-        line_offsets_by_file,
+        input.resolved_modules,
+        input.config,
+        input.suppressions,
+        input.virtual_prefixes,
+        input.generated_patterns,
+        input.generated_type_prefixes,
+        input.line_offsets_by_file,
     )
     .into_iter()
     .map(UnresolvedImportFinding::with_actions)

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -2072,6 +2072,7 @@ fn run_member_detectors(input: MemberDetectorInput<'_>) -> AnalysisResults {
     results
 }
 
+#[derive(Clone, Copy)]
 struct DependencyDetectorInput<'a> {
     graph: &'a ModuleGraph,
     pkg: Option<&'a PackageJson>,
@@ -2156,6 +2157,7 @@ fn run_dependency_detectors(input: DependencyDetectorInput<'_>) -> AnalysisResul
     results
 }
 
+#[derive(Clone, Copy)]
 struct UnresolvedImportDetectorInput<'a> {
     resolved_modules: &'a [ResolvedModule],
     config: &'a ResolvedConfig,

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -807,15 +807,7 @@ struct FrameworkSpecificFindingsInput<'a> {
 }
 
 fn populate_framework_specific_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
-    populate_invalid_client_export_findings(
-        input.graph,
-        input.modules,
-        input.config,
-        input.declared_deps,
-        input.suppressions,
-        input.line_offsets_by_file,
-        input.results,
-    );
+    populate_invalid_client_export_findings(input);
     populate_mixed_client_server_barrel_findings(input);
     populate_misplaced_directive_findings(
         input.graph,
@@ -950,24 +942,16 @@ fn populate_unused_load_data_key_findings(
 /// Populate `invalid_client_exports` when the rule is enabled. Gated on the
 /// project declaring `next` inside the detector (see
 /// [`find_invalid_client_exports`]).
-fn populate_invalid_client_export_findings(
-    graph: &ModuleGraph,
-    modules: &[ModuleInfo],
-    config: &ResolvedConfig,
-    declared_deps: &FxHashSet<String>,
-    suppressions: &SuppressionContext<'_>,
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-    results: &mut AnalysisResults,
-) {
-    if config.rules.invalid_client_export == Severity::Off {
+fn populate_invalid_client_export_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
+    if input.config.rules.invalid_client_export == Severity::Off {
         return;
     }
-    results.invalid_client_exports = find_invalid_client_exports(
-        graph,
-        modules,
-        declared_deps,
-        suppressions,
-        line_offsets_by_file,
+    input.results.invalid_client_exports = find_invalid_client_exports(
+        input.graph,
+        input.modules,
+        input.declared_deps,
+        input.suppressions,
+        input.line_offsets_by_file,
     )
     .into_iter()
     .map(InvalidClientExportFinding::with_actions)

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -845,15 +845,7 @@ fn populate_framework_specific_findings(input: &mut FrameworkSpecificFindingsInp
         input.line_offsets_by_file,
         input.results,
     );
-    populate_unused_load_data_key_findings(
-        input.graph,
-        input.modules,
-        input.config,
-        input.declared_deps,
-        input.suppressions,
-        input.line_offsets_by_file,
-        input.results,
-    );
+    populate_unused_load_data_key_findings(input);
     populate_prop_drilling_findings(input);
     populate_thin_wrapper_findings(input);
     populate_render_fan_in(input);
@@ -889,34 +881,26 @@ fn populate_render_fan_in(input: &mut FrameworkSpecificFindingsInput<'_>) {
 /// project declaring `@sveltejs/kit` inside the detector (see
 /// [`find_unused_load_data_keys`]). Runs as a sequential populate because it
 /// needs the run's `declared_deps` for the dep gate.
-fn populate_unused_load_data_key_findings(
-    graph: &ModuleGraph,
-    modules: &[ModuleInfo],
-    config: &ResolvedConfig,
-    declared_deps: &FxHashSet<String>,
-    suppressions: &SuppressionContext<'_>,
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-    results: &mut AnalysisResults,
-) {
-    if config.rules.unused_load_data_keys == Severity::Off {
+fn populate_unused_load_data_key_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
+    if input.config.rules.unused_load_data_keys == Severity::Off {
         return;
     }
     let result = find_unused_load_data_keys(
-        graph,
-        modules,
-        declared_deps,
-        suppressions,
-        line_offsets_by_file,
-        &config.root,
+        input.graph,
+        input.modules,
+        input.declared_deps,
+        input.suppressions,
+        input.line_offsets_by_file,
+        &input.config.root,
     );
     if result.global_abstain {
-        results.unused_load_data_keys_global_abstain = true;
+        input.results.unused_load_data_keys_global_abstain = true;
         tracing::debug!(
             "unused-load-data-key: abstained project-wide (a whole-object use of \
              page.data / $page.data was seen; any key could be read reflectively)"
         );
     }
-    results.unused_load_data_keys = result
+    input.results.unused_load_data_keys = result
         .findings
         .into_iter()
         .map(UnusedLoadDataKeyFinding::with_actions)

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -809,15 +809,7 @@ struct FrameworkSpecificFindingsInput<'a> {
 fn populate_framework_specific_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
     populate_invalid_client_export_findings(input);
     populate_mixed_client_server_barrel_findings(input);
-    populate_misplaced_directive_findings(
-        input.graph,
-        input.modules,
-        input.config,
-        input.declared_deps,
-        input.suppressions,
-        input.line_offsets_by_file,
-        input.results,
-    );
+    populate_misplaced_directive_findings(input);
     populate_unprovided_inject_findings(input);
     populate_unrendered_component_findings(input);
     populate_unused_component_prop_findings(
@@ -981,24 +973,16 @@ fn populate_mixed_client_server_barrel_findings(input: &mut FrameworkSpecificFin
 /// Populate `misplaced_directives` when the rule is enabled. Gated on the
 /// project declaring `next` inside the detector (see
 /// [`find_misplaced_directives`]).
-fn populate_misplaced_directive_findings(
-    graph: &ModuleGraph,
-    modules: &[ModuleInfo],
-    config: &ResolvedConfig,
-    declared_deps: &FxHashSet<String>,
-    suppressions: &SuppressionContext<'_>,
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-    results: &mut AnalysisResults,
-) {
-    if config.rules.misplaced_directive == Severity::Off {
+fn populate_misplaced_directive_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
+    if input.config.rules.misplaced_directive == Severity::Off {
         return;
     }
-    results.misplaced_directives = find_misplaced_directives(
-        graph,
-        modules,
-        declared_deps,
-        suppressions,
-        line_offsets_by_file,
+    input.results.misplaced_directives = find_misplaced_directives(
+        input.graph,
+        input.modules,
+        input.declared_deps,
+        input.suppressions,
+        input.line_offsets_by_file,
     )
     .into_iter()
     .map(MisplacedDirectiveFinding::with_actions)

--- a/crates/core/src/analyze/policy/mod.rs
+++ b/crates/core/src/analyze/policy/mod.rs
@@ -132,7 +132,7 @@ pub fn find_policy_violations(
             continue;
         };
 
-        collect_banned_imports(PolicyCollectionInput {
+        collect_banned_imports(&mut PolicyCollectionInput {
             in_scope: &in_scope,
             module,
             node,
@@ -141,7 +141,7 @@ pub fn find_policy_violations(
             line_offsets_by_file,
             violations: &mut violations,
         });
-        collect_banned_calls(PolicyCollectionInput {
+        collect_banned_calls(&mut PolicyCollectionInput {
             in_scope: &in_scope,
             module,
             node,
@@ -213,7 +213,7 @@ struct PolicyCollectionInput<'a> {
     violations: &'a mut Vec<PolicyViolation>,
 }
 
-fn collect_banned_imports(input: PolicyCollectionInput<'_>) {
+fn collect_banned_imports(input: &mut PolicyCollectionInput<'_>) {
     for (_, rule) in input.in_scope {
         if rule.rule.kind != RulePackRuleKind::BannedImport {
             continue;
@@ -279,7 +279,7 @@ fn collect_banned_imports(input: PolicyCollectionInput<'_>) {
 /// Emit one finding per unique callee path matched by the first applicable
 /// `banned-call` rule (config order), mirroring the boundary forbidden-call
 /// first-pattern-wins behavior.
-fn collect_banned_calls(input: PolicyCollectionInput<'_>) {
+fn collect_banned_calls(input: &mut PolicyCollectionInput<'_>) {
     for callee_use in &input.module.callee_uses {
         let matched = input.in_scope.iter().find_map(|(_, rule)| {
             if rule.rule.kind != RulePackRuleKind::BannedCall {

--- a/crates/core/src/analyze/policy/mod.rs
+++ b/crates/core/src/analyze/policy/mod.rs
@@ -132,15 +132,15 @@ pub fn find_policy_violations(
             continue;
         };
 
-        collect_banned_imports(
-            &in_scope,
+        collect_banned_imports(PolicyCollectionInput {
+            in_scope: &in_scope,
             module,
             node,
             master,
             suppressions,
             line_offsets_by_file,
-            &mut violations,
-        );
+            violations: &mut violations,
+        });
         collect_banned_calls(
             &in_scope,
             module,
@@ -203,23 +203,26 @@ fn compile_rules(config: &ResolvedConfig) -> Vec<CompiledRule<'_>> {
 
 /// Emit one finding per `banned-import` rule match over the module's imports
 /// and re-exports.
-fn collect_banned_imports(
-    in_scope: &[(usize, &CompiledRule<'_>)],
-    module: &ModuleInfo,
-    node: &crate::graph::ModuleNode,
+struct PolicyCollectionInput<'a> {
+    in_scope: &'a [(usize, &'a CompiledRule<'a>)],
+    module: &'a ModuleInfo,
+    node: &'a crate::graph::ModuleNode,
     master: Severity,
-    suppressions: &SuppressionContext<'_>,
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-    violations: &mut Vec<PolicyViolation>,
-) {
-    for (_, rule) in in_scope {
+    suppressions: &'a SuppressionContext<'a>,
+    line_offsets_by_file: &'a LineOffsetsMap<'a>,
+    violations: &'a mut Vec<PolicyViolation>,
+}
+
+fn collect_banned_imports(input: PolicyCollectionInput<'_>) {
+    for (_, rule) in input.in_scope {
         if rule.rule.kind != RulePackRuleKind::BannedImport {
             continue;
         }
-        let Some(severity) = wire_severity(rule.effective_severity(master)) else {
+        let Some(severity) = wire_severity(rule.effective_severity(input.master)) else {
             continue;
         };
-        let sites = module
+        let sites = input
+            .module
             .imports
             .iter()
             .map(|import| {
@@ -229,7 +232,7 @@ fn collect_banned_imports(
                     import.span.start,
                 )
             })
-            .chain(module.re_exports.iter().map(|re_export| {
+            .chain(input.module.re_exports.iter().map(|re_export| {
                 (
                     re_export.source.as_str(),
                     re_export.is_type_only,
@@ -249,12 +252,17 @@ fn collect_banned_imports(
                 continue;
             }
             let (line, col) =
-                byte_offset_to_line_col(line_offsets_by_file, node.file_id, span_start);
-            if suppressions.is_policy_suppressed(node.file_id, line, rule.pack, &rule.rule.id) {
+                byte_offset_to_line_col(input.line_offsets_by_file, input.node.file_id, span_start);
+            if input.suppressions.is_policy_suppressed(
+                input.node.file_id,
+                line,
+                rule.pack,
+                &rule.rule.id,
+            ) {
                 continue;
             }
-            violations.push(PolicyViolation {
-                path: node.path.clone(),
+            input.violations.push(PolicyViolation {
+                path: input.node.path.clone(),
                 line,
                 col,
                 pack: rule.pack.to_owned(),

--- a/crates/core/src/analyze/policy/mod.rs
+++ b/crates/core/src/analyze/policy/mod.rs
@@ -141,15 +141,15 @@ pub fn find_policy_violations(
             line_offsets_by_file,
             violations: &mut violations,
         });
-        collect_banned_calls(
-            &in_scope,
+        collect_banned_calls(PolicyCollectionInput {
+            in_scope: &in_scope,
             module,
             node,
             master,
             suppressions,
             line_offsets_by_file,
-            &mut violations,
-        );
+            violations: &mut violations,
+        });
     }
 
     for (index, rule) in rules.iter().enumerate() {
@@ -279,34 +279,34 @@ fn collect_banned_imports(input: PolicyCollectionInput<'_>) {
 /// Emit one finding per unique callee path matched by the first applicable
 /// `banned-call` rule (config order), mirroring the boundary forbidden-call
 /// first-pattern-wins behavior.
-fn collect_banned_calls(
-    in_scope: &[(usize, &CompiledRule<'_>)],
-    module: &ModuleInfo,
-    node: &crate::graph::ModuleNode,
-    master: Severity,
-    suppressions: &SuppressionContext<'_>,
-    line_offsets_by_file: &LineOffsetsMap<'_>,
-    violations: &mut Vec<PolicyViolation>,
-) {
-    for callee_use in &module.callee_uses {
-        let matched = in_scope.iter().find_map(|(_, rule)| {
+fn collect_banned_calls(input: PolicyCollectionInput<'_>) {
+    for callee_use in &input.module.callee_uses {
+        let matched = input.in_scope.iter().find_map(|(_, rule)| {
             if rule.rule.kind != RulePackRuleKind::BannedCall {
                 return None;
             }
-            let severity = wire_severity(rule.effective_severity(master))?;
-            rule.matches_callee(module, &callee_use.callee_path)
+            let severity = wire_severity(rule.effective_severity(input.master))?;
+            rule.matches_callee(input.module, &callee_use.callee_path)
                 .then_some((rule, severity))
         });
         let Some((rule, severity)) = matched else {
             continue;
         };
-        let (line, col) =
-            byte_offset_to_line_col(line_offsets_by_file, node.file_id, callee_use.span_start);
-        if suppressions.is_policy_suppressed(node.file_id, line, rule.pack, &rule.rule.id) {
+        let (line, col) = byte_offset_to_line_col(
+            input.line_offsets_by_file,
+            input.node.file_id,
+            callee_use.span_start,
+        );
+        if input.suppressions.is_policy_suppressed(
+            input.node.file_id,
+            line,
+            rule.pack,
+            &rule.rule.id,
+        ) {
             continue;
         }
-        violations.push(PolicyViolation {
-            path: node.path.clone(),
+        input.violations.push(PolicyViolation {
+            path: input.node.path.clone(),
             line,
             col,
             pack: rule.pack.to_owned(),

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -211,36 +211,47 @@ fn shared_dep_sets<'a>(
 ///
 /// Filters `dep_names` against usage data and category-specific rules, returning
 /// `UnusedDependency` entries for deps that are unused.
-pub fn collect_unused_for_category(
-    dep_names: Vec<String>,
-    category: &DepCategoryConfig,
-    shared: &SharedDepSets<'_>,
-    is_used: impl Fn(&str) -> bool,
-    used_in_workspaces: impl Fn(&str) -> Vec<PathBuf>,
-    pkg_path: &Path,
-    pkg_content: Option<&str>,
-) -> Vec<UnusedDependency> {
-    dep_names
+pub struct UnusedCategoryInput<'a> {
+    pub dep_names: Vec<String>,
+    pub category: &'a DepCategoryConfig,
+    pub shared: &'a SharedDepSets<'a>,
+    pub is_used: &'a dyn Fn(&str) -> bool,
+    pub used_in_workspaces: &'a dyn Fn(&str) -> Vec<PathBuf>,
+    pub pkg_path: &'a Path,
+    pub pkg_content: Option<&'a str>,
+}
+
+pub fn collect_unused_for_category(input: UnusedCategoryInput<'_>) -> Vec<UnusedDependency> {
+    input
+        .dep_names
         .into_iter()
-        .filter(|dep| !is_used(dep))
-        .filter(|dep| !shared.script_used.contains(dep.as_str()))
-        .filter(|dep| !category.check_implicit || !is_implicit_dependency(dep))
+        .filter(|dep| !(input.is_used)(dep))
+        .filter(|dep| !input.shared.script_used.contains(dep.as_str()))
+        .filter(|dep| !input.category.check_implicit || !is_implicit_dependency(dep))
         .filter(|dep| {
-            !category.check_known_tooling || !crate::plugins::is_known_tooling_dependency(dep)
+            !input.category.check_known_tooling || !crate::plugins::is_known_tooling_dependency(dep)
         })
         .filter(|dep| {
-            !category.check_plugin_tooling || !shared.plugin_tooling.contains(dep.as_str())
+            !input.category.check_plugin_tooling
+                || !input.shared.plugin_tooling.contains(dep.as_str())
         })
-        .filter(|dep| !shared.plugin_referenced.contains(dep.as_str()))
-        .filter(|dep| !shared.package_plugin_referenced.contains(dep.as_str()))
-        .filter(|dep| !shared.ignore_deps.contains(dep.as_str()))
+        .filter(|dep| !input.shared.plugin_referenced.contains(dep.as_str()))
+        .filter(|dep| {
+            !input
+                .shared
+                .package_plugin_referenced
+                .contains(dep.as_str())
+        })
+        .filter(|dep| !input.shared.ignore_deps.contains(dep.as_str()))
         .map(|dep| {
-            let line = pkg_content.map_or(1, |c| find_dep_line_in_json(c, &dep));
-            let used_in_workspaces = used_in_workspaces(&dep);
+            let line = input
+                .pkg_content
+                .map_or(1, |c| find_dep_line_in_json(c, &dep));
+            let used_in_workspaces = (input.used_in_workspaces)(&dep);
             UnusedDependency {
                 package_name: dep,
-                location: category.location.clone(),
-                path: pkg_path.to_path_buf(),
+                location: input.category.location.clone(),
+                path: input.pkg_path.to_path_buf(),
                 line,
                 used_in_workspaces,
             }
@@ -425,35 +436,35 @@ pub fn find_unused_dependencies(
     let is_used_globally = |dep: &str| used_packages.contains(dep) || root_peer_used.contains(dep);
     let no_workspace_context = |_dep: &str| Vec::new();
 
-    let mut unused_deps = collect_unused_for_category(
-        pkg.production_dependency_names(),
-        &prod_category(),
-        &shared,
-        is_used_globally,
-        no_workspace_context,
-        &root_pkg_path,
-        root_pkg_content.as_deref(),
-    );
+    let mut unused_deps = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: pkg.production_dependency_names(),
+        category: &prod_category(),
+        shared: &shared,
+        is_used: &is_used_globally,
+        used_in_workspaces: &no_workspace_context,
+        pkg_path: &root_pkg_path,
+        pkg_content: root_pkg_content.as_deref(),
+    });
 
-    let mut unused_dev_deps = collect_unused_for_category(
-        pkg.dev_dependency_names(),
-        &dev_category(),
-        &shared,
-        is_used_globally,
-        no_workspace_context,
-        &root_pkg_path,
-        root_pkg_content.as_deref(),
-    );
+    let mut unused_dev_deps = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: pkg.dev_dependency_names(),
+        category: &dev_category(),
+        shared: &shared,
+        is_used: &is_used_globally,
+        used_in_workspaces: &no_workspace_context,
+        pkg_path: &root_pkg_path,
+        pkg_content: root_pkg_content.as_deref(),
+    });
 
-    let mut unused_optional_deps = collect_unused_for_category(
-        pkg.optional_dependency_names(),
-        &optional_category(),
-        &shared,
-        is_used_globally,
-        no_workspace_context,
-        &root_pkg_path,
-        root_pkg_content.as_deref(),
-    );
+    let mut unused_optional_deps = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: pkg.optional_dependency_names(),
+        category: &optional_category(),
+        shared: &shared,
+        is_used: &is_used_globally,
+        used_in_workspaces: &no_workspace_context,
+        pkg_path: &root_pkg_path,
+        pkg_content: root_pkg_content.as_deref(),
+    });
 
     let root_flagged: FxHashSet<String> = unused_deps
         .iter()
@@ -613,33 +624,33 @@ fn collect_workspace_unused_categories(
     let is_used_in_workspace = |dep: &str| usage.is_used_in_workspace(dep);
     let used_in_workspaces = |dep: &str| usage.used_in_other_workspaces(dep);
 
-    let prod = collect_unused_for_category(
-        ws_pkg.production_dependency_names(),
-        &prod_category(),
-        ws_shared,
-        is_used_in_workspace,
-        used_in_workspaces,
-        ws_pkg_path,
-        Some(ws_pkg_content),
-    );
-    let dev = collect_unused_for_category(
-        ws_pkg.dev_dependency_names(),
-        &dev_category(),
-        ws_shared,
-        is_used_in_workspace,
-        used_in_workspaces,
-        ws_pkg_path,
-        Some(ws_pkg_content),
-    );
-    let optional = collect_unused_for_category(
-        ws_pkg.optional_dependency_names(),
-        &optional_category(),
-        ws_shared,
-        is_used_in_workspace,
-        used_in_workspaces,
-        ws_pkg_path,
-        Some(ws_pkg_content),
-    );
+    let prod = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: ws_pkg.production_dependency_names(),
+        category: &prod_category(),
+        shared: ws_shared,
+        is_used: &is_used_in_workspace,
+        used_in_workspaces: &used_in_workspaces,
+        pkg_path: ws_pkg_path,
+        pkg_content: Some(ws_pkg_content),
+    });
+    let dev = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: ws_pkg.dev_dependency_names(),
+        category: &dev_category(),
+        shared: ws_shared,
+        is_used: &is_used_in_workspace,
+        used_in_workspaces: &used_in_workspaces,
+        pkg_path: ws_pkg_path,
+        pkg_content: Some(ws_pkg_content),
+    });
+    let optional = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: ws_pkg.optional_dependency_names(),
+        category: &optional_category(),
+        shared: ws_shared,
+        is_used: &is_used_in_workspace,
+        used_in_workspaces: &used_in_workspaces,
+        pkg_path: ws_pkg_path,
+        pkg_content: Some(ws_pkg_content),
+    });
 
     (prod, dev, optional)
 }

--- a/crates/core/src/analyze/unused_deps_tests/collect_unused.rs
+++ b/crates/core/src/analyze/unused_deps_tests/collect_unused.rs
@@ -1,4 +1,5 @@
 use super::helpers::*;
+use crate::analyze::unused_deps::UnusedCategoryInput;
 
 #[test]
 fn collect_unused_empty_deps_returns_empty() {
@@ -16,15 +17,15 @@ fn collect_unused_empty_deps_returns_empty() {
         check_known_tooling: false,
         check_plugin_tooling: true,
     };
-    let result = collect_unused_for_category(
-        vec![],
-        &category,
-        &shared,
-        |_| false,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: vec![],
+        category: &category,
+        shared: &shared,
+        is_used: &|_| false,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert!(result.is_empty());
 }
 
@@ -45,15 +46,15 @@ fn collect_unused_all_used_returns_empty() {
         check_plugin_tooling: false,
     };
     let deps = vec!["react".to_string(), "lodash".to_string()];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |_| true,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|_| true,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert!(result.is_empty());
 }
 
@@ -78,15 +79,15 @@ fn collect_unused_some_unused_are_flagged() {
         "lodash".to_string(),
         "axios".to_string(),
     ];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |dep| dep == "react",
-        |_| Vec::new(),
-        Path::new("/project/package.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|dep| dep == "react",
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/project/package.json"),
+        pkg_content: None,
+    });
     assert_eq!(result.len(), 2);
     assert!(result.iter().any(|d| d.package_name == "lodash"));
     assert!(result.iter().any(|d| d.package_name == "axios"));
@@ -114,15 +115,15 @@ fn collect_unused_implicit_filter_skips_react_dom() {
         check_plugin_tooling: false,
     };
     let deps = vec!["react-dom".to_string(), "lodash".to_string()];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |_| false,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|_| false,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].package_name, "lodash");
 }
@@ -144,15 +145,15 @@ fn collect_unused_implicit_filter_disabled_keeps_react_dom() {
         check_plugin_tooling: false,
     };
     let deps = vec!["react-dom".to_string()];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |_| false,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|_| false,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].package_name, "react-dom");
 }
@@ -174,15 +175,15 @@ fn collect_unused_known_tooling_filter_skips_jest() {
         check_plugin_tooling: false,
     };
     let deps = vec!["jest".to_string(), "my-lib".to_string()];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |_| false,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|_| false,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].package_name, "my-lib");
 }
@@ -210,15 +211,15 @@ fn collect_unused_plugin_tooling_filter() {
         check_plugin_tooling: true,
     };
     let deps = vec!["my-runtime".to_string(), "other".to_string()];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |_| false,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|_| false,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].package_name, "other");
 }
@@ -246,15 +247,15 @@ fn collect_unused_plugin_tooling_disabled_keeps_dep() {
         check_plugin_tooling: false,
     };
     let deps = vec!["my-runtime".to_string()];
-    let result = collect_unused_for_category(
-        deps,
-        &category,
-        &shared,
-        |_| false,
-        |_| Vec::new(),
-        Path::new("/pkg.json"),
-        None,
-    );
+    let result = collect_unused_for_category(UnusedCategoryInput {
+        dep_names: deps,
+        category: &category,
+        shared: &shared,
+        is_used: &|_| false,
+        used_in_workspaces: &|_| Vec::new(),
+        pkg_path: Path::new("/pkg.json"),
+        pkg_content: None,
+    });
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].package_name, "my-runtime");
 }

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -537,7 +537,7 @@ struct AngularTokenChainCreditInput<'a, 'b> {
     accessed_members: &'a mut FxHashMap<ExportKey, FxHashSet<String>>,
 }
 
-fn credit_angular_token_chain_member(input: AngularTokenChainCreditInput<'_, '_>) {
+fn credit_angular_token_chain_member(input: &mut AngularTokenChainCreditInput<'_, '_>) {
     let mut interface_names: Vec<&str> = vec![input.type_name];
     if let Some(export_keys) = input.local_to_export_keys.get(input.type_name) {
         for export_key in export_keys {
@@ -808,7 +808,7 @@ impl<'a> AngularTemplateChainContext<'a, '_> {
             let Some(type_name) = component.component_bindings.get(object) else {
                 continue;
             };
-            credit_angular_token_chain_member(AngularTokenChainCreditInput {
+            credit_angular_token_chain_member(&mut AngularTokenChainCreditInput {
                 graph: self.graph,
                 type_name,
                 member,

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -527,38 +527,42 @@ pub(super) fn export_key_with_origins(graph: &ModuleGraph, key: &ExportKey) -> V
 /// binding resolves to; the member is credited on every class implementing any
 /// candidate interface (and directly on the resolved export, harmless for a
 /// memberless token const).
-fn credit_angular_token_chain_member<'a>(
-    graph: &ModuleGraph,
+struct AngularTokenChainCreditInput<'a, 'b> {
+    graph: &'a ModuleGraph,
     type_name: &'a str,
-    member: &str,
-    local_to_export_keys: &FxHashMap<&str, Vec<ExportKey>>,
-    token_to_interface: &FxHashMap<ExportKey, &'a str>,
-    implementers_by_name: &FxHashMap<&'a str, Vec<ExportKey>>,
-    accessed_members: &mut FxHashMap<ExportKey, FxHashSet<String>>,
-) {
-    let mut interface_names: Vec<&str> = vec![type_name];
-    if let Some(export_keys) = local_to_export_keys.get(type_name) {
+    member: &'a str,
+    local_to_export_keys: &'a FxHashMap<&'b str, Vec<ExportKey>>,
+    token_to_interface: &'a FxHashMap<ExportKey, &'a str>,
+    implementers_by_name: &'a FxHashMap<&'a str, Vec<ExportKey>>,
+    accessed_members: &'a mut FxHashMap<ExportKey, FxHashSet<String>>,
+}
+
+fn credit_angular_token_chain_member(input: AngularTokenChainCreditInput<'_, '_>) {
+    let mut interface_names: Vec<&str> = vec![input.type_name];
+    if let Some(export_keys) = input.local_to_export_keys.get(input.type_name) {
         for export_key in export_keys {
-            accessed_members
+            input
+                .accessed_members
                 .entry(export_key.clone())
                 .or_default()
-                .insert(member.to_string());
-            for resolved in export_key_with_origins(graph, export_key) {
-                if let Some(interface) = token_to_interface.get(&resolved) {
+                .insert(input.member.to_string());
+            for resolved in export_key_with_origins(input.graph, export_key) {
+                if let Some(interface) = input.token_to_interface.get(&resolved) {
                     interface_names.push(interface);
                 }
             }
         }
     }
     for interface in interface_names {
-        let Some(implementers) = implementers_by_name.get(interface) else {
+        let Some(implementers) = input.implementers_by_name.get(interface) else {
             continue;
         };
         for implementer_key in implementers {
-            accessed_members
+            input
+                .accessed_members
                 .entry(implementer_key.clone())
                 .or_default()
-                .insert(member.to_string());
+                .insert(input.member.to_string());
         }
     }
 }
@@ -804,15 +808,15 @@ impl<'a> AngularTemplateChainContext<'a, '_> {
             let Some(type_name) = component.component_bindings.get(object) else {
                 continue;
             };
-            credit_angular_token_chain_member(
-                self.graph,
+            credit_angular_token_chain_member(AngularTokenChainCreditInput {
+                graph: self.graph,
                 type_name,
                 member,
-                &component.local_to_export_keys,
-                self.token_to_interface,
-                self.implementers_by_name,
-                self.accessed_members,
-            );
+                local_to_export_keys: &component.local_to_export_keys,
+                token_to_interface: self.token_to_interface,
+                implementers_by_name: self.implementers_by_name,
+                accessed_members: self.accessed_members,
+            });
         }
     }
 

--- a/crates/core/src/analyze/unused_overrides.rs
+++ b/crates/core/src/analyze/unused_overrides.rs
@@ -249,37 +249,39 @@ pub fn find_unused_dependency_overrides(
     let mut findings = Vec::new();
     let yaml_path = config.root.join(PNPM_WORKSPACE_FILE);
     let json_path = config.root.join(ROOT_PACKAGE_JSON);
-    collect_unused_from_source(
-        &state.workspace_yaml_data,
-        DependencyOverrideSource::PnpmWorkspaceYaml,
-        &yaml_path,
-        &state.declared_packages,
-        &state.lockfile_packages,
-        &config.compiled_ignore_dependency_overrides,
-        &mut findings,
-    );
-    collect_unused_from_source(
-        &state.package_json_data,
-        DependencyOverrideSource::PnpmPackageJson,
-        &json_path,
-        &state.declared_packages,
-        &state.lockfile_packages,
-        &config.compiled_ignore_dependency_overrides,
-        &mut findings,
-    );
+    collect_unused_from_source(UnusedOverrideSourceInput {
+        data: &state.workspace_yaml_data,
+        source: DependencyOverrideSource::PnpmWorkspaceYaml,
+        source_path: &yaml_path,
+        declared: &state.declared_packages,
+        resolved: &state.lockfile_packages,
+        ignore_rules: &config.compiled_ignore_dependency_overrides,
+        findings: &mut findings,
+    });
+    collect_unused_from_source(UnusedOverrideSourceInput {
+        data: &state.package_json_data,
+        source: DependencyOverrideSource::PnpmPackageJson,
+        source_path: &json_path,
+        declared: &state.declared_packages,
+        resolved: &state.lockfile_packages,
+        ignore_rules: &config.compiled_ignore_dependency_overrides,
+        findings: &mut findings,
+    });
     findings
 }
 
-fn collect_unused_from_source(
-    data: &PnpmOverrideData,
+struct UnusedOverrideSourceInput<'a> {
+    data: &'a PnpmOverrideData,
     source: DependencyOverrideSource,
-    source_path: &std::path::Path,
-    declared: &FxHashSet<String>,
-    resolved: &FxHashSet<String>,
-    ignore_rules: &[CompiledIgnoreDependencyOverrideRule],
-    findings: &mut Vec<UnusedDependencyOverride>,
-) {
-    for entry in &data.entries {
+    source_path: &'a std::path::Path,
+    declared: &'a FxHashSet<String>,
+    resolved: &'a FxHashSet<String>,
+    ignore_rules: &'a [CompiledIgnoreDependencyOverrideRule],
+    findings: &'a mut Vec<UnusedDependencyOverride>,
+}
+
+fn collect_unused_from_source(input: UnusedOverrideSourceInput<'_>) {
+    for entry in &input.data.entries {
         let Some(parsed) = entry.parsed_key.as_ref() else {
             continue;
         };
@@ -290,22 +292,23 @@ fn collect_unused_from_source(
             continue;
         }
 
-        let target_declared = declared.contains(&parsed.target_package);
-        let target_resolved = resolved.contains(&parsed.target_package);
+        let target_declared = input.declared.contains(&parsed.target_package);
+        let target_resolved = input.resolved.contains(&parsed.target_package);
         let parent_declared = parsed
             .parent_package
             .as_ref()
-            .is_some_and(|p| declared.contains(p));
+            .is_some_and(|p| input.declared.contains(p));
         let parent_resolved = parsed
             .parent_package
             .as_ref()
-            .is_some_and(|p| resolved.contains(p));
+            .is_some_and(|p| input.resolved.contains(p));
         if target_declared || target_resolved || parent_declared || parent_resolved {
             continue;
         }
 
-        let source_label = source_label_for(source);
-        if ignore_rules
+        let source_label = source_label_for(input.source);
+        if input
+            .ignore_rules
             .iter()
             .any(|rule| rule.matches(&parsed.target_package, source_label))
         {
@@ -314,14 +317,14 @@ fn collect_unused_from_source(
 
         let hint = Some(HINT_MAY_BE_TRANSITIVE.to_string());
 
-        findings.push(UnusedDependencyOverride {
+        input.findings.push(UnusedDependencyOverride {
             raw_key: entry.raw_key.clone(),
             target_package: parsed.target_package.clone(),
             parent_package: parsed.parent_package.clone(),
             version_constraint: parsed.target_version_selector.clone(),
             version_range: value.clone(),
-            source,
-            path: source_path.to_path_buf(),
+            source: input.source,
+            path: input.source_path.to_path_buf(),
             line: entry.line,
             hint,
         });

--- a/crates/core/src/analyze/unused_overrides.rs
+++ b/crates/core/src/analyze/unused_overrides.rs
@@ -249,7 +249,7 @@ pub fn find_unused_dependency_overrides(
     let mut findings = Vec::new();
     let yaml_path = config.root.join(PNPM_WORKSPACE_FILE);
     let json_path = config.root.join(ROOT_PACKAGE_JSON);
-    collect_unused_from_source(UnusedOverrideSourceInput {
+    collect_unused_from_source(&mut UnusedOverrideSourceInput {
         data: &state.workspace_yaml_data,
         source: DependencyOverrideSource::PnpmWorkspaceYaml,
         source_path: &yaml_path,
@@ -258,7 +258,7 @@ pub fn find_unused_dependency_overrides(
         ignore_rules: &config.compiled_ignore_dependency_overrides,
         findings: &mut findings,
     });
-    collect_unused_from_source(UnusedOverrideSourceInput {
+    collect_unused_from_source(&mut UnusedOverrideSourceInput {
         data: &state.package_json_data,
         source: DependencyOverrideSource::PnpmPackageJson,
         source_path: &json_path,
@@ -280,7 +280,7 @@ struct UnusedOverrideSourceInput<'a> {
     findings: &'a mut Vec<UnusedDependencyOverride>,
 }
 
-fn collect_unused_from_source(input: UnusedOverrideSourceInput<'_>) {
+fn collect_unused_from_source(input: &mut UnusedOverrideSourceInput<'_>) {
     for entry in &input.data.entries {
         let Some(parsed) = entry.parsed_key.as_ref() else {
             continue;

--- a/crates/core/src/plugins/eslint.rs
+++ b/crates/core/src/plugins/eslint.rs
@@ -146,15 +146,15 @@ fn extract_eslint_config(
         visited,
         depth,
     });
-    add_eslint_override_config(
+    add_eslint_override_config(EslintConfigInput {
         result,
-        &parse_source,
+        parse_source: &parse_source,
         parse_path,
         config_path,
         root,
         visited,
         depth,
-    );
+    });
     add_eslint_resolver_dependencies(result, &parse_source, parse_path);
 }
 
@@ -248,45 +248,46 @@ fn add_eslint_top_level_config(input: EslintConfigInput<'_>) {
     }
 }
 
-fn add_eslint_override_config(
-    result: &mut PluginResult,
-    parse_source: &str,
-    parse_path: &Path,
-    config_path: &Path,
-    root: &Path,
-    visited: &mut FxHashSet<PathBuf>,
-    depth: usize,
-) {
+fn add_eslint_override_config(input: EslintConfigInput<'_>) {
     let override_parsers = config_parser::extract_config_array_nested_string_or_array(
-        parse_source,
-        parse_path,
+        input.parse_source,
+        input.parse_path,
         &["overrides"],
         &["parser"],
     );
     for parser in &override_parsers {
-        result
+        input
+            .result
             .referenced_dependencies
             .push(crate::resolve::extract_package_name(parser));
     }
     let override_plugins = config_parser::extract_config_array_nested_string_or_array(
-        parse_source,
-        parse_path,
+        input.parse_source,
+        input.parse_path,
         &["overrides"],
         &["plugins"],
     );
     for plugin in &override_plugins {
-        result
+        input
+            .result
             .referenced_dependencies
             .push(resolve_eslint_plugin_name(plugin));
     }
     let override_extends = config_parser::extract_config_array_nested_string_or_array(
-        parse_source,
-        parse_path,
+        input.parse_source,
+        input.parse_path,
         &["overrides"],
         &["extends"],
     );
     for ext in &override_extends {
-        process_extends_entry(ext, config_path, root, result, visited, depth);
+        process_extends_entry(
+            ext,
+            input.config_path,
+            input.root,
+            input.result,
+            input.visited,
+            input.depth,
+        );
     }
 }
 

--- a/crates/core/src/plugins/eslint.rs
+++ b/crates/core/src/plugins/eslint.rs
@@ -137,15 +137,15 @@ fn extract_eslint_config(
     let parse_path: &Path = &parse_path_buf;
 
     add_eslint_import_dependencies(root, result, &parse_source, parse_path);
-    add_eslint_top_level_config(
+    add_eslint_top_level_config(EslintConfigInput {
         result,
-        &parse_source,
+        parse_source: &parse_source,
         parse_path,
         config_path,
         root,
         visited,
         depth,
-    );
+    });
     add_eslint_override_config(
         result,
         &parse_source,
@@ -189,40 +189,60 @@ fn add_eslint_import_dependencies(
     }
 }
 
-fn add_eslint_top_level_config(
-    result: &mut PluginResult,
-    parse_source: &str,
-    parse_path: &Path,
-    config_path: &Path,
-    root: &Path,
-    visited: &mut FxHashSet<PathBuf>,
+struct EslintConfigInput<'a> {
+    result: &'a mut PluginResult,
+    parse_source: &'a str,
+    parse_path: &'a Path,
+    config_path: &'a Path,
+    root: &'a Path,
+    visited: &'a mut FxHashSet<PathBuf>,
     depth: usize,
-) {
-    let plugins =
-        config_parser::extract_config_shallow_strings(parse_source, parse_path, "plugins");
+}
+
+fn add_eslint_top_level_config(input: EslintConfigInput<'_>) {
+    let plugins = config_parser::extract_config_shallow_strings(
+        input.parse_source,
+        input.parse_path,
+        "plugins",
+    );
     for plugin in &plugins {
-        result
+        input
+            .result
             .referenced_dependencies
             .push(resolve_eslint_plugin_name(plugin));
     }
 
-    let extends =
-        config_parser::extract_config_shallow_strings(parse_source, parse_path, "extends");
+    let extends = config_parser::extract_config_shallow_strings(
+        input.parse_source,
+        input.parse_path,
+        "extends",
+    );
     for ext in &extends {
-        process_extends_entry(ext, config_path, root, result, visited, depth);
+        process_extends_entry(
+            ext,
+            input.config_path,
+            input.root,
+            input.result,
+            input.visited,
+            input.depth,
+        );
     }
 
     if let Some(parser) =
-        config_parser::extract_config_string(parse_source, parse_path, &["parser"])
+        config_parser::extract_config_string(input.parse_source, input.parse_path, &["parser"])
     {
         let dep = crate::resolve::extract_package_name(&parser);
-        result.referenced_dependencies.push(dep);
+        input.result.referenced_dependencies.push(dep);
     }
 
-    let plugin_keys =
-        config_parser::extract_config_object_keys(parse_source, parse_path, &["plugins"]);
+    let plugin_keys = config_parser::extract_config_object_keys(
+        input.parse_source,
+        input.parse_path,
+        &["plugins"],
+    );
     for key in &plugin_keys {
-        result
+        input
+            .result
             .referenced_dependencies
             .push(resolve_eslint_plugin_name(key));
     }

--- a/crates/core/src/plugins/eslint.rs
+++ b/crates/core/src/plugins/eslint.rs
@@ -137,7 +137,7 @@ fn extract_eslint_config(
     let parse_path: &Path = &parse_path_buf;
 
     add_eslint_import_dependencies(root, result, &parse_source, parse_path);
-    add_eslint_top_level_config(EslintConfigInput {
+    add_eslint_top_level_config(&mut EslintConfigInput {
         result,
         parse_source: &parse_source,
         parse_path,
@@ -146,7 +146,7 @@ fn extract_eslint_config(
         visited,
         depth,
     });
-    add_eslint_override_config(EslintConfigInput {
+    add_eslint_override_config(&mut EslintConfigInput {
         result,
         parse_source: &parse_source,
         parse_path,
@@ -199,7 +199,7 @@ struct EslintConfigInput<'a> {
     depth: usize,
 }
 
-fn add_eslint_top_level_config(input: EslintConfigInput<'_>) {
+fn add_eslint_top_level_config(input: &mut EslintConfigInput<'_>) {
     let plugins = config_parser::extract_config_shallow_strings(
         input.parse_source,
         input.parse_path,
@@ -248,7 +248,7 @@ fn add_eslint_top_level_config(input: EslintConfigInput<'_>) {
     }
 }
 
-fn add_eslint_override_config(input: EslintConfigInput<'_>) {
+fn add_eslint_override_config(input: &mut EslintConfigInput<'_>) {
     let override_parsers = config_parser::extract_config_array_nested_string_or_array(
         input.parse_source,
         input.parse_path,

--- a/crates/core/src/plugins/registry/helpers.rs
+++ b/crates/core/src/plugins/registry/helpers.rs
@@ -13,7 +13,7 @@ use fallow_config::{ExternalPluginDef, PackageJson, PluginDetection, UsedClassMe
 use crate::discover::SOURCE_EXTENSIONS;
 
 use super::super::{PathRule, Plugin, PluginResult, PluginUsedExportRule, UsedExportRule};
-use super::{AggregatedPluginResult, PluginRegexValidationError};
+use super::{AggregatedPluginResult, PluginRegexValidationError, PluginRegexValidationErrorInput};
 
 /// True when a config pattern names a source-extension config file living
 /// directly in some directory (no path separator, no leading dot, all expanded
@@ -364,26 +364,30 @@ fn collect_path_rule_regex_errors(
     for pattern in &rule.exclude_regexes {
         if let Err(source) = regex::Regex::new(pattern) {
             errors.push(PluginRegexValidationError::new(
-                plugin_name,
-                config_path,
-                rule_kind,
-                "exclude_regexes",
-                &rule.pattern,
-                pattern,
-                &source,
+                PluginRegexValidationErrorInput {
+                    plugin_name,
+                    config_path,
+                    rule_kind,
+                    field: "exclude_regexes",
+                    rule_pattern: &rule.pattern,
+                    regex_pattern: pattern,
+                    source: &source,
+                },
             ));
         }
     }
     for pattern in &rule.exclude_segment_regexes {
         if let Err(source) = regex::Regex::new(pattern) {
             errors.push(PluginRegexValidationError::new(
-                plugin_name,
-                config_path,
-                rule_kind,
-                "exclude_segment_regexes",
-                &rule.pattern,
-                pattern,
-                &source,
+                PluginRegexValidationErrorInput {
+                    plugin_name,
+                    config_path,
+                    rule_kind,
+                    field: "exclude_segment_regexes",
+                    rule_pattern: &rule.pattern,
+                    regex_pattern: pattern,
+                    source: &source,
+                },
             ));
         }
     }

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -609,15 +609,15 @@ impl PluginRegistry {
 
         let mut resolved_ws_plugins: FxHashSet<&str> = FxHashSet::default();
         for (plugin, matchers) in &workspace_matchers {
-            resolve_plugin_matching_files(
-                *plugin,
+            resolve_plugin_matching_files(PluginMatchingFilesInput {
+                plugin: *plugin,
                 matchers,
                 relative_files,
                 root,
-                &mut result,
-                &mut regex_errors,
-                &mut resolved_ws_plugins,
-            );
+                result: &mut result,
+                regex_errors: &mut regex_errors,
+                resolved_plugins: &mut resolved_ws_plugins,
+            });
         }
 
         let ws_json_configs = if root == project_root {
@@ -755,15 +755,15 @@ fn resolve_plugin_config_files(input: PluginConfigResolutionInput<'_>) {
 
     let mut resolved_plugins: FxHashSet<&str> = FxHashSet::default();
     for (plugin, matchers) in input.config_matchers {
-        resolve_plugin_matching_files(
-            *plugin,
+        resolve_plugin_matching_files(PluginMatchingFilesInput {
+            plugin: *plugin,
             matchers,
-            input.relative_files,
-            input.root,
-            input.result,
-            input.regex_errors,
-            &mut resolved_plugins,
-        );
+            relative_files: input.relative_files,
+            root: input.root,
+            result: input.result,
+            regex_errors: input.regex_errors,
+            resolved_plugins: &mut resolved_plugins,
+        });
     }
 
     let json_configs = discover_config_files(
@@ -783,21 +783,25 @@ fn resolve_plugin_config_files(input: PluginConfigResolutionInput<'_>) {
     }
 }
 
-fn resolve_plugin_matching_files<'a>(
-    plugin: &'a dyn Plugin,
-    matchers: &[globset::GlobMatcher],
-    relative_files: &'a [(PathBuf, String)],
-    root: &Path,
-    result: &mut AggregatedPluginResult,
-    regex_errors: &mut Vec<PluginRegexValidationError>,
-    resolved_plugins: &mut FxHashSet<&'a str>,
-) {
+struct PluginMatchingFilesInput<'plugins, 'data, 'state> {
+    plugin: &'plugins dyn Plugin,
+    matchers: &'data [globset::GlobMatcher],
+    relative_files: &'data [(PathBuf, String)],
+    root: &'data Path,
+    result: &'state mut AggregatedPluginResult,
+    regex_errors: &'state mut Vec<PluginRegexValidationError>,
+    resolved_plugins: &'state mut FxHashSet<&'plugins str>,
+}
+
+fn resolve_plugin_matching_files(input: PluginMatchingFilesInput<'_, '_, '_>) {
     use rayon::prelude::*;
 
-    let plugin_hits: Vec<&PathBuf> = relative_files
+    let plugin_hits: Vec<&PathBuf> = input
+        .relative_files
         .par_iter()
         .filter_map(|(abs_path, rel_path)| {
-            matchers
+            input
+                .matchers
                 .iter()
                 .any(|m| m.is_match(rel_path.as_str()))
                 .then_some(abs_path)
@@ -807,17 +811,17 @@ fn resolve_plugin_matching_files<'a>(
         let Ok(source) = std::fs::read_to_string(abs_path) else {
             continue;
         };
-        let plugin_result = plugin.resolve_config(abs_path, &source, root);
+        let plugin_result = input.plugin.resolve_config(abs_path, &source, input.root);
         if plugin_result.is_empty() {
             continue;
         }
-        resolved_plugins.insert(plugin.name());
+        input.resolved_plugins.insert(input.plugin.name());
         process_resolved_plugin_config(
-            plugin,
+            input.plugin,
             abs_path,
             plugin_result,
-            result,
-            regex_errors,
+            input.result,
+            input.regex_errors,
             "resolved config",
             abs_path.display(),
         );

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -94,6 +94,7 @@ impl PluginRegexValidationError {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct PluginRegexValidationErrorInput<'a> {
     pub(crate) plugin_name: &'a str,
     pub(crate) config_path: Option<&'a Path>,
@@ -469,7 +470,7 @@ impl PluginRegistry {
             Vec::new()
         };
 
-        resolve_plugin_config_files(PluginConfigResolutionInput {
+        resolve_plugin_config_files(&mut PluginConfigResolutionInput {
             config_matchers: &config_matchers,
             relative_files: &relative_files,
             config_search_roots,
@@ -611,7 +612,7 @@ impl PluginRegistry {
 
         let mut resolved_ws_plugins: FxHashSet<&str> = FxHashSet::default();
         for (plugin, matchers) in &workspace_matchers {
-            resolve_plugin_matching_files(PluginMatchingFilesInput {
+            resolve_plugin_matching_files(&mut PluginMatchingFilesInput {
                 plugin: *plugin,
                 matchers,
                 relative_files,
@@ -750,14 +751,14 @@ struct PluginConfigResolutionInput<'a> {
     regex_errors: &'a mut Vec<PluginRegexValidationError>,
 }
 
-fn resolve_plugin_config_files(input: PluginConfigResolutionInput<'_>) {
+fn resolve_plugin_config_files(input: &mut PluginConfigResolutionInput<'_>) {
     if input.config_matchers.is_empty() {
         return;
     }
 
     let mut resolved_plugins: FxHashSet<&str> = FxHashSet::default();
     for (plugin, matchers) in input.config_matchers {
-        resolve_plugin_matching_files(PluginMatchingFilesInput {
+        resolve_plugin_matching_files(&mut PluginMatchingFilesInput {
             plugin: *plugin,
             matchers,
             relative_files: input.relative_files,
@@ -795,7 +796,7 @@ struct PluginMatchingFilesInput<'plugins, 'data, 'state> {
     resolved_plugins: &'state mut FxHashSet<&'plugins str>,
 }
 
-fn resolve_plugin_matching_files(input: PluginMatchingFilesInput<'_, '_, '_>) {
+fn resolve_plugin_matching_files(input: &mut PluginMatchingFilesInput<'_, '_, '_>) {
     use rayon::prelude::*;
 
     let plugin_hits: Vec<&PathBuf> = input

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -816,15 +816,15 @@ fn resolve_plugin_matching_files(input: PluginMatchingFilesInput<'_, '_, '_>) {
             continue;
         }
         input.resolved_plugins.insert(input.plugin.name());
-        process_resolved_plugin_config(
-            input.plugin,
+        process_resolved_plugin_config(ResolvedPluginConfigInput {
+            plugin: input.plugin,
             abs_path,
             plugin_result,
-            input.result,
-            input.regex_errors,
-            "resolved config",
-            abs_path.display(),
-        );
+            result: input.result,
+            regex_errors: input.regex_errors,
+            message: "resolved config",
+            config_display: abs_path.display(),
+        });
     }
 }
 
@@ -846,37 +846,42 @@ fn resolve_plugin_filesystem_config(
         .strip_prefix(root)
         .map(|p| p.to_string_lossy())
         .unwrap_or_default();
-    process_resolved_plugin_config(
+    process_resolved_plugin_config(ResolvedPluginConfigInput {
         plugin,
         abs_path,
         plugin_result,
         result,
         regex_errors,
-        "resolved config (filesystem fallback)",
-        rel,
-    );
+        message: "resolved config (filesystem fallback)",
+        config_display: rel,
+    });
 }
 
-fn process_resolved_plugin_config(
-    plugin: &dyn Plugin,
-    abs_path: &Path,
+struct ResolvedPluginConfigInput<'a, D> {
+    plugin: &'a dyn Plugin,
+    abs_path: &'a Path,
     plugin_result: PluginResult,
-    result: &mut AggregatedPluginResult,
-    regex_errors: &mut Vec<PluginRegexValidationError>,
+    result: &'a mut AggregatedPluginResult,
+    regex_errors: &'a mut Vec<PluginRegexValidationError>,
     message: &'static str,
-    config_display: impl std::fmt::Display,
-) {
+    config_display: D,
+}
+
+fn process_resolved_plugin_config(input: ResolvedPluginConfigInput<'_, impl std::fmt::Display>) {
     tracing::debug!(
-        plugin = plugin.name(),
-        config = %config_display,
-        entries = plugin_result.entry_patterns.len(),
-        deps = plugin_result.referenced_dependencies.len(),
-        message
+        plugin = input.plugin.name(),
+        config = %input.config_display,
+        entries = input.plugin_result.entry_patterns.len(),
+        deps = input.plugin_result.referenced_dependencies.len(),
+        input.message
     );
-    if let Err(mut errors) =
-        process_config_result(plugin.name(), plugin_result, result, Some(abs_path))
-    {
-        regex_errors.append(&mut errors);
+    if let Err(mut errors) = process_config_result(
+        input.plugin.name(),
+        input.plugin_result,
+        input.result,
+        Some(input.abs_path),
+    ) {
+        input.regex_errors.append(&mut errors);
     }
 }
 

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -81,25 +81,27 @@ pub struct PluginRegexValidationError {
 }
 
 impl PluginRegexValidationError {
-    pub(crate) fn new(
-        plugin_name: &str,
-        config_path: Option<&Path>,
-        rule_kind: &'static str,
-        field: &'static str,
-        rule_pattern: &str,
-        regex_pattern: &str,
-        source: &regex::Error,
-    ) -> Self {
+    pub(crate) fn new(input: PluginRegexValidationErrorInput<'_>) -> Self {
         Self {
-            plugin_name: plugin_name.to_owned(),
-            config_path: config_path.map(Path::to_path_buf),
-            rule_kind,
-            field,
-            rule_pattern: rule_pattern.to_owned(),
-            regex_pattern: regex_pattern.to_owned(),
-            source: source.to_string(),
+            plugin_name: input.plugin_name.to_owned(),
+            config_path: input.config_path.map(Path::to_path_buf),
+            rule_kind: input.rule_kind,
+            field: input.field,
+            rule_pattern: input.rule_pattern.to_owned(),
+            regex_pattern: input.regex_pattern.to_owned(),
+            source: input.source.to_string(),
         }
     }
+}
+
+pub(crate) struct PluginRegexValidationErrorInput<'a> {
+    pub(crate) plugin_name: &'a str,
+    pub(crate) config_path: Option<&'a Path>,
+    pub(crate) rule_kind: &'static str,
+    pub(crate) field: &'static str,
+    pub(crate) rule_pattern: &'a str,
+    pub(crate) regex_pattern: &'a str,
+    pub(crate) source: &'a regex::Error,
 }
 
 impl fmt::Display for PluginRegexValidationError {

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -467,15 +467,15 @@ impl PluginRegistry {
             Vec::new()
         };
 
-        resolve_plugin_config_files(
-            &config_matchers,
-            &relative_files,
+        resolve_plugin_config_files(PluginConfigResolutionInput {
+            config_matchers: &config_matchers,
+            relative_files: &relative_files,
             config_search_roots,
             production_mode,
             root,
-            &mut result,
-            &mut regex_errors,
-        );
+            result: &mut result,
+            regex_errors: &mut regex_errors,
+        });
 
         process_package_json_inline_configs(
             &active,
@@ -738,40 +738,48 @@ fn plugin_warn_dedupe() -> &'static std::sync::Mutex<FxHashSet<String>> {
     WARNED.get_or_init(|| std::sync::Mutex::new(FxHashSet::default()))
 }
 
-fn resolve_plugin_config_files(
-    config_matchers: &[(&dyn Plugin, Vec<globset::GlobMatcher>)],
-    relative_files: &[(PathBuf, String)],
-    config_search_roots: &[&Path],
+struct PluginConfigResolutionInput<'a> {
+    config_matchers: &'a [(&'a dyn Plugin, Vec<globset::GlobMatcher>)],
+    relative_files: &'a [(PathBuf, String)],
+    config_search_roots: &'a [&'a Path],
     production_mode: bool,
-    root: &Path,
-    result: &mut AggregatedPluginResult,
-    regex_errors: &mut Vec<PluginRegexValidationError>,
-) {
-    if config_matchers.is_empty() {
+    root: &'a Path,
+    result: &'a mut AggregatedPluginResult,
+    regex_errors: &'a mut Vec<PluginRegexValidationError>,
+}
+
+fn resolve_plugin_config_files(input: PluginConfigResolutionInput<'_>) {
+    if input.config_matchers.is_empty() {
         return;
     }
 
     let mut resolved_plugins: FxHashSet<&str> = FxHashSet::default();
-    for (plugin, matchers) in config_matchers {
+    for (plugin, matchers) in input.config_matchers {
         resolve_plugin_matching_files(
             *plugin,
             matchers,
-            relative_files,
-            root,
-            result,
-            regex_errors,
+            input.relative_files,
+            input.root,
+            input.result,
+            input.regex_errors,
             &mut resolved_plugins,
         );
     }
 
     let json_configs = discover_config_files(
-        config_matchers,
+        input.config_matchers,
         &resolved_plugins,
-        config_search_roots,
-        production_mode,
+        input.config_search_roots,
+        input.production_mode,
     );
     for (abs_path, plugin) in &json_configs {
-        resolve_plugin_filesystem_config(*plugin, abs_path, root, result, regex_errors);
+        resolve_plugin_filesystem_config(
+            *plugin,
+            abs_path,
+            input.root,
+            input.result,
+            input.regex_errors,
+        );
     }
 }
 

--- a/crates/extract/src/sfc_template/shared.rs
+++ b/crates/extract/src/sfc_template/shared.rs
@@ -87,15 +87,15 @@ pub(super) fn merge_expression_usage_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(
+    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
         usage,
         snippet,
-        TemplateSnippetKind::Expression,
+        kind: TemplateSnippetKind::Expression,
         imported_bindings,
         bound_targets,
         locals,
-        false,
-    );
+        allow_dollar_prefixed_refs: false,
+    });
 }
 
 pub(super) fn merge_statement_usage_with_bound_targets(
@@ -105,15 +105,15 @@ pub(super) fn merge_statement_usage_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(
+    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
         usage,
         snippet,
-        TemplateSnippetKind::Statement,
+        kind: TemplateSnippetKind::Statement,
         imported_bindings,
         bound_targets,
         locals,
-        false,
-    );
+        allow_dollar_prefixed_refs: false,
+    });
 }
 
 pub(super) fn merge_expression_usage_allow_dollar_refs_with_bound_targets(
@@ -123,15 +123,15 @@ pub(super) fn merge_expression_usage_allow_dollar_refs_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(
+    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
         usage,
         snippet,
-        TemplateSnippetKind::Expression,
+        kind: TemplateSnippetKind::Expression,
         imported_bindings,
         bound_targets,
         locals,
-        true,
-    );
+        allow_dollar_prefixed_refs: true,
+    });
 }
 
 pub(super) fn merge_statement_usage_allow_dollar_refs_with_bound_targets(
@@ -141,15 +141,15 @@ pub(super) fn merge_statement_usage_allow_dollar_refs_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(
+    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
         usage,
         snippet,
-        TemplateSnippetKind::Statement,
+        kind: TemplateSnippetKind::Statement,
         imported_bindings,
         bound_targets,
         locals,
-        true,
-    );
+        allow_dollar_prefixed_refs: true,
+    });
 }
 
 fn merge_snippet_usage(
@@ -169,23 +169,27 @@ fn merge_snippet_usage(
     ));
 }
 
-fn merge_snippet_usage_with_bound_targets(
-    usage: &mut TemplateUsage,
-    snippet: &str,
+struct BoundSnippetUsageInput<'a> {
+    usage: &'a mut TemplateUsage,
+    snippet: &'a str,
     kind: TemplateSnippetKind,
-    imported_bindings: &FxHashSet<String>,
-    bound_targets: &FxHashMap<String, String>,
-    locals: &[String],
+    imported_bindings: &'a FxHashSet<String>,
+    bound_targets: &'a FxHashMap<String, String>,
+    locals: &'a [String],
     allow_dollar_prefixed_refs: bool,
-) {
-    usage.merge(analyze_template_snippet_with_bound_targets(
-        snippet,
-        kind,
-        imported_bindings,
-        bound_targets,
-        locals,
-        allow_dollar_prefixed_refs,
-    ));
+}
+
+fn merge_snippet_usage_with_bound_targets(input: BoundSnippetUsageInput<'_>) {
+    input
+        .usage
+        .merge(analyze_template_snippet_with_bound_targets(
+            input.snippet,
+            input.kind,
+            input.imported_bindings,
+            input.bound_targets,
+            input.locals,
+            input.allow_dollar_prefixed_refs,
+        ));
 }
 
 pub(super) fn merge_component_tag_usage(

--- a/crates/extract/src/sfc_template/shared.rs
+++ b/crates/extract/src/sfc_template/shared.rs
@@ -87,7 +87,7 @@ pub(super) fn merge_expression_usage_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
+    merge_snippet_usage_with_bound_targets(&mut BoundSnippetUsageInput {
         usage,
         snippet,
         kind: TemplateSnippetKind::Expression,
@@ -105,7 +105,7 @@ pub(super) fn merge_statement_usage_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
+    merge_snippet_usage_with_bound_targets(&mut BoundSnippetUsageInput {
         usage,
         snippet,
         kind: TemplateSnippetKind::Statement,
@@ -123,7 +123,7 @@ pub(super) fn merge_expression_usage_allow_dollar_refs_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
+    merge_snippet_usage_with_bound_targets(&mut BoundSnippetUsageInput {
         usage,
         snippet,
         kind: TemplateSnippetKind::Expression,
@@ -141,7 +141,7 @@ pub(super) fn merge_statement_usage_allow_dollar_refs_with_bound_targets(
     bound_targets: &FxHashMap<String, String>,
     locals: &[String],
 ) {
-    merge_snippet_usage_with_bound_targets(BoundSnippetUsageInput {
+    merge_snippet_usage_with_bound_targets(&mut BoundSnippetUsageInput {
         usage,
         snippet,
         kind: TemplateSnippetKind::Statement,
@@ -179,7 +179,7 @@ struct BoundSnippetUsageInput<'a> {
     allow_dollar_prefixed_refs: bool,
 }
 
-fn merge_snippet_usage_with_bound_targets(input: BoundSnippetUsageInput<'_>) {
+fn merge_snippet_usage_with_bound_targets(input: &mut BoundSnippetUsageInput<'_>) {
     input
         .usage
         .merge(analyze_template_snippet_with_bound_targets(

--- a/crates/extract/src/sfc_template/svelte.rs
+++ b/crates/extract/src/sfc_template/svelte.rs
@@ -92,15 +92,15 @@ pub(super) fn collect_template_usage_with_bound_targets(
                 let Some((tag, next_index)) = scan_curly_section(&markup, index, 1, 1) else {
                     break;
                 };
-                apply_tag(
-                    tag.trim(),
-                    index,
-                    next_index,
+                apply_tag(SvelteTagInput {
+                    tag: tag.trim(),
+                    tag_start: index,
+                    tag_end: next_index,
                     imported_bindings,
                     bound_targets,
-                    &mut scopes,
-                    &mut usage,
-                );
+                    scopes: &mut scopes,
+                    usage: &mut usage,
+                });
                 index = next_index;
             }
             b'<' => {
@@ -236,41 +236,49 @@ fn strip_non_template_content(source: &str) -> String {
     visible
 }
 
-fn apply_tag(
-    tag: &str,
+struct SvelteTagInput<'a> {
+    tag: &'a str,
     tag_start: usize,
     tag_end: usize,
-    imported_bindings: &FxHashSet<String>,
-    bound_targets: &FxHashMap<String, String>,
-    scopes: &mut Vec<SvelteScopeFrame>,
-    usage: &mut TemplateUsage,
-) {
-    if tag.is_empty() {
+    imported_bindings: &'a FxHashSet<String>,
+    bound_targets: &'a FxHashMap<String, String>,
+    scopes: &'a mut Vec<SvelteScopeFrame>,
+    usage: &'a mut TemplateUsage,
+}
+
+fn apply_tag(input: SvelteTagInput<'_>) {
+    if input.tag.is_empty() {
         return;
     }
 
-    if apply_svelte_block_tag(tag, imported_bindings, bound_targets, scopes, usage) {
+    if apply_svelte_block_tag(
+        input.tag,
+        input.imported_bindings,
+        input.bound_targets,
+        input.scopes,
+        input.usage,
+    ) {
         return;
     }
 
     if apply_svelte_expression_directive(
-        tag,
-        tag_start,
-        tag_end,
-        imported_bindings,
-        bound_targets,
-        scopes,
-        usage,
+        input.tag,
+        input.tag_start,
+        input.tag_end,
+        input.imported_bindings,
+        input.bound_targets,
+        input.scopes,
+        input.usage,
     ) {
         return;
     }
 
     merge_expression_usage_allow_dollar_refs_with_bound_targets(
-        usage,
-        tag,
-        imported_bindings,
-        bound_targets,
-        &current_locals(scopes),
+        input.usage,
+        input.tag,
+        input.imported_bindings,
+        input.bound_targets,
+        &current_locals(input.scopes),
     );
 }
 

--- a/crates/extract/src/sfc_template/svelte.rs
+++ b/crates/extract/src/sfc_template/svelte.rs
@@ -92,7 +92,7 @@ pub(super) fn collect_template_usage_with_bound_targets(
                 let Some((tag, next_index)) = scan_curly_section(&markup, index, 1, 1) else {
                     break;
                 };
-                apply_tag(SvelteTagInput {
+                apply_tag(&mut SvelteTagInput {
                     tag: tag.trim(),
                     tag_start: index,
                     tag_end: next_index,
@@ -246,7 +246,7 @@ struct SvelteTagInput<'a> {
     usage: &'a mut TemplateUsage,
 }
 
-fn apply_tag(input: SvelteTagInput<'_>) {
+fn apply_tag(input: &mut SvelteTagInput<'_>) {
     if input.tag.is_empty() {
         return;
     }
@@ -261,7 +261,7 @@ fn apply_tag(input: SvelteTagInput<'_>) {
         return;
     }
 
-    if apply_svelte_expression_directive(SvelteExpressionDirectiveInput {
+    if apply_svelte_expression_directive(&mut SvelteExpressionDirectiveInput {
         tag: input.tag,
         tag_start: input.tag_start,
         tag_end: input.tag_end,
@@ -366,7 +366,7 @@ struct SvelteExpressionDirectiveInput<'a> {
     usage: &'a mut TemplateUsage,
 }
 
-fn apply_svelte_expression_directive(input: SvelteExpressionDirectiveInput<'_>) -> bool {
+fn apply_svelte_expression_directive(input: &mut SvelteExpressionDirectiveInput<'_>) -> bool {
     if let Some(expr) = input.tag.strip_prefix("@attach") {
         apply_expression_tag(
             expr,

--- a/crates/extract/src/sfc_template/svelte.rs
+++ b/crates/extract/src/sfc_template/svelte.rs
@@ -261,15 +261,15 @@ fn apply_tag(input: SvelteTagInput<'_>) {
         return;
     }
 
-    if apply_svelte_expression_directive(
-        input.tag,
-        input.tag_start,
-        input.tag_end,
-        input.imported_bindings,
-        input.bound_targets,
-        input.scopes,
-        input.usage,
-    ) {
+    if apply_svelte_expression_directive(SvelteExpressionDirectiveInput {
+        tag: input.tag,
+        tag_start: input.tag_start,
+        tag_end: input.tag_end,
+        imported_bindings: input.imported_bindings,
+        bound_targets: input.bound_targets,
+        scopes: input.scopes,
+        usage: input.usage,
+    }) {
         return;
     }
 
@@ -356,55 +356,89 @@ fn apply_svelte_block_tag(
     false
 }
 
-fn apply_svelte_expression_directive(
-    tag: &str,
+struct SvelteExpressionDirectiveInput<'a> {
+    tag: &'a str,
     tag_start: usize,
     tag_end: usize,
-    imported_bindings: &FxHashSet<String>,
-    bound_targets: &FxHashMap<String, String>,
-    scopes: &mut [SvelteScopeFrame],
-    usage: &mut TemplateUsage,
-) -> bool {
-    if let Some(expr) = tag.strip_prefix("@attach") {
-        apply_expression_tag(expr, imported_bindings, bound_targets, scopes, usage);
-        return true;
-    }
+    imported_bindings: &'a FxHashSet<String>,
+    bound_targets: &'a FxHashMap<String, String>,
+    scopes: &'a mut [SvelteScopeFrame],
+    usage: &'a mut TemplateUsage,
+}
 
-    if let Some(expr) = tag.strip_prefix("@html") {
-        if let Some(sink) = crate::template_usage::template_html_sink(expr, tag_start, tag_end) {
-            usage.security_sinks.push(sink);
-        }
-        merge_expression_usage_allow_dollar_refs_with_bound_targets(
-            usage,
-            expr.trim(),
-            imported_bindings,
-            bound_targets,
-            &current_locals(scopes),
+fn apply_svelte_expression_directive(input: SvelteExpressionDirectiveInput<'_>) -> bool {
+    if let Some(expr) = input.tag.strip_prefix("@attach") {
+        apply_expression_tag(
+            expr,
+            input.imported_bindings,
+            input.bound_targets,
+            input.scopes,
+            input.usage,
         );
         return true;
     }
 
-    if let Some(expr) = tag.strip_prefix("@render") {
-        apply_expression_tag(expr, imported_bindings, bound_targets, scopes, usage);
+    if let Some(expr) = input.tag.strip_prefix("@html") {
+        if let Some(sink) =
+            crate::template_usage::template_html_sink(expr, input.tag_start, input.tag_end)
+        {
+            input.usage.security_sinks.push(sink);
+        }
+        merge_expression_usage_allow_dollar_refs_with_bound_targets(
+            input.usage,
+            expr.trim(),
+            input.imported_bindings,
+            input.bound_targets,
+            &current_locals(input.scopes),
+        );
         return true;
     }
 
-    if let Some(stmt) = tag.strip_prefix("@const") {
-        apply_const_tag(stmt, imported_bindings, bound_targets, scopes, usage);
+    if let Some(expr) = input.tag.strip_prefix("@render") {
+        apply_expression_tag(
+            expr,
+            input.imported_bindings,
+            input.bound_targets,
+            input.scopes,
+            input.usage,
+        );
         return true;
     }
 
-    if let Some(expr) = tag.strip_prefix("@debug") {
-        apply_expression_tag(expr, imported_bindings, bound_targets, scopes, usage);
+    if let Some(stmt) = input.tag.strip_prefix("@const") {
+        apply_const_tag(
+            stmt,
+            input.imported_bindings,
+            input.bound_targets,
+            input.scopes,
+            input.usage,
+        );
         return true;
     }
 
-    if let Some(expr) = tag.strip_prefix(":else if") {
-        apply_expression_tag(expr, imported_bindings, bound_targets, scopes, usage);
+    if let Some(expr) = input.tag.strip_prefix("@debug") {
+        apply_expression_tag(
+            expr,
+            input.imported_bindings,
+            input.bound_targets,
+            input.scopes,
+            input.usage,
+        );
         return true;
     }
 
-    if tag.starts_with(":else") {
+    if let Some(expr) = input.tag.strip_prefix(":else if") {
+        apply_expression_tag(
+            expr,
+            input.imported_bindings,
+            input.bound_targets,
+            input.scopes,
+            input.usage,
+        );
+        return true;
+    }
+
+    if input.tag.starts_with(":else") {
         return true;
     }
 

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -235,7 +235,7 @@ fn resolve_module_imports(
             .unwrap_or(file_path)
     };
 
-    Some(build_resolved_module(
+    Some(build_resolved_module(ResolvedModuleBuildInput {
         module,
         ctx,
         file_path,
@@ -243,39 +243,50 @@ fn resolve_module_imports(
         canonical_paths,
         files,
         all_imports,
-    ))
+    }))
 }
 
-fn build_resolved_module(
-    module: &ModuleInfo,
-    ctx: &ResolveContext<'_>,
-    file_path: &Path,
-    from_dir: &Path,
-    canonical_paths: &[PathBuf],
-    files: &[DiscoveredFile],
+struct ResolvedModuleBuildInput<'a> {
+    module: &'a ModuleInfo,
+    ctx: &'a ResolveContext<'a>,
+    file_path: &'a Path,
+    from_dir: &'a Path,
+    canonical_paths: &'a [PathBuf],
+    files: &'a [DiscoveredFile],
     all_imports: Vec<types::ResolvedImport>,
-) -> ResolvedModule {
+}
+
+fn build_resolved_module(input: ResolvedModuleBuildInput<'_>) -> ResolvedModule {
     ResolvedModule {
-        file_id: module.file_id,
-        path: file_path.to_path_buf(),
-        exports: module.exports.clone(),
-        re_exports: resolve_re_exports(ctx, file_path, &module.re_exports),
-        resolved_imports: all_imports,
-        resolved_dynamic_imports: resolve_dynamic_imports(ctx, file_path, &module.dynamic_imports),
-        resolved_dynamic_patterns: resolve_dynamic_patterns(
-            from_dir,
-            &module.dynamic_import_patterns,
-            canonical_paths,
-            files,
+        file_id: input.module.file_id,
+        path: input.file_path.to_path_buf(),
+        exports: input.module.exports.clone(),
+        re_exports: resolve_re_exports(input.ctx, input.file_path, &input.module.re_exports),
+        resolved_imports: input.all_imports,
+        resolved_dynamic_imports: resolve_dynamic_imports(
+            input.ctx,
+            input.file_path,
+            &input.module.dynamic_imports,
         ),
-        member_accesses: module.member_accesses.clone(),
-        whole_object_uses: module.whole_object_uses.clone(),
-        has_cjs_exports: module.has_cjs_exports,
-        has_angular_component_template_url: module.has_angular_component_template_url,
-        unused_import_bindings: module.unused_import_bindings.iter().cloned().collect(),
-        type_referenced_import_bindings: module.type_referenced_import_bindings.clone(),
-        value_referenced_import_bindings: module.value_referenced_import_bindings.clone(),
-        namespace_object_aliases: module.namespace_object_aliases.clone(),
+        resolved_dynamic_patterns: resolve_dynamic_patterns(
+            input.from_dir,
+            &input.module.dynamic_import_patterns,
+            input.canonical_paths,
+            input.files,
+        ),
+        member_accesses: input.module.member_accesses.clone(),
+        whole_object_uses: input.module.whole_object_uses.clone(),
+        has_cjs_exports: input.module.has_cjs_exports,
+        has_angular_component_template_url: input.module.has_angular_component_template_url,
+        unused_import_bindings: input
+            .module
+            .unused_import_bindings
+            .iter()
+            .cloned()
+            .collect(),
+        type_referenced_import_bindings: input.module.type_referenced_import_bindings.clone(),
+        value_referenced_import_bindings: input.module.value_referenced_import_bindings.clone(),
+        namespace_object_aliases: input.module.namespace_object_aliases.clone(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Continue the SIG audit loop from round 51 through round 100.
- Group long helper argument lists across CLI, core, config, extract, and graph code paths.
- Preserve existing output behavior, including CodeClimate off-severity handling.

## Verification
- cargo check --workspace
- cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings
- cargo test -p fallow-cli -p fallow-mcp
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- typos .
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- real fixture smokes for check, health, CodeClimate, markdown, compact, human output, Svelte, and Vue