### PR TITLE
fix(review): harden final follow-up edges

### DIFF
--- a/crates/cli/src/audit_keys.rs
+++ b/crates/cli/src/audit_keys.rs
@@ -329,8 +329,13 @@ fn policy_violation_key(
 }
 
 fn stale_suppression_key(item: &fallow_core::results::StaleSuppression, root: &Path) -> String {
+    let rule_id = if item.missing_reason {
+        "missing-suppression-reason"
+    } else {
+        "stale-suppression"
+    };
     format!(
-        "stale-suppression:{}:{}",
+        "{rule_id}:{}:{}",
         relative_key_path(&item.path, root),
         item.description()
     )
@@ -1810,16 +1815,10 @@ fn annotate_policy_json(
     annotate_issue_array(
         json,
         "stale_suppressions",
-        results.stale_suppressions.iter().map(|item| {
-            issue_was_introduced(
-                &format!(
-                    "stale-suppression:{}:{}",
-                    relative_key_path(&item.path, root),
-                    item.description()
-                ),
-                base,
-            )
-        }),
+        results
+            .stale_suppressions
+            .iter()
+            .map(|item| issue_was_introduced(&stale_suppression_key(item, root), base)),
     );
 }
 
@@ -2318,6 +2317,20 @@ mod tests {
                 kind_known: true,
             },
             missing_reason: false,
+            actions: StaleSuppression::actions_for(false),
+        });
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/app.ts"),
+            line: 2,
+            col: 0,
+            origin: SuppressionOrigin::Comment {
+                issue_kind: Some("unused-export".to_string()),
+                reason: None,
+                is_file_level: false,
+                kind_known: true,
+            },
+            missing_reason: true,
+            actions: StaleSuppression::actions_for(true),
         });
         results.unresolved_catalog_references.push(
             UnresolvedCatalogReferenceFinding::with_actions(UnresolvedCatalogReference {
@@ -2383,6 +2396,9 @@ mod tests {
         assert!(
             keys.contains("stale-suppression:src/app.ts:// fallow-ignore-next-line unused-export")
         );
+        assert!(keys.contains(
+            "missing-suppression-reason:src/app.ts:// fallow-ignore-next-line unused-export"
+        ));
         assert!(
             keys.contains("unresolved-catalog-reference:packages/app/package.json:9:default:react")
         );

--- a/crates/cli/src/baseline.rs
+++ b/crates/cli/src/baseline.rs
@@ -481,9 +481,25 @@ fn baseline_member_import_keys(
         stale_suppressions: results
             .stale_suppressions
             .iter()
-            .map(|s| format!("{}:{}", relative_path(&s.path, root), s.line))
+            .map(|s| stale_suppression_baseline_key(s, root))
             .collect(),
     }
+}
+
+fn stale_suppression_baseline_key(
+    suppression: &fallow_core::results::StaleSuppression,
+    root: &Path,
+) -> String {
+    let rule_id = if suppression.missing_reason {
+        "missing-suppression-reason"
+    } else {
+        "stale-suppression"
+    };
+    format!(
+        "{rule_id}:{}:{}",
+        relative_path(&suppression.path, root),
+        suppression.line
+    )
 }
 
 fn enum_member_baseline_keys(
@@ -1359,12 +1375,13 @@ impl BaselineFilterContext<'_> {
             .map(String::as_str)
             .collect();
         results.stale_suppressions.retain(|suppression| {
-            let key = format!(
+            let key = stale_suppression_baseline_key(suppression, self.root);
+            let legacy_key = format!(
                 "{}:{}",
                 relative_path(&suppression.path, self.root),
                 suppression.line
             );
-            !baseline_stale.contains(key.as_str())
+            !baseline_stale.contains(key.as_str()) && !baseline_stale.contains(legacy_key.as_str())
         });
     }
 
@@ -3447,6 +3464,47 @@ mod tests {
         assert!(filtered.unused_store_members.is_empty(), "store members");
         assert!(filtered.unresolved_imports.is_empty(), "unresolved imports");
         assert!(filtered.duplicate_exports.is_empty(), "duplicate exports");
+    }
+
+    #[test]
+    fn stale_suppression_baseline_keys_include_missing_reason_state() {
+        let root = Path::new("/project");
+        let stale = fallow_core::results::StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin: fallow_core::results::SuppressionOrigin::Comment {
+                issue_kind: Some("unused-export".to_string()),
+                reason: None,
+                is_file_level: false,
+                kind_known: true,
+            },
+            missing_reason: false,
+            actions: fallow_core::results::StaleSuppression::actions_for(false),
+        };
+        let missing = fallow_core::results::StaleSuppression {
+            missing_reason: true,
+            actions: fallow_core::results::StaleSuppression::actions_for(true),
+            ..stale.clone()
+        };
+        let results = AnalysisResults {
+            stale_suppressions: vec![stale, missing],
+            ..Default::default()
+        };
+        let baseline = BaselineData::from_results(&results, root);
+
+        assert_eq!(
+            baseline.stale_suppressions,
+            vec![
+                "stale-suppression:src/file.ts:1",
+                "missing-suppression-reason:src/file.ts:1",
+            ]
+        );
+
+        let mut legacy_baseline = BaselineData::from_results(&AnalysisResults::default(), root);
+        legacy_baseline.stale_suppressions = vec!["src/file.ts:1".to_string()];
+        let filtered = filter_new_issues(results, &legacy_baseline, root);
+        assert!(filtered.stale_suppressions.is_empty());
     }
 
     fn runtime_finding(

--- a/crates/cli/src/report/codeclimate.rs
+++ b/crates/cli/src/report/codeclimate.rs
@@ -1371,18 +1371,28 @@ fn push_stale_suppression_issues(
     issues: &mut Vec<CodeClimateIssue>,
     suppressions: &[fallow_core::results::StaleSuppression],
     root: &Path,
-    severity: Severity,
+    rules: &RulesConfig,
 ) {
     if suppressions.is_empty() {
         return;
     }
-    let level = severity_to_codeclimate(severity);
     for s in suppressions {
+        let severity = if s.missing_reason {
+            rules.require_suppression_reason
+        } else {
+            rules.stale_suppressions
+        };
+        let level = severity_to_codeclimate(severity);
         let path = cc_path(&s.path, root);
         let line_str = s.line.to_string();
-        let fp = fingerprint_hash(&["fallow/stale-suppression", &path, &line_str]);
+        let check_name = if s.missing_reason {
+            "fallow/missing-suppression-reason"
+        } else {
+            "fallow/stale-suppression"
+        };
+        let fp = fingerprint_hash(&[check_name, &path, &line_str]);
         issues.push(cc_issue(
-            "fallow/stale-suppression",
+            check_name,
             &s.display_message(),
             level,
             "Bug Risk",
@@ -1936,7 +1946,7 @@ impl CodeClimateBuilder<'_> {
             &mut self.issues,
             &self.results.stale_suppressions,
             self.root,
-            self.rules.stale_suppressions,
+            self.rules,
         );
         push_unused_catalog_entry_issues(
             &mut self.issues,
@@ -2259,6 +2269,70 @@ mod tests {
         assert!(output.is_array());
         let arr = output.as_array().unwrap();
         assert!(!arr.is_empty());
+    }
+
+    #[test]
+    fn codeclimate_missing_suppression_reason_uses_reason_rule_severity() {
+        let root = PathBuf::from("/project");
+        let mut results = AnalysisResults::default();
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin: SuppressionOrigin::Comment {
+                issue_kind: Some("unused-exports".to_string()),
+                reason: None,
+                is_file_level: false,
+                kind_known: true,
+            },
+            missing_reason: true,
+            actions: StaleSuppression::actions_for(true),
+        });
+        let mut rules = RulesConfig::default();
+        rules.stale_suppressions = Severity::Off;
+        rules.require_suppression_reason = Severity::Error;
+
+        let output = issues_to_value(&build_codeclimate(&results, &root, &rules));
+
+        assert_eq!(output[0]["check_name"], "fallow/missing-suppression-reason");
+        assert_eq!(output[0]["severity"], "major");
+    }
+
+    #[test]
+    fn codeclimate_stale_and_missing_suppression_have_distinct_identities() {
+        let root = PathBuf::from("/project");
+        let mut results = AnalysisResults::default();
+        let origin = SuppressionOrigin::Comment {
+            issue_kind: Some("unused-exports".to_string()),
+            reason: None,
+            is_file_level: false,
+            kind_known: true,
+        };
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin: origin.clone(),
+            missing_reason: false,
+            actions: StaleSuppression::actions_for(false),
+        });
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin,
+            missing_reason: true,
+            actions: StaleSuppression::actions_for(true),
+        });
+        let mut rules = RulesConfig::default();
+        rules.stale_suppressions = Severity::Warn;
+        rules.require_suppression_reason = Severity::Error;
+
+        let output = issues_to_value(&build_codeclimate(&results, &root, &rules));
+
+        assert_eq!(output[0]["check_name"], "fallow/stale-suppression");
+        assert_eq!(output[1]["check_name"], "fallow/missing-suppression-reason");
+        assert_ne!(output[0]["fingerprint"], output[1]["fingerprint"]);
     }
 
     #[test]

--- a/crates/cli/src/report/sarif.rs
+++ b/crates/cli/src/report/sarif.rs
@@ -843,13 +843,25 @@ fn sarif_stale_suppression_fields(
     level: &'static str,
 ) -> SarifFields {
     SarifFields {
-        rule_id: "fallow/stale-suppression",
+        rule_id: if suppression.missing_reason {
+            "fallow/missing-suppression-reason"
+        } else {
+            "fallow/stale-suppression"
+        },
         level,
         message: suppression.display_message(),
         uri: relative_uri(&suppression.path, root),
         region: Some((suppression.line, suppression.col + 1)),
         source_path: Some(suppression.path.clone()),
         properties: None,
+    }
+}
+
+fn stale_suppression_severity(suppression: &StaleSuppression, rules: &RulesConfig) -> Severity {
+    if suppression.missing_reason {
+        rules.require_suppression_reason
+    } else {
+        rules.stale_suppressions
     }
 }
 
@@ -1161,6 +1173,11 @@ fn sarif_graph_rule_specs(rules: &RulesConfig) -> Vec<SarifRuleSpec> {
         "fallow/stale-suppression",
         "Suppression comment or tag no longer matches any issue",
         rules.stale_suppressions,
+    ));
+    specs.push((
+        "fallow/missing-suppression-reason",
+        "Suppression comment or tag is missing a required reason",
+        rules.require_suppression_reason,
     ));
     specs
 }
