### PR TITLE
chore(benchmarks): switch codspeed benches to criterion2

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build benchmark shard
         # Keep PR feedback focused: split simulation shards without adding a noisy suite.
         # large_analysis stays out because it exceeds the fast benchmark budget.
-        run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }}
+        run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }} --features codspeed
 
       - name: Run benchmark shard
         uses: CodSpeedHQ/action@c145068895e045cc725ee76fcd2307624b65c3af # v4.17.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc43e46599f3d77fcf2f2ca89e4d962910b0c19c44e7b58679cbbdfd1820a662"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "bpaf"
+version = "0.9.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b86829876e7e200161a5aa6ea688d46c32d64d70ee3100127790dde84688d6e"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +302,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "castaway"
@@ -335,6 +353,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +399,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
 ]
 
 [[package]]
@@ -403,48 +447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codspeed-divan-compat"
-version = "4.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ea79fd0b1f2128cfac6308369013dba92df47baf4a4f66b57d8158224a361d"
-dependencies = [
- "clap",
- "codspeed",
- "codspeed-divan-compat-macros",
- "codspeed-divan-compat-walltime",
- "regex",
-]
-
-[[package]]
-name = "codspeed-divan-compat-macros"
-version = "4.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70e4ddd6beedefeb48f59d5f85fc21365a66e7976408c3d39f6cbbc4f03e08c"
-dependencies = [
- "divan-macros",
- "itertools 0.14.0",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "codspeed-divan-compat-walltime"
-version = "4.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490c04f6076be6eacfafb496b8b237f3efbbed93838f2689115cc6f35fcf81c9"
-dependencies = [
- "cfg-if",
- "clap",
- "codspeed",
- "condtype",
- "divan-macros",
- "libc",
- "regex-lite",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,12 +484,6 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
-
-[[package]]
-name = "condtype"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
@@ -620,6 +616,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion2"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861a56bb48e3ba7a2a38580a91577e17d90db946649f5c342fd74ba864180def"
+dependencies = [
+ "anes",
+ "bpaf",
+ "cast",
+ "ciborium",
+ "codspeed",
+ "colored 3.1.1",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "walkdir",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +658,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -851,17 +872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "divan-macros"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,7 +982,7 @@ dependencies = [
 name = "fallow-benchmarks"
 version = "2.98.0"
 dependencies = [
- "codspeed-divan-compat",
+ "criterion2",
  "fallow-cli",
  "tempfile",
 ]
@@ -1056,7 +1066,7 @@ name = "fallow-core"
 version = "2.98.0"
 dependencies = [
  "bitcode",
- "codspeed-divan-compat",
+ "criterion2",
  "dhat",
  "dunce",
  "fallow-config",
@@ -1486,6 +1496,17 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
  "serde",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2239,6 +2260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,15 +2963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,12 +3156,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-st
 notify = "8"
 
 # Testing
-divan = { package = "codspeed-divan-compat", version = "4.7" }
+criterion2 = { version = "3.0.3", default-features = false }
 dhat = "0.3"
 insta = { version = "1", features = ["yaml"] }
 proptest = "1"
@@ -114,7 +114,7 @@ pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 
-# Restriction lints — catch common mistakes and enforce discipline
+# Restriction lints, catch common mistakes and enforce discipline
 dbg_macro = "warn"
 todo = "warn"
 print_stdout = "warn"
@@ -137,7 +137,7 @@ pathbuf_init_then_push = "warn"         # Use PathBuf::from() directly
 excessive_nesting = "warn"              # Catch deeply nested control flow (threshold in .clippy.toml)
 allow_attributes_without_reason = "warn" # Force reason on #[allow] to catch unjustified suppressions
 unimplemented = "warn"                  # Catch leftover unimplemented!() calls
-filetype_is_file = "warn"               # FileType::is_file() misses symlinks — use !is_dir()
+filetype_is_file = "warn"               # FileType::is_file() misses symlinks, use !is_dir()
 rest_pat_in_fully_bound_structs = "warn" # Catch `..` in patterns where all fields are already bound
 pub_underscore_fields = "warn"           # Catch accidentally public _-prefixed fields
 non_zero_suggestions = "warn"            # Suggest NonZero types for naturally non-zero values
@@ -165,7 +165,7 @@ cast_possible_truncation = "allow"
 cast_sign_loss = "allow"
 cast_precision_loss = "allow"
 cast_possible_wrap = "allow"
-too_many_lines = "warn"                 # SIG unit size — threshold in .clippy.toml
+too_many_lines = "warn"                 # SIG unit size, threshold in .clippy.toml
 items_after_statements = "allow"
 single_match_else = "allow"
 if_not_else = "allow"
@@ -226,7 +226,7 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 opt-level = 3
-panic = "abort"                         # Smaller binary — no unwind tables needed
+panic = "abort"                         # Smaller binary, no unwind tables needed
 
 # Profile-with-debug: release-equivalent codegen + debuginfo retained.
 # Use for samply / Instruments / perf without enabling LTO+strip in the
@@ -246,7 +246,7 @@ lto = "thin"
 debug-assertions = true
 overflow-checks = true
 
-# Optimize heavy deps for size — not in the hot path
+# Optimize heavy deps for size, not in the hot path
 [profile.release.package.regex-syntax]
 opt-level = "z"
 [profile.release.package.clap_builder]

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -14,9 +14,12 @@ name = "programmatic_commands"
 harness = false
 
 [dev-dependencies]
-divan = { workspace = true }
+criterion2 = { workspace = true }
 fallow-cli = { workspace = true }
 tempfile = { workspace = true }
+
+[features]
+codspeed = ["criterion2/codspeed"]
 
 [lints]
 workspace = true

--- a/crates/benchmarks/benches/programmatic_commands.rs
+++ b/crates/benchmarks/benches/programmatic_commands.rs
@@ -7,7 +7,7 @@
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-use divan::Bencher;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use fallow_cli::programmatic::{
     AnalysisOptions, ComplexityOptions, DeadCodeOptions, DuplicationMode, DuplicationOptions,
     compute_health, detect_circular_dependencies, detect_dead_code, detect_duplication,
@@ -15,10 +15,6 @@ use fallow_cli::programmatic::{
 use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
-
-fn main() {
-    divan::main();
-}
 
 struct CommandInput {
     _temp_dir: TempDir,
@@ -697,114 +693,159 @@ fn create_warm_workspace_project() -> CommandInput {
     input
 }
 
-#[divan::bench]
-fn dead_code_package_library_exports(bencher: Bencher) {
-    bencher
-        .with_inputs(create_library_project)
-        .bench_refs(|input| {
-            let options = DeadCodeOptions {
-                analysis: analysis_options(&input.root, true),
-                ..DeadCodeOptions::default()
-            };
-            detect_dead_code(&options)
-        });
-}
-
-#[divan::bench]
-fn dead_code_next_app_router_segments(bencher: Bencher) {
-    bencher
-        .with_inputs(create_next_app_project)
-        .bench_refs(|input| {
-            let options = DeadCodeOptions {
-                analysis: analysis_options(&input.root, true),
-                ..DeadCodeOptions::default()
-            };
-            detect_dead_code(&options)
-        });
-}
-
-#[divan::bench]
-fn dead_code_workspace_monorepo_cross_package(bencher: Bencher) {
-    bencher
-        .with_inputs(create_workspace_project)
-        .bench_refs(|input| {
-            let options = DeadCodeOptions {
-                analysis: analysis_options(&input.root, true),
-                ..DeadCodeOptions::default()
-            };
-            detect_dead_code(&options)
-        });
-}
-
-#[divan::bench]
-fn dead_code_workspace_monorepo_cross_package_warm_cache(bencher: Bencher) {
-    bencher
-        .with_inputs(create_warm_workspace_project)
-        .bench_refs(|input| {
-            let options = DeadCodeOptions {
-                analysis: analysis_options(&input.root, false),
-                ..DeadCodeOptions::default()
-            };
-            detect_dead_code(&options)
-        });
-}
-
-#[divan::bench]
-fn duplication_next_route_callbacks_repeated_auth(bencher: Bencher) {
-    bencher
-        .with_inputs(create_duplication_project)
-        .bench_refs(|input| {
-            let options = DuplicationOptions {
-                analysis: analysis_options(&input.root, true),
-                mode: DuplicationMode::Mild,
-                min_tokens: 35,
-                min_lines: 5,
-                min_occurrences: 2,
-                ..DuplicationOptions::default()
-            };
-            detect_duplication(&options)
-        });
-}
-
-#[divan::bench]
-fn circular_dependencies_domain_graph_cycles(bencher: Bencher) {
-    bencher
-        .with_inputs(create_circular_project)
-        .bench_refs(|input| {
-            let options = DeadCodeOptions {
-                analysis: analysis_options(&input.root, true),
-                ..DeadCodeOptions::default()
-            };
-            detect_circular_dependencies(&options)
-        });
-}
-
-#[divan::bench]
-fn health_complex_service_scoring(bencher: Bencher) {
-    bencher
-        .with_inputs(create_health_project)
-        .bench_refs(|input| {
-            let options = ComplexityOptions {
-                analysis: analysis_options(&input.root, true),
-                complexity: true,
-                file_scores: true,
-                hotspots: true,
-                targets: true,
-                ..ComplexityOptions::default()
-            };
-            compute_health(&options)
-        });
-}
-
-#[divan::bench]
-fn health_css_tailwind_design_system(bencher: Bencher) {
-    bencher.with_inputs(create_css_project).bench_refs(|input| {
-        let options = ComplexityOptions {
-            analysis: analysis_options(&input.root, true),
-            css: true,
-            score: true,
-            ..ComplexityOptions::default()
-        };
-        compute_health(&options)
+fn dead_code_package_library_exports(c: &mut Criterion) {
+    c.bench_function("dead_code_package_library_exports", |bencher| {
+        bencher.iter_batched_ref(
+            create_library_project,
+            |input| {
+                let options = DeadCodeOptions {
+                    analysis: analysis_options(&input.root, true),
+                    ..DeadCodeOptions::default()
+                };
+                detect_dead_code(&options)
+            },
+            BatchSize::LargeInput,
+        );
     });
 }
+
+fn dead_code_next_app_router_segments(c: &mut Criterion) {
+    c.bench_function("dead_code_next_app_router_segments", |bencher| {
+        bencher.iter_batched_ref(
+            create_next_app_project,
+            |input| {
+                let options = DeadCodeOptions {
+                    analysis: analysis_options(&input.root, true),
+                    ..DeadCodeOptions::default()
+                };
+                detect_dead_code(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn dead_code_workspace_monorepo_cross_package(c: &mut Criterion) {
+    c.bench_function("dead_code_workspace_monorepo_cross_package", |bencher| {
+        bencher.iter_batched_ref(
+            create_workspace_project,
+            |input| {
+                let options = DeadCodeOptions {
+                    analysis: analysis_options(&input.root, true),
+                    ..DeadCodeOptions::default()
+                };
+                detect_dead_code(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn dead_code_workspace_monorepo_cross_package_warm_cache(c: &mut Criterion) {
+    c.bench_function(
+        "dead_code_workspace_monorepo_cross_package_warm_cache",
+        |bencher| {
+            bencher.iter_batched_ref(
+                create_warm_workspace_project,
+                |input| {
+                    let options = DeadCodeOptions {
+                        analysis: analysis_options(&input.root, false),
+                        ..DeadCodeOptions::default()
+                    };
+                    detect_dead_code(&options)
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
+fn duplication_next_route_callbacks_repeated_auth(c: &mut Criterion) {
+    c.bench_function(
+        "duplication_next_route_callbacks_repeated_auth",
+        |bencher| {
+            bencher.iter_batched_ref(
+                create_duplication_project,
+                |input| {
+                    let options = DuplicationOptions {
+                        analysis: analysis_options(&input.root, true),
+                        mode: DuplicationMode::Mild,
+                        min_tokens: 35,
+                        min_lines: 5,
+                        min_occurrences: 2,
+                        ..DuplicationOptions::default()
+                    };
+                    detect_duplication(&options)
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
+fn circular_dependencies_domain_graph_cycles(c: &mut Criterion) {
+    c.bench_function("circular_dependencies_domain_graph_cycles", |bencher| {
+        bencher.iter_batched_ref(
+            create_circular_project,
+            |input| {
+                let options = DeadCodeOptions {
+                    analysis: analysis_options(&input.root, true),
+                    ..DeadCodeOptions::default()
+                };
+                detect_circular_dependencies(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn health_complex_service_scoring(c: &mut Criterion) {
+    c.bench_function("health_complex_service_scoring", |bencher| {
+        bencher.iter_batched_ref(
+            create_health_project,
+            |input| {
+                let options = ComplexityOptions {
+                    analysis: analysis_options(&input.root, true),
+                    complexity: true,
+                    file_scores: true,
+                    hotspots: true,
+                    targets: true,
+                    ..ComplexityOptions::default()
+                };
+                compute_health(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn health_css_tailwind_design_system(c: &mut Criterion) {
+    c.bench_function("health_css_tailwind_design_system", |bencher| {
+        bencher.iter_batched_ref(
+            create_css_project,
+            |input| {
+                let options = ComplexityOptions {
+                    analysis: analysis_options(&input.root, true),
+                    css: true,
+                    score: true,
+                    ..ComplexityOptions::default()
+                };
+                compute_health(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(
+    benches,
+    dead_code_package_library_exports,
+    dead_code_next_app_router_segments,
+    dead_code_workspace_monorepo_cross_package,
+    dead_code_workspace_monorepo_cross_package_warm_cache,
+    duplication_next_route_callbacks_repeated_auth,
+    circular_dependencies_domain_graph_cycles,
+    health_complex_service_scoring,
+    health_css_tailwind_design_system
+);
+criterion_main!(benches);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -63,13 +63,14 @@ tracing = { workspace = true }
 schemars = { workspace = true, optional = true }
 
 [features]
+codspeed = ["criterion2/codspeed"]
 # Mirrors fallow-types' `schema` feature: enables `#[derive(schemars::JsonSchema)]`
 # on `DuplicationReport` and friends so the public JSON output contract can be
 # regenerated from the Rust source of truth.
 schema = ["dep:schemars", "fallow-types/schema"]
 
 [dev-dependencies]
-divan = { workspace = true }
+criterion2 = { workspace = true }
 proptest = { workspace = true }
 dhat = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -10,14 +10,10 @@
 
 use std::path::PathBuf;
 
-use divan::Bencher;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rustc_hash::FxHashSet;
 
 mod helpers;
-
-fn main() {
-    divan::main();
-}
 
 struct ParseFileInput {
     temp_dir: PathBuf,
@@ -133,11 +129,14 @@ export default function App({ name, age }: Props) {
     ParseFileInput { temp_dir, file }
 }
 
-#[divan::bench]
-fn parse_single_file(bencher: Bencher) {
-    bencher
-        .with_inputs(create_parse_file_input)
-        .bench_refs(|input| fallow_core::extract::parse_single_file(&input.file));
+fn parse_single_file(c: &mut Criterion) {
+    c.bench_function("parse_single_file", |bencher| {
+        bencher.iter_batched_ref(
+            create_parse_file_input,
+            |input| fallow_core::extract::parse_single_file(&input.file),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 fn create_full_pipeline_input() -> ConfigInput {
@@ -177,11 +176,14 @@ export type Type{i} = {{ value: number }};
     ConfigInput { temp_dir, config }
 }
 
-#[divan::bench]
-fn full_pipeline_10_files(bencher: Bencher) {
-    bencher
-        .with_inputs(create_full_pipeline_input)
-        .bench_refs(|input| fallow_core::analyze(&input.config));
+fn full_pipeline_10_files(c: &mut Criterion) {
+    c.bench_function("full_pipeline_10_files", |bencher| {
+        bencher.iter_batched_ref(
+            create_full_pipeline_input,
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 fn create_synthetic_config_input(name: &str, file_count: usize) -> ConfigInput {
@@ -189,18 +191,24 @@ fn create_synthetic_config_input(name: &str, file_count: usize) -> ConfigInput {
     ConfigInput { temp_dir, config }
 }
 
-#[divan::bench]
-fn full_pipeline_100_files(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_synthetic_config_input("100", 100))
-        .bench_refs(|input| fallow_core::analyze(&input.config));
+fn full_pipeline_100_files(c: &mut Criterion) {
+    c.bench_function("full_pipeline_100_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_synthetic_config_input("100", 100),
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn full_pipeline_1000_files(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_synthetic_config_input("1000", 1000))
-        .bench_refs(|input| fallow_core::analyze(&input.config));
+fn full_pipeline_1000_files(c: &mut Criterion) {
+    c.bench_function("full_pipeline_1000_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_synthetic_config_input("1000", 1000),
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 struct ReExportInput {
@@ -417,17 +425,20 @@ fn create_re_export_input() -> ReExportInput {
     }
 }
 
-#[divan::bench]
-fn resolve_re_export_chains(bencher: Bencher) {
-    bencher
-        .with_inputs(create_re_export_input)
-        .bench_refs(|input| {
-            fallow_core::graph::ModuleGraph::build(
-                &input.resolved_modules,
-                &input.entry_points,
-                &input.files,
-            );
-        });
+fn resolve_re_export_chains(c: &mut Criterion) {
+    c.bench_function("resolve_re_export_chains", |bencher| {
+        bencher.iter_batched_ref(
+            create_re_export_input,
+            |input| {
+                fallow_core::graph::ModuleGraph::build(
+                    &input.resolved_modules,
+                    &input.entry_points,
+                    &input.files,
+                );
+            },
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 #[expect(
@@ -716,17 +727,20 @@ fn create_cache_round_trip_input() -> fallow_core::extract::ModuleInfo {
     }
 }
 
-#[divan::bench]
-fn cache_round_trip(bencher: Bencher) {
+fn cache_round_trip(c: &mut Criterion) {
     use fallow_core::cache::{cached_to_module, module_to_cached};
     use fallow_core::discover::FileId;
 
-    bencher
-        .with_inputs(create_cache_round_trip_input)
-        .bench_refs(|module| {
-            let cached = module_to_cached(module, 0, 0);
-            let _ = cached_to_module(&cached, FileId(0));
-        });
+    c.bench_function("cache_round_trip", |bencher| {
+        bencher.iter_batched_ref(
+            create_cache_round_trip_input,
+            |module| {
+                let cached = module_to_cached(module, 0, 0);
+                let _ = cached_to_module(&cached, FileId(0));
+            },
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 fn make_hashed_tokens(hashes: &[u64]) -> Vec<fallow_core::duplicates::normalize::HashedToken> {
@@ -808,44 +822,55 @@ fn make_diverse_files(n: usize, tokens_per_file: usize) -> DupeInput {
         .collect()
 }
 
-#[divan::bench]
-fn dupe_detect_2x500_identical(bencher: Bencher) {
+fn dupe_detect_2x500_identical(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 500);
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
+    c.bench_function("dupe_detect_2x500_identical", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn dupe_detect_2x2000_identical(bencher: Bencher) {
+fn dupe_detect_2x2000_identical(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 2000);
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
+    c.bench_function("dupe_detect_2x2000_identical", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn dupe_detect_10x500_identical(bencher: Bencher) {
+fn dupe_detect_10x500_identical(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(10, 500);
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
+    c.bench_function("dupe_detect_10x500_identical", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn dupe_detect_50x200_diverse(bencher: Bencher) {
+fn dupe_detect_50x200_diverse(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_diverse_files(50, 200);
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
+    c.bench_function("dupe_detect_50x200_diverse", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn dupe_detect_100x200_mixed(bencher: Bencher) {
+fn dupe_detect_100x200_mixed(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let hashes: Vec<u64> = (1..=200).collect();
     let data: DupeInput = (0..100)
@@ -865,13 +890,16 @@ fn dupe_detect_100x200_mixed(bencher: Bencher) {
         })
         .collect();
 
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
+    c.bench_function("dupe_detect_100x200_mixed", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn dupe_detect_100x200_mixed_focused(bencher: Bencher) {
+fn dupe_detect_100x200_mixed_focused(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     use rustc_hash::FxHashSet;
 
@@ -894,16 +922,41 @@ fn dupe_detect_100x200_mixed_focused(bencher: Bencher) {
         .collect();
     let focus: FxHashSet<PathBuf> = std::iter::once(PathBuf::from("dir0/file0.ts")).collect();
 
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect_touching_files(d, &focus));
+    c.bench_function("dupe_detect_100x200_mixed_focused", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect_touching_files(d, &focus),
+            BatchSize::LargeInput,
+        );
+    });
 }
 
-#[divan::bench]
-fn dupe_detect_2x5000_identical(bencher: Bencher) {
+fn dupe_detect_2x5000_identical(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 5000);
-    bencher
-        .with_inputs(|| data.clone())
-        .bench_values(|d| CloneDetector::new(30, 5, false).detect(d));
+    c.bench_function("dupe_detect_2x5000_identical", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
 }
+
+criterion_group!(
+    benches,
+    parse_single_file,
+    full_pipeline_10_files,
+    full_pipeline_100_files,
+    full_pipeline_1000_files,
+    resolve_re_export_chains,
+    cache_round_trip,
+    dupe_detect_2x500_identical,
+    dupe_detect_2x2000_identical,
+    dupe_detect_10x500_identical,
+    dupe_detect_50x200_diverse,
+    dupe_detect_100x200_mixed,
+    dupe_detect_100x200_mixed_focused,
+    dupe_detect_2x5000_identical
+);
+criterion_main!(benches);

--- a/crates/core/benches/large_analysis.rs
+++ b/crates/core/benches/large_analysis.rs
@@ -8,13 +8,9 @@
     reason = "ADR-008: benchmark exercises the workspace path-dep fallow_core::analyze surface"
 )]
 
-use divan::Bencher;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 mod helpers;
-
-fn main() {
-    divan::main();
-}
 
 struct ConfigInput {
     temp_dir: std::path::PathBuf,
@@ -63,41 +59,55 @@ fn create_dupes_input(name: &str, file_count: usize) -> DupesInput {
     }
 }
 
-#[divan::bench]
-fn full_pipeline_5000_files(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_config_input("5000", 5000, true))
-        .bench_refs(|input| fallow_core::analyze(&input.config));
+fn bench_large_analysis(c: &mut Criterion) {
+    let mut group = c.benchmark_group("large_analysis");
+
+    group.bench_function("full_pipeline_5000_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_config_input("5000", 5000, true),
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("full_pipeline_1000_files_warm_cache", |bencher| {
+        bencher.iter_batched_ref(
+            || create_warm_config_input("1000-warm", 1000),
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("full_pipeline_5000_files_warm_cache", |bencher| {
+        bencher.iter_batched_ref(
+            || create_warm_config_input("5000-warm", 5000),
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("dupes_full_pipeline_1000_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_dupes_input("1000", 1000),
+            |input| {
+                fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("dupes_full_pipeline_5000_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_dupes_input("5000", 5000),
+            |input| {
+                fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
 }
 
-#[divan::bench]
-fn full_pipeline_1000_files_warm_cache(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_warm_config_input("1000-warm", 1000))
-        .bench_refs(|input| fallow_core::analyze(&input.config));
-}
-
-#[divan::bench]
-fn full_pipeline_5000_files_warm_cache(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_warm_config_input("5000-warm", 5000))
-        .bench_refs(|input| fallow_core::analyze(&input.config));
-}
-
-#[divan::bench]
-fn dupes_full_pipeline_1000_files(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_dupes_input("1000", 1000))
-        .bench_refs(|input| {
-            fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
-        });
-}
-
-#[divan::bench]
-fn dupes_full_pipeline_5000_files(bencher: Bencher) {
-    bencher
-        .with_inputs(|| create_dupes_input("5000", 5000))
-        .bench_refs(|input| {
-            fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
-        });
-}
+criterion_group!(benches, bench_large_analysis);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Replace the Divan benchmark harness with criterion2.
- Keep CodSpeed coverage through a `codspeed` feature on benchmark packages.
- Convert the core and programmatic benchmark suites to Criterion-style groups.

## Verification
- `cargo check --workspace`
- `cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings`
- `cargo clippy -p fallow-core -p fallow-benchmarks --benches --features codspeed -- -D warnings`
- `cargo test -p fallow-cli -p fallow-mcp`
- `cargo test --workspace --all-targets --no-run`
- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `typos .`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- CodSpeed build and simulation for `analysis`, `large_analysis`, and `programmatic_commands`
