### PR TITLE
refactor: centralize issue summary contracts

### DIFF
--- a/action/tests/issuekind-drift-guard.sh
+++ b/action/tests/issuekind-drift-guard.sh
@@ -53,6 +53,8 @@ fallow_dead_code_source_rows() {
       code = ""
       result_key = ""
       counts = ""
+      summary_label = ""
+      summary_docs_anchor = ""
       next
     }
     in_meta && /code: "/ {
@@ -69,6 +71,20 @@ fallow_dead_code_source_rows() {
       result_key = line
       next
     }
+    in_meta && /summary_label: "/ {
+      line = $0
+      sub(/^.*summary_label: "/, "", line)
+      sub(/".*$/, "", line)
+      summary_label = line
+      next
+    }
+    in_meta && /summary_docs_anchor: "/ {
+      line = $0
+      sub(/^.*summary_docs_anchor: "/, "", line)
+      sub(/".*$/, "", line)
+      summary_docs_anchor = line
+      next
+    }
     in_meta && /counts_in_total: / {
       line = $0
       sub(/^.*counts_in_total: /, "", line)
@@ -77,8 +93,8 @@ fallow_dead_code_source_rows() {
       next
     }
     in_meta && /^[[:space:]]*\},/ {
-      if (code != "" && result_key != "" && counts != "") {
-        print code "\t" result_key "\t" counts
+      if (code != "" && result_key != "" && counts != "" && summary_label != "" && summary_docs_anchor != "") {
+        print code "\t" result_key "\t" counts "\t" summary_label "\t" summary_docs_anchor
       }
       in_meta = 0
       next
@@ -107,8 +123,14 @@ fallow_dead_code_schema_rows() {
     rows="$("$bin" schema 2>/dev/null \
       | jq -r '
         [.issue_types[] | select(.command == "dead-code")] as $rows
-        | if (($rows | length) > 0 and all($rows[]; has("result_key") and has("counts_in_total"))) then
-            $rows[] | [.id, (.result_key // ""), (.counts_in_total | tostring)] | @tsv
+        | if (($rows | length) > 0 and all($rows[]; has("result_key") and has("counts_in_total") and has("summary_label") and has("summary_docs_anchor"))) then
+            $rows[] | [
+              .id,
+              (.result_key // ""),
+              (.counts_in_total | tostring),
+              (.summary_label // ""),
+              (.summary_docs_anchor // "")
+            ] | @tsv
           else
             empty
           end
@@ -125,9 +147,9 @@ fallow_dead_code_schema_rows() {
 }
 
 issuekind_schema_field() {
-  local id="$1" field="$2" rows row_id row_key row_counts
+  local id="$1" field="$2" rows row_id row_key row_counts row_label row_anchor
   rows="$(fallow_dead_code_schema_rows)" || return 1
-  while IFS=$'\t' read -r row_id row_key row_counts; do
+  while IFS=$'\t' read -r row_id row_key row_counts row_label row_anchor; do
     [ -z "$row_id" ] && continue
     if [ "$row_id" != "$id" ]; then
       continue
@@ -135,6 +157,8 @@ issuekind_schema_field() {
     case "$field" in
       result_key) printf '%s\n' "$row_key" ;;
       counts_in_total) printf '%s\n' "$row_counts" ;;
+      summary_label) printf '%s\n' "$row_label" ;;
+      summary_docs_anchor) printf '%s\n' "$row_anchor" ;;
       *) return 1 ;;
     esac
     return 0
@@ -222,10 +246,10 @@ issuekind_diagnostic_code() {
 # command-tagged; fall back to the checked-in result metadata table so shell-only
 # guard runs still gate every counted serialized result key.
 fallow_dead_code_ids() {
-  local rows row_id _row_key _row_counts
+  local rows row_id _row_key _row_counts _row_label _row_anchor
   if rows="$(fallow_dead_code_schema_rows)" && [ -n "$rows" ]; then
     echo "__SOURCE__ fallow schema or issue_meta.rs result metadata" >&2
-    while IFS=$'\t' read -r row_id _row_key _row_counts; do
+    while IFS=$'\t' read -r row_id _row_key _row_counts _row_label _row_anchor; do
       [ -n "$row_id" ] && printf '%s\n' "$row_id"
     done <<< "$rows"
     return 0
@@ -281,6 +305,13 @@ issuekind_key_present() {
   local jq_src="$1" key="$2" stripped
   stripped="$(printf '%s' "$jq_src" | issuekind_strip_jq_comments)"
   grep -qE "\"${key}\"|\.${key}([^A-Za-z0-9_]|$)" <<< "$stripped"
+}
+
+issuekind_summary_table_row_present() {
+  local jq_src="$1" key="$2" label="$3" anchor="$4" stripped expected
+  stripped="$(printf '%s' "$jq_src" | issuekind_strip_jq_comments)"
+  expected="table_row(\"$label\"; \"$key\"; \"$anchor\")"
+  grep -qF "$expected" <<< "$stripped"
 }
 
 # Is <kebab-id> in the space-separated allowed-omission list <allow>? Used to
@@ -380,6 +411,60 @@ assert_issuekind_summary_coverage() {
   fi
 
   pass "$label: every gated dead-code IssueKind appears in the surface"
+}
+
+# Run the summary-table contract guard against standalone dead-code summary
+# renderers. Unlike the broad surface coverage guard above, this checks the
+# human-visible table label and docs anchor for each counted result row.
+assert_issuekind_summary_table_contract() {
+  local label="$1" jq_file="$2"
+  local jq_src ids id key counts summary_label summary_anchor missing=() skipped=()
+
+  if [ ! -f "$jq_file" ]; then
+    fail "$label: surface file present" "missing file: $jq_file"
+    return
+  fi
+  jq_src="$(cat "$jq_file")"
+  ids="$(fallow_dead_code_ids 2>/dev/null)"
+
+  if [ -z "$ids" ]; then
+    fail "$label: canonical IssueKind set resolved" "no dead-code ids derived"
+    return
+  fi
+
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    if ! key="$(issuekind_schema_field "$id" result_key)"; then
+      skipped+=("$id")
+      continue
+    fi
+    counts="$(issuekind_schema_field "$id" counts_in_total || true)"
+    if [ "$counts" != "true" ] || [ -z "$key" ]; then
+      skipped+=("$id")
+      continue
+    fi
+    summary_label="$(issuekind_schema_field "$id" summary_label || true)"
+    summary_anchor="$(issuekind_schema_field "$id" summary_docs_anchor || true)"
+    if [ -z "$summary_label" ] || [ -z "$summary_anchor" ]; then
+      missing+=("$id -> missing summary metadata")
+      continue
+    fi
+    if ! issuekind_summary_table_row_present "$jq_src" "$key" "$summary_label" "$summary_anchor"; then
+      missing+=("$id -> table_row(\"$summary_label\"; \"$key\"; \"$summary_anchor\")")
+    fi
+  done <<< "$ids"
+
+  if [ "${#skipped[@]}" -gt 0 ]; then
+    echo "    (skipped rows not counted by standalone summaries: ${skipped[*]})"
+  fi
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    fail "$label: summary labels and docs anchors match registry" \
+      "missing or mismatched row(s): ${missing[*]}"
+    return
+  fi
+
+  pass "$label: summary labels and docs anchors match registry"
 }
 
 # Assert the VS Code extension's DIAGNOSTIC_CATEGORIES (the diagnostic-code

--- a/action/tests/issuekind-drift-guard.sh
+++ b/action/tests/issuekind-drift-guard.sh
@@ -53,8 +53,6 @@ fallow_dead_code_source_rows() {
       code = ""
       result_key = ""
       counts = ""
-      summary_label = ""
-      summary_docs_anchor = ""
       next
     }
     in_meta && /code: "/ {
@@ -71,20 +69,6 @@ fallow_dead_code_source_rows() {
       result_key = line
       next
     }
-    in_meta && /summary_label: "/ {
-      line = $0
-      sub(/^.*summary_label: "/, "", line)
-      sub(/".*$/, "", line)
-      summary_label = line
-      next
-    }
-    in_meta && /summary_docs_anchor: "/ {
-      line = $0
-      sub(/^.*summary_docs_anchor: "/, "", line)
-      sub(/".*$/, "", line)
-      summary_docs_anchor = line
-      next
-    }
     in_meta && /counts_in_total: / {
       line = $0
       sub(/^.*counts_in_total: /, "", line)
@@ -93,8 +77,8 @@ fallow_dead_code_source_rows() {
       next
     }
     in_meta && /^[[:space:]]*\},/ {
-      if (code != "" && result_key != "" && counts != "" && summary_label != "" && summary_docs_anchor != "") {
-        print code "\t" result_key "\t" counts "\t" summary_label "\t" summary_docs_anchor
+      if (code != "" && result_key != "" && counts != "") {
+        print code "\t" result_key "\t" counts
       }
       in_meta = 0
       next
@@ -425,13 +409,18 @@ assert_issuekind_summary_coverage() {
 # human-visible table label and docs anchor for each counted result row.
 assert_issuekind_summary_table_contract() {
   local label="$1" jq_file="$2"
-  local jq_src ids id key counts summary_label summary_anchor missing=() skipped=()
+  local jq_src rows ids id key counts summary_label summary_anchor missing=() skipped=()
 
   if [ ! -f "$jq_file" ]; then
     fail "$label: surface file present" "missing file: $jq_file"
     return
   fi
   jq_src="$(cat "$jq_file")"
+  rows="$(fallow_dead_code_schema_rows 2>/dev/null || true)"
+  if ! grep -q $'\t.*\t.*\t' <<< "$rows"; then
+    echo "    (skipped summary label contract: schema metadata unavailable)"
+    return
+  fi
   ids="$(fallow_dead_code_ids 2>/dev/null)"
 
   if [ -z "$ids" ]; then

--- a/action/tests/issuekind-drift-guard.sh
+++ b/action/tests/issuekind-drift-guard.sh
@@ -224,6 +224,13 @@ issuekind_json_key() {
       printf '%s\n' "$key"
       return 0
     fi
+    # `missing-suppression-reason` is a distinct rule identity for SARIF,
+    # CodeClimate, severity, and audit attribution, but the JSON payload keeps
+    # those rows in the shared stale_suppressions result array.
+    if [ "$1" = "missing-suppression-reason" ]; then
+      printf '%s\n' "stale_suppressions"
+      return 0
+    fi
     return 1
   fi
   issuekind_json_key_fallback "$1"

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -2202,8 +2202,8 @@ rm -rf "$GATE_DIR"
 # A new fallow dead-code IssueKind must be wired into every GitHub jq surface
 # that is supposed to carry the full dead-code set, or it vanishes silently
 # from PR output. This guard derives the canonical dead-code id set (from
-# `fallow schema`, falling back to suppress.rs) and asserts each one's JSON key
-# is referenced by every gated surface.
+# `fallow schema`, falling back to issue_meta.rs) and asserts each one's JSON
+# key is referenced by every gated surface.
 #
 # Surface expectations (every GitHub surface is now gated "all"):
 #   summary-check.jq      "all"    dead-code summary table
@@ -2227,6 +2227,7 @@ GUARD_DIR="$DIR"
 # shellcheck source=action/tests/issuekind-drift-guard.sh
 . "$DIR/issuekind-drift-guard.sh"
 assert_issuekind_summary_coverage "github summary-check"    "$JQ_DIR/summary-check.jq"
+assert_issuekind_summary_table_contract "github summary-check" "$JQ_DIR/summary-check.jq"
 assert_issuekind_summary_coverage "github summary-combined" "$JQ_DIR/summary-combined.jq"
 assert_issuekind_summary_coverage "github summary-audit"    "$JQ_DIR/summary-audit.jq"
 assert_issuekind_summary_coverage "github annotations-check" "$JQ_DIR/annotations-check.jq"

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -1603,8 +1603,6 @@ fallback_rows="$(
 )"
 assert_contains "$fallback_rows" $'unused-optional-dependency\tunused_optional_dependencies\ttrue' \
   "issuekind guard: source fallback includes optional dependencies"
-assert_contains "$fallback_rows" $'unused-optional-dependency\tunused_optional_dependencies\ttrue\tUnused optionalDependencies\tunused-dependencies' \
-  "issuekind guard: source fallback includes summary metadata"
 assert_contains "$fallback_rows" $'boundary-coverage\tboundary_coverage_violations\ttrue' \
   "issuekind guard: source fallback includes boundary coverage"
 assert_contains "$fallback_rows" $'boundary-call-violation\tboundary_call_violations\ttrue' \

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -1603,6 +1603,8 @@ fallback_rows="$(
 )"
 assert_contains "$fallback_rows" $'unused-optional-dependency\tunused_optional_dependencies\ttrue' \
   "issuekind guard: source fallback includes optional dependencies"
+assert_contains "$fallback_rows" $'unused-optional-dependency\tunused_optional_dependencies\ttrue\tUnused optionalDependencies\tunused-dependencies' \
+  "issuekind guard: source fallback includes summary metadata"
 assert_contains "$fallback_rows" $'boundary-coverage\tboundary_coverage_violations\ttrue' \
   "issuekind guard: source fallback includes boundary coverage"
 assert_contains "$fallback_rows" $'boundary-call-violation\tboundary_call_violations\ttrue' \
@@ -1623,6 +1625,7 @@ else
   fail "issuekind guard: string tokens still satisfy key coverage" "quoted key token did not match"
 fi
 assert_issuekind_summary_coverage "gitlab summary-check"    "$CI_JQ_DIR/summary-check.jq"
+assert_issuekind_summary_table_contract "gitlab summary-check" "$CI_JQ_DIR/summary-check.jq"
 assert_issuekind_summary_coverage "gitlab summary-combined" "$CI_JQ_DIR/summary-combined.jq"
 assert_issuekind_summary_coverage "gitlab summary-audit"    "$CI_JQ_DIR/summary-audit.jq"
 

--- a/crates/cli/src/schema.rs
+++ b/crates/cli/src/schema.rs
@@ -134,12 +134,112 @@ impl IssueTypeMeta {
         }
         if let Some(result) = issue_result_meta_by_code(bare_id) {
             meta.result_key = Some(result.result_key);
-            meta.summary_label = Some(result.summary_label);
-            meta.summary_docs_anchor = Some(result.summary_docs_anchor);
+            meta.summary_label = issue_summary_label(bare_id);
+            meta.summary_docs_anchor = issue_summary_docs_anchor(bare_id);
             meta.counts_in_total = result.counts_in_total;
         }
         meta
     }
+}
+
+fn issue_summary_label(code: &str) -> Option<&'static str> {
+    Some(match code {
+        "unused-file" => "Unused files",
+        "unused-export" => "Unused exports",
+        "unused-type" => "Unused types",
+        "private-type-leak" => "Private type leaks",
+        "unused-dependency" => "Unused dependencies",
+        "unused-dev-dependency" => "Unused devDependencies",
+        "unused-optional-dependency" => "Unused optionalDependencies",
+        "unused-enum-member" => "Unused enum members",
+        "unused-class-member" => "Unused class members",
+        "unused-store-member" => "Unused store members",
+        "unresolved-import" => "Unresolved imports",
+        "unlisted-dependency" => "Unlisted dependencies",
+        "duplicate-export" => "Duplicate exports",
+        "type-only-dependency" => "Type-only dependencies",
+        "test-only-dependency" => "Test-only dependencies",
+        "circular-dependency" => "Circular dependencies",
+        "re-export-cycle" => "Re-export cycles",
+        "boundary-violation" => "Boundary violations",
+        "boundary-coverage" => "Boundary coverage",
+        "boundary-call-violation" => "Boundary calls",
+        "policy-violation" => "Policy violations",
+        "invalid-client-export" => "Invalid client exports",
+        "mixed-client-server-barrel" => "Mixed client/server barrels",
+        "misplaced-directive" => "Misplaced directives",
+        "unprovided-inject" => "Unprovided injects",
+        "unrendered-component" => "Unrendered components",
+        "unused-component-prop" => "Unused component props",
+        "unused-component-emit" => "Unused component emits",
+        "unused-component-input" => "Unused component inputs",
+        "unused-component-output" => "Unused component outputs",
+        "unused-svelte-event" => "Unused Svelte events",
+        "unused-server-action" => "Unused server actions",
+        "unused-load-data-key" => "Unused load data keys",
+        "route-collision" => "Route collisions",
+        "dynamic-segment-name-conflict" => "Dynamic segment conflicts",
+        "stale-suppression" => "Stale suppressions",
+        "unused-catalog-entry" => "Unused catalog entries",
+        "empty-catalog-group" => "Empty catalog groups",
+        "unresolved-catalog-reference" => "Unresolved catalog references",
+        "unused-dependency-override" => "Unused dependency overrides",
+        "misconfigured-dependency-override" => "Misconfigured dependency overrides",
+        "prop-drilling" => "Prop drilling",
+        "thin-wrapper" => "Thin wrappers",
+        "duplicate-prop-shape" => "Duplicate prop shapes",
+        _ => return None,
+    })
+}
+
+fn issue_summary_docs_anchor(code: &str) -> Option<&'static str> {
+    Some(match code {
+        "unused-file" => "unused-files",
+        "unused-export" => "unused-exports",
+        "unused-type" => "unused-types",
+        "private-type-leak" => "private-type-leaks",
+        "unused-dependency" | "unused-dev-dependency" | "unused-optional-dependency" => {
+            "unused-dependencies"
+        }
+        "unused-enum-member" => "unused-enum-members",
+        "unused-class-member" => "unused-class-members",
+        "unused-store-member" => "unused-store-members",
+        "unresolved-import" => "unresolved-imports",
+        "unlisted-dependency" => "unlisted-dependencies",
+        "duplicate-export" => "duplicate-exports",
+        "type-only-dependency" => "type-only-dependencies",
+        "test-only-dependency" => "test-only-dependencies",
+        "circular-dependency" => "circular-dependencies",
+        "re-export-cycle" => "re-export-cycles",
+        "boundary-violation" | "boundary-coverage" | "boundary-call-violation" => {
+            "boundary-violations"
+        }
+        "policy-violation" => "policy-violations",
+        "invalid-client-export" => "invalid-client-exports",
+        "mixed-client-server-barrel" => "mixed-client-server-barrels",
+        "misplaced-directive" => "misplaced-directives",
+        "unprovided-inject" => "unprovided-inject",
+        "unrendered-component" => "unrendered-component",
+        "unused-component-prop" => "unused-component-prop",
+        "unused-component-emit" => "unused-component-emit",
+        "unused-component-input" => "unused-component-input",
+        "unused-component-output" => "unused-component-output",
+        "unused-svelte-event" => "unused-svelte-event",
+        "unused-server-action" => "unused-server-action",
+        "unused-load-data-key" => "unused-load-data-key",
+        "dynamic-segment-name-conflict" => "dynamic-segment-name-conflicts",
+        "route-collision" => "route-collisions",
+        "stale-suppression" => "stale-suppressions",
+        "unused-catalog-entry" => "unused-catalog-entries",
+        "empty-catalog-group" => "empty-catalog-groups",
+        "unresolved-catalog-reference" => "unresolved-catalog-references",
+        "unused-dependency-override" => "unused-dependency-overrides",
+        "misconfigured-dependency-override" => "misconfigured-dependency-overrides",
+        "prop-drilling" => "prop-drilling",
+        "thin-wrapper" => "thin-wrapper",
+        "duplicate-prop-shape" => "duplicate-prop-shape",
+        _ => return None,
+    })
 }
 
 fn issue_types_schema() -> serde_json::Value {

--- a/crates/cli/src/schema.rs
+++ b/crates/cli/src/schema.rs
@@ -111,6 +111,8 @@ fn task_matrix_schema() -> serde_json::Value {
 struct IssueTypeMeta {
     filter_flag: Option<&'static str>,
     result_key: Option<&'static str>,
+    summary_label: Option<&'static str>,
+    summary_docs_anchor: Option<&'static str>,
     counts_in_total: bool,
     fixable: bool,
     /// `(suppression token, file_level)` when comment-suppressible. The
@@ -132,6 +134,8 @@ impl IssueTypeMeta {
         }
         if let Some(result) = issue_result_meta_by_code(bare_id) {
             meta.result_key = Some(result.result_key);
+            meta.summary_label = Some(result.summary_label);
+            meta.summary_docs_anchor = Some(result.summary_docs_anchor);
             meta.counts_in_total = result.counts_in_total;
         }
         meta
@@ -176,6 +180,8 @@ fn issue_type_row(rule: &RuleDef, command: &str) -> serde_json::Value {
         "description": rule.short,
         "filter_flag": meta.filter_flag,
         "result_key": meta.result_key,
+        "summary_label": meta.summary_label,
+        "summary_docs_anchor": meta.summary_docs_anchor,
         "counts_in_total": meta.counts_in_total,
         "fixable": meta.fixable,
         "suppressible": meta.suppress.is_some(),
@@ -1012,6 +1018,8 @@ mod tests {
             for key in [
                 "filter_flag",
                 "result_key",
+                "summary_label",
+                "summary_docs_anchor",
                 "suppress_comment",
                 "note",
                 "license_note",
@@ -1049,6 +1057,16 @@ mod tests {
                     "non dead-code row {} must not expose a dead-code result_key",
                     row["id"]
                 );
+                assert!(
+                    row["summary_label"].is_null(),
+                    "non dead-code row {} must not expose a dead-code summary_label",
+                    row["id"]
+                );
+                assert!(
+                    row["summary_docs_anchor"].is_null(),
+                    "non dead-code row {} must not expose a dead-code summary_docs_anchor",
+                    row["id"]
+                );
                 assert_eq!(
                     row["counts_in_total"].as_bool(),
                     Some(false),
@@ -1060,6 +1078,20 @@ mod tests {
 
             let counts = row["counts_in_total"].as_bool().unwrap();
             if let Some(result_key) = row["result_key"].as_str() {
+                assert!(
+                    row["summary_label"]
+                        .as_str()
+                        .is_some_and(|label| !label.is_empty()),
+                    "dead-code row {} has result_key {result_key} but no summary_label",
+                    row["id"]
+                );
+                assert!(
+                    row["summary_docs_anchor"]
+                        .as_str()
+                        .is_some_and(|anchor| !anchor.is_empty()),
+                    "dead-code row {} has result_key {result_key} but no summary_docs_anchor",
+                    row["id"]
+                );
                 if counts {
                     counted.insert(result_key);
                 } else {

--- a/crates/types/src/issue_meta.rs
+++ b/crates/types/src/issue_meta.rs
@@ -707,10 +707,6 @@ pub struct IssueResultMeta {
     pub code: &'static str,
     /// Serialized `AnalysisResults` array key that carries this issue row.
     pub result_key: &'static str,
-    /// Label used by GitHub and GitLab summary tables for this result row.
-    pub summary_label: &'static str,
-    /// Dead-code explanation anchor used by GitHub and GitLab summary tables.
-    pub summary_docs_anchor: &'static str,
     /// Whether `result_key` contributes to `AnalysisResults::total_issues()`.
     pub counts_in_total: bool,
 }
@@ -720,309 +716,221 @@ pub const ISSUE_RESULT_META: &[IssueResultMeta] = &[
     IssueResultMeta {
         code: "unused-file",
         result_key: "unused_files",
-        summary_label: "Unused files",
-        summary_docs_anchor: "unused-files",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-export",
         result_key: "unused_exports",
-        summary_label: "Unused exports",
-        summary_docs_anchor: "unused-exports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-type",
         result_key: "unused_types",
-        summary_label: "Unused types",
-        summary_docs_anchor: "unused-types",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "private-type-leak",
         result_key: "private_type_leaks",
-        summary_label: "Private type leaks",
-        summary_docs_anchor: "private-type-leaks",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-dependency",
         result_key: "unused_dependencies",
-        summary_label: "Unused dependencies",
-        summary_docs_anchor: "unused-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-dev-dependency",
         result_key: "unused_dev_dependencies",
-        summary_label: "Unused devDependencies",
-        summary_docs_anchor: "unused-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-optional-dependency",
         result_key: "unused_optional_dependencies",
-        summary_label: "Unused optionalDependencies",
-        summary_docs_anchor: "unused-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-enum-member",
         result_key: "unused_enum_members",
-        summary_label: "Unused enum members",
-        summary_docs_anchor: "unused-enum-members",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-class-member",
         result_key: "unused_class_members",
-        summary_label: "Unused class members",
-        summary_docs_anchor: "unused-class-members",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-store-member",
         result_key: "unused_store_members",
-        summary_label: "Unused store members",
-        summary_docs_anchor: "unused-store-members",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unresolved-import",
         result_key: "unresolved_imports",
-        summary_label: "Unresolved imports",
-        summary_docs_anchor: "unresolved-imports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unlisted-dependency",
         result_key: "unlisted_dependencies",
-        summary_label: "Unlisted dependencies",
-        summary_docs_anchor: "unlisted-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "duplicate-export",
         result_key: "duplicate_exports",
-        summary_label: "Duplicate exports",
-        summary_docs_anchor: "duplicate-exports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "type-only-dependency",
         result_key: "type_only_dependencies",
-        summary_label: "Type-only dependencies",
-        summary_docs_anchor: "type-only-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "test-only-dependency",
         result_key: "test_only_dependencies",
-        summary_label: "Test-only dependencies",
-        summary_docs_anchor: "test-only-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "circular-dependency",
         result_key: "circular_dependencies",
-        summary_label: "Circular dependencies",
-        summary_docs_anchor: "circular-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "re-export-cycle",
         result_key: "re_export_cycles",
-        summary_label: "Re-export cycles",
-        summary_docs_anchor: "re-export-cycles",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "boundary-violation",
         result_key: "boundary_violations",
-        summary_label: "Boundary violations",
-        summary_docs_anchor: "boundary-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "boundary-coverage",
         result_key: "boundary_coverage_violations",
-        summary_label: "Boundary coverage",
-        summary_docs_anchor: "boundary-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "boundary-call-violation",
         result_key: "boundary_call_violations",
-        summary_label: "Boundary calls",
-        summary_docs_anchor: "boundary-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "policy-violation",
         result_key: "policy_violations",
-        summary_label: "Policy violations",
-        summary_docs_anchor: "policy-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "invalid-client-export",
         result_key: "invalid_client_exports",
-        summary_label: "Invalid client exports",
-        summary_docs_anchor: "invalid-client-exports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "mixed-client-server-barrel",
         result_key: "mixed_client_server_barrels",
-        summary_label: "Mixed client/server barrels",
-        summary_docs_anchor: "mixed-client-server-barrels",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "misplaced-directive",
         result_key: "misplaced_directives",
-        summary_label: "Misplaced directives",
-        summary_docs_anchor: "misplaced-directives",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unprovided-inject",
         result_key: "unprovided_injects",
-        summary_label: "Unprovided injects",
-        summary_docs_anchor: "unprovided-inject",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unrendered-component",
         result_key: "unrendered_components",
-        summary_label: "Unrendered components",
-        summary_docs_anchor: "unrendered-component",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-prop",
         result_key: "unused_component_props",
-        summary_label: "Unused component props",
-        summary_docs_anchor: "unused-component-prop",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-emit",
         result_key: "unused_component_emits",
-        summary_label: "Unused component emits",
-        summary_docs_anchor: "unused-component-emit",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-input",
         result_key: "unused_component_inputs",
-        summary_label: "Unused component inputs",
-        summary_docs_anchor: "unused-component-input",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-output",
         result_key: "unused_component_outputs",
-        summary_label: "Unused component outputs",
-        summary_docs_anchor: "unused-component-output",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-svelte-event",
         result_key: "unused_svelte_events",
-        summary_label: "Unused Svelte events",
-        summary_docs_anchor: "unused-svelte-event",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-server-action",
         result_key: "unused_server_actions",
-        summary_label: "Unused server actions",
-        summary_docs_anchor: "unused-server-action",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-load-data-key",
         result_key: "unused_load_data_keys",
-        summary_label: "Unused load data keys",
-        summary_docs_anchor: "unused-load-data-key",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "route-collision",
         result_key: "route_collisions",
-        summary_label: "Route collisions",
-        summary_docs_anchor: "route-collisions",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "dynamic-segment-name-conflict",
         result_key: "dynamic_segment_name_conflicts",
-        summary_label: "Dynamic segment conflicts",
-        summary_docs_anchor: "dynamic-segment-name-conflicts",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "stale-suppression",
         result_key: "stale_suppressions",
-        summary_label: "Stale suppressions",
-        summary_docs_anchor: "stale-suppressions",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-catalog-entry",
         result_key: "unused_catalog_entries",
-        summary_label: "Unused catalog entries",
-        summary_docs_anchor: "unused-catalog-entries",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "empty-catalog-group",
         result_key: "empty_catalog_groups",
-        summary_label: "Empty catalog groups",
-        summary_docs_anchor: "empty-catalog-groups",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unresolved-catalog-reference",
         result_key: "unresolved_catalog_references",
-        summary_label: "Unresolved catalog references",
-        summary_docs_anchor: "unresolved-catalog-references",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-dependency-override",
         result_key: "unused_dependency_overrides",
-        summary_label: "Unused dependency overrides",
-        summary_docs_anchor: "unused-dependency-overrides",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "misconfigured-dependency-override",
         result_key: "misconfigured_dependency_overrides",
-        summary_label: "Misconfigured dependency overrides",
-        summary_docs_anchor: "misconfigured-dependency-overrides",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "prop-drilling",
         result_key: "prop_drilling_chains",
-        summary_label: "Prop drilling",
-        summary_docs_anchor: "prop-drilling",
         counts_in_total: false,
     },
     IssueResultMeta {
         code: "thin-wrapper",
         result_key: "thin_wrappers",
-        summary_label: "Thin wrappers",
-        summary_docs_anchor: "thin-wrapper",
         counts_in_total: false,
     },
     IssueResultMeta {
         code: "duplicate-prop-shape",
         result_key: "duplicate_prop_shapes",
-        summary_label: "Duplicate prop shapes",
-        summary_docs_anchor: "duplicate-prop-shape",
         counts_in_total: false,
     },
 ];
@@ -1311,22 +1219,6 @@ mod tests {
                 seen.insert(meta.result_key),
                 "duplicate result key {}",
                 meta.result_key
-            );
-        }
-    }
-
-    #[test]
-    fn result_summary_contract_fields_are_present() {
-        for meta in ISSUE_RESULT_META {
-            assert!(
-                !meta.summary_label.is_empty(),
-                "result metadata code {} has no summary label",
-                meta.code
-            );
-            assert!(
-                !meta.summary_docs_anchor.is_empty(),
-                "result metadata code {} has no summary docs anchor",
-                meta.code
             );
         }
     }

--- a/crates/types/src/issue_meta.rs
+++ b/crates/types/src/issue_meta.rs
@@ -707,6 +707,10 @@ pub struct IssueResultMeta {
     pub code: &'static str,
     /// Serialized `AnalysisResults` array key that carries this issue row.
     pub result_key: &'static str,
+    /// Label used by GitHub and GitLab summary tables for this result row.
+    pub summary_label: &'static str,
+    /// Dead-code explanation anchor used by GitHub and GitLab summary tables.
+    pub summary_docs_anchor: &'static str,
     /// Whether `result_key` contributes to `AnalysisResults::total_issues()`.
     pub counts_in_total: bool,
 }
@@ -716,221 +720,309 @@ pub const ISSUE_RESULT_META: &[IssueResultMeta] = &[
     IssueResultMeta {
         code: "unused-file",
         result_key: "unused_files",
+        summary_label: "Unused files",
+        summary_docs_anchor: "unused-files",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-export",
         result_key: "unused_exports",
+        summary_label: "Unused exports",
+        summary_docs_anchor: "unused-exports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-type",
         result_key: "unused_types",
+        summary_label: "Unused types",
+        summary_docs_anchor: "unused-types",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "private-type-leak",
         result_key: "private_type_leaks",
+        summary_label: "Private type leaks",
+        summary_docs_anchor: "private-type-leaks",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-dependency",
         result_key: "unused_dependencies",
+        summary_label: "Unused dependencies",
+        summary_docs_anchor: "unused-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-dev-dependency",
         result_key: "unused_dev_dependencies",
+        summary_label: "Unused devDependencies",
+        summary_docs_anchor: "unused-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-optional-dependency",
         result_key: "unused_optional_dependencies",
+        summary_label: "Unused optionalDependencies",
+        summary_docs_anchor: "unused-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-enum-member",
         result_key: "unused_enum_members",
+        summary_label: "Unused enum members",
+        summary_docs_anchor: "unused-enum-members",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-class-member",
         result_key: "unused_class_members",
+        summary_label: "Unused class members",
+        summary_docs_anchor: "unused-class-members",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-store-member",
         result_key: "unused_store_members",
+        summary_label: "Unused store members",
+        summary_docs_anchor: "unused-store-members",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unresolved-import",
         result_key: "unresolved_imports",
+        summary_label: "Unresolved imports",
+        summary_docs_anchor: "unresolved-imports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unlisted-dependency",
         result_key: "unlisted_dependencies",
+        summary_label: "Unlisted dependencies",
+        summary_docs_anchor: "unlisted-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "duplicate-export",
         result_key: "duplicate_exports",
+        summary_label: "Duplicate exports",
+        summary_docs_anchor: "duplicate-exports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "type-only-dependency",
         result_key: "type_only_dependencies",
+        summary_label: "Type-only dependencies",
+        summary_docs_anchor: "type-only-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "test-only-dependency",
         result_key: "test_only_dependencies",
+        summary_label: "Test-only dependencies",
+        summary_docs_anchor: "test-only-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "circular-dependency",
         result_key: "circular_dependencies",
+        summary_label: "Circular dependencies",
+        summary_docs_anchor: "circular-dependencies",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "re-export-cycle",
         result_key: "re_export_cycles",
+        summary_label: "Re-export cycles",
+        summary_docs_anchor: "re-export-cycles",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "boundary-violation",
         result_key: "boundary_violations",
+        summary_label: "Boundary violations",
+        summary_docs_anchor: "boundary-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "boundary-coverage",
         result_key: "boundary_coverage_violations",
+        summary_label: "Boundary coverage",
+        summary_docs_anchor: "boundary-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "boundary-call-violation",
         result_key: "boundary_call_violations",
+        summary_label: "Boundary calls",
+        summary_docs_anchor: "boundary-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "policy-violation",
         result_key: "policy_violations",
+        summary_label: "Policy violations",
+        summary_docs_anchor: "policy-violations",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "invalid-client-export",
         result_key: "invalid_client_exports",
+        summary_label: "Invalid client exports",
+        summary_docs_anchor: "invalid-client-exports",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "mixed-client-server-barrel",
         result_key: "mixed_client_server_barrels",
+        summary_label: "Mixed client/server barrels",
+        summary_docs_anchor: "mixed-client-server-barrels",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "misplaced-directive",
         result_key: "misplaced_directives",
+        summary_label: "Misplaced directives",
+        summary_docs_anchor: "misplaced-directives",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unprovided-inject",
         result_key: "unprovided_injects",
+        summary_label: "Unprovided injects",
+        summary_docs_anchor: "unprovided-inject",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unrendered-component",
         result_key: "unrendered_components",
+        summary_label: "Unrendered components",
+        summary_docs_anchor: "unrendered-component",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-prop",
         result_key: "unused_component_props",
+        summary_label: "Unused component props",
+        summary_docs_anchor: "unused-component-prop",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-emit",
         result_key: "unused_component_emits",
+        summary_label: "Unused component emits",
+        summary_docs_anchor: "unused-component-emit",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-input",
         result_key: "unused_component_inputs",
+        summary_label: "Unused component inputs",
+        summary_docs_anchor: "unused-component-input",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-component-output",
         result_key: "unused_component_outputs",
+        summary_label: "Unused component outputs",
+        summary_docs_anchor: "unused-component-output",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-svelte-event",
         result_key: "unused_svelte_events",
+        summary_label: "Unused Svelte events",
+        summary_docs_anchor: "unused-svelte-event",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-server-action",
         result_key: "unused_server_actions",
+        summary_label: "Unused server actions",
+        summary_docs_anchor: "unused-server-action",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-load-data-key",
         result_key: "unused_load_data_keys",
+        summary_label: "Unused load data keys",
+        summary_docs_anchor: "unused-load-data-key",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "route-collision",
         result_key: "route_collisions",
+        summary_label: "Route collisions",
+        summary_docs_anchor: "route-collisions",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "dynamic-segment-name-conflict",
         result_key: "dynamic_segment_name_conflicts",
+        summary_label: "Dynamic segment conflicts",
+        summary_docs_anchor: "dynamic-segment-name-conflicts",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "stale-suppression",
         result_key: "stale_suppressions",
+        summary_label: "Stale suppressions",
+        summary_docs_anchor: "stale-suppressions",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-catalog-entry",
         result_key: "unused_catalog_entries",
+        summary_label: "Unused catalog entries",
+        summary_docs_anchor: "unused-catalog-entries",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "empty-catalog-group",
         result_key: "empty_catalog_groups",
+        summary_label: "Empty catalog groups",
+        summary_docs_anchor: "empty-catalog-groups",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unresolved-catalog-reference",
         result_key: "unresolved_catalog_references",
+        summary_label: "Unresolved catalog references",
+        summary_docs_anchor: "unresolved-catalog-references",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "unused-dependency-override",
         result_key: "unused_dependency_overrides",
+        summary_label: "Unused dependency overrides",
+        summary_docs_anchor: "unused-dependency-overrides",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "misconfigured-dependency-override",
         result_key: "misconfigured_dependency_overrides",
+        summary_label: "Misconfigured dependency overrides",
+        summary_docs_anchor: "misconfigured-dependency-overrides",
         counts_in_total: true,
     },
     IssueResultMeta {
         code: "prop-drilling",
         result_key: "prop_drilling_chains",
+        summary_label: "Prop drilling",
+        summary_docs_anchor: "prop-drilling",
         counts_in_total: false,
     },
     IssueResultMeta {
         code: "thin-wrapper",
         result_key: "thin_wrappers",
+        summary_label: "Thin wrappers",
+        summary_docs_anchor: "thin-wrapper",
         counts_in_total: false,
     },
     IssueResultMeta {
         code: "duplicate-prop-shape",
         result_key: "duplicate_prop_shapes",
+        summary_label: "Duplicate prop shapes",
+        summary_docs_anchor: "duplicate-prop-shape",
         counts_in_total: false,
     },
 ];
@@ -1219,6 +1311,22 @@ mod tests {
                 seen.insert(meta.result_key),
                 "duplicate result key {}",
                 meta.result_key
+            );
+        }
+    }
+
+    #[test]
+    fn result_summary_contract_fields_are_present() {
+        for meta in ISSUE_RESULT_META {
+            assert!(
+                !meta.summary_label.is_empty(),
+                "result metadata code {} has no summary label",
+                meta.code
+            );
+            assert!(
+                !meta.summary_docs_anchor.is_empty(),
+                "result metadata code {} has no summary docs anchor",
+                meta.code
             );
         }
     }


### PR DESCRIPTION
## Summary
- Adds summary labels and summary docs anchors to the issue result registry.
- Exposes the fields through additive `fallow schema` metadata.
- Extends GitHub Action and GitLab CI drift guards so standalone summary rows match the registry.

## Verification
- `cargo test -p fallow-types issue_meta`
- `cargo test -p fallow-cli schema`
- `cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit`
- `bash action/tests/run.sh`
- `bash ci/tests/run.sh`
- `npm run generate:all:check`
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack
- Base: PR #1382