### PR TITLE
feat(inspect): add CLI evidence bundle flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,13 +397,37 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2
       - uses: ./.github/actions/setup-rust
       - name: Build fallow binary
         run: cargo build --bin fallow
-      - name: Analyze VS Code extension
+      - name: Dead-code dogfood VS Code extension
         run: ./target/debug/fallow dead-code --root editors/vscode --format json --quiet
-      - name: Analyze npm wrapper package
+      - name: Health dogfood VS Code extension
+        run: ./target/debug/fallow health --root editors/vscode --format json --quiet --score --targets --top 10 --report-only
+      - name: Duplication dogfood VS Code extension
+        run: ./target/debug/fallow dupes --root editors/vscode --format json --quiet --top 10
+      - name: Dead-code dogfood npm wrapper package
         run: ./target/debug/fallow dead-code --root npm/fallow --format json --quiet
+      - name: Health dogfood npm wrapper package
+        run: ./target/debug/fallow health --root npm/fallow --format json --quiet --score --targets --top 10 --report-only
+      - name: Duplication dogfood npm wrapper package
+        run: ./target/debug/fallow dupes --root npm/fallow --format json --quiet --top 10
+      - name: Audit dogfood smoke
+        run: |
+          base=HEAD
+          if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            base=HEAD~1
+          fi
+          set +e
+          ./target/debug/fallow audit --base "$base" --format json --quiet > /tmp/fallow-self-audit.json
+          code=$?
+          set -e
+          test -s /tmp/fallow-self-audit.json
+          if [ "$code" -gt 1 ]; then
+            exit "$code"
+          fi
 
   vscode:
     name: VS Code Extension

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Common agent workflow:
 ```bash
 npx fallow audit --format json
 npx fallow --format json
+npx fallow inspect --file src/api.ts --format json
 npx fallow --coverage coverage/coverage-final.json --format json
 npx fallow fix --dry-run --format json
 ```
