### PR TITLE
ci: use summary output for real-world benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while streaming progress and preserving diagnostics through a script-local timeout.
+- **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while streaming progress, preserving diagnostics through a script-local timeout, and avoiding unused full-report serialization.
 
 ## [2.99.0] - 2026-06-18
 

--- a/benchmarks/bench-ci.sh
+++ b/benchmarks/bench-ci.sh
@@ -145,12 +145,12 @@ run_fallow() {
     local heartbeat_ticks=$((HEARTBEAT_SECONDS * 10))
 
     if command -v setsid >/dev/null 2>&1; then
-        setsid "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" >/dev/null 2>/dev/null &
+        setsid "${FALLOW_BIN}" --quiet --format json --summary "$@" --root "${dir}" >/dev/null 2>/dev/null &
         pid=$!
         kill_target="-${pid}"
     elif command -v python3 >/dev/null 2>&1; then
         python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
-            "${FALLOW_BIN}" --quiet --format json "$@" --root "${dir}" >/dev/null 2>/dev/null &
+            "${FALLOW_BIN}" --quiet --format json --summary "$@" --root "${dir}" >/dev/null 2>/dev/null &
         pid=$!
         kill_target="-${pid}"
     else


### PR DESCRIPTION
## Summary
- run real-world benchmark fallow invocations with `--summary` because the benchmark script discards fallow report bodies
- preserve the same combined analysis timing surface while avoiding huge unused JSON report serialization on large projects

## Evidence
- main run 27766555606 streamed progress and reached Next.js, then the full-report benchmark process exited 143 before a cold result

## Validation
- bash -n benchmarks/bench-ci.sh
- git diff --check
- ./benchmarks/bench-ci.sh --fallow-bin ./target/release/fallow --clone-dir benchmarks/fixtures/real-world --runs 1