### PR TITLE
fix(vscode): forward inspect production opt-out

### DIFF
--- a/editors/vscode/src/commands.ts
+++ b/editors/vscode/src/commands.ts
@@ -423,8 +423,10 @@ export const buildInspectArgs = (options: InspectArgsOptions): string[] => {
     args.push("--workspace", options.workspace);
   }
 
-  if (options.production) {
+  if (options.production === true) {
     args.push("--production");
+  } else if (options.production === false) {
+    args.push("--no-production");
   }
 
   if (options.configPath) {

--- a/editors/vscode/test/commands.test.ts
+++ b/editors/vscode/test/commands.test.ts
@@ -123,6 +123,7 @@ import {
   execFallow,
   FallowExecError,
   findCliBinary,
+  buildInspectArgs,
   runInspectActiveFile,
   resolveCliBinary,
   resolveCliForRun,
@@ -747,6 +748,29 @@ describe("runInspectActiveFile", () => {
       setActiveEditor(null);
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("forwards inspect production false as --no-production", () => {
+    expect(
+      buildInspectArgs({
+        filePath: "src/extension.ts",
+        production: false,
+        workspace: "app",
+        configPath: "/repo/.fallowrc.json",
+      }),
+    ).toEqual([
+      "inspect",
+      "--file",
+      "src/extension.ts",
+      "--format",
+      "json",
+      "--quiet",
+      "--workspace",
+      "app",
+      "--no-production",
+      "--config",
+      "/repo/.fallowrc.json",
+    ]);
   });
 
   it("resolves relative inspect config paths from the active editor workspace root", async () => {


### PR DESCRIPTION
Forward the explicit VS Code production=false override to fallow inspect as --no-production so editor inspect matches the sidebar and project-level CLI behavior.

Add a focused argument-builder regression test for the false override.