@@ -239,7 +240,7 @@ For full adoption instead of one-off review, see the [Fallow compliance happy pa
 
 See [Agent integration](https://docs.fallow.tools/integrations/mcp) for MCP setup and the full list of structured tools.
 
-The MCP server includes `inspect_target` for agents that need one evidence bundle for a file or exported symbol, combining trace, dead-code, duplication, complexity, and security signals without inventing a new analysis pass.
+Use `fallow inspect --file <path>` or `fallow inspect --symbol <file>:<export>` when an agent needs one evidence bundle before editing. The MCP server exposes the same flow as `inspect_target`, combining trace, dead-code, duplication, complexity, and security signals without inventing a new analysis pass.
 
 The MCP server also exposes `code_execute`, a bounded read-only Code Mode tool for composing multiple fallow analysis calls in one JavaScript snippet. It can call analysis helpers such as `fallow.projectInfo`, `fallow.audit`, and `fallow.checkHealth`, but it does not expose mutating fix tools.
 

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -14,7 +14,7 @@ ERRORS=()
 # --- Helpers ---
 
 pass() { PASSED=$((PASSED + 1)); echo "  ✓ $1"; }
-fail() { FAILED=$((FAILED + 1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+fail() { FAILED=$((FAILED + 1)); ERRORS+=("$1: $2"); echo "  ✗ $1 - $2"; }
 
 assert_contains() {
   local output="$1" expected="$2" name="$3"
@@ -73,6 +73,130 @@ assert_json_value() {
     fail "$name" "expected $expected, got $actual"
   fi
 }
+
+# --- Repository config hygiene ---
+
+echo ""
+echo "=== Repository config hygiene ==="
+
+DUPLICATE_CONFIG_KEYS=$(cd "$DIR/../.." && node <<'NODE'
+const { readdirSync, readFileSync, statSync } = require("node:fs");
+const { join } = require("node:path");
+
+const ignored = new Set([".git", "target", "node_modules"]);
+const configNames = new Set([".fallowrc.json", ".fallowrc.jsonc"]);
+const issues = [];
+
+const stripJsonc = (input) => {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    const next = input[i + 1];
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === "\"") {
+      inString = true;
+      output += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      while (i < input.length && input[i] !== "\n") i += 1;
+      output += "\n";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      i += 2;
+      while (i < input.length && !(input[i] === "*" && input[i + 1] === "/")) i += 1;
+      i += 1;
+      output += " ";
+      continue;
+    }
+    output += char;
+  }
+  return output;
+};
+
+const findDuplicateKeys = (source, path) => {
+  const stripped = stripJsonc(source);
+  const duplicatePattern = /"([^"\\]*(?:\\.[^"\\]*)*)"\s*:/g;
+  const stack = [];
+  const objectKeys = [new Set()];
+  let match;
+  let i = 0;
+  let inString = false;
+  let escaped = false;
+  while (i < stripped.length) {
+    const char = stripped[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      i += 1;
+      continue;
+    }
+    if (char === "\"") {
+      duplicatePattern.lastIndex = i;
+      match = duplicatePattern.exec(stripped);
+      if (match && match.index === i) {
+        const key = JSON.parse(`"${match[1]}"`);
+        const current = objectKeys[objectKeys.length - 1];
+        if (current.has(key)) {
+          issues.push(`${path}: duplicate key ${[...stack, key].join(".")}`);
+        }
+        current.add(key);
+        i = duplicatePattern.lastIndex;
+        continue;
+      }
+      inString = true;
+    } else if (char === "{") {
+      objectKeys.push(new Set());
+      stack.push("<object>");
+    } else if (char === "}") {
+      objectKeys.pop();
+      stack.pop();
+    }
+    i += 1;
+  }
+};
+
+const walk = (dir) => {
+  for (const entry of readdirSync(dir)) {
+    if (ignored.has(entry)) continue;
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walk(path);
+    } else if (configNames.has(entry)) {
+      findDuplicateKeys(readFileSync(path, "utf8"), path);
+    }
+  }
+};
+
+walk(".");
+for (const issue of issues) console.log(issue);
+process.exit(issues.length === 0 ? 0 : 1);
+NODE
+)
+if [ -z "$DUPLICATE_CONFIG_KEYS" ]; then
+  pass "repo fallow configs have no duplicate JSON keys"
+else
+  fail "repo fallow configs have no duplicate JSON keys" "$DUPLICATE_CONFIG_KEYS"
+fi
 
 # --- Install script tests ---
 

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -813,6 +813,118 @@ assert_contains "$OUT_COMBINED_PROD" "Runtime coverage" "combined prod: has runt
 assert_contains "$OUT_COMBINED_PROD" "hotPath" "combined prod: shows hot path"
 assert_contains "$OUT_COMBINED_PROD" "hot path touched" "combined prod (GitLab, verdict hot-path-touched): header uses 'touched' framing"
 
+echo "  renderer semantic parity (GitHub vs GitLab):"
+PARITY_OUT=$(node - "$SHARED_JQ_DIR" "$CI_JQ_DIR" "$DIR/../../action/tests/fixtures" <<'NODE'
+const { execFileSync } = require("node:child_process");
+const { readFileSync } = require("node:fs");
+const [actionJqDir, gitlabJqDir, fixturesDir] = process.argv.slice(2);
+
+const readFixture = (fixture) => JSON.parse(readFileSync(`${fixturesDir}/${fixture}`, "utf8"));
+const checkFixture = readFixture("check.json");
+const healthFixture = readFixture("health.json");
+const dupesFixture = readFixture("dupes.json");
+const auditFixture = {
+  schema_version: 3,
+  command: "audit",
+  verdict: "fail",
+  changed_files_count: 2,
+  elapsed_ms: 42,
+  summary: { dead_code_issues: 1, complexity_findings: 3, duplication_clone_groups: 1 },
+  attribution: {
+    gate: "new-only",
+    dead_code_introduced: 1,
+    dead_code_inherited: 0,
+    complexity_introduced: 2,
+    complexity_inherited: 1,
+    duplication_introduced: 0,
+    duplication_inherited: 1,
+  },
+  dead_code: {
+    ...checkFixture,
+    unused_exports: checkFixture.unused_exports.map((item) => ({ ...item, introduced: true })),
+    unused_dependencies: checkFixture.unused_dependencies.map((item) => ({
+      ...item,
+      introduced: false,
+    })),
+  },
+  complexity: {
+    ...healthFixture,
+    findings: [
+      { ...healthFixture.findings[0], coverage_tier: "partial" },
+      { ...healthFixture.findings[1], coverage_tier: "high" },
+      healthFixture.findings[2],
+    ],
+    summary: {
+      ...healthFixture.summary,
+      coverage_model: "istanbul",
+      istanbul_matched: 8,
+      istanbul_total: 10,
+    },
+  },
+  duplication: {
+    ...dupesFixture,
+    clone_groups: dupesFixture.clone_groups.map((item) => ({ ...item, introduced: false })),
+  },
+};
+
+const cases = [
+  { name: "summary-check", fixture: "check.json" },
+  { name: "summary-health", fixture: "health.json" },
+  { name: "summary-audit", input: auditFixture },
+  { name: "summary-combined", fixture: "combined.json" },
+];
+
+const render = (dir, testCase) => {
+  const args = ["-r", "-f", `${dir}/${testCase.name}.jq`];
+  const options = { encoding: "utf8" };
+  if (testCase.fixture) {
+    args.push(`${fixturesDir}/${testCase.fixture}`);
+  } else {
+    options.input = JSON.stringify(testCase.input);
+  }
+  return execFileSync("jq", args, options);
+};
+
+const normalize = (text) =>
+  text
+    .split(/\r?\n/)
+    .map((line) =>
+      line
+        .replace(/^> \[![A-Z]+\]$/, "")
+        .replace(/^> :warning: /, "> ")
+        .replace(/^> :bulb: /, "> ")
+        .replace(/^> :chart_with_upwards_trend: /, "> ")
+        .replace(/^# :seedling: Fallow$/, "# Fallow")
+        .replace(/^# .* Fallow$/, "# Fallow"),
+    )
+    .filter((line) => line.trim() !== "")
+    .filter((line) => !line.startsWith("> Run `fallow fix --dry-run`"))
+    .filter((line) => !line.startsWith("> Intentionally public?"))
+    .filter((line) => !line.startsWith("> Add [`/** @public */`"))
+    .filter((line) => !line.startsWith("> Add [`// fallow-ignore-next-line`"))
+    .join("\n");
+
+const failures = [];
+for (const testCase of cases) {
+  const github = normalize(render(actionJqDir, testCase));
+  const gitlab = normalize(render(gitlabJqDir, testCase));
+  if (github !== gitlab) {
+    failures.push(`${testCase.name}: normalized output drifted`);
+  }
+}
+
+if (failures.length > 0) {
+  console.log(failures.join("\n"));
+  process.exit(1);
+}
+NODE
+)
+if [ -z "$PARITY_OUT" ]; then
+  pass "renderer parity: normalized GitHub and GitLab summaries match"
+else
+  fail "renderer parity: normalized GitHub and GitLab summaries match" "$PARITY_OUT"
+fi
+
 # =========================================================================
 # Shared summary scripts (reused from action/jq/, should still work)
 # =========================================================================

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -2776,7 +2776,7 @@ mod tests {
             .expect("node_modules tsconfig should be written");
 
         let base_sha = git_rev_parse(root, "HEAD").expect("HEAD should resolve");
-        let first = BaseWorktree::create(root, "HEAD", Some(&base_sha))
+        let first = BaseWorktree::reuse_or_create(root, &base_sha)
             .expect("persistent base worktree should be created");
         let worktree_path = first.path().to_path_buf();
         assert!(
@@ -2790,7 +2790,7 @@ mod tests {
         );
         drop(first);
 
-        let reused = BaseWorktree::create(root, "HEAD", Some(&base_sha))
+        let reused = BaseWorktree::reuse_or_create(root, &base_sha)
             .expect("ready persistent base worktree should be reused");
         assert_eq!(reused.path(), worktree_path.as_path());
         assert!(
@@ -2798,8 +2798,7 @@ mod tests {
             "ready persistent worktree should refresh missing node_modules context"
         );
 
-        remove_audit_worktree(root, reused.path());
-        let _ = fs::remove_dir_all(reused.path());
+        cleanup_reusable_worktree(root, reused.path());
     }
 
     fn remove_node_modules_context(worktree_path: &Path) {

--- a/crates/cli/src/bin/schema_emit.rs
+++ b/crates/cli/src/bin/schema_emit.rs
@@ -52,10 +52,12 @@ use fallow_cli::output_envelope::{
     CoverageSetupPackageManager, CoverageSetupRuntimeTarget, CoverageSetupSchemaVersion,
     CoverageSetupSnippet, DupesOutput, ExplainOutput, FallowOutput, GitHubReviewComment,
     GitHubReviewSide, GitLabReviewComment, GitLabReviewPosition, GitLabReviewPositionType,
-    GroupByMode, HealthOutput, ListBoundariesOutput, ReviewCheckConclusion, ReviewComment,
-    ReviewEnvelopeEvent, ReviewEnvelopeMeta, ReviewEnvelopeOutput, ReviewEnvelopeSchema,
-    ReviewEnvelopeSummary, ReviewProvider, ReviewReconcileOutput, ReviewReconcileSchema,
-    WorkspaceInfo, WorkspacesOutput,
+    GroupByMode, HealthOutput, InspectEvidence, InspectEvidenceScope, InspectEvidenceSection,
+    InspectFileIdentity, InspectIdentity, InspectOutput, InspectSectionStatus,
+    InspectSymbolIdentity, InspectTargetDescriptor, ListBoundariesOutput, ReviewCheckConclusion,
+    ReviewComment, ReviewEnvelopeEvent, ReviewEnvelopeMeta, ReviewEnvelopeOutput,
+    ReviewEnvelopeSchema, ReviewEnvelopeSummary, ReviewProvider, ReviewReconcileOutput,
+    ReviewReconcileSchema, WorkspaceInfo, WorkspacesOutput,
 };
 use fallow_cli::report::dupes_grouping::{
     AttributedCloneGroup, AttributedInstance, DuplicationGroup,
@@ -303,6 +305,13 @@ const DERIVED_DEFINITION_NAMES: &[&str] = &[
     "CoverageSetupSnippet",
     "DupesOutput",
     "ExplainOutput",
+    "InspectEvidence",
+    "InspectEvidenceSection",
+    "InspectFileIdentity",
+    "InspectIdentity",
+    "InspectOutput",
+    "InspectSymbolIdentity",
+    "InspectTargetDescriptor",
     "GitHubReviewComment",
     "GitLabReviewComment",
     "GitLabReviewPosition",
@@ -311,6 +320,8 @@ const DERIVED_DEFINITION_NAMES: &[&str] = &[
     "ReviewEnvelopeOutput",
     "ReviewEnvelopeSummary",
     "ReviewReconcileOutput",
+    "InspectEvidenceScope",
+    "InspectSectionStatus",
     "FallowOutput",
     "BoundariesListLogicalGroup",
     "BoundariesListRule",
@@ -705,6 +716,15 @@ fn register_per_command_envelope_definitions(generator: &mut schemars::SchemaGen
     let _ = generator.subschema_for::<fallow_cli::health_types::HealthReport>();
     let _ = generator.subschema_for::<GroupByMode>();
     let _ = generator.subschema_for::<ExplainOutput>();
+    let _ = generator.subschema_for::<InspectOutput>();
+    let _ = generator.subschema_for::<InspectTargetDescriptor>();
+    let _ = generator.subschema_for::<InspectIdentity>();
+    let _ = generator.subschema_for::<InspectFileIdentity>();
+    let _ = generator.subschema_for::<InspectSymbolIdentity>();
+    let _ = generator.subschema_for::<InspectEvidence>();
+    let _ = generator.subschema_for::<InspectEvidenceSection>();
+    let _ = generator.subschema_for::<InspectSectionStatus>();
+    let _ = generator.subschema_for::<InspectEvidenceScope>();
     let _ = generator.subschema_for::<CodeClimateOutput>();
     let _ = generator.subschema_for::<CodeClimateIssue>();
     let _ = generator.subschema_for::<CodeClimateIssueKind>();
@@ -801,6 +821,11 @@ const FALLOW_OUTPUT_VARIANTS: &[(&str, &[&str], &str)] = &[
         "explain",
         &["ExplainOutput"],
         "`fallow explain <issue-type> --format json`. Required `id`, `name`,\n`rationale`, `example`, `how_to_fix`, `docs`; no `schema_version`.",
+    ),
+    (
+        "inspect_target",
+        &["InspectOutput"],
+        "`fallow inspect --format json`. Required `target`, `identity`,\n`evidence`, and `warnings`; no `schema_version`.",
     ),
     (
         "review-envelope",
@@ -954,8 +979,8 @@ fn rewrite_document_root_one_of(document: &mut Value) -> Result<(), String> {
             "Schemas for the JSON output of fallow commands. Object-shaped \
              envelopes covered by the `FallowOutput` contract carry a top-level \
              `kind` discriminator (for example `dead-code`, `dead-code-grouped`, \
-             `health`, `dupes`, `combined`, `audit`, `explain`, `impact`, \
-             `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, \
+             `health`, `dupes`, `combined`, `audit`, `explain`, `inspect_target`, \
+             `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, \
              `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of \
              probing for unique field presence. `--legacy-envelope` removes \
              only the document-root `kind` for one compatibility cycle. \
@@ -1221,6 +1246,7 @@ mod drift_tests {
             match value {
                 FallowOutput::Audit(_) => "Audit",
                 FallowOutput::Explain(_) => "Explain",
+                FallowOutput::Inspect(_) => "Inspect",
                 FallowOutput::ReviewEnvelope(_) => "ReviewEnvelope",
                 FallowOutput::ReviewReconcile(_) => "ReviewReconcile",
                 FallowOutput::CoverageSetup(_) => "CoverageSetup",

--- a/crates/cli/src/inspect.rs
+++ b/crates/cli/src/inspect.rs
@@ -1,0 +1,384 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use fallow_config::OutputFormat;
+use serde_json::{Value, json};
+
+use crate::error::emit_error;
+use crate::output_envelope::{
+    FallowOutput, InspectEvidence, InspectEvidenceScope, InspectEvidenceSection,
+    InspectFileIdentity, InspectIdentity, InspectOutput, InspectSectionStatus,
+    InspectSymbolIdentity, InspectTargetDescriptor, serialize_root_output,
+};
+use crate::report;
+use crate::report::sink::outln;
+
+#[derive(Clone)]
+pub enum InspectTarget {
+    File { file: String },
+    Symbol { file: String, export_name: String },
+}
+
+pub struct InspectOptions<'a> {
+    pub root: &'a Path,
+    pub config_path: &'a Option<PathBuf>,
+    pub output: OutputFormat,
+    pub no_cache: bool,
+    pub threads: usize,
+    pub quiet: bool,
+    pub production: bool,
+    pub workspace: Option<&'a Vec<String>>,
+    pub target: InspectTarget,
+}
+
+struct NormalizedTarget<'a> {
+    file: &'a str,
+    export_name: Option<&'a str>,
+}
+
+impl<'a> NormalizedTarget<'a> {
+    fn new(target: &'a InspectTarget) -> Result<Self, String> {
+        match target {
+            InspectTarget::File { file } => {
+                require_non_empty("file", file)?;
+                Ok(Self {
+                    file,
+                    export_name: None,
+                })
+            }
+            InspectTarget::Symbol { file, export_name } => {
+                require_non_empty("symbol file", file)?;
+                require_non_empty("symbol export", export_name)?;
+                Ok(Self {
+                    file,
+                    export_name: Some(export_name),
+                })
+            }
+        }
+    }
+
+    fn target_descriptor(&self) -> InspectTargetDescriptor {
+        match self.export_name {
+            Some(export_name) => InspectTargetDescriptor::Symbol {
+                file: self.file.to_string(),
+                export_name: export_name.to_string(),
+            },
+            None => InspectTargetDescriptor::File {
+                file: self.file.to_string(),
+            },
+        }
+    }
+}
+
+pub fn run_inspect(opts: &InspectOptions<'_>) -> ExitCode {
+    let target = match NormalizedTarget::new(&opts.target) {
+        Ok(target) => target,
+        Err(message) => return emit_error(&message, 2, opts.output),
+    };
+
+    let trace_file = match run_required_json(opts, trace_file_args(target.file)) {
+        Ok(value) => value,
+        Err(message) => return emit_error(&message, 2, opts.output),
+    };
+    let trace_export = match target.export_name {
+        Some(export_name) => {
+            match run_required_json(opts, trace_export_args(target.file, export_name)) {
+                Ok(value) => Some(value),
+                Err(message) => return emit_error(&message, 2, opts.output),
+            }
+        }
+        None => None,
+    };
+
+    let mut warnings = Vec::new();
+    if target.export_name.is_some() {
+        warnings.push(
+            "dead_code, duplication, complexity, and security evidence is file-scoped in v1; file:line symbol narrowing is a follow-up"
+                .to_string(),
+        );
+    }
+
+    let evidence = InspectEvidence {
+        trace_file: InspectEvidenceSection::ok(InspectEvidenceScope::File, trace_file.clone()),
+        trace_export: trace_export
+            .clone()
+            .map(|value| InspectEvidenceSection::ok(InspectEvidenceScope::Symbol, value)),
+        dead_code: optional_section(
+            opts,
+            dead_code_args(target.file),
+            InspectEvidenceScope::File,
+            |value| value,
+        ),
+        duplication: optional_section(
+            opts,
+            dupes_args(),
+            InspectEvidenceScope::ProjectFilteredToFile,
+            |value| filter_path_array(&value, target.file, "clone_groups"),
+        ),
+        complexity: optional_section(
+            opts,
+            health_args(),
+            InspectEvidenceScope::ProjectFilteredToFile,
+            |value| filter_path_array(&value, target.file, "findings"),
+        ),
+        security: optional_section(
+            opts,
+            security_args(target.file),
+            InspectEvidenceScope::File,
+            |value| value,
+        ),
+    };
+    push_inspect_warnings(&mut warnings, &evidence);
+
+    let identity = match trace_export.as_ref() {
+        Some(export) => InspectIdentity::Symbol(InspectSymbolIdentity {
+            file: target.file.to_string(),
+            export_name: target.export_name.unwrap_or_default().to_string(),
+            file_reachable: export.get("file_reachable").cloned(),
+            is_entry_point: export.get("is_entry_point").cloned(),
+            is_used: export.get("is_used").cloned(),
+            reason: export.get("reason").cloned(),
+        }),
+        None => InspectIdentity::File(InspectFileIdentity {
+            file: target.file.to_string(),
+            is_reachable: trace_file.get("is_reachable").cloned(),
+            is_entry_point: trace_file.get("is_entry_point").cloned(),
+            export_count: trace_file
+                .get("exports")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            import_count: trace_file
+                .get("imports_from")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            imported_by_count: trace_file
+                .get("imported_by")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+        }),
+    };
+
+    let bundle = InspectOutput {
+        target: target.target_descriptor(),
+        identity,
+        evidence,
+        warnings,
+    };
+
+    match opts.output {
+        OutputFormat::Json => {
+            let value = match serialize_root_output(FallowOutput::Inspect(bundle)) {
+                Ok(value) => value,
+                Err(err) => {
+                    return emit_error(
+                        &format!("failed to serialize inspect output: {err}"),
+                        2,
+                        opts.output,
+                    );
+                }
+            };
+            report::emit_json(&value, "inspect")
+        }
+        OutputFormat::Human => {
+            print_human(&bundle, opts.quiet);
+            ExitCode::SUCCESS
+        }
+        _ => emit_error("inspect supports --format json or human", 2, opts.output),
+    }
+}
+
+fn print_human(bundle: &InspectOutput, quiet: bool) {
+    outln!("Inspect target");
+    outln!();
+    outln!("  target: {}", json_display(&bundle.target));
+    outln!("  identity: {}", json_display(&bundle.identity));
+    if !bundle.warnings.is_empty() && !quiet {
+        outln!();
+        for warning in &bundle.warnings {
+            outln!("  warning: {warning}");
+        }
+    }
+}
+
+fn json_display(value: &impl serde::Serialize) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "<unprintable>".to_string())
+}
+
+fn run_required_json(opts: &InspectOptions<'_>, args: Vec<String>) -> Result<Value, String> {
+    run_child_json(opts, args).and_then(|output| output.value)
+}
+
+fn optional_section<F>(
+    opts: &InspectOptions<'_>,
+    args: Vec<String>,
+    scope: InspectEvidenceScope,
+    filter: F,
+) -> InspectEvidenceSection
+where
+    F: FnOnce(Value) -> Value,
+{
+    match run_child_json(opts, args) {
+        Ok(output) => match output.value {
+            Ok(value) => InspectEvidenceSection::ok(scope, filter(value)),
+            Err(message) => InspectEvidenceSection::error(scope, message),
+        },
+        Err(message) => InspectEvidenceSection::error(scope, message),
+    }
+}
+
+struct ChildJson {
+    value: Result<Value, String>,
+}
+
+fn run_child_json(opts: &InspectOptions<'_>, args: Vec<String>) -> Result<ChildJson, String> {
+    let binary = std::env::current_exe()
+        .map_err(|err| format!("failed to locate current fallow binary: {err}"))?;
+    let mut command = Command::new(binary);
+    command.args(build_child_args(opts, args));
+    let output = command
+        .output()
+        .map_err(|err| format!("failed to run child analysis: {err}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let code = output.status.code().unwrap_or(2);
+    if code > 1 {
+        let message = if stderr.trim().is_empty() {
+            format!("child analysis exited with code {code}")
+        } else {
+            stderr.trim().to_string()
+        };
+        return Err(message);
+    }
+    if stdout.trim().is_empty() {
+        return Ok(ChildJson {
+            value: Err("child analysis returned no JSON".to_string()),
+        });
+    }
+    Ok(ChildJson {
+        value: serde_json::from_str(&stdout)
+            .map_err(|err| format!("child analysis returned invalid JSON: {err}")),
+    })
+}
+
+fn build_child_args(opts: &InspectOptions<'_>, command_args: Vec<String>) -> Vec<String> {
+    let command_name = command_args.first().map(String::as_str);
+    let mut args = vec![
+        "--root".to_string(),
+        opts.root.to_string_lossy().to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+    if let Some(config) = opts.config_path.as_ref() {
+        args.extend(["--config".to_string(), config.to_string_lossy().to_string()]);
+    }
+    if opts.no_cache {
+        args.push("--no-cache".to_string());
+    }
+    args.extend(["--threads".to_string(), opts.threads.to_string()]);
+    if opts.production && command_name != Some("security") {
+        args.push("--production".to_string());
+    }
+    if let Some(workspace) = opts.workspace {
+        args.extend(["--workspace".to_string(), workspace.join(",")]);
+    }
+    args.extend(command_args);
+    args
+}
+
+fn trace_file_args(file: &str) -> Vec<String> {
+    vec![
+        "dead-code".to_string(),
+        "--trace-file".to_string(),
+        file.to_string(),
+    ]
+}
+
+fn trace_export_args(file: &str, export_name: &str) -> Vec<String> {
+    vec![
+        "dead-code".to_string(),
+        "--trace".to_string(),
+        format!("{file}:{export_name}"),
+    ]
+}
+
+fn dead_code_args(file: &str) -> Vec<String> {
+    vec![
+        "dead-code".to_string(),
+        "--file".to_string(),
+        file.to_string(),
+    ]
+}
+
+fn dupes_args() -> Vec<String> {
+    vec!["dupes".to_string()]
+}
+
+fn health_args() -> Vec<String> {
+    vec!["health".to_string(), "--complexity".to_string()]
+}
+
+fn security_args(file: &str) -> Vec<String> {
+    vec![
+        "security".to_string(),
+        "--file".to_string(),
+        file.to_string(),
+    ]
+}
+
+fn filter_path_array(value: &Value, file: &str, key: &str) -> Value {
+    let matched = value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| value_mentions_file(item, file))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let matched_count = matched.len();
+
+    json!({
+        key: matched,
+        "matched_count": matched_count,
+        "summary": value.get("summary").cloned(),
+        "stats": value.get("stats").cloned(),
+    })
+}
+
+fn value_mentions_file(value: &Value, file: &str) -> bool {
+    match value {
+        Value::String(s) => path_eq(s, file),
+        Value::Array(items) => items.iter().any(|item| value_mentions_file(item, file)),
+        Value::Object(map) => map.values().any(|item| value_mentions_file(item, file)),
+        _ => false,
+    }
+}
+
+fn path_eq(left: &str, right: &str) -> bool {
+    left.replace('\\', "/") == right.replace('\\', "/")
+}
+
+fn push_inspect_warnings(warnings: &mut Vec<String>, evidence: &InspectEvidence) {
+    push_warning(warnings, "dead_code", &evidence.dead_code);
+    push_warning(warnings, "duplication", &evidence.duplication);
+    push_warning(warnings, "complexity", &evidence.complexity);
+    push_warning(warnings, "security", &evidence.security);
+}
+
+fn push_warning(warnings: &mut Vec<String>, section: &str, evidence: &InspectEvidenceSection) {
+    if matches!(evidence.status, InspectSectionStatus::Error)
+        && let Some(message) = evidence.message.as_ref()
+    {
+        warnings.push(format!("{section} evidence unavailable: {message}"));
+    }
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -39,6 +39,7 @@ mod health;
 mod health_types;
 mod impact;
 mod init;
+mod inspect;
 mod license;
 mod list;
 mod migrate;
@@ -112,6 +113,7 @@ Workflow:
 
 Project inspection:
   list           List discovered files, entry points, plugins, boundaries, and workspaces
+  inspect        Inspect one file or exported symbol as a bundled evidence query
   workspaces     Show monorepo workspace discovery diagnostics
   explain        Explain one issue type without running analysis
   impact         Show what fallow has done for you (opt-in, local-only)
@@ -152,6 +154,7 @@ When the agent is about to...
   consolidate duplication                  fallow dupes --trace dup:<fingerprint>
   find feature flags                       fallow flags
   surface security candidates              fallow security
+  inspect a target before editing          fallow inspect --file <path>
   understand a finding                     fallow explain <issue-type>
   scope a monorepo                         --workspace <glob> / --changed-workspaces <ref>";
 
@@ -594,6 +597,22 @@ enum Command {
         /// Don't clear the screen between re-analyses
         #[arg(long)]
         no_clear: bool,
+    },
+
+    /// Inspect one file or exported symbol as a bundled evidence query
+    Inspect {
+        /// File to inspect.
+        #[arg(
+            long,
+            value_name = "PATH",
+            conflicts_with = "symbol",
+            required_unless_present = "symbol"
+        )]
+        file: Option<String>,
+
+        /// Exported symbol to inspect, formatted as FILE:EXPORT.
+        #[arg(long, value_name = "FILE:EXPORT", conflicts_with = "file")]
+        symbol: Option<String>,
     },
 
     /// Auto-fix issues: remove unused exports, dependencies, and enum
@@ -3129,6 +3148,7 @@ fn command_rejects_output_gate(command: Option<&Command>) -> bool {
                 | Command::Config { .. }
                 | Command::Ci { .. }
                 | Command::List { .. }
+                | Command::Inspect { .. }
                 | Command::Flags { .. }
                 | Command::Migrate { .. }
                 | Command::License { .. }
@@ -3387,6 +3407,7 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
             },
         ),
         Command::Watch { no_clear } => dispatch_watch(dispatch, no_clear),
+        Command::Inspect { file, symbol } => dispatch_inspect_command(dispatch, file, symbol),
         fix @ Command::Fix { .. } => dispatch_fix_command(&fix, dispatch),
         init @ Command::Init { .. } => dispatch_init_command(init, root, quiet),
         Command::Hooks { subcommand } => run_hooks_command(root, subcommand, output),
@@ -3420,6 +3441,52 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
             dispatch_setup_hooks_command(&setup_hooks, dispatch)
         }
     }
+}
+
+fn dispatch_inspect_command(
+    dispatch: &DispatchContext<'_>,
+    file: Option<String>,
+    symbol: Option<String>,
+) -> ExitCode {
+    let target = match (file, symbol) {
+        (Some(file), None) => inspect::InspectTarget::File { file },
+        (None, Some(symbol)) => match symbol.rsplit_once(':') {
+            Some((file, export_name))
+                if !file.trim().is_empty() && !export_name.trim().is_empty() =>
+            {
+                inspect::InspectTarget::Symbol {
+                    file: file.to_string(),
+                    export_name: export_name.to_string(),
+                }
+            }
+            _ => {
+                return emit_error(
+                    "--symbol must be formatted as FILE:EXPORT",
+                    2,
+                    dispatch.output,
+                );
+            }
+        },
+        _ => {
+            return emit_error(
+                "inspect requires exactly one of --file or --symbol",
+                2,
+                dispatch.output,
+            );
+        }
+    };
+
+    inspect::run_inspect(&inspect::InspectOptions {
+        root: dispatch.root,
+        config_path: &dispatch.cli.config,
+        output: dispatch.output,
+        no_cache: dispatch.cli.no_cache,
+        threads: dispatch.threads,
+        quiet: dispatch.quiet,
+        production: dispatch.cli.production,
+        workspace: dispatch.cli.workspace.as_ref(),
+        target,
+    })
 }
 
 fn dispatch_security_command(command: Command, dispatch: &DispatchContext<'_>) -> ExitCode {
@@ -4064,6 +4131,7 @@ fn telemetry_workflow_for_command(
         Some(Command::Dupes { .. }) => telemetry::Workflow::Dupes,
         Some(Command::Health { .. }) => telemetry::Workflow::Health,
         Some(Command::Audit { .. }) => telemetry::Workflow::Audit,
+        Some(Command::Inspect { .. }) => telemetry::Workflow::ProjectInventory,
         Some(Command::Ci { .. }) => match output {
             fallow_config::OutputFormat::ReviewGitlab
             | fallow_config::OutputFormat::PrCommentGitlab

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -499,6 +499,117 @@ pub struct ExplainOutput {
     pub docs: String,
 }
 
+/// Envelope emitted by `fallow inspect --format json`.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(title = "fallow inspect --format json"))]
+pub struct InspectOutput {
+    pub target: InspectTargetDescriptor,
+    pub identity: InspectIdentity,
+    pub evidence: InspectEvidence,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InspectTargetDescriptor {
+    File { file: String },
+    Symbol { file: String, export_name: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum InspectIdentity {
+    File(InspectFileIdentity),
+    Symbol(InspectSymbolIdentity),
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct InspectFileIdentity {
+    pub file: String,
+    pub is_reachable: Option<serde_json::Value>,
+    pub is_entry_point: Option<serde_json::Value>,
+    pub export_count: Option<usize>,
+    pub import_count: Option<usize>,
+    pub imported_by_count: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct InspectSymbolIdentity {
+    pub file: String,
+    pub export_name: String,
+    pub file_reachable: Option<serde_json::Value>,
+    pub is_entry_point: Option<serde_json::Value>,
+    pub is_used: Option<serde_json::Value>,
+    pub reason: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct InspectEvidence {
+    pub trace_file: InspectEvidenceSection,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_export: Option<InspectEvidenceSection>,
+    pub dead_code: InspectEvidenceSection,
+    pub duplication: InspectEvidenceSection,
+    pub complexity: InspectEvidenceSection,
+    pub security: InspectEvidenceSection,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct InspectEvidenceSection {
+    pub status: InspectSectionStatus,
+    pub scope: InspectEvidenceScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl InspectEvidenceSection {
+    #[must_use]
+    pub fn ok(scope: InspectEvidenceScope, data: serde_json::Value) -> Self {
+        Self {
+            status: InspectSectionStatus::Ok,
+            scope,
+            message: None,
+            data: Some(data),
+        }
+    }
+
+    #[must_use]
+    pub fn error(scope: InspectEvidenceScope, message: String) -> Self {
+        Self {
+            status: InspectSectionStatus::Error,
+            scope,
+            message: Some(message),
+            data: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum InspectSectionStatus {
+    Ok,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum InspectEvidenceScope {
+    Symbol,
+    File,
+    ProjectFilteredToFile,
+}
+
 /// Envelope emitted by `fallow --format codeclimate` and
 /// `fallow --format gitlab-codequality`. GitLab Code Quality consumes the
 /// same shape. The wire form is a bare JSON array, not an object.
@@ -1027,6 +1138,10 @@ pub enum FallowOutput {
     /// `rationale`, `example`, `how_to_fix`, `docs`; no `schema_version`.
     #[serde(rename = "explain")]
     Explain(ExplainOutput),
+    /// `fallow inspect --format json`. Required `target`, `identity`,
+    /// `evidence`, and `warnings`; no `schema_version`.
+    #[serde(rename = "inspect_target")]
+    Inspect(InspectOutput),
     /// `fallow --format review-github` / `--format review-gitlab`. Required
     /// `body`, `comments`, `meta`; no `schema_version`.
     #[serde(rename = "review-envelope")]

--- a/crates/cli/tests/inspect_tests.rs
+++ b/crates/cli/tests/inspect_tests.rs
@@ -1,0 +1,97 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "integration tests keep fixture setup concise"
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{parse_json, run_fallow_in_root};
+use tempfile::tempdir;
+
+fn write_project(root: &std::path::Path) {
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"inspect-fixture","type":"module"}"#,
+    )
+    .unwrap();
+    std::fs::write(root.join("tsconfig.json"), r#"{"include":["src"]}"#).unwrap();
+    std::fs::write(root.join(".fallowrc.json"), r#"{"entry":["src/index.ts"]}"#).unwrap();
+    std::fs::write(
+        root.join("src/index.ts"),
+        "import { fetchUser } from './api';\nexport const boot = () => fetchUser('1');\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/api.ts"),
+        "export const fetchUser = (id: string) => ({ id });\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn inspect_file_outputs_typed_evidence_bundle() {
+    let dir = tempdir().unwrap();
+    write_project(dir.path());
+
+    let output = run_fallow_in_root(
+        "inspect",
+        dir.path(),
+        &["--file", "src/api.ts", "--format", "json", "--quiet"],
+    );
+    assert_eq!(output.code, 0, "inspect should exit 0: {}", output.stderr);
+
+    let json = parse_json(&output);
+    assert_eq!(json["kind"].as_str(), Some("inspect_target"));
+    assert_eq!(json["target"]["type"].as_str(), Some("file"));
+    assert_eq!(json["target"]["file"].as_str(), Some("src/api.ts"));
+    assert_eq!(json["identity"]["file"].as_str(), Some("src/api.ts"));
+    assert_eq!(
+        json["evidence"]["trace_file"]["status"].as_str(),
+        Some("ok")
+    );
+    assert_eq!(
+        json["evidence"]["dead_code"]["scope"].as_str(),
+        Some("file")
+    );
+    assert_eq!(
+        json["evidence"]["duplication"]["scope"].as_str(),
+        Some("project_filtered_to_file")
+    );
+}
+
+#[test]
+fn inspect_symbol_outputs_trace_export_section() {
+    let dir = tempdir().unwrap();
+    write_project(dir.path());
+
+    let output = run_fallow_in_root(
+        "inspect",
+        dir.path(),
+        &[
+            "--symbol",
+            "src/api.ts:fetchUser",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+    );
+    assert_eq!(output.code, 0, "inspect should exit 0: {}", output.stderr);
+
+    let json = parse_json(&output);
+    assert_eq!(json["kind"].as_str(), Some("inspect_target"));
+    assert_eq!(json["target"]["type"].as_str(), Some("symbol"));
+    assert_eq!(json["target"]["export_name"].as_str(), Some("fetchUser"));
+    assert_eq!(json["identity"]["export_name"].as_str(), Some("fetchUser"));
+    assert_eq!(
+        json["evidence"]["trace_export"]["status"].as_str(),
+        Some("ok")
+    );
+    assert!(
+        json["warnings"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+    );
+}

--- a/crates/cli/tests/schema_tests.rs
+++ b/crates/cli/tests/schema_tests.rs
@@ -53,6 +53,7 @@ fn schema_has_commands_array() {
     );
     assert!(names.contains(&"health"), "should list health command");
     assert!(names.contains(&"dupes"), "should list dupes command");
+    assert!(names.contains(&"inspect"), "should list inspect command");
     assert!(names.contains(&"explain"), "should list explain command");
 }
 

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -216,7 +216,7 @@ fn read_source(path: &std::path::Path) -> String {
 
 /// Check whether any two files in a cycle belong to different workspace packages.
 /// Uses longest-prefix-match to assign each file to a workspace root.
-/// Files outside all workspace roots (e.g., root-level shared code) are ignored —
+/// Files outside all workspace roots (e.g., root-level shared code) are ignored,
 /// only cycles between two distinct named workspaces are flagged.
 fn is_cross_package_cycle(
     files: &[std::path::PathBuf],
@@ -1454,7 +1454,60 @@ struct DeadCodeDetectorInput<'a> {
     collect_usages: bool,
 }
 
+struct ParallelDeadCodeDetectorResults {
+    unused_files: Vec<UnusedFileFinding>,
+    export_results: AnalysisResults,
+    member_results: AnalysisResults,
+    dependency_results: AnalysisResults,
+    unresolved_imports: Vec<UnresolvedImportFinding>,
+    duplicate_exports: Vec<DuplicateExportFinding>,
+    boundary_violations: Vec<BoundaryViolationFinding>,
+    boundary_coverage_violations: Vec<BoundaryCoverageViolationFinding>,
+    boundary_call_violations: Vec<BoundaryCallViolationFinding>,
+    policy_violations: Vec<PolicyViolationFinding>,
+    circular_dependencies: Vec<CircularDependencyFinding>,
+    re_export_cycles: Vec<ReExportCycleFinding>,
+    export_usages: Vec<crate::results::ExportUsage>,
+}
+
+impl ParallelDeadCodeDetectorResults {
+    fn into_analysis_results(self) -> AnalysisResults {
+        AnalysisResults {
+            unused_files: self.unused_files,
+            unused_exports: self.export_results.unused_exports,
+            unused_types: self.export_results.unused_types,
+            private_type_leaks: self.export_results.private_type_leaks,
+            stale_suppressions: self.export_results.stale_suppressions,
+            unused_enum_members: self.member_results.unused_enum_members,
+            unused_class_members: self.member_results.unused_class_members,
+            unused_store_members: self.member_results.unused_store_members,
+            unused_dependencies: self.dependency_results.unused_dependencies,
+            unused_dev_dependencies: self.dependency_results.unused_dev_dependencies,
+            unused_optional_dependencies: self.dependency_results.unused_optional_dependencies,
+            unlisted_dependencies: self.dependency_results.unlisted_dependencies,
+            type_only_dependencies: self.dependency_results.type_only_dependencies,
+            test_only_dependencies: self.dependency_results.test_only_dependencies,
+            unresolved_imports: self.unresolved_imports,
+            duplicate_exports: self.duplicate_exports,
+            boundary_violations: self.boundary_violations,
+            boundary_coverage_violations: self.boundary_coverage_violations,
+            boundary_call_violations: self.boundary_call_violations,
+            policy_violations: self.policy_violations,
+            circular_dependencies: self.circular_dependencies,
+            re_export_cycles: self.re_export_cycles,
+            export_usages: self.export_usages,
+            ..AnalysisResults::default()
+        }
+    }
+}
+
 fn run_parallel_dead_code_detectors(input: DeadCodeDetectorInput<'_>) -> AnalysisResults {
+    collect_parallel_dead_code_detector_results(input).into_analysis_results()
+}
+
+fn collect_parallel_dead_code_detector_results(
+    input: DeadCodeDetectorInput<'_>,
+) -> ParallelDeadCodeDetectorResults {
     let (
         (unused_files, export_results),
         (
@@ -1488,21 +1541,11 @@ fn run_parallel_dead_code_detectors(input: DeadCodeDetectorInput<'_>) -> Analysi
         },
     );
 
-    AnalysisResults {
+    ParallelDeadCodeDetectorResults {
         unused_files,
-        unused_exports: export_results.unused_exports,
-        unused_types: export_results.unused_types,
-        private_type_leaks: export_results.private_type_leaks,
-        stale_suppressions: export_results.stale_suppressions,
-        unused_enum_members: member_results.unused_enum_members,
-        unused_class_members: member_results.unused_class_members,
-        unused_store_members: member_results.unused_store_members,
-        unused_dependencies: dependency_results.unused_dependencies,
-        unused_dev_dependencies: dependency_results.unused_dev_dependencies,
-        unused_optional_dependencies: dependency_results.unused_optional_dependencies,
-        unlisted_dependencies: dependency_results.unlisted_dependencies,
-        type_only_dependencies: dependency_results.type_only_dependencies,
-        test_only_dependencies: dependency_results.test_only_dependencies,
+        export_results,
+        member_results,
+        dependency_results,
         unresolved_imports,
         duplicate_exports,
         boundary_violations,
@@ -1512,7 +1555,6 @@ fn run_parallel_dead_code_detectors(input: DeadCodeDetectorInput<'_>) -> Analysi
         circular_dependencies,
         re_export_cycles,
         export_usages,
-        ..AnalysisResults::default()
     }
 }
 

--- a/crates/mcp/src/tools/inspect_target.rs
+++ b/crates/mcp/src/tools/inspect_target.rs
@@ -1,457 +1,54 @@
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content, RawContent};
-use serde::Serialize;
-use serde_json::{Value, json};
+use rmcp::model::{CallToolResult, Content};
 
-use crate::params::{
-    AnalyzeParams, FindDupesParams, HealthParams, InspectTarget, InspectTargetParams,
-    SecurityCandidatesParams, TraceExportParams, TraceFileParams,
-};
+use crate::params::{InspectTarget, InspectTargetParams};
 
-use super::{
-    build_analyze_args, build_find_dupes_args, build_health_args, build_security_candidates_args,
-    build_trace_export_args, build_trace_file_args, run_tool, validation_error_body,
-};
+use super::{push_global, push_scope, run_tool, validation_error_body};
 
 const TOOL: &str = "inspect_target";
 
-#[derive(Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum SectionStatus {
-    Ok,
-    Error,
-}
-
-#[derive(Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum EvidenceScope {
-    Symbol,
-    File,
-    ProjectFilteredToFile,
-}
-
-#[derive(Serialize)]
-struct EvidenceSection {
-    status: SectionStatus,
-    scope: EvidenceScope,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<Value>,
-}
-
-impl EvidenceSection {
-    fn ok(scope: EvidenceScope, data: Value) -> Self {
-        Self {
-            status: SectionStatus::Ok,
-            scope,
-            message: None,
-            data: Some(data),
-        }
-    }
-
-    fn error(scope: EvidenceScope, message: String) -> Self {
-        Self {
-            status: SectionStatus::Error,
-            scope,
-            message: Some(message),
-            data: None,
-        }
-    }
-}
-
-#[derive(Serialize)]
-struct InspectEvidence {
-    trace_file: EvidenceSection,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    trace_export: Option<EvidenceSection>,
-    dead_code: EvidenceSection,
-    duplication: EvidenceSection,
-    complexity: EvidenceSection,
-    security: EvidenceSection,
-}
-
-#[derive(Serialize)]
-struct InspectBundle {
-    kind: &'static str,
-    target: Value,
-    identity: Value,
-    evidence: InspectEvidence,
-    warnings: Vec<String>,
-}
-
-struct NormalizedTarget<'a> {
-    file: &'a str,
-    export_name: Option<&'a str>,
-}
-
-impl<'a> NormalizedTarget<'a> {
-    fn from_params(params: &'a InspectTargetParams) -> Result<Self, String> {
-        match &params.target {
-            InspectTarget::File { file } => {
-                require_non_empty("target.file", file)?;
-                Ok(Self {
-                    file,
-                    export_name: None,
-                })
-            }
-            InspectTarget::Symbol { file, export_name } => {
-                require_non_empty("target.file", file)?;
-                require_non_empty("target.export_name", export_name)?;
-                Ok(Self {
-                    file,
-                    export_name: Some(export_name),
-                })
-            }
-        }
-    }
-
-    fn target_json(&self) -> Value {
-        match self.export_name {
-            Some(export_name) => json!({
-                "type": "symbol",
-                "file": self.file,
-                "export_name": export_name,
-            }),
-            None => json!({
-                "type": "file",
-                "file": self.file,
-            }),
-        }
-    }
-}
-
-/// Run the composed `inspect_target` MCP tool.
+/// Run the composed `inspect_target` MCP tool through the shared CLI inspect flow.
 pub async fn inspect_target(
     binary: &str,
     params: &InspectTargetParams,
 ) -> Result<CallToolResult, McpError> {
-    let target = match NormalizedTarget::from_params(params) {
-        Ok(target) => target,
-        Err(message) => return Ok(error_result(message)),
-    };
-
-    let trace_file = match run_inspect_trace_file(binary, params, target.file).await? {
-        RequiredJson::Value(value) => value,
-        RequiredJson::ToolError(result) => return Ok(result),
-    };
-
-    let mut warnings = Vec::new();
-    let trace_export = match run_inspect_trace_export(binary, params, &target).await? {
-        RequiredJson::Value(value) => value,
-        RequiredJson::ToolError(result) => return Ok(result),
-    };
-
-    if target.export_name.is_some() {
-        warnings.push(
-            "dead_code, duplication, complexity, and security evidence is file-scoped in v1; file:line symbol narrowing is a follow-up"
-                .to_string(),
-        );
-    }
-
-    let identity = match trace_export.as_ref() {
-        Some(export) => json!({
-            "file": target.file,
-            "export_name": target.export_name,
-            "file_reachable": export.get("file_reachable"),
-            "is_entry_point": export.get("is_entry_point"),
-            "is_used": export.get("is_used"),
-            "reason": export.get("reason"),
-        }),
-        None => json!({
-            "file": target.file,
-            "is_reachable": trace_file.get("is_reachable"),
-            "is_entry_point": trace_file.get("is_entry_point"),
-            "export_count": trace_file.get("exports").and_then(Value::as_array).map(Vec::len),
-            "import_count": trace_file.get("imports_from").and_then(Value::as_array).map(Vec::len),
-            "imported_by_count": trace_file.get("imported_by").and_then(Value::as_array).map(Vec::len),
-        }),
-    };
-
-    let evidence =
-        collect_inspect_evidence(binary, params, &target, trace_file, trace_export).await;
-    push_inspect_warnings(&mut warnings, &evidence);
-
-    let bundle = InspectBundle {
-        kind: TOOL,
-        target: target.target_json(),
-        identity,
-        evidence,
-        warnings,
-    };
-
-    let text = serde_json::to_string(&bundle).map_err(|err| {
-        McpError::internal_error(
-            format!("failed to serialize inspect_target output: {err}"),
-            None,
-        )
-    })?;
-    Ok(CallToolResult::success(vec![Content::text(text)]))
-}
-
-async fn run_inspect_trace_file(
-    binary: &str,
-    params: &InspectTargetParams,
-    file: &str,
-) -> Result<RequiredJson, McpError> {
-    let args = match build_trace_file_args(&TraceFileParams {
-        file: file.to_string(),
-        root: params.root.clone(),
-        config: params.config.clone(),
-        production: params.production,
-        workspace: params.workspace.clone(),
-        no_cache: params.no_cache,
-        threads: params.threads,
-    }) {
-        Ok(args) => args,
-        Err(message) => return Ok(RequiredJson::ToolError(error_result(message))),
-    };
-    run_required_json(binary, args).await
-}
-
-async fn run_inspect_trace_export(
-    binary: &str,
-    params: &InspectTargetParams,
-    target: &NormalizedTarget<'_>,
-) -> Result<RequiredJson<Option<Value>>, McpError> {
-    let Some(export_name) = target.export_name else {
-        return Ok(RequiredJson::Value(None));
-    };
-    let args = match build_trace_export_args(&TraceExportParams {
-        file: target.file.to_string(),
-        export_name: export_name.to_string(),
-        root: params.root.clone(),
-        config: params.config.clone(),
-        production: params.production,
-        workspace: params.workspace.clone(),
-        no_cache: params.no_cache,
-        threads: params.threads,
-    }) {
-        Ok(args) => args,
-        Err(message) => return Ok(RequiredJson::ToolError(error_result(message))),
-    };
-    match run_required_json(binary, args).await? {
-        RequiredJson::Value(value) => Ok(RequiredJson::Value(Some(value))),
-        RequiredJson::ToolError(result) => Ok(RequiredJson::ToolError(result)),
+    match build_inspect_args(params) {
+        Ok(args) => run_tool(binary, TOOL, &args).await,
+        Err(message) => Ok(CallToolResult::error(vec![Content::text(
+            validation_error_body(message),
+        )])),
     }
 }
 
-async fn collect_inspect_evidence(
-    binary: &str,
-    params: &InspectTargetParams,
-    target: &NormalizedTarget<'_>,
-    trace_file: Value,
-    trace_export: Option<Value>,
-) -> InspectEvidence {
-    let dead_code = inspect_dead_code_section(binary, params, target.file).await;
-    let duplication = inspect_duplication_section(binary, params, target.file).await;
-    let complexity = inspect_complexity_section(binary, params, target.file).await;
-    let security = inspect_security_section(binary, params, target.file).await;
+fn build_inspect_args(params: &InspectTargetParams) -> Result<Vec<String>, String> {
+    let mut args = vec![
+        "inspect".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+    push_global(
+        &mut args,
+        params.root.as_deref(),
+        params.config.as_deref(),
+        params.no_cache,
+        params.threads,
+    );
+    push_scope(&mut args, params.production, params.workspace.as_deref());
 
-    InspectEvidence {
-        trace_file: EvidenceSection::ok(EvidenceScope::File, trace_file),
-        trace_export: trace_export.map(|value| EvidenceSection::ok(EvidenceScope::Symbol, value)),
-        dead_code,
-        duplication,
-        complexity,
-        security,
-    }
-}
-
-fn push_inspect_warnings(warnings: &mut Vec<String>, evidence: &InspectEvidence) {
-    push_warning(warnings, "dead_code", &evidence.dead_code);
-    push_warning(warnings, "duplication", &evidence.duplication);
-    push_warning(warnings, "complexity", &evidence.complexity);
-    push_warning(warnings, "security", &evidence.security);
-}
-
-enum RequiredJson<T = Value> {
-    Value(T),
-    ToolError(CallToolResult),
-}
-
-async fn inspect_dead_code_section(
-    binary: &str,
-    params: &InspectTargetParams,
-    file: &str,
-) -> EvidenceSection {
-    match build_dead_code_args(params, file) {
-        Ok(args) => optional_section(binary, args, EvidenceScope::File, |value| value).await,
-        Err(message) => EvidenceSection::error(EvidenceScope::File, message),
-    }
-}
-
-async fn inspect_duplication_section(
-    binary: &str,
-    params: &InspectTargetParams,
-    file: &str,
-) -> EvidenceSection {
-    match build_dupes_args(params) {
-        Ok(args) => {
-            optional_section(
-                binary,
-                args,
-                EvidenceScope::ProjectFilteredToFile,
-                |value| filter_path_array(&value, file, "clone_groups"),
-            )
-            .await
+    match &params.target {
+        InspectTarget::File { file } => {
+            require_non_empty("target.file", file)?;
+            args.extend(["--file".to_string(), file.clone()]);
         }
-        Err(message) => EvidenceSection::error(EvidenceScope::ProjectFilteredToFile, message),
+        InspectTarget::Symbol { file, export_name } => {
+            require_non_empty("target.file", file)?;
+            require_non_empty("target.export_name", export_name)?;
+            args.extend(["--symbol".to_string(), format!("{file}:{export_name}")]);
+        }
     }
-}
 
-async fn inspect_complexity_section(
-    binary: &str,
-    params: &InspectTargetParams,
-    file: &str,
-) -> EvidenceSection {
-    optional_section(
-        binary,
-        build_health_args(&HealthParams {
-            root: params.root.clone(),
-            config: params.config.clone(),
-            production: params.production,
-            workspace: params.workspace.clone(),
-            complexity: Some(true),
-            no_cache: params.no_cache,
-            threads: params.threads,
-            ..Default::default()
-        }),
-        EvidenceScope::ProjectFilteredToFile,
-        |value| filter_path_array(&value, file, "findings"),
-    )
-    .await
-}
-
-async fn inspect_security_section(
-    binary: &str,
-    params: &InspectTargetParams,
-    file: &str,
-) -> EvidenceSection {
-    match build_security_candidates_args(&SecurityCandidatesParams {
-        root: params.root.clone(),
-        config: params.config.clone(),
-        workspace: params.workspace.clone(),
-        paths: Some(vec![file.to_string()]),
-        no_cache: params.no_cache,
-        threads: params.threads,
-        ..Default::default()
-    }) {
-        Ok(args) => optional_section(binary, args, EvidenceScope::File, |value| value).await,
-        Err(message) => EvidenceSection::error(EvidenceScope::File, message),
-    }
-}
-
-fn build_dead_code_args(params: &InspectTargetParams, file: &str) -> Result<Vec<String>, String> {
-    build_analyze_args(&AnalyzeParams {
-        root: params.root.clone(),
-        config: params.config.clone(),
-        production: params.production,
-        workspace: params.workspace.clone(),
-        file: Some(vec![file.to_string()]),
-        no_cache: params.no_cache,
-        threads: params.threads,
-        ..Default::default()
-    })
-}
-
-fn build_dupes_args(params: &InspectTargetParams) -> Result<Vec<String>, String> {
-    build_find_dupes_args(&FindDupesParams {
-        root: params.root.clone(),
-        config: params.config.clone(),
-        workspace: params.workspace.clone(),
-        no_cache: params.no_cache,
-        threads: params.threads,
-        ..Default::default()
-    })
-}
-
-async fn run_required_json(binary: &str, args: Vec<String>) -> Result<RequiredJson, McpError> {
-    let result = run_tool(binary, TOOL, &args).await?;
-    if result.is_error == Some(true) {
-        return Ok(RequiredJson::ToolError(result));
-    }
-    parse_result_json(&result)
-        .map(RequiredJson::Value)
-        .map_err(|message| McpError::internal_error(message, None))
-}
-
-async fn optional_section<F>(
-    binary: &str,
-    args: Vec<String>,
-    scope: EvidenceScope,
-    filter: F,
-) -> EvidenceSection
-where
-    F: FnOnce(Value) -> Value,
-{
-    match run_tool(binary, TOOL, &args).await {
-        Ok(result) if result.is_error == Some(true) => EvidenceSection::error(
-            scope,
-            result_text(&result).unwrap_or("command failed").to_string(),
-        ),
-        Ok(result) => match parse_result_json(&result) {
-            Ok(value) => EvidenceSection::ok(scope, filter(value)),
-            Err(message) => EvidenceSection::error(scope, message),
-        },
-        Err(err) => EvidenceSection::error(scope, err.to_string()),
-    }
-}
-
-fn parse_result_json(result: &CallToolResult) -> Result<Value, String> {
-    let text = result_text(result).ok_or_else(|| "tool returned no text content".to_string())?;
-    serde_json::from_str(text).map_err(|err| format!("tool returned invalid JSON: {err}"))
-}
-
-fn result_text(result: &CallToolResult) -> Option<&str> {
-    let content = result.content.first()?;
-    let RawContent::Text(text) = &content.raw else {
-        return None;
-    };
-    Some(&text.text)
-}
-
-fn filter_path_array(value: &Value, file: &str, key: &str) -> Value {
-    let matched = value
-        .get(key)
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter(|item| value_mentions_file(item, file))
-                .cloned()
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let matched_count = matched.len();
-
-    json!({
-        key: matched,
-        "matched_count": matched_count,
-        "summary": value.get("summary").cloned(),
-        "stats": value.get("stats").cloned(),
-    })
-}
-
-fn value_mentions_file(value: &Value, file: &str) -> bool {
-    match value {
-        Value::String(s) => path_eq(s, file),
-        Value::Array(items) => items.iter().any(|item| value_mentions_file(item, file)),
-        Value::Object(map) => map.values().any(|item| value_mentions_file(item, file)),
-        _ => false,
-    }
-}
-
-fn path_eq(left: &str, right: &str) -> bool {
-    left.replace('\\', "/") == right.replace('\\', "/")
-}
-
-fn push_warning(warnings: &mut Vec<String>, section: &str, evidence: &EvidenceSection) {
-    if matches!(evidence.status, SectionStatus::Error)
-        && let Some(message) = evidence.message.as_ref()
-    {
-        warnings.push(format!("{section} evidence unavailable: {message}"));
-    }
+    Ok(args)
 }
 
 fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
@@ -459,8 +56,4 @@ fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
         return Err(format!("{field} must not be empty"));
     }
     Ok(())
-}
-
-fn error_result(message: impl Into<String>) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(validation_error_body(message))])
 }

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Fallow JSON Output Schemas",
-  "description": "Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator (for example `dead-code`, `dead-code-grouped`, `health`, `dupes`, `combined`, `audit`, `explain`, `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of probing for unique field presence. `--legacy-envelope` removes only the document-root `kind` for one compatibility cycle. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.",
+  "description": "Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator (for example `dead-code`, `dead-code-grouped`, `health`, `dupes`, `combined`, `audit`, `explain`, `inspect_target`, `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of probing for unique field presence. `--legacy-envelope` removes only the document-root `kind` for one compatibility cycle. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.",
   "oneOf": [
     {
       "$ref": "#/definitions/FallowOutput"
@@ -7961,6 +7961,26 @@
           ]
         },
         {
+          "description": "`fallow inspect --format json`. Required `target`, `identity`,\n`evidence`, and `warnings`; no `schema_version`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InspectOutput"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "inspect_target"
+                }
+              },
+              "required": [
+                "kind"
+              ]
+            }
+          ]
+        },
+        {
           "description": "`fallow --format review-github` / `--format review-gitlab`. Required\n`body`, `comments`, `meta`; no `schema_version`.",
           "allOf": [
             {
@@ -15511,6 +15531,208 @@
         "not_checked"
       ],
       "description": "Detector status codes for framework health observability."
+    },
+    "InspectEvidence": {
+      "type": "object",
+      "properties": {
+        "trace_file": {
+          "$ref": "#/definitions/InspectEvidenceSection"
+        },
+        "trace_export": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InspectEvidenceSection"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dead_code": {
+          "$ref": "#/definitions/InspectEvidenceSection"
+        },
+        "duplication": {
+          "$ref": "#/definitions/InspectEvidenceSection"
+        },
+        "complexity": {
+          "$ref": "#/definitions/InspectEvidenceSection"
+        },
+        "security": {
+          "$ref": "#/definitions/InspectEvidenceSection"
+        }
+      },
+      "required": [
+        "trace_file",
+        "dead_code",
+        "duplication",
+        "complexity",
+        "security"
+      ]
+    },
+    "InspectEvidenceSection": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/InspectSectionStatus"
+        },
+        "scope": {
+          "$ref": "#/definitions/InspectEvidenceScope"
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": true
+      },
+      "required": [
+        "status",
+        "scope"
+      ]
+    },
+    "InspectFileIdentity": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "is_reachable": true,
+        "is_entry_point": true,
+        "export_count": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "import_count": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "imported_by_count": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "file"
+      ]
+    },
+    "InspectIdentity": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/InspectFileIdentity"
+        },
+        {
+          "$ref": "#/definitions/InspectSymbolIdentity"
+        }
+      ]
+    },
+    "InspectOutput": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/InspectTargetDescriptor"
+        },
+        "identity": {
+          "$ref": "#/definitions/InspectIdentity"
+        },
+        "evidence": {
+          "$ref": "#/definitions/InspectEvidence"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "target",
+        "identity",
+        "evidence",
+        "warnings"
+      ],
+      "title": "fallow inspect --format json",
+      "description": "Envelope emitted by `fallow inspect --format json`."
+    },
+    "InspectSymbolIdentity": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "export_name": {
+          "type": "string"
+        },
+        "file_reachable": true,
+        "is_entry_point": true,
+        "is_used": true,
+        "reason": true
+      },
+      "required": [
+        "file",
+        "export_name"
+      ]
+    },
+    "InspectTargetDescriptor": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "file"
+            }
+          },
+          "required": [
+            "type",
+            "file"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "export_name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "symbol"
+            }
+          },
+          "required": [
+            "type",
+            "file",
+            "export_name"
+          ]
+        }
+      ]
+    },
+    "InspectEvidenceScope": {
+      "type": "string",
+      "enum": [
+        "symbol",
+        "file",
+        "project_filtered_to_file"
+      ]
+    },
+    "InspectSectionStatus": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "error"
+      ]
     }
   }
 }

--- a/editors/vscode/.fallowrc.json
+++ b/editors/vscode/.fallowrc.json
@@ -13,10 +13,6 @@
     "../src/generated/output-contract.js"
   ],
   "ignoreDependencies": ["@vscode/vsce"],
-  "ignoreUnresolvedImports": [
-    "./generated/output-contract.js",
-    "../src/generated/output-contract.js"
-  ],
   "ignoreExports": [
     {
       "file": "src/types.ts",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -89,6 +89,11 @@
         "icon": "$(shield)"
       },
       {
+        "command": "fallow.inspectActiveFile",
+        "title": "Fallow: Inspect Active File",
+        "icon": "$(inspect)"
+      },
+      {
         "command": "fallow.selectWorkspace",
         "title": "Fallow: Select Workspace Scope...",
         "icon": "$(layers)"

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -61,6 +61,7 @@ import type {
   FallowCheckResult,
   FallowCombinedResult,
   FallowDupesResult,
+  FallowInspectResult,
   FallowFixResult,
   FixAction,
   HealthOutput,
@@ -374,6 +375,31 @@ export interface RunAnalysisOptions {
   readonly force?: boolean;
   readonly backoff?: AnalysisFailureBackoff;
 }
+
+export interface InspectArgsOptions {
+  readonly filePath: string;
+  readonly production: boolean | undefined;
+  readonly workspace: string;
+  readonly configPath: string;
+}
+
+export const buildInspectArgs = (options: InspectArgsOptions): string[] => {
+  const args = ["inspect", "--file", options.filePath, "--format", "json", "--quiet"];
+
+  if (options.workspace) {
+    args.push("--workspace", options.workspace);
+  }
+
+  if (options.production) {
+    args.push("--production");
+  }
+
+  if (options.configPath) {
+    args.push("--config", options.configPath);
+  }
+
+  return args;
+};
 
 const analysisBackoff = new AnalysisFailureBackoff();
 
@@ -780,6 +806,89 @@ export const runAudit = async (
     throw err;
   } finally {
     auditInFlight = false;
+  }
+};
+
+const activeEditorInspectTarget = (): {
+  readonly document: vscode.TextDocument;
+  readonly root: string;
+  readonly filePath: string;
+} | null => {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    void vscode.window.showWarningMessage("Fallow: no active editor to inspect.");
+    return null;
+  }
+
+  if (editor.document.uri.scheme !== "file") {
+    void vscode.window.showWarningMessage("Fallow: active editor is not a file on disk.");
+    return null;
+  }
+
+  const folder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+  const root = folder?.uri.fsPath ?? getWorkspaceRoot();
+  if (!root) {
+    void vscode.window.showWarningMessage("Fallow: no workspace folder open.");
+    return null;
+  }
+
+  const relative = path.relative(root, editor.document.uri.fsPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    void vscode.window.showWarningMessage("Fallow: active editor is outside the workspace.");
+    return null;
+  }
+
+  return {
+    document: editor.document,
+    root,
+    filePath: relative.split(path.sep).join(path.posix.sep),
+  };
+};
+
+export const runInspectActiveFile = async (
+  context: vscode.ExtensionContext,
+  outputChannel?: vscode.OutputChannel,
+): Promise<FallowInspectResult | null> => {
+  const target = activeEditorInspectTarget();
+  if (!target) {
+    return null;
+  }
+
+  try {
+    if (target.document.isDirty) {
+      const saved = await target.document.save();
+      if (!saved) {
+        void vscode.window.showWarningMessage(
+          `Fallow inspect cancelled because ${target.filePath} could not be saved.`,
+        );
+        return null;
+      }
+    }
+
+    const { binary } = await resolveCliForRun(context, outputChannel);
+    const args = buildInspectArgs({
+      filePath: target.filePath,
+      production: getProductionOverride(),
+      workspace: resolveActiveWorkspaceScope(context),
+      configPath: getResolvedConfigPath(),
+    });
+
+    const output = await execFallow(binary, args, target.root);
+    if (output.trim().length === 0) {
+      void vscode.window.showWarningMessage("Fallow inspect returned no output.");
+      return null;
+    }
+
+    const result = JSON.parse(output) as FallowInspectResult;
+    outputChannel?.appendLine(`Fallow inspect: ${target.filePath}`);
+    outputChannel?.appendLine(JSON.stringify(result, null, 2));
+    outputChannel?.show();
+    void vscode.window.showInformationMessage(`Fallow inspect complete: ${target.filePath}`);
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Fallow inspect failed: ${message}`);
+    return null;
   }
 };
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -34,6 +34,7 @@ import {
   runAudit,
   runFix,
   runHealthAnalysis,
+  runInspectActiveFile,
   runSecurityAnalysis,
   runWorkspaces,
 } from "./commands.js";
@@ -749,6 +750,11 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Extens
   );
   context.subscriptions.push(
     vscode.commands.registerCommand("fallow.analyzeSecurity", runSecurityAnalysisCommand),
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("fallow.inspectActiveFile", () =>
+      runInspectActiveFile(context, outputChannel),
+    ),
   );
 
   // Re-run the sidebar after a scope change so the tree views and status bar

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -25,7 +25,7 @@
 
 
 /**
- * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator (for example `dead-code`, `dead-code-grouped`, `health`, `dupes`, `combined`, `audit`, `explain`, `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of probing for unique field presence. `--legacy-envelope` removes only the document-root `kind` for one compatibility cycle. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.
+ * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator (for example `dead-code`, `dead-code-grouped`, `health`, `dupes`, `combined`, `audit`, `explain`, `inspect_target`, `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of probing for unique field presence. `--legacy-envelope` removes only the document-root `kind` for one compatibility cycle. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.
  */
 export type FallowJsonOutput = (FallowOutput | CodeClimateOutput)
 /**
@@ -51,6 +51,8 @@ export type FallowOutput = ((AuditOutput & {
 kind: "audit"
 }) | (ExplainOutput & {
 kind: "explain"
+}) | (InspectOutput & {
+kind: "inspect_target"
 }) | (ReviewEnvelopeOutput & {
 kind: "review-envelope"
 }) | (ReviewReconcileOutput & {
@@ -589,6 +591,17 @@ export type CssCandidateActionType = ("verify-unused" | "verify-undefined" | "co
  * Discriminant for [`UnusedAtRule::kind`].
  */
 export type UnusedAtRuleKind = ("property-registration" | "layer")
+export type InspectTargetDescriptor = ({
+file: string
+type: "file"
+} | {
+file: string
+export_name: string
+type: "symbol"
+})
+export type InspectIdentity = (InspectFileIdentity | InspectSymbolIdentity)
+export type InspectSectionStatus = ("ok" | "error")
+export type InspectEvidenceScope = ("symbol" | "file" | "project_filtered_to_file")
 /**
  * Singleton GitHub review-event marker.
  */
@@ -6405,6 +6418,45 @@ rationale: string
 example: string
 how_to_fix: string
 docs: string
+}
+/**
+ * Envelope emitted by `fallow inspect --format json`.
+ */
+export interface InspectOutput {
+target: InspectTargetDescriptor
+identity: InspectIdentity
+evidence: InspectEvidence
+warnings: string[]
+}
+export interface InspectFileIdentity {
+file: string
+is_reachable?: unknown
+is_entry_point?: unknown
+export_count?: (number | null)
+import_count?: (number | null)
+imported_by_count?: (number | null)
+}
+export interface InspectSymbolIdentity {
+file: string
+export_name: string
+file_reachable?: unknown
+is_entry_point?: unknown
+is_used?: unknown
+reason?: unknown
+}
+export interface InspectEvidence {
+trace_file: InspectEvidenceSection
+trace_export?: (InspectEvidenceSection | null)
+dead_code: InspectEvidenceSection
+duplication: InspectEvidenceSection
+complexity: InspectEvidenceSection
+security: InspectEvidenceSection
+}
+export interface InspectEvidenceSection {
+status: InspectSectionStatus
+scope: InspectEvidenceScope
+message?: (string | null)
+data?: unknown
 }
 /**
  * Envelope emitted by `fallow --format review-github` / `review-gitlab`.

--- a/editors/vscode/src/types.ts
+++ b/editors/vscode/src/types.ts
@@ -61,6 +61,7 @@ export type {
   EntryPoints,
   FindingSeverity,
   FixAction as SuggestionFixAction,
+  FallowOutput,
   HealthFinding,
   HealthOutput,
   HealthReport,
@@ -114,7 +115,10 @@ export type {
   WorkspacesOutput,
 } from "./generated/output-contract.js";
 
+import type { FallowOutput } from "./generated/output-contract.js";
+
 export type { CheckOutput as FallowCheckResult } from "./generated/output-contract.js";
+export type FallowInspectResult = Extract<FallowOutput, { kind: "inspect_target" }>;
 // The VS Code extension reads dupes only via the combined invocation
 // (`fallow --format json`), where `combined.dupes` is the typed
 // `DupesReportPayload` body (introduced in #409), NOT the full

--- a/editors/vscode/test/commands.test.ts
+++ b/editors/vscode/test/commands.test.ts
@@ -13,6 +13,18 @@ let mockInstalledCli: string | null = null;
 let mockDownloadedCli: string | null = null;
 let mockExtensionVersion: string | null = null;
 let mockBinaryVersions: Readonly<Record<string, string | null>> = {};
+let mockActiveTextEditor:
+  | {
+      readonly document: {
+        readonly uri: {
+          readonly scheme: string;
+          readonly fsPath: string;
+        };
+        readonly isDirty: boolean;
+        readonly save: () => Promise<boolean>;
+      };
+    }
+  | undefined;
 
 vi.mock("node:fs", () => ({
   existsSync: (p: string) => mockFiles.has(p),
@@ -23,6 +35,9 @@ vi.mock("vscode", () => ({
     Separator: -1,
   },
   window: {
+    get activeTextEditor() {
+      return mockActiveTextEditor;
+    },
     showWarningMessage: vi.fn(),
     showInformationMessage: vi.fn(),
     showErrorMessage: vi.fn(async () => undefined),
@@ -31,6 +46,17 @@ vi.mock("vscode", () => ({
   },
   workspace: {
     workspaceFolders: undefined,
+    getWorkspaceFolder: vi.fn((uri: { readonly fsPath: string }) => {
+      const workspace = mockWorkspace as {
+        readonly workspaceFolders:
+          | ReadonlyArray<{ readonly uri: { readonly fsPath: string } }>
+          | undefined;
+      };
+      return (
+        workspace.workspaceFolders?.find((folder) => uri.fsPath.startsWith(folder.uri.fsPath)) ??
+        undefined
+      );
+    }),
   },
   commands: {
     executeCommand: vi.fn(),
@@ -90,6 +116,7 @@ import {
   execFallow,
   FallowExecError,
   findCliBinary,
+  runInspectActiveFile,
   resolveCliBinary,
   resolveCliForRun,
   runAnalysis,
@@ -181,6 +208,24 @@ const setWorkspaceRoot = (root: string | null): void => {
     workspaceFolders: ReadonlyArray<{ readonly uri: { readonly fsPath: string } }> | undefined;
   };
   workspace.workspaceFolders = root === null ? undefined : [{ uri: { fsPath: root } }];
+};
+
+interface ActiveEditorOptions {
+  readonly isDirty?: boolean;
+  readonly save?: () => Promise<boolean>;
+}
+
+const setActiveEditor = (fsPath: string | null, options: ActiveEditorOptions = {}): void => {
+  mockActiveTextEditor =
+    fsPath === null
+      ? undefined
+      : {
+          document: {
+            uri: { scheme: "file", fsPath },
+            isDirty: options.isDirty ?? false,
+            save: options.save ?? (() => Promise.resolve(true)),
+          },
+        };
 };
 
 const restoreMaxFileSizeEnv = (value: string | undefined): void => {
@@ -620,6 +665,143 @@ describe("runHealthAnalysis no-workspace gate (#902)", () => {
     resetHealthNoWorkspaceWarning();
     await runHealthAnalysis(context);
     expect(mockWindow.showWarningMessage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("runInspectActiveFile", () => {
+  beforeEach(() => {
+    mockLspPath = "";
+    mockLocalBinary = null;
+    mockPathBinary = null;
+    mockInstalledCli = null;
+    mockDownloadedCli = null;
+    mockExtensionVersion = null;
+    mockBinaryVersions = {};
+    setWorkspaceRoot(null);
+    setActiveEditor(null);
+    vi.clearAllMocks();
+  });
+
+  it("runs inspect for the active file and writes the JSON bundle to the output channel", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fallow-vscode-inspect-"));
+    const script = join(dir, "fallow-cli.js");
+    const filePath = join(dir, "src", "extension.ts");
+    const logPath = join(dir, "spawn.log");
+    const output = JSON.stringify({
+      kind: "inspect_target",
+      target: { type: "file", file: "src/extension.ts" },
+      identity: { file: "src/extension.ts" },
+      evidence: {},
+      warnings: [],
+    });
+    const outputChannel = {
+      appendLine: vi.fn(),
+      show: vi.fn(),
+    } as unknown as vscode.OutputChannel;
+
+    try {
+      await writeFile(
+        script,
+        [
+          "#!/usr/bin/env node",
+          'const fs = require("node:fs");',
+          `fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args: process.argv.slice(2) }) + "\\n");`,
+          `process.stdout.write(${JSON.stringify(output)});`,
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(script, 0o755);
+
+      mockPathBinary = script;
+      setWorkspaceRoot(dir);
+      setActiveEditor(filePath);
+
+      const result = await runInspectActiveFile(workspaceContext, outputChannel);
+      const calls = await readSpawnLog(logPath);
+
+      expect(result?.kind).toBe("inspect_target");
+      expect(calls[0]?.args).toEqual([
+        "inspect",
+        "--file",
+        "src/extension.ts",
+        "--format",
+        "json",
+        "--quiet",
+      ]);
+      expect(outputChannel.appendLine).toHaveBeenCalledWith("Fallow inspect: src/extension.ts");
+      expect(outputChannel.show).toHaveBeenCalled();
+    } finally {
+      setWorkspaceRoot(null);
+      setActiveEditor(null);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("saves a dirty active file before running inspect", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fallow-vscode-inspect-save-"));
+    const script = join(dir, "fallow-cli.js");
+    const filePath = join(dir, "src", "extension.ts");
+    const logPath = join(dir, "spawn.log");
+    const save = vi.fn<() => Promise<boolean>>().mockResolvedValue(true);
+
+    try {
+      await writeFile(
+        script,
+        [
+          "#!/usr/bin/env node",
+          'const fs = require("node:fs");',
+          `fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args: process.argv.slice(2) }) + "\\n");`,
+          'process.stdout.write(\'{"kind":"inspect_target","warnings":[]}\');',
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(script, 0o755);
+
+      mockPathBinary = script;
+      setWorkspaceRoot(dir);
+      setActiveEditor(filePath, { isDirty: true, save });
+
+      const result = await runInspectActiveFile(workspaceContext);
+      const calls = await readSpawnLog(logPath);
+
+      expect(save).toHaveBeenCalledOnce();
+      expect(result?.kind).toBe("inspect_target");
+      expect(calls[0]?.args).toContain("src/extension.ts");
+    } finally {
+      setWorkspaceRoot(null);
+      setActiveEditor(null);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not run inspect when saving a dirty active file fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fallow-vscode-inspect-save-fail-"));
+    const script = join(dir, "fallow-cli.js");
+    const filePath = join(dir, "src", "extension.ts");
+    const logPath = join(dir, "spawn.log");
+    const save = vi.fn<() => Promise<boolean>>().mockResolvedValue(false);
+
+    try {
+      await writeFile(script, "#!/usr/bin/env node\n", "utf8");
+      await chmod(script, 0o755);
+
+      mockPathBinary = script;
+      setWorkspaceRoot(dir);
+      setActiveEditor(filePath, { isDirty: true, save });
+
+      const result = await runInspectActiveFile(workspaceContext);
+
+      expect(result).toBeNull();
+      expect(save).toHaveBeenCalledOnce();
+      expect(mockWindow.showWarningMessage).toHaveBeenCalledWith(
+        "Fallow inspect cancelled because src/extension.ts could not be saved.",
+      );
+      await expect(readSpawnLog(logPath)).rejects.toThrow();
+    } finally {
+      setWorkspaceRoot(null);
+      setActiveEditor(null);
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -25,7 +25,7 @@
 
 
 /**
- * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator (for example `dead-code`, `dead-code-grouped`, `health`, `dupes`, `combined`, `audit`, `explain`, `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of probing for unique field presence. `--legacy-envelope` removes only the document-root `kind` for one compatibility cycle. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.
+ * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator (for example `dead-code`, `dead-code-grouped`, `health`, `dupes`, `combined`, `audit`, `explain`, `inspect_target`, `impact`, `security`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `review-envelope`, and `review-reconcile`). Consumers should branch on `kind` instead of probing for unique field presence. `--legacy-envelope` removes only the document-root `kind` for one compatibility cycle. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.
  */
 export type FallowJsonOutput = (FallowOutput | CodeClimateOutput)
 /**
@@ -51,6 +51,8 @@ export type FallowOutput = ((AuditOutput & {
 kind: "audit"
 }) | (ExplainOutput & {
 kind: "explain"
+}) | (InspectOutput & {
+kind: "inspect_target"
 }) | (ReviewEnvelopeOutput & {
 kind: "review-envelope"
 }) | (ReviewReconcileOutput & {
@@ -589,6 +591,17 @@ export type CssCandidateActionType = ("verify-unused" | "verify-undefined" | "co
  * Discriminant for [`UnusedAtRule::kind`].
  */
 export type UnusedAtRuleKind = ("property-registration" | "layer")
