### PR TITLE
test(config,ci): make env-var tests deterministic on Windows CI

### DIFF
--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -1622,14 +1622,24 @@ mod tests {
         assert!(!is_github_bot_comment(&comment));
     }
 
+    // Serializes the FALLOW_BOT_LOGIN env-mutating tests so the GitHub and
+    // GitLab override cases cannot overwrite each other's value when run in
+    // parallel (which raced and failed on Windows CI).
+    static BOT_LOGIN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
-    #[allow(unsafe_code, reason = "test-only env mutation, single-threaded run")]
+    #[allow(
+        unsafe_code,
+        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
+    )]
     fn github_bot_check_accepts_explicit_login_override() {
+        let _env = BOT_LOGIN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "fallow-bot-account" },
         });
-        // SAFETY: This test owns the FALLOW_BOT_LOGIN override and clears it
-        // before returning.
+        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
         unsafe {
             std::env::set_var("FALLOW_BOT_LOGIN", "fallow-bot-account");
         }
@@ -2370,14 +2380,19 @@ mod tests {
     // --- is_gitlab_bot_note: FALLOW_BOT_LOGIN path (lines 1356-1364) ---
 
     #[test]
-    #[allow(unsafe_code, reason = "test-only env mutation, single-threaded run")]
+    #[allow(
+        unsafe_code,
+        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
+    )]
     fn gitlab_bot_check_accepts_explicit_login_override() {
+        let _env = BOT_LOGIN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let note = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "fallow-gl-bot" },
         });
-        // SAFETY: This test owns the FALLOW_BOT_LOGIN override and clears it
-        // before returning.
+        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
         unsafe {
             std::env::set_var("FALLOW_BOT_LOGIN", "fallow-gl-bot");
         }

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -313,9 +313,14 @@ fn normalize_url_for_dedup(url: &str) -> String {
 
 /// Read the `FALLOW_EXTENDS_TIMEOUT_SECS` env var, falling back to [`DEFAULT_URL_TIMEOUT_SECS`].
 fn url_timeout() -> Duration {
-    std::env::var("FALLOW_EXTENDS_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok().filter(|&n| n > 0))
+    url_timeout_from(std::env::var("FALLOW_EXTENDS_TIMEOUT_SECS").ok().as_deref())
+}
+
+/// Parse a raw `FALLOW_EXTENDS_TIMEOUT_SECS` value into a timeout, falling back
+/// to [`DEFAULT_URL_TIMEOUT_SECS`] for absent, zero, or non-numeric input. Pure
+/// so the parsing branches stay testable without mutating the process env.
+fn url_timeout_from(raw: Option<&str>) -> Duration {
+    raw.and_then(|v| v.parse::<u64>().ok().filter(|&n| n > 0))
         .map_or(
             Duration::from_secs(DEFAULT_URL_TIMEOUT_SECS),
             Duration::from_secs,
@@ -4182,80 +4187,37 @@ thresholdOverrides = [
     // url_timeout: env var override
     // ------------------------------------------------------------------
 
+    // These exercise the pure `url_timeout_from` parser rather than mutating the
+    // process-global env var, so they stay deterministic under parallel test
+    // execution (an env-mutating version raced and failed on Windows CI).
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "set_var is unsafe in edition 2024; env mutation is safe within a single-threaded test"
-    )]
     fn url_timeout_uses_env_var_when_set() {
-        let key = "FALLOW_EXTENDS_TIMEOUT_SECS";
-        let previous = std::env::var(key).ok();
-
-        // SAFETY: test-only; single-threaded; we restore previous value
-        unsafe { std::env::set_var(key, "15") };
-        let t = url_timeout();
-        if let Some(prev) = previous {
-            // SAFETY: test-only restore
-            unsafe { std::env::set_var(key, prev) };
-        } else {
-            // SAFETY: test-only restore
-            unsafe { std::env::remove_var(key) };
-        }
-
-        assert_eq!(t.as_secs(), 15);
+        assert_eq!(url_timeout_from(Some("15")).as_secs(), 15);
     }
 
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "set_var is unsafe in edition 2024; env mutation is safe within a single-threaded test"
-    )]
     fn url_timeout_zero_falls_back_to_default() {
-        let key = "FALLOW_EXTENDS_TIMEOUT_SECS";
-        let previous = std::env::var(key).ok();
-
-        // SAFETY: test-only; single-threaded; we restore previous value
-        unsafe { std::env::set_var(key, "0") };
-        let t = url_timeout();
-        if let Some(prev) = previous {
-            // SAFETY: test-only restore
-            unsafe { std::env::set_var(key, prev) };
-        } else {
-            // SAFETY: test-only restore
-            unsafe { std::env::remove_var(key) };
-        }
-
         assert_eq!(
-            t,
+            url_timeout_from(Some("0")),
             Duration::from_secs(DEFAULT_URL_TIMEOUT_SECS),
             "zero should fall back to the hardcoded default"
         );
     }
 
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "set_var is unsafe in edition 2024; env mutation is safe within a single-threaded test"
-    )]
     fn url_timeout_non_numeric_falls_back_to_default() {
-        let key = "FALLOW_EXTENDS_TIMEOUT_SECS";
-        let previous = std::env::var(key).ok();
-
-        // SAFETY: test-only; single-threaded; we restore previous value
-        unsafe { std::env::set_var(key, "not-a-number") };
-        let t = url_timeout();
-        if let Some(prev) = previous {
-            // SAFETY: test-only restore
-            unsafe { std::env::set_var(key, prev) };
-        } else {
-            // SAFETY: test-only restore
-            unsafe { std::env::remove_var(key) };
-        }
-
         assert_eq!(
-            t,
+            url_timeout_from(Some("not-a-number")),
             Duration::from_secs(DEFAULT_URL_TIMEOUT_SECS),
             "non-numeric value should fall back to the hardcoded default"
+        );
+    }
+
+    #[test]
+    fn url_timeout_absent_uses_default() {
+        assert_eq!(
+            url_timeout_from(None),
+            Duration::from_secs(DEFAULT_URL_TIMEOUT_SECS)
         );
     }
 


### PR DESCRIPTION
The `url_timeout` and `FALLOW_BOT_LOGIN` tests added during the coverage work mutated process-global env vars and read them back, which races under cargo's default parallel test execution. They passed on macOS by scheduling luck but failed the `Check (windows-latest)` job (`left: 15s, right: 5s`).

- `config/parsing.rs`: extract a pure `url_timeout_from(Option<&str>)` parser and test its branches directly (no env mutation, no unsafe).
- `ci.rs`: serialize the two `FALLOW_BOT_LOGIN` override tests behind a shared mutex so the GitHub and GitLab cases cannot overwrite each other's value.

Verified locally with `--test-threads=16`: both suites pass; clippy clean.