### PR TITLE
ci: stream real-world benchmark progress

### DIFF
--- a/.github/workflows/bench-real-world.yml
+++ b/.github/workflows/bench-real-world.yml
@@ -48,7 +48,7 @@ jobs:
             --clone-dir /tmp/fallow-bench-ci \
             --runs 3 \
             > bench-real-world.json \
-            2>bench-real-world-stderr.txt
+            2> >(tee bench-real-world-stderr.txt >&2)
         continue-on-error: true
 
       - name: Store benchmark result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while preserving benchmark diagnostics through a script-local timeout.
+- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while streaming progress and preserving diagnostics through a script-local timeout.
 
 ## [2.99.0] - 2026-06-18
 


### PR DESCRIPTION
## Summary
- stream real-world benchmark stderr to Actions logs with tee while preserving bench-real-world-stderr.txt
- avoid silent benchmark steps being terminated before artifacts and summaries can run

## Evidence
- main runs 27760911515, 27762082396, and 27763802714 exited 143 during the silent benchmark step before artifact upload

## Validation
- bash -n benchmarks/bench-ci.sh
- bash -n -c for the workflow command redirect shape
- PROJECT_TIMEOUT_SECONDS=1 ./benchmarks/bench-ci.sh ... 2> >(tee ... >&2)