### PR TITLE
chore: add post-pr 1300 follow-up tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,14 @@ jobs:
 
       - name: Run tests
         if: matrix.os != 'windows-latest'
-        run: cargo test --workspace --all-targets
+        # Benchmark targets exceed this job's timeout and are covered by the
+        # dedicated benchmark workflows.
+        run: cargo test --workspace --lib --bins --tests
 
       - name: Run tests (Windows)
         if: matrix.os == 'windows-latest'
-        # Windows push checks catch path and filesystem regressions, but bench
-        # target execution can exceed this job's timeout. Dedicated benchmark
-        # workflows cover benchmark execution separately.
+        # Windows push checks catch path and filesystem regressions.
+        # Benchmark targets are covered by dedicated benchmark workflows.
         run: cargo test --workspace --lib --bins --tests
 
       - name: Run runtime-coverage integration tests (feature-gated stub sidecar)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,7 @@ version = "2.98.0"
 dependencies = [
  "criterion2",
  "fallow-cli",
+ "fallow-core",
  "tempfile",
 ]
 

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -16,6 +16,7 @@ harness = false
 [dev-dependencies]
 criterion2 = { workspace = true }
 fallow-cli = { workspace = true }
+fallow-core = { workspace = true }
 tempfile = { workspace = true }
 
 [features]

--- a/crates/benchmarks/benches/programmatic_commands.rs
+++ b/crates/benchmarks/benches/programmatic_commands.rs
@@ -5,12 +5,18 @@
 )]
 
 use std::fmt::Write as _;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use fallow_cli::programmatic::{
     AnalysisOptions, ComplexityOptions, DeadCodeOptions, DuplicationMode, DuplicationOptions,
     compute_health, detect_circular_dependencies, detect_dead_code, detect_duplication,
+};
+use fallow_core::{
+    cache::{CacheStore, module_to_cached},
+    discover::{DiscoveredFile, FileId},
+    extract::{parse_all_files, parse_single_file},
 };
 use tempfile::TempDir;
 
@@ -19,6 +25,12 @@ const BENCH_THREADS: usize = 4;
 struct CommandInput {
     _temp_dir: TempDir,
     root: PathBuf,
+}
+
+struct ExtractCacheInput {
+    _temp_dir: TempDir,
+    files: Vec<DiscoveredFile>,
+    cache: CacheStore,
 }
 
 fn write_file(root: &Path, path: &str, source: impl AsRef<str>) {
@@ -73,6 +85,44 @@ fn analysis_options(root: &Path, no_cache: bool) -> AnalysisOptions {
         threads: Some(BENCH_THREADS),
         ..AnalysisOptions::default()
     }
+}
+
+fn is_source_path(path: &Path) -> bool {
+    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+        return false;
+    };
+
+    matches!(extension, "css" | "js" | "jsx" | "ts" | "tsx")
+}
+
+fn collect_source_paths(dir: &Path, paths: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("benchmark fixture directory is readable") {
+        let entry = entry.expect("benchmark fixture entry is readable");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_source_paths(&path, paths);
+        } else if is_source_path(&path) {
+            paths.push(path);
+        }
+    }
+}
+
+fn discovered_source_files(root: &Path) -> Vec<DiscoveredFile> {
+    let mut paths = Vec::new();
+    collect_source_paths(root, &mut paths);
+    paths.sort();
+
+    paths
+        .into_iter()
+        .enumerate()
+        .map(|(index, path)| DiscoveredFile {
+            id: FileId(u32::try_from(index).expect("benchmark fixture file count fits in u32")),
+            size_bytes: fs::metadata(&path)
+                .expect("benchmark fixture metadata is readable")
+                .len(),
+            path,
+        })
+        .collect()
 }
 
 fn create_library_project() -> CommandInput {
@@ -683,13 +733,48 @@ export const App = () => (
     }
 }
 
-fn create_warm_workspace_project() -> CommandInput {
+fn create_warm_metadata_workspace_project() -> CommandInput {
     let input = create_workspace_project();
     let options = DeadCodeOptions {
         analysis: analysis_options(&input.root, false),
         ..DeadCodeOptions::default()
     };
     let _ = detect_dead_code(&options).expect("warm cache priming succeeds");
+    input
+}
+
+fn create_warm_hash_workspace_project() -> ExtractCacheInput {
+    let CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    } = create_workspace_project();
+    let files = discovered_source_files(&root);
+    let mut cache = CacheStore::new();
+
+    for file in &files {
+        let module = parse_single_file(file).expect("benchmark fixture parses");
+        let cached = module_to_cached(&module, 1, 1);
+        cache.insert(&file.path, cached);
+    }
+
+    ExtractCacheInput {
+        _temp_dir: temp_dir,
+        files,
+        cache,
+    }
+}
+
+fn create_warm_complexity_health_project() -> CommandInput {
+    let input = create_health_project();
+    let options = ComplexityOptions {
+        analysis: analysis_options(&input.root, false),
+        complexity: true,
+        file_scores: true,
+        hotspots: true,
+        targets: true,
+        ..ComplexityOptions::default()
+    };
+    let _ = compute_health(&options).expect("warm complexity cache priming succeeds");
     input
 }
 
