### PR TITLE
refactor(review-app): namespace persisted state under fallow-review instead of fre

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -43,8 +43,3 @@ vulnerabilit = "vulnerabilit"
 # `sais` is the SA-IS algorithm (Suffix Array by Induced Sorting) used for
 # clone-detection suffix array construction, not a misspelling of "says".
 sais = "sais"
-# The review app namespaces its persisted UI state and QA env under the
-# `fre` (fallow review) prefix: "fre:sidebar-width", "fre:collapsed-stages",
-# FRE_SHOTS_DIR, "/tmp/fre-qa". Intentional, not a misspelling of "free".
-fre = "fre"
-FRE = "FRE"

--- a/apps/review-electron/e2e/shots.e2e.ts
+++ b/apps/review-electron/e2e/shots.e2e.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 
 const appDir = resolve(__dirname, "..");
 const worktreeRoot = resolve(appDir, "..", "..");
-const shots = process.env["FRE_SHOTS_DIR"] ?? "/tmp/fre-qa";
+const shots = process.env["FALLOW_REVIEW_SHOTS_DIR"] ?? "/tmp/fallow-review-qa";
 
 const safe = async (fn: () => Promise<void>): Promise<void> => {
   try {
@@ -167,7 +167,7 @@ test("capture the review error state", async () => {
 // brief, so the (otherwise all-additions) review renders the decision surface.
 test("capture the decision surface", async () => {
   const fixture = resolve(appDir, "fixtures", "sample-review-with-decisions.json");
-  const stub = "/tmp/fre-fallow-stub.sh";
+  const stub = "/tmp/fallow-review-stub.sh";
   writeFileSync(stub, `#!/bin/sh\ncat ${JSON.stringify(fixture)}\n`);
   chmodSync(stub, 0o755);
   const app: ElectronApplication = await electron.launch({

--- a/apps/review-electron/src/renderer/src/App.tsx
+++ b/apps/review-electron/src/renderer/src/App.tsx
@@ -47,7 +47,7 @@ const MODES: { id: RightMode; label: string; icon: typeof FileDiff }[] = [
 const SIDEBAR_MIN = 320;
 const SIDEBAR_MAX = 760;
 const SIDEBAR_DEFAULT = 420;
-const SIDEBAR_KEY = "fre:sidebar-width";
+const SIDEBAR_KEY = "fallow-review:sidebar-width";
 
 /** Restore the persisted sidebar width, clamped to the allowed range. */
 const readSidebarWidth = (): number => {

--- a/apps/review-electron/src/renderer/src/components/StageList.tsx
+++ b/apps/review-electron/src/renderer/src/components/StageList.tsx
@@ -13,7 +13,7 @@ type Props = {
   onOpenDiff: (path: string) => void;
 };
 
-const COLLAPSED_KEY = "fre:collapsed-stages";
+const COLLAPSED_KEY = "fallow-review:collapsed-stages";
 
 /** Restore which stage groups were collapsed (keyed by module dir). */
 const readCollapsed = (): Set<string> => {


### PR DESCRIPTION
The review app keyed its persisted UI state and QA env under a terse `fre` prefix (`fre:sidebar-width`, `fre:collapsed-stages`, `FRE_SHOTS_DIR`, `/tmp/fre-qa`). typos reads `fre`/`FRE` as a misspelling of "free", which reddened the Typos CI job and forced the stopgap allowlist added earlier. This renames the prefix to the explicit `fallow-review` namespace across the localStorage keys, the e2e `FALLOW_REVIEW_SHOTS_DIR` env, and the tmp paths, then drops the now-unneeded `_typos.toml` allowlist.

String-literal-only: the `SIDEBAR_KEY`/`COLLAPSED_KEY` identifiers and all references are unchanged. No persisted-state migration needed (the app is new).