### PR TITLE
feat: expose framework health diagnostics

### DIFF
--- a/crates/cli/src/health/assembly.rs
+++ b/crates/cli/src/health/assembly.rs
@@ -48,6 +48,7 @@ pub(super) fn assemble_health_report(
         health_trend,
         has_istanbul_coverage,
         runtime_coverage,
+        framework_health,
         large_functions,
         sev_critical,
         sev_high,
@@ -139,6 +140,7 @@ pub(super) fn assemble_health_report(
         },
         health_trend,
         actions_meta: build_health_actions_meta(action_ctx),
+        framework_health,
         css_analytics: None,
         render_fan_in_top,
     };

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -15,7 +15,7 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
-use fallow_config::{OutputFormat, ResolvedConfig};
+use fallow_config::{OutputFormat, PackageJson, ResolvedConfig, Severity};
 
 use crate::baseline::{HealthBaselineData, filter_new_health_findings, filter_new_health_targets};
 use crate::check::{get_changed_files, resolve_workspace_scope};
@@ -2559,6 +2559,9 @@ fn build_health_output_parts(
             action_ctx: &action_ctx,
         });
 
+    let framework_health =
+        build_framework_health_diagnostics(build.config, analysis_data.framework_health_facts);
+
     let report = build_health_report_from_pipeline(
         opts,
         &action_ctx,
@@ -2579,6 +2582,7 @@ fn build_health_output_parts(
             targets: derived_sections.targets,
             target_thresholds: derived_sections.target_thresholds,
             has_istanbul_coverage: build.has_istanbul_coverage,
+            framework_health,
             sev_critical: build.sev_critical,
             sev_high: build.sev_high,
             sev_moderate: build.sev_moderate,
@@ -2684,6 +2688,7 @@ struct HealthReportPipelineInput {
     targets: Vec<RefactoringTarget>,
     target_thresholds: Option<crate::health_types::TargetThresholds>,
     has_istanbul_coverage: bool,
+    framework_health: Option<crate::health_types::FrameworkHealthDiagnostics>,
     sev_critical: usize,
     sev_high: usize,
     sev_moderate: usize,
@@ -2719,6 +2724,7 @@ fn build_health_report_from_pipeline(
             health_trend: input.vital_data.health_trend,
             has_istanbul_coverage: input.has_istanbul_coverage,
             runtime_coverage: input.analysis_data.runtime_coverage,
+            framework_health: input.framework_health,
             large_functions: input.vital_data.large_functions,
             sev_critical: input.sev_critical,
             sev_high: input.sev_high,
@@ -3755,10 +3761,347 @@ struct HealthAnalysisData {
     score_output: Option<scoring::FileScoreOutput>,
     files_scored: Option<usize>,
     average_maintainability: Option<f64>,
+    framework_health_facts: Option<FrameworkHealthFacts>,
     file_scores_ms: f64,
     git_churn_ms: f64,
     git_churn_cache_hit: bool,
     churn_fetch: Option<hotspots::ChurnFetchResult>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct FrameworkHealthFacts {
+    unused_load_data_keys_global_abstain: bool,
+}
+
+fn build_framework_health_diagnostics(
+    config: &ResolvedConfig,
+    facts: Option<FrameworkHealthFacts>,
+) -> Option<crate::health_types::FrameworkHealthDiagnostics> {
+    let facts = facts?;
+    let detected_frameworks = detect_frameworks(config);
+    if detected_frameworks.is_empty() {
+        return None;
+    }
+
+    let mut detectors = Vec::new();
+    for framework in &detected_frameworks {
+        add_framework_detectors(&mut detectors, framework, &config.rules, facts);
+    }
+
+    if detectors.is_empty() {
+        return None;
+    }
+
+    Some(crate::health_types::FrameworkHealthDiagnostics {
+        detected_frameworks,
+        detectors,
+    })
+}
+
+fn detect_frameworks(config: &ResolvedConfig) -> Vec<String> {
+    let mut deps = rustc_hash::FxHashSet::default();
+    if let Ok(pkg) = PackageJson::load(&config.root.join("package.json")) {
+        deps.extend(pkg.all_dependency_names());
+    }
+    for workspace in fallow_config::discover_workspaces(&config.root) {
+        if let Ok(pkg) = PackageJson::load(&workspace.root.join("package.json")) {
+            deps.extend(pkg.all_dependency_names());
+        }
+    }
+
+    let mut frameworks = Vec::new();
+    if deps.contains("react") || deps.contains("preact") || deps.contains("next") {
+        frameworks.push("react".to_string());
+    }
+    if deps.contains("next") {
+        frameworks.push("next".to_string());
+    }
+    if deps.contains("vue") || deps.contains("@vue/runtime-core") {
+        frameworks.push("vue".to_string());
+    }
+    if deps.contains("nuxt") {
+        frameworks.push("nuxt".to_string());
+    }
+    if deps.contains("svelte") || deps.contains("@sveltejs/kit") {
+        frameworks.push("svelte".to_string());
+    }
+    if deps.contains("@sveltejs/kit") {
+        frameworks.push("sveltekit".to_string());
+    }
+    if deps.contains("@angular/core") {
+        frameworks.push("angular".to_string());
+    }
+    frameworks.sort_unstable();
+    frameworks.dedup();
+    frameworks
+}
+
+fn add_framework_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+    facts: FrameworkHealthFacts,
+) {
+    match framework {
+        "angular" => add_angular_detectors(detectors, framework, rules),
+        "next" => add_next_detectors(detectors, framework, rules),
+        "nuxt" => add_nuxt_detectors(detectors, framework, rules),
+        "vue" => add_vue_detectors(detectors, framework, rules),
+        "react" => add_react_detectors(detectors, framework, rules),
+        "svelte" => add_svelte_detectors(detectors, framework, rules),
+        "sveltekit" => add_sveltekit_detectors(detectors, framework, rules, facts),
+        _ => {}
+    }
+}
+
+fn add_angular_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+) {
+    add_detector(
+        detectors,
+        framework,
+        "unrendered-component",
+        rules.unrendered_components,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-input",
+        rules.unused_component_inputs,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-output",
+        rules.unused_component_outputs,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unprovided-inject",
+        rules.unprovided_injects,
+    );
+}
+
+fn add_next_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+) {
+    add_detector(
+        detectors,
+        framework,
+        "invalid-client-export",
+        rules.invalid_client_export,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "mixed-client-server-barrel",
+        rules.mixed_client_server_barrel,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "misplaced-directive",
+        rules.misplaced_directive,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "route-collision",
+        rules.route_collision,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "dynamic-segment-name-conflict",
+        rules.dynamic_segment_name_conflict,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-server-action",
+        rules.unused_server_actions,
+    );
+}
+
+fn add_nuxt_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+) {
+    add_detector(
+        detectors,
+        framework,
+        "unrendered-component",
+        rules.unrendered_components,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-prop",
+        rules.unused_component_props,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-emit",
+        rules.unused_component_emits,
+    );
+    add_not_checked_detector(
+        detectors,
+        framework,
+        "unprovided-inject",
+        "requires_vue_runtime_dependency",
+    );
+}
+
+fn add_vue_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+) {
+    add_detector(
+        detectors,
+        framework,
+        "unrendered-component",
+        rules.unrendered_components,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-prop",
+        rules.unused_component_props,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-emit",
+        rules.unused_component_emits,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unprovided-inject",
+        rules.unprovided_injects,
+    );
+}
+
+fn add_react_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+) {
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-prop",
+        rules.unused_component_props,
+    );
+    add_detector(detectors, framework, "prop-drilling", rules.prop_drilling);
+    add_detector(detectors, framework, "thin-wrapper", rules.thin_wrapper);
+    add_detector(
+        detectors,
+        framework,
+        "duplicate-prop-shape",
+        rules.duplicate_prop_shape,
+    );
+}
+
+fn add_svelte_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+) {
+    add_detector(
+        detectors,
+        framework,
+        "unrendered-component",
+        rules.unrendered_components,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-component-prop",
+        rules.unused_component_props,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unused-svelte-event",
+        rules.unused_svelte_events,
+    );
+    add_detector(
+        detectors,
+        framework,
+        "unprovided-inject",
+        rules.unprovided_injects,
+    );
+}
+
+fn add_sveltekit_detectors(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    rules: &fallow_config::RulesConfig,
+    facts: FrameworkHealthFacts,
+) {
+    if facts.unused_load_data_keys_global_abstain && rules.unused_load_data_keys != Severity::Off {
+        detectors.push(crate::health_types::FrameworkHealthDetector {
+            id: "unused-load-data-key".to_string(),
+            framework: framework.to_string(),
+            status: crate::health_types::FrameworkHealthDetectorStatus::Abstained,
+            reason: Some("unused_load_data_keys_global_abstain".to_string()),
+        });
+    } else {
+        add_detector(
+            detectors,
+            framework,
+            "unused-load-data-key",
+            rules.unused_load_data_keys,
+        );
+    }
+}
+
+fn add_detector(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    id: &str,
+    severity: Severity,
+) {
+    let (status, reason) = if severity == Severity::Off {
+        (
+            crate::health_types::FrameworkHealthDetectorStatus::DisabledByConfig,
+            Some("disabled_by_config".to_string()),
+        )
+    } else {
+        (
+            crate::health_types::FrameworkHealthDetectorStatus::Active,
+            None,
+        )
+    };
+    detectors.push(crate::health_types::FrameworkHealthDetector {
+        id: id.to_string(),
+        framework: framework.to_string(),
+        status,
+        reason,
+    });
+}
+
+fn add_not_checked_detector(
+    detectors: &mut Vec<crate::health_types::FrameworkHealthDetector>,
+    framework: &str,
+    id: &str,
+    reason: &str,
+) {
+    detectors.push(crate::health_types::FrameworkHealthDetector {
+        id: id.to_string(),
+        framework: framework.to_string(),
+        status: crate::health_types::FrameworkHealthDetectorStatus::NotChecked,
+        reason: Some(reason.to_string()),
+    });
 }
 
 struct HealthRuntimeSectionsInput<'a> {
