### PR TITLE
perf(cli): stream SARIF file output

### DIFF
--- a/crates/cli/src/check/output.rs
+++ b/crates/cli/src/check/output.rs
@@ -1,3 +1,4 @@
+use std::io::{BufWriter, Write};
 use std::process::ExitCode;
 
 use fallow_config::{OutputFormat, ResolvedConfig};
@@ -72,29 +73,35 @@ pub fn write_sarif_file(
     quiet: bool,
 ) {
     let sarif = report::build_sarif(results, &config.root, &config.rules);
-    match serde_json::to_string_pretty(&sarif) {
-        Ok(json) => {
-            if let Some(parent) = sarif_path.parent()
-                && !parent.as_os_str().is_empty()
-                && let Err(e) = std::fs::create_dir_all(parent)
-            {
-                eprintln!(
-                    "Warning: failed to create directory for SARIF file '{}': {e}",
-                    sarif_path.display()
-                );
-            }
-            if let Err(e) = std::fs::write(sarif_path, json) {
-                eprintln!(
-                    "Warning: failed to write SARIF file '{}': {e}",
-                    sarif_path.display()
-                );
-            } else if !quiet {
-                eprintln!("SARIF output written to {}", sarif_path.display());
-            }
-        }
+    if let Some(parent) = sarif_path.parent()
+        && !parent.as_os_str().is_empty()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!(
+            "Warning: failed to create directory for SARIF file '{}': {e}",
+            sarif_path.display()
+        );
+    }
+    let file = match std::fs::File::create(sarif_path) {
+        Ok(file) => file,
         Err(e) => {
-            eprintln!("Warning: failed to serialize SARIF output: {e}");
+            eprintln!(
+                "Warning: failed to write SARIF file '{}': {e}",
+                sarif_path.display()
+            );
+            return;
         }
+    };
+    let mut writer = BufWriter::new(file);
+    if let Err(e) = serde_json::to_writer_pretty(&mut writer, &sarif) {
+        eprintln!("Warning: failed to serialize SARIF output: {e}");
+    } else if let Err(e) = writer.flush() {
+        eprintln!(
+            "Warning: failed to write SARIF file '{}': {e}",
+            sarif_path.display()
+        );
+    } else if !quiet {
+        eprintln!("SARIF output written to {}", sarif_path.display());
     }
 }
 


### PR DESCRIPTION
Write SARIF files through a buffered JSON writer instead of first building a pretty JSON string in memory.

The output remains byte-identical on the SARIF fixture, and the final measured SARIF-file path improved from the earlier baseline to 27.8 ms mean on the synthetic output fixture.

Validation: cargo check --workspace, cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings, cargo test -p fallow-cli -p fallow-mcp, cargo test --workspace --lib --bins --tests --examples, cargo doc with rustdoc warnings denied, release build, SARIF/JSON smoke.