### PR TITLE
feat: detect unused svelte component props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`fallow dupes` now scans authored web-format code outside JS and TS.** Duplicate detection now tokenizes `.css`, `.scss`, `.sass`, and `.less` files, plus Vue and Svelte template and style regions and Astro template and style regions. SFC and Astro regions keep section boundaries, so a clone candidate cannot be formed by stitching script, markup, and style tokens together. Warm duplicate-token caches refresh on upgrade because older caches stored these files as empty or script-only streams.
 
+- **`unused-component-prop` now covers Svelte 5 `$props()` destructures.** Svelte components that declare a prop through `$props()` and never read it in their script or markup now report through the existing `unused-component-prop` rule. The finding keeps the same output shape, severity, manual action, and suppression token as Vue and React component-prop findings. It stays conservative by requiring a declared `svelte` or `@sveltejs/kit` dependency and abstaining when a `$props()` destructure contains rest, computed, nested, or whole-object shapes that could hide a use.
+
 ## [2.99.0] - 2026-06-18
 
 ### Added

--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -319,8 +319,8 @@ pub const CHECK_RULES: &[RuleDef] = &[
         id: "fallow/unused-component-prop",
         category: "Dead code",
         name: "Unused component props",
-        short: "A Vue defineProps prop or React component prop is referenced nowhere in its own component",
-        full: "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop.",
+        short: "A Vue, Svelte, or React component prop is referenced nowhere in its own component",
+        full: "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop.",
         docs_path: "explanations/dead-code#unused-component-props",
     },
     RuleDef {

--- a/crates/cli/src/report/human/mod.rs
+++ b/crates/cli/src/report/human/mod.rs
@@ -202,7 +202,7 @@ fn section_component_footer_text(title: &str) -> Option<(&'static str, &'static 
             "https://docs.fallow.tools/explanations/dead-code#unrendered-components",
         )),
         "Unused component props" => Some((
-            "A Vue defineProps prop or React component prop referenced nowhere inside its own component (remove it or use it)",
+            "A Vue, Svelte, or React component prop referenced nowhere inside its own component (remove it or use it)",
             "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
         )),
         "Prop drilling" => Some((

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_circular_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_circular_deps_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1927
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_duplicate_exports_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_duplicate_exports_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1253
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_empty.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_empty.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 413
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_mixed_severity.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_mixed_severity.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 805
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_multiple_exports_same_file.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_multiple_exports_same_file.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1330
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_output.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_output.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 402
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_cycles_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_cycles_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1985
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_variant.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_re_export_variant.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 747
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_type_only_deps.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_type_only_deps.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 2032
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unlisted_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unlisted_deps_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1183
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unresolved_imports_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unresolved_imports_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1159
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_class_members_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_class_members_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1224
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_deps_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1141
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_dev_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_dev_deps_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 2085
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_enum_members_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_enum_members_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1202
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_exports_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_exports_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1103
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_files_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_files_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1083
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_optional_deps_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_optional_deps_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 2128
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_types_only.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_unused_types_only.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1123
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/cli/tests/snapshots/snapshot_tests__sarif_workspace_deps.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__sarif_workspace_deps.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/snapshot_tests.rs
-assertion_line: 1409
 expression: redact_sarif_version(&json_str)
 ---
 {
@@ -355,10 +354,10 @@ expression: redact_sarif_version(&json_str)
             {
               "id": "fallow/unused-component-prop",
               "shortDescription": {
-                "text": "A Vue defineProps prop or React component prop is referenced nowhere in its own component"
+                "text": "A Vue, Svelte, or React component prop is referenced nowhere in its own component"
               },
               "fullDescription": {
-                "text": "A declared component prop referenced nowhere inside its own component, in either of two framework shapes: a Vue `<script setup>` defineProps prop (unused in neither script nor template), or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. vue-tsc / Volar / tsc check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
+                "text": "A declared component prop referenced nowhere inside its own component, in these framework shapes: a Vue `<script setup>` defineProps prop, a Svelte 5 `$props()` prop, or a React/Preact prop destructured from a component's first parameter and read nowhere in its body. Framework type checkers check caller-side prop correctness, not this in-component dead-input direction. Conservative: Vue abstains on `$attrs` fallthrough, whole-object props use, defineExpose, defineModel, and imported prop-type aliases; Svelte abstains on rest, computed, nested, and whole-object `$props()` shapes; React abstains on rest spread (`{...rest}`), props forwarded by spread, props passed wholesale to a hook, `forwardRef` / imported-interface props, and exported public-API component props. Default warn; suppress or remove the prop."
               },
               "helpUri": "https://docs.fallow.tools/explanations/dead-code#unused-component-props",
               "defaultConfiguration": {

--- a/crates/config/src/config/rules.rs
+++ b/crates/config/src/config/rules.rs
@@ -107,12 +107,11 @@ pub struct RulesConfig {
     /// lower; warn encodes that without failing CI.
     #[serde(default, alias = "unrendered-component")]
     pub unrendered_components: Severity,
-    /// Vue `<script setup>` `defineProps` declared prop referenced nowhere
-    /// inside its own single-file component (neither `<script>` nor
-    /// `<template>`). The single-file dead-input direction. Defaults to `warn`,
-    /// not `error`: a prop can be part of a deliberately-stable public component
-    /// API, so analyzer confidence is lower; warn encodes that without failing
-    /// CI.
+    /// Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, or React
+    /// declared prop referenced nowhere inside its own component. The
+    /// single-component dead-input direction. Defaults to `warn`, not `error`: a
+    /// prop can be part of a deliberately-stable public component API, so
+    /// analyzer confidence is lower; warn encodes that without failing CI.
     #[serde(default, alias = "unused-component-prop")]
     pub unused_component_props: Severity,
     /// Vue `<script setup>` `defineEmits` declared event emitted nowhere inside

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -1028,13 +1028,13 @@ fn populate_unrendered_component_findings(input: &mut FrameworkSpecificFindingsI
 }
 
 /// Populate `unused_component_props` when the rule is enabled. Gated on the
-/// project declaring `vue` / `@vue/runtime-core` / `nuxt` inside the detector
-/// (see [`find_unused_component_props`]).
+/// project declaring the matching framework dependency inside the detector (see
+/// [`find_unused_component_props`]).
 fn populate_unused_component_prop_findings(input: &mut FrameworkSpecificFindingsInput<'_>) {
     if input.config.rules.unused_component_props == Severity::Off {
         return;
     }
-    // Vue arm: one component per `.vue` SFC, flagged from `component_props`.
+    // Vue/Svelte arm: one component per SFC, flagged from `component_props`.
     input.results.unused_component_props = find_unused_component_props(
         input.graph,
         input.modules,
@@ -1071,7 +1071,7 @@ fn populate_unused_component_prop_findings(input: &mut FrameworkSpecificFindings
             .map(UnusedComponentPropFinding::with_actions),
     );
 
-    // Inline-suppression filter over BOTH arms: a `// fallow-ignore-next-line
+    // Inline-suppression filter over ALL arms: a `// fallow-ignore-next-line
     // unused-component-prop` above the prop (or a file-level
     // `// fallow-ignore-file unused-component-prop`) drops the finding. The
     // finding's `path` is the absolute graph node path, so it maps directly to a

--- a/crates/core/src/analyze/unused_component_prop.rs
+++ b/crates/core/src/analyze/unused_component_prop.rs
@@ -1,6 +1,6 @@
-//! Detection of unused Vue `<script setup>` `defineProps` props: a declared prop
-//! referenced NOWHERE inside its own single-file component (neither `<script>`
-//! nor `<template>`).
+//! Detection of unused Vue `<script setup>` `defineProps` props and Svelte 5
+//! `$props()` props: a declared prop referenced NOWHERE inside its own
+//! single-file component (neither `<script>` nor `<template>`).
 //!
 //! Single-file finding, zero-FP doctrine. The harvest + usage flags live on
 //! `ModuleInfo.component_props` (set during extraction); this detector only reads
@@ -8,7 +8,7 @@
 //! finding per genuinely-unused prop.
 //!
 //! Abstain ladder (each abstains the WHOLE file's prop findings):
-//! - `has_unharvestable_props`: a type-reference `defineProps<Props>()` arg.
+//! - `has_unharvestable_props`: opaque or imported prop declarations.
 //! - `has_props_attrs_fallthrough`: `v-bind="$attrs"/$props/props"` or a
 //!   rest-destructure of the props return.
 //! - `has_define_expose`: a prop may be re-exposed.
@@ -26,9 +26,9 @@ use crate::results::UnusedComponentProp;
 
 use super::{LineOffsetsMap, byte_offset_to_line_col};
 
-/// Find Vue `<script setup>` `defineProps` props referenced nowhere in their own
-/// SFC. Returns empty unless the project declares `vue` / `@vue/runtime-core` /
-/// `nuxt`.
+/// Find Vue `<script setup>` `defineProps` and Svelte 5 `$props()` props
+/// referenced nowhere in their own SFC. Returns framework findings only when
+/// the matching framework dependency is declared.
 #[must_use]
 pub fn find_unused_component_props(
     graph: &ModuleGraph,
@@ -36,10 +36,11 @@ pub fn find_unused_component_props(
     declared_deps: &FxHashSet<String>,
     line_offsets_by_file: &LineOffsetsMap<'_>,
 ) -> Vec<UnusedComponentProp> {
-    let gated = declared_deps.contains("vue")
+    let vue_gated = declared_deps.contains("vue")
         || declared_deps.contains("@vue/runtime-core")
         || declared_deps.contains("nuxt");
-    if !gated {
+    let svelte_gated = declared_deps.contains("svelte") || declared_deps.contains("@sveltejs/kit");
+    if !vue_gated && !svelte_gated {
         return Vec::new();
     }
 
@@ -51,8 +52,13 @@ pub fn find_unused_component_props(
         if !node.is_reachable() {
             continue;
         }
-        if !is_vue_file(&node.path) {
+        let Some(framework) = component_prop_framework(&node.path) else {
             continue;
+        };
+        match framework {
+            ComponentPropFramework::Vue if !vue_gated => continue,
+            ComponentPropFramework::Svelte if !svelte_gated => continue,
+            _ => {}
         }
         let Some(module) = modules_by_id.get(&node.file_id) else {
             continue;
@@ -96,12 +102,22 @@ pub fn find_unused_component_props(
     findings
 }
 
-/// Whether the path is a Vue SFC (`.vue`).
-fn is_vue_file(path: &Path) -> bool {
-    path.extension().and_then(|e| e.to_str()) == Some("vue")
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ComponentPropFramework {
+    Vue,
+    Svelte,
 }
 
-/// The component name: the `.vue` file stem.
+/// Whether the path is an SFC whose props feed `unused-component-prop`.
+fn component_prop_framework(path: &Path) -> Option<ComponentPropFramework> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("vue") => Some(ComponentPropFramework::Vue),
+        Some("svelte") => Some(ComponentPropFramework::Svelte),
+        _ => None,
+    }
+}
+
+/// The component name: the SFC file stem.
 fn component_name_for(path: &Path) -> String {
     path.file_stem()
         .and_then(|s| s.to_str())

--- a/crates/core/tests/integration_test/unused_component_props.rs
+++ b/crates/core/tests/integration_test/unused_component_props.rs
@@ -1,4 +1,5 @@
-//! `unused-component-prop`: a Vue `defineProps` prop used nowhere in its SFC.
+//! `unused-component-prop`: Vue `defineProps` and Svelte `$props()` props used
+//! nowhere in their own SFC.
 //! Covers the FP-safety regressions: a renamed-destructure prop used via its
 //! local alias is NOT flagged, and a custom-named `defineProps` return spread
 //! via `v-bind` abstains the whole component.
@@ -41,5 +42,51 @@ fn flags_unused_props_but_credits_alias_and_abstains_on_forward() {
     assert!(
         !flagged.contains(&"shown"),
         "a template-rendered prop must not be flagged: {flagged:?}"
+    );
+}
+
+#[test]
+fn flags_unused_svelte_props_but_credits_usage_and_abstains_on_opaque_shapes() {
+    let root = fixture_path("unused-svelte-component-prop");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let flagged: Vec<(&str, &str)> = results
+        .unused_component_props
+        .iter()
+        .map(|p| (p.prop.component_name.as_str(), p.prop.prop_name.as_str()))
+        .collect();
+
+    assert!(
+        flagged.contains(&("DeadProp", "deadProp")),
+        "an unused Svelte $props prop should be flagged: {flagged:?}"
+    );
+    assert!(
+        !flagged.contains(&("ScriptUsed", "usedScript")),
+        "a Svelte prop read in script must not be flagged: {flagged:?}"
+    );
+    assert!(
+        !flagged.contains(&("TemplateUsed", "shown")),
+        "a Svelte prop read in template must not be flagged: {flagged:?}"
+    );
+    assert!(
+        !flagged.contains(&("RestAbstain", "forwarded")),
+        "a Svelte props rest binding must abstain the component: {flagged:?}"
+    );
+    assert!(
+        !flagged.contains(&("ComputedAbstain", "computed")),
+        "a Svelte computed props key must abstain the component: {flagged:?}"
+    );
+}
+
+#[test]
+fn svelte_props_are_gated_on_svelte_dependency() {
+    let root = fixture_path("unused-svelte-component-prop-no-dep");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.unused_component_props.is_empty(),
+        "Svelte $props findings require a Svelte dependency: {:?}",
+        results.unused_component_props
     );
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -737,8 +737,9 @@ pub struct CachedModule {
     /// Whether the module had an unknowable-key provide. Round-trips so the
     /// `unprovided-inject` project-wide abstain holds on warm-cache loads.
     pub has_dynamic_provide: bool,
-    /// Vue `<script setup>` `defineProps` declared props. Round-trips so the
-    /// `unused-component-prop` detector sees them on warm-cache loads.
+    /// Vue `<script setup>` `defineProps` and Svelte 5 `$props()` declared props.
+    /// Round-trips so the `unused-component-prop` detector sees them on
+    /// warm-cache loads.
     pub component_props: Vec<fallow_types::extract::ComponentProp>,
     /// Whether the template spreads `$attrs`/`$props`/`props` or the
     /// `defineProps` return is rest-destructured. Round-trips for the abstain.

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -700,11 +700,10 @@ fn merge_script_into_module(input: &mut SfcScriptMergeInput<'_>) {
         merge_vue_props_emits_into(input, &parser_return.program);
     }
 
-    // Svelte 5 `$props()` rune harvesting. Groundwork for the W2.2 dead-event /
-    // template-root crediting; this unit ships no detector for Svelte props
-    // (the compiler + eslint cover single-file prop deadness). `$props` is an
-    // instance-only rune, so harvest ONLY the template-visible instance script,
-    // never the module script (`<script context="module">` / `<script module>`).
+    // Svelte 5 `$props()` rune harvesting for `unused-component-prop`. `$props`
+    // is an instance-only rune, so harvest ONLY the template-visible instance
+    // script, never the module script (`<script context="module">` /
+    // `<script module>`).
     if input.kind == SfcKind::Svelte && is_template_visible_script(input.kind, input.script) {
         merge_svelte_props_into(
             input.combined,

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -485,7 +485,7 @@ fn check_unrendered_component(
     None
 }
 
-/// Check if the position is on an unused Vue component prop anchor.
+/// Check if the position is on an unused component prop anchor.
 #[expect(
     clippy::cast_possible_truncation,
     reason = "prop name lengths are bounded by source size"

--- a/crates/types/src/envelope.rs
+++ b/crates/types/src/envelope.rs
@@ -111,7 +111,7 @@ pub struct CheckSummary {
     /// Vue/Svelte components reachable but rendered nowhere in the project.
     #[serde(default)]
     pub unrendered_components: usize,
-    /// Vue `<script setup>` props referenced nowhere inside their own SFC.
+    /// Vue, Svelte, or React props referenced nowhere inside their own component.
     #[serde(default)]
     pub unused_component_props: usize,
     /// Vue `<script setup>` emits emitted nowhere inside their own SFC.

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -165,14 +165,15 @@ pub struct ModuleInfo {
     /// Vue/Svelte SFC that some file actually imports-and-uses, distinguishing it
     /// from a component reachable only through a barrel re-export.
     pub referenced_import_bindings: Vec<String>,
-    /// Vue `<script setup>` `defineProps` declared props. Consumed by the
-    /// `unused-component-prop` detector to flag a prop referenced nowhere in its
-    /// own SFC. Each entry carries `used_in_script` / `used_in_template`.
+    /// Vue `<script setup>` `defineProps` and Svelte 5 `$props()` declared
+    /// props. Consumed by the `unused-component-prop` detector to flag a prop
+    /// referenced nowhere in its own SFC. Each entry carries `used_in_script` /
+    /// `used_in_template`.
     pub component_props: Vec<ComponentProp>,
     /// `true` when the template spreads the whole props/attrs object
-    /// (`v-bind="$attrs"` / `v-bind="$props"` / `v-bind="props"`) or the
-    /// `defineProps` return is destructured with a rest element. Either form can
-    /// consume a prop indirectly, so the detector abstains on the whole file.
+    /// (`v-bind="$attrs"` / `v-bind="$props"` / `v-bind="props"`) or the props
+    /// return is destructured with a rest element. Either form can consume a prop
+    /// indirectly, so the detector abstains on the whole file.
     pub has_props_attrs_fallthrough: bool,
     /// `true` when the SFC calls `defineExpose(...)`. A prop may be re-exposed,
     /// so the detector conservatively abstains on the whole file.
@@ -180,10 +181,10 @@ pub struct ModuleInfo {
     /// `true` when the SFC calls `defineModel(...)`. Two-way model props are out
     /// of scope for v1, so the detector abstains on the whole file.
     pub has_define_model: bool,
-    /// `true` when `defineProps` was called with an unharvestable argument (a
-    /// type-reference type argument such as `defineProps<Props>()` whose names
-    /// require cross-file type resolution). The detector abstains on the whole
-    /// file so a prop is never falsely flagged.
+    /// `true` when props were declared through an unharvestable shape, such as a
+    /// Vue type-reference argument or an opaque Svelte `$props()` destructure.
+    /// The detector abstains on the whole file so a prop is never falsely
+    /// flagged.
     pub has_unharvestable_props: bool,
     /// Vue `<script setup>` `defineEmits` declared events. Consumed by the
     /// `unused-component-emit` detector to flag an event emitted nowhere in its
@@ -1386,18 +1387,18 @@ pub struct DiKeySite {
     pub span_start: u32,
 }
 
-/// A Vue `<script setup>` `defineProps` declared prop, harvested from the
-/// runtime object form (`defineProps({ foo: {...} })`) or the inline TS literal
-/// form (`defineProps<{ foo: T }>()`). `used_in_script` / `used_in_template`
-/// are set during extraction; the `unused-component-prop` detector flags a prop
-/// where neither is true. See `harvest_define_props` in `sfc.rs`.
+/// A component prop declared by Vue `<script setup>` `defineProps` or Svelte 5
+/// `$props()`. `used_in_script` / `used_in_template` are set during extraction;
+/// the `unused-component-prop` detector flags a prop where neither is true. See
+/// `harvest_define_props` and `harvest_svelte_props` in `sfc_props.rs`.
 #[derive(Debug, Clone, bitcode::Encode, bitcode::Decode)]
 pub struct ComponentProp {
     /// The declared prop name.
     pub name: String,
     /// The template/script-visible local binding name: the destructure alias for
-    /// `const { name: alias } = defineProps()`, otherwise the prop name itself.
-    /// A renamed prop is read through this local, so usage must be checked against
+    /// `const { name: alias } = defineProps()` or
+    /// `let { name: alias } = $props()`, otherwise the prop name itself. A
+    /// renamed prop is read through this local, so usage must be checked against
     /// it, not the declared name.
     pub local: String,
     /// Start byte offset of the prop declaration (anchors the finding).

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -316,8 +316,8 @@ pub struct AnalysisResults {
     /// carries a typed `actions` array natively. Default severity is `warn`.
     #[serde(default)]
     pub dynamic_segment_name_conflicts: Vec<DynamicSegmentNameConflictFinding>,
-    /// Vue `<script setup>` `defineProps` props referenced nowhere in their own
-    /// SFC (neither `<script>` nor `<template>`). Wrapped in
+    /// Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props
+    /// referenced nowhere in their own component. Wrapped in
     /// [`UnusedComponentPropFinding`] so each entry carries a typed `actions`
     /// array natively. Default severity is `warn`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1371,17 +1371,17 @@ pub struct UnrenderedComponent {
     pub col: u32,
 }
 
-/// A Vue `<script setup>` `defineProps` declared prop that is referenced NOWHERE
-/// inside its own single-file component (neither `<script>` nor `<template>`).
-/// Single-file finding, zero-FP doctrine: the whole file abstains on any
-/// fallthrough / expose / model / unharvestable-type signal.
+/// A Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, or React declared
+/// prop that is referenced NOWHERE inside its own component. Single-component
+/// finding, zero-FP doctrine: the component abstains on any opaque public or
+/// fallthrough signal.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct UnusedComponentProp {
-    /// The `.vue` SFC declaring the unused prop.
+    /// The component file declaring the unused prop.
     #[serde(serialize_with = "serde_path::serialize")]
     pub path: PathBuf,
-    /// The component name (the `.vue` file stem).
+    /// The component name.
     pub component_name: String,
     /// The declared prop name that is never referenced.
     pub prop_name: String,

--- a/crates/types/src/suppress.rs
+++ b/crates/types/src/suppress.rs
@@ -120,9 +120,9 @@ pub enum IssueKind {
     /// A component defined in the project that is exported but never rendered
     /// (no JSX usage) anywhere across the analyzed project.
     UnrenderedComponent,
-    /// A Vue `<script setup>` `defineProps` declared prop that is referenced
-    /// NOWHERE inside its own single-file component (neither `<script>` nor
-    /// `<template>`). Single-file dead-input direction.
+    /// A Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, or React
+    /// declared prop that is referenced NOWHERE inside its own component.
+    /// Single-component dead-input direction.
     UnusedComponentProp,
     /// A Vue `<script setup>` `defineEmits` declared event that is EMITTED
     /// nowhere inside its own single-file component (no `emit('<name>')` call).

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -683,7 +683,7 @@
           "items": {
             "$ref": "#/definitions/UnusedComponentPropFinding"
           },
-          "description": "Vue `<script setup>` `defineProps` props referenced nowhere in their own\nSFC (neither `<script>` nor `<template>`). Wrapped in\n[`UnusedComponentPropFinding`] so each entry carries a typed `actions`\narray natively. Default severity is `warn`."
+          "description": "Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props\nreferenced nowhere in their own component. Wrapped in\n[`UnusedComponentPropFinding`] so each entry carries a typed `actions`\narray natively. Default severity is `warn`."
         },
         "unused_component_emits": {
           "type": "array",
@@ -1144,7 +1144,7 @@
           "items": {
             "$ref": "#/definitions/UnusedComponentPropFinding"
           },
-          "description": "Vue `<script setup>` `defineProps` props referenced nowhere in their own\nSFC (neither `<script>` nor `<template>`). Wrapped in\n[`UnusedComponentPropFinding`] so each entry carries a typed `actions`\narray natively. Default severity is `warn`."
+          "description": "Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props\nreferenced nowhere in their own component. Wrapped in\n[`UnusedComponentPropFinding`] so each entry carries a typed `actions`\narray natively. Default severity is `warn`."
         },
         "unused_component_emits": {
           "type": "array",
@@ -5044,7 +5044,7 @@
         },
         "unused_component_props": {
           "type": "integer",
-          "description": "Vue `<script setup>` props referenced nowhere inside their own SFC."
+          "description": "Vue, Svelte, or React props referenced nowhere inside their own component."
         },
         "unused_component_emits": {
           "type": "integer",
@@ -5902,7 +5902,7 @@
           "items": {
             "$ref": "#/definitions/UnusedComponentPropFinding"
           },
-          "description": "Vue `<script setup>` `defineProps` props referenced nowhere in their own\nSFC (neither `<script>` nor `<template>`). Wrapped in\n[`UnusedComponentPropFinding`] so each entry carries a typed `actions`\narray natively. Default severity is `warn`."
+          "description": "Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props\nreferenced nowhere in their own component. Wrapped in\n[`UnusedComponentPropFinding`] so each entry carries a typed `actions`\narray natively. Default severity is `warn`."
         },
         "unused_component_emits": {
           "type": "array",
@@ -13465,11 +13465,11 @@
       "properties": {
         "path": {
           "type": "string",
-          "description": "The `.vue` SFC declaring the unused prop."
+          "description": "The component file declaring the unused prop."
         },
         "component_name": {
           "type": "string",
-          "description": "The component name (the `.vue` file stem)."
+          "description": "The component name."
         },
         "prop_name": {
           "type": "string",

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -1132,8 +1132,8 @@ route_collisions?: RouteCollisionFinding[]
  */
 dynamic_segment_name_conflicts?: DynamicSegmentNameConflictFinding[]
 /**
- * Vue `<script setup>` `defineProps` props referenced nowhere in their own
- * SFC (neither `<script>` nor `<template>`). Wrapped in
+ * Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props
+ * referenced nowhere in their own component. Wrapped in
  * [`UnusedComponentPropFinding`] so each entry carries a typed `actions`
  * array natively. Default severity is `warn`.
  */
@@ -1303,7 +1303,7 @@ unprovided_injects?: number
  */
 unrendered_components?: number
 /**
- * Vue `<script setup>` props referenced nowhere inside their own SFC.
+ * Vue, Svelte, or React props referenced nowhere inside their own component.
  */
 unused_component_props?: number
 /**
@@ -2976,11 +2976,11 @@ introduced?: (AuditIntroduced | null)
  */
 export interface UnusedComponentPropFinding {
 /**
- * The `.vue` SFC declaring the unused prop.
+ * The component file declaring the unused prop.
  */
 path: string
 /**
- * The component name (the `.vue` file stem).
+ * The component name.
  */
 component_name: string
 /**
@@ -7227,8 +7227,8 @@ route_collisions?: RouteCollisionFinding[]
  */
 dynamic_segment_name_conflicts?: DynamicSegmentNameConflictFinding[]
 /**
- * Vue `<script setup>` `defineProps` props referenced nowhere in their own
- * SFC (neither `<script>` nor `<template>`). Wrapped in
+ * Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props
+ * referenced nowhere in their own component. Wrapped in
  * [`UnusedComponentPropFinding`] so each entry carries a typed `actions`
  * array natively. Default severity is `warn`.
  */

--- a/npm/fallow/skills/fallow/SKILL.md
+++ b/npm/fallow/skills/fallow/SKILL.md
@@ -162,7 +162,7 @@ Run `fallow <command> --help` for the full flag list per command (see also refer
 | `misplaced-directive` | - | - | `// fallow-ignore-next-line misplaced-directive` | "use client" / "use server" directive is not in the leading position and is ignored; Requires the project to declare next |
 | `unprovided-inject` | `--unprovided-injects` | - | `// fallow-ignore-next-line unprovided-inject` | inject() / getContext() reads a key that no provide() / setContext() supplies |
 | `unrendered-component` | `--unrendered-components` | - | `// fallow-ignore-next-line unrendered-component` | A Vue / Svelte component is reachable through a barrel but rendered nowhere |
-| `unused-component-prop` | `--unused-component-props` | - | `// fallow-ignore-next-line unused-component-prop` | A Vue defineProps prop or React component prop is referenced nowhere in its own component |
+| `unused-component-prop` | `--unused-component-props` | - | `// fallow-ignore-next-line unused-component-prop` | A Vue, Svelte, or React component prop is referenced nowhere in its own component |
 | `unused-component-emit` | `--unused-component-emits` | - | `// fallow-ignore-next-line unused-component-emit` | A Vue <script setup> defineEmits event is emitted nowhere in its own component |
 | `unused-component-input` | `--unused-component-inputs` | - | `// fallow-ignore-next-line unused-component-input` | An Angular @Input() / signal input() / model() is read nowhere in its own component (class body or template); needs `@angular/core` dep |
 | `unused-component-output` | `--unused-component-outputs` | - | `// fallow-ignore-next-line unused-component-output` | An Angular @Output() / signal output() is emitted (.emit()) nowhere in its own component; needs `@angular/core` dep |

--- a/npm/fallow/skills/fallow/references/cli-reference.md
+++ b/npm/fallow/skills/fallow/references/cli-reference.md
@@ -64,7 +64,7 @@ Common global flags for this command: [`--format`](#global-flags), [`--quiet`](#
 | `--unused-store-members` | Unused Pinia store members |
 | `--unprovided-injects` | inject() / getContext() reads a key that no provide() / setContext() supplies |
 | `--unrendered-components` | A Vue / Svelte component is reachable through a barrel but rendered nowhere |
-| `--unused-component-props` | A Vue defineProps prop or React component prop is referenced nowhere in its own component |
+| `--unused-component-props` | A Vue, Svelte, or React component prop is referenced nowhere in its own component |
 | `--unused-component-emits` | A Vue <script setup> defineEmits event is emitted nowhere in its own component |
 | `--unused-component-inputs` | An Angular @Input() / signal input() / model() is read nowhere in its own component (class body or template); needs `@angular/core` dep |
 | `--unused-component-outputs` | An Angular @Output() / signal output() is emitted (.emit()) nowhere in its own component; needs `@angular/core` dep |

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -1132,8 +1132,8 @@ route_collisions?: RouteCollisionFinding[]
  */
 dynamic_segment_name_conflicts?: DynamicSegmentNameConflictFinding[]
 /**
- * Vue `<script setup>` `defineProps` props referenced nowhere in their own
- * SFC (neither `<script>` nor `<template>`). Wrapped in
+ * Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props
+ * referenced nowhere in their own component. Wrapped in
  * [`UnusedComponentPropFinding`] so each entry carries a typed `actions`
  * array natively. Default severity is `warn`.
  */
@@ -1303,7 +1303,7 @@ unprovided_injects?: number
  */
 unrendered_components?: number
 /**
- * Vue `<script setup>` props referenced nowhere inside their own SFC.
+ * Vue, Svelte, or React props referenced nowhere inside their own component.
  */
 unused_component_props?: number
 /**
@@ -2976,11 +2976,11 @@ introduced?: (AuditIntroduced | null)
  */
 export interface UnusedComponentPropFinding {
 /**
- * The `.vue` SFC declaring the unused prop.
+ * The component file declaring the unused prop.
  */
 path: string
 /**
- * The component name (the `.vue` file stem).
+ * The component name.
  */
 component_name: string
 /**
@@ -7227,8 +7227,8 @@ route_collisions?: RouteCollisionFinding[]
  */
 dynamic_segment_name_conflicts?: DynamicSegmentNameConflictFinding[]
 /**
- * Vue `<script setup>` `defineProps` props referenced nowhere in their own
- * SFC (neither `<script>` nor `<template>`). Wrapped in
+ * Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, and React props
+ * referenced nowhere in their own component. Wrapped in
  * [`UnusedComponentPropFinding`] so each entry carries a typed `actions`
  * array natively. Default severity is `warn`.
  */

--- a/schema.json
+++ b/schema.json
@@ -1047,7 +1047,7 @@
           "default": "error"
         },
         "unused-component-props": {
-          "description": "Vue `<script setup>` `defineProps` declared prop referenced nowhere\ninside its own single-file component (neither `<script>` nor\n`<template>`). The single-file dead-input direction. Defaults to `warn`,\nnot `error`: a prop can be part of a deliberately-stable public component\nAPI, so analyzer confidence is lower; warn encodes that without failing\nCI.",
+          "description": "Vue `<script setup>` `defineProps`, Svelte 5 `$props()`, or React\ndeclared prop referenced nowhere inside its own component. The\nsingle-component dead-input direction. Defaults to `warn`, not `error`: a\nprop can be part of a deliberately-stable public component API, so\nanalyzer confidence is lower; warn encodes that without failing CI.",
           "$ref": "#/$defs/Severity",
           "default": "error"
         },

--- a/tests/fixtures/unused-svelte-component-prop-no-dep/package.json
+++ b/tests/fixtures/unused-svelte-component-prop-no-dep/package.json
@@ -1,0 +1,1 @@
+{ "name": "unused-svelte-component-prop-no-dep-fixture", "version": "0.0.0", "private": true, "main": "src/main.ts", "dependencies": {} }

--- a/tests/fixtures/unused-svelte-component-prop-no-dep/src/DeadProp.svelte
+++ b/tests/fixtures/unused-svelte-component-prop-no-dep/src/DeadProp.svelte
@@ -1,0 +1,5 @@
+<script>
+  let { deadProp } = $props();
+</script>
+
+<p>Dead prop component</p>

--- a/tests/fixtures/unused-svelte-component-prop-no-dep/src/main.ts
+++ b/tests/fixtures/unused-svelte-component-prop-no-dep/src/main.ts
@@ -1,0 +1,3 @@
+import DeadProp from "./DeadProp.svelte";
+
+new DeadProp({ target: document.body });

--- a/tests/fixtures/unused-svelte-component-prop/package.json
+++ b/tests/fixtures/unused-svelte-component-prop/package.json
@@ -1,0 +1,1 @@
+{ "name": "unused-svelte-component-prop-fixture", "version": "0.0.0", "private": true, "main": "src/main.ts", "dependencies": { "svelte": "^5.0.0" } }

--- a/tests/fixtures/unused-svelte-component-prop/src/App.svelte
+++ b/tests/fixtures/unused-svelte-component-prop/src/App.svelte
@@ -1,0 +1,13 @@
+<script>
+  import ComputedAbstain from "./ComputedAbstain.svelte";
+  import DeadProp from "./DeadProp.svelte";
+  import RestAbstain from "./RestAbstain.svelte";
+  import ScriptUsed from "./ScriptUsed.svelte";
+  import TemplateUsed from "./TemplateUsed.svelte";
+</script>
+
+<DeadProp deadProp="unused" />
+<ScriptUsed usedScript="script" />
+<TemplateUsed shown="template" />
+<RestAbstain forwarded="forwarded" other="opaque" />
+<ComputedAbstain computed="computed" />

--- a/tests/fixtures/unused-svelte-component-prop/src/ComputedAbstain.svelte
+++ b/tests/fixtures/unused-svelte-component-prop/src/ComputedAbstain.svelte
@@ -1,0 +1,8 @@
+<script>
+  const key = "dynamic";
+  let { computed, [key]: dynamic } = $props();
+
+  console.log(dynamic);
+</script>
+
+<p>Computed abstain component</p>

--- a/tests/fixtures/unused-svelte-component-prop/src/DeadProp.svelte
+++ b/tests/fixtures/unused-svelte-component-prop/src/DeadProp.svelte
@@ -1,0 +1,5 @@
+<script>
+  let { deadProp } = $props();
+</script>
+
+<p>Dead prop component</p>

--- a/tests/fixtures/unused-svelte-component-prop/src/RestAbstain.svelte
+++ b/tests/fixtures/unused-svelte-component-prop/src/RestAbstain.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { forwarded, ...rest } = $props();
+
+  console.log(rest);
+</script>
+
+<p>Rest abstain component</p>

--- a/tests/fixtures/unused-svelte-component-prop/src/ScriptUsed.svelte
+++ b/tests/fixtures/unused-svelte-component-prop/src/ScriptUsed.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { usedScript } = $props();
+
+  console.log(usedScript);
+</script>
+
+<p>Script usage component</p>

--- a/tests/fixtures/unused-svelte-component-prop/src/TemplateUsed.svelte
+++ b/tests/fixtures/unused-svelte-component-prop/src/TemplateUsed.svelte
@@ -1,0 +1,5 @@
+<script>
+  let { shown } = $props();
+</script>
+
+<p>{shown}</p>

--- a/tests/fixtures/unused-svelte-component-prop/src/main.ts
+++ b/tests/fixtures/unused-svelte-component-prop/src/main.ts
@@ -1,0 +1,3 @@
+import App from "./App.svelte";
+
+new App({ target: document.body });


### PR DESCRIPTION
Adds Svelte 5 `$props()` support to the existing `unused-component-prop` finding.\n\nThe implementation reuses the current finding shape and suppression token, with conservative abstains for opaque prop usage.