### PR TITLE
chore: harden CodSpeed benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,6 +45,14 @@ jobs:
             cache_key: programmatic-commands
             package: fallow-benchmarks
             bench: programmatic_commands
+          - label: real sources
+            cache_key: real-sources
+            package: fallow-benchmarks
+            bench: real_sources
+          - label: scaling analysis
+            cache_key: scaling-analysis
+            package: fallow-core
+            bench: scaling_analysis
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -13,6 +13,10 @@ description = "CodSpeed benchmark suites for fallow"
 name = "programmatic_commands"
 harness = false
 
+[[bench]]
+name = "real_sources"
+harness = false
+
 [dev-dependencies]
 criterion2 = { workspace = true }
 fallow-cli = { workspace = true }

--- a/crates/benchmarks/benches/real_sources.rs
+++ b/crates/benchmarks/benches/real_sources.rs
@@ -1,0 +1,164 @@
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "benches use unwrap and expect to keep fixture setup concise"
+)]
+
+use std::path::{Path, PathBuf};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use fallow_cli::programmatic::{AnalysisOptions, DeadCodeOptions, detect_dead_code};
+use fallow_core::{
+    discover::{DiscoveredFile, FileId},
+    extract::parse_single_file,
+};
+use tempfile::TempDir;
+
+const BENCH_THREADS: usize = 4;
+const ZOD_TYPES_SOURCE: &str =
+    include_str!("../../../benchmarks/fixtures/real-world/zod/src/types.ts");
+
+struct RealSourceInput {
+    _temp_dir: TempDir,
+    root: PathBuf,
+    file: DiscoveredFile,
+}
+
+fn write_file(root: &Path, path: &str, source: &str) {
+    let path = root.join(path);
+    std::fs::create_dir_all(path.parent().expect("fixture file has parent")).unwrap();
+    std::fs::write(path, source).unwrap();
+}
+
+fn create_zod_types_project() -> RealSourceInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{"name":"bench-zod-types","private":true,"type":"module","main":"src/types.ts","dependencies":{}}"#,
+    );
+    write_file(&root, "src/types.ts", ZOD_TYPES_SOURCE);
+    write_file(
+        &root,
+        "src/errors.ts",
+        r"
+export const defaultErrorMap = {};
+export const getErrorMap = () => defaultErrorMap;
+export type IssueData = { code?: string };
+export type StringValidation = unknown;
+export type ZodCustomIssue = { code: string };
+export class ZodError extends Error {}
+export type ZodErrorMap = unknown;
+export type ZodIssue = unknown;
+export const ZodIssueCode = {};
+",
+    );
+    write_file(
+        &root,
+        "src/helpers/enumUtil.ts",
+        "export const enumUtil = {};\n",
+    );
+    write_file(
+        &root,
+        "src/helpers/errorUtil.ts",
+        "export const errorUtil = {};\n",
+    );
+    write_file(
+        &root,
+        "src/helpers/parseUtil.ts",
+        r#"
+export const DIRTY = "dirty";
+export const INVALID = "invalid";
+export const OK = "ok";
+export const addIssueToContext = () => {};
+export const isAborted = () => false;
+export const isAsync = () => false;
+export const isDirty = () => false;
+export const isValid = () => true;
+export const makeIssue = () => ({});
+export type AsyncParseReturnType<T = unknown> = Promise<T>;
+export type ParseContext = { common?: unknown };
+export type ParseInput = { data: unknown };
+export type ParseParams = unknown;
+export type ParsePath = Array<string | number>;
+export type ParseReturnType<T = unknown> = T;
+export class ParseStatus {}
+export type SyncParseReturnType<T = unknown> = T;
+"#,
+    );
+    write_file(
+        &root,
+        "src/helpers/partialUtil.ts",
+        "export const partialUtil = {};\n",
+    );
+    write_file(
+        &root,
+        "src/helpers/typeAliases.ts",
+        "export type Primitive = string | number | boolean | null | undefined;\n",
+    );
+    write_file(
+        &root,
+        "src/helpers/util.ts",
+        r#"
+export const getParsedType = () => "unknown";
+export const objectUtil = {};
+export const util = {};
+export type ZodParsedType = string;
+"#,
+    );
+    write_file(
+        &root,
+        "src/standard-schema.ts",
+        "export type StandardSchemaV1 = unknown;\n",
+    );
+
+    let file_path = root.join("src/types.ts");
+    let file = DiscoveredFile {
+        id: FileId(0),
+        size_bytes: std::fs::metadata(&file_path).unwrap().len(),
+        path: file_path,
+    };
+
+    RealSourceInput {
+        _temp_dir: temp_dir,
+        root,
+        file,
+    }
+}
+
+fn zod_types_parse(c: &mut Criterion) {
+    c.bench_function("zod_types_parse", |bencher| {
+        bencher.iter_batched_ref(
+            create_zod_types_project,
+            |input| parse_single_file(&input.file),
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+fn zod_types_dead_code(c: &mut Criterion) {
+    c.bench_function("zod_types_dead_code", |bencher| {
+        bencher.iter_batched_ref(
+            create_zod_types_project,
+            |input| {
+                let options = DeadCodeOptions {
+                    analysis: AnalysisOptions {
+                        root: Some(input.root.clone()),
+                        no_cache: true,
+                        threads: Some(BENCH_THREADS),
+                        ..AnalysisOptions::default()
+                    },
+                    include_entry_exports: true,
+                    ..DeadCodeOptions::default()
+                };
+                detect_dead_code(&options)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(benches, zod_types_parse, zod_types_dead_code);
+criterion_main!(benches);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -87,5 +87,9 @@ name = "large_analysis"
 harness = false
 
 [[bench]]
+name = "scaling_analysis"
+harness = false
+
+[[bench]]
 name = "allocations"
 harness = false

--- a/crates/core/benches/allocations.rs
+++ b/crates/core/benches/allocations.rs
@@ -26,7 +26,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 mod helpers;
 
 fn main() {
-    let (temp_dir, config) = helpers::create_synthetic_project("alloc-bench", 100);
+    let (_temp_dir, config) = helpers::create_synthetic_project("alloc-bench", 100);
 
     let profiler = dhat::Profiler::builder().testing().build();
 
@@ -34,8 +34,6 @@ fn main() {
 
     let stats = dhat::HeapStats::get();
     drop(profiler);
-
-    let _ = std::fs::remove_dir_all(&temp_dir);
 
     #[expect(
         clippy::print_stdout,

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -12,37 +12,27 @@ use std::path::PathBuf;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rustc_hash::FxHashSet;
+use tempfile::TempDir;
 
 mod helpers;
 
 struct ParseFileInput {
-    temp_dir: PathBuf,
+    _temp_dir: TempDir,
     file: fallow_core::discover::DiscoveredFile,
 }
 
-impl Drop for ParseFileInput {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.temp_dir);
-    }
-}
-
 struct ConfigInput {
-    temp_dir: PathBuf,
+    _temp_dir: TempDir,
     config: fallow_config::ResolvedConfig,
 }
 
-impl Drop for ConfigInput {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.temp_dir);
-    }
-}
-
 fn create_parse_file_input() -> ParseFileInput {
-    let temp_dir = std::env::temp_dir().join("fallow-bench");
-    let _ = std::fs::remove_dir_all(&temp_dir);
-    std::fs::create_dir_all(&temp_dir).unwrap();
+    let temp_dir = tempfile::Builder::new()
+        .prefix("fallow-bench-parse-")
+        .tempdir()
+        .unwrap();
 
-    let test_file = temp_dir.join("bench.ts");
+    let test_file = temp_dir.path().join("bench.ts");
     std::fs::write(
         &test_file,
         r"
@@ -126,7 +116,10 @@ export default function App({ name, age }: Props) {
         size_bytes: std::fs::metadata(&test_file).unwrap().len(),
     };
 
-    ParseFileInput { temp_dir, file }
+    ParseFileInput {
+        _temp_dir: temp_dir,
+        file,
+    }
 }
 
 fn parse_single_file(c: &mut Criterion) {
@@ -140,12 +133,15 @@ fn parse_single_file(c: &mut Criterion) {
 }
 
 fn create_full_pipeline_input() -> ConfigInput {
-    let temp_dir = std::env::temp_dir().join("fallow-bench-project");
-    let _ = std::fs::remove_dir_all(&temp_dir);
-    std::fs::create_dir_all(temp_dir.join("src")).unwrap();
+    let temp_dir = tempfile::Builder::new()
+        .prefix("fallow-bench-project-")
+        .tempdir()
+        .unwrap();
+    let root = temp_dir.path().to_path_buf();
+    std::fs::create_dir_all(root.join("src")).unwrap();
 
     std::fs::write(
-        temp_dir.join("package.json"),
+        root.join("package.json"),
         r#"{"name": "bench-project", "main": "src/index.ts", "dependencies": {"react": "^18"}}"#,
     )
     .unwrap();
@@ -158,7 +154,7 @@ export function fn{i}() {{ return {i}; }}
 export type Type{i} = {{ value: number }};
 "
         );
-        std::fs::write(temp_dir.join(format!("src/module{i}.ts")), content).unwrap();
+        std::fs::write(root.join(format!("src/module{i}.ts")), content).unwrap();
     }
 
     let imports: Vec<String> = (0..5)
@@ -166,14 +162,17 @@ export type Type{i} = {{ value: number }};
         .collect();
     let uses: Vec<String> = (0..5).map(|i| format!("console.log(value{i});")).collect();
     std::fs::write(
-        temp_dir.join("src/index.ts"),
+        root.join("src/index.ts"),
         format!("{}\n{}\n", imports.join("\n"), uses.join("\n")),
     )
     .unwrap();
 
-    let config = helpers::create_test_config(temp_dir.clone());
+    let config = helpers::create_test_config(root);
 
-    ConfigInput { temp_dir, config }
+    ConfigInput {
+        _temp_dir: temp_dir,
+        config,
+    }
 }
 
 fn full_pipeline_10_files(c: &mut Criterion) {
@@ -188,7 +187,10 @@ fn full_pipeline_10_files(c: &mut Criterion) {
 
 fn create_synthetic_config_input(name: &str, file_count: usize) -> ConfigInput {
     let (temp_dir, config) = helpers::create_synthetic_project(name, file_count);
-    ConfigInput { temp_dir, config }
+    ConfigInput {
+        _temp_dir: temp_dir,
+        config,
+    }
 }
 
 fn full_pipeline_100_files(c: &mut Criterion) {

--- a/crates/core/benches/helpers.rs
+++ b/crates/core/benches/helpers.rs
@@ -8,6 +8,7 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use fallow_config::{BoundaryConfig, FallowConfig, OutputFormat};
+use tempfile::TempDir;
 
 #[must_use]
 pub fn create_test_config(root: PathBuf) -> fallow_config::ResolvedConfig {
@@ -66,7 +67,7 @@ pub fn make_config(root: PathBuf, no_cache: bool) -> fallow_config::ResolvedConf
 pub fn create_synthetic_project(
     name: &str,
     file_count: usize,
-) -> (PathBuf, fallow_config::ResolvedConfig) {
+) -> (TempDir, fallow_config::ResolvedConfig) {
     create_synthetic_project_with_cache(name, file_count, true)
 }
 
@@ -78,13 +79,16 @@ pub fn create_synthetic_project_with_cache(
     name: &str,
     file_count: usize,
     no_cache: bool,
-) -> (PathBuf, fallow_config::ResolvedConfig) {
-    let temp_dir = std::env::temp_dir().join(format!("fallow-bench-{name}"));
-    let _ = std::fs::remove_dir_all(&temp_dir);
-    std::fs::create_dir_all(temp_dir.join("src")).unwrap();
+) -> (TempDir, fallow_config::ResolvedConfig) {
+    let temp_dir = tempfile::Builder::new()
+        .prefix(&format!("fallow-bench-{name}-"))
+        .tempdir()
+        .unwrap();
+    let root = temp_dir.path().to_path_buf();
+    std::fs::create_dir_all(root.join("src")).unwrap();
 
     std::fs::write(
-        temp_dir.join("package.json"),
+        root.join("package.json"),
         r#"{"name": "bench-project", "main": "src/index.ts", "dependencies": {"react": "^18"}}"#,
     )
     .unwrap();
@@ -98,7 +102,7 @@ export type Type{i} = {{ value: number }};
 export const helper{i} = () => value{i} + 1;
 "
         );
-        std::fs::write(temp_dir.join(format!("src/module{i}.ts")), content).unwrap();
+        std::fs::write(root.join(format!("src/module{i}.ts")), content).unwrap();
     }
 
     let used_count = file_count / 2;
@@ -109,12 +113,12 @@ export const helper{i} = () => value{i} + 1;
         .map(|i| format!("console.log(value{i});"))
         .collect();
     std::fs::write(
-        temp_dir.join("src/index.ts"),
+        root.join("src/index.ts"),
         format!("{}\n{}\n", imports.join("\n"), uses.join("\n")),
     )
     .unwrap();
 
-    let config = make_config(temp_dir.clone(), no_cache);
+    let config = make_config(root, no_cache);
     (temp_dir, config)
 }
 
@@ -128,13 +132,16 @@ export const helper{i} = () => value{i} + 1;
 pub fn create_dupe_project(
     name: &str,
     file_count: usize,
-) -> (PathBuf, fallow_config::ResolvedConfig) {
-    let temp_dir = std::env::temp_dir().join(format!("fallow-bench-dupes-{name}"));
-    let _ = std::fs::remove_dir_all(&temp_dir);
-    std::fs::create_dir_all(temp_dir.join("src")).unwrap();
+) -> (TempDir, fallow_config::ResolvedConfig) {
+    let temp_dir = tempfile::Builder::new()
+        .prefix(&format!("fallow-bench-dupes-{name}-"))
+        .tempdir()
+        .unwrap();
+    let root = temp_dir.path().to_path_buf();
+    std::fs::create_dir_all(root.join("src")).unwrap();
 
     std::fs::write(
-        temp_dir.join("package.json"),
+        root.join("package.json"),
         r#"{"name": "bench-dupes", "main": "src/index.ts"}"#,
     )
     .unwrap();
@@ -189,11 +196,11 @@ pub fn create_dupe_project(
             content.push('\n');
         }
         writeln!(&mut content, "export const helper_{i} = {i};").unwrap();
-        std::fs::write(temp_dir.join(format!("src/module{i}.ts")), content).unwrap();
+        std::fs::write(root.join(format!("src/module{i}.ts")), content).unwrap();
     }
 
-    std::fs::write(temp_dir.join("src/index.ts"), "export const main = true;\n").unwrap();
+    std::fs::write(root.join("src/index.ts"), "export const main = true;\n").unwrap();
 
-    let config = create_test_config(temp_dir.clone());
+    let config = create_test_config(root);
     (temp_dir, config)
 }

--- a/crates/core/benches/large_analysis.rs
+++ b/crates/core/benches/large_analysis.rs
@@ -9,37 +9,29 @@
 )]
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
 
 mod helpers;
 
 struct ConfigInput {
-    temp_dir: std::path::PathBuf,
+    _temp_dir: TempDir,
     config: fallow_config::ResolvedConfig,
 }
 
-impl Drop for ConfigInput {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.temp_dir);
-    }
-}
-
 struct DupesInput {
-    temp_dir: std::path::PathBuf,
+    _temp_dir: TempDir,
     root: std::path::PathBuf,
     files: Vec<fallow_core::discover::DiscoveredFile>,
     config: fallow_config::DuplicatesConfig,
 }
 
-impl Drop for DupesInput {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.temp_dir);
-    }
-}
-
 fn create_config_input(name: &str, file_count: usize, no_cache: bool) -> ConfigInput {
     let (temp_dir, config) =
         helpers::create_synthetic_project_with_cache(name, file_count, no_cache);
-    ConfigInput { temp_dir, config }
+    ConfigInput {
+        _temp_dir: temp_dir,
+        config,
+    }
 }
 
 fn create_warm_config_input(name: &str, file_count: usize) -> ConfigInput {
@@ -52,7 +44,7 @@ fn create_dupes_input(name: &str, file_count: usize) -> DupesInput {
     let (temp_dir, resolved_config) = helpers::create_dupe_project(name, file_count);
     let files = fallow_core::discover::discover_files(&resolved_config);
     DupesInput {
-        temp_dir,
+        _temp_dir: temp_dir,
         root: resolved_config.root,
         files,
         config: fallow_config::DuplicatesConfig::default(),

--- a/crates/core/benches/scaling_analysis.rs
+++ b/crates/core/benches/scaling_analysis.rs
@@ -1,0 +1,72 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "benches use unwrap and expect to keep fixture setup concise"
+)]
+#![expect(
+    deprecated,
+    reason = "ADR-008: benchmark exercises the workspace path-dep fallow_core::analyze surface"
+)]
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+mod helpers;
+
+struct ConfigInput {
+    _temp_dir: TempDir,
+    config: fallow_config::ResolvedConfig,
+}
+
+struct DupesInput {
+    _temp_dir: TempDir,
+    root: std::path::PathBuf,
+    files: Vec<fallow_core::discover::DiscoveredFile>,
+    config: fallow_config::DuplicatesConfig,
+}
+
+fn create_config_input(name: &str, file_count: usize) -> ConfigInput {
+    let (temp_dir, config) = helpers::create_synthetic_project(name, file_count);
+    ConfigInput {
+        _temp_dir: temp_dir,
+        config,
+    }
+}
+
+fn create_dupes_input(name: &str, file_count: usize) -> DupesInput {
+    let (temp_dir, resolved_config) = helpers::create_dupe_project(name, file_count);
+    let files = fallow_core::discover::discover_files(&resolved_config);
+    DupesInput {
+        _temp_dir: temp_dir,
+        root: resolved_config.root,
+        files,
+        config: fallow_config::DuplicatesConfig::default(),
+    }
+}
+
+fn bench_scaling_analysis(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scaling_analysis");
+
+    group.bench_function("full_pipeline_2000_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_config_input("2000", 2000),
+            |input| fallow_core::analyze(&input.config),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("dupes_full_pipeline_1000_files", |bencher| {
+        bencher.iter_batched_ref(
+            || create_dupes_input("1000", 1000),
+            |input| {
+                fallow_core::duplicates::find_duplicates(&input.root, &input.files, &input.config);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_scaling_analysis);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Make core benchmark fixtures use owned temporary directories instead of fixed paths under the system temp dir.
- Add a pinned real-source CodSpeed shard using the vendored Zod fixture.
- Add a bounded scaling shard to PR CodSpeed coverage while leaving the slow full suite on main/manual.

## Verification
- [x] `cargo check --workspace`
- [x] `cargo check --benches -p fallow-core -p fallow-benchmarks --features codspeed`
- [x] `cargo test --workspace --lib --bins --tests`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `typos .github/workflows/bench.yml crates/core/benches crates/benchmarks`
- [x] `fallow audit --format json --quiet`
- [x] `cargo codspeed build -p fallow-core --bench analysis --features codspeed`
- [x] `cargo codspeed run -p fallow-core --bench analysis`
- [x] `cargo codspeed build -p fallow-core --bench scaling_analysis --features codspeed`
- [x] `cargo codspeed run -p fallow-core --bench scaling_analysis`
- [x] `cargo codspeed build -p fallow-benchmarks --bench real_sources --features codspeed`
- [x] `cargo codspeed run -p fallow-benchmarks --bench real_sources`

Note: `cargo test --workspace --all-targets` was stopped after it entered the long Criterion benchmark run for `large_analysis`. Bench targets were instead covered by `cargo check --benches`, strict clippy with `--all-targets`, and targeted CodSpeed build/run checks.