@@ -1879,7 +1896,11 @@ fn push_suppression_sarif_results(
     snippets: &mut SourceSnippetCache,
 ) {
     push_sarif_results(sarif_results, &results.stale_suppressions, snippets, |s| {
-        sarif_stale_suppression_fields(s, root, severity_to_sarif_level(rules.stale_suppressions))
+        sarif_stale_suppression_fields(
+            s,
+            root,
+            severity_to_sarif_level(stale_suppression_severity(s, rules)),
+        )
     });
 }
 
@@ -2629,6 +2650,84 @@ mod tests {
     }
 
     #[test]
+    fn sarif_missing_suppression_reason_uses_reason_rule_severity() {
+        let root = PathBuf::from("/project");
+        let mut results = AnalysisResults::default();
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin: SuppressionOrigin::Comment {
+                issue_kind: Some("unused-exports".to_string()),
+                reason: None,
+                is_file_level: false,
+                kind_known: true,
+            },
+            missing_reason: true,
+            actions: StaleSuppression::actions_for(true),
+        });
+        let mut rules = RulesConfig::default();
+        rules.stale_suppressions = Severity::Off;
+        rules.require_suppression_reason = Severity::Error;
+
+        let sarif = build_sarif(&results, &root, &rules);
+
+        assert_eq!(
+            sarif["runs"][0]["results"][0]["ruleId"],
+            "fallow/missing-suppression-reason"
+        );
+        assert_eq!(sarif["runs"][0]["results"][0]["level"], "error");
+        let rule_ids: Vec<&str> = sarif["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|rule| rule["id"].as_str().unwrap())
+            .collect();
+        assert!(rule_ids.contains(&"fallow/missing-suppression-reason"));
+    }
+
+    #[test]
+    fn sarif_stale_and_missing_suppression_have_distinct_identities() {
+        let root = PathBuf::from("/project");
+        let mut results = AnalysisResults::default();
+        let origin = SuppressionOrigin::Comment {
+            issue_kind: Some("unused-exports".to_string()),
+            reason: None,
+            is_file_level: false,
+            kind_known: true,
+        };
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin: origin.clone(),
+            missing_reason: false,
+            actions: StaleSuppression::actions_for(false),
+        });
+        results.stale_suppressions.push(StaleSuppression {
+            path: root.join("src/file.ts"),
+            line: 1,
+            col: 0,
+            origin,
+            missing_reason: true,
+            actions: StaleSuppression::actions_for(true),
+        });
+        let mut rules = RulesConfig::default();
+        rules.stale_suppressions = Severity::Warn;
+        rules.require_suppression_reason = Severity::Error;
+
+        let sarif = build_sarif(&results, &root, &rules);
+        let results = sarif["runs"][0]["results"].as_array().unwrap();
+
+        assert_eq!(results[0]["ruleId"], "fallow/stale-suppression");
+        assert_eq!(results[1]["ruleId"], "fallow/missing-suppression-reason");
+        assert_ne!(
+            results[0]["partialFingerprints"][fingerprint::FINGERPRINT_KEY],
+            results[1]["partialFingerprints"][fingerprint::FINGERPRINT_KEY]
+        );
+    }
+
+    #[test]
     fn sarif_has_tool_driver_info() {
         let root = PathBuf::from("/project");
         let results = AnalysisResults::default();
@@ -2652,7 +2751,7 @@ mod tests {
         let rules = sarif["runs"][0]["tool"]["driver"]["rules"]
             .as_array()
             .expect("rules should be an array");
-        assert_eq!(rules.len(), 44);
+        assert_eq!(rules.len(), 45);
 
         let rule_ids: Vec<&str> = rules.iter().map(|r| r["id"].as_str().unwrap()).collect();
         assert!(rule_ids.contains(&"fallow/duplicate-prop-shape"));

--- a/crates/cli/src/report/test_helpers.rs
+++ b/crates/cli/src/report/test_helpers.rs
@@ -267,6 +267,7 @@ pub fn sample_results(root: &Path) -> AnalysisResults {
             kind_known: false,
         },
         missing_reason: false,
+        actions: StaleSuppression::actions_for(false),
     });
 
     r

