### PR TITLE
fix(ci): stream real-world benchmark logs

### DIFF
--- a/.github/workflows/bench-real-world.yml
+++ b/.github/workflows/bench-real-world.yml
@@ -48,7 +48,7 @@ jobs:
             --clone-dir /tmp/fallow-bench-ci \
             --runs 3 \
             > bench-real-world.json \
-            2>bench-real-world-stderr.txt
+            2> >(tee bench-real-world-stderr.txt >&2)
         continue-on-error: true
 
       - name: Store benchmark result


### PR DESCRIPTION
## Summary

- stream real-world benchmark stderr to the Actions log while preserving the artifact file
- keep benchmark behavior unchanged, only improve liveness and failure diagnostics

## Validation

- Ruby YAML parse for `.github/workflows/bench-real-world.yml`
- `bash -n` on the benchmark run script block
- `git diff --check`
