### PR TITLE
fix: track CodSpeed benchmark fixture

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,10 +45,10 @@ jobs:
             cache_key: programmatic-commands
             package: fallow-benchmarks
             bench: programmatic_commands
-          - label: real sources
-            cache_key: real-sources
+          - label: representative sources
+            cache_key: representative-sources
             package: fallow-benchmarks
-            bench: real_sources
+            bench: representative_sources
           - label: scaling analysis
             cache_key: scaling-analysis
             package: fallow-core

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ name = "programmatic_commands"
 harness = false
 
 [[bench]]
-name = "real_sources"
+name = "representative_sources"
 harness = false
 
 [dev-dependencies]

--- a/crates/benchmarks/benches/representative_sources.rs
+++ b/crates/benchmarks/benches/representative_sources.rs
@@ -15,8 +15,7 @@ use fallow_core::{
 use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
-const ZOD_TYPES_SOURCE: &str =
-    include_str!("../../../benchmarks/fixtures/real-world/zod/src/types.ts");
+const REPRESENTATIVE_TYPES_SOURCE: &str = include_str!("../fixtures/representative-types.ts");
 
 struct RealSourceInput {
     _temp_dir: TempDir,
@@ -30,16 +29,16 @@ fn write_file(root: &Path, path: &str, source: &str) {
     std::fs::write(path, source).unwrap();
 }
 
-fn create_zod_types_project() -> RealSourceInput {
+fn create_representative_types_project() -> RealSourceInput {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
 
     write_file(
         &root,
         "package.json",
-        r#"{"name":"bench-zod-types","private":true,"type":"module","main":"src/types.ts","dependencies":{}}"#,
+        r#"{"name":"bench-representative-types","private":true,"type":"module","main":"src/types.ts","dependencies":{}}"#,
     );
-    write_file(&root, "src/types.ts", ZOD_TYPES_SOURCE);
+    write_file(&root, "src/types.ts", REPRESENTATIVE_TYPES_SOURCE);
     write_file(
         &root,
         "src/errors.ts",
@@ -128,20 +127,20 @@ export type ZodParsedType = string;
     }
 }
 
-fn zod_types_parse(c: &mut Criterion) {
-    c.bench_function("zod_types_parse", |bencher| {
+fn representative_types_parse(c: &mut Criterion) {
+    c.bench_function("representative_types_parse", |bencher| {
         bencher.iter_batched_ref(
-            create_zod_types_project,
+            create_representative_types_project,
             |input| parse_single_file(&input.file),
             BatchSize::LargeInput,
         );
     });
 }
 
-fn zod_types_dead_code(c: &mut Criterion) {
-    c.bench_function("zod_types_dead_code", |bencher| {
+fn representative_types_dead_code(c: &mut Criterion) {
+    c.bench_function("representative_types_dead_code", |bencher| {
         bencher.iter_batched_ref(
-            create_zod_types_project,
+            create_representative_types_project,
             |input| {
                 let options = DeadCodeOptions {
                     analysis: AnalysisOptions {
@@ -160,5 +159,9 @@ fn zod_types_dead_code(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, zod_types_parse, zod_types_dead_code);
+criterion_group!(
+    benches,
+    representative_types_parse,
+    representative_types_dead_code
+);
 criterion_main!(benches);

--- a/crates/benchmarks/fixtures/representative-types.ts
+++ b/crates/benchmarks/fixtures/representative-types.ts
@@ -1,0 +1,260 @@
+import { defaultErrorMap, getErrorMap } from "./errors";
+import { enumUtil } from "./helpers/enumUtil";
+import { errorUtil } from "./helpers/errorUtil";
+import {
+  addIssueToContext,
+  AsyncParseReturnType,
+  DIRTY,
+  INVALID,
+  isAborted,
+  isAsync,
+  isDirty,
+  isValid,
+  makeIssue,
+  OK,
+  ParseContext,
+  ParseInput,
+  ParseParams,
+  ParsePath,
+  ParseReturnType,
+  ParseStatus,
+  SyncParseReturnType,
+} from "./helpers/parseUtil";
+import { partialUtil } from "./helpers/partialUtil";
+import { Primitive } from "./helpers/typeAliases";
+import { getParsedType, objectUtil, util, ZodParsedType } from "./helpers/util";
+import type { StandardSchemaV1 } from "./standard-schema";
+
+export type IssueData = {
+  code?: string;
+  message?: string;
+  path?: ParsePath;
+};
+
+export type ParseResult<T> =
+  | { status: typeof OK; value: T }
+  | { status: typeof DIRTY; value: T; issues: IssueData[] }
+  | { status: typeof INVALID; issues: IssueData[] };
+
+export type TypeDef<TInput = unknown, TOutput = TInput> = {
+  readonly input: TInput;
+  readonly output: TOutput;
+  readonly async: boolean;
+  readonly description?: string;
+};
+
+export type SchemaShape = Record<string, BaseType<unknown, unknown>>;
+
+export type InferInput<T extends BaseType<unknown, unknown>> =
+  T extends BaseType<infer Input, unknown> ? Input : never;
+
+export type InferOutput<T extends BaseType<unknown, unknown>> =
+  T extends BaseType<unknown, infer Output> ? Output : never;
+
+export type ObjectInput<TShape extends SchemaShape> = {
+  [Key in keyof TShape]: InferInput<TShape[Key]>;
+};
+
+export type ObjectOutput<TShape extends SchemaShape> = {
+  [Key in keyof TShape]: InferOutput<TShape[Key]>;
+};
+
+export type UnionInput<TItems extends readonly BaseType<unknown, unknown>[]> =
+  TItems[number] extends BaseType<infer Input, unknown> ? Input : never;
+
+export type UnionOutput<TItems extends readonly BaseType<unknown, unknown>[]> =
+  TItems[number] extends BaseType<unknown, infer Output> ? Output : never;
+
+export interface TypeChecks<TInput, TOutput> {
+  parse(input: TInput, params?: ParseParams): TOutput;
+  safeParse(input: TInput, params?: ParseParams): ParseResult<TOutput>;
+  parseAsync(input: TInput, params?: ParseParams): AsyncParseReturnType<TOutput>;
+  transform<Next>(fn: (value: TOutput) => Next): BaseType<TInput, Next>;
+}
+
+export abstract class BaseType<TInput = unknown, TOutput = TInput>
+  implements TypeChecks<TInput, TOutput>
+{
+  readonly _def: TypeDef<TInput, TOutput>;
+  readonly standard: StandardSchemaV1;
+
+  protected constructor(def: TypeDef<TInput, TOutput>) {
+    this._def = def;
+    this.standard = {};
+  }
+
+  parse(input: TInput, params?: ParseParams): TOutput {
+    const result = this.safeParse(input, params);
+    if (result.status === OK) {
+      return result.value;
+    }
+    throw new Error("Invalid input");
+  }
+
+  safeParse(input: TInput, params?: ParseParams): ParseResult<TOutput> {
+    const context: ParseContext = { common: { params, errorMap: defaultErrorMap } };
+    const parsed = this._parse({ data: input }, context);
+    if (isValid(parsed)) {
+      return { status: OK, value: parsed as TOutput };
+    }
+    const issue = makeIssue();
+    addIssueToContext(context, issue);
+    return { status: INVALID, issues: [issue as IssueData] };
+  }
+
+  async parseAsync(input: TInput, params?: ParseParams): Promise<TOutput> {
+    const result = this.safeParse(input, params);
+    if (isAsync(result)) {
+      return result;
+    }
+    return this.parse(input, params);
+  }
+
+  transform<Next>(fn: (value: TOutput) => Next): BaseType<TInput, Next> {
+    return new EffectType(this, fn);
+  }
+
+  describe(description: string): this {
+    objectUtil;
+    util;
+    errorUtil;
+    enumUtil;
+    partialUtil;
+    getErrorMap();
+    getParsedType();
+    return new (this.constructor as new (def: TypeDef<TInput, TOutput>) => this)({
+      ...this._def,
+      description,
+    });
+  }
+
+  protected abstract _parse(
+    input: ParseInput,
+    context: ParseContext,
+  ): ParseReturnType<TOutput> | SyncParseReturnType<TOutput>;
+}
+
+export class StringType extends BaseType<Primitive, string> {
+  constructor() {
+    super({ input: "", output: "", async: false });
+  }
+
+  min(length: number): this {
+    return this.describe(`min:${length}`);
+  }
+
+  max(length: number): this {
+    return this.describe(`max:${length}`);
+  }
+
+  email(): this {
+    return this.describe("email");
+  }
+
+  protected _parse(input: ParseInput): string {
+    return String(input.data);
+  }
+}
+
+export class NumberType extends BaseType<Primitive, number> {
+  constructor() {
+    super({ input: 0, output: 0, async: false });
+  }
+
+  int(): this {
+    return this.describe("int");
+  }
+
+  positive(): this {
+    return this.describe("positive");
+  }
+
+  protected _parse(input: ParseInput): number {
+    return Number(input.data);
+  }
+}
+
+export class ObjectType<TShape extends SchemaShape> extends BaseType<
+  ObjectInput<TShape>,
+  ObjectOutput<TShape>
+> {
+  constructor(readonly shape: TShape) {
+    super({ input: {} as ObjectInput<TShape>, output: {} as ObjectOutput<TShape>, async: false });
+  }
+
+  extend<TNext extends SchemaShape>(next: TNext): ObjectType<TShape & TNext> {
+    return new ObjectType({ ...this.shape, ...next });
+  }
+
+  pick<TKey extends keyof TShape>(keys: readonly TKey[]): ObjectType<Pick<TShape, TKey>> {
+    const picked = {} as Pick<TShape, TKey>;
+    for (const key of keys) {
+      picked[key] = this.shape[key];
+    }
+    return new ObjectType(picked);
+  }
+
+  protected _parse(input: ParseInput): ObjectOutput<TShape> {
+    if (isAborted(input) || isDirty(input)) {
+      throw new Error("Parse status cannot be reused");
+    }
+    return input.data as ObjectOutput<TShape>;
+  }
+}
+
+export class UnionType<TItems extends readonly BaseType<unknown, unknown>[]> extends BaseType<
+  UnionInput<TItems>,
+  UnionOutput<TItems>
+> {
+  constructor(readonly items: TItems) {
+    super({ input: undefined as UnionInput<TItems>, output: undefined as UnionOutput<TItems>, async: false });
+  }
+
+  protected _parse(input: ParseInput): UnionOutput<TItems> {
+    for (const item of this.items) {
+      const result = item.safeParse(input.data);
+      if (result.status === OK) {
+        return result.value as UnionOutput<TItems>;
+      }
+    }
+    throw new Error("No union branch matched");
+  }
+}
+
+export class EffectType<TInput, TMiddle, TOutput> extends BaseType<TInput, TOutput> {
+  constructor(
+    readonly inner: BaseType<TInput, TMiddle>,
+    readonly effect: (value: TMiddle) => TOutput,
+  ) {
+    super({ input: undefined as TInput, output: undefined as TOutput, async: false });
+  }
+
+  protected _parse(input: ParseInput, context: ParseContext): TOutput {
+    const value = this.inner.parse(input.data as TInput);
+    if (context.common) {
+      new ParseStatus();
+    }
+    return this.effect(value);
+  }
+}
+
+export const string = (): StringType => new StringType();
+export const number = (): NumberType => new NumberType();
+export const object = <TShape extends SchemaShape>(shape: TShape): ObjectType<TShape> =>
+  new ObjectType(shape);
+export const union = <TItems extends readonly BaseType<unknown, unknown>[]>(
+  items: TItems,
+): UnionType<TItems> => new UnionType(items);
+
+export const userSchema = object({
+  id: string().min(1),
+  email: string().email(),
+  age: number().int().positive(),
+}).extend({
+  role: union([string(), number()]),
+});
+
+export type UserInput = InferInput<typeof userSchema>;
+export type UserOutput = InferOutput<typeof userSchema>;
+
+export const parseUser = (input: UserInput): UserOutput => userSchema.parse(input);


### PR DESCRIPTION
## Summary
- Replace the machine-local benchmark corpus path with a tracked crate-local TypeScript fixture.
- Rename the shard to representative sources so clean CI checkouts build the target.

## Verification
- [x] cargo check --benches -p fallow-benchmarks --features codspeed
- [x] cargo clippy -p fallow-benchmarks --bench representative_sources --features codspeed -- -D warnings
- [x] cargo codspeed build -p fallow-benchmarks --bench representative_sources --features codspeed
- [x] cargo codspeed run -p fallow-benchmarks --bench representative_sources
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] npm run fmt:js:check