### PR TITLE
ci(zizmor): suppress adhoc-packages for ci.yml and release.yml

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -40,3 +40,12 @@ rules:
   template-injection:
     ignore:
       - ci.yml
+  # ci.yml smoke-installs the freshly built (unpublished) npm tarball, which has
+  # no lockfile by definition. release.yml installs pinned npm (the required
+  # two-step bootstrap) and pinned @vscode/vsce / ovsx publisher CLIs. All use
+  # exact version pins plus --ignore-scripts, so the ad-hoc install surface is
+  # already hardened (see .claude/rules/release-workflow.md).
+  adhoc-packages:
+    ignore:
+      - ci.yml
+      - release.yml


### PR DESCRIPTION
zizmor v1.26.1 (pulled by the unpinned `uvx zizmor` in the Actions Security job) added the `adhoc-packages` audit, turning the CI workflow red on `main` with four findings. All four are deliberate, version-pinned, `--ignore-scripts`-hardened installs already covered by the release-workflow security boundary:

- `ci.yml`: smoke-installs the freshly built (unpublished, lockfile-less) npm tarball.
- `release.yml`: the required two-step pinned-npm bootstrap and the pinned `@vscode/vsce` / `ovsx` publisher CLIs.

Ignoring the audit for those two files matches the existing per-rule suppressions in `.github/zizmor.yml`. Verified locally: `zizmor --config .github/zizmor.yml --min-confidence medium .github/ action.yml` now exits 0 with no findings.