### PR TITLE
fix(telemetry): classify CLI failure reasons

### DIFF
--- a/.github/scripts/check-telemetry-fail-rate.mjs
+++ b/.github/scripts/check-telemetry-fail-rate.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_POSTHOG_HOST = "https://eu.posthog.com";
+const DEFAULT_WINDOW_DAYS = 14;
+const DEFAULT_MIN_TARGET_EVENTS = 500;
+const DEFAULT_MIN_BASELINE_EVENTS = 1000;
+const DEFAULT_MAX_DELTA_POINTS = 5;
+const DEFAULT_MAX_MULTIPLIER = 1.5;
+
+const REQUIRED_ENV = ["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"];
+
+const parseNumber = (value, fallback) => {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`expected a number, got ${value}`);
+  }
+  return parsed;
+};
+
+const parseInteger = (value, fallback) => {
+  const parsed = parseNumber(value, fallback);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`expected a non-negative integer, got ${value}`);
+  }
+  return parsed;
+};
+
+const parseArgs = (argv) => {
+  const args = {
+    targetVersion: process.env.FALLOW_TELEMETRY_TARGET_VERSION ?? null,
+    fixturePath: null,
+    windowDays: parseInteger(process.env.FALLOW_TELEMETRY_WINDOW_DAYS, DEFAULT_WINDOW_DAYS),
+    minTargetEvents: parseInteger(
+      process.env.FALLOW_TELEMETRY_MIN_TARGET_EVENTS,
+      DEFAULT_MIN_TARGET_EVENTS,
+    ),
+    minBaselineEvents: parseInteger(
+      process.env.FALLOW_TELEMETRY_MIN_BASELINE_EVENTS,
+      DEFAULT_MIN_BASELINE_EVENTS,
+    ),
+    maxDeltaPoints: parseNumber(
+      process.env.FALLOW_TELEMETRY_MAX_DELTA_POINTS,
+      DEFAULT_MAX_DELTA_POINTS,
+    ),
+    maxMultiplier: parseNumber(process.env.FALLOW_TELEMETRY_MAX_MULTIPLIER, DEFAULT_MAX_MULTIPLIER),
+  };
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--target") {
+      args.targetVersion = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--fixture") {
+      args.fixturePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--window-days") {
+      args.windowDays = parseInteger(next, args.windowDays);
+      index += 1;
+      continue;
+    }
+    if (arg === "--min-target-events") {
+      args.minTargetEvents = parseInteger(next, args.minTargetEvents);
+      index += 1;
+      continue;
+    }
+    if (arg === "--min-baseline-events") {
+      args.minBaselineEvents = parseInteger(next, args.minBaselineEvents);
+      index += 1;
+      continue;
+    }
+    if (arg === "--max-delta-points") {
+      args.maxDeltaPoints = parseNumber(next, args.maxDeltaPoints);
+      index += 1;
+      continue;
+    }
+    if (arg === "--max-multiplier") {
+      args.maxMultiplier = parseNumber(next, args.maxMultiplier);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  if (typeof args.targetVersion !== "string" || args.targetVersion.trim() === "") {
+    throw new Error("missing target version, pass --target or FALLOW_TELEMETRY_TARGET_VERSION");
+  }
+  return { ...args, targetVersion: normalizeVersion(args.targetVersion) };
+};
+
+const normalizeVersion = (version) => version.trim().replace(/^v/, "");
+
+const failRate = (row) => (row.events === 0 ? 0 : row.failed / row.events);
+
+const formatPercent = (value) => `${(value * 100).toFixed(2)}%`;
+
+const compareVersions = (left, right) => {
+  const a = normalizeVersion(left)
+    .split(".")
+    .map((part) => Number.parseInt(part, 10));
+  const b = normalizeVersion(right)
+    .split(".")
+    .map((part) => Number.parseInt(part, 10));
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const diff = (a[index] || 0) - (b[index] || 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+};
+
+export const parseRows = (rawRows) => {
+  if (!Array.isArray(rawRows)) {
+    throw new Error("PostHog response did not include an array result");
+  }
+  return rawRows
+    .map((row) => {
+      const version = Array.isArray(row) ? row[0] : row.version;
+      const events = Number(Array.isArray(row) ? row[1] : row.events);
+      const failed = Number(Array.isArray(row) ? row[2] : row.failed);
+      if (typeof version !== "string" || version.trim() === "") {
+        return null;
+      }
+      if (!Number.isFinite(events) || events < 0 || !Number.isFinite(failed) || failed < 0) {
+        throw new Error(`invalid telemetry row for ${version}`);
+      }
+      if (failed > events) {
+        throw new Error(`failed events exceed total events for ${version}`);
+      }
+      return {
+        version: normalizeVersion(version),
+        events,
+        failed,
+      };
+    })
+    .filter((row) => row !== null);
+};
+
+export const computeGate = ({
+  rows,
+  targetVersion,
+  minTargetEvents,
+  minBaselineEvents,
+  maxDeltaPoints,
+  maxMultiplier,
+}) => {
+  const normalizedTarget = normalizeVersion(targetVersion);
+  const target = rows.find((row) => row.version === normalizedTarget);
+  if (!target) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: `target ${normalizedTarget} has no telemetry in the window`,
+    };
+  }
+  if (target.events < minTargetEvents) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: `target ${normalizedTarget} has fewer than ${minTargetEvents} events`,
+      target,
+    };
+  }
+
+  const baselineRows = rows.filter(
+    (row) =>
+      row.version !== normalizedTarget &&
+      row.events > 0 &&
+      compareVersions(row.version, normalizedTarget) < 0,
+  );
+  const baseline = baselineRows.reduce(
+    (acc, row) => ({
+      events: acc.events + row.events,
+      failed: acc.failed + row.failed,
+    }),
+    { events: 0, failed: 0 },
+  );
+
+  if (baseline.events < minBaselineEvents) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: `baseline has fewer than ${minBaselineEvents} events`,
+      target,
+      baseline,
+    };
+  }
+
+  const targetRate = failRate(target);
+  const baselineRate = failRate(baseline);
+  const delta = targetRate - baselineRate;
+  const deltaLimit = maxDeltaPoints / 100;
+  const multiplierExceeded =
+    baselineRate === 0 ? targetRate > 0 : targetRate >= baselineRate * maxMultiplier;
+  const failed = delta >= deltaLimit && multiplierExceeded;
+
+  return {
+    ok: !failed,
+    skipped: false,
+    target,
+    baseline,
+    targetRate,
+    baselineRate,
+    delta,
+    reason: failed
+      ? `target fail rate ${formatPercent(targetRate)} exceeds baseline ${formatPercent(baselineRate)}`
+      : `target fail rate ${formatPercent(targetRate)} is within baseline ${formatPercent(baselineRate)}`,
+  };
+};
+
+const telemetryQuery = (windowDays) => `
+SELECT
+  properties.fallow_version AS version,
+  count() AS events,
+  sum(if(event = 'workflow_failed', 1, 0)) AS failed
+FROM events
+WHERE timestamp >= now() - INTERVAL ${windowDays} DAY
+  AND event IN ('workflow_completed', 'workflow_failed')
+  AND notEmpty(toString(properties.fallow_version))
+GROUP BY version
+ORDER BY events DESC
+LIMIT 200
+`;
+
+const posthogRows = async ({ host, projectId, apiKey, windowDays }) => {
+  const url = new URL(`/api/projects/${projectId}/query/`, host);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: "fallow release telemetry fail-rate gate",
+      query: {
+        kind: "HogQLQuery",
+        query: telemetryQuery(windowDays),
+      },
+    }),
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail = body && typeof body.detail === "string" ? body.detail : response.statusText;
+    throw new Error(`PostHog query failed: ${response.status} ${detail}`);
+  }
+  const result = body?.results ?? body?.result;
+  return parseRows(result);
+};
+
+const loadRows = async (args) => {
+  if (args.fixturePath) {
+    return parseRows(JSON.parse(readFileSync(args.fixturePath, "utf8")));
+  }
+  const missing = REQUIRED_ENV.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`missing environment: ${missing.join(", ")}`);
+  }
+  return posthogRows({
+    host: process.env.POSTHOG_HOST || DEFAULT_POSTHOG_HOST,
+    projectId: process.env.POSTHOG_PROJECT_ID,
+    apiKey: process.env.POSTHOG_PERSONAL_API_KEY,
+    windowDays: args.windowDays,
+  });
+};
+
+const main = async (argv) => {
+  const args = parseArgs(argv);
+  const rows = await loadRows(args);
+  const result = computeGate({ rows, ...args });
+  if (result.skipped) {
+    console.log(`SKIP telemetry fail-rate gate: ${result.reason}`);
+    return 0;
+  }
+  const targetLine = `${result.target.version}: ${formatPercent(result.targetRate)} (${result.target.failed}/${result.target.events})`;
+  const baselineLine = `baseline: ${formatPercent(result.baselineRate)} (${result.baseline.failed}/${result.baseline.events})`;
+  if (result.ok) {
+    console.log(`OK telemetry fail-rate gate: ${targetLine}; ${baselineLine}`);
+    return 0;
+  }
+  console.error(`::error::telemetry fail-rate regression: ${targetLine}; ${baselineLine}`);
+  return 1;
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv)
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err) => {
+      console.error(`::error::${err.message}`);
+      process.exit(1);
+    });
+}

