### PR TITLE
ci: relax real-world benchmark watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete.
+- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while preserving benchmark diagnostics on timeout.
 
 ## [2.99.0] - 2026-06-18
 

--- a/benchmarks/bench-ci.sh
+++ b/benchmarks/bench-ci.sh
@@ -20,14 +20,18 @@ FALLOW_BIN=""
 CLONE_DIR="/tmp/fallow-bench-ci"
 RUNS=3
 export FALLOW_QUIET="${FALLOW_QUIET:-1}"
-PROJECT_TIMEOUT_SECONDS="${PROJECT_TIMEOUT_SECONDS:-60}"
+PROJECT_TIMEOUT_SECONDS="${PROJECT_TIMEOUT_SECONDS:-120}"
 QUERY_MAX_COLD_MS="${QUERY_MAX_COLD_MS:-5000}"
 TIMEOUT_BIN=""
+TIMEOUT_ARGS=()
 
 if command -v timeout >/dev/null 2>&1; then
     TIMEOUT_BIN="timeout"
 elif command -v gtimeout >/dev/null 2>&1; then
     TIMEOUT_BIN="gtimeout"
+fi
+if [[ -n "${TIMEOUT_BIN}" ]] && "${TIMEOUT_BIN}" --help 2>&1 | rg -q -- "--foreground"; then
+    TIMEOUT_ARGS=(--foreground)
 fi
 
 # Parse arguments
@@ -129,7 +133,7 @@ run_fallow() {
     local dir="$1"; shift
 
     if [[ -n "${TIMEOUT_BIN}" ]]; then
-        "${TIMEOUT_BIN}" "${PROJECT_TIMEOUT_SECONDS}" \
+        "${TIMEOUT_BIN}" "${TIMEOUT_ARGS[@]}" "${PROJECT_TIMEOUT_SECONDS}" \
             "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" \
             >/dev/null 2>/dev/null
     else


### PR DESCRIPTION
## Summary
- raise the per-project real-world benchmark watchdog for the expanded Next.js combined-analysis surface on GitHub Actions
- use timeout foreground mode when available so timeout diagnostics and benchmark artifacts are preserved

## Evidence
- previous main real-world benchmark run 27760911515 exited 143 during the benchmark step before artifacts were uploaded

## Validation
- bash -n benchmarks/bench-ci.sh
- git diff --check
- ./benchmarks/bench-ci.sh --fallow-bin ./target/release/fallow --clone-dir benchmarks/fixtures/real-world --runs 1