--- a/crates/cli/tests/snapshot_tests.rs
+++ b/crates/cli/tests/snapshot_tests.rs
@@ -1036,6 +1036,7 @@ fn json_stale_suppression_unknown_kind_snapshot() {
             kind_known: false,
         },
         missing_reason: false,
+        actions: StaleSuppression::actions_for(false),
     });
     results.stale_suppressions.push(StaleSuppression {
         path: root.join("src/utils.ts"),
@@ -1048,6 +1049,7 @@ fn json_stale_suppression_unknown_kind_snapshot() {
             kind_known: true,
         },
         missing_reason: false,
+        actions: StaleSuppression::actions_for(false),
     });
     let value = build_json(&results, &root, Duration::ZERO).expect("JSON build should succeed");
     let json_str = serde_json::to_string_pretty(&value).expect("should serialize");

--- a/crates/cli/tests/snapshots/snapshot_tests__json_stale_suppression_unknown_kind.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_stale_suppression_unknown_kind.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1056
 expression: redact_version(&json_str)
 ---
 {
@@ -80,7 +81,21 @@ expression: redact_version(&json_str)
         "issue_kind": "complexity-typo",
         "is_file_level": false,
         "kind_known": false
-      }
+      },
+      "actions": [
+        {
+          "type": "remove-stale-suppression",
+          "auto_fixable": false,
+          "description": "Remove or update the stale suppression"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress this stale suppression finding with a comment above the suppression",
+          "comment": "// fallow-ignore-next-line stale-suppression",
+          "scope": "per-location"
+        }
+      ]
     },
     {
       "path": "src/utils.ts",
@@ -90,7 +105,21 @@ expression: redact_version(&json_str)
         "type": "comment",
         "issue_kind": "unused-export",
         "is_file_level": false
-      }
+      },
+      "actions": [
+        {
+          "type": "remove-stale-suppression",
+          "auto_fixable": false,
+          "description": "Remove or update the stale suppression"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress this stale suppression finding with a comment above the suppression",
+          "comment": "// fallow-ignore-next-line stale-suppression",
+          "scope": "per-location"
+        }
+      ]
     }
   ],
   "unused_catalog_entries": [],

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_circular_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_circular_deps_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1927
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_duplicate_exports_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_duplicate_exports_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1253
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_empty.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_empty.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 413
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_mixed_severity.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_mixed_severity.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 805
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -516,6 +517,15 @@ expression: redact_sarif_version(&json_str)
                 "text": "A fallow-ignore-next-line, fallow-ignore-file, or @expected-unused suppression that no longer matches any active issue. The underlying problem was fixed but the suppression was left behind. Remove it to keep the codebase clean."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