+export type InspectTargetDescriptor = ({
+file: string
+type: "file"
+} | {
+file: string
+export_name: string
+type: "symbol"
+})
+export type InspectIdentity = (InspectFileIdentity | InspectSymbolIdentity)
+export type InspectSectionStatus = ("ok" | "error")
+export type InspectEvidenceScope = ("symbol" | "file" | "project_filtered_to_file")
 /**
  * Singleton GitHub review-event marker.
  */
@@ -6405,6 +6418,45 @@ rationale: string
 example: string
 how_to_fix: string
 docs: string
+}
+/**
+ * Envelope emitted by `fallow inspect --format json`.
+ */
+export interface InspectOutput {
+target: InspectTargetDescriptor
+identity: InspectIdentity
+evidence: InspectEvidence
+warnings: string[]
+}
+export interface InspectFileIdentity {
+file: string
+is_reachable?: unknown
+is_entry_point?: unknown
+export_count?: (number | null)
+import_count?: (number | null)
+imported_by_count?: (number | null)
+}
+export interface InspectSymbolIdentity {
+file: string
+export_name: string
+file_reachable?: unknown
+is_entry_point?: unknown
+is_used?: unknown
+reason?: unknown
+}
+export interface InspectEvidence {
+trace_file: InspectEvidenceSection
+trace_export?: (InspectEvidenceSection | null)
+dead_code: InspectEvidenceSection
+duplication: InspectEvidenceSection
+complexity: InspectEvidenceSection
+security: InspectEvidenceSection
+}
+export interface InspectEvidenceSection {
+status: InspectSectionStatus
+scope: InspectEvidenceScope
+message?: (string | null)
+data?: unknown
 }
 /**
  * Envelope emitted by `fallow --format review-github` / `review-gitlab`.


### PR DESCRIPTION
Expose `fallow inspect` as the CLI and editor path for the same evidence bundle that MCP `inspect_target` returns. The CLI composes trace, dead-code, duplication, complexity, and security evidence without adding a new analyzer pass.

Route the MCP tool through the CLI adapter, document the typed `inspect_target` root output in the schema, and regenerate the VS Code and npm contracts. The VS Code command now saves dirty active files before inspection and consumes the generated output type.

Tighten dogfood coverage for health, duplication, audit, duplicate config keys, and GitHub/GitLab renderer parity while keeping the core dead-code orchestration refactor local to result collection.
