### PR TITLE
docs(benchmarks): refresh comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,39 +932,41 @@ Fallow is not an AI assistant. It is the deterministic codebase intelligence lay
 
 ## Performance
 
-Benchmarked on real open-source projects, cold runs (no cache) so both tools work from scratch, median of 5 runs with 2 warmups. The dead-code table uses fallow 2.91.0, knip 5.87.0 and 6.6.1, Apple M5, Node 22. The duplication table uses fallow 2.99.0, jscpd 5.0.10, Apple M5, Node 24. Fastest tool per row in bold.
+Benchmarked on real open-source projects, cold runs (no cache) so both tools work from scratch, median of 5 runs with 2 warmups. The benchmark scripts print exact tool and environment versions for reproducible local runs. Fastest tool per row in bold.
 
 ### Dead code: fallow vs knip
 
-| Project | Files | fallow | knip v5 | knip v6 |
-|:--------|------:|-------:|--------:|--------:|
-| [zod](https://github.com/colinhacks/zod) | 174 | **35ms** | 655ms | 328ms |
-| [preact](https://github.com/preactjs/preact) | 244 | **49ms** | 822ms | 2.05s |
-| [fastify](https://github.com/fastify/fastify) | 286 | **50ms** | 890ms | 225ms |
-| [vue/core](https://github.com/vuejs/core) | 522 | **142ms** | incomplete¹ | incomplete¹ |
-| [TanStack/query](https://github.com/TanStack/query) | 901 | **447ms** | 2.87s | 1.19s |
-| [vite](https://github.com/vitejs/vite) | 1,420 | **897ms** | incomplete¹ | incomplete¹ |
-| [astro](https://github.com/withastro/astro) | 2,859 | 2.19s | 3.74s | **1.29s** |
-| [svelte](https://github.com/sveltejs/svelte) | 3,337 | **779ms** | 2.80s | 978ms |
-| [TypeScript](https://github.com/microsoft/TypeScript) | 38,146 | 2.19s | 3.03s | **804ms** |
-| [next.js](https://github.com/vercel/next.js) | 20,552 | **3.35s** | incomplete¹ | incomplete¹ |
+| Project | Files | fallow | knip | Faster |
+|:--------|------:|-------:|-----:|-------:|
+| [astro](https://github.com/withastro/astro) | 2,859 | 4.10s | **1.38s** | knip 3.0x |
+| [fastify](https://github.com/fastify/fastify) | 286 | **80ms** | 207ms | fallow 2.6x |
+| [next.js](https://github.com/vercel/next.js) | 20,558 | 3.56s | **2.26s** | knip 1.6x |
+| [preact](https://github.com/preactjs/preact) | 244 | **105ms** | 2.29s | fallow 21.8x |
+| [TanStack/query](https://github.com/TanStack/query) | 901 | **634ms** | 1.09s | fallow 1.7x |
+| [svelte](https://github.com/sveltejs/svelte) | 3,337 | 761ms | **697ms** | knip 1.1x |
+| [TypeScript](https://github.com/microsoft/TypeScript) | 38,146 | 2.63s | **830ms** | knip 3.2x |
+| [vite](https://github.com/vitejs/vite) | 1,420 | **885ms** | 2.21s | fallow 2.5x |
+| [vue/core](https://github.com/vuejs/core) | 522 | **164ms** | 505ms | fallow 3.1x |
+| [zod](https://github.com/colinhacks/zod) | 174 | **59ms** | 269ms | fallow 4.6x |
 
-fallow is fastest on small-to-medium projects (roughly 5-18x faster than knip v5 and 2.7-9x than knip v6; preact is an outlier where knip v6 happens to be slow). On large projects, knip v6's Oxc-based parser is competitive or faster (astro, TypeScript), there, fallow's edge is doing more in one tool, not raw dead-code speed. fallow's persistent cache makes repeat (warm) runs faster again; the table uses the conservative cold numbers.
+fallow is faster on smaller projects in this set, while current knip is faster on several larger framework and compiler repositories. fallow's edge is doing more in one tool, not always raw dead-code speed. fallow's persistent cache makes repeat (warm) runs faster again; the table uses the conservative cold numbers.
 
-¹ knip loads and executes a project's config and JSON files to read plugin settings, which is its design and works well on apps. A few framework monorepos trip that up where fallow (purely syntactic, no config execution) completes with no setup: **vite**, a workspace `package.json` carries a UTF-8 BOM that knip's `JSON.parse` rejects (a robustness gap, reportable upstream); **vue/core**, a private `sfc-playground/vite.config.ts` fails to load; **next.js**, the framework's own monorepo needs a build for its jest config and per-workspace entry config for its `dist`-published packages (this is the framework source, not a Next.js app, which is what knip's Next.js plugin targets). All are fixable with knip config; the point is fallow needs none.
+### Duplication: fallow vs jscpd
 
-### Duplication: fallow vs jscpd v5
+| Project | Files | fallow | jscpd | Faster |
+|:--------|------:|-------:|------:|-------:|
+| [astro](https://github.com/withastro/astro) | 2,859 | 750ms | **196ms** | jscpd 3.8x |
+| [fastify](https://github.com/fastify/fastify) | 286 | 142ms | **73ms** | jscpd 1.9x |
+| [next.js](https://github.com/vercel/next.js) | 20,552 | 3.13s | **900ms** | jscpd 3.5x |
+| [preact](https://github.com/preactjs/preact) | 244 | 90ms | **54ms** | jscpd 1.7x |
+| [TanStack/query](https://github.com/TanStack/query) | 901 | 174ms | **63ms** | jscpd 2.8x |
+| [svelte](https://github.com/sveltejs/svelte) | 3,337 | 371ms | **180ms** | jscpd 2.1x |
+| [TypeScript](https://github.com/microsoft/TypeScript) | 38,146 | 40.26s | **5.06s** | jscpd 8.0x |
+| [vite](https://github.com/vitejs/vite) | 1,420 | 217ms | **77ms** | jscpd 2.8x |
+| [vue/core](https://github.com/vuejs/core) | 522 | 171ms | **80ms** | jscpd 2.1x |
+| [zod](https://github.com/colinhacks/zod) | 174 | 84ms | **57ms** | jscpd 1.5x |
 
-| Project | Files | fallow | jscpd v5 | Faster |
-|:--------|------:|-------:|---------:|-------:|
-| [preact](https://github.com/preactjs/preact) | 244 | 83ms | **51ms** | jscpd 1.6x |
-| [fastify](https://github.com/fastify/fastify) | 286 | 135ms | **66ms** | jscpd 2.0x |
-| [vue/core](https://github.com/vuejs/core) | 522 | 168ms | **78ms** | jscpd 2.2x |
-| [TanStack/query](https://github.com/TanStack/query) | 901 | 178ms | **57ms** | jscpd 3.1x |
-| [svelte](https://github.com/sveltejs/svelte) | 3,337 | 383ms | **170ms** | jscpd 2.3x |
-| [next.js](https://github.com/vercel/next.js) | 20,552 | 2.62s | **775ms** | jscpd 3.4x |
-
-jscpd v5's Rust rewrite is now faster for raw duplication scanning on these projects. fallow's duplication checker remains part of the broader audit flow, alongside dead code, dependency, complexity, CSS, framework, and security checks.
+jscpd's Rust rewrite is now faster for raw duplication scanning on these projects. fallow's duplication checker remains part of the broader audit flow, alongside dead code, dependency, complexity, CSS, framework, and security checks.
 
 No TypeScript compiler, no Node.js runtime needed to analyze your code. [Fallow vs linters](https://docs.fallow.tools/explanations/fallow-vs-linters) | [Reproduce benchmarks](https://github.com/fallow-rs/fallow/tree/main/benchmarks)
 

--- a/benchmarks/bench-ci.sh
+++ b/benchmarks/bench-ci.sh
@@ -44,7 +44,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ---------------------------------------------------------------------------
-# Project list — same as download-fixtures.mjs and conformance/run-all.sh
+# Project list, same as download-fixtures.mjs and conformance/run-all.sh
 # ---------------------------------------------------------------------------
 
 PROJECTS=(

--- a/benchmarks/bench-circular.mjs
+++ b/benchmarks/bench-circular.mjs
@@ -48,7 +48,7 @@ const dpdmVersion = hasDpdm
   : "n/a";
 const rustVersion = spawnSync("rustc", ["--version"], { stdio: "pipe" }).stdout?.toString().trim();
 
-console.log(`\n=== Fallow vs madge/dpdm — Circular Dependency Detection ===\n`);
+console.log(`\n=== Fallow vs madge/dpdm: Circular Dependency Detection ===\n`);
 printEnvironment();
 console.log(`Tools:`);
 console.log(`  fallow dead-code --circular-deps  ${fallowVersion}`);
@@ -257,7 +257,7 @@ function benchmarkProject(name, dir) {
       Mean: fmt(fs.mean),
       Median: fmt(fs.median),
       Max: fmt(fs.max),
-      Speedup: "—",
+      Speedup: "--",
       Memory: fmtMem(fallowRss),
       Cycles: fallowCycles,
     },

--- a/benchmarks/bench-dupes.mjs
+++ b/benchmarks/bench-dupes.mjs
@@ -13,6 +13,15 @@ const runSynthetic = args.includes("--synthetic") || !hasFilter;
 const runRealWorld = args.includes("--real-world") || !hasFilter;
 const RUNS = parseInt(args.find((a) => a.startsWith("--runs="))?.split("=")[1] ?? "5");
 const WARMUP = parseInt(args.find((a) => a.startsWith("--warmup="))?.split("=")[1] ?? "2");
+const projectsArg = args.find((a) => a.startsWith("--projects="))?.split("=")[1];
+const projectFilter = projectsArg
+  ? new Set(
+      projectsArg
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+  : null;
 
 console.log("Building fallow (release)...");
 const buildResult = spawnSync("cargo", ["build", "--release"], {
@@ -293,8 +302,10 @@ if (runSynthetic) {
     const order = ["tiny", "small", "medium", "large", "xlarge"];
     for (const p of readdirSync(d)
       .filter((x) => existsSync(join(d, x, "package.json")))
-      .toSorted((a, b) => order.indexOf(a) - order.indexOf(b)))
+      .toSorted((a, b) => order.indexOf(a) - order.indexOf(b))) {
+      if (projectFilter && !projectFilter.has(p)) continue;
       results.push(benchmarkProject(p, join(d, p)));
+    }
   }
 }
 
@@ -306,8 +317,10 @@ if (runRealWorld) {
     console.log("--- Real-World Projects (Duplication) ---\n");
     for (const p of readdirSync(d)
       .filter((x) => existsSync(join(d, x, "package.json")))
-      .toSorted())
+      .toSorted()) {
+      if (projectFilter && !projectFilter.has(p)) continue;
       results.push(benchmarkProject(p, join(d, p)));
+    }
   }
 }
 
@@ -317,7 +330,7 @@ if (results.length > 0) {
     results.map((r) => ({
       Project: r.name,
       Files: r.files,
-      "Fallow (median)": fmt(r.fallow.median),
+      "Fallow cold (median)": fmt(r.fallow.median),
       "jscpd (median)": fmt(r.jscpd.median),
       "Faster tool": r.relative,
       "Fallow RSS": fmtMem(r.fPeakRss),

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -35,29 +35,21 @@ if (buildResult.status !== 0) {
 }
 const fallowBin = join(rootDir, "target", "release", "fallow");
 const knipBin = join(__dirname, "node_modules", ".bin", "knip");
-const knip6Bin = join(__dirname, "knip6", "node_modules", ".bin", "knip");
 if (!existsSync(knipBin)) {
-  console.error("knip v5 not found. Run: cd benchmarks && npm install");
+  console.error("knip not found. Run: cd benchmarks && npm install");
   process.exit(1);
-}
-const hasKnip6 = existsSync(knip6Bin);
-if (!hasKnip6) {
-  console.warn("knip v6 not found. Run: cd benchmarks/knip6 && npm install knip@6");
 }
 
 const fallowVersion = spawnSync(fallowBin, ["--version"], { stdio: "pipe" })
   .stdout?.toString()
   .trim();
 const knipVersion = spawnSync(knipBin, ["--version"], { stdio: "pipe" }).stdout?.toString().trim();
-const knip6Version = hasKnip6
-  ? spawnSync(knip6Bin, ["--version"], { stdio: "pipe" }).stdout?.toString().trim()
-  : null;
 const rustVersion = spawnSync("rustc", ["--version"], { stdio: "pipe" }).stdout?.toString().trim();
 
 console.log(`\n=== Fallow vs Knip Benchmark Suite ===\n`);
 printEnvironment();
 console.log(
-  `Tools:\n  fallow   ${fallowVersion}\n  knip v5  ${knipVersion}${knip6Version ? `\n  knip v6  ${knip6Version}` : ""}\nConfig: ${RUNS} runs, ${WARMUP} warmup\n`,
+  `Tools:\n  fallow   ${fallowVersion}\n  knip     ${knipVersion}\nConfig: ${RUNS} runs, ${WARMUP} warmup\n`,
 );
 
 function printEnvironment() {
@@ -134,7 +126,7 @@ function timeRunWithMemory(cmd, cmdArgs, cwd) {
     if (match) peakRssBytes = parseInt(match[1]);
   }
 
-  // stdout for fallow comes from the time wrapper's child process — it's on stdout
+  // stdout for fallow comes from the time wrapper child process.
   const stdout = result.stdout?.toString() ?? "";
 
   return { elapsed, status: result.status, signal: result.signal, stdout, stderr, peakRssBytes };
@@ -215,6 +207,18 @@ function fmtMem(bytes) {
   return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`;
 }
 
+function formatMultiplier(value) {
+  return `${value.toFixed(1)}x`;
+}
+
+function relativeSpeed(fallowMedian, comparisonMedian, comparisonName) {
+  if (fallowMedian <= comparisonMedian) {
+    return `fallow ${formatMultiplier(comparisonMedian / fallowMedian)}`;
+  }
+
+  return `${comparisonName} ${formatMultiplier(fallowMedian / comparisonMedian)}`;
+}
+
 function clearFallowCache(dir) {
   const cacheDir = join(dir, ".fallow");
   if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });
@@ -224,26 +228,21 @@ function benchmarkProject(name, dir) {
   const files = countSourceFiles(dir);
   console.log(`### ${name} (${files} source files)\n`);
 
-  // --- Cold cache (no cache) ---
-  const fArgsCold = ["check", "--quiet", "--format", "json", "--no-cache"];
+  // Cold cache, no persisted fallow cache.
+  const fArgsCold = ["dead-code", "--quiet", "--format", "json", "--no-cache"];
   const kArgs = ["--reporter", "json"];
   for (let i = 0; i < WARMUP; i++) {
     timeRun(fallowBin, fArgsCold, dir);
     timeRun(knipBin, kArgs, dir);
-    if (hasKnip6) timeRun(knip6Bin, kArgs, dir);
   }
 
   const fTimesCold = [],
-    kTimes = [],
-    k6Times = [];
+    kTimes = [];
   let fIssues = "?",
     kIssues = "error",
-    k6Issues = "error",
     fPeakRss = 0,
-    kPeakRss = 0,
-    k6PeakRss = 0;
-  let kErrorReason = null,
-    k6ErrorReason = null;
+    kPeakRss = 0;
+  let kErrorReason = null;
 
   for (let i = 0; i < RUNS; i++) {
     const fr = timeRunWithMemory(fallowBin, fArgsCold, dir);
@@ -265,26 +264,12 @@ function benchmarkProject(name, dir) {
     } else if (kErrorReason == null) {
       kErrorReason = kSummary.error;
     }
-    if (hasKnip6) {
-      const k6r = timeRunWithMemory(knip6Bin, kArgs, dir);
-      const k6Summary = summarizeBenchmarkRun(k6r);
-      if (k6Summary.valid) {
-        k6Times.push(k6r.elapsed);
-        if (k6Issues === "error") {
-          k6Issues = k6Summary.issues;
-          k6PeakRss = k6r.peakRssBytes;
-        }
-      } else if (k6ErrorReason == null) {
-        k6ErrorReason = k6Summary.error;
-      }
-    }
   }
 
-  // --- Warm cache ---
   // Warmup runs below settle the OS file cache + Spotlight indexing of cache.bin
-  // so the first measured warm run isn't penalized vs the cold loop's warmups.
+  // so the first measured warm run is comparable to the cold loop warmups.
   clearFallowCache(dir);
-  const fArgsWarm = ["check", "--quiet", "--format", "json"];
+  const fArgsWarm = ["dead-code", "--quiet", "--format", "json"];
   // Populate cache
   const populate = timeRun(fallowBin, fArgsWarm, dir);
   const populateSummary = summarizeBenchmarkRun(populate);
@@ -307,14 +292,11 @@ function benchmarkProject(name, dir) {
   const fsCold = stats(fTimesCold),
     fsWarm = stats(fTimesWarm);
   const ks = kTimes.length > 0 ? stats(kTimes) : null;
-  const k6s = hasKnip6 && k6Times.length > 0 ? stats(k6Times) : null;
-  const speedupColdV5 = ks ? ks.median / fsCold.median : null;
-  const speedupWarmV5 = ks ? ks.median / fsWarm.median : null;
-  const speedupColdV6 = k6s ? k6s.median / fsCold.median : null;
-  const speedupWarmV6 = k6s ? k6s.median / fsWarm.median : null;
+  const relative = ks ? relativeSpeed(fsCold.median, ks.median, "knip") : "--";
+  const speedupCold = ks ? ks.median / fsCold.median : null;
+  const speedupWarm = ks ? ks.median / fsWarm.median : null;
   const cacheSpeedup = fsCold.median / fsWarm.median;
 
-  const fmtSpeedup = (v) => (v != null ? `${v.toFixed(1)}x` : "--");
   const rows = [
     {
       Tool: "fallow (cold)",
@@ -322,8 +304,7 @@ function benchmarkProject(name, dir) {
       Mean: fmt(fsCold.mean),
       Median: fmt(fsCold.median),
       Max: fmt(fsCold.max),
-      "vs knip v5": fmtSpeedup(speedupColdV5),
-      ...(hasKnip6 ? { "vs knip v6": fmtSpeedup(speedupColdV6) } : {}),
+      Relative: relative,
       Memory: fmtMem(fPeakRss),
       Issues: fIssues,
     },
@@ -333,75 +314,41 @@ function benchmarkProject(name, dir) {
       Mean: fmt(fsWarm.mean),
       Median: fmt(fsWarm.median),
       Max: fmt(fsWarm.max),
-      "vs knip v5": fmtSpeedup(speedupWarmV5),
-      ...(hasKnip6 ? { "vs knip v6": fmtSpeedup(speedupWarmV6) } : {}),
+      Relative: ks ? relativeSpeed(fsWarm.median, ks.median, "knip") : "--",
       Memory: "-",
       Issues: fIssues,
     },
   ];
   if (ks) {
     rows.push({
-      Tool: "knip v5",
+      Tool: "knip",
       Min: fmt(ks.min),
       Mean: fmt(ks.mean),
       Median: fmt(ks.median),
       Max: fmt(ks.max),
-      "vs knip v5": "1.0x",
-      ...(hasKnip6 ? { "vs knip v6": "-" } : {}),
+      Relative: relative,
       Memory: fmtMem(kPeakRss),
       Issues: kIssues,
     });
   } else {
     rows.push({
-      Tool: "knip v5",
+      Tool: "knip",
       Min: "--",
       Mean: "--",
       Median: "--",
       Max: "--",
-      "vs knip v5": "--",
-      ...(hasKnip6 ? { "vs knip v6": "--" } : {}),
+      Relative: "--",
       Memory: "--",
       Issues: kIssues,
     });
-  }
-  if (hasKnip6) {
-    if (k6s) {
-      rows.push({
-        Tool: "knip v6",
-        Min: fmt(k6s.min),
-        Mean: fmt(k6s.mean),
-        Median: fmt(k6s.median),
-        Max: fmt(k6s.max),
-        "vs knip v5": ks ? `${(ks.median / k6s.median).toFixed(1)}x` : "--",
-        "vs knip v6": "1.0x",
-        Memory: fmtMem(k6PeakRss),
-        Issues: k6Issues,
-      });
-    } else {
-      rows.push({
-        Tool: "knip v6",
-        Min: "--",
-        Mean: "--",
-        Median: "--",
-        Max: "--",
-        "vs knip v5": "--",
-        "vs knip v6": "--",
-        Memory: "--",
-        Issues: k6Issues,
-      });
-    }
   }
   console.table(rows);
   console.log(`  Cache speedup: ${cacheSpeedup.toFixed(2)}x (warm vs cold)`);
   console.log(`  fallow cold: [${fTimesCold.map((t) => t.toFixed(0)).join(", ")}]`);
   console.log(`  fallow warm: [${fTimesWarm.map((t) => t.toFixed(0)).join(", ")}]`);
   console.log(
-    `  knip v5:     ${kTimes.length > 0 ? `[${kTimes.map((t) => t.toFixed(0)).join(", ")}]` : `[error — ${kErrorReason ?? kIssues}]`}`,
+    `  knip:        ${kTimes.length > 0 ? `[${kTimes.map((t) => t.toFixed(0)).join(", ")}]` : `[error: ${kErrorReason ?? kIssues}]`}`,
   );
-  if (hasKnip6)
-    console.log(
-      `  knip v6:     ${k6Times.length > 0 ? `[${k6Times.map((t) => t.toFixed(0)).join(", ")}]` : `[error — ${k6ErrorReason ?? k6Issues}]`}`,
-    );
   console.log("");
 
   return {
@@ -410,22 +357,16 @@ function benchmarkProject(name, dir) {
     fallowCold: fsCold,
     fallowWarm: fsWarm,
     knip: ks,
-    knip6: k6s,
-    speedupColdV5,
-    speedupWarmV5,
-    speedupColdV6,
-    speedupWarmV6,
+    relative,
+    speedupCold,
+    speedupWarm,
     cacheSpeedup,
     fIssues,
     kIssues,
-    k6Issues,
     fPeakRss,
     kPeakRss,
-    k6PeakRss,
     kError: !ks,
-    k6Error: !k6s,
     kErrorReason,
-    k6ErrorReason,
   };
 }
 
@@ -465,53 +406,28 @@ if (results.length > 0) {
     results.map((r) => ({
       Project: r.name,
       Files: r.files,
-      "Cold (median)": fmt(r.fallowCold.median),
-      "Warm (median)": fmt(r.fallowWarm.median),
-      "Knip v5 (median)": r.knip ? fmt(r.knip.median) : "error",
-      ...(hasKnip6 ? { "Knip v6 (median)": r.knip6 ? fmt(r.knip6.median) : "error" } : {}),
-      "vs v5 (cold)": r.speedupColdV5 != null ? `${r.speedupColdV5.toFixed(1)}x` : "--",
-      ...(hasKnip6
-        ? { "vs v6 (cold)": r.speedupColdV6 != null ? `${r.speedupColdV6.toFixed(1)}x` : "--" }
-        : {}),
+      "Fallow cold (median)": fmt(r.fallowCold.median),
+      "Fallow warm (median)": fmt(r.fallowWarm.median),
+      "knip (median)": r.knip ? fmt(r.knip.median) : "error",
+      "Faster tool": r.relative,
       "Cache effect": `${r.cacheSpeedup.toFixed(2)}x`,
       "Fallow RSS": fmtMem(r.fPeakRss),
-      "Knip v5 RSS": r.kError ? "--" : fmtMem(r.kPeakRss),
-      ...(hasKnip6 ? { "Knip v6 RSS": r.k6Error ? "--" : fmtMem(r.k6PeakRss) } : {}),
+      "knip RSS": r.kError ? "--" : fmtMem(r.kPeakRss),
     })),
   );
-  const v5Valid = results.filter((r) => r.speedupColdV5 != null);
-  if (v5Valid.length > 0) {
+  const valid = results.filter((r) => r.speedupCold != null);
+  if (valid.length > 0) {
     console.log(
-      `Average speedup vs knip v5 (cold): ${(v5Valid.reduce((s, r) => s + r.speedupColdV5, 0) / v5Valid.length).toFixed(1)}x (${v5Valid.length}/${results.length} projects)`,
+      `Average speedup vs knip (cold): ${(valid.reduce((s, r) => s + r.speedupCold, 0) / valid.length).toFixed(1)}x (${valid.length}/${results.length} projects)`,
     );
     console.log(
-      `Average speedup vs knip v5 (warm): ${(v5Valid.reduce((s, r) => s + r.speedupWarmV5, 0) / v5Valid.length).toFixed(1)}x`,
+      `Average speedup vs knip (warm): ${(valid.reduce((s, r) => s + r.speedupWarm, 0) / valid.length).toFixed(1)}x`,
     );
   }
-  if (hasKnip6) {
-    const v6Valid = results.filter((r) => r.speedupColdV6 != null);
-    if (v6Valid.length > 0) {
-      console.log(
-        `Average speedup vs knip v6 (cold): ${(v6Valid.reduce((s, r) => s + r.speedupColdV6, 0) / v6Valid.length).toFixed(1)}x (${v6Valid.length}/${results.length} projects)`,
-      );
-      console.log(
-        `Average speedup vs knip v6 (warm): ${(v6Valid.reduce((s, r) => s + r.speedupWarmV6, 0) / v6Valid.length).toFixed(1)}x`,
-      );
-    }
-  }
-  const v5ErrorProjects = results.filter((r) => r.kError);
-  if (v5ErrorProjects.length > 0) {
-    console.log(`\nknip v5 errors:`);
-    for (const project of v5ErrorProjects)
-      console.log(`  ${project.name}: ${project.kErrorReason}`);
-  }
-  if (hasKnip6) {
-    const v6ErrorProjects = results.filter((r) => r.k6Error);
-    if (v6ErrorProjects.length > 0) {
-      console.log(`\nknip v6 errors:`);
-      for (const project of v6ErrorProjects)
-        console.log(`  ${project.name}: ${project.k6ErrorReason}`);
-    }
+  const errorProjects = results.filter((r) => r.kError);
+  if (errorProjects.length > 0) {
+    console.log(`\nknip errors:`);
+    for (const project of errorProjects) console.log(`  ${project.name}: ${project.kErrorReason}`);
   }
   console.log(
     `Average cache effect:              ${(results.reduce((s, r) => s + r.cacheSpeedup, 0) / results.length).toFixed(2)}x\n`,

--- a/benchmarks/compare.mjs
+++ b/benchmarks/compare.mjs
@@ -224,12 +224,11 @@ for (const [project, summary] of Object.entries(allSummaries)) {
   console.log(`${project}:`);
   for (const [cat, counts] of Object.entries(summary)) {
     if (counts.both === 0 && counts.onlyFallow === 0 && counts.onlyKnip === 0) continue;
+    const knipComparable = counts.both + counts.onlyKnip;
     const pct =
-      counts.both + counts.onlyFallow + counts.onlyKnip > 0
-        ? ((counts.both / (counts.both + counts.onlyKnip)) * 100).toFixed(0)
-        : "100";
+      knipComparable > 0 ? `${((counts.both / knipComparable) * 100).toFixed(0)}%` : "n/a";
     console.log(
-      `  ${cat}: agree=${counts.both} fallow-only=${counts.onlyFallow} knip-only=${counts.onlyKnip} (${pct}% knip coverage)`,
+      `  ${cat}: agree=${counts.both} fallow-only=${counts.onlyFallow} knip-only=${counts.onlyKnip} (${pct} knip coverage)`,
     );
   }
 }

--- a/benchmarks/download-fixtures.mjs
+++ b/benchmarks/download-fixtures.mjs
@@ -85,7 +85,7 @@ for (const fixture of FIXTURES) {
     }
     console.log(`  ${fixture.name}: ready (${countSourceFiles(dest)} source files)`);
   } catch (err) {
-    console.error(`  ${fixture.name}: FAILED — ${err.message}`);
+    console.error(`  ${fixture.name}: FAILED - ${err.message}`);
     allOk = false;
   }
 }

--- a/benchmarks/package-lock.json
+++ b/benchmarks/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "dpdm": "^4.0.0",
         "jscpd": "^5.0.10",
-        "knip": "^5.0.0",
+        "knip": "^6.17.1",
         "madge": "^8.0.0",
         "tinybench": "^3.0.0"
       }
@@ -73,20 +73,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -110,54 +110,382 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
+      "integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
+      "cpu": [
+        "arm"
+      ],
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
+      "integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
+      "integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
+      "integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
+      "integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
+      "integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
+      "integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
+      "integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
+      "integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
+      "integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
+      "integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
+      "integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
+      "integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
+      "integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
+      "integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
+      "integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
+      "integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
+      "integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
+      "cpu": [
+        "arm64"
+      ],
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
-        "node": ">= 8"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
+      "integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
+      "cpu": [
+        "ia32"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
-        "node": ">= 8"
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
+      "integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
+      "integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
-      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.3.tgz",
+      "integrity": "sha512-eNU11A2WNizh04v3uyaJCootrHIaS0B9aHYXvAvVnPNk4xYSjMUjHnhQ6dewPN2MRYDskV85d1N0Aw0WNWhcyg==",
       "cpu": [
         "arm"
       ],
@@ -168,9 +496,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-android-arm64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
-      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.3.tgz",
+      "integrity": "sha512-8Q+ZjTLvn2dIcWsrmhdrEihm7q+ag/k+mkry7Z+t0QbbHaVxXQfvH9AewyVMh/WrpEKhQ3DDgx9fYbqeCpeOEw==",
       "cpu": [
         "arm64"
       ],
@@ -181,7 +509,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-darwin-arm64": {
-      "version": "11.19.1",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz",
+      "integrity": "sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==",
       "cpu": [
         "arm64"
       ],
@@ -192,9 +522,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-darwin-x64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
-      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.3.tgz",
+      "integrity": "sha512-HbNc23FAQYbuyDV2vBWMez4u4mrsm5RAkniGZAWqr6lYZ3N4beeqIb776jzwRl8qL2zRhHVXpUj97X0QgogVzg==",
       "cpu": [
         "x64"
       ],
@@ -205,9 +535,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-freebsd-x64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
-      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.3.tgz",
+      "integrity": "sha512-K6xNsTUPEUdfrn0+kbMq5nOUB5w1C5pavPQngt4TM2FpN91lP0PBe2srSpamb4d69O7h86oAi/qWX/kZNRSjkw==",
       "cpu": [
         "x64"
       ],
@@ -218,9 +548,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
-      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.3.tgz",
+      "integrity": "sha512-VcFmOpcpWX1zoEy8M58tR2M9YxM+Z9RuQhqAx5q0CTmrruaP7Gveejg75hzd/5sg5nk9G3aLALEa3hE2FsmmTQ==",
       "cpu": [
         "arm"
       ],
@@ -231,9 +561,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
-      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.3.tgz",
+      "integrity": "sha512-quVoxFLBy43hWaQbbDtQNRwAX5vX76mv7n64icAtQcJ3eNgVeblqmkupF/hAneNthdqSlnd1sTjb3aQSaDPaCQ==",
       "cpu": [
         "arm"
       ],
@@ -244,9 +574,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
-      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.3.tgz",
+      "integrity": "sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==",
       "cpu": [
         "arm64"
       ],
@@ -260,9 +590,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
-      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.3.tgz",
+      "integrity": "sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==",
       "cpu": [
         "arm64"
       ],
@@ -276,9 +606,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
-      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.3.tgz",
+      "integrity": "sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==",
       "cpu": [
         "ppc64"
       ],
@@ -292,9 +622,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
-      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.3.tgz",
+      "integrity": "sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==",
       "cpu": [
         "riscv64"
       ],
@@ -308,9 +638,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
-      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.3.tgz",
+      "integrity": "sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==",
       "cpu": [
         "riscv64"
       ],
@@ -324,9 +654,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
-      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.3.tgz",
+      "integrity": "sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==",
       "cpu": [
         "s390x"
       ],
@@ -340,9 +670,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
-      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz",
+      "integrity": "sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==",
       "cpu": [
         "x64"
       ],
@@ -356,9 +686,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
-      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.3.tgz",
+      "integrity": "sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==",
       "cpu": [
         "x64"
       ],
@@ -372,9 +702,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
-      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.3.tgz",
+      "integrity": "sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==",
       "cpu": [
         "arm64"
       ],
@@ -385,25 +715,58 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
-      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.3.tgz",
+      "integrity": "sha512-i8oluoel5kru/j1WNrjmQSiA3GQ7wvIYVR1IwIoZtKogAhya2iub+ZKIeSIkcJOrnzQ18Tzl/F+kL3fYOxZLvA==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.11.0",
+        "@emnapi/runtime": "1.11.0",
+        "@napi-rs/wasm-runtime": "^1.1.5"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
-      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.3.tgz",
+      "integrity": "sha512-M/8dw8dD6aOs+NlPJax401CZB9I7Aut84isQLgALGGwke4Afvw+/7yYhZb94yXf6t2sPLhQLmSmtSV+2FhsOWg==",
       "cpu": [
         "arm64"
       ],
@@ -413,23 +776,10 @@
         "win32"
       ]
     },
-    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
-      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
-      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz",
+      "integrity": "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==",
       "cpu": [
         "x64"
       ],
@@ -526,21 +876,13 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "25.5.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
@@ -785,16 +1127,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -1363,27 +1695,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fd-package-json": {
       "version": "2.0.0",
       "license": "MIT",
@@ -1440,16 +1751,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/formatly": {
@@ -1528,6 +1829,18 @@
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "license": "ISC"
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1543,16 +1856,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/gonzales-pe": {
@@ -1644,23 +1947,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -1671,13 +1957,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-obj": {
@@ -1729,7 +2008,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -1781,7 +2062,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "5.87.0",
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.17.1.tgz",
+      "integrity": "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==",
       "funding": [
         {
           "type": "github",
@@ -1794,18 +2077,18 @@
       ],
       "license": "ISC",
       "dependencies": {
-        "@nodelib/fs.walk": "^1.2.3",
-        "fast-glob": "^3.3.3",
+        "fdir": "^6.5.0",
         "formatly": "^0.3.0",
-        "jiti": "^2.6.0",
-        "minimist": "^1.2.8",
-        "oxc-resolver": "^11.19.1",
-        "picocolors": "^1.1.1",
-        "picomatch": "^4.0.1",
-        "smol-toml": "^1.5.2",
+        "get-tsconfig": "4.14.0",
+        "jiti": "^2.7.0",
+        "oxc-parser": "^0.135.0",
+        "oxc-resolver": "^11.20.0",
+        "picomatch": "^4.0.4",
+        "smol-toml": "^1.6.1",
         "strip-json-comments": "5.0.3",
-        "unbash": "^2.2.0",
-        "yaml": "^2.8.2",
+        "tinyglobby": "^0.2.17",
+        "unbash": "^4.0.1",
+        "yaml": "^2.9.0",
         "zod": "^4.1.11"
       },
       "bin": {
@@ -1813,11 +2096,7 @@
         "knip-bun": "bin/knip-bun.js"
       },
       "engines": {
-        "node": ">=18.18.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18",
-        "typescript": ">=5.0.4 <7"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/log-symbols": {
@@ -2027,34 +2306,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mimic-fn": {
@@ -2267,33 +2518,71 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
+      "integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.135.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.135.0",
+        "@oxc-parser/binding-android-arm64": "0.135.0",
+        "@oxc-parser/binding-darwin-arm64": "0.135.0",
+        "@oxc-parser/binding-darwin-x64": "0.135.0",
+        "@oxc-parser/binding-freebsd-x64": "0.135.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.135.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.135.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.135.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.135.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.135.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.135.0"
+      }
+    },
     "node_modules/oxc-resolver": {
-      "version": "11.19.1",
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
+      "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
-        "@oxc-resolver/binding-android-arm64": "11.19.1",
-        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
-        "@oxc-resolver/binding-darwin-x64": "11.19.1",
-        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
-        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
-        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
-        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
-        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
-        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
-        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
-        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
-        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
-        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
-        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
-        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
+        "@oxc-resolver/binding-android-arm-eabi": "11.21.3",
+        "@oxc-resolver/binding-android-arm64": "11.21.3",
+        "@oxc-resolver/binding-darwin-arm64": "11.21.3",
+        "@oxc-resolver/binding-darwin-x64": "11.21.3",
+        "@oxc-resolver/binding-freebsd-x64": "11.21.3",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.21.3",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-x64-musl": "11.21.3",
+        "@oxc-resolver/binding-openharmony-arm64": "11.21.3",
+        "@oxc-resolver/binding-wasm32-wasi": "11.21.3",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.21.3"
       }
     },
     "node_modules/parse-ms": {
@@ -2332,7 +2621,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2448,24 +2739,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/quote-unquote": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
@@ -2565,6 +2838,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -2606,35 +2888,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -2701,7 +2954,9 @@
       "license": "ISC"
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -2873,29 +3128,19 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2967,16 +3212,13 @@
       }
     },
     "node_modules/unbash": {
-      "version": "2.2.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz",
+      "integrity": "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.18.2",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -3095,7 +3337,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "dpdm": "^4.0.0",
     "jscpd": "^5.0.10",
-    "knip": "^5.0.0",
+    "knip": "^6.17.1",
     "madge": "^8.0.0",
     "tinybench": "^3.0.0"
   }


### PR DESCRIPTION
Refresh the benchmark harness to compare dead-code runs against the current installed knip package instead of carrying legacy knip version columns. Align dead-code and dupes benchmark summaries around the same comparator and faster-tool fields, and keep the comparison helper from reporting n/a when knip has no comparable findings.

Update the README performance section with current real-world benchmark medians from the refreshed harness, and keep benchmark scripts ASCII-clean for the repo style rules.

Verification:
- cargo build --workspace
- cargo test --workspace --lib --bins --tests --examples
- npm run fmt:js:check
- npm run lint:js
- typos .
- benchmark and comparison smokes