+              "defaultConfiguration": {
+                "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
               "defaultConfiguration": {
                 "level": "warning"
               }

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_multiple_exports_same_file.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_multiple_exports_same_file.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1330
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_output.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_output.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 402
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_cycles_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_cycles_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1985
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_variant.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_variant.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 747
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_type_only_deps.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_type_only_deps.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 2032
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unlisted_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unlisted_deps_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1183
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unresolved_imports_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unresolved_imports_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1159
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_class_members_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_class_members_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1224
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_deps_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1141
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_dev_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_dev_deps_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 2085
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_enum_members_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_enum_members_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1202
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_exports_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_exports_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1103
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_files_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_files_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1083
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_optional_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_optional_deps_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 2128
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_types_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_types_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1123
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_workspace_deps.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_workspace_deps.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
+assertion_line: 1409
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -518,6 +519,15 @@ expression: redact_sarif_version(&json_str)
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#stale-suppressions",
               "defaultConfiguration": {
                 "level": "warning"
+              }
+            },
+            {
+              "id": "fallow/missing-suppression-reason",
+              "shortDescription": {
+                "text": "Suppression comment or tag is missing a required reason"
+              },
+              "defaultConfiguration": {
+                "level": "none"
               }
             },
             {

--- a/crates/config/src/workspace/pnpm_catalog.rs
+++ b/crates/config/src/workspace/pnpm_catalog.rs
@@ -164,19 +164,22 @@ pub fn parse_package_json_catalog_data(source: &str) -> PnpmCatalogData {
     let workspaces = root
         .get("workspaces")
         .and_then(serde_json::Value::as_object);
-    let default_value = workspaces
-        .and_then(|workspace| workspace.get("catalog"))
-        .or_else(|| root.get("catalog"));
-    let named_value = workspaces
-        .and_then(|workspace| workspace.get("catalogs"))
-        .or_else(|| root.get("catalogs"));
+    let workspace_default_value = workspaces.and_then(|workspace| workspace.get("catalog"));
+    let workspace_named_value = workspaces.and_then(|workspace| workspace.get("catalogs"));
+    let default_value = workspace_default_value.or_else(|| root.get("catalog"));
+    let named_value = workspace_named_value.or_else(|| root.get("catalogs"));
+    let default_line_key = if workspace_default_value.is_some() {
+        workspace_catalog_key("default")
+    } else {
+        "default".to_string()
+    };
     let line_index = build_package_json_line_index(source);
 
     let mut catalogs = Vec::new();
     let mut empty_named_catalog_groups = Vec::new();
 
     if let Some(default_map) = default_value.and_then(serde_json::Value::as_object) {
-        let entries = collect_json_entries(default_map, &line_index, "default");
+        let entries = collect_json_entries(default_map, &line_index, &default_line_key);
         if !entries.is_empty() {
             catalogs.push(PnpmCatalog {
                 name: "default".to_string(),
@@ -185,14 +188,20 @@ pub fn parse_package_json_catalog_data(source: &str) -> PnpmCatalogData {
         }
     }
 
+    let named_from_workspace = workspace_named_value.is_some();
     if let Some(named_map) = named_value.and_then(serde_json::Value::as_object) {
         for (name, catalog_value) in named_map {
+            let line_key = if named_from_workspace {
+                workspace_catalog_key(name)
+            } else {
+                name.clone()
+            };
             if let Some(catalog_map) = catalog_value.as_object() {
-                let entries = collect_json_entries(catalog_map, &line_index, name);
+                let entries = collect_json_entries(catalog_map, &line_index, &line_key);
                 if entries.is_empty() {
                     empty_named_catalog_groups.push(PnpmCatalogGroup {
                         name: name.clone(),
-                        line: line_index.group_line_for(name).unwrap_or(1),
+                        line: line_index.group_line_for(&line_key).unwrap_or(1),
                     });
                 } else {
                     catalogs.push(PnpmCatalog {
@@ -203,7 +212,7 @@ pub fn parse_package_json_catalog_data(source: &str) -> PnpmCatalogData {
             } else if catalog_value.is_null() {
                 empty_named_catalog_groups.push(PnpmCatalogGroup {
                     name: name.clone(),
-                    line: line_index.group_line_for(name).unwrap_or(1),
+                    line: line_index.group_line_for(&line_key).unwrap_or(1),
                 });
             }
         }
@@ -247,10 +256,16 @@ fn collect_json_entries(
         .collect()
 }
 
+fn workspace_catalog_key(name: &str) -> String {
+    format!("workspaces.{name}")
+}
+
 /// Maps `(catalog_name, package_name)` to its 1-based source line.
 ///
-/// `catalog_name` is `"default"` for entries under the top-level `catalog:`
-/// key, or the named catalog key for entries under `catalogs.<name>:`.
+/// `catalog_name` is `"default"` for entries under the top-level `catalog`
+/// key, the named catalog key for entries under top-level `catalogs.<name>`,
+/// or `workspaces.<name>` for Bun package.json catalogs nested below
+/// `workspaces`.
 struct CatalogLineIndex {
     entries: Vec<((String, String), u32)>,
     groups: Vec<(String, u32)>,
@@ -344,6 +359,7 @@ fn build_package_json_line_index(source: &str) -> CatalogLineIndex {
     let mut groups = Vec::new();
     let mut current_depth: u32 = 0;
     let mut workspaces_depth: Option<u32> = None;
+    let mut current_section_prefix: Option<&'static str> = None;
     let mut section: Section = Section::None;
     let mut section_depth: u32 = 0;
     let mut named_catalog: Option<(String, u32)> = None;
@@ -363,11 +379,17 @@ fn build_package_json_line_index(source: &str) -> CatalogLineIndex {
         if let Some(name) = key {
             match section {
                 Section::DefaultCatalog if parent_depth == section_depth => {
-                    entries.push((("default".to_string(), name.to_string()), line_no));
+                    let catalog_name = current_section_prefix.map_or_else(
+                        || "default".to_string(),
+                        |prefix| format!("{prefix}.default"),
+                    );
+                    entries.push(((catalog_name, name.to_string()), line_no));
                 }
                 Section::NamedCatalogs if parent_depth == section_depth => {
-                    groups.push((name.to_string(), line_no));
-                    named_catalog = Some((name.to_string(), parent_depth));
+                    let catalog_name = current_section_prefix
+                        .map_or_else(|| name.to_string(), |prefix| format!("{prefix}.{name}"));
+                    groups.push((catalog_name.clone(), line_no));
+                    named_catalog = Some((catalog_name, parent_depth));
                 }
                 Section::NamedCatalogs => {
                     if let Some((catalog_name, group_depth)) = &named_catalog
@@ -390,10 +412,16 @@ fn build_package_json_line_index(source: &str) -> CatalogLineIndex {
             if in_supported_parent && name == "catalog" && opens > 0 {
                 section = Section::DefaultCatalog;
                 section_depth = parent_depth.saturating_add(1);
+                current_section_prefix = workspaces_depth
+                    .is_some_and(|depth| parent_depth == depth)
+                    .then_some("workspaces");
                 named_catalog = None;
             } else if in_supported_parent && name == "catalogs" && opens > 0 {
                 section = Section::NamedCatalogs;
                 section_depth = parent_depth.saturating_add(1);
+                current_section_prefix = workspaces_depth
+                    .is_some_and(|depth| parent_depth == depth)
+                    .then_some("workspaces");
                 named_catalog = None;
             }
         }
@@ -404,6 +432,7 @@ fn build_package_json_line_index(source: &str) -> CatalogLineIndex {
             && current_depth < section_depth
         {
             section = Section::None;
+            current_section_prefix = None;
             named_catalog = None;
         }
         if let Some(depth) = workspaces_depth
@@ -653,6 +682,26 @@ mod tests {
             .collect();
         assert_eq!(entries, vec!["react"]);
         assert_eq!(data.catalogs[0].entries[0].line, 5);
+    }
+
+    #[test]
+    fn workspaces_catalog_line_wins_when_top_level_catalog_appears_first() {
+        let json = r#"{
+  "catalog": {
+    "react": "^18.0.0"
+  },
+  "workspaces": {
+    "packages": ["packages/*"],
+    "catalog": {
+      "react": "^19.0.0"
+    }
+  }
+}
+"#;
+        let data = parse_package_json_catalog_data(json);
+        assert_eq!(data.catalogs.len(), 1);
+        assert_eq!(data.catalogs[0].entries[0].package_name, "react");
+        assert_eq!(data.catalogs[0].entries[0].line, 8);
     }
 
     #[test]

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -1,7 +1,11 @@
 use std::sync::LazyLock;
 
-use oxc_ast::ast::{Declaration, Expression};
-use oxc_ast_visit::Visit;
+use oxc_ast::ast::{
+    ArrowFunctionExpression, BlockStatement, Declaration, Expression, FormalParameter, Function,
+    FunctionBody, Statement, VariableDeclaration, VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_syntax::scope::ScopeFlags;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -245,6 +249,7 @@ fn collect_exports_used_in_file(module: &ModuleInfo, path: &std::path::Path) -> 
 struct ValueExportDependencyCollector {
     deps_by_export: FxHashMap<String, FxHashSet<String>>,
     current_export: Option<String>,
+    shadowed_names: FxHashSet<String>,
 }
 
 impl ValueExportDependencyCollector {
@@ -252,13 +257,82 @@ impl ValueExportDependencyCollector {
         Self {
             deps_by_export: FxHashMap::default(),
             current_export: None,
+            shadowed_names: FxHashSet::default(),
         }
     }
 
     fn collect_for_export(&mut self, export_name: &str, expression: &Expression<'_>) {
         self.current_export = Some(export_name.to_string());
+        self.shadowed_names.clear();
         self.visit_expression(expression);
+        self.shadowed_names.clear();
         self.current_export = None;
+    }
+
+    fn with_child_scope(&mut self, visit: impl FnOnce(&mut Self)) {
+        let previous = self.shadowed_names.clone();
+        visit(self);
+        self.shadowed_names = previous;
+    }
+
+    fn collect_direct_statement_bindings(&mut self, statement: &Statement<'_>) {
+        match statement {
+            Statement::VariableDeclaration(variable) => {
+                self.collect_variable_declaration_bindings(variable);
+            }
+            Statement::FunctionDeclaration(function) => {
+                if let Some(id) = function.id.as_ref() {
+                    self.shadowed_names.insert(id.name.to_string());
+                }
+            }
+            Statement::ExportNamedDeclaration(export) if export.source.is_none() => {
+                if let Some(declaration) = export.declaration.as_ref() {
+                    self.collect_declaration_bindings(declaration);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_declaration_bindings(&mut self, declaration: &Declaration<'_>) {
+        match declaration {
+            Declaration::VariableDeclaration(variable) => {
+                self.collect_variable_declaration_bindings(variable);
+            }
+            Declaration::FunctionDeclaration(function) => {
+                if let Some(id) = function.id.as_ref() {
+                    self.shadowed_names.insert(id.name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_variable_declaration_bindings(&mut self, variable: &VariableDeclaration<'_>) {
+        for declarator in &variable.declarations {
+            self.collect_variable_declarator_bindings(declarator);
+        }
+    }
+
+    fn collect_variable_declarator_bindings(&mut self, decl: &VariableDeclarator<'_>) {
+        for binding in decl.id.get_binding_identifiers() {
+            self.shadowed_names.insert(binding.name.to_string());
+        }
+    }
+
+    fn collect_block_bindings(&mut self, block: &BlockStatement<'_>) {
+        for statement in &block.body {
+            self.collect_direct_statement_bindings(statement);
+        }
+    }
+
+    fn collect_function_body_bindings(&mut self, body: Option<&FunctionBody<'_>>) {
+        let Some(body) = body else {
+            return;
+        };
+        for statement in &body.statements {
+            self.collect_direct_statement_bindings(statement);
+        }
     }
 }
 
@@ -290,10 +364,46 @@ impl<'a> Visit<'a> for ValueExportDependencyCollector {
         let Some(current_export) = self.current_export.as_ref() else {
             return;
         };
+        if self.shadowed_names.contains(ident.name.as_str()) {
+            return;
+        }
         self.deps_by_export
             .entry(current_export.clone())
             .or_default()
             .insert(ident.name.to_string());
+    }
+
+    fn visit_formal_parameter(&mut self, param: &FormalParameter<'a>) {
+        for binding in param.pattern.get_binding_identifiers() {
+            self.shadowed_names.insert(binding.name.to_string());
+        }
+        walk::walk_formal_parameter(self, param);
+    }
+
+    fn visit_arrow_function_expression(&mut self, expr: &ArrowFunctionExpression<'a>) {
+        self.with_child_scope(|collector| {
+            collector.collect_function_body_bindings(Some(&expr.body));
+            walk::walk_arrow_function_expression(collector, expr);
+        });
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        self.with_child_scope(|collector| {
+            collector.collect_function_body_bindings(func.body.as_deref());
+            walk::walk_function(collector, func, flags);
+        });
+    }
+
+    fn visit_block_statement(&mut self, block: &BlockStatement<'a>) {
+        self.with_child_scope(|collector| {
+            collector.collect_block_bindings(block);
+            walk::walk_block_statement(collector, block);
+        });
+    }
+
+    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        self.collect_variable_declarator_bindings(decl);
+        walk::walk_variable_declarator(self, decl);
     }
 }
 
@@ -431,6 +541,7 @@ fn stale_expected_unused_suppression(
             reason: export.expected_unused_reason.clone(),
         },
         missing_reason: false,
+        actions: StaleSuppression::actions_for(false),
     }
 }
 
@@ -606,6 +717,7 @@ fn unused_export_for_module(
                     reason: None,
                 },
                 missing_reason: true,
+                actions: StaleSuppression::actions_for(true),
             });
         }
         if is_referenced {

--- a/crates/core/src/suppress.rs
+++ b/crates/core/src/suppress.rs
@@ -339,6 +339,7 @@ impl<'a> SuppressionContext<'a> {
                         kind_known: true,
                     },
                     missing_reason: false,
+                    actions: StaleSuppression::actions_for(false),
                 });
             }
         }
@@ -357,6 +358,7 @@ impl<'a> SuppressionContext<'a> {
                         kind_known: false,
                     },
                     missing_reason: false,
+                    actions: StaleSuppression::actions_for(false),
                 });
             }
         }
@@ -388,6 +390,7 @@ impl<'a> SuppressionContext<'a> {
                         kind_known: true,
                     },
                     missing_reason: true,
+                    actions: StaleSuppression::actions_for(true),
                 });
             }
         }
@@ -410,6 +413,7 @@ impl<'a> SuppressionContext<'a> {
                         kind_known: false,
                     },
                     missing_reason: true,
+                    actions: StaleSuppression::actions_for(true),
                 });
             }
         }

--- a/crates/core/tests/integration_test/issue_1304_effect_schema_same_name.rs
+++ b/crates/core/tests/integration_test/issue_1304_effect_schema_same_name.rs
@@ -32,4 +32,16 @@ fn same_name_effect_schema_type_alias_keeps_nested_schema_value_used() {
         unused_export_names.contains(&"UnusedParentSchema"),
         "unused parent schemas must remain reportable, found: {unused_export_names:?}"
     );
+    assert!(
+        unused_export_names.contains(&"ShadowedChildSchema"),
+        "shadowed same-file references must not credit unrelated exports, found: {unused_export_names:?}"
+    );
+    assert!(
+        !unused_export_names.contains(&"BlockScopedChildSchema"),
+        "block-local shadows must not hide later real same-file export references, found: {unused_export_names:?}"
+    );
+    assert!(
+        unused_export_names.contains(&"HoistedShadowChildSchema"),
+        "same-scope hoisted declarations must shadow earlier references, found: {unused_export_names:?}"
+    );
 }

--- a/crates/lsp/src/code_actions/quick_fix.rs
+++ b/crates/lsp/src/code_actions/quick_fix.rs
@@ -663,7 +663,7 @@ fn build_parent_rewrite_edit(
                     clippy::cast_possible_truncation,
                     reason = "header length is bounded by source size"
                 )]
-                character: header.len() as u32,
+                character: header.encode_utf16().count() as u32,
             },
         },
         new_text,