@@ -741,12 +826,12 @@ fn dead_code_workspace_monorepo_cross_package(c: &mut Criterion) {
     });
 }
 
-fn dead_code_workspace_monorepo_cross_package_warm_cache(c: &mut Criterion) {
+fn dead_code_workspace_monorepo_cross_package_warm_metadata_hit(c: &mut Criterion) {
     c.bench_function(
-        "dead_code_workspace_monorepo_cross_package_warm_cache",
+        "dead_code_workspace_monorepo_cross_package_warm_metadata_hit",
         |bencher| {
             bencher.iter_batched_ref(
-                create_warm_workspace_project,
+                create_warm_metadata_workspace_project,
                 |input| {
                     let options = DeadCodeOptions {
                         analysis: analysis_options(&input.root, false),
@@ -758,6 +843,21 @@ fn dead_code_workspace_monorepo_cross_package_warm_cache(c: &mut Criterion) {
             );
         },
     );
+}
+
+fn extract_workspace_monorepo_warm_hash_hit(c: &mut Criterion) {
+    c.bench_function("extract_workspace_monorepo_warm_hash_hit", |bencher| {
+        bencher.iter_batched_ref(
+            create_warm_hash_workspace_project,
+            |input| {
+                let result = parse_all_files(&input.files, Some(&input.cache), false);
+                assert_eq!(result.cache_hits, input.files.len());
+                assert_eq!(result.cache_misses, 0);
+                result
+            },
+            BatchSize::LargeInput,
+        );
+    });
 }
 
 fn duplication_next_route_callbacks_repeated_auth(c: &mut Criterion) {
@@ -819,6 +919,26 @@ fn health_complex_service_scoring(c: &mut Criterion) {
     });
 }
 
+fn health_complex_service_warm_complexity_hit(c: &mut Criterion) {
+    c.bench_function("health_complex_service_warm_complexity_hit", |bencher| {
+        bencher.iter_batched_ref(
+            create_warm_complexity_health_project,
+            |input| {
+                let options = ComplexityOptions {
+                    analysis: analysis_options(&input.root, false),
+                    complexity: true,
+                    file_scores: true,
+                    hotspots: true,
+                    targets: true,
+                    ..ComplexityOptions::default()
+                };
+                compute_health(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
 fn health_css_tailwind_design_system(c: &mut Criterion) {
     c.bench_function("health_css_tailwind_design_system", |bencher| {
         bencher.iter_batched_ref(
@@ -842,10 +962,12 @@ criterion_group!(
     dead_code_package_library_exports,
     dead_code_next_app_router_segments,
     dead_code_workspace_monorepo_cross_package,
-    dead_code_workspace_monorepo_cross_package_warm_cache,
+    dead_code_workspace_monorepo_cross_package_warm_metadata_hit,
+    extract_workspace_monorepo_warm_hash_hit,
     duplication_next_route_callbacks_repeated_auth,
     circular_dependencies_domain_graph_cycles,
     health_complex_service_scoring,
+    health_complex_service_warm_complexity_hit,
     health_css_tailwind_design_system
 );
 criterion_main!(benches);

--- a/docs/analyzer-authoring.md
+++ b/docs/analyzer-authoring.md
@@ -19,6 +19,17 @@ there first when the finding has a stable issue code, LSP diagnostic code,
 filter flag, or suppression token. Keep prose and caveats in the surface that
 owns them.
 
+## Optional Scaffold
+
+To start from a checklist-only plan:
+
+```bash
+npm run scaffold:analyzer -- unused-example
+```
+
+The command writes `.plans/analyzers/unused-example.md` and does not edit Rust
+source.
+
 ## Implementation Checklist
 
 Use this as the default map for a new finding:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "commitlint": "commitlint",
     "generate:all": "node scripts/generate-all.mjs",
     "generate:all:check": "node scripts/generate-all.mjs --check",
+    "scaffold:analyzer": "node scripts/scaffold-analyzer-plan.mjs",
     "lint:js": "oxlint --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src scripts commitlint.config.mjs",
     "fmt:js": "oxfmt --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src scripts commitlint.config.mjs",
     "fmt:js:check": "oxfmt --check --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src scripts commitlint.config.mjs"

--- a/scripts/scaffold-analyzer-plan.mjs
+++ b/scripts/scaffold-analyzer-plan.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CODE_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+const ANALYZER_PLAN_DIR = path.join(REPO_ROOT, ".plans", "analyzers");
+
+const usage = () => {
+  console.error("Usage: npm run scaffold:analyzer -- <kebab-code> [--force]");
+};
+
+const parseArgs = (args) => {
+  const force = args.includes("--force");
+  const values = args.filter((arg) => arg !== "--force");
+
+  if (values.length !== 1) {
+    return { ok: false, error: "expected exactly one analyzer code" };
+  }
+
+  const [code] = values;
+  if (!CODE_PATTERN.test(code)) {
+    return {
+      ok: false,
+      error: "analyzer code must be lowercase kebab case, for example unused-store-member",
+    };
+  }
+
+  return { ok: true, data: { code, force } };
+};
+
+const assertPlanPath = (targetPath) => {
+  const relative = path.relative(ANALYZER_PLAN_DIR, targetPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("refusing to write outside .plans/analyzers");
+  }
+};
+
+const assertWritablePlanPath = (targetPath) => {
+  const planDirRealPath = fs.realpathSync(ANALYZER_PLAN_DIR);
+  const targetParentRealPath = fs.realpathSync(path.dirname(targetPath));
+  if (targetParentRealPath !== planDirRealPath) {
+    throw new Error("refusing to write outside .plans/analyzers");
+  }
+
+  let targetStats = null;
+  try {
+    targetStats = fs.lstatSync(targetPath);
+  } catch (error) {
+    if (!error || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  if (targetStats?.isSymbolicLink()) {
+    throw new Error("refusing to overwrite a symlink plan file");
+  }
+  if (targetStats && !targetStats.isFile()) {
+    throw new Error("refusing to overwrite a non-file plan path");
+  }
+};
+
+const planTemplate = (code) => `# ${code}
+
+Status: draft
+
+## Contract
+
+- [ ] Add or verify the shared metadata row in \`crates/types/src/issue_meta.rs\`.
+- [ ] Pick the stable \`rule_id\`, issue \`code\`, rules key, aliases, suppression token, and docs anchor.
+- [ ] Decide whether the finding needs an \`IssueKind\` in \`crates/types/src/suppress.rs\`.
+- [ ] Add \`actions\` entries only when agents can apply or suppress the finding safely.
+
+## Implementation
+
+- [ ] Keep extraction, graph facts, and reporting in the narrowest crate that owns the stage.
+- [ ] Reuse existing framework detection and config resolution helpers before adding new abstractions.
+- [ ] Add rule severity defaults, aliases, and unknown-key suggestions in \`crates/config/src/config/rules.rs\`.
+- [ ] Add \`fallow explain\` coverage in \`crates/cli/src/explain.rs\`.
+- [ ] Update LSP, MCP, schemas, generated types, and CI-facing formats when the finding is user visible.
+
+## Fixture Matrix
+
+| Fixture kind | Path or test | Proof |
+| --- | --- | --- |
+| Positive minimal | TBD | Finding appears for the smallest real shape. |
+| Negative abstain | TBD | Analyzer stays silent when prerequisites are missing. |
+| False-positive guard | TBD | Nearby valid pattern does not report. |
+| Suppression | TBD | Intended suppression is consumed. |
+| Filter and severity | TBD | Rule key, CLI filter, and severity gate select the finding. |
+| Output contract | TBD | JSON, SARIF, compact, and human output stay stable. |
+| Framework regression | TBD | Distilled real-world framework pattern keeps working. |
+
+## Verification
+
+- [ ] \`cargo test --workspace --all-targets\`
+- [ ] \`npm run generate:all:check\`
+- [ ] Real project smoke with \`--format json --quiet\`
+`;
+
+const main = () => {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (!parsed.ok) {
+    console.error(parsed.error);
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const { code, force } = parsed.data;
+  const targetPath = path.join(ANALYZER_PLAN_DIR, `${code}.md`);
+  assertPlanPath(targetPath);
+
+  fs.mkdirSync(ANALYZER_PLAN_DIR, { recursive: true });
+  assertWritablePlanPath(targetPath);
+  fs.writeFileSync(targetPath, planTemplate(code), {
+    encoding: "utf8",
+    flag: force ? "w" : "wx",
+  });
+  console.log(path.relative(REPO_ROOT, targetPath));
+};
+
+try {
+  main();
+} catch (error) {
+  if (error && error.code === "EEXIST") {
+    console.error("plan already exists, pass --force to overwrite it");
+  } else {
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add warm metadata-hit, hash-hit, and health complexity cache benchmarks
- add an analyzer-plan scaffold command with duplicate, invalid-code, force, and symlink overwrite guards
- document the scaffold in the analyzer authoring guide
- keep CI test jobs on correctness tests while dedicated benchmark workflows run benchmark targets

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check -p fallow-benchmarks --benches
- cargo test --workspace --lib --bins --tests
- npm run fmt:js:check
- npm run lint:js
- npm run generate:all:check
- targeted benchmark runs for the new warm-cache cases
- scaffold create, duplicate, force, invalid-code, and symlink overwrite checks
- real-project JSON smoke on this repo
