### PR TITLE
fix: make dupes compact output agent friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fallow dupes --format compact` now emits traceable clone lines.** Duplication compact output uses the `code-duplication` issue tag and includes the stable `dup:<id>` fingerprint plus group, token, line, and instance metadata on each clone instance line, so agents can jump straight to `fallow dupes --trace dup:<id>` without scraping human output.
+
 ## [2.99.0] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ fallow dupes --mode semantic              # Catch clones with renamed variables
 fallow dupes --skip-local                 # Only cross-directory duplicates
 fallow dupes --group-by owner             # Partition clone groups by CODEOWNERS team
 fallow dupes --group-by directory         # Partition clone groups by directory
+fallow dupes --format compact             # One parseable line per clone instance
 fallow dupes --trace src/utils.ts:42      # Show all clones of code at this location
 fallow dupes --trace dup:7f3a2c1e         # Deep-dive a clone group by its dup:<id> fingerprint
 ```

--- a/crates/cli/src/report/compact.rs
+++ b/crates/cli/src/report/compact.rs
@@ -1,7 +1,7 @@
 use crate::report::sink::outln;
 use std::path::Path;
 
-use fallow_core::duplicates::DuplicationReport;
+use fallow_core::duplicates::{CloneFingerprintSet, DuplicationReport};
 use fallow_core::results::{AnalysisResults, UnusedExport, UnusedMember};
 
 use super::grouping::ResultGroup;
@@ -881,17 +881,20 @@ fn build_coverage_intelligence_compact_lines(
 }
 
 pub(super) fn print_duplication_compact(report: &DuplicationReport, root: &Path) {
-    for (i, group) in report.clone_groups.iter().enumerate() {
+    let fingerprints = CloneFingerprintSet::from_groups(&report.clone_groups);
+    for (index, group) in report.clone_groups.iter().enumerate() {
+        let fingerprint = fingerprints.fingerprint_for_group(group);
         for instance in &group.instances {
-            let relative =
-                normalize_uri(&relative_path(&instance.file, root).display().to_string());
             outln!(
-                "clone-group-{}:{}:{}-{}:{}tokens",
-                i + 1,
-                relative,
+                "code-duplication:{}:{}-{}:fingerprint={},group={},tokens={},lines={},instances={}",
+                compact_path(&instance.file, root),
                 instance.start_line,
                 instance.end_line,
-                group.token_count
+                fingerprint,
+                index + 1,
+                group.token_count,
+                group.line_count,
+                group.instances.len(),
             );
         }
     }

--- a/crates/cli/tests/dupes_tests.rs
+++ b/crates/cli/tests/dupes_tests.rs
@@ -447,6 +447,37 @@ fn dupes_json_paths_are_relative() {
 }
 
 #[test]
+fn dupes_compact_output_includes_traceable_clone_metadata() {
+    let output = run_fallow(
+        "dupes",
+        "duplicate-code",
+        &["--format", "compact", "--quiet"],
+    );
+    assert!(
+        output.stdout.contains("code-duplication:"),
+        "compact dupes output should use the code-duplication issue tag. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains(":fingerprint=dup:"),
+        "compact dupes output should include traceable clone fingerprints. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains(",tokens=")
+            && output.stdout.contains(",lines=")
+            && output.stdout.contains(",instances="),
+        "compact dupes output should include parseable clone metadata. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("clone-group-"),
+        "compact dupes output should not rely on ordinal-only clone labels. stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
 fn dupes_human_output_snapshot() {
     let output = run_fallow("dupes", "duplicate-code", &["--quiet"]);
     let root = fixture_path("duplicate-code");

--- a/npm/fallow/skills/fallow/references/cli-reference.md
+++ b/npm/fallow/skills/fallow/references/cli-reference.md
@@ -1645,7 +1645,7 @@ Set `FALLOW_FORMAT=json` and `FALLOW_QUIET=1` in your agent environment to avoid
 | `human` | Colored terminal output | Interactive use |
 | `json` | Machine-readable JSON | Agent integration, CI pipelines |
 | `sarif` | Static Analysis Results Interchange Format | GitHub Code Scanning, SARIF-compatible tools |
-| `compact` | Grep-friendly: `type:path:line:name` per line | Quick filtering |
+| `compact` | Grep-friendly: one issue per line. Dupes lines include `code-duplication:path:start-end:fingerprint=dup:<id>,...` | Quick filtering |
 | `markdown` | Markdown tables | Documentation, PR comments |
 | `codeclimate` / `gitlab-codequality` | CodeClimate JSON array | GitLab Code Quality, CodeClimate-compatible tools |
 | `pr-comment-github` / `pr-comment-gitlab` | Sticky PR/MR comment markdown with HTML-comment marker for upsert | Posted by the action / template `comment.sh` scripts |


### PR DESCRIPTION
## Summary

- make `fallow dupes --format compact` emit `code-duplication` lines with stable `dup:<id>` fingerprints
- include group, token, line, and instance metadata on each clone instance line
- add regression coverage and update compact-output docs

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p fallow-cli dupes_compact_output_includes_traceable_clone_metadata`
- `cargo test --workspace --lib --bins --tests`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `target/debug/fallow audit --format json --quiet`
- real-project compact dupes smoke