@@ -1737,6 +1737,38 @@ mod tests {
         assert_eq!(edits[0].new_text, "");
         assert_eq!(edits[1].range.start.line, 1);
         assert_eq!(edits[1].new_text, "  react17: {}");
+    }
+
+    #[test]
+    fn catalog_action_parent_rewrite_uses_utf16_character_offsets() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = workspace_yaml_uri(&dir);
+
+        let mut results = AnalysisResults::default();
+        results
+            .unused_catalog_entries
+            .push(make_catalog_entry("react", "日本", 3, vec![]));
+
+        let lines = vec!["catalogs:", "  \"日本\":", "    react: ^17.0.2"];
+        let actions = build_remove_catalog_entry_actions(
+            &results,
+            dir.path(),
+            &uri,
+            &make_range(2, 2),
+            &lines,
+        );
+
+        assert_eq!(actions.len(), 1);
+        let ca = unwrap_code_action(&actions[0]);
+        let changes = ca.edit.as_ref().unwrap().changes.as_ref().unwrap();
+        let edits = changes.get(&uri).unwrap();
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[1].range.start.character, 0);
+        assert_eq!(
+            edits[1].range.end.character,
+            lines[1].encode_utf16().count() as u32
+        );
+        assert_eq!(edits[1].new_text, "  \"日本\": {}");
     }
 
     #[test]

--- a/crates/lsp/src/diagnostics/mod.rs
+++ b/crates/lsp/src/diagnostics/mod.rs
@@ -855,6 +855,7 @@ mod severity_gate {
                                 kind_known: true,
                             },
                             missing_reason: false,