--- a/.github/scripts/check-telemetry-fail-rate.test.mjs
+++ b/.github/scripts/check-telemetry-fail-rate.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { computeGate, parseRows } from "./check-telemetry-fail-rate.mjs";
+
+const OPTIONS = {
+  targetVersion: "2.101.0",
+  minTargetEvents: 100,
+  minBaselineEvents: 100,
+  maxDeltaPoints: 5,
+  maxMultiplier: 1.5,
+};
+
+test("fails when the target fail rate jumps above the trailing baseline", () => {
+  const rows = parseRows([
+    ["2.101.0", 1000, 200],
+    ["2.100.0", 1200, 24],
+    ["2.99.0", 800, 16],
+  ]);
+
+  const result = computeGate({ rows, ...OPTIONS });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.skipped, false);
+  assert.equal(result.targetRate, 0.2);
+  assert.equal(result.baselineRate, 0.02);
+});
+
+test("passes when the target is within the baseline envelope", () => {
+  const rows = parseRows([
+    ["2.101.0", 1000, 35],
+    ["2.100.0", 1200, 30],
+    ["2.99.0", 800, 20],
+  ]);
+
+  const result = computeGate({ rows, ...OPTIONS });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, false);
+});
+
+test("skips until the target has enough telemetry", () => {
+  const rows = parseRows([
+    ["2.101.0", 99, 80],
+    ["2.100.0", 1000, 20],
+  ]);
+
+  const result = computeGate({ rows, ...OPTIONS });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.match(result.reason, /target 2\.101\.0/);
+});
+
+test("skips until the baseline has enough telemetry", () => {
+  const rows = parseRows([
+    ["2.101.0", 1000, 200],
+    ["2.100.0", 99, 2],
+  ]);
+
+  const result = computeGate({ rows, ...OPTIONS });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.match(result.reason, /baseline/);
+});
+
+test("ignores newer versions when building the baseline", () => {
+  const rows = parseRows([
+    ["2.102.0", 1000, 800],
+    ["2.101.0", 1000, 40],
+    ["2.100.0", 1000, 20],
+  ]);
+
+  const result = computeGate({ rows, ...OPTIONS });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.baseline.failed, 20);
+});
+
+test("accepts object rows from fixtures", () => {
+  const rows = parseRows([
+    { version: "v2.101.0", events: "1000", failed: "200" },
+    { version: "2.100.0", events: 1000, failed: 20 },
+  ]);
+
+  assert.deepEqual(rows, [
+    { version: "2.101.0", events: 1000, failed: 200 },
+    { version: "2.100.0", events: 1000, failed: 20 },
+  ]);
+});

