### PR TITLE
ci: keep benchmark watchdog in script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while preserving benchmark diagnostics on timeout.
+- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while preserving benchmark diagnostics through a script-local timeout.
 
 ## [2.99.0] - 2026-06-18
 

--- a/benchmarks/bench-ci.sh
+++ b/benchmarks/bench-ci.sh
@@ -20,19 +20,8 @@ FALLOW_BIN=""
 CLONE_DIR="/tmp/fallow-bench-ci"
 RUNS=3
 export FALLOW_QUIET="${FALLOW_QUIET:-1}"
-PROJECT_TIMEOUT_SECONDS="${PROJECT_TIMEOUT_SECONDS:-120}"
+PROJECT_TIMEOUT_SECONDS="${PROJECT_TIMEOUT_SECONDS:-300}"
 QUERY_MAX_COLD_MS="${QUERY_MAX_COLD_MS:-5000}"
-TIMEOUT_BIN=""
-TIMEOUT_ARGS=()
-
-if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="timeout"
-elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="gtimeout"
-fi
-if [[ -n "${TIMEOUT_BIN}" ]] && "${TIMEOUT_BIN}" --help 2>&1 | rg -q -- "--foreground"; then
-    TIMEOUT_ARGS=(--foreground)
-fi
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -131,15 +120,31 @@ clear_cache() {
 # Sets: ELAPSED_MS
 run_fallow() {
     local dir="$1"; shift
+    local elapsed_ticks=0
+    local pid
+    local run_status
+    local timeout_ticks=$((PROJECT_TIMEOUT_SECONDS * 10))
 
-    if [[ -n "${TIMEOUT_BIN}" ]]; then
-        "${TIMEOUT_BIN}" "${TIMEOUT_ARGS[@]}" "${PROJECT_TIMEOUT_SECONDS}" \
-            "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" \
-            >/dev/null 2>/dev/null
-    else
-        "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" \
-            >/dev/null 2>/dev/null
-    fi
+    "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" >/dev/null 2>/dev/null &
+    pid=$!
+
+    while kill -0 "${pid}" 2>/dev/null; do
+        if (( elapsed_ticks >= timeout_ticks )); then
+            kill -TERM "${pid}" 2>/dev/null || true
+            sleep 2
+            if kill -0 "${pid}" 2>/dev/null; then
+                kill -KILL "${pid}" 2>/dev/null || true
+            fi
+            wait "${pid}" 2>/dev/null || true
+            return 124
+        fi
+        sleep 0.1
+        elapsed_ticks=$((elapsed_ticks + 1))
+    done
+
+    wait "${pid}"
+    run_status=$?
+    return "${run_status}"
 }
 
 time_fallow() {


### PR DESCRIPTION
## Summary
- replace the external timeout wrapper in the real-world benchmark script with a script-local PID watchdog
- keep timeout failures as ordinary script failures so stderr summaries and artifacts can still be produced
- increase the per-project headroom for the expanded Next.js combined-analysis surface on GitHub Actions

## Evidence
- main real-world benchmark runs 27760911515 and 27762082396 exited 143 from the benchmark step before artifacts were uploaded

## Validation
- bash -n benchmarks/bench-ci.sh
- git diff --check
- PROJECT_TIMEOUT_SECONDS=1 ./benchmarks/bench-ci.sh --fallow-bin ./target/release/fallow --clone-dir benchmarks/fixtures/real-world --runs 1
- ./benchmarks/bench-ci.sh --fallow-bin ./target/release/fallow --clone-dir benchmarks/fixtures/real-world --runs 1