+                            actions: fallow_core::results::StaleSuppression::actions_for(false),
                         });
                 }),
             ),

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -369,12 +369,16 @@ struct DocumentState {
     text: String,
 }
 
-/// Per-URI version map captured at `run_analysis` entry, threaded through to
+/// Per-URI document state captured at `run_analysis` entry, threaded through to
 /// `publish_collected_diagnostics` so it can drop per-URI publishes whose
-/// document has been edited during the analysis run. A type alias so future
-/// readers can grep for the snapshot's identity (it is also a stable seam
-/// for tests).
-type VersionSnapshot = FxHashMap<Uri, i32>;
+/// open buffer differs from what the disk-based analyzer saw.
+#[derive(Debug, Clone, Copy)]
+struct DocumentSnapshot {
+    version: i32,
+    matches_disk: bool,
+}
+
+type VersionSnapshot = FxHashMap<Uri, DocumentSnapshot>;
 
 fn initialization_config_path(opts: &serde_json::Value, root: Option<&Path>) -> Option<PathBuf> {
     let raw = opts.get("configPath").and_then(|v| v.as_str())?.trim();
@@ -1094,7 +1098,15 @@ impl FallowLspServer {
             .read()
             .await
             .iter()
-            .map(|(uri, state)| (uri.clone(), state.version))
+            .map(|(uri, state)| {
+                (
+                    uri.clone(),
+                    DocumentSnapshot {
+                        version: state.version,
+                        matches_disk: Self::document_matches_disk(uri, &state.text),
+                    },
+                )
+            })
             .collect();
 
         self.client
@@ -1153,16 +1165,15 @@ impl FallowLspServer {
                 self.publish_collected_diagnostics(all_diagnostics, &version_snapshot)
                     .await;
 
-                self.client
-                    .send_notification::<AnalysisComplete>(analysis_complete_params(
-                        &output.results,
-                        &output.duplication,
-                    ))
-                    .await;
-
+                let complete_params =
+                    analysis_complete_params(&output.results, &output.duplication);
                 *self.results.write().await = Some(output.results);
                 *self.duplication.write().await = Some(output.duplication);
                 *self.inline_complexity.write().await = output.inline_complexity;
+
+                self.client
+                    .send_notification::<AnalysisComplete>(complete_params)
+                    .await;
 
                 self.spawn_code_lens_refresh();
 
@@ -1199,10 +1210,14 @@ impl FallowLspServer {
     /// these are cross-file diagnostics anchored to files the user never
     /// `did_open`'d via the LSP (e.g. `package.json` for unlisted dependencies,
     /// `pnpm-workspace.yaml` for catalog references). No version race exists for them.
-    fn opened_mid_run_buffer_matches_disk(uri: &Uri, state: &DocumentState) -> bool {
+    fn document_matches_disk(uri: &Uri, text: &str) -> bool {
         uri.to_file_path()
             .and_then(|path| std::fs::read_to_string(path).ok())
-            .is_some_and(|disk_text| disk_text == state.text)
+            .is_some_and(|disk_text| disk_text == text)
+    }
+
+    fn opened_mid_run_buffer_matches_disk(uri: &Uri, state: &DocumentState) -> bool {
+        Self::document_matches_disk(uri, &state.text)
     }
 
     fn uri_is_stale(
@@ -1211,7 +1226,9 @@ impl FallowLspServer {
         live_documents: &FxHashMap<Uri, DocumentState>,
     ) -> bool {
         match (snapshot.get(uri), live_documents.get(uri)) {
-            (Some(&snapshot_version), Some(live_state)) => live_state.version > snapshot_version,
+            (Some(snapshot_state), Some(live_state)) => {
+                !snapshot_state.matches_disk || live_state.version > snapshot_state.version
+            }
             (Some(_), None) => true,
             (None, Some(live_state)) => !Self::opened_mid_run_buffer_matches_disk(uri, live_state),
             (None, None) => false,
@@ -1264,7 +1281,11 @@ impl FallowLspServer {
 
             if !use_pull_diagnostics || !live_documents.contains_key(uri) {
                 self.client
-                    .publish_diagnostics(uri.clone(), filtered.clone(), snapshot.get(uri).copied())
+                    .publish_diagnostics(
+                        uri.clone(),
+                        filtered.clone(),
+                        snapshot.get(uri).map(|state| state.version),
+                    )
                     .await;
             }
 
@@ -1290,7 +1311,7 @@ impl FallowLspServer {
                         .publish_diagnostics(
                             old_uri.clone(),
                             vec![],
-                            snapshot.get(old_uri).copied(),
+                            snapshot.get(old_uri).map(|state| state.version),
                         )
                         .await;
                 }
@@ -2653,6 +2674,7 @@ export function choose(value: number): string {
                     kind_known: true,
                 },
                 missing_reason: false,
+                actions: fallow_core::results::StaleSuppression::actions_for(false),
             }],
             unused_catalog_entries: vec![
                 fallow_core::results::UnusedCatalogEntryFinding::with_actions(
@@ -3198,6 +3220,28 @@ export function choose(value: number): string {
         );
     }
 
+    fn snapshot_for(uri: &Uri, version: i32) -> VersionSnapshot {
+        std::iter::once((
+            uri.clone(),
+            DocumentSnapshot {
+                version,
+                matches_disk: true,
+            },
+        ))
+        .collect()
+    }
+
+    fn dirty_snapshot_for(uri: &Uri, version: i32) -> VersionSnapshot {
+        std::iter::once((
+            uri.clone(),
+            DocumentSnapshot {
+                version,
+                matches_disk: false,
+            },
+        ))
+        .collect()
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn publish_skips_uri_when_live_version_advanced_past_snapshot() {
         let (service, _) = LspService::build(FallowLspServer::new).finish();
@@ -3205,7 +3249,7 @@ export function choose(value: number): string {
 
         let uri = "file:///stale.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
 
         install_document(backend, &uri, 2, "v2").await;
 
@@ -3228,7 +3272,7 @@ export function choose(value: number): string {
 
         let uri = "file:///fresh.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
 
         let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
         diags_by_file.insert(uri.clone(), vec![make_diagnostic()]);
@@ -3246,6 +3290,32 @@ export function choose(value: number): string {
             cached_len,
             Some(1),
             "equal versions are not stale; publish must reach the cache"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn publish_skips_uri_when_snapshot_buffer_differs_from_disk() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let file_path = temp.path().join("dirty-at-start.ts");
+        std::fs::write(&file_path, "export const disk = 1;\n")
+            .expect("fixture file should be written");
+
+        let (service, _) = LspService::build(FallowLspServer::new).finish();
+        let backend = service.inner();
+        let uri = Uri::from_file_path(&file_path).expect("temp path should convert to file URI");
+
+        install_document(backend, &uri, 1, "export const buffer = 1;\n").await;
+        let snapshot = dirty_snapshot_for(&uri, 1);
+
+        let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
+        diags_by_file.insert(uri.clone(), vec![make_diagnostic()]);
+        backend
+            .publish_collected_diagnostics(diags_by_file, &snapshot)
+            .await;
+
+        assert!(
+            !backend.cached_diagnostics.read().await.contains_key(&uri),
+            "same-version dirty buffers are stale because analysis read disk, not the open buffer"
         );
     }
 
@@ -3330,7 +3400,7 @@ export function choose(value: number): string {
 
         let uri = "file:///closed.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
 
         backend.documents.write().await.remove(&uri);
 
@@ -3369,7 +3439,7 @@ export function choose(value: number): string {
 
         let uri = "file:///versioned.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 7, "v7").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 7)).collect();
+        let snapshot = snapshot_for(&uri, 7);
 
         let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
         diags_by_file.insert(uri.clone(), vec![make_diagnostic()]);
@@ -3431,7 +3501,7 @@ export function choose(value: number): string {
         backend.client_pulls.store(true, Ordering::SeqCst);
         let uri = "file:///refresh.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
         let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
         diags_by_file.insert(uri.clone(), vec![make_diagnostic()]);
 
@@ -3575,7 +3645,7 @@ export function choose(value: number): string {
         // `client_pulls` is intentionally NOT set: this client never pulls.
         let uri = "file:///never-pulled.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
         let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
         diags_by_file.insert(uri.clone(), vec![make_diagnostic()]);
 
@@ -3648,7 +3718,7 @@ export function choose(value: number): string {
         // `client_pulls` is intentionally NOT set: this client never pulls.
         let uri = "file:///render.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "doRender();").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
 
         let finding = fallow_core::results::SecurityFinding {
             finding_id: String::new(),
@@ -4057,7 +4127,7 @@ export function choose(value: number): string {
 
         let uri = "file:///clearing.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot_v1: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot_v1 = snapshot_for(&uri, 1);
 
         let mut first_run: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
         first_run.insert(uri.clone(), vec![make_diagnostic()]);
@@ -4094,7 +4164,7 @@ export function choose(value: number): string {
 
         let uri = "file:///tracked.ts".parse::<Uri>().unwrap();
         install_document(backend, &uri, 1, "v1").await;
-        let snapshot: VersionSnapshot = std::iter::once((uri.clone(), 1)).collect();
+        let snapshot = snapshot_for(&uri, 1);
         install_document(backend, &uri, 2, "v2").await;
 
         let mut diags_by_file: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();

--- a/crates/types/src/output.rs
+++ b/crates/types/src/output.rs
@@ -228,6 +228,10 @@ pub enum FixActionType {
     /// segments at the conflicting position to a single consistent slug name
     /// (manual).
     ResolveDynamicSegmentNameConflict,
+    /// Add a human-authored reason to a suppression that requires one.
+    AddSuppressionReason,
+    /// Remove or update a suppression that no longer matches a finding.
+    RemoveStaleSuppression,
 }
 
 /// Inline-comment suppression for a single finding line.

--- a/crates/types/src/output_dead_code.rs
+++ b/crates/types/src/output_dead_code.rs
@@ -2553,6 +2553,8 @@ mod position_0_invariants {
                 FixActionType::ResolveDynamicSegmentNameConflict => {
                     "resolve-dynamic-segment-name-conflict"
                 }
+                FixActionType::AddSuppressionReason => "add-suppression-reason",
+                FixActionType::RemoveStaleSuppression => "remove-stale-suppression",
             },
             IssueAction::SuppressLine(_) => "suppress-line",
             IssueAction::SuppressFile(_) => "suppress-file",

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -8,7 +8,9 @@ use crate::extract::{
     MemberKind, SecurityControlKind, SecurityUrlShape, SkippedSecurityCalleeExpressionKind,
     SkippedSecurityCalleeReason,
 };
-use crate::output::IssueAction;
+use crate::output::{
+    FixAction, FixActionType, IssueAction, SuppressLineAction, SuppressLineKind, SuppressLineScope,
+};
 use crate::output_dead_code::{
     BoundaryCallViolationFinding, BoundaryCoverageViolationFinding, BoundaryViolationFinding,
     CircularDependencyFinding, DuplicateExportFinding, DuplicatePropShapeFinding,
@@ -2876,9 +2878,47 @@ pub struct StaleSuppression {
     /// comment or tag that has no reason.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub missing_reason: bool,
+    /// Suggested next steps. Always emitted.
+    pub actions: Vec<IssueAction>,
 }
 
 impl StaleSuppression {
+    /// Build the typed action list for this suppression finding.
+    #[must_use]
+    pub fn actions_for(missing_reason: bool) -> Vec<IssueAction> {
+        let (kind, description) = if missing_reason {
+            (
+                FixActionType::AddSuppressionReason,
+                "Add a human-authored reason after `--` on the suppression",
+            )
+        } else {
+            (
+                FixActionType::RemoveStaleSuppression,
+                "Remove or update the stale suppression",
+            )
+        };
+        let mut actions = vec![IssueAction::Fix(FixAction {
+            kind,
+            auto_fixable: false,
+            description: description.to_string(),
+            note: None,
+            available_in_catalogs: None,
+            suggested_target: None,
+        })];
+        if !missing_reason {
+            actions.push(IssueAction::SuppressLine(SuppressLineAction {
+                kind: SuppressLineKind::SuppressLine,
+                auto_fixable: false,
+                description:
+                    "Suppress this stale suppression finding with a comment above the suppression"
+                        .to_string(),
+                comment: "// fallow-ignore-next-line stale-suppression".to_string(),
+                scope: Some(SuppressLineScope::PerLocation),
+            }));
+        }
+        actions
+    }
+
     /// Produce a human-readable description of this stale suppression.
     #[must_use]
     pub fn description(&self) -> String {

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -4509,13 +4509,21 @@
         "missing_reason": {
           "type": "boolean",
           "description": "True when `rules.require-suppression-reason` reported a suppression\ncomment or tag that has no reason."
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IssueAction"
+          },
+          "description": "Suggested next steps. Always emitted."
         }
       },
       "required": [
         "path",
         "line",
         "col",
-        "origin"
+        "origin",
+        "actions"
       ],
       "description": "A suppression comment or JSDoc tag that no longer matches any issue."
     },
@@ -6501,6 +6509,16 @@
           "type": "string",
           "const": "resolve-dynamic-segment-name-conflict",
           "description": "Resolve a Next.js dynamic-segment name conflict by renaming the dynamic\nsegments at the conflicting position to a single consistent slug name\n(manual)."
+        },
+        {
+          "type": "string",
+          "const": "add-suppression-reason",
+          "description": "Add a human-authored reason to a suppression that requires one."
+        },
+        {
+          "type": "string",
+          "const": "remove-stale-suppression",
+          "description": "Remove or update a suppression that no longer matches a finding."
         }
       ],
       "description": "Discriminant string for [`FixAction`]. Kebab-case per the JSON output\ncontract."

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -174,7 +174,7 @@ export type IssueAction = (FixAction | SuppressLineAction | SuppressFileAction |
  * Discriminant string for [`FixAction`]. Kebab-case per the JSON output
  * contract.
  */
-export type FixActionType = ("remove-export" | "delete-file" | "remove-dependency" | "move-dependency" | "remove-enum-member" | "remove-class-member" | "resolve-import" | "install-dependency" | "remove-duplicate" | "move-to-dev" | "refactor-cycle" | "refactor-re-export-cycle" | "refactor-boundary" | "export-type" | "remove-catalog-entry" | "remove-empty-catalog-group" | "update-catalog-reference" | "add-catalog-entry" | "remove-catalog-reference" | "remove-dependency-override" | "fix-dependency-override" | "resolve-policy-violation" | "move-to-server-module" | "split-mixed-barrel" | "hoist-directive" | "wire-server-action" | "provide-inject" | "use-load-data" | "render-component" | "use-component-prop" | "emit-component-event" | "wire-svelte-event" | "resolve-route-collision" | "resolve-dynamic-segment-name-conflict")
+export type FixActionType = ("remove-export" | "delete-file" | "remove-dependency" | "move-dependency" | "remove-enum-member" | "remove-class-member" | "resolve-import" | "install-dependency" | "remove-duplicate" | "move-to-dev" | "refactor-cycle" | "refactor-re-export-cycle" | "refactor-boundary" | "export-type" | "remove-catalog-entry" | "remove-empty-catalog-group" | "update-catalog-reference" | "add-catalog-entry" | "remove-catalog-reference" | "remove-dependency-override" | "fix-dependency-override" | "resolve-policy-violation" | "move-to-server-module" | "split-mixed-barrel" | "hoist-directive" | "wire-server-action" | "provide-inject" | "use-load-data" | "render-component" | "use-component-prop" | "emit-component-event" | "wire-svelte-event" | "resolve-route-collision" | "resolve-dynamic-segment-name-conflict" | "add-suppression-reason" | "remove-stale-suppression")
 /**
  * Singleton discriminant for [`SuppressLineAction`].
  */
@@ -2445,6 +2445,10 @@ origin: SuppressionOrigin
  * comment or tag that has no reason.
  */
 missing_reason?: boolean
+/**
+ * Suggested next steps. Always emitted.
+ */
+actions: IssueAction[]
 }
 /**
  * Wire-shape envelope for an [`UnusedCatalogEntry`] finding. Per-instance

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -174,7 +174,7 @@ export type IssueAction = (FixAction | SuppressLineAction | SuppressFileAction |
  * Discriminant string for [`FixAction`]. Kebab-case per the JSON output
  * contract.
  */
-export type FixActionType = ("remove-export" | "delete-file" | "remove-dependency" | "move-dependency" | "remove-enum-member" | "remove-class-member" | "resolve-import" | "install-dependency" | "remove-duplicate" | "move-to-dev" | "refactor-cycle" | "refactor-re-export-cycle" | "refactor-boundary" | "export-type" | "remove-catalog-entry" | "remove-empty-catalog-group" | "update-catalog-reference" | "add-catalog-entry" | "remove-catalog-reference" | "remove-dependency-override" | "fix-dependency-override" | "resolve-policy-violation" | "move-to-server-module" | "split-mixed-barrel" | "hoist-directive" | "wire-server-action" | "provide-inject" | "use-load-data" | "render-component" | "use-component-prop" | "emit-component-event" | "wire-svelte-event" | "resolve-route-collision" | "resolve-dynamic-segment-name-conflict")
+export type FixActionType = ("remove-export" | "delete-file" | "remove-dependency" | "move-dependency" | "remove-enum-member" | "remove-class-member" | "resolve-import" | "install-dependency" | "remove-duplicate" | "move-to-dev" | "refactor-cycle" | "refactor-re-export-cycle" | "refactor-boundary" | "export-type" | "remove-catalog-entry" | "remove-empty-catalog-group" | "update-catalog-reference" | "add-catalog-entry" | "remove-catalog-reference" | "remove-dependency-override" | "fix-dependency-override" | "resolve-policy-violation" | "move-to-server-module" | "split-mixed-barrel" | "hoist-directive" | "wire-server-action" | "provide-inject" | "use-load-data" | "render-component" | "use-component-prop" | "emit-component-event" | "wire-svelte-event" | "resolve-route-collision" | "resolve-dynamic-segment-name-conflict" | "add-suppression-reason" | "remove-stale-suppression")
 /**
  * Singleton discriminant for [`SuppressLineAction`].
  */
@@ -2445,6 +2445,10 @@ origin: SuppressionOrigin
  * comment or tag that has no reason.
  */
 missing_reason?: boolean
+/**
+ * Suggested next steps. Always emitted.
+ */
+actions: IssueAction[]
 }
 /**
  * Wire-shape envelope for an [`UnusedCatalogEntry`] finding. Per-instance

--- a/tests/fixtures/issue-1304-effect-schema-same-name/src/route.ts
+++ b/tests/fixtures/issue-1304-effect-schema-same-name/src/route.ts
@@ -1,5 +1,11 @@
-import { AssistantPromptResponse } from "./schema";
+import {
+  AssistantPromptResponse,
+  BlockScopedParentSchema,
+  HoistedShadowParentSchema,
+} from "./schema";
 
 export const route = {
+  blockScoped: BlockScopedParentSchema,
+  hoistedShadow: HoistedShadowParentSchema,
   response: AssistantPromptResponse,
 };

--- a/tests/fixtures/issue-1304-effect-schema-same-name/src/schema.ts
+++ b/tests/fixtures/issue-1304-effect-schema-same-name/src/schema.ts
@@ -56,3 +56,38 @@ export const OrphanChildSchema = Schema.Struct({
 export const UnusedParentSchema = Schema.Struct({
   children: Schema.Array(OrphanChildSchema),
 });
+
+export const ShadowedParentSchema = [1].map(
+  (ShadowedChildSchema) => ShadowedChildSchema,
+);
+
+export const ShadowedChildSchema = Schema.Struct({
+  id: Schema.String,
+});
+
+export const BlockScopedParentSchema = (() => {
+  {
+    const BlockScopedChildSchema = Schema.String;
+    void BlockScopedChildSchema;
+  }
+
+  return Schema.Struct({
+    child: BlockScopedChildSchema,
+  });
+})();
+
+export const BlockScopedChildSchema = Schema.Struct({
+  id: Schema.String,
+});
+
+export const HoistedShadowParentSchema = (() => {
+  return HoistedShadowChildSchema;
+
+  function HoistedShadowChildSchema() {
+    return Schema.String;
+  }
+})();
+
+export const HoistedShadowChildSchema = Schema.Struct({
+  id: Schema.String,
+});


### PR DESCRIPTION
Address final review findings across suppression reporting, catalog parsing, same-file export dependency credit, and LSP diagnostics.

Stale suppression findings now carry typed actions, split missing-reason identities across SARIF, CodeClimate, audit, and baselines, and keep generated schemas and editor contracts in sync. Package.json catalog line mapping now respects workspace catalog precedence.

The same-file export dependency collector now handles shadowed bindings without leaking block-local names, and LSP diagnostics avoid stale open buffers while emitting UTF-16-safe quick fixes.

Follow-up to #1305, #1306, #1307, and #1308.