### PR TITLE
feat(dupes): add private rolling duplicate detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ Fallow is not an AI assistant. It is the deterministic codebase intelligence lay
 
 ## Performance
 
-Benchmarked on real open-source projects, cold runs (no cache) so both tools work from scratch, median of 5 runs with 2 warmups. The benchmark scripts print exact tool and environment versions for reproducible local runs. Fastest tool per row in bold.
+Benchmarked on real open-source projects, cold runs (no cache) so each tool works from scratch. The benchmark scripts print exact tool and environment versions for reproducible local runs. Fastest tool per row in bold.
 
 ### Dead code: fallow vs knip
 
@@ -963,20 +963,22 @@ fallow is faster on smaller projects in this set, while current knip is faster o
 
 ### Duplication: fallow vs jscpd
 
-| Project | Files | fallow | jscpd | Faster |
-|:--------|------:|-------:|------:|-------:|
-| [astro](https://github.com/withastro/astro) | 2,859 | 750ms | **196ms** | jscpd 3.8x |
-| [fastify](https://github.com/fastify/fastify) | 286 | 142ms | **73ms** | jscpd 1.9x |
-| [next.js](https://github.com/vercel/next.js) | 20,552 | 3.13s | **900ms** | jscpd 3.5x |
-| [preact](https://github.com/preactjs/preact) | 244 | 90ms | **54ms** | jscpd 1.7x |
-| [TanStack/query](https://github.com/TanStack/query) | 901 | 174ms | **63ms** | jscpd 2.8x |
-| [svelte](https://github.com/sveltejs/svelte) | 3,337 | 371ms | **180ms** | jscpd 2.1x |
-| [TypeScript](https://github.com/microsoft/TypeScript) | 38,146 | 40.26s | **5.06s** | jscpd 8.0x |
-| [vite](https://github.com/vitejs/vite) | 1,420 | 217ms | **77ms** | jscpd 2.8x |
-| [vue/core](https://github.com/vuejs/core) | 522 | 171ms | **80ms** | jscpd 2.1x |
-| [zod](https://github.com/colinhacks/zod) | 174 | 84ms | **57ms** | jscpd 1.5x |
+Cold median of 3 measured runs. `Clone groups` and `Dup %` come from each tool's own report, so they are useful for scale but not a byte-for-byte equivalence check.
 
-jscpd's Rust rewrite is now faster for raw duplication scanning on these projects. fallow's duplication checker remains part of the broader audit flow, alongside dead code, dependency, complexity, CSS, framework, and security checks.
+| Project | Files | fallow | jscpd | Faster | fallow clone groups | fallow dup % | jscpd clone groups | jscpd dup % |
+|:--------|------:|-------:|------:|-------:|--------------------:|-------------:|-------------------:|------------:|
+| [astro](https://github.com/withastro/astro) | 2,859 | 656ms | **217ms** | jscpd 3.0x | 1,242 | 16.3% | 1,494 | 9.7% |
+| [fastify](https://github.com/fastify/fastify) | 286 | 122ms | **68ms** | jscpd 1.8x | 1,128 | 39.0% | 1,131 | 23.5% |
+| [next.js](https://github.com/vercel/next.js) | 20,552 | 13.56s | **1.07s** | jscpd 12.7x | 4,485 | 26.3% | 7,287 | 16.4% |
+| [preact](https://github.com/preactjs/preact) | 244 | 70ms | **51ms** | jscpd 1.4x | 368 | 20.2% | 421 | 12.3% |
+| [TanStack/query](https://github.com/TanStack/query) | 901 | 171ms | **100ms** | jscpd 1.7x | 1,084 | 32.7% | 1,237 | 19.4% |
+| [svelte](https://github.com/sveltejs/svelte) | 3,337 | 329ms | **193ms** | jscpd 1.7x | 528 | 13.6% | 658 | 9.1% |
+| [TypeScript](https://github.com/microsoft/TypeScript) | 38,146 | 14.97s | **5.22s** | jscpd 2.9x | 2,749 | 26.9% | 51,158 | 45.8% |
+| [vite](https://github.com/vitejs/vite) | 1,420 | 210ms | **81ms** | jscpd 2.6x | 219 | 13.6% | 260 | 5.1% |
+| [vue/core](https://github.com/vuejs/core) | 522 | 158ms | **80ms** | jscpd 2.0x | 864 | 15.7% | 696 | 6.9% |
+| [zod](https://github.com/colinhacks/zod) | 174 | 71ms | **55ms** | jscpd 1.3x | 78 | 94.1% | 140 | 49.6% |
+
+jscpd remains faster for raw duplication scanning on these projects. fallow's duplication checker runs inside the broader audit flow, alongside dead code, dependency, complexity, CSS, framework, and security checks.
 
 No TypeScript compiler, no Node.js runtime needed to analyze your code. [Fallow vs linters](https://docs.fallow.tools/explanations/fallow-vs-linters) | [Reproduce benchmarks](https://github.com/fallow-rs/fallow/tree/main/benchmarks)
 

--- a/benchmarks/bench-dupes.mjs
+++ b/benchmarks/bench-dupes.mjs
@@ -22,6 +22,7 @@ const projectFilter = projectsArg
         .filter(Boolean),
     )
   : null;
+const JS_WEB_FORMATS = "typescript,javascript,tsx,jsx";
 
 console.log("Building fallow (release)...");
 const buildResult = spawnSync("cargo", ["build", "--release"], {
@@ -37,6 +38,18 @@ const fallowBin = join(rootDir, "target", "release", "fallow");
 const jscpdBin = join(__dirname, "node_modules", ".bin", "jscpd");
 if (!existsSync(jscpdBin)) {
   console.error("jscpd not found. Run: cd benchmarks && npm install");
+  process.exit(1);
+}
+
+const packageLock = JSON.parse(readFileSync(join(__dirname, "package-lock.json"), "utf8"));
+const actualJscpdPackage = JSON.parse(
+  readFileSync(join(__dirname, "node_modules", "jscpd", "package.json"), "utf8"),
+);
+const expectedJscpdVersion = packageLock.packages?.["node_modules/jscpd"]?.version;
+if (expectedJscpdVersion && actualJscpdPackage.version !== expectedJscpdVersion) {
+  console.error(
+    `jscpd version mismatch: node_modules has ${actualJscpdPackage.version}, package-lock expects ${expectedJscpdVersion}. Run: npm ci --prefix benchmarks`,
+  );
   process.exit(1);
 }
 
@@ -210,7 +223,7 @@ function benchmarkProject(name, dir) {
     "--reporters",
     "json",
     "--format",
-    "typescript,javascript",
+    JS_WEB_FORMATS,
     "--output",
     jscpdReportDir,
     "--min-tokens",

--- a/benchmarks/compare-dupes-rolling.mjs
+++ b/benchmarks/compare-dupes-rolling.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, "..");
+const args = process.argv.slice(2);
+const RUNS = Number.parseInt(args.find((arg) => arg.startsWith("--runs="))?.split("=")[1] ?? "1");
+const SKIP_BUILD = args.includes("--skip-build");
+const SAMPLE_COUNT = Number.parseInt(
+  args.find((arg) => arg.startsWith("--samples="))?.split("=")[1] ?? "0",
+);
+const writeReprosArg = args.find((arg) => arg.startsWith("--write-repros="))?.split("=")[1];
+const writeReprosDir = writeReprosArg ? resolve(writeReprosArg) : null;
+const projectsArg = args.find((arg) => arg.startsWith("--projects="))?.split("=")[1];
+const projectFilter = projectsArg
+  ? new Set(
+      projectsArg
+        .split(",")
+        .map((project) => project.trim())
+        .filter(Boolean),
+    )
+  : null;
+
+const fallowBin = join(rootDir, "target", "release", "fallow");
+
+if (!SKIP_BUILD) {
+  const build = spawnSync("cargo", ["build", "--release"], {
+    cwd: rootDir,
+    stdio: "pipe",
+    timeout: 300000,
+  });
+  if (build.status !== 0) {
+    console.error(build.stderr?.toString() ?? "release build failed");
+    process.exit(1);
+  }
+}
+
+if (!existsSync(fallowBin)) {
+  console.error("release binary not found. Run without --skip-build first.");
+  process.exit(1);
+}
+
+const fixturesRoot = join(__dirname, "fixtures", "real-world");
+if (!existsSync(fixturesRoot)) {
+  console.error("real-world fixtures not found. Run: npm run download-fixtures");
+  process.exit(1);
+}
+
+const projects = readdirSync(fixturesRoot)
+  .filter((name) => existsSync(join(fixturesRoot, name, "package.json")))
+  .filter((name) => !projectFilter || projectFilter.has(name))
+  .toSorted();
+
+if (projects.length === 0) {
+  console.error("no projects matched");
+  process.exit(1);
+}
+
+const results = projects.map((project) => compareProject(project, join(fixturesRoot, project)));
+
+console.table(
+  results.map((result) => ({
+    Project: result.project,
+    Files: result.files,
+    "Default median": fmt(result.defaultMedian),
+    "Rolling median": fmt(result.rollingMedian),
+    Speedup: `${(result.defaultMedian / result.rollingMedian).toFixed(2)}x`,
+    "Exact missing": result.exactMissing,
+    "Exact extra": result.exactExtra,
+    "Coverage missing": result.coverageMissing,
+    "Coverage extra": result.coverageExtra,
+  })),
+);
+
+for (const result of results) {
+  if (SAMPLE_COUNT > 0 && result.samples.hasDrift) {
+    printSamples(result);
+  }
+  if (writeReprosDir && result.samples.hasDrift) {
+    writeSampleRepro(result);
+  }
+}
+
+function compareProject(project, dir) {
+  const defaultRuns = [];
+  const rollingRuns = [];
+
+  for (let index = 0; index < RUNS; index++) {
+    defaultRuns.push(runFallow(dir, false));
+    rollingRuns.push(runFallow(dir, true));
+  }
+
+  const defaultLines = parseCompact(defaultRuns.at(-1).stdout);
+  const rollingLines = parseCompact(rollingRuns.at(-1).stdout);
+  const comparison = compareLines(defaultLines, rollingLines);
+
+  return {
+    project,
+    files: countSourceFiles(dir),
+    defaultMedian: median(defaultRuns.map((run) => run.elapsed)),
+    rollingMedian: median(rollingRuns.map((run) => run.elapsed)),
+    exactMissing: comparison.missing.length,
+    exactExtra: comparison.extra.length,
+    coverageMissing: comparison.coverageMissing.length,
+    coverageExtra: comparison.coverageExtra.length,
+    dir,
+    samples: comparison,
+  };
+}
+
+function runFallow(dir, rolling) {
+  const env = rolling ? { ...process.env, FALLOW_DUPES_ROLLING: "1" } : process.env;
+  const start = performance.now();
+  const result = spawnSync(
+    fallowBin,
+    ["dupes", "--format", "compact", "--quiet", "--no-cache", "--root", dir],
+    {
+      cwd: rootDir,
+      env,
+      stdio: "pipe",
+      timeout: 600000,
+      maxBuffer: 100 * 1024 * 1024,
+    },
+  );
+  const elapsed = performance.now() - start;
+  if (result.status !== 0) {
+    console.error(result.stderr?.toString() ?? "fallow dupes failed");
+    process.exit(result.status ?? 1);
+  }
+  return { elapsed, stdout: result.stdout?.toString() ?? "" };
+}
+
+function parseCompact(stdout) {
+  return stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const normalized = line.replace(/^clone-group-\d+:/, "");
+      const match = normalized.match(/^(.*):(\d+)-(\d+):(\d+)tokens$/);
+      if (!match) {
+        throw new Error(`unexpected compact line: ${line}`);
+      }
+      return {
+        key: normalized,
+        file: match[1],
+        start: Number.parseInt(match[2]),
+        end: Number.parseInt(match[3]),
+        tokens: Number.parseInt(match[4]),
+      };
+    });
+}
+
+function compareLines(defaultLines, rollingLines) {
+  const defaultSet = new Set(defaultLines.map((line) => line.key));
+  const rollingSet = new Set(rollingLines.map((line) => line.key));
+  const missing = defaultLines.filter((line) => !rollingSet.has(line.key));
+  const extra = rollingLines.filter((line) => !defaultSet.has(line.key));
+  const defaultByFile = groupByFile(defaultLines);
+  const rollingByFile = groupByFile(rollingLines);
+
+  return {
+    missing,
+    extra,
+    coverageMissing: uncoveredBy(missing, rollingByFile),
+    coverageExtra: uncoveredBy(extra, defaultByFile),
+    hasDrift: missing.length > 0 || extra.length > 0,
+  };
+}
+
+function printSamples(result) {
+  console.log(`\n### ${result.project} drift samples`);
+  console.log("Top missing files:", formatTopFiles(result.samples.missing));
+  console.log("Top extra files:", formatTopFiles(result.samples.extra));
+  printLineSamples("Coverage missing", result.samples.coverageMissing);
+  printLineSamples("Coverage extra", result.samples.coverageExtra);
+}
+
+function formatTopFiles(lines) {
+  const counts = new Map();
+  for (const line of lines) {
+    counts.set(line.file, (counts.get(line.file) ?? 0) + 1);
+  }
+  return [...counts]
+    .toSorted((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, SAMPLE_COUNT)
+    .map(([file, count]) => `${file} (${count})`)
+    .join(", ");
+}
+
+function printLineSamples(label, lines) {
+  console.log(`${label}:`);
+  for (const line of lines.slice(0, SAMPLE_COUNT)) {
+    console.log(`  ${line.file}:${line.start}-${line.end}:${line.tokens}tokens`);
+  }
+}
+
+function writeSampleRepro(result) {
+  const sampleLimit = SAMPLE_COUNT > 0 ? SAMPLE_COUNT : 10;
+  const lines = [
+    ...result.samples.missing.slice(0, sampleLimit),
+    ...result.samples.extra.slice(0, sampleLimit),
+    ...result.samples.coverageMissing.slice(0, sampleLimit),
+    ...result.samples.coverageExtra.slice(0, sampleLimit),
+  ];
+  const files = [...new Set(lines.map((line) => line.file))].toSorted();
+  if (files.length === 0) {
+    return;
+  }
+
+  const reproDir = join(writeReprosDir, result.project);
+  rmSync(reproDir, { recursive: true, force: true });
+  mkdirSync(reproDir, { recursive: true });
+  writeFileSync(
+    join(reproDir, "package.json"),
+    `${JSON.stringify({ name: `${result.project}-dupes-repro`, version: "1.0.0" }, null, 2)}\n`,
+  );
+
+  let copied = 0;
+  for (const file of files) {
+    const source = resolveSampleSource(result.dir, file);
+    if (!source) {
+      console.warn(`Skipping missing sampled file: ${file}`);
+      continue;
+    }
+    const target = join(reproDir, decodeSamplePath(file));
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(source, target);
+    copied += 1;
+  }
+
+  console.log(`Wrote ${copied} sampled repro files to ${reproDir}`);
+}
+
+function resolveSampleSource(root, file) {
+  const direct = join(root, file);
+  if (existsSync(direct)) {
+    return direct;
+  }
+  const decoded = join(root, decodeSamplePath(file));
+  return existsSync(decoded) ? decoded : null;
+}
+
+function decodeSamplePath(file) {
+  try {
+    return decodeURIComponent(file);
+  } catch {
+    return file;
+  }
+}
+
+function groupByFile(lines) {
+  const grouped = new Map();
+  for (const line of lines) {
+    const group = grouped.get(line.file) ?? [];
+    group.push(line);
+    grouped.set(line.file, group);
+  }
+  return grouped;
+}
+
+function uncoveredBy(lines, otherByFile) {
+  const uncovered = [];
+  for (const line of lines) {
+    const candidates = otherByFile.get(line.file) ?? [];
+    if (!candidates.some((other) => other.start <= line.start && other.end >= line.end)) {
+      uncovered.push(line);
+    }
+  }
+  return uncovered;
+}
+
+function countSourceFiles(dir) {
+  let count = 0;
+  const walk = (current) => {
+    for (const entry of readdirSync(current)) {
+      if (["node_modules", ".git", "dist", "report"].includes(entry)) continue;
+      const path = join(current, entry);
+      const stat = statSync(path);
+      if (stat.isDirectory()) {
+        walk(path);
+      } else if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(entry)) {
+        count += 1;
+      }
+    }
+  };
+  walk(dir);
+  return count;
+}
+
+function median(values) {
+  const sorted = [...values].toSorted((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+function fmt(ms) {
+  return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`;
+}

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -12,6 +12,7 @@
     "bench:dupes": "node bench-dupes.mjs",
     "bench:dupes:synthetic": "node bench-dupes.mjs --synthetic",
     "bench:dupes:real-world": "node bench-dupes.mjs --real-world",
+    "bench:dupes:rolling": "node compare-dupes-rolling.mjs",
     "generate:circular": "node generate-circular-fixtures.mjs",
     "bench:circular": "node bench-circular.mjs",
     "bench:circular:synthetic": "node bench-circular.mjs --synthetic",

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -831,6 +831,25 @@ fn make_diverse_files(n: usize, tokens_per_file: usize) -> DupeInput {
         .collect()
 }
 
+/// Build files that repeat several shared blocks with per-file separators.
+/// This creates many high-LCP intervals without requiring a huge fixture.
+fn make_interval_pressure_files(n: usize, blocks: usize, block_tokens: usize) -> DupeInput {
+    (0..n)
+        .map(|i| {
+            let mut hashes = Vec::with_capacity(blocks * (block_tokens + 1));
+            for block in 0..blocks {
+                hashes.extend((1..=block_tokens as u64).map(|token| token + block as u64 * 10_000));
+                hashes.push(1_000_000 + (i * blocks + block) as u64);
+            }
+            (
+                PathBuf::from(format!("dir{i}/pressure{i}.ts")),
+                make_hashed_tokens(&hashes),
+                make_file_tokens_for(hashes.len()),
+            )
+        })
+        .collect()
+}
+
 fn dupe_detect_2x500_identical(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 500);
@@ -940,6 +959,18 @@ fn dupe_detect_100x200_mixed_focused(c: &mut Criterion) {
     });
 }
 
+fn dupe_detect_80x20x80_interval_pressure(c: &mut Criterion) {
+    use fallow_core::duplicates::detect::CloneDetector;
+    let data = make_interval_pressure_files(80, 20, 80);
+    c.bench_function("dupe_detect_80x20x80_interval_pressure", |bencher| {
+        bencher.iter_batched(
+            || data.clone(),
+            |d| CloneDetector::new(30, 5, false).detect(d),
+            BatchSize::LargeInput,
+        );
+    });
+}
+
 fn dupe_detect_2x5000_identical(c: &mut Criterion) {
     use fallow_core::duplicates::detect::CloneDetector;
     let data = make_identical_files(2, 5000);
@@ -966,6 +997,7 @@ criterion_group!(
     dupe_detect_50x200_diverse,
     dupe_detect_100x200_mixed,
     dupe_detect_100x200_mixed_focused,
+    dupe_detect_80x20x80_interval_pressure,
     dupe_detect_2x5000_identical
 );
 criterion_main!(benches);

--- a/crates/core/src/duplicates/detect/extraction.rs
+++ b/crates/core/src/duplicates/detect/extraction.rs
@@ -23,6 +23,7 @@ pub(super) struct CloneGroupExtractionInput<'a> {
     pub(super) min_tokens: usize,
     pub(super) files: &'a [FileData],
     pub(super) focus_file_ids: Option<&'a [bool]>,
+    pub(super) may_have_boundaries: bool,
 }
 
 pub(super) fn extract_clone_groups(input: &CloneGroupExtractionInput<'_>) -> Vec<RawGroup> {
@@ -41,7 +42,12 @@ pub(super) fn extract_clone_groups(input: &CloneGroupExtractionInput<'_>) -> Vec
     let focus_prefix = input
         .focus_file_ids
         .map(|ids| build_focus_prefix(sa, file_of, ids));
-    let boundary_prefixes = build_boundary_prefixes(files);
+    let boundary_prefixes = if input.may_have_boundaries {
+        build_boundary_prefixes(files)
+    } else {
+        Vec::new()
+    };
+    let has_boundaries = input.may_have_boundaries && boundary_prefixes.iter().any(Option::is_some);
 
     #[expect(
         clippy::needless_range_loop,
@@ -73,6 +79,7 @@ pub(super) fn extract_clone_groups(input: &CloneGroupExtractionInput<'_>) -> Vec
                     file_offsets,
                     files,
                     boundary_prefixes: &boundary_prefixes,
+                    has_boundaries,
                     interval_begin,
                     interval_end,
                     length: top_lcp,
@@ -82,7 +89,10 @@ pub(super) fn extract_clone_groups(input: &CloneGroupExtractionInput<'_>) -> Vec
             }
         }
 
-        if i < n {
+        if i < n
+            && cur_lcp >= input.min_tokens
+            && stack.last().is_none_or(|&(last_lcp, _)| last_lcp < cur_lcp)
+        {
             stack.push((cur_lcp, start));
         }
     }
@@ -151,6 +161,7 @@ struct RawGroupInput<'a> {
     file_offsets: &'a [usize],
     files: &'a [FileData],
     boundary_prefixes: &'a [Option<Vec<u32>>],
+    has_boundaries: bool,
     interval_begin: usize,
     interval_end: usize,
     length: usize,
@@ -177,7 +188,9 @@ fn build_raw_group(input: &RawGroupInput<'_>) -> Option<RawGroup> {
         if offset_in_file + length > files[fid].hashed_tokens.len() {
             continue;
         }
-        if range_contains_boundary(boundary_prefixes[fid].as_ref(), offset_in_file, length) {
+        if input.has_boundaries
+            && range_contains_boundary(boundary_prefixes[fid].as_ref(), offset_in_file, length)
+        {
             continue;
         }
 
@@ -185,6 +198,20 @@ fn build_raw_group(input: &RawGroupInput<'_>) -> Option<RawGroup> {
     }
 
     if instances.len() < 2 {
+        return None;
+    }
+
+    if instances.len() == 2 {
+        if instances[1] < instances[0] {
+            instances.swap(0, 1);
+        }
+        let first = instances[0];
+        let second = instances[1];
+
+        if first.0 != second.0 || second.1 >= first.1 + length {
+            return Some(RawGroup { instances, length });
+        }
+
         return None;
     }
 

--- a/crates/core/src/duplicates/detect/mod.rs
+++ b/crates/core/src/duplicates/detect/mod.rs
@@ -9,6 +9,7 @@ mod extraction;
 mod filtering;
 mod lcp;
 mod ranking;
+mod rolling;
 mod statistics;
 mod suffix_array;
 mod utils;
@@ -22,8 +23,11 @@ use oxc_span::Span;
 use rustc_hash::FxHashSet;
 
 use super::normalize::HashedToken;
-use super::tokenize::FileTokens;
+use super::tokenize::{FileTokens, TokenKind};
 use super::types::{DuplicationReport, DuplicationStats};
+
+const ROLLING_DETECTOR_ENV: &str = "FALLOW_DUPES_ROLLING";
+const ROLLING_BOUNDARY_FALLBACK_FILE_RATIO: f64 = 0.20;
 
 /// Data for a single file being analyzed.
 struct FileData {
@@ -127,6 +131,20 @@ impl CloneDetector {
         totals: CorpusTotals,
         focus_file_ids: Option<&[bool]>,
     ) -> DuplicationReport {
+        if std::env::var_os(ROLLING_DETECTOR_ENV).is_some() {
+            let boundary_summary = summarize_boundaries(files);
+            if !boundary_summary.is_component_heavy {
+                return rolling::detect(
+                    files,
+                    self.min_tokens,
+                    self.min_lines,
+                    self.skip_local,
+                    totals,
+                    boundary_summary.has_any_boundary,
+                );
+            }
+        }
+
         let (text, file_of, file_offsets, rank_time, concat_time) = rank_and_concatenate(files);
 
         if text.is_empty() {
@@ -213,6 +231,7 @@ impl CloneDetector {
             min_tokens: self.min_tokens,
             files,
             focus_file_ids,
+            may_have_boundaries: files_may_have_boundaries(files),
         });
         let extract_time = t0.elapsed();
         tracing::debug!(
@@ -315,6 +334,57 @@ fn build_focus_file_ids(files: &[FileData], focus_files: &FxHashSet<PathBuf>) ->
         .iter()
         .map(|file| normalized.contains(dunce::simplified(&file.path)))
         .collect()
+}
+
+#[derive(Clone, Copy)]
+struct BoundarySummary {
+    is_component_heavy: bool,
+    has_any_boundary: bool,
+}
+
+fn summarize_boundaries(files: &[FileData]) -> BoundarySummary {
+    let mut files_with_tokens = 0_usize;
+    let mut files_with_boundaries = 0_usize;
+
+    for file in files {
+        if file.hashed_tokens.is_empty() {
+            continue;
+        }
+
+        files_with_tokens += 1;
+        if file_has_boundary(file) {
+            files_with_boundaries += 1;
+        }
+    }
+
+    BoundarySummary {
+        is_component_heavy: files_with_tokens > 0
+            && (files_with_boundaries as f64 / files_with_tokens as f64)
+                >= ROLLING_BOUNDARY_FALLBACK_FILE_RATIO,
+        has_any_boundary: files_with_boundaries > 0,
+    }
+}
+
+fn file_has_boundary(file: &FileData) -> bool {
+    file.hashed_tokens.iter().any(|token| {
+        file.file_tokens
+            .tokens
+            .get(token.original_index)
+            .is_some_and(|source| matches!(source.kind, TokenKind::Boundary(_)))
+    })
+}
+
+fn files_may_have_boundaries(files: &[FileData]) -> bool {
+    files.iter().any(file_may_have_boundaries)
+}
+
+fn file_may_have_boundaries(file: &FileData) -> bool {
+    matches!(
+        file.path
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("astro" | "css" | "less" | "sass" | "scss" | "svelte" | "vue")
+    )
 }
 
 fn trace_clone_detection_input(

--- a/crates/core/src/duplicates/detect/rolling.rs
+++ b/crates/core/src/duplicates/detect/rolling.rs
@@ -1,0 +1,936 @@
+use rustc_hash::FxHashMap;
+
+use super::extraction::RawGroup;
+use super::{CorpusTotals, FileData, filtering, ranking, statistics};
+use crate::duplicates::tokenize::TokenKind;
+use crate::duplicates::types::DuplicationReport;
+
+const HASH_BASE: u64 = 0x0000_0100_0000_01b3;
+const MAX_ADJACENCY_LOOKAHEAD_PAIRS: usize = 512;
+const CHILD_BUCKET_PREALLOC_LIMIT: usize = 64;
+
+#[derive(Clone, Copy)]
+struct Occurrence {
+    file_id: usize,
+    offset: usize,
+}
+
+struct SeedClass {
+    key_file_id: usize,
+    key_offset: usize,
+    occurrences: SeedOccurrences,
+}
+
+enum SeedOccurrences {
+    One(Occurrence),
+    Many(Vec<Occurrence>),
+}
+
+enum SeedBucket {
+    One(SeedClass),
+    Many(Vec<SeedClass>),
+}
+
+impl SeedOccurrences {
+    fn push(&mut self, occurrence: Occurrence) {
+        match self {
+            Self::One(first) => {
+                *self = Self::Many(vec![*first, occurrence]);
+            }
+            Self::Many(occurrences) => occurrences.push(occurrence),
+        }
+    }
+
+    fn into_many(self) -> Option<Vec<Occurrence>> {
+        match self {
+            Self::One(_) => None,
+            Self::Many(occurrences) => Some(occurrences),
+        }
+    }
+}
+
+impl SeedBucket {
+    fn insert_or_append(
+        &mut self,
+        ranked_files: &[Vec<u32>],
+        file_id: usize,
+        offset: usize,
+        min_tokens: usize,
+    ) {
+        match self {
+            Self::One(class) => {
+                if same_window(
+                    ranked_files,
+                    class.key_file_id,
+                    class.key_offset,
+                    file_id,
+                    offset,
+                    min_tokens,
+                ) {
+                    class.occurrences.push(Occurrence { file_id, offset });
+                } else {
+                    let first = std::mem::replace(
+                        class,
+                        SeedClass {
+                            key_file_id: file_id,
+                            key_offset: offset,
+                            occurrences: SeedOccurrences::One(Occurrence { file_id, offset }),
+                        },
+                    );
+                    *self = Self::Many(vec![
+                        first,
+                        SeedClass {
+                            key_file_id: file_id,
+                            key_offset: offset,
+                            occurrences: SeedOccurrences::One(Occurrence { file_id, offset }),
+                        },
+                    ]);
+                }
+            }
+            Self::Many(classes) => {
+                if let Some(class) = classes.iter_mut().find(|class| {
+                    same_window(
+                        ranked_files,
+                        class.key_file_id,
+                        class.key_offset,
+                        file_id,
+                        offset,
+                        min_tokens,
+                    )
+                }) {
+                    class.occurrences.push(Occurrence { file_id, offset });
+                } else {
+                    classes.push(SeedClass {
+                        key_file_id: file_id,
+                        key_offset: offset,
+                        occurrences: SeedOccurrences::One(Occurrence { file_id, offset }),
+                    });
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn detect(
+    files: &[FileData],
+    min_tokens: usize,
+    min_lines: usize,
+    skip_local: bool,
+    totals: CorpusTotals,
+    may_have_boundaries: bool,
+) -> DuplicationReport {
+    let t0 = std::time::Instant::now();
+    let ranked_files = ranking::rank_reduce(files);
+    let rank_time = t0.elapsed();
+
+    let t0 = std::time::Instant::now();
+    let boundary_prefixes = if may_have_boundaries {
+        build_boundary_prefixes(files)
+    } else {
+        std::iter::repeat_with(|| None).take(files.len()).collect()
+    };
+    let has_boundaries = may_have_boundaries && boundary_prefixes.iter().any(Option::is_some);
+    let seed_buckets = build_seed_buckets(
+        &ranked_files,
+        &boundary_prefixes,
+        has_boundaries,
+        min_tokens,
+    );
+    let seed_time = t0.elapsed();
+
+    let t0 = std::time::Instant::now();
+    let (raw_groups, seed_class_count) = build_raw_groups(
+        &ranked_files,
+        &boundary_prefixes,
+        has_boundaries,
+        seed_buckets,
+        min_tokens,
+    );
+    let raw_time = t0.elapsed();
+    tracing::debug!(
+        elapsed_us = raw_time.as_micros(),
+        raw_groups = raw_groups.len(),
+        seed_classes = seed_class_count,
+        "rolling_step3_raw_groups"
+    );
+
+    let t0 = std::time::Instant::now();
+    let clone_groups = filtering::build_groups(raw_groups, files, min_lines, skip_local);
+    let build_time = t0.elapsed();
+
+    let t0 = std::time::Instant::now();
+    let stats = statistics::compute_stats(&clone_groups, totals.files, totals.lines, totals.tokens);
+    let stats_time = t0.elapsed();
+
+    tracing::info!(
+        total_us = (rank_time + seed_time + raw_time + build_time + stats_time).as_micros(),
+        rank_us = rank_time.as_micros(),
+        seed_us = seed_time.as_micros(),
+        raw_us = raw_time.as_micros(),
+        build_us = build_time.as_micros(),
+        stats_us = stats_time.as_micros(),
+        total_tokens = totals.tokens,
+        clone_groups = clone_groups.len(),
+        "rolling clone detection complete"
+    );
+
+    DuplicationReport {
+        clone_groups,
+        clone_families: vec![],
+        mirrored_directories: vec![],
+        stats,
+    }
+}
+
+fn build_seed_buckets(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    min_tokens: usize,
+) -> FxHashMap<u64, SeedBucket> {
+    let mut buckets: FxHashMap<u64, SeedBucket> = FxHashMap::default();
+    let base_power = hash_base_power(min_tokens);
+
+    for (file_id, tokens) in ranked_files.iter().enumerate() {
+        if tokens.len() < min_tokens {
+            continue;
+        }
+
+        let last_offset = tokens.len() - min_tokens;
+        let mut hash = initial_window_hash(tokens, min_tokens);
+        for offset in 0..=tokens.len() - min_tokens {
+            if has_boundaries
+                && range_contains_boundary(boundary_prefixes[file_id].as_ref(), offset, min_tokens)
+            {
+                if offset < last_offset {
+                    hash = roll_window_hash(
+                        hash,
+                        tokens[offset],
+                        tokens[offset + min_tokens],
+                        base_power,
+                    );
+                }
+                continue;
+            }
+
+            match buckets.get_mut(&hash) {
+                Some(bucket) => {
+                    bucket.insert_or_append(ranked_files, file_id, offset, min_tokens);
+                }
+                None => {
+                    buckets.insert(
+                        hash,
+                        SeedBucket::One(SeedClass {
+                            key_file_id: file_id,
+                            key_offset: offset,
+                            occurrences: SeedOccurrences::One(Occurrence { file_id, offset }),
+                        }),
+                    );
+                }
+            }
+
+            if offset < last_offset {
+                hash = roll_window_hash(
+                    hash,
+                    tokens[offset],
+                    tokens[offset + min_tokens],
+                    base_power,
+                );
+            }
+        }
+    }
+
+    buckets
+}
+
+fn build_raw_groups(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    seed_buckets: FxHashMap<u64, SeedBucket>,
+    min_tokens: usize,
+) -> (Vec<RawGroup>, usize) {
+    let mut groups = Vec::new();
+    let mut seed_class_count = 0_usize;
+
+    for bucket in seed_buckets.into_values() {
+        match bucket {
+            SeedBucket::One(class) => {
+                process_seed_class(
+                    ranked_files,
+                    boundary_prefixes,
+                    has_boundaries,
+                    class,
+                    min_tokens,
+                    &mut seed_class_count,
+                    &mut groups,
+                );
+            }
+            SeedBucket::Many(classes) => {
+                for class in classes {
+                    process_seed_class(
+                        ranked_files,
+                        boundary_prefixes,
+                        has_boundaries,
+                        class,
+                        min_tokens,
+                        &mut seed_class_count,
+                        &mut groups,
+                    );
+                }
+            }
+        }
+    }
+
+    (groups, seed_class_count)
+}
+
+fn process_seed_class(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    class: SeedClass,
+    min_tokens: usize,
+    seed_class_count: &mut usize,
+    groups: &mut Vec<RawGroup>,
+) {
+    let Some(occurrences) = class.occurrences.into_many() else {
+        return;
+    };
+    *seed_class_count += 1;
+
+    let is_left_maximal = is_left_maximal(
+        ranked_files,
+        boundary_prefixes,
+        has_boundaries,
+        &occurrences,
+        min_tokens,
+    );
+
+    if is_left_maximal {
+        collect_extended_groups(
+            ranked_files,
+            boundary_prefixes,
+            has_boundaries,
+            &occurrences,
+            min_tokens,
+            groups,
+        );
+    }
+}
+
+fn same_window(
+    ranked_files: &[Vec<u32>],
+    left_file_id: usize,
+    left_offset: usize,
+    right_file_id: usize,
+    right_offset: usize,
+    length: usize,
+) -> bool {
+    ranked_files[left_file_id][left_offset..left_offset + length]
+        == ranked_files[right_file_id][right_offset..right_offset + length]
+}
+
+fn is_left_maximal(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    occurrences: &[Occurrence],
+    length: usize,
+) -> bool {
+    let Some(first) = occurrences.first() else {
+        return false;
+    };
+    if first.offset == 0 {
+        return true;
+    }
+
+    let previous = ranked_files[first.file_id][first.offset - 1];
+    if occurrences.iter().any(|occurrence| {
+        occurrence.offset == 0
+            || ranked_files[occurrence.file_id][occurrence.offset - 1] != previous
+            || (has_boundaries
+                && range_contains_boundary(
+                    boundary_prefixes[occurrence.file_id].as_ref(),
+                    occurrence.offset - 1,
+                    length + 1,
+                ))
+    }) {
+        return true;
+    }
+
+    if has_same_file_pair_at_or_extending_to_adjacency(
+        ranked_files,
+        boundary_prefixes,
+        has_boundaries,
+        occurrences,
+        length,
+    ) {
+        return true;
+    }
+
+    let current_count = count_non_overlapping_instances(occurrences, length, false);
+    let extended_count = count_non_overlapping_instances(occurrences, length + 1, true);
+    current_count >= 2 && extended_count < current_count
+}
+
+fn collect_extended_groups(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    occurrences: &[Occurrence],
+    mut length: usize,
+    groups: &mut Vec<RawGroup>,
+) {
+    if occurrences.len() == 2 {
+        let length = extend_pair_length(
+            ranked_files,
+            boundary_prefixes,
+            has_boundaries,
+            occurrences[0],
+            occurrences[1],
+            length,
+        );
+        push_raw_group(occurrences, length, groups);
+        return;
+    }
+
+    length = extend_uniform_length(
+        ranked_files,
+        boundary_prefixes,
+        has_boundaries,
+        occurrences,
+        length,
+    );
+
+    let mut first_child: Option<(u32, Occurrence)> = None;
+    let mut children: Option<FxHashMap<u32, SeedOccurrences>> = None;
+    for &occurrence in occurrences {
+        let tokens = &ranked_files[occurrence.file_id];
+        if occurrence.offset + length >= tokens.len()
+            || (has_boundaries
+                && range_contains_boundary(
+                    boundary_prefixes[occurrence.file_id].as_ref(),
+                    occurrence.offset,
+                    length + 1,
+                ))
+        {
+            continue;
+        }
+
+        let token = tokens[occurrence.offset + length];
+        if let Some(children) = children.as_mut() {
+            insert_child_occurrence(children, token, occurrence);
+        } else if let Some((first_token, first_occurrence)) = first_child.take() {
+            let mut child_map = FxHashMap::default();
+            child_map.reserve(occurrences.len().min(CHILD_BUCKET_PREALLOC_LIMIT));
+            insert_child_occurrence(&mut child_map, first_token, first_occurrence);
+            insert_child_occurrence(&mut child_map, token, occurrence);
+            children = Some(child_map);
+        } else {
+            first_child = Some((token, occurrence));
+        }
+    }
+
+    push_raw_group(occurrences, length, groups);
+
+    let Some(children) = children else {
+        return;
+    };
+
+    for child in children
+        .into_values()
+        .filter_map(SeedOccurrences::into_many)
+    {
+        if is_left_maximal(
+            ranked_files,
+            boundary_prefixes,
+            has_boundaries,
+            &child,
+            length + 1,
+        ) {
+            collect_extended_groups(
+                ranked_files,
+                boundary_prefixes,
+                has_boundaries,
+                &child,
+                length + 1,
+                groups,
+            );
+        }
+    }
+}
+
+fn insert_child_occurrence(
+    children: &mut FxHashMap<u32, SeedOccurrences>,
+    token: u32,
+    occurrence: Occurrence,
+) {
+    children
+        .entry(token)
+        .and_modify(|occurrences| occurrences.push(occurrence))
+        .or_insert(SeedOccurrences::One(occurrence));
+}
+
+fn extend_uniform_length(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    occurrences: &[Occurrence],
+    mut length: usize,
+) -> usize {
+    let Some(first) = occurrences.first() else {
+        return length;
+    };
+
+    loop {
+        let Some(next) = next_extension_token(
+            ranked_files,
+            boundary_prefixes,
+            has_boundaries,
+            *first,
+            length,
+        ) else {
+            return length;
+        };
+
+        if occurrences[1..].iter().all(|&occurrence| {
+            next_extension_token(
+                ranked_files,
+                boundary_prefixes,
+                has_boundaries,
+                occurrence,
+                length,
+            ) == Some(next)
+        }) {
+            length += 1;
+            continue;
+        }
+
+        return length;
+    }
+}
+
+fn next_extension_token(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    occurrence: Occurrence,
+    length: usize,
+) -> Option<u32> {
+    let tokens = &ranked_files[occurrence.file_id];
+    if occurrence.offset + length >= tokens.len()
+        || (has_boundaries
+            && range_contains_boundary(
+                boundary_prefixes[occurrence.file_id].as_ref(),
+                occurrence.offset,
+                length + 1,
+            ))
+    {
+        return None;
+    }
+
+    Some(tokens[occurrence.offset + length])
+}
+
+fn extend_pair_length(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    left: Occurrence,
+    right: Occurrence,
+    length: usize,
+) -> usize {
+    let mut extended = length;
+    let left_tokens = &ranked_files[left.file_id];
+    let right_tokens = &ranked_files[right.file_id];
+    let left_boundary = has_boundaries
+        .then(|| boundary_prefixes[left.file_id].as_ref())
+        .flatten();
+    let right_boundary = has_boundaries
+        .then(|| boundary_prefixes[right.file_id].as_ref())
+        .flatten();
+
+    if left_boundary.is_none() && right_boundary.is_none() {
+        while left.offset + extended < left_tokens.len()
+            && right.offset + extended < right_tokens.len()
+            && left_tokens[left.offset + extended] == right_tokens[right.offset + extended]
+        {
+            extended += 1;
+        }
+
+        return extended;
+    }
+
+    while left.offset + extended < left_tokens.len()
+        && right.offset + extended < right_tokens.len()
+        && left_tokens[left.offset + extended] == right_tokens[right.offset + extended]
+        && !range_contains_boundary(left_boundary, left.offset, extended + 1)
+        && !range_contains_boundary(right_boundary, right.offset, extended + 1)
+    {
+        extended += 1;
+    }
+
+    extended
+}
+
+fn count_non_overlapping_instances(
+    occurrences: &[Occurrence],
+    length: usize,
+    shift_left: bool,
+) -> usize {
+    debug_assert_occurrences_sorted(occurrences);
+
+    let mut count = 0_usize;
+    let mut last: Option<(usize, usize)> = None;
+    for occurrence in occurrences {
+        let file_id = occurrence.file_id;
+        let offset = if shift_left {
+            occurrence.offset - 1
+        } else {
+            occurrence.offset
+        };
+        if let Some((last_file_id, last_offset)) = last
+            && file_id == last_file_id
+            && offset < last_offset + length
+        {
+            continue;
+        }
+        count += 1;
+        last = Some((file_id, offset));
+    }
+
+    count
+}
+
+fn has_same_file_pair_at_or_extending_to_adjacency(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    occurrences: &[Occurrence],
+    length: usize,
+) -> bool {
+    debug_assert_occurrences_sorted(occurrences);
+
+    let mut checked_pairs = 0_usize;
+    for (index, occurrence) in occurrences.iter().enumerate() {
+        let file_id = occurrence.file_id;
+        let left = occurrence.offset;
+        for candidate in &occurrences[index + 1..] {
+            let right_file_id = candidate.file_id;
+            let right = candidate.offset;
+            if file_id != right_file_id {
+                break;
+            }
+            if right == left + length {
+                return true;
+            }
+            if right < left + length {
+                continue;
+            }
+            checked_pairs += 1;
+            if checked_pairs > MAX_ADJACENCY_LOOKAHEAD_PAIRS {
+                return false;
+            }
+            if pair_extends_to_adjacency(
+                ranked_files,
+                boundary_prefixes,
+                has_boundaries,
+                file_id,
+                left,
+                right,
+                length,
+            ) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn pair_extends_to_adjacency(
+    ranked_files: &[Vec<u32>],
+    boundary_prefixes: &[Option<Vec<u32>>],
+    has_boundaries: bool,
+    file_id: usize,
+    left: usize,
+    right: usize,
+    length: usize,
+) -> bool {
+    let tokens = &ranked_files[file_id];
+    let distance = right - left;
+    let mut extended = length;
+    let boundary = has_boundaries
+        .then(|| boundary_prefixes[file_id].as_ref())
+        .flatten();
+
+    if boundary.is_none() {
+        while extended < distance
+            && right + extended < tokens.len()
+            && tokens[left + extended] == tokens[right + extended]
+        {
+            extended += 1;
+        }
+
+        return extended == distance;
+    }
+
+    while extended < distance
+        && right + extended < tokens.len()
+        && tokens[left + extended] == tokens[right + extended]
+        && !range_contains_boundary(boundary, left, extended + 1)
+        && !range_contains_boundary(boundary, right, extended + 1)
+    {
+        extended += 1;
+    }
+
+    extended == distance
+}
+
+fn push_raw_group(occurrences: &[Occurrence], length: usize, groups: &mut Vec<RawGroup>) {
+    debug_assert_occurrences_sorted(occurrences);
+
+    let mut deduped = Vec::with_capacity(occurrences.len());
+    for occurrence in occurrences {
+        let file_id = occurrence.file_id;
+        let offset = occurrence.offset;
+        if let Some(&(last_file_id, last_offset)) = deduped.last()
+            && file_id == last_file_id
+            && offset < last_offset + length
+        {
+            continue;
+        }
+        deduped.push((file_id, offset));
+    }
+
+    if deduped.len() >= 2 {
+        groups.push(RawGroup {
+            instances: deduped,
+            length,
+        });
+    }
+}
+
+fn debug_assert_occurrences_sorted(occurrences: &[Occurrence]) {
+    debug_assert!(occurrences.windows(2).all(|pair| {
+        pair[0].file_id < pair[1].file_id
+            || (pair[0].file_id == pair[1].file_id && pair[0].offset <= pair[1].offset)
+    }));
+}
+
+fn build_boundary_prefixes(files: &[FileData]) -> Vec<Option<Vec<u32>>> {
+    files
+        .iter()
+        .map(|file| {
+            if !file
+                .hashed_tokens
+                .iter()
+                .any(|token| hashed_token_is_boundary(file, token.original_index))
+            {
+                return None;
+            }
+
+            let mut prefix = Vec::with_capacity(file.hashed_tokens.len() + 1);
+            let mut count = 0_u32;
+            prefix.push(count);
+            for token in &file.hashed_tokens {
+                if hashed_token_is_boundary(file, token.original_index) {
+                    count += 1;
+                }
+                prefix.push(count);
+            }
+            Some(prefix)
+        })
+        .collect()
+}
+
+fn hashed_token_is_boundary(file: &FileData, original_index: usize) -> bool {
+    file.file_tokens
+        .tokens
+        .get(original_index)
+        .is_some_and(|source| matches!(source.kind, TokenKind::Boundary(_)))
+}
+
+fn range_contains_boundary(prefix: Option<&Vec<u32>>, offset: usize, length: usize) -> bool {
+    prefix.is_some_and(|prefix| prefix[offset] != prefix[offset + length])
+}
+
+fn hash_base_power(length: usize) -> u64 {
+    let mut power = 1_u64;
+    for _ in 1..length {
+        power = power.wrapping_mul(HASH_BASE);
+    }
+    power
+}
+
+fn initial_window_hash(tokens: &[u32], length: usize) -> u64 {
+    let mut hash = 0_u64;
+    for &token in &tokens[..length] {
+        hash = hash.wrapping_mul(HASH_BASE).wrapping_add(u64::from(token));
+    }
+    hash
+}
+
+fn roll_window_hash(hash: u64, outgoing: u32, incoming: u32, base_power: u64) -> u64 {
+    hash.wrapping_sub(u64::from(outgoing).wrapping_mul(base_power))
+        .wrapping_mul(HASH_BASE)
+        .wrapping_add(u64::from(incoming))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use oxc_span::Span;
+
+    use super::*;
+    use crate::duplicates::normalize::HashedToken;
+    use crate::duplicates::tokenize::{FileTokens, SourceToken, TokenKind};
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test span values are trivially small"
+    )]
+    fn make_file(path: &str, hashes: &[u64]) -> FileData {
+        let source = std::iter::repeat_n("x", hashes.len())
+            .collect::<Vec<_>>()
+            .join("\n");
+        FileData {
+            path: PathBuf::from(path),
+            hashed_tokens: hashes
+                .iter()
+                .enumerate()
+                .map(|(index, &hash)| HashedToken {
+                    hash,
+                    original_index: index,
+                })
+                .collect(),
+            file_tokens: FileTokens {
+                tokens: (0..hashes.len())
+                    .map(|index| SourceToken {
+                        kind: TokenKind::Identifier(format!("t{index}")),
+                        span: Span::new((index * 2) as u32, (index * 2 + 1) as u32),
+                    })
+                    .collect(),
+                atomic_invocation_spans: Vec::new(),
+                source,
+                line_count: hashes.len(),
+            },
+            atomic_invocation_spans: Vec::new(),
+        }
+    }
+
+    fn totals(files: &[FileData]) -> CorpusTotals {
+        CorpusTotals {
+            files: files.len(),
+            lines: files.iter().map(|file| file.file_tokens.line_count).sum(),
+            tokens: files.iter().map(|file| file.hashed_tokens.len()).sum(),
+        }
+    }
+
+    #[test]
+    fn rolling_detects_exact_duplicate_across_files() {
+        let files = vec![
+            make_file("a.ts", &[1, 2, 3, 4, 5]),
+            make_file("b.ts", &[1, 2, 3, 4, 5]),
+        ];
+
+        let report = detect(&files, 3, 1, false, totals(&files), false);
+
+        assert_eq!(report.clone_groups.len(), 1);
+        assert_eq!(report.clone_groups[0].instances.len(), 2);
+        assert_eq!(report.clone_groups[0].token_count, 5);
+    }
+
+    #[test]
+    fn rolling_keeps_long_subgroup_when_seed_has_extra_occurrence() {
+        let files = vec![
+            make_file("a.ts", &[1, 2, 3, 4, 5, 6, 7, 8]),
+            make_file("b.ts", &[1, 2, 3, 4, 5, 6, 7, 8]),
+            make_file("c.ts", &[1, 2, 3, 9, 10, 11]),
+        ];
+
+        let report = detect(&files, 3, 1, false, totals(&files), false);
+
+        assert!(
+            report
+                .clone_groups
+                .iter()
+                .any(|group| group.token_count == 8 && group.instances.len() == 2),
+            "expected the long pair clone to survive alongside the broad short seed"
+        );
+    }
+
+    #[test]
+    fn rolling_keeps_adjacent_same_file_clone_that_extends_from_seed() {
+        let files = vec![make_file("a.ts", &[5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5])];
+
+        let report = detect(&files, 3, 1, false, totals(&files), false);
+
+        assert_eq!(report.clone_groups.len(), 1);
+        assert_eq!(report.clone_groups[0].instances.len(), 2);
+        assert_eq!(report.clone_groups[0].token_count, 5);
+    }
+
+    #[test]
+    fn adjacency_lookahead_checks_past_intervening_occurrences() {
+        let ranked_files = vec![vec![1, 2, 1, 2, 1, 1, 2, 1, 2, 1]];
+        let occurrences = vec![
+            Occurrence {
+                file_id: 0,
+                offset: 0,
+            },
+            Occurrence {
+                file_id: 0,
+                offset: 2,
+            },
+            Occurrence {
+                file_id: 0,
+                offset: 5,
+            },
+        ];
+
+        assert!(has_same_file_pair_at_or_extending_to_adjacency(
+            &ranked_files,
+            &[None],
+            false,
+            &occurrences,
+            3,
+        ));
+    }
+
+    #[test]
+    fn rolling_extends_long_multi_occurrence_clone_iteratively() {
+        let tokens: Vec<u32> = (0..20_000).collect();
+        let ranked_files = vec![tokens.clone(), tokens.clone(), tokens];
+        let occurrences = vec![
+            Occurrence {
+                file_id: 0,
+                offset: 0,
+            },
+            Occurrence {
+                file_id: 1,
+                offset: 0,
+            },
+            Occurrence {
+                file_id: 2,
+                offset: 0,
+            },
+        ];
+        let mut groups = Vec::new();
+
+        collect_extended_groups(
+            &ranked_files,
+            &[None, None, None],
+            false,
+            &occurrences,
+            3,
+            &mut groups,
+        );
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].length, 20_000);
+        assert_eq!(groups[0].instances, vec![(0, 0), (1, 0), (2, 0)]);
+    }
+}

--- a/crates/core/src/duplicates/detect/tests.rs
+++ b/crates/core/src/duplicates/detect/tests.rs
@@ -40,6 +40,86 @@ fn make_file_tokens(source: &str, count: usize) -> FileTokens {
     }
 }
 
+fn make_boundary_test_file(path: &str, has_boundary: bool) -> FileData {
+    let kind = if has_boundary {
+        TokenKind::Boundary("markup".to_string())
+    } else {
+        TokenKind::Identifier("value".to_string())
+    };
+    FileData {
+        path: PathBuf::from(path),
+        hashed_tokens: vec![HashedToken {
+            hash: 1,
+            original_index: 0,
+        }],
+        file_tokens: FileTokens {
+            tokens: vec![SourceToken {
+                kind,
+                span: Span::new(0, 1),
+            }],
+            atomic_invocation_spans: Vec::new(),
+            source: "x".to_string(),
+            line_count: 1,
+        },
+        atomic_invocation_spans: Vec::new(),
+    }
+}
+
+#[test]
+fn component_heavy_corpus_detects_boundary_ratio_at_threshold() {
+    let files = vec![
+        make_boundary_test_file("a.astro", true),
+        make_boundary_test_file("b.ts", false),
+        make_boundary_test_file("c.ts", false),
+        make_boundary_test_file("d.ts", false),
+        make_boundary_test_file("e.ts", false),
+    ];
+
+    let summary = summarize_boundaries(&files);
+    assert!(summary.is_component_heavy);
+    assert!(summary.has_any_boundary);
+}
+
+#[test]
+fn component_heavy_corpus_ignores_sparse_boundary_files() {
+    let mut files = vec![make_boundary_test_file("a.mdx", true)];
+    for index in 0..10 {
+        files.push(make_boundary_test_file(&format!("file{index}.ts"), false));
+    }
+
+    let summary = summarize_boundaries(&files);
+    assert!(!summary.is_component_heavy);
+    assert!(summary.has_any_boundary);
+}
+
+#[test]
+fn boundary_precheck_skips_plain_js_ts_corpus() {
+    let files = vec![
+        make_boundary_test_file("a.ts", false),
+        make_boundary_test_file("b.tsx", false),
+        make_boundary_test_file("c.js", false),
+        make_boundary_test_file("d.jsx", false),
+    ];
+
+    assert!(!files_may_have_boundaries(&files));
+}
+
+#[test]
+fn boundary_precheck_keeps_component_and_style_corpus() {
+    for path in [
+        "App.vue",
+        "Counter.svelte",
+        "page.astro",
+        "style.css",
+        "style.scss",
+        "style.sass",
+        "style.less",
+    ] {
+        let files = vec![make_boundary_test_file(path, false)];
+        assert!(files_may_have_boundaries(&files), "{path}");
+    }
+}
+
 #[test]
 fn empty_input_produces_empty_report() {
     let detector = CloneDetector::new(5, 1, false);
@@ -683,6 +763,7 @@ fn extract_clone_groups_for_test(
         min_tokens,
         files,
         focus_file_ids,
+        may_have_boundaries: files_may_have_boundaries(files),
     })
 }
 

--- a/plans/jscpd-benchmark-research.md
+++ b/plans/jscpd-benchmark-research.md
@@ -1,0 +1,325 @@
+# jscpd v5 duplication performance research
+
+Written for fallow after rechecking the `jscpd 5.0.10` comparison.
+
+## Summary
+
+jscpd v5 is still much faster than fallow for raw duplication scanning because it uses a different detection strategy.
+
+Fallow currently builds a suffix array and LCP array, then materializes every LCP interval above `min_tokens` into raw clone candidates before later filters reduce the result. On large repos this interval extraction dominates runtime.
+
+jscpd v5 uses rolling `min_tokens` window hashes and an open-clone state machine. It extends contiguous matches while scanning and emits one clone when a match region ends. That avoids materializing the large intermediate LCP interval set.
+
+## Key evidence
+
+### Next.js fallow profile
+
+Command shape:
+
+```bash
+RUST_LOG=fallow_core::duplicates=debug \
+  ./target/release/fallow dupes \
+  --format compact \
+  --quiet \
+  --performance \
+  --summary \
+  --no-cache \
+  --root benchmarks/fixtures/real-world/next.js
+```
+
+Observed step timings:
+
+| Step | Time |
+| --- | ---: |
+| Tokenize files | about 1.0s |
+| Rank reduce | about 6ms |
+| Concatenate | about 3ms |
+| Suffix array | about 838ms |
+| LCP array | about 14ms |
+| Extract raw groups | about 11.8s |
+| Build final groups | about 279ms |
+| Stats | about 6ms |
+
+The run produced `437942` raw groups, then reduced them to `4524` final clone groups.
+
+Main conclusion: fallow is not primarily slow because of parsing, reporting, JSON serialization, or the suffix array itself. The bottleneck is `step5_extract_groups`.
+
+Relevant fallow code:
+
+- `crates/core/src/duplicates/detect/mod.rs`, suffix array and extraction pipeline.
+- `crates/core/src/duplicates/detect/extraction.rs`, stack-based LCP interval extraction.
+- `crates/core/src/duplicates/detect/filtering.rs`, late subset and line filtering.
+
+### Final private rolling smoke
+
+Current-tree repeated command for the two main parity probes:
+
+```bash
+node benchmarks/compare-dupes-rolling.mjs --skip-build --projects=zod,next.js --runs=3 --samples=12
+```
+
+Result:
+
+| Project | Default | Rolling | Speedup | Exact drift | Coverage drift |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| next.js | 12.96s | 6.50s | 1.99x | 7 missing / 11 extra | 3 missing / 3 extra |
+| zod | 45ms | 22ms | 2.01x | 0 missing / 0 extra | 0 missing / 0 extra |
+
+Decision: the private rolling path is useful as a performance prototype, but it is not ready to replace the default detector until the remaining `next.js` coverage drift is resolved.
+
+Current-tree broader single-run fixture comparison:
+
+```bash
+node benchmarks/compare-dupes-rolling.mjs --skip-build --projects=typescript,next.js,zod,vite,astro,svelte,vue-core --runs=1 --samples=0
+```
+
+| Project | Default | Rolling | Speedup | Coverage drift |
+| --- | ---: | ---: | ---: | ---: |
+| astro | 695ms | 499ms | 1.39x | 0 missing / 0 extra |
+| next.js | 13.06s | 6.36s | 2.05x | 3 missing / 3 extra |
+| svelte | 281ms | 204ms | 1.38x | 0 missing / 0 extra |
+| typescript | 14.33s | 7.67s | 1.87x | 0 missing / 0 extra |
+| vite | 239ms | 137ms | 1.75x | 0 missing / 0 extra |
+| vue-core | 129ms | 62ms | 2.06x | 0 missing / 1 extra |
+| zod | 48ms | 24ms | 2.02x | 0 missing / 0 extra |
+
+Decision update: rolling is not a direct default replacement yet. It is now faster on TypeScript after the uniform-extension fix and remains promising on `next.js`, `vite`, and `zod`. The private path now uses a component-heavy corpus fallback for Astro/Svelte-style projects, which removes the largest component-corpus coverage drift while preserving the main JS/TS speed wins. The latest one-run Svelte sample is faster again after lazy child-map allocation, but smaller mixed component repos can still have low single-digit drift, so this remains private.
+
+Latest drift diagnosis: the component-corpus extras are mostly broad lexical parent pairs inside `.astro` and `.svelte` markup regions, not explicit section-boundary crossings. Examples include Astro footer/header markup where rolling emits a broad line range that the suffix path decomposes into smaller groups, and Svelte formatted-vs-flattened markup fixtures where rolling reports broad template spans that default output does not cover. This points at rolling pair emission and subset ordering rather than token namespace leakage.
+
+Latest Next.js sampled-repro diagnosis: `benchmarks/compare-dupes-rolling.mjs --write-repros=/tmp/fallow-rolling-repros --samples=8 --projects=next.js` copies the sampled drift files into a small repro project. In that sampled project, the ReactRefresh missing group disappears, so that miss depends on files outside the bounded sample. The sampled project still reproduces the `next-after-app-api-usage` line-shifted miss and the `large-shell/[slug]/page.tsx` broad rolling extra. That makes `next-after` and `large-shell` better next parity targets than ReactRefresh.
+
+### jscpd v5 algorithm
+
+jscpd v5 npm package is a small JS wrapper around a native Rust binary, for example `cpd-darwin-arm64/cpd-bin/cpd`.
+
+Relevant upstream code:
+
+- `rust/crates/cpd-core/src/detect.rs`
+- `rust/crates/cpd-finder/src/orchestrate.rs`
+- `rust/crates/cpd-tokenizer/src/tokenizer.rs`
+
+Algorithm shape:
+
+- Pre-hash detection tokens during tokenization.
+- Group prepared sources by format.
+- For each format group, scan rolling windows of length `min_tokens`.
+- Store first occurrences in an `FxHashMap<u64, Occurrence>`.
+- Verify hash hits by comparing the underlying token hash slice.
+- Maintain one `open_clone` for contiguous matches.
+- Flush one clone per contiguous region.
+- Use a capped secondary occurrence pass for repeated windows.
+
+This is why jscpd can process a large corpus without building the broad intermediate set fallow builds.
+
+### Things ruled out
+
+`--top 20` does not improve fallow runtime materially. The expensive candidate extraction already happened before truncation.
+
+`--min-occurrences 3` does not improve fallow runtime materially. It cuts report volume, but too late.
+
+The persistent token cache helps only slightly on the Next.js fixture. Tokenization is not the dominant cost.
+
+jscpd with `--workers 1` remains much faster than fallow. The gap is not mainly parallelism.
+
+Equalizing `--max-size` did not explain the Next.js gap.
+
+Adding `tsx,jsx` to the jscpd benchmark command increases jscpd's workload, but it remains very fast. The benchmark should include those formats for fairness.
+
+### Follow-up extraction experiments
+
+Kept changes:
+
+- Only push LCP stack entries when `cur_lcp >= min_tokens` and the LCP rises above the previous stack top. This reduces zero and flat plateau work without changing default compact output on `next.js`.
+- Add a two-instance raw group fast path in `build_raw_group`. This skips sort and dedupe allocation for the common pair case while preserving default compact output on `next.js`.
+- Skip per-instance boundary prefix checks when no file in the analyzed corpus has section-boundary tokens. This preserves default compact output on `next.js` and helps JS-only projects avoid an unnecessary hot-loop branch.
+- Add `benchmarks/compare-dupes-rolling.mjs` for default-vs-rolling timing, exact compact drift, line-coverage drift, and optional bounded drift samples via `--samples=N`. Current smoke result: `zod` remains clean, while `next.js` is faster with rolling but still reports coverage drift, so rolling remains private.
+- Replace the rolling prototype's per-offset `min_tokens` hash scan with O(1) rolling hash updates and skip boundary checks in rolling recursion when the corpus has no section-boundary tokens. This keeps `zod` clean and improves the private prototype, but does not solve the remaining `next.js` coverage drift.
+- Let rolling seed exploration continue when a same-file pair can extend until its ranges become adjacent, and check past intervening same-file occurrences with a bounded pair guard. This fixes adjacent repeated-block misses without the broad root-seed relaxation that made `zod` pathological. Current `next.js` smoke drift is down to low single-digit coverage misses/extras, but rolling still remains private.
+- Reuse the ordered occurrence invariant in rolling raw-group helpers instead of allocating and sorting temporary `(file_id, offset)` vectors. This preserves the current `next.js` drift profile and keeps `zod` exact while reducing private-path overhead.
+- Add a rolling two-occurrence extension fast path that scans the pair directly instead of allocating child maps one token at a time. This preserves the current drift profile and reduces the private path's raw-extension time on `next.js`.
+- Hoist rolling pair-extension boundary-prefix lookups out of the per-token loops and use a no-boundary fast path per pair. This preserves the current `next.js` and `zod` drift profile while improving the private rolling path's repeated cold-scan median.
+- Replace the recursive uniform multi-occurrence extension path with an iterative loop. The previous recursive shape overflowed the stack on the TypeScript fixture; the iterative version preserves output and lets the broader real-world comparison complete.
+- Fast-forward uniform multi-occurrence extension by scanning the common next token directly instead of rebuilding child maps one token at a time. This preserves the TypeScript drift profile and changes the repeated TypeScript rolling median from slower than default to faster than default.
+- Store rolling seed classes as a single occurrence until a duplicate window is found. This mirrors jscpd's first-hit storage shape more closely, avoids a `Vec` allocation for every unique rolling window, preserves the current drift profile, and improves the private rolling path on the main real-project probes.
+- Store rolling child buckets as a single occurrence until a duplicate next-token child is found. This avoids allocating a `Vec` for singleton children in recursive raw-group expansion, preserves the current drift profile, and improves the private rolling path on the broad real-project smoke.
+- Make rolling left-maximal overlap counts lazy after the adjacency checks. This avoids two non-overlap scans when adjacency already proves a seed left-maximal, preserves the current drift profile, and improves the private rolling path's within-run speedup on the main probes.
+- Preallocate recursive rolling child hash maps up to a capped size. This reduces hash-map growth in the child-grouping hot path, preserves the current drift profile, and improves most broad real-project probes despite noisy `next.js` wall time.
+- Reuse the component-boundary scan result when entering the private rolling path. This avoids rescanning JS-only corpora to discover that no boundary prefixes are needed, preserves the current drift profile, and improves the repeated `next.js` rolling median.
+- Add a private hybrid fallback for component-heavy corpora based on the share of files with section-boundary tokens. This keeps rolling active for large JS/TS corpora such as `next.js` and `typescript`, while falling back to the suffix detector for Astro/Svelte-style corpora where rolling emitted broad markup parent pairs.
+- Skip suffix-extraction boundary-prefix construction for corpora whose file extensions cannot produce boundary tokens. This is a conservative cleanup for plain JS/TS projects; it does not move the dominant `next.js` extraction bottleneck by itself.
+- Combine rolling's exact-adjacent same-file check and bounded extends-to-adjacency scan into one pass. This preserves the current drift profile, avoids a duplicate same-file scan inside left-maximality, and improved the broad real-project smoke on the largest probes.
+- Add `--write-repros=<DIR>` to `benchmarks/compare-dupes-rolling.mjs`. It copies the sampled missing and extra drift files into a small project, decodes compact-output path escapes such as `%5Bslug%5D`, and lets the next parity loop test reduced repros before changing rolling semantics.
+- Store rolling hash buckets as a single `SeedClass` until a real hash collision creates a second distinct seed class. This avoids allocating a `Vec<SeedClass>` for the common one-class rolling hash bucket, preserves the current drift profile, and improves the repeated `next.js` and `zod` rolling medians.
+- Consume rolling seed buckets directly when building raw groups instead of first materializing a separate `Vec<SeedClass>`. This preserves the current drift profile, removes an intermediate allocation and traversal, and improves the repeated main probes.
+- Lazily allocate recursive rolling child maps only after seeing a second extendable child occurrence. Groups with zero or one extendable child cannot recurse, so this avoids needless hash-map work, preserves the current drift profile, and improves the repeated main probes.
+
+Rejected changes:
+
+- Capping raw-group temporary vector capacity at 16 regressed `next.js` extraction and build time because large intervals reallocated heavily.
+- In-place dedupe of sorted raw instances preserved output but regressed `next.js` build time.
+- A special exact two-suffix interval helper preserved output but regressed `next.js` extraction time.
+- Lazy allocation for the first two valid instances preserved output but regressed `next.js` extraction time. The added hot-loop branching outweighed avoided allocations.
+- Relaxing rolling child left-maximality did not reduce `next.js` drift and made rolling slower.
+- Suppressing rolling parent seed groups when extendable children exist made `next.js` faster but lost too much default coverage, so it is not acceptable as a parity path.
+- Caching per-file token lengths for the suffix extraction hot loop preserved output but was neutral to slightly worse on `next.js`, so it was not kept.
+- Sorting rolling seed classes and child groups made comparisons deterministic but slowed the private path on `next.js`, so it was not kept in the speed-focused prototype.
+- Replacing the bounded same-file pair guard with a distance-window guard kept the speed gain but worsened `next.js` coverage drift, so the pair guard remains the better private prototype.
+- Recursing into every extendable rolling child class after a split preserved the current `next.js` drift but regressed `zod`, so the child left-maximality guard remains.
+- Raising the rolling adjacent-pair lookahead cap from 512 to 4096 did not reduce the remaining `next.js` drift and slowed the private path, so the lower cap remains.
+- Splitting suffix extraction into a separate no-boundary hot loop and hoisting per-file token lengths preserved output but regressed the measured `next.js` profile, so the current single loop remains.
+- Treating adjacent line intervals as continuous in `remove_line_subsets` removed one rolling-only same-file extra, but it also changed default `next.js` output and worsened rolling parity, so the shared filter stays unchanged.
+- Special-casing three-occurrence rolling child splitting preserved the current drift profile but slowed the private path, so the hash-map child splitter remains.
+- Suppressing rolling pair groups that share starts with near-length multi-instance raw groups fixed the ReactRefresh raw-group suppression locally, but it caused broad `next.js` drift and slowed the private path, so rolling pair groups stay unpruned.
+- Sorting rolling token-subset filtering to prefer near-length multi-instance groups over pairs reduced one local suppression mode, but it caused broad `next.js` drift, so the shared length-descending subset order remains.
+- Preallocating raw-group output vectors in suffix extraction and rolling preserved output, but the measured `next.js` profile was not better, so the default `Vec::new()` growth remains.
+- Reordering the rolling left-maximal checks to run the count-based condition before the bounded adjacency-extension search preserved drift, but the repeated `next.js` rolling median regressed, so the original boolean order remains.
+- Preallocating the rolling seed bucket map by total window count matched jscpd's store-sizing shape, but the repeated `next.js` rolling median regressed and exact drift changed without improving coverage drift, so the default growing map remains.
+- Recursing into split child groups with at least four occurrences and an adjacent same-file pair did not reduce the remaining `next.js` coverage drift and slowed the repeated `next.js` rolling median, so the stricter child left-maximal gate remains.
+- Specializing uniform multi-occurrence extension for no-boundary corpora removed boundary checks from the hot loop, but repeated real-project comparison regressed TypeScript and Vite versus the previous rolling medians, so the shared `next_extension_token` path remains.
+- Adding a three-instance suffix-extraction fast path preserved focused duplicate tests, but the interval-pressure benchmark regressed from the current baseline, so the generic `sort_unstable` plus dedupe path remains.
+- Returning only occurrence vectors from rolling seed building removed unused key fields after duplicate-window discovery, but repeated real-project comparison regressed the private rolling medians, especially TypeScript, so the post-filter `SeedClass` shape remains.
+- Removing rolling-only same-file bridge groups eliminated the small extra-coverage samples on `next.js` and `vue-core`, but it also caused broad missing coverage (`next.js`: 789 coverage misses, `vue-core`: 186 coverage misses), so rolling keeps those bridge groups.
+- Replacing recursive rolling child hash maps with linear buckets for small occurrence sets helped some small fixtures, but worsened the main large probes (`next.js` and TypeScript) at both 8- and 4-occurrence cutoffs, so child grouping keeps the hash-map path plus single-occurrence bucket storage.
+- Replacing the no-boundary prefix vector with an empty slice removed a small allocation, but regressed the main broad real-project probes. The rolling path keeps a per-file `None` prefix vector so indexing shape stays uniform.
+- Returning early from rolling left-maximality for two-occurrence classes after the previous-token and adjacency checks preserved the current drift profile, but repeated `next.js` and `zod` comparison did not improve the rolling median, so the count fallback remains unchanged.
+- Replacing rolling seed bucket `get_mut` plus `insert` with the hash map entry API preserved drift but did not improve the repeated `next.js` and `zod` medians, so the previous insertion shape remains.
+- Combining the two rolling non-overlap count scans inside left-maximality into a single pass preserved the current drift profile, but repeated `next.js` comparison regressed the rolling median, so the separate scans remain.
+- Specializing rolling left-maximality for two-occurrence seed classes preserved the current drift profile, but repeated `next.js` comparison regressed the rolling median, so the generic path remains.
+- Storing each rolling occurrence's previous token rank improved the locality of the left-maximal prefix check in theory, but it enlarged the occurrence record and regressed the repeated `next.js` rolling median while preserving the same drift, so occurrences remain `(file_id, offset)` only.
+- Specializing rolling raw-group push for two-occurrence groups preserved the current drift profile, but repeated `next.js` and `zod` comparison did not improve the rolling median, so the generic dedupe helper remains.
+- Splitting rolling recursive child-bucket collection into boundary and no-boundary helper functions preserved the current drift profile, but repeated `next.js` comparison regressed the rolling median, so the inline child scan remains.
+
+## Benchmark correction needed
+
+Current comparator commands should not use only:
+
+```bash
+--format typescript,javascript
+```
+
+For JS/TS web projects, use:
+
+```bash
+--format typescript,javascript,tsx,jsx
+```
+
+Otherwise jscpd skips `.tsx` and `.jsx` while fallow includes them.
+
+Keep the existing benchmark guard in `benchmarks/bench-dupes.mjs` that checks `node_modules/jscpd/package.json` against `package-lock.json`. The previous stale local install made `jscpd 4.2.5` look much slower than the locked `5.0.10`.
+
+## Implementation plan
+
+### 1. Add a fair benchmark mode for jscpd v5
+
+Goal: prevent bad conclusions before changing code.
+
+Work:
+
+- Update `benchmarks/bench-dupes.mjs` jscpd args to include `tsx,jsx`.
+- Consider moving the format list to a named constant, for example `JS_WEB_FORMATS`.
+- Keep version mismatch guard.
+- Record both time and tool-specific duplication volume.
+- Label clone groups and duplication percentage as tool-specific metrics, not equivalent recall.
+
+Validation:
+
+- `node benchmarks/bench-dupes.mjs --real-world --runs=1 --warmup=0 --projects=zod`
+- One heavier spot check on `next.js`.
+
+### 2. Add a fallow duplicate detection benchmark that isolates extraction
+
+Goal: make the bottleneck measurable in CI or local perf loops.
+
+Work:
+
+- Add or extend a benchmark around `CloneDetector::detect`.
+- Include a fixture pattern that reproduces high LCP interval pressure.
+- Track at least:
+  - tokens
+  - raw groups
+  - final clone groups
+  - extraction time
+  - total detection time
+
+Validation:
+
+- `cargo check -p fallow-core --benches`
+- Targeted benchmark run against the new detector benchmark.
+
+### 3. Prototype a rolling-window detector path
+
+Goal: test whether jscpd's algorithm class fits fallow's output requirements.
+
+Work:
+
+- Add an internal alternative detector behind a private config gate or feature flag.
+- Reuse fallow's current tokenization and normalization first.
+- Group streams by source namespace or format so JS, style, and markup do not cross-match accidentally.
+- Use rolling `min_tokens` hashes and verify token slices on hash hits.
+- Emit maximal contiguous clone regions instead of every LCP interval.
+- Preserve current `CloneGroup` output shape.
+
+Validation:
+
+- Existing duplicate tests.
+- New tests for:
+  - identical files
+  - overlapping same-file clones
+  - 3+ repeated files
+  - `.vue`, `.svelte`, `.astro` section boundaries
+  - CSS or style token boundaries
+  - import-ignore behavior
+  - `skip_local`
+  - `min_lines`
+
+Risk:
+
+- jscpd's model emits pair-like clones. Fallow groups all instances into richer clone groups. The prototype must either group equivalent pair clones or accept a changed grouping model only with explicit review.
+
+### 4. Compare detector semantics before optimizing further
+
+Goal: avoid a faster but worse detector.
+
+Work:
+
+- Run current suffix-array detector and rolling prototype on the same fixture set.
+- Compare:
+  - total duplicated lines
+  - final clone groups
+  - sampled findings
+  - same-file overlap behavior
+  - repeated multi-file clone grouping
+  - false-positive noise from very common token windows
+
+Decision:
+
+- Keep rolling detector only if it materially improves large-project runtime and preserves useful fallow findings.
+- If grouping quality drops, consider a hybrid approach:
+  - rolling windows find candidate regions
+  - current grouping and reporting logic build final clone groups from those candidates
+
+### 5. Optimize current LCP extraction only if rolling prototype is too risky
+
+Fallback path:
+
+- Add earlier interval pruning in `extract_clone_groups`.
+- Avoid building raw groups that are clearly contained in already-covered intervals.
+- Push line and token coverage checks closer to extraction.
+- Cap pathological repeated-window intervals before `RawGroup` allocation.
+
+Expected impact:
+
+- Smaller than a rolling detector rewrite, but lower semantic risk.
+
+## Proposed priority
+
+1. Fix benchmark fairness for `tsx,jsx`.
+2. Add an isolated benchmark for the extraction bottleneck.
+3. Prototype rolling-window detection behind a private switch.
+4. Compare semantics and performance on `zod`, `svelte`, `vue-core`, `query`, `vite`, `next.js`, and `typescript`.
+5. Decide between rolling detector, hybrid candidate detector, or targeted LCP extraction pruning.
+
+## Current working hypothesis
+
+The best long-term direction is not to micro-optimize suffix-array construction. The measured hot path is LCP interval extraction and raw-group materialization. A candidate-first rolling-window detector, possibly feeding fallow's existing grouping/reporting surface, is the most promising route to close the jscpd gap.


### PR DESCRIPTION
Add a private FALLOW_DUPES_ROLLING detector path to compare a rolling-window candidate-first strategy against the current suffix-array extraction. The default detector remains intact, component-heavy corpora fall back to the suffix path, and the prototype reuses existing filtering and statistics so parity can be measured without changing public CLI behavior.

Refresh the jscpd benchmark harness and README with corrected jscpd v5 comparison data, a version-mismatch guard, JS web formats, and a dedicated rolling comparator. Add interval-pressure benchmark coverage, rolling detector tests, and the research plan covering kept and rejected optimization rounds.