### PR TITLE
fix(security): reject unsupported workflow flags

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2002,7 +2002,11 @@ fn parse_min_occurrences(s: &str) -> Result<usize, String> {
 /// Read `FALLOW_FORMAT` env var and parse it into a Format value.
 fn format_from_env() -> Option<Format> {
     let val = std::env::var("FALLOW_FORMAT").ok()?;
-    match val.to_lowercase().as_str() {
+    parse_format_arg(&val)
+}
+
+fn parse_format_arg(value: &str) -> Option<Format> {
+    match value.to_lowercase().as_str() {
         "json" => Some(Format::Json),
         "human" => Some(Format::Human),
         "sarif" => Some(Format::Sarif),
@@ -2968,6 +2972,7 @@ fn telemetry_analysis_mode_for_command(command: Option<&Command>) -> telemetry::
 }
 
 fn handle_cli_parse_error(err: &clap::Error) -> ExitCode {
+    let exit_code = u8::try_from(err.exit_code()).unwrap_or(2);
     if err.kind() == clap::error::ErrorKind::DisplayHelp
         && let Some(target) = security_help_target(std::env::args_os().skip(1))
     {
@@ -2975,9 +2980,54 @@ fn handle_cli_parse_error(err: &clap::Error) -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    let exit_code = err.exit_code();
+    if matches!(
+        parse_error_output_format(std::env::args_os().skip(1)),
+        fallow_config::OutputFormat::Json
+    ) {
+        return emit_error(
+            err.to_string().trim(),
+            exit_code,
+            fallow_config::OutputFormat::Json,
+        );
+    }
+
     let _ = err.print();
-    ExitCode::from(u8::try_from(exit_code).unwrap_or(2))
+    ExitCode::from(exit_code)
+}
+
+fn parse_error_output_format<I, S>(args: I) -> fallow_config::OutputFormat
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args: Vec<String> = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_string_lossy().into_owned())
+        .collect();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if matches!(arg.as_str(), "--format" | "--output" | "-f") {
+            return iter
+                .next()
+                .and_then(|value| parse_format_arg(value))
+                .unwrap_or(Format::Human)
+                .into();
+        }
+        let short_format_value = if arg.starts_with("--") {
+            None
+        } else {
+            arg.strip_prefix("-f")
+        };
+        if let Some(value) = arg
+            .strip_prefix("--format=")
+            .or_else(|| arg.strip_prefix("--output="))
+            .or(short_format_value)
+            .filter(|value| !value.is_empty())
+        {
+            return parse_format_arg(value).unwrap_or(Format::Human).into();
+        }
+    }
+    format_from_env().unwrap_or(Format::Human).into()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3091,7 +3141,7 @@ Options:
       --changed-since <REF>          Scope analysis to files changed since this git ref
       --diff-file <PATH>             Unified diff for line-level scoping
       --diff-stdin                   Read the unified diff from stdin
-      --file <PATH>                  Scope diagnostics to selected files
+      --file <PATH>                  Scope diagnostics to selected files: use `fallow security --file <PATH> blind-spots`
   -w, --workspace <WORKSPACE>        Scope output to selected workspaces
       --changed-workspaces <REF>     Scope output to workspaces touched since this git ref
   -o, --output-file <PATH>           Write the report to a file instead of stdout
@@ -3506,19 +3556,25 @@ fn dispatch_security_command(command: Command, dispatch: &DispatchContext<'_>) -
     let root = dispatch.root;
     let threads = dispatch.threads;
     let (output, quiet, fail_on_issues) = dispatch.ci_defaults();
+    let derived_flags = SecurityDerivedFlagState {
+        output,
+        ci: cli.ci,
+        fail_on_issues,
+        sarif_file: cli.sarif_file.as_deref(),
+        summary: cli.summary,
+        explain: cli.explain,
+        runtime_coverage: runtime_coverage.as_deref(),
+        min_invocations_hot,
+        file: file.as_slice(),
+        gate,
+        surface,
+    };
     if let Some(SecuritySubcommand::Survivors {
         candidates,
         verdicts,
     }) = &subcommand
     {
-        if let Some(code) = validate_security_survivors_flags(
-            output,
-            runtime_coverage.as_deref(),
-            min_invocations_hot,
-            file.as_slice(),
-            gate,
-            surface,
-        ) {
+        if let Some(code) = validate_security_survivors_flags(&derived_flags) {
             return code;
         }
         return security::run_survivors(&security::SecuritySurvivorsOptions {
@@ -3550,9 +3606,7 @@ fn dispatch_security_command(command: Command, dispatch: &DispatchContext<'_>) -
         explain: cli.explain,
     };
     if matches!(subcommand, Some(SecuritySubcommand::BlindSpots)) {
-        if let Some(code) =
-            validate_security_blind_spots_flags(output, fail_on_issues, cli.summary, gate, surface)
-        {
+        if let Some(code) = validate_security_blind_spots_flags(&derived_flags) {
             return code;
         }
         security::run_blind_spots(&opts)
@@ -3561,23 +3615,40 @@ fn dispatch_security_command(command: Command, dispatch: &DispatchContext<'_>) -
     }
 }
 
-fn validate_security_survivors_flags(
+struct SecurityDerivedFlagState<'a> {
     output: fallow_config::OutputFormat,
-    runtime_coverage: Option<&Path>,
+    ci: bool,
+    fail_on_issues: bool,
+    sarif_file: Option<&'a Path>,
+    summary: bool,
+    explain: bool,
+    runtime_coverage: Option<&'a Path>,
     min_invocations_hot: u64,
-    file: &[PathBuf],
+    file: &'a [PathBuf],
     gate: Option<security::SecurityGateMode>,
     surface: bool,
-) -> Option<ExitCode> {
-    let flag = if runtime_coverage.is_some() {
+}
+
+fn validate_security_survivors_flags(flags: &SecurityDerivedFlagState<'_>) -> Option<ExitCode> {
+    let flag = if flags.ci {
+        Some("--ci")
+    } else if flags.fail_on_issues {
+        Some("--fail-on-issues")
+    } else if flags.sarif_file.is_some() {
+        Some("--sarif-file")
+    } else if flags.summary {
+        Some("--summary")
+    } else if flags.explain {
+        Some("--explain")
+    } else if flags.runtime_coverage.is_some() {
         Some("--runtime-coverage")
-    } else if min_invocations_hot != DEFAULT_MIN_INVOCATIONS_HOT {
+    } else if flags.min_invocations_hot != DEFAULT_MIN_INVOCATIONS_HOT {
         Some("--min-invocations-hot")
-    } else if !file.is_empty() {
+    } else if !flags.file.is_empty() {
         Some("--file")
-    } else if gate.is_some() {
+    } else if flags.gate.is_some() {
         Some("--gate")
-    } else if surface {
+    } else if flags.surface {
         Some("--surface")
     } else {
         None
@@ -3585,24 +3656,28 @@ fn validate_security_survivors_flags(
     Some(emit_error(
         &format!("{flag} is not valid with `fallow security survivors`."),
         2,
-        output,
+        flags.output,
     ))
 }
 
-fn validate_security_blind_spots_flags(
-    output: fallow_config::OutputFormat,
-    fail_on_issues: bool,
-    summary: bool,
-    gate: Option<security::SecurityGateMode>,
-    surface: bool,
-) -> Option<ExitCode> {
-    let flag = if fail_on_issues {
+fn validate_security_blind_spots_flags(flags: &SecurityDerivedFlagState<'_>) -> Option<ExitCode> {
+    let flag = if flags.ci {
+        Some("--ci")
+    } else if flags.fail_on_issues {
         Some("--fail-on-issues")
-    } else if summary {
+    } else if flags.sarif_file.is_some() {
+        Some("--sarif-file")
+    } else if flags.summary {
         Some("--summary")
-    } else if gate.is_some() {
+    } else if flags.explain {
+        Some("--explain")
+    } else if flags.runtime_coverage.is_some() {
+        Some("--runtime-coverage")
+    } else if flags.min_invocations_hot != DEFAULT_MIN_INVOCATIONS_HOT {
+        Some("--min-invocations-hot")
+    } else if flags.gate.is_some() {
         Some("--gate")
-    } else if surface {
+    } else if flags.surface {
         Some("--surface")
     } else {
         None
@@ -3610,7 +3685,7 @@ fn validate_security_blind_spots_flags(
     Some(emit_error(
         &format!("{flag} is not valid with `fallow security blind-spots`."),
         2,
-        output,
+        flags.output,
     ))
 }
 

--- a/crates/cli/tests/security_workflow_tests.rs
+++ b/crates/cli/tests/security_workflow_tests.rs
@@ -41,6 +41,17 @@ fn security_finding_json(
     })
 }
 
+fn write_empty_survivor_inputs(dir: &tempfile::TempDir) -> (String, String) {
+    let candidates = dir.path().join("candidates.json");
+    let verdicts = dir.path().join("verdicts.json");
+    std::fs::write(&candidates, r#"{"security_findings":[]}"#).expect("write candidates");
+    std::fs::write(&verdicts, "[]").expect("write verdicts");
+    (
+        candidates.to_string_lossy().to_string(),
+        verdicts.to_string_lossy().to_string(),
+    )
+}
+
 #[test]
 fn security_survivors_renders_verifier_filtered_candidates() {
     let dir = tempfile::tempdir().expect("temp dir");
@@ -167,18 +178,17 @@ fn security_subcommand_help_reaches_subcommands() {
     assert!(!blind_spots.stdout.contains("markdown"));
     assert!(!blind_spots.stdout.contains("--baseline"));
     assert!(!blind_spots.stdout.contains("--gate"));
+    assert!(
+        blind_spots
+            .stdout
+            .contains("fallow security --file <PATH> blind-spots")
+    );
 }
 
 #[test]
 fn security_survivors_rejects_candidate_generation_flags() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let candidates = dir.path().join("candidates.json");
-    let verdicts = dir.path().join("verdicts.json");
-    std::fs::write(&candidates, r#"{"security_findings":[]}"#).expect("write candidates");
-    std::fs::write(&verdicts, "[]").expect("write verdicts");
-
-    let candidates = candidates.to_string_lossy().to_string();
-    let verdicts = verdicts.to_string_lossy().to_string();
+    let (candidates, verdicts) = write_empty_survivor_inputs(&dir);
     let output = run_fallow_raw(&[
         "security",
         "--surface",
@@ -194,6 +204,72 @@ fn security_survivors_rejects_candidate_generation_flags() {
 }
 
 #[test]
+fn security_survivors_rejects_hidden_parent_flags() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (candidates, verdicts) = write_empty_survivor_inputs(&dir);
+    let sarif = dir.path().join("out.sarif").to_string_lossy().to_string();
+    let output = run_fallow_raw(&[
+        "security",
+        "survivors",
+        "--candidates",
+        &candidates,
+        "--verdicts",
+        &verdicts,
+        "--sarif-file",
+        &sarif,
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(output.code, 2);
+    let json = parse_json(&output);
+    assert_eq!(
+        json["message"],
+        "--sarif-file is not valid with `fallow security survivors`."
+    );
+
+    let output = run_fallow_raw(&[
+        "security",
+        "survivors",
+        "--candidates",
+        &candidates,
+        "--verdicts",
+        &verdicts,
+        "--fail-on-issues",
+    ]);
+
+    assert_eq!(output.code, 2);
+    assert!(
+        output
+            .stderr
+            .contains("--fail-on-issues is not valid with `fallow security survivors`.")
+    );
+}
+
+#[test]
+fn security_survivors_parse_errors_honor_json_format() {
+    let output = run_fallow_raw(&[
+        "security",
+        "survivors",
+        "--candidates",
+        "/tmp/fallow-missing-candidates.json",
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(output.code, 2);
+    assert!(output.stderr.is_empty());
+    let json = parse_json(&output);
+    assert_eq!(json["error"], true);
+    assert_eq!(json["exit_code"], 2);
+    assert!(
+        json["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("--verdicts <PATH>"))
+    );
+}
+
+#[test]
 fn security_blind_spots_rejects_gate_flags() {
     let output = run_fallow(
         "security",
@@ -206,5 +282,46 @@ fn security_blind_spots_rejects_gate_flags() {
     assert_eq!(
         json["message"],
         "--gate is not valid with `fallow security blind-spots`."
+    );
+}
+
+#[test]
+fn security_blind_spots_rejects_hidden_parent_flags() {
+    let output = run_fallow(
+        "security",
+        "security-tls-validation-disabled-895",
+        &[
+            "--runtime-coverage",
+            "/tmp/fallow-missing-runtime.json",
+            "blind-spots",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert_eq!(output.code, 2);
+    let json = parse_json(&output);
+    assert_eq!(
+        json["message"],
+        "--runtime-coverage is not valid with `fallow security blind-spots`."
+    );
+
+    let output = run_fallow(
+        "security",
+        "security-tls-validation-disabled-895",
+        &[
+            "--sarif-file",
+            "/tmp/fallow-blind-spots.sarif",
+            "blind-spots",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert_eq!(output.code, 2);
+    let json = parse_json(&output);
+    assert_eq!(
+        json["message"],
+        "--sarif-file is not valid with `fallow security blind-spots`."
     );
 }

--- a/docs/security-agent-verification.md
+++ b/docs/security-agent-verification.md
@@ -152,7 +152,7 @@ The verifier should return a compact verdict object:
 }
 ```
 
-`fallow-security-verdict/v1` is a supported input contract for `fallow security survivors`. Reject extra prose around the JSON object so the survivor renderer can parse the verdict without model-specific cleanup.
+`fallow-security-verdict/v1` is a supported input contract for `fallow security survivors`. Reject extra prose around the JSON object so the survivor renderer can parse the verdict without model-specific cleanup. Fallow persists `reason`, `rationale`, `confidence`, `impact`, and `fix_direction` in survivor output. `evidence_checked` and `dismissal_reason` are harness-owned audit fields today; fallow accepts verdict objects that include them, but does not render those fields.
 
 The survivor renderer accepts either an array of verdict objects or this wrapper shape:
 


### PR DESCRIPTION
## Summary

- return structured JSON for parser errors when `--format json` is requested
- reject unsupported parent flags on `security survivors` and `security blind-spots`
- clarify which verifier verdict fields fallow preserves in survivor output

## Validation

- `cargo test -p fallow-cli --test security_workflow_tests`
- `cargo test -p fallow-cli`
- `cargo clippy -p fallow-cli -- -D warnings`
- `cargo check --workspace`
- `cargo fmt --all -- --check`