--- a/.github/workflows/telemetry-fail-rate.yml
+++ b/.github/workflows/telemetry-fail-rate.yml
@@ -1,0 +1,49 @@
+name: Telemetry fail-rate gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_version:
+        description: "Published fallow version to check"
+        required: false
+        type: string
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions: {}
+
+jobs:
+  fail-rate:
+    name: Check published CLI fail rate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+
+      - name: Resolve target version
+        id: target
+        shell: bash
+        env:
+          INPUT_TARGET_VERSION: ${{ inputs.target_version }}
+        run: |
+          set -euo pipefail
+          target="$INPUT_TARGET_VERSION"
+          if [ -z "$target" ]; then
+            target="$(npm view fallow version)"
+          fi
+          printf 'version=%s\n' "$target" >> "$GITHUB_OUTPUT"
+
+      - name: Check telemetry fail rate
+        env:
+          FALLOW_TELEMETRY_TARGET_VERSION: ${{ steps.target.outputs.version }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: node .github/scripts/check-telemetry-fail-rate.mjs

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -319,6 +319,20 @@ fn take_last_two_segments(path: &str) -> Option<String> {
 }
 
 fn emit_cloud_error(err: &CloudError, output: OutputFormat) -> ExitCode {
+    match err {
+        CloudError::Auth(_) | CloudError::TierRequired(_) => {
+            crate::telemetry::note_failure_reason(crate::telemetry::FailureReason::Auth);
+        }
+        CloudError::Network(_) | CloudError::Server(_) => {
+            crate::telemetry::note_failure_reason(crate::telemetry::FailureReason::Network);
+        }
+        CloudError::Validation(_) => {
+            crate::telemetry::note_failure_reason(crate::telemetry::FailureReason::Validation);
+        }
+        CloudError::NotFound(_) => {
+            crate::telemetry::note_failure_reason(crate::telemetry::FailureReason::Config);
+        }
+    }
     emit_error(err.message(), err.exit_code(), output)
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2987,13 +2987,16 @@ fn record_run_epilogue(
     parent_run: Option<&str>,
 ) -> ExitCode {
     let cache_notice_printed = cache_notice::maybe_print_created_notice();
+    let effective_failure_reason = failure_reason
+        .or_else(telemetry::noted_failure_reason)
+        .or_else(|| fallback_failure_reason_for(&run, exit_code));
     telemetry::record_workflow(&telemetry::WorkflowRecord {
         workflow: run.workflow,
         output: run.output,
         quiet: run.quiet,
         elapsed: run.start.elapsed(),
         exit_code,
-        failure_reason,
+        failure_reason: effective_failure_reason,
         parent_run,
         context: run.context,
     });
@@ -3002,6 +3005,39 @@ fn record_run_epilogue(
         update_check::maybe_nudge(run.output, run.quiet, note_printed || cache_notice_printed);
     }
     exit_code
+}
+
+fn fallback_failure_reason_for(
+    run: &TelemetryRun,
+    exit_code: ExitCode,
+) -> Option<telemetry::FailureReason> {
+    if matches!(exit_code, ExitCode::SUCCESS) || exit_code == ExitCode::from(1) {
+        return None;
+    }
+    if exit_code == ExitCode::from(api::NETWORK_EXIT_CODE) {
+        return Some(telemetry::FailureReason::Network);
+    }
+    if exit_code == ExitCode::from(12) {
+        return Some(telemetry::FailureReason::Auth);
+    }
+    if matches!(
+        run.context.analysis_mode,
+        telemetry::AnalysisMode::ProductionCoverage
+    ) && exit_code == ExitCode::from(3)
+    {
+        return Some(telemetry::FailureReason::Auth);
+    }
+    if matches!(
+        run.context.analysis_mode,
+        telemetry::AnalysisMode::Static
+            | telemetry::AnalysisMode::Security
+            | telemetry::AnalysisMode::Fix
+            | telemetry::AnalysisMode::RuntimeCoverage
+            | telemetry::AnalysisMode::ProductionCoverage
+    ) {
+        return Some(telemetry::FailureReason::Analysis);
+    }
+    Some(telemetry::FailureReason::Unknown)
 }
 
 fn start_telemetry_run(cli: &Cli, fmt: &FormatConfig) -> TelemetryRun {
@@ -6126,6 +6162,52 @@ mod tests {
     fn emit_error_returns_given_exit_code() {
         let code = emit_error("test error", 2, fallow_config::OutputFormat::Human);
         assert_eq!(code, ExitCode::from(2));
+    }
+
+    fn telemetry_run_for_mode(mode: telemetry::AnalysisMode) -> TelemetryRun {
+        TelemetryRun {
+            workflow: telemetry::Workflow::Health,
+            output: fallow_config::OutputFormat::Json,
+            quiet: true,
+            start: std::time::Instant::now(),
+            context: telemetry::WorkflowContext {
+                run_scope: telemetry::RunScope::FullProject,
+                config_shape: telemetry::ConfigShape::Default,
+                output_destination: telemetry::OutputDestination::Stdout,
+                analysis_mode: mode,
+            },
+        }
+    }
+
+    #[test]
+    fn fallback_failure_reason_skips_success_and_findings() {
+        let run = telemetry_run_for_mode(telemetry::AnalysisMode::Static);
+
+        assert_eq!(fallback_failure_reason_for(&run, ExitCode::SUCCESS), None);
+        assert_eq!(fallback_failure_reason_for(&run, ExitCode::from(1)), None);
+    }
+
+    #[test]
+    fn fallback_failure_reason_classifies_network_auth_and_analysis() {
+        let static_run = telemetry_run_for_mode(telemetry::AnalysisMode::Static);
+        let cloud_run = telemetry_run_for_mode(telemetry::AnalysisMode::ProductionCoverage);
+
+        assert_eq!(
+            fallback_failure_reason_for(&static_run, ExitCode::from(api::NETWORK_EXIT_CODE)),
+            Some(telemetry::FailureReason::Network),
+        );
+        assert_eq!(
+            fallback_failure_reason_for(&static_run, ExitCode::from(12)),
+            Some(telemetry::FailureReason::Auth),
+        );
+        assert_eq!(
+            fallback_failure_reason_for(&cloud_run, ExitCode::from(3)),
+            Some(telemetry::FailureReason::Auth),
+        );
+        assert_eq!(
+            fallback_failure_reason_for(&static_run, ExitCode::from(2)),
+            Some(telemetry::FailureReason::Analysis),
+        );
     }
 
     #[test]

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -364,6 +364,11 @@ fn failure_reason() -> Option<FailureReason> {
     failure_reason_from_state(FAILURE_REASON.load(Ordering::Relaxed))
 }
 
+/// Return the failure reason recorded by lower-level code, if any.
+pub fn noted_failure_reason() -> Option<FailureReason> {
+    failure_reason()
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum ResultCountBucket {
     #[serde(rename = "0")]

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -213,6 +213,7 @@ fn inspect_event_output(
         .env_remove("FALLOW_AGENT_SOURCE")
         .env_remove("FALLOW_INTEGRATION_SURFACE")
         .env_remove("FALLOW_MCP_TOOL")
+        .env_remove("FALLOW_API_KEY")
         .env("FALLOW_TELEMETRY", "inspect")
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", home.path().join(".config"))
@@ -783,10 +784,41 @@ fn health_coverage_flag_reports_runtime_coverage_mode_without_path() {
     );
     assert_eq!(event["workflow"].as_str(), Some("health"));
     assert_eq!(event["analysis_mode"].as_str(), Some("runtime_coverage"));
+    assert_eq!(event["failure_reason"].as_str(), Some("analysis"));
     assert!(
         !event.to_string().contains("missing-coverage.json"),
         "telemetry event must not include raw coverage paths"
     );
+}
+
+#[test]
+fn cloud_runtime_missing_api_key_sets_auth_failure_reason() {
+    let dir = tempfile::tempdir().expect("temp project");
+    write_clean_project(dir.path());
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &[
+            "coverage",
+            "analyze",
+            "--cloud",
+            "--repo",
+            "owner/repo",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 3,
+        "missing API key should fail before network: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("runtime_coverage_setup"));
+    assert_eq!(event["analysis_mode"].as_str(), Some("production_coverage"));
+    assert_eq!(event["failure_reason"].as_str(), Some("auth"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Classify CLI workflow failures that previously reached telemetry with no concrete `failure_reason`.
- Preserve explicit lower-level cloud runtime failure classes before generic error handling.
- Add a scheduled PostHog fail-rate gate for the published CLI version against a trailing baseline.

## Validation

- `cargo build --workspace`
- `cargo test --workspace --lib --bins --tests`
- `cargo check --benches`
- `cargo test -p fallow-cli --test telemetry_tests failure_reason -- --nocapture`
- `cargo test -p fallow-cli --bin fallow fallback_failure_reason -- --nocapture`
- `node --test .github/scripts/check-telemetry-fail-rate.test.mjs`
- `npm run lint:js`
- `npm run fmt:js:check`
- `actionlint .github/workflows/telemetry-fail-rate.yml`
- `zizmor .github/workflows/telemetry-fail-rate.yml`
- Real-project smoke against `fallow-cloud-2`: missing cloud auth now emits `failure_reason: auth`.

`cargo test --workspace --all-targets` entered benchmark sampling and was stopped after the correctness suite and bench compilecheck were green.

Fixes fallow-rs/fallow-cloud#375.
Fixes fallow-rs/fallow-cloud#376.