@@ -3882,6 +4225,14 @@ fn prepare_health_analysis_data(
         input.pre_computed_analysis,
         needs_analysis_output,
     )?;
+    let framework_health_facts =
+        shared_analysis_output
+            .as_ref()
+            .map(|output| FrameworkHealthFacts {
+                unused_load_data_keys_global_abstain: output
+                    .results
+                    .unused_load_data_keys_global_abstain,
+            });
     if let Some(graph) = shared_analysis_output
         .as_ref()
         .and_then(|output| output.graph.as_ref())
@@ -3933,6 +4284,7 @@ fn prepare_health_analysis_data(
         score_output,
         files_scored,
         average_maintainability,
+        framework_health_facts,
         file_scores_ms,
         git_churn_ms,
         git_churn_cache_hit,
@@ -4963,6 +5315,7 @@ struct HealthReportAssembly {
     health_trend: Option<crate::health_types::HealthTrend>,
     has_istanbul_coverage: bool,
     runtime_coverage: Option<crate::health_types::RuntimeCoverageReport>,
+    framework_health: Option<crate::health_types::FrameworkHealthDiagnostics>,
     large_functions: Vec<LargeFunctionEntry>,
     sev_critical: usize,
     sev_high: usize,

--- a/crates/cli/src/health_types/mod.rs
+++ b/crates/cli/src/health_types/mod.rs
@@ -807,6 +807,43 @@ pub struct CssAnalyticsSummary {
     pub notable_truncated_files: u32,
 }
 
+/// Framework-specific health detector coverage surfaced for agent consumers.
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FrameworkHealthDiagnostics {
+    /// Detected framework IDs, sorted and deduplicated.
+    pub detected_frameworks: Vec<String>,
+    /// Detector coverage for the detected frameworks.
+    pub detectors: Vec<FrameworkHealthDetector>,
+}
+
+/// Status for one framework-specific health detector.
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FrameworkHealthDetector {
+    /// Rule or detector ID, matching fallow's stable rule names where possible.
+    pub id: String,
+    /// Framework ID that made this detector relevant.
+    pub framework: String,
+    /// Whether the detector ran, was disabled, abstained, or could not be checked.
+    pub status: FrameworkHealthDetectorStatus,
+    /// Stable reason code for non-active statuses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Detector status codes for framework health observability.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum FrameworkHealthDetectorStatus {
+    Active,
+    DisabledByConfig,
+    Abstained,
+    #[allow(dead_code, reason = "reserved for analysis paths that skip a detector")]
+    NotChecked,
+}
+
 /// Result of complexity analysis for reporting.
 #[derive(Debug, Clone, serde::Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -889,6 +926,10 @@ pub struct HealthReport {
     /// back to the report root.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actions_meta: Option<HealthActionsMeta>,
+    /// Optional framework-specific detector coverage. Present only when the
+    /// health run already needed the dead-code analysis output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub framework_health: Option<FrameworkHealthDiagnostics>,
     /// Structural CSS analytics (specificity hotspots, `!important` density,
     /// over-complex selectors, deep nesting). Present only with `--css`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -928,6 +969,7 @@ impl Default for HealthReport {
             target_thresholds: None,
             health_trend: None,
             actions_meta: None,
+            framework_health: None,
             css_analytics: None,
             render_fan_in_top: rustc_hash::FxHashMap::default(),
         }
@@ -952,6 +994,7 @@ mod tests {
         assert!(!json.contains("threshold_overrides"));
         assert!(!json.contains("vital_signs"));
         assert!(!json.contains("health_score"));
+        assert!(!json.contains("framework_health"));
     }
 
     #[test]

--- a/crates/cli/tests/exit_code_tests.rs
+++ b/crates/cli/tests/exit_code_tests.rs
@@ -119,6 +119,123 @@ fn human_explain_adds_inline_descriptions_for_analysis_commands() {
 }
 
 #[test]
+fn health_json_reports_framework_abstains() {
+    let output = run_fallow(
+        "health",
+        "sveltekit-load-data-global-abstain",
+        &["--format", "json", "--quiet", "--score"],
+    );
+    assert_eq!(output.code, 0, "health should pass: {}", output.stderr);
+    let json = parse_json(&output);
+    assert!(
+        json.pointer("/framework_health/detected_frameworks")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|frameworks| frameworks.iter().any(|framework| framework == "sveltekit")),
+        "SvelteKit should be detected: {}",
+        output.stdout
+    );
+    let detectors = json
+        .pointer("/framework_health/detectors")
+        .and_then(serde_json::Value::as_array)
+        .expect("framework detectors should be present");
+    let abstain = detectors
+        .iter()
+        .find(|detector| {
+            detector.get("id").and_then(serde_json::Value::as_str) == Some("unused-load-data-key")
+                && detector
+                    .get("framework")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("sveltekit")
+        })
+        .expect("unused-load-data-key detector should be reported");
+    assert_eq!(
+        abstain.get("status").and_then(serde_json::Value::as_str),
+        Some("abstained")
+    );
+    assert_eq!(
+        abstain.get("reason").and_then(serde_json::Value::as_str),
+        Some("unused_load_data_keys_global_abstain")
+    );
+}
+
+#[test]
+fn health_json_reports_disabled_framework_detectors() {
+    let output = run_fallow(
+        "health",
+        "unused-react-prop",
+        &["--format", "json", "--quiet", "--score"],
+    );
+    assert_eq!(output.code, 0, "health should pass: {}", output.stderr);
+    let json = parse_json(&output);
+    let detectors = json
+        .pointer("/framework_health/detectors")
+        .and_then(serde_json::Value::as_array)
+        .expect("framework detectors should be present");
+    for id in ["prop-drilling", "thin-wrapper", "duplicate-prop-shape"] {
+        let detector = detectors
+            .iter()
+            .find(|detector| {
+                detector.get("id").and_then(serde_json::Value::as_str) == Some(id)
+                    && detector
+                        .get("framework")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("react")
+            })
+            .unwrap_or_else(|| panic!("{id} should be reported"));
+        assert_eq!(
+            detector.get("status").and_then(serde_json::Value::as_str),
+            Some("disabled_by_config")
+        );
+        assert_eq!(
+            detector.get("reason").and_then(serde_json::Value::as_str),
+            Some("disabled_by_config")
+        );
+    }
+}
+
+#[test]
+fn health_json_reports_not_checked_framework_detectors() {
+    let output = run_fallow(
+        "health",
+        "nuxt-auto-import-components",
+        &["--format", "json", "--quiet", "--score"],
+    );
+    assert_eq!(output.code, 0, "health should pass: {}", output.stderr);
+    let json = parse_json(&output);
+    let detectors = json
+        .pointer("/framework_health/detectors")
+        .and_then(serde_json::Value::as_array)
+        .expect("framework detectors should be present");
+    assert!(
+        !detectors.iter().any(|detector| {
+            detector
+                .get("framework")
+                .and_then(serde_json::Value::as_str)
+                == Some("vue")
+        }),
+        "Nuxt-only projects should not synthesize a Vue detector row"
+    );
+    let detector = detectors
+        .iter()
+        .find(|detector| {
+            detector.get("id").and_then(serde_json::Value::as_str) == Some("unprovided-inject")
+                && detector
+                    .get("framework")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("nuxt")
+        })
+        .expect("Nuxt unprovided-inject detector should be reported");
+    assert_eq!(
+        detector.get("status").and_then(serde_json::Value::as_str),
+        Some("not_checked")
+    );
+    assert_eq!(
+        detector.get("reason").and_then(serde_json::Value::as_str),
+        Some("requires_vue_runtime_dependency")
+    );
+}
+
+#[test]
 fn combined_human_explain_renders_inline_descriptions() {
     let combined = run_fallow_combined("basic-project", &["--quiet", "--explain"]);
     assert!(

--- a/crates/cli/tests/snapshot_tests.rs
+++ b/crates/cli/tests/snapshot_tests.rs
@@ -2494,6 +2494,7 @@ fn sample_health_report(root: &Path) -> HealthReport {
         runtime_coverage: None,
         coverage_intelligence: None,
         actions_meta: None,
+        framework_health: None,
         css_analytics: None,
         render_fan_in_top: rustc_hash::FxHashMap::default(),
     }
@@ -2758,6 +2759,7 @@ fn empty_health_report() -> HealthReport {
         runtime_coverage: None,
         coverage_intelligence: None,
         actions_meta: None,
+        framework_health: None,
         css_analytics: None,
         render_fan_in_top: rustc_hash::FxHashMap::default(),
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -538,6 +538,11 @@ pub fn analyze_with_parse_result(
     let graph = build_analysis_graph(&resolved, &entry_points, files, modules, workspaces);
     let graph_ms = t.elapsed().as_secs_f64() * 1000.0;
 
+    let mut analysis_modules = modules.to_vec();
+    for module in &mut analysis_modules {
+        module.release_resolution_payload();
+    }
+
     let t = Instant::now();
     progress.set_stage("analyzing...");
     #[expect(
@@ -550,7 +555,7 @@ pub fn analyze_with_parse_result(
         &resolved,
         Some(&plugin_result),
         workspaces,
-        modules,
+        &analysis_modules,
         false,
     );
     let analyze_ms = t.elapsed().as_secs_f64() * 1000.0;

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -1398,6 +1398,17 @@
           ],
           "description": "Audit breadcrumb explaining systemic action-array adjustments. Present\nonly when at least one adjustment was made (e.g., health finding\nsuppression hints omitted because a baseline is active). When --group-by\nis active, each entry of `groups` may carry its own `actions_meta`\ndescribing the same omission so per-group consumers do not need to walk\nback to the report root."
         },
+        "framework_health": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FrameworkHealthDiagnostics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional framework-specific detector coverage. Present only when the\nhealth run already needed the dead-code analysis output."
+        },
         "css_analytics": {
           "anyOf": [
             {
@@ -2352,6 +2363,17 @@
             }
           ],
           "description": "Audit breadcrumb explaining systemic action-array adjustments. Present\nonly when at least one adjustment was made (e.g., health finding\nsuppression hints omitted because a baseline is active). When --group-by\nis active, each entry of `groups` may carry its own `actions_meta`\ndescribing the same omission so per-group consumers do not need to walk\nback to the report root."
+        },
+        "framework_health": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FrameworkHealthDiagnostics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional framework-specific detector coverage. Present only when the\nhealth run already needed the dead-code analysis output."
         },
         "css_analytics": {
           "anyOf": [
@@ -4384,7 +4406,7 @@
       "properties": {
         "package_name": {
           "type": "string",
-          "description": "Production dependency that is only imported by test files , consider\nmoving to devDependencies."
+          "description": "Production dependency that is only imported by test files, consider\nmoving to devDependencies."
         },
         "path": {
           "type": "string",
@@ -9002,7 +9024,7 @@
       "properties": {
         "package_name": {
           "type": "string",
-          "description": "Production dependency that is only imported by test files , consider\nmoving to devDependencies."
+          "description": "Production dependency that is only imported by test files, consider\nmoving to devDependencies."
         },
         "path": {
           "type": "string",
@@ -15425,6 +15447,70 @@
         "sampled_count"
       ],
       "description": "One file inside a blind-spot group."
+    },
+    "FrameworkHealthDiagnostics": {
+      "type": "object",
+      "properties": {
+        "detected_frameworks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Detected framework IDs, sorted and deduplicated."
+        },
+        "detectors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FrameworkHealthDetector"
+          },
+          "description": "Detector coverage for the detected frameworks."
+        }
+      },
+      "required": [
+        "detected_frameworks",
+        "detectors"
+      ],
+      "description": "Framework-specific health detector coverage surfaced for agent consumers."
+    },
+    "FrameworkHealthDetector": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Rule or detector ID, matching fallow's stable rule names where possible."
+        },
+        "framework": {
+          "type": "string",
+          "description": "Framework ID that made this detector relevant."
+        },
+        "status": {
+          "description": "Whether the detector ran, was disabled, abstained, or could not be checked.",
+          "$ref": "#/definitions/FrameworkHealthDetectorStatus"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Stable reason code for non-active statuses."
+        }
+      },
+      "required": [
+        "id",
+        "framework",
+        "status"
+      ],
+      "description": "Status for one framework-specific health detector."
+    },
+    "FrameworkHealthDetectorStatus": {
+      "type": "string",
+      "enum": [
+        "active",
+        "disabled_by_config",
+        "abstained",
+        "not_checked"
+      ],
+      "description": "Detector status codes for framework health observability."
     }
   }
 }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -578,6 +578,10 @@ export type RefactoringTargetActionType = ("apply-refactoring" | "suppress-line"
  */
 export type TrendDirection = ("improving" | "declining" | "stable")
 /**
+ * Detector status codes for framework health observability.
+ */
+export type FrameworkHealthDetectorStatus = ("active" | "disabled_by_config" | "abstained" | "not_checked")
+/**
  * Discriminant for [`CssCandidateAction::kind`].
  */
 export type CssCandidateActionType = ("verify-unused" | "verify-undefined" | "consolidate" | "replace-with-token" | "standardize")
@@ -2150,7 +2154,7 @@ introduced?: (AuditIntroduced | null)
  */
 export interface TestOnlyDependencyFinding {
 /**
- * Production dependency that is only imported by test files , consider
+ * Production dependency that is only imported by test files, consider
  * moving to devDependencies.
  */
 package_name: string
@@ -3937,6 +3941,11 @@ health_trend?: (HealthTrend | null)
  */
 actions_meta?: (HealthActionsMeta | null)
 /**
+ * Optional framework-specific detector coverage. Present only when the
+ * health run already needed the dead-code analysis output.
+ */
+framework_health?: (FrameworkHealthDiagnostics | null)
+/**
  * Structural CSS analytics (specificity hotspots, `!important` density,
  * over-complex selectors, deep nesting). Present only with `--css`.
  */
@@ -5574,6 +5583,37 @@ reason: string
 scope: string
 }
 /**
+ * Framework-specific health detector coverage surfaced for agent consumers.
+ */
+export interface FrameworkHealthDiagnostics {
+/**
+ * Detected framework IDs, sorted and deduplicated.
+ */
+detected_frameworks: string[]
+/**
+ * Detector coverage for the detected frameworks.
+ */
+detectors: FrameworkHealthDetector[]
+}
+/**
+ * Status for one framework-specific health detector.
+ */
+export interface FrameworkHealthDetector {
+/**
+ * Rule or detector ID, matching fallow's stable rule names where possible.
+ */
+id: string
+/**
+ * Framework ID that made this detector relevant.
+ */
+framework: string
+status: FrameworkHealthDetectorStatus
+/**
+ * Stable reason code for non-active statuses.
+ */
+reason?: (string | null)
+}
+/**
  * Structural CSS analytics surfaced by `fallow health --css`.
  */
 export interface CssAnalyticsReport {
@@ -6720,6 +6760,11 @@ health_trend?: (HealthTrend | null)
  * back to the report root.
  */
 actions_meta?: (HealthActionsMeta | null)
+/**
+ * Optional framework-specific detector coverage. Present only when the
+ * health run already needed the dead-code analysis output.
+ */
+framework_health?: (FrameworkHealthDiagnostics | null)
 /**
  * Structural CSS analytics (specificity hotspots, `!important` density,
  * over-complex selectors, deep nesting). Present only with `--css`.

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -578,6 +578,10 @@ export type RefactoringTargetActionType = ("apply-refactoring" | "suppress-line"
  */
 export type TrendDirection = ("improving" | "declining" | "stable")
 /**
+ * Detector status codes for framework health observability.
+ */
+export type FrameworkHealthDetectorStatus = ("active" | "disabled_by_config" | "abstained" | "not_checked")
+/**
  * Discriminant for [`CssCandidateAction::kind`].
  */
 export type CssCandidateActionType = ("verify-unused" | "verify-undefined" | "consolidate" | "replace-with-token" | "standardize")
@@ -2150,7 +2154,7 @@ introduced?: (AuditIntroduced | null)
  */
 export interface TestOnlyDependencyFinding {
 /**
- * Production dependency that is only imported by test files , consider
+ * Production dependency that is only imported by test files, consider
  * moving to devDependencies.
  */
 package_name: string
@@ -3937,6 +3941,11 @@ health_trend?: (HealthTrend | null)
  */
 actions_meta?: (HealthActionsMeta | null)
 /**
+ * Optional framework-specific detector coverage. Present only when the
+ * health run already needed the dead-code analysis output.
+ */
+framework_health?: (FrameworkHealthDiagnostics | null)
+/**
  * Structural CSS analytics (specificity hotspots, `!important` density,
  * over-complex selectors, deep nesting). Present only with `--css`.
  */
@@ -5574,6 +5583,37 @@ reason: string
 scope: string
 }
 /**
+ * Framework-specific health detector coverage surfaced for agent consumers.
+ */
+export interface FrameworkHealthDiagnostics {
+/**
+ * Detected framework IDs, sorted and deduplicated.
+ */
+detected_frameworks: string[]
+/**
+ * Detector coverage for the detected frameworks.
+ */
+detectors: FrameworkHealthDetector[]
+}
+/**
+ * Status for one framework-specific health detector.
+ */
+export interface FrameworkHealthDetector {
+/**
+ * Rule or detector ID, matching fallow's stable rule names where possible.
+ */
+id: string
+/**
+ * Framework ID that made this detector relevant.
+ */
+framework: string
+status: FrameworkHealthDetectorStatus
+/**
+ * Stable reason code for non-active statuses.
+ */
+reason?: (string | null)
+}
+/**
  * Structural CSS analytics surfaced by `fallow health --css`.
  */
 export interface CssAnalyticsReport {
@@ -6720,6 +6760,11 @@ health_trend?: (HealthTrend | null)
  * back to the report root.
  */
 actions_meta?: (HealthActionsMeta | null)
+/**
+ * Optional framework-specific detector coverage. Present only when the
+ * health run already needed the dead-code analysis output.
+ */
+framework_health?: (FrameworkHealthDiagnostics | null)
 /**
  * Structural CSS analytics (specificity hotspots, `!important` density,
  * over-complex selectors, deep nesting). Present only with `--css`.


### PR DESCRIPTION
## Summary
- Add optional `framework_health` diagnostics to `fallow health --format json` when health already has analysis data.
- Report detected framework IDs and detector statuses (`active`, `disabled_by_config`, `abstained`, `not_checked`) with stable reason codes.
- Preserve pre-parsed health analysis parity for release-derived module fields used by framework detectors.

## Verification
- `cargo build --workspace`
- `cargo test --workspace --lib --bins --tests --examples`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `npm run generate:all`
- `npm run generate:all:check`
- Real SvelteKit smoke on `/tmp/fallow-smoke-svelte-realworld`
- Nuxt-only fixture smoke for `not_checked` detector coverage
