### PR TITLE
ci(codspeed): harden benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/bench.yml'
+      - '.github/actions/setup-rust/**'
   push:
     branches: [main]
     paths:
@@ -17,21 +18,27 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/bench.yml'
+      - '.github/actions/setup-rust/**'
   workflow_dispatch:
 
 concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions: {}
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
 
 jobs:
   benchmark:
     name: CodSpeed fast simulation (${{ matrix.label }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -55,6 +62,8 @@ jobs:
             bench: scaling_analysis
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -79,9 +88,14 @@ jobs:
     name: CodSpeed full simulation (large analysis)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
         with:


### PR DESCRIPTION
Aligns the CodSpeed benchmark workflow with the working sibling-project setup while keeping the existing cargo-codspeed shard model.

The jobs now request OIDC only where CodSpeed uploads need it, avoid persisting checkout credentials, include setup-rust changes in workflow triggers, and build with debug metadata for better CodSpeed analysis input.