### PR TITLE
docs(mcp): cover devDependency install for MCP server setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`fallow dupes` avoids cross-format clone groups for web-format tokens.** Duplicate token hashes now include the active source namespace, so JS, style, and markup regions do not form clone groups with each other just because their punctuation or identifier shapes match. Large-corpus duplicate detection also prefilters files with no repeated `minTokens` shingle before suffix-array analysis, and the real-world benchmark watchdog now allows the expanded Next.js combined-analysis surface to complete on CI while streaming progress, preserving diagnostics through a script-local timeout, and avoiding unused full-report serialization.
 
+### Documentation
+
+- **MCP server setup now covers project devDependency installs.** The MCP config snippets previously assumed `fallow-mcp` was on your `PATH` (a global install). When fallow is installed as a project devDependency, the binary lives in `node_modules/.bin/` and the server fails to start with `ENOENT`. The MCP integration guide, quickstart, and npm README now show the package-manager runner variants (`npx` / `pnpm exec` / `yarn` / `bunx`) alongside the global form. Thanks to the reporter for flagging it. (Closes [#1343](https://github.com/fallow-rs/fallow/issues/1343).)
+
 ## [2.99.0] - 2026-06-18
 
 ### Added

--- a/npm/fallow/README.md
+++ b/npm/fallow/README.md
@@ -88,6 +88,23 @@ Fallow gives AI agents structured repo truth instead of forcing them to infer ev
 
 Every issue in `--format json` carries a machine-actionable `actions` array with an `auto_fixable` flag so agents can self-correct.
 
+### MCP server
+
+Agents that speak MCP can launch the bundled `fallow-mcp` server. Installed as a devDependency, the binary lives in `node_modules/.bin/` and is not on your `PATH`, so launch it through your package manager's runner:
+
+```json
+{
+  "mcpServers": {
+    "fallow": {
+      "command": "npx",
+      "args": ["fallow-mcp"]
+    }
+  }
+}
+```
+
+Swap `npx` for `pnpm exec` / `yarn` / `bunx` to match your package manager. If `fallow-mcp` is installed globally (on your `PATH`), `"command": "fallow-mcp"` works directly. See the [MCP integration guide](https://docs.fallow.tools/integrations/mcp).
+
 ## Framework support
 
 122 built-in plugins covering Next.js, Nuxt, Remix, Qwik, SvelteKit, Gatsby, Astro, Angular, NestJS, AdonisJS, Ember, Expo Router, Vite, Webpack, Vitest, Jest, Playwright, Cypress, Storybook, ESLint, TypeScript, Tailwind, UnoCSS, Prisma, Drizzle, Convex, Turborepo, Hardhat, and many more. Auto-detected from your `package.json`.


### PR DESCRIPTION
The MCP config example assumed `fallow-mcp` was on `PATH` (a global install). As a project devDependency the binary lives in `node_modules/.bin/` and the server fails with `ENOENT`, so document launching it via the package manager runner (`npx` / `pnpm exec` / `yarn` / `bunx`) in the npm README's agents section, plus a `### Documentation` CHANGELOG entry.

The matching MCP integration guide, quickstart, and `mcp.mdx` snippets are updated in the fallow-docs companion repo.

Closes #1343.