### PR TITLE
ci(coverage): enforce a hard 92% coverage floor

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,6 +47,19 @@ jobs:
           echo "COVERAGE=$COVERAGE" >> "$GITHUB_ENV"
           echo "Coverage: $COVERAGE%"
 
+      - name: Enforce coverage floor
+        # Hard gate: fail if workspace line coverage drops below the floor.
+        # Ratcheted upward over time; raise only, never lower. Current main ~92.7%.
+        run: |
+          FLOOR=92.0
+          awk -v cov="$COVERAGE" -v floor="$FLOOR" 'BEGIN {
+            if (cov + 0 < floor + 0) {
+              printf "FAIL: coverage %.1f%% is below the floor of %.1f%%\n", cov, floor
+              exit 1
+            }
+            printf "OK: coverage %.1f%% meets the floor of %.1f%%\n", cov, floor
+          }'
+
       - name: Compute badge color
         run: |
           int=${COVERAGE%.*}


### PR DESCRIPTION
Coverage was computed by `coverage.yml` for the badge + trend metric only, with no gate, so a regression below the measured ~92.7% would ship silently. This adds a hard floor (the Coverage job fails below 92.0%) right after the compute step.

The floor ratchets upward only and closes the CRAP loop: complexity is already gated via clippy, but coverage was measured and never enforced. First of a series of Rust quality-gate ratchets.