### PR TITLE
fix(inspect): preserve inspect scope in child runs

### DIFF
--- a/benchmarks/bench-ci.sh
+++ b/benchmarks/bench-ci.sh
@@ -140,18 +140,30 @@ run_fallow() {
     local elapsed_ticks=0
     local pid
     local run_status
+    local kill_target
     local timeout_ticks=$((PROJECT_TIMEOUT_SECONDS * 10))
     local heartbeat_ticks=$((HEARTBEAT_SECONDS * 10))
 
-    "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" >/dev/null 2>/dev/null &
-    pid=$!
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" >/dev/null 2>/dev/null &
+        pid=$!
+        kill_target="-${pid}"
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
+            "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" >/dev/null 2>/dev/null &
+        pid=$!
+        kill_target="-${pid}"
+    else
+        echo "python3 or setsid is required for benchmark timeout cleanup" >&2
+        return 127
+    fi
 
     while kill -0 "${pid}" 2>/dev/null; do
         if (( elapsed_ticks >= timeout_ticks )); then
-            kill -TERM "${pid}" 2>/dev/null || true
+            kill -TERM -- "${kill_target}" 2>/dev/null || true
             sleep 2
             if kill -0 "${pid}" 2>/dev/null; then
-                kill -KILL "${pid}" 2>/dev/null || true
+                kill -KILL -- "${kill_target}" 2>/dev/null || true
             fi
             wait "${pid}" 2>/dev/null || true
             return 124
@@ -183,6 +195,16 @@ time_fallow() {
 
     ELAPSED_MS=$(( (end - start) / 1000000 ))
     return "${run_status}"
+}
+
+fallow_failure_message() {
+    local phase="$1"
+    local run_status="$2"
+    if [[ "${run_status}" -eq 124 ]]; then
+        echo "    FAIL: fallow timed out during ${phase} after ${PROJECT_TIMEOUT_SECONDS}s"
+    else
+        echo "    FAIL: fallow exited with status ${run_status} during ${phase}"
+    fi
 }
 
 median() {
@@ -242,8 +264,11 @@ for entry in "${PROJECTS[@]}"; do
     cold_times=()
     for (( i=0; i<RUNS; i++ )); do
         clear_cache "${dest}"
-        if ! time_fallow "${dest}" --no-cache; then
-            echo "    FAIL: fallow timed out or errored during cold run after ${PROJECT_TIMEOUT_SECONDS}s" >&2
+        if time_fallow "${dest}" --no-cache; then
+            :
+        else
+            run_status=$?
+            fallow_failure_message "cold run" "${run_status}" >&2
             exit 1
         fi
         cold_times+=("${ELAPSED_MS}")
@@ -253,15 +278,21 @@ for entry in "${PROJECTS[@]}"; do
     # --- Warm runs (with cache) ---
     clear_cache "${dest}"
     # Populate cache
-    if ! run_fallow "${dest}"; then
-        echo "    FAIL: fallow timed out or errored while warming cache after ${PROJECT_TIMEOUT_SECONDS}s" >&2
+    if run_fallow "${dest}"; then
+        :
+    else
+        run_status=$?
+        fallow_failure_message "cache warmup" "${run_status}" >&2
         exit 1
     fi
     # Measure
     warm_times=()
     for (( i=0; i<RUNS; i++ )); do
-        if ! time_fallow "${dest}"; then
-            echo "    FAIL: fallow timed out or errored during warm run after ${PROJECT_TIMEOUT_SECONDS}s" >&2
+        if time_fallow "${dest}"; then
+            :
+        else
+            run_status=$?
+            fallow_failure_message "warm run" "${run_status}" >&2
             exit 1
         fi
         warm_times+=("${ELAPSED_MS}")

--- a/crates/cli/src/inspect.rs
+++ b/crates/cli/src/inspect.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 use fallow_config::OutputFormat;
@@ -24,6 +24,8 @@ pub struct InspectOptions<'a> {
     pub config_path: &'a Option<PathBuf>,
     pub output: OutputFormat,
     pub no_cache: bool,
+    pub no_production: bool,
+    pub max_file_size: Option<u32>,
     pub threads: usize,
     pub quiet: bool,
     pub production: bool,
@@ -31,16 +33,18 @@ pub struct InspectOptions<'a> {
     pub target: InspectTarget,
 }
 
-struct NormalizedTarget<'a> {
-    file: &'a str,
-    export_name: Option<&'a str>,
+#[derive(Debug)]
+struct NormalizedTarget {
+    file: String,
+    export_name: Option<String>,
 }
 
-impl<'a> NormalizedTarget<'a> {
-    fn new(target: &'a InspectTarget) -> Result<Self, String> {
+impl NormalizedTarget {
+    fn new(root: &Path, target: &InspectTarget) -> Result<Self, String> {
         match target {
             InspectTarget::File { file } => {
                 require_non_empty("file", file)?;
+                let file = normalize_target_file(root, file)?;
                 Ok(Self {
                     file,
                     export_name: None,
@@ -49,40 +53,42 @@ impl<'a> NormalizedTarget<'a> {
             InspectTarget::Symbol { file, export_name } => {
                 require_non_empty("symbol file", file)?;
                 require_non_empty("symbol export", export_name)?;
+                let file = normalize_target_file(root, file)?;
                 Ok(Self {
                     file,
-                    export_name: Some(export_name),
+                    export_name: Some(export_name.clone()),
                 })
             }
         }
     }
 
     fn target_descriptor(&self) -> InspectTargetDescriptor {
-        match self.export_name {
+        match self.export_name.as_deref() {
             Some(export_name) => InspectTargetDescriptor::Symbol {
-                file: self.file.to_string(),
+                file: self.file.clone(),
                 export_name: export_name.to_string(),
             },
             None => InspectTargetDescriptor::File {
-                file: self.file.to_string(),
+                file: self.file.clone(),
             },
         }
     }
 }
 
 pub fn run_inspect(opts: &InspectOptions<'_>) -> ExitCode {
-    let target = match NormalizedTarget::new(&opts.target) {
+    let target = match NormalizedTarget::new(opts.root, &opts.target) {
         Ok(target) => target,
         Err(message) => return emit_error(&message, 2, opts.output),
     };
 
-    let trace_file = match run_required_json(opts, trace_file_args(target.file)) {
+    let target_file = target.file.as_str();
+    let trace_file = match run_required_json(opts, trace_file_args(target_file)) {
         Ok(value) => value,
         Err(message) => return emit_error(&message, 2, opts.output),
     };
-    let trace_export = match target.export_name {
+    let trace_export = match target.export_name.as_deref() {
         Some(export_name) => {
-            match run_required_json(opts, trace_export_args(target.file, export_name)) {
+            match run_required_json(opts, trace_export_args(target_file, export_name)) {
                 Ok(value) => Some(value),
                 Err(message) => return emit_error(&message, 2, opts.output),
             }
@@ -105,7 +111,7 @@ pub fn run_inspect(opts: &InspectOptions<'_>) -> ExitCode {
             .map(|value| InspectEvidenceSection::ok(InspectEvidenceScope::Symbol, value)),
         dead_code: optional_section(
             opts,
-            dead_code_args(target.file),
+            dead_code_args(target_file),
             InspectEvidenceScope::File,
             |value| value,
         ),
@@ -113,17 +119,17 @@ pub fn run_inspect(opts: &InspectOptions<'_>) -> ExitCode {
             opts,
             dupes_args(),
             InspectEvidenceScope::ProjectFilteredToFile,
-            |value| filter_path_array(&value, target.file, "clone_groups"),
+            |value| filter_path_array(&value, target_file, "clone_groups"),
         ),
         complexity: optional_section(
             opts,
             health_args(),
             InspectEvidenceScope::ProjectFilteredToFile,
-            |value| filter_path_array(&value, target.file, "findings"),
+            |value| filter_path_array(&value, target_file, "findings"),
         ),
         security: optional_section(
             opts,
-            security_args(target.file),
+            security_args(target_file),
             InspectEvidenceScope::File,
             |value| value,
         ),
@@ -132,15 +138,15 @@ pub fn run_inspect(opts: &InspectOptions<'_>) -> ExitCode {
 
     let identity = match trace_export.as_ref() {
         Some(export) => InspectIdentity::Symbol(InspectSymbolIdentity {
-            file: target.file.to_string(),
-            export_name: target.export_name.unwrap_or_default().to_string(),
+            file: target.file.clone(),
+            export_name: target.export_name.clone().unwrap_or_default(),
             file_reachable: export.get("file_reachable").cloned(),
             is_entry_point: export.get("is_entry_point").cloned(),
             is_used: export.get("is_used").cloned(),
             reason: export.get("reason").cloned(),
         }),
         None => InspectIdentity::File(InspectFileIdentity {
-            file: target.file.to_string(),
+            file: target.file.clone(),
             is_reachable: trace_file.get("is_reachable").cloned(),
             is_entry_point: trace_file.get("is_entry_point").cloned(),
             export_count: trace_file
@@ -192,6 +198,16 @@ fn print_human(bundle: &InspectOutput, quiet: bool) {
     outln!();
     outln!("  target: {}", json_display(&bundle.target));
     outln!("  identity: {}", json_display(&bundle.identity));
+    outln!();
+    outln!("Evidence");
+    print_evidence_summary("trace_file", &bundle.evidence.trace_file);
+    if let Some(section) = bundle.evidence.trace_export.as_ref() {
+        print_evidence_summary("trace_export", section);
+    }
+    print_evidence_summary("dead_code", &bundle.evidence.dead_code);
+    print_evidence_summary("duplication", &bundle.evidence.duplication);
+    print_evidence_summary("complexity", &bundle.evidence.complexity);
+    print_evidence_summary("security", &bundle.evidence.security);
     if !bundle.warnings.is_empty() && !quiet {
         outln!();
         for warning in &bundle.warnings {
@@ -202,6 +218,42 @@ fn print_human(bundle: &InspectOutput, quiet: bool) {
 
 fn json_display(value: &impl serde::Serialize) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "<unprintable>".to_string())
+}
+
+fn print_evidence_summary(name: &str, section: &InspectEvidenceSection) {
+    let status = match section.status {
+        InspectSectionStatus::Ok => "ok",
+        InspectSectionStatus::Error => "error",
+    };
+    let detail = evidence_detail(section)
+        .map(|detail| format!(" ({detail})"))
+        .unwrap_or_default();
+    outln!(
+        "  {name}: {status} [{}]{detail}",
+        evidence_scope_label(section.scope)
+    );
+}
+
+fn evidence_scope_label(scope: InspectEvidenceScope) -> &'static str {
+    match scope {
+        InspectEvidenceScope::Symbol => "symbol",
+        InspectEvidenceScope::File => "file",
+        InspectEvidenceScope::ProjectFilteredToFile => "project filtered to file",
+    }
+}
+
+fn evidence_detail(section: &InspectEvidenceSection) -> Option<String> {
+    if let Some(message) = section.message.as_deref() {
+        return Some(message.to_string());
+    }
+    let data = section.data.as_ref()?;
+    if let Some(count) = data.get("matched_count").and_then(Value::as_u64) {
+        return Some(format!("matches: {count}"));
+    }
+    if let Some(exports) = data.get("exports").and_then(Value::as_array) {
+        return Some(format!("exports: {}", exports.len()));
+    }
+    None
 }
 
 fn run_required_json(opts: &InspectOptions<'_>, args: Vec<String>) -> Result<Value, String> {
@@ -242,11 +294,7 @@ fn run_child_json(opts: &InspectOptions<'_>, args: Vec<String>) -> Result<ChildJ
     let stderr = String::from_utf8_lossy(&output.stderr);
     let code = output.status.code().unwrap_or(2);
     if code > 1 {
-        let message = if stderr.trim().is_empty() {
-            format!("child analysis exited with code {code}")
-        } else {
-            stderr.trim().to_string()
-        };
+        let message = child_error_message(code, &stdout, &stderr);
         return Err(message);
     }
     if stdout.trim().is_empty() {
@@ -274,6 +322,12 @@ fn build_child_args(opts: &InspectOptions<'_>, command_args: Vec<String>) -> Vec
     }
     if opts.no_cache {
         args.push("--no-cache".to_string());
+    }
+    if opts.no_production && command_name != Some("security") {
+        args.push("--no-production".to_string());
+    }
+    if let Some(max_file_size) = opts.max_file_size {
+        args.extend(["--max-file-size".to_string(), max_file_size.to_string()]);
     }
     args.extend(["--threads".to_string(), opts.threads.to_string()]);
     if opts.production && command_name != Some("security") {
@@ -361,6 +415,86 @@ fn path_eq(left: &str, right: &str) -> bool {
     left.replace('\\', "/") == right.replace('\\', "/")
 }
 
+fn normalize_target_file(root: &Path, file: &str) -> Result<String, String> {
+    let raw = file.trim();
+    let normalized_raw = raw.replace('\\', "/");
+    let path = Path::new(&normalized_raw);
+    let relative = if path.is_absolute() {
+        let absolute = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        absolute
+            .strip_prefix(root)
+            .map_err(|_| {
+                format!(
+                    "inspect target must be inside the project root: {}",
+                    absolute.display()
+                )
+            })?
+            .to_path_buf()
+    } else {
+        path.to_path_buf()
+    };
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!(
+                    "inspect target must be a root-relative path inside the project: {raw}"
+                ));
+            }
+        }
+    }
+    if parts.is_empty() {
+        return Err("inspect target file must not be empty".to_string());
+    }
+    Ok(parts.join("/"))
+}
+
+fn child_error_message(code: i32, stdout: &str, stderr: &str) -> String {
+    structured_child_message(stdout)
+        .or_else(|| {
+            let trimmed = strip_ansi(stderr.trim());
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .unwrap_or_else(|| format!("child analysis exited with code {code}"))
+}
+
+fn structured_child_message(stdout: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(stdout.trim()).ok()?;
+    value
+        .get("message")
+        .or_else(|| value.get("error_message"))
+        .and_then(Value::as_str)
+        .map(strip_ansi)
+        .filter(|message| !message.is_empty())
+}
+
+fn strip_ansi(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for next in chars.by_ref() {
+                if ('@'..='~').contains(&next) {
+                    break;
+                }
+            }
+            continue;
+        }
+        if ch.is_control() && ch != '\n' && ch != '\t' {
+            continue;
+        }
+        output.push(ch);
+    }
+    output.trim().to_string()
+}
+
 fn push_inspect_warnings(warnings: &mut Vec<String>, evidence: &InspectEvidence) {
     push_warning(warnings, "dead_code", &evidence.dead_code);
     push_warning(warnings, "duplication", &evidence.duplication);
@@ -381,4 +515,99 @@ fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
         return Err(format!("{field} must not be empty"));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inspect_options<'a>(
+        root: &'a Path,
+        config_path: &'a Option<PathBuf>,
+        target: InspectTarget,
+    ) -> InspectOptions<'a> {
+        InspectOptions {
+            root,
+            config_path,
+            output: OutputFormat::Json,
+            no_cache: true,
+            no_production: true,
+            max_file_size: Some(2),
+            threads: 3,
+            quiet: true,
+            production: false,
+            workspace: None,
+            target,
+        }
+    }
+
+    #[test]
+    fn normalized_target_uses_root_relative_posix_path() {
+        let root = PathBuf::from("/repo");
+        let file = "/repo/./src/api.ts".to_string();
+
+        let target = NormalizedTarget::new(&root, &InspectTarget::File { file }).unwrap();
+
+        assert_eq!(target.file, "src/api.ts");
+    }
+
+    #[test]
+    fn normalized_target_rejects_parent_paths() {
+        let root = PathBuf::from("/repo");
+        let file = "../other.ts".to_string();
+
+        let err = NormalizedTarget::new(&root, &InspectTarget::File { file }).unwrap_err();
+
+        assert!(err.contains("inside the project"));
+    }
+
+    #[test]
+    fn child_args_forward_global_inspect_overrides() {
+        let root = PathBuf::from("/repo");
+        let config_path = Some(PathBuf::from("/repo/.fallowrc.json"));
+        let opts = inspect_options(
+            &root,
+            &config_path,
+            InspectTarget::File {
+                file: "src/api.ts".to_string(),
+            },
+        );
+
+        let args = build_child_args(&opts, dead_code_args("src/api.ts"));
+
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--config", "/repo/.fallowrc.json"])
+        );
+        assert!(args.contains(&"--no-cache".to_string()));
+        assert!(args.contains(&"--no-production".to_string()));
+        assert!(args.windows(2).any(|pair| pair == ["--max-file-size", "2"]));
+        assert!(args.windows(2).any(|pair| pair == ["--threads", "3"]));
+    }
+
+    #[test]
+    fn child_args_do_not_forward_production_overrides_to_security() {
+        let root = PathBuf::from("/repo");
+        let config_path = None;
+        let opts = inspect_options(
+            &root,
+            &config_path,
+            InspectTarget::File {
+                file: "src/api.ts".to_string(),
+            },
+        );
+
+        let args = build_child_args(&opts, security_args("src/api.ts"));
+
+        assert!(!args.contains(&"--no-production".to_string()));
+        assert!(!args.contains(&"--production".to_string()));
+    }
+
+    #[test]
+    fn child_error_prefers_structured_stdout_message() {
+        let stdout = r#"{"message":"\u001b[31mconfig failed\u001b[0m","exit_code":2}"#;
+        let stderr = "warning before JSON\n";
+
+        assert_eq!(child_error_message(2, stdout, stderr), "config failed");
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3531,6 +3531,8 @@ fn dispatch_inspect_command(
         config_path: &dispatch.cli.config,
         output: dispatch.output,
         no_cache: dispatch.cli.no_cache,
+        no_production: dispatch.cli.no_production,
+        max_file_size: dispatch.cli.max_file_size,
         threads: dispatch.threads,
         quiet: dispatch.quiet,
         production: dispatch.cli.production,

--- a/crates/cli/tests/inspect_tests.rs
+++ b/crates/cli/tests/inspect_tests.rs
@@ -63,6 +63,30 @@ fn inspect_file_outputs_typed_evidence_bundle() {
 }
 
 #[test]
+fn inspect_file_accepts_absolute_path_inside_root() {
+    let dir = tempdir().unwrap();
+    write_project(dir.path());
+
+    let file = dir.path().join("src/api.ts");
+    let output = run_fallow_in_root(
+        "inspect",
+        dir.path(),
+        &[
+            "--file",
+            file.to_str().unwrap(),
+            "--format",
+            "json",
+            "--quiet",
+        ],
+    );
+    assert_eq!(output.code, 0, "inspect should exit 0: {}", output.stderr);
+
+    let json = parse_json(&output);
+    assert_eq!(json["target"]["file"].as_str(), Some("src/api.ts"));
+    assert_eq!(json["identity"]["file"].as_str(), Some("src/api.ts"));
+}
+
+#[test]
 fn inspect_symbol_outputs_trace_export_section() {
     let dir = tempdir().unwrap();
     write_project(dir.path());
@@ -93,5 +117,22 @@ fn inspect_symbol_outputs_trace_export_section() {
         json["warnings"]
             .as_array()
             .is_some_and(|items| !items.is_empty())
+    );
+}
+
+#[test]
+fn inspect_human_output_includes_evidence_summary() {
+    let dir = tempdir().unwrap();
+    write_project(dir.path());
+
+    let output = run_fallow_in_root("inspect", dir.path(), &["--file", "src/api.ts"]);
+    assert_eq!(output.code, 0, "inspect should exit 0: {}", output.stderr);
+
+    assert!(output.stdout.contains("Evidence"));
+    assert!(output.stdout.contains("trace_file: ok [file]"));
+    assert!(
+        output
+            .stdout
+            .contains("duplication: ok [project filtered to file]")
     );
 }

--- a/crates/mcp/src/tools/inspect_target.rs
+++ b/crates/mcp/src/tools/inspect_target.rs
@@ -34,7 +34,12 @@ fn build_inspect_args(params: &InspectTargetParams) -> Result<Vec<String>, Strin
         params.no_cache,
         params.threads,
     );
-    push_scope(&mut args, params.production, params.workspace.as_deref());
+    if params.production == Some(false) {
+        args.push("--no-production".to_string());
+        push_scope(&mut args, None, params.workspace.as_deref());
+    } else {
+        push_scope(&mut args, params.production, params.workspace.as_deref());
+    }
 
     match &params.target {
         InspectTarget::File { file } => {
@@ -56,4 +61,30 @@ fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
         return Err(format!("{field} must not be empty"));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_false_forces_inspect_out_of_production_mode() {
+        let params = InspectTargetParams {
+            root: None,
+            config: None,
+            no_cache: None,
+            threads: None,
+            production: Some(false),
+            workspace: Some("pkg-a".to_string()),
+            target: InspectTarget::File {
+                file: "src/api.ts".to_string(),
+            },
+        };
+
+        let args = build_inspect_args(&params).unwrap();
+
+        assert!(args.contains(&"--no-production".to_string()));
+        assert!(args.windows(2).any(|pair| pair == ["--workspace", "pkg-a"]));
+        assert!(!args.contains(&"--production".to_string()));
+    }
 }

--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -371,6 +371,38 @@ const execAnalysisTolerant = async (
   }
 };
 
+const execInspectWithManagedFallback = async (
+  context: vscode.ExtensionContext,
+  initialBinary: string | null,
+  args: ReadonlyArray<string>,
+  cwd: string,
+  outputChannel?: vscode.OutputChannel,
+): Promise<string> => {
+  try {
+    return await execFallow(initialBinary, args, cwd);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!parseUnknownSubcommand(message, "inspect")) {
+      throw err;
+    }
+
+    if (getAutoDownload()) {
+      const managed =
+        (await getInstalledCliPath(context, outputChannel)) ?? (await downloadCliBinary(context));
+      if (managed && managed !== initialBinary) {
+        outputChannel?.appendLine(
+          "Fallow: resolved CLI does not support inspect; switched to the managed CLI.",
+        );
+        return execFallow(managed, args, cwd);
+      }
+    }
+
+    throw new Error(
+      "The resolved fallow CLI does not support `fallow inspect`. Update the fallow binary, or enable fallow.autoDownload so the extension can use the managed CLI.",
+    );
+  }
+};
+
 export interface RunAnalysisOptions {
   readonly force?: boolean;
   readonly backoff?: AnalysisFailureBackoff;
@@ -870,10 +902,16 @@ export const runInspectActiveFile = async (
       filePath: target.filePath,
       production: getProductionOverride(),
       workspace: resolveActiveWorkspaceScope(context),
-      configPath: getResolvedConfigPath(),
+      configPath: getResolvedConfigPath(target.root),
     });
 
-    const output = await execFallow(binary, args, target.root);
+    const output = await execInspectWithManagedFallback(
+      context,
+      binary,
+      args,
+      target.root,
+      outputChannel,
+    );
     if (output.trim().length === 0) {
       void vscode.window.showWarningMessage("Fallow inspect returned no output.");
       return null;

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -14,7 +14,8 @@ import { getDiagnosticCategories } from "./diagnosticFilter.js";
 
 const SECTION = "fallow";
 
-const getConfig = (): vscode.WorkspaceConfiguration => vscode.workspace.getConfiguration(SECTION);
+const getConfig = (resource?: vscode.Uri): vscode.WorkspaceConfiguration =>
+  vscode.workspace.getConfiguration(SECTION, resource);
 
 const getConfiguredValue = <T>(key: string): T | undefined => {
   const inspected = getConfig().inspect<T>(key);
@@ -30,15 +31,17 @@ const getConfiguredValue = <T>(key: string): T | undefined => {
 
 export const getLspPath = (): string => getConfig().get<string>("lspPath", "");
 
-const getConfigPath = (): string => getConfig().get<string>("configPath", "").trim();
+const getConfigPath = (resource?: vscode.Uri): string =>
+  getConfig(resource).get<string>("configPath", "").trim();
 
-export const getResolvedConfigPath = (): string => {
-  const configPath = getConfigPath();
+export const getResolvedConfigPath = (workspaceRootOverride?: string): string => {
+  const resource = workspaceRootOverride ? vscode.Uri.file(workspaceRootOverride) : undefined;
+  const configPath = getConfigPath(resource);
   if (!configPath || path.isAbsolute(configPath)) {
     return configPath;
   }
 
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const workspaceRoot = workspaceRootOverride ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   return workspaceRoot ? path.resolve(workspaceRoot, configPath) : configPath;
 };
 

--- a/editors/vscode/src/security-utils.ts
+++ b/editors/vscode/src/security-utils.ts
@@ -102,11 +102,19 @@ export const hopRoleLabel = (role: TraceHopRole): string => {
  * phrasing (`The subcommand 'security' wasn't recognized`). Unrelated errors
  * return false so genuine failures stay loud.
  */
-export const parseUnknownSubcommand = (message: string): boolean => {
-  if (/unrecognized subcommand '?security'?/i.test(message)) {
+export const parseUnknownSubcommand = (message: string, subcommand = "security"): boolean => {
+  const escaped = subcommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (
+    new RegExp(`unrecognized subcommand (?:['"]${escaped}['"]|${escaped}\\b)`, "i").test(message)
+  ) {
     return true;
   }
-  if (/subcommand '?security'? (?:wasn't|was not) recognized/i.test(message)) {
+  if (
+    new RegExp(
+      `subcommand (?:['"]${escaped}['"]|${escaped}\\b) (?:wasn't|was not) recognized`,
+      "i",
+    ).test(message)
+  ) {
     return true;
   }
   return false;

--- a/editors/vscode/test/commands.test.ts
+++ b/editors/vscode/test/commands.test.ts
@@ -13,6 +13,8 @@ let mockInstalledCli: string | null = null;
 let mockDownloadedCli: string | null = null;
 let mockExtensionVersion: string | null = null;
 let mockBinaryVersions: Readonly<Record<string, string | null>> = {};
+let mockConfigPathSetting = "";
+let mockResolvedConfigRoots: string[] = [];
 let mockActiveTextEditor:
   | {
       readonly document: {
@@ -93,7 +95,12 @@ vi.mock("../src/config.js", () => ({
   getComplexityDecorationCap: () => 200,
   getIssueTypes: () => ({}),
   getChangedSince: () => "",
-  getResolvedConfigPath: () => "",
+  getResolvedConfigPath: (workspaceRoot?: string) => {
+    mockResolvedConfigRoots.push(workspaceRoot ?? "");
+    return mockConfigPathSetting && workspaceRoot
+      ? join(workspaceRoot, mockConfigPathSetting)
+      : mockConfigPathSetting;
+  },
   getWorkspaceScope: () => "",
 }));
 
@@ -131,6 +138,11 @@ const workspaceContext = {
     get: () => "",
   },
 } as unknown as vscode.ExtensionContext;
+
+beforeEach(() => {
+  mockConfigPathSetting = "";
+  mockResolvedConfigRoots = [];
+});
 
 const emptyCheck = {
   schema_version: 7,
@@ -730,6 +742,104 @@ describe("runInspectActiveFile", () => {
       ]);
       expect(outputChannel.appendLine).toHaveBeenCalledWith("Fallow inspect: src/extension.ts");
       expect(outputChannel.show).toHaveBeenCalled();
+    } finally {
+      setWorkspaceRoot(null);
+      setActiveEditor(null);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves relative inspect config paths from the active editor workspace root", async () => {
+    const firstRoot = await mkdtemp(join(tmpdir(), "fallow-vscode-root-a-"));
+    const secondRoot = await mkdtemp(join(tmpdir(), "fallow-vscode-root-b-"));
+    const script = join(secondRoot, "fallow-cli.js");
+    const filePath = join(secondRoot, "src", "extension.ts");
+    const logPath = join(secondRoot, "spawn.log");
+
+    try {
+      await writeFile(
+        script,
+        [
+          "#!/usr/bin/env node",
+          'const fs = require("node:fs");',
+          `fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args: process.argv.slice(2) }) + "\\n");`,
+          'process.stdout.write(\'{"kind":"inspect_target","warnings":[]}\');',
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(script, 0o755);
+
+      mockPathBinary = script;
+      mockConfigPathSetting = ".config/fallow.json";
+      const workspace = mockWorkspace as {
+        workspaceFolders: ReadonlyArray<{ readonly uri: { readonly fsPath: string } }>;
+      };
+      workspace.workspaceFolders = [
+        { uri: { fsPath: firstRoot } },
+        { uri: { fsPath: secondRoot } },
+      ];
+      setActiveEditor(filePath);
+
+      await expect(runInspectActiveFile(workspaceContext)).resolves.not.toBeNull();
+      const calls = await readSpawnLog(logPath);
+
+      expect(mockResolvedConfigRoots).toContain(secondRoot);
+      expect(calls[0]?.args).toContain(join(secondRoot, ".config/fallow.json"));
+    } finally {
+      setWorkspaceRoot(null);
+      setActiveEditor(null);
+      await rm(firstRoot, { recursive: true, force: true });
+      await rm(secondRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("retries inspect with the managed CLI when the resolved CLI rejects the subcommand", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "fallow-vscode-inspect-managed-"));
+    const staleScript = join(dir, "stale-fallow.js");
+    const managedScript = join(dir, "managed-fallow.js");
+    const filePath = join(dir, "src", "extension.ts");
+    const logPath = join(dir, "spawn.log");
+    const outputChannel = {
+      appendLine: vi.fn(),
+      show: vi.fn(),
+    } as unknown as vscode.OutputChannel;
+
+    try {
+      await writeFile(
+        staleScript,
+        [
+          "#!/usr/bin/env node",
+          'process.stderr.write("error: unrecognized subcommand \\"inspect\\"\\n");',
+          "process.exit(2);",
+        ].join("\n"),
+        "utf8",
+      );
+      await writeFile(
+        managedScript,
+        [
+          "#!/usr/bin/env node",
+          'const fs = require("node:fs");',
+          `fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args: process.argv.slice(2) }) + "\\n");`,
+          'process.stdout.write(\'{"kind":"inspect_target","warnings":[]}\');',
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(staleScript, 0o755);
+      await chmod(managedScript, 0o755);
+
+      mockPathBinary = staleScript;
+      mockInstalledCli = managedScript;
+      setWorkspaceRoot(dir);
+      setActiveEditor(filePath);
+
+      const result = await runInspectActiveFile(workspaceContext, outputChannel);
+      const calls = await readSpawnLog(logPath);
+
+      expect(result?.kind).toBe("inspect_target");
+      expect(calls).toHaveLength(1);
+      expect(outputChannel.appendLine).toHaveBeenCalledWith(
+        "Fallow: resolved CLI does not support inspect; switched to the managed CLI.",
+      );
     } finally {
       setWorkspaceRoot(null);
       setActiveEditor(null);

--- a/editors/vscode/test/config.test.ts
+++ b/editors/vscode/test/config.test.ts
@@ -12,15 +12,22 @@ type InspectValue<T> = {
 
 let inspected: Record<string, InspectValue<unknown> | undefined> = {};
 let configured: Record<string, unknown> = {};
+let scopedConfigured: Record<string, Record<string, unknown>> = {};
 
 vi.mock("vscode", () => ({
   workspace: {
     workspaceFolders: undefined,
-    getConfiguration: () => ({
-      get: <T>(key: string, fallback: T): T => (configured[key] as T | undefined) ?? fallback,
+    getConfiguration: (_section: string, resource?: { readonly fsPath: string }) => ({
+      get: <T>(key: string, fallback: T): T =>
+        ((resource ? scopedConfigured[resource.fsPath]?.[key] : undefined) as T | undefined) ??
+        (configured[key] as T | undefined) ??
+        fallback,
       inspect: <T>(key: string): InspectValue<T> | undefined =>
         inspected[key] as InspectValue<T> | undefined,
     }),
+  },
+  Uri: {
+    file: (fsPath: string) => ({ fsPath }),
   },
 }));
 
@@ -35,6 +42,7 @@ import {
   getDuplicationThresholdOverride,
   getDiagnosticSeverity,
   getMutedDiagnosticCategories,
+  getResolvedConfigPath,
   getHealthInlineComplexity,
   getProductionOverride,
 } from "../src/config.js";
@@ -43,6 +51,7 @@ describe("duplication setting overrides", () => {
   beforeEach(() => {
     inspected = {};
     configured = {};
+    scopedConfigured = {};
   });
 
   it("ignores package defaults so project config can win", () => {
@@ -110,6 +119,7 @@ describe("production override setting (#1055)", () => {
   beforeEach(() => {
     inspected = {};
     configured = {};
+    scopedConfigured = {};
   });
 
   it("defers to the project config when unset or auto", () => {
@@ -142,6 +152,7 @@ describe("production override setting (#1055)", () => {
 describe("diagnostics severity setting", () => {
   beforeEach(() => {
     configured = {};
+    scopedConfigured = {};
   });
 
   it("defaults to warning", () => {
@@ -158,6 +169,26 @@ describe("diagnostics severity setting", () => {
   it("falls back to warning for unknown values", () => {
     configured = { "diagnostics.severity": "quiet" };
     expect(getDiagnosticSeverity()).toBe("warning");
+  });
+});
+
+describe("resolved config path", () => {
+  beforeEach(() => {
+    configured = {};
+    scopedConfigured = {};
+  });
+
+  it("reads folder-scoped config when a workspace root override is supplied", () => {
+    configured = { configPath: ".fallow-root.json" };
+    scopedConfigured = {
+      "/repo/packages/app": {
+        configPath: ".fallow-app.json",
+      },
+    };
+
+    expect(getResolvedConfigPath("/repo/packages/app")).toBe(
+      "/repo/packages/app/.fallow-app.json",
+    );
   });
 });
 

--- a/editors/vscode/test/security-utils.test.ts
+++ b/editors/vscode/test/security-utils.test.ts
@@ -155,4 +155,13 @@ describe("parseUnknownSubcommand", () => {
     expect(parseUnknownSubcommand("fallow exited with code 2")).toBe(false);
     expect(parseUnknownSubcommand("unrecognized subcommand 'health'")).toBe(false);
   });
+
+  it("supports explicit subcommand names without prefix matches", () => {
+    expect(parseUnknownSubcommand('error: unrecognized subcommand "inspect"', "inspect")).toBe(
+      true,
+    );
+    expect(parseUnknownSubcommand("error: unrecognized subcommand inspection", "inspect")).toBe(
+      false,
+    );
+  });
 });

--- a/npm/fallow/skills/fallow/SKILL.md
+++ b/npm/fallow/skills/fallow/SKILL.md
@@ -95,6 +95,7 @@ Route by intent before reaching for the big analysis commands. Same matrix as `f
 | `fallow` | Run full codebase analysis: cleanup + duplication + health (default) | `--only`, `--skip`, `--production`, `--production-dead-code`, `--production-health`, `--production-dupes`, `--ci`, `--fail-on-issues`, `--group-by`, `--summary`, `--fail-on-regression`, `--tolerance`, `--regression-baseline`, `--save-regression-baseline`, `--score`, `--trend`, `--save-snapshot`, `--include-entry-exports` |
 | `dead-code` | Dead code analysis (`check` is an alias) | `--unused-exports`, `--changed-since`, `--changed-workspaces`, `--production`, `--file`, `--include-entry-exports`, `--stale-suppressions`, `--ci`, `--group-by`, `--summary`, `--fail-on-regression`, `--tolerance`, `--regression-baseline`, `--save-regression-baseline` |
 | `watch` | Watch for changes and re-run analysis | `--no-clear` |
+| `inspect` | Inspect one file or exported symbol as a bundled evidence query | `--file`, `--symbol` |
 | `fix` | Auto-remove unused exports/deps | `--dry-run`, `--yes` (required in non-TTY) |
 | `init` | Generate config file, AGENTS.md agent guide, or pre-commit hook | `--toml`, `--agents`, `--hooks`, `--branch` |
 | `hooks` | Inspect, install, or remove fallow-managed Git and agent hooks | `status`, `install --target git`, `install --target agent`, `uninstall --target git`, `uninstall --target agent` |


### PR DESCRIPTION
Normalize inspect targets before child analysis so absolute editor paths compare against root-relative analyzer output, and forward parent execution flags consistently without passing production toggles to security children.

Make VS Code inspect resolve folder-scoped config, retry stale CLIs with the managed binary, and keep subcommand fallback parsing precise. Improve benchmark timeout cleanup and diagnostics while updating the generated fallow skill command list.