### PR TITLE
test(unused-members): cover issue-844 typed-instance crediting at monorepo path-alias scale

### DIFF
--- a/crates/core/tests/integration_test/issue_844_usememo_instance.rs
+++ b/crates/core/tests/integration_test/issue_844_usememo_instance.rs
@@ -25,3 +25,28 @@ fn usememo_bound_instance_method_credits_class_member() {
         "a genuinely-unused member on the same class must still report: {unused_members:?}"
     );
 }
+
+/// Issue #844 (monorepo scale): the same `useMemo`-bound typed-instance
+/// crediting must hold when the instance's class is imported across packages
+/// through a tsconfig `@services/*` path alias, not just within one package.
+#[test]
+fn usememo_bound_instance_method_credits_across_monorepo_path_alias() {
+    let root = fixture_path("issue-844-typed-instance-monorepo-alias");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.member.parent_name, m.member.member_name))
+        .collect();
+
+    assert!(
+        !unused.contains(&"DataService.fetchData".to_string()),
+        "DataService.fetchData is called via a useMemo-wrapped instance through a path alias and must not be reported unused; found: {unused:?}"
+    );
+    assert!(
+        unused.contains(&"DataService.unusedMethod".to_string()),
+        "DataService.unusedMethod is genuinely unused and must still be reported; found: {unused:?}"
+    );
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/package.json
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mono/app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "@mono/services": "1.0.0"
+  }
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/src/app.ts
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/src/app.ts
@@ -1,0 +1,13 @@
+import { DataService } from '@services/data-service';
+
+// Typed locally-instantiated instance via wrapper call (useMemo-style).
+// The first array-destructured element is bound to DataService.
+const [svc] = useMemo(() => new DataService(), []);
+svc.fetchData();
+
+export class App {}
+
+// Simulate useMemo without an actual import to keep the fixture dependency-free.
+function useMemo<T>(factory: () => T, _deps: unknown[]): [T] {
+    return [factory()];
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/src/index.ts
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/src/index.ts
@@ -1,0 +1,1 @@
+export { App } from './app';

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/tsconfig.json
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/apps/app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@services/*": ["../../packages/services/src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/package.json
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "issue-844-typed-instance-monorepo-alias",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"]
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/packages/services/package.json
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/packages/services/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@mono/services",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/packages/services/src/data-service.ts
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/packages/services/src/data-service.ts
@@ -1,0 +1,7 @@
+export class DataService {
+    fetchData(): string {
+        return 'data';
+    }
+
+    unusedMethod(): void {}
+}

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/packages/services/src/index.ts
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/packages/services/src/index.ts
@@ -1,0 +1,1 @@
+export { DataService } from './data-service';

--- a/tests/fixtures/issue-844-typed-instance-monorepo-alias/tsconfig.json
+++ b/tests/fixtures/issue-844-typed-instance-monorepo-alias/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["apps/**/*.ts", "apps/**/*.tsx", "packages/**/*.ts"]
+}


### PR DESCRIPTION
Issue #844's useMemo-bound typed-instance crediting already works and is guarded by a single-package regression test in `issue_844_usememo_instance.rs`. This adds a second regression test exercising the same behavior across a multi-package monorepo where the instance's class is imported through a tsconfig `@services/*` path alias, locking down the crediting at cross-package scale.

Test-only: one test function reparented into the existing issue_844 module plus a monorepo fixture. No source change. Salvaged from a stale branch whose only net-new value over main was this extra coverage.