### PR TITLE
refactor: centralize ts alias policy

### DIFF
--- a/crates/cli/src/audit_keys.rs
+++ b/crates/cli/src/audit_keys.rs
@@ -425,7 +425,8 @@ struct FrameworkFindingSlices<'a> {
 /// finding type is added): `annotate_dead_code_json` (same key formats, this
 /// file) and the per-collection severity branches in
 /// `crates/cli/src/check/rules.rs` (`apply_rules`, `has_error_severity_issues`).
-/// TypeScript mirror: `editors/vscode/scripts/codegen-types.mjs` (`BARE_DEAD_CODE_ALIASES`).
+/// TypeScript mirror: `editors/vscode/scripts/codegen-types.mjs` derives
+/// backwards-compatible aliases from `fallow schema` `ts_alias` rows.
 pub(super) fn dead_code_keys(
     results: &fallow_core::results::AnalysisResults,
     root: &Path,
@@ -1121,7 +1122,8 @@ impl<'a> DeadCodeKeyCollector<'a> {
 /// finding type is added): `annotate_dead_code_json` (same key formats, this
 /// file) and the per-collection severity branches in
 /// `crates/cli/src/check/rules.rs` (`apply_rules`, `has_error_severity_issues`).
-/// TypeScript mirror: `editors/vscode/scripts/codegen-types.mjs` (`BARE_DEAD_CODE_ALIASES`).
+/// TypeScript mirror: `editors/vscode/scripts/codegen-types.mjs` derives
+/// backwards-compatible aliases from `fallow schema` `ts_alias` rows.
 pub(super) fn retain_introduced_dead_code(
     results: &mut fallow_core::results::AnalysisResults,
     root: &Path,

--- a/crates/cli/src/schema.rs
+++ b/crates/cli/src/schema.rs
@@ -1,7 +1,9 @@
 use std::process::ExitCode;
 
 use clap::CommandFactory;
-use fallow_types::issue_meta::{issue_meta_by_code, issue_result_meta_by_code};
+#[cfg(test)]
+use fallow_types::issue_meta::result_issue_metas;
+use fallow_types::issue_meta::{TsAliasMeta, issue_meta_by_code, issue_result_meta_by_code};
 use fallow_types::mcp_manifest::{MCP_TOOLS, RUNTIME_COVERAGE_LICENSE_NOTE};
 
 use crate::Cli;
@@ -115,6 +117,7 @@ struct IssueTypeMeta {
     summary_docs_anchor: Option<&'static str>,
     sarif_rule_ids: Option<Vec<String>>,
     codeclimate_check_names: Option<Vec<String>>,
+    ts_alias: Option<TsAliasMeta>,
     counts_in_total: bool,
     fixable: bool,
     /// `(suppression token, file_level)` when comment-suppressible. The
@@ -143,6 +146,7 @@ impl IssueTypeMeta {
             if !codeclimate_check_names.is_empty() {
                 meta.codeclimate_check_names = Some(codeclimate_check_names);
             }
+            meta.ts_alias = result.ts_alias();
             meta.counts_in_total = result.counts_in_total;
         }
         meta
@@ -291,6 +295,10 @@ fn issue_type_row(rule: &RuleDef, command: &str) -> serde_json::Value {
         "summary_docs_anchor": meta.summary_docs_anchor,
         "sarif_rule_ids": meta.sarif_rule_ids,
         "codeclimate_check_names": meta.codeclimate_check_names,
+        "ts_alias": meta.ts_alias.map(|alias| serde_json::json!({
+            "name": alias.name,
+            "parent": alias.parent,
+        })),
         "counts_in_total": meta.counts_in_total,
         "fixable": meta.fixable,
         "suppressible": meta.suppress.is_some(),
@@ -1131,6 +1139,7 @@ mod tests {
                 "summary_docs_anchor",
                 "sarif_rule_ids",
                 "codeclimate_check_names",
+                "ts_alias",
                 "suppress_comment",
                 "note",
                 "license_note",
@@ -1186,6 +1195,11 @@ mod tests {
                 assert!(
                     row["codeclimate_check_names"].is_null(),
                     "non dead-code row {} must not expose dead-code codeclimate_check_names",
+                    row["id"]
+                );
+                assert!(
+                    row["ts_alias"].is_null(),
+                    "non dead-code row {} must not expose a dead-code ts_alias",
                     row["id"]
                 );
                 assert_eq!(
@@ -1295,6 +1309,80 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn dead_code_ts_alias_contract_is_explicit() {
+        let schema = schema();
+        let rows = schema["issue_types"].as_array().unwrap();
+        let aliases: FxHashSet<(String, String, String)> = rows
+            .iter()
+            .filter(|row| row["command"].as_str() == Some("dead-code"))
+            .filter_map(|row| {
+                let alias = row["ts_alias"].as_object()?;
+                Some((
+                    row["id"].as_str().unwrap().to_string(),
+                    alias["name"].as_str().unwrap().to_string(),
+                    alias["parent"].as_str().unwrap().to_string(),
+                ))
+            })
+            .collect();
+        let expected: FxHashSet<(String, String, String)> = result_issue_metas()
+            .filter_map(|meta| {
+                let alias = meta.ts_alias()?;
+                Some((
+                    meta.code.to_string(),
+                    alias.name.to_string(),
+                    alias.parent.to_string(),
+                ))
+            })
+            .collect();
+
+        assert!(aliases.contains(&(
+            "unused-dependency".to_string(),
+            "UnusedDependency".to_string(),
+            "UnusedDependencyFinding".to_string()
+        )));
+        assert!(aliases.contains(&(
+            "unused-dev-dependency".to_string(),
+            "UnusedDependency".to_string(),
+            "UnusedDevDependencyFinding".to_string()
+        )));
+        assert!(aliases.contains(&(
+            "unused-optional-dependency".to_string(),
+            "UnusedDependency".to_string(),
+            "UnusedOptionalDependencyFinding".to_string()
+        )));
+        assert!(aliases.contains(&(
+            "unused-class-member".to_string(),
+            "UnusedMember".to_string(),
+            "UnusedClassMemberFinding".to_string()
+        )));
+        assert!(aliases.contains(&(
+            "unused-enum-member".to_string(),
+            "UnusedMember".to_string(),
+            "UnusedEnumMemberFinding".to_string()
+        )));
+        assert!(aliases.contains(&(
+            "unused-store-member".to_string(),
+            "UnusedMember".to_string(),
+            "UnusedStoreMemberFinding".to_string()
+        )));
+        assert_eq!(
+            expected, aliases,
+            "schema ts_alias rows must exactly mirror IssueResultMeta::ts_alias()"
+        );
+
+        for (_, name, parent) in aliases {
+            assert!(
+                name.chars().next().is_some_and(char::is_uppercase),
+                "TS alias name must be PascalCase: {name}"
+            );
+            assert!(
+                parent.ends_with("Finding"),
+                "TS alias parent must target a finding wrapper: {parent}"
+            );
         }
     }
 

--- a/crates/types/src/issue_meta.rs
+++ b/crates/types/src/issue_meta.rs
@@ -711,6 +711,15 @@ pub struct IssueResultMeta {
     pub counts_in_total: bool,
 }
 
+/// TypeScript backwards-compat alias emitted for this result row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TsAliasMeta {
+    /// Bare alias name kept available from the published `fallow/types` subpath.
+    pub name: &'static str,
+    /// Generated `*Finding` wrapper type the alias resolves to.
+    pub parent: &'static str,
+}
+
 impl IssueResultMeta {
     /// SARIF rule ids used by the CLI SARIF formatter for this result row.
     #[must_use]
@@ -735,6 +744,103 @@ impl IssueResultMeta {
             return Vec::new();
         }
         self.sarif_rule_ids()
+    }
+
+    /// Published TypeScript alias policy for backwards-compatible bare names.
+    #[must_use]
+    pub fn ts_alias(self) -> Option<TsAliasMeta> {
+        let alias = match self.code {
+            "unused-file" => TsAliasMeta {
+                name: "UnusedFile",
+                parent: "UnusedFileFinding",
+            },
+            "unused-export" => TsAliasMeta {
+                name: "UnusedExport",
+                parent: "UnusedExportFinding",
+            },
+            "private-type-leak" => TsAliasMeta {
+                name: "PrivateTypeLeak",
+                parent: "PrivateTypeLeakFinding",
+            },
+            "unused-dependency" => TsAliasMeta {
+                name: "UnusedDependency",
+                parent: "UnusedDependencyFinding",
+            },
+            "unused-dev-dependency" => TsAliasMeta {
+                name: "UnusedDependency",
+                parent: "UnusedDevDependencyFinding",
+            },
+            "unused-optional-dependency" => TsAliasMeta {
+                name: "UnusedDependency",
+                parent: "UnusedOptionalDependencyFinding",
+            },
+            "unused-enum-member" => TsAliasMeta {
+                name: "UnusedMember",
+                parent: "UnusedEnumMemberFinding",
+            },
+            "unused-class-member" => TsAliasMeta {
+                name: "UnusedMember",
+                parent: "UnusedClassMemberFinding",
+            },
+            "unused-store-member" => TsAliasMeta {
+                name: "UnusedMember",
+                parent: "UnusedStoreMemberFinding",
+            },
+            "unresolved-import" => TsAliasMeta {
+                name: "UnresolvedImport",
+                parent: "UnresolvedImportFinding",
+            },
+            "unlisted-dependency" => TsAliasMeta {
+                name: "UnlistedDependency",
+                parent: "UnlistedDependencyFinding",
+            },
+            "duplicate-export" => TsAliasMeta {
+                name: "DuplicateExport",
+                parent: "DuplicateExportFinding",
+            },
+            "type-only-dependency" => TsAliasMeta {
+                name: "TypeOnlyDependency",
+                parent: "TypeOnlyDependencyFinding",
+            },
+            "test-only-dependency" => TsAliasMeta {
+                name: "TestOnlyDependency",
+                parent: "TestOnlyDependencyFinding",
+            },
+            "circular-dependency" => TsAliasMeta {
+                name: "CircularDependency",
+                parent: "CircularDependencyFinding",
+            },
+            "re-export-cycle" => TsAliasMeta {
+                name: "ReExportCycle",
+                parent: "ReExportCycleFinding",
+            },
+            "boundary-violation" => TsAliasMeta {
+                name: "BoundaryViolation",
+                parent: "BoundaryViolationFinding",
+            },
+            "unused-catalog-entry" => TsAliasMeta {
+                name: "UnusedCatalogEntry",
+                parent: "UnusedCatalogEntryFinding",
+            },
+            "empty-catalog-group" => TsAliasMeta {
+                name: "EmptyCatalogGroup",
+                parent: "EmptyCatalogGroupFinding",
+            },
+            "unresolved-catalog-reference" => TsAliasMeta {
+                name: "UnresolvedCatalogReference",
+                parent: "UnresolvedCatalogReferenceFinding",
+            },
+            "unused-dependency-override" => TsAliasMeta {
+                name: "UnusedDependencyOverride",
+                parent: "UnusedDependencyOverrideFinding",
+            },
+            "misconfigured-dependency-override" => TsAliasMeta {
+                name: "MisconfiguredDependencyOverride",
+                parent: "MisconfiguredDependencyOverrideFinding",
+            },
+            _ => return None,
+        };
+        Some(alias)
     }
 }
 
@@ -1336,6 +1442,50 @@ mod tests {
         let result_codes: BTreeSet<&str> = result_issue_metas().map(|meta| meta.code).collect();
         let codeclimate_codes: BTreeSet<&str> = CODECLIMATE_RESULT_CODES.iter().copied().collect();
         assert!(codeclimate_codes.is_subset(&result_codes));
+    }
+
+    #[test]
+    fn ts_alias_policy_is_explicit() {
+        let aliases: BTreeSet<(&str, &str)> = result_issue_metas()
+            .filter_map(|meta| meta.ts_alias().map(|alias| (alias.name, alias.parent)))
+            .collect();
+
+        assert_eq!(
+            BTreeSet::from([
+                ("BoundaryViolation", "BoundaryViolationFinding"),
+                ("CircularDependency", "CircularDependencyFinding"),
+                ("DuplicateExport", "DuplicateExportFinding"),
+                ("EmptyCatalogGroup", "EmptyCatalogGroupFinding"),
+                (
+                    "MisconfiguredDependencyOverride",
+                    "MisconfiguredDependencyOverrideFinding",
+                ),
+                ("PrivateTypeLeak", "PrivateTypeLeakFinding"),
+                ("ReExportCycle", "ReExportCycleFinding"),
+                ("TestOnlyDependency", "TestOnlyDependencyFinding"),
+                ("TypeOnlyDependency", "TypeOnlyDependencyFinding"),
+                ("UnlistedDependency", "UnlistedDependencyFinding"),
+                (
+                    "UnresolvedCatalogReference",
+                    "UnresolvedCatalogReferenceFinding",
+                ),
+                ("UnresolvedImport", "UnresolvedImportFinding"),
+                ("UnusedCatalogEntry", "UnusedCatalogEntryFinding"),
+                ("UnusedDependency", "UnusedDependencyFinding",),
+                ("UnusedDependency", "UnusedDevDependencyFinding",),
+                ("UnusedDependency", "UnusedOptionalDependencyFinding",),
+                (
+                    "UnusedDependencyOverride",
+                    "UnusedDependencyOverrideFinding",
+                ),
+                ("UnusedExport", "UnusedExportFinding"),
+                ("UnusedFile", "UnusedFileFinding"),
+                ("UnusedMember", "UnusedClassMemberFinding"),
+                ("UnusedMember", "UnusedEnumMemberFinding"),
+                ("UnusedMember", "UnusedStoreMemberFinding"),
+            ]),
+            aliases
+        );
     }
 
     #[test]

--- a/editors/vscode/scripts/codegen-types.mjs
+++ b/editors/vscode/scripts/codegen-types.mjs
@@ -12,6 +12,7 @@
  *      `pnpm --filter fallow-vscode check:codegen`
  */
 import { compile } from "json-schema-to-typescript";
+import { execFileSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,6 +21,9 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const EXTENSION_ROOT = resolve(SCRIPT_DIR, "..");
 const REPO_ROOT = resolve(EXTENSION_ROOT, "..", "..");
 const SCHEMA_PATH = resolve(REPO_ROOT, "docs", "output-schema.json");
+// Optional test hook: provide a captured `fallow schema` JSON file instead of
+// invoking Cargo while keeping normal codegen on the live capability manifest.
+const CAPABILITY_SCHEMA_PATH_ENV = "FALLOW_CODEGEN_CAPABILITY_SCHEMA";
 const SCHEMA_VERSION_SOURCE = resolve(
   REPO_ROOT,
   "crates",
@@ -317,73 +321,6 @@ const FLATTEN_DEDUPED_ALIASES = [
 ];
 
 /**
- * Bare-name backwards-compat aliases for the dead-code findings wrapped by
- * the #384 schema-derive ladder. Each maps the pre-wrapper bare name to its
- * `*Finding` envelope. jstt drops the orphan inner definitions because every
- * field is subsumed by the flattening wrapper, so external `fallow/types`
- * consumers importing the bare names would break at upgrade time without
- * these aliases. The published v2.x stable surface guarantees the bare
- * names; the kind-tagged `FallowOutput` major bump (#413) will remove them
- * after one minor cycle of `@deprecated` JSDoc.
- *
- * Generated under the same "Backwards-compat aliases" section as the
- * `FLATTEN_DEDUPED_ALIASES` dupes / health-secondary entries.
- */
-const BARE_DEAD_CODE_ALIASES = [
-  { name: "BoundaryViolation", parent: "BoundaryViolationFinding" },
-  { name: "CircularDependency", parent: "CircularDependencyFinding" },
-  { name: "DuplicateExport", parent: "DuplicateExportFinding" },
-  { name: "EmptyCatalogGroup", parent: "EmptyCatalogGroupFinding" },
-  {
-    name: "MisconfiguredDependencyOverride",
-    parent: "MisconfiguredDependencyOverrideFinding",
-  },
-  { name: "PrivateTypeLeak", parent: "PrivateTypeLeakFinding" },
-  { name: "ReExportCycle", parent: "ReExportCycleFinding" },
-  { name: "TestOnlyDependency", parent: "TestOnlyDependencyFinding" },
-  { name: "TypeOnlyDependency", parent: "TypeOnlyDependencyFinding" },
-  { name: "UnlistedDependency", parent: "UnlistedDependencyFinding" },
-  {
-    name: "UnresolvedCatalogReference",
-    parent: "UnresolvedCatalogReferenceFinding",
-  },
-  { name: "UnresolvedImport", parent: "UnresolvedImportFinding" },
-  { name: "UnusedCatalogEntry", parent: "UnusedCatalogEntryFinding" },
-  {
-    name: "UnusedDependencyOverride",
-    parent: "UnusedDependencyOverrideFinding",
-  },
-  { name: "UnusedExport", parent: "UnusedExportFinding" },
-  { name: "UnusedFile", parent: "UnusedFileFinding" },
-];
-
-/**
- * Bare-name union aliases for the dead-code findings whose pre-wrapper
- * shape was a union of multiple `*Finding` types (e.g. pre-#384
- * `UnusedDependency` covered the production / dev / optional dep variants).
- * The wire shape is unchanged; the bare names exist for the same
- * `json-schema-to-typescript` orphan reason as `BARE_DEAD_CODE_ALIASES`.
- */
-const BARE_DEAD_CODE_UNION_ALIASES = [
-  {
-    name: "UnusedDependency",
-    parents: [
-      "UnusedDependencyFinding",
-      "UnusedDevDependencyFinding",
-      "UnusedOptionalDependencyFinding",
-    ],
-  },
-  {
-    name: "UnusedMember",
-    parents: [
-      "UnusedClassMemberFinding",
-      "UnusedEnumMemberFinding",
-      "UnusedStoreMemberFinding",
-    ],
-  },
-];
-
-/**
  * Header emitted above the appended aliases so the published
  * `npm/fallow/types/output-contract.d.ts` (and the extension-internal
  * mirror) carry the alias policy inline. Public-consumer reference lives
@@ -421,7 +358,7 @@ const BACKWARDS_COMPAT_ALIASES_HEADER = `
 `;
 
 /**
- * Build the JSDoc description for a uniform `BARE_DEAD_CODE_ALIASES` entry
+ * Build the JSDoc description for a uniform schema-backed dead-code alias
  * (`X = XFinding`). Kept terse because each alias has the same rationale:
  * #384 wrapped the bare finding and jstt drops the orphan.
  */
@@ -437,7 +374,7 @@ function bareDeadCodeAliasDescription(name, parent) {
 }
 
 /**
- * Build the JSDoc description for a `BARE_DEAD_CODE_UNION_ALIASES` entry
+ * Build the JSDoc description for a schema-backed dead-code union alias
  * (`X = A | B | ...`). Same rationale as the single-parent template.
  */
 function bareDeadCodeUnionAliasDescription(name, parents) {
@@ -452,6 +389,60 @@ function bareDeadCodeUnionAliasDescription(name, parents) {
   );
 }
 
+async function loadCapabilitySchema() {
+  const schemaPath = process.env[CAPABILITY_SCHEMA_PATH_ENV];
+  if (schemaPath) {
+    return JSON.parse(await readFile(schemaPath, "utf8"));
+  }
+  const raw = execFileSync(
+    "cargo",
+    ["run", "--quiet", "-p", "fallow-cli", "--bin", "fallow", "--", "schema"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    },
+  );
+  return JSON.parse(raw);
+}
+
+function deadCodeAliasesFromCapabilitySchema(schema) {
+  const groups = new Map();
+  for (const issue of schema.issue_types ?? []) {
+    if (issue.command !== "dead-code" || !issue.ts_alias) {
+      continue;
+    }
+    const { name, parent } = issue.ts_alias;
+    if (typeof name !== "string" || typeof parent !== "string") {
+      throw new Error(
+        `Invalid ts_alias on issue type ${issue.id}: expected string name and parent`,
+      );
+    }
+    const parents = groups.get(name) ?? new Set();
+    parents.add(parent);
+    groups.set(name, parents);
+  }
+  if (groups.size === 0) {
+    throw new Error(
+      "No dead-code ts_alias rows found in fallow schema capability manifest",
+    );
+  }
+
+  const singles = [];
+  const unions = [];
+  for (const [name, parentSet] of [...groups.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    const parents = [...parentSet].sort((a, b) => a.localeCompare(b));
+    if (parents.length === 1) {
+      singles.push({ name, parent: parents[0] });
+    } else {
+      unions.push({ name, parents });
+    }
+  }
+  return { singles, unions };
+}
+
 /**
  * Append aliases for serde-flattened inner types that jstt dedupes (see
  * `FLATTEN_DEDUPED_ALIASES` for the full rationale and extension recipe).
@@ -463,7 +454,7 @@ function bareDeadCodeUnionAliasDescription(name, parents) {
  * `DuplicationReport` whose `clone_groups[]` items always carried injected
  * `actions[]` even before the typed wrapper migration).
  */
-function appendDedupedFlattenAliases(contents) {
+function appendDedupedFlattenAliases(contents, deadCodeAliases) {
   let out = contents;
   let backwardsCompatHeaderEmitted = false;
   for (const alias of FLATTEN_DEDUPED_ALIASES) {
@@ -481,19 +472,19 @@ function appendDedupedFlattenAliases(contents) {
           .join(" | ")}>`;
     out += `\n/**\n * ${alias.description}\n */\nexport type ${alias.name} = ${rhs};\n`;
   }
-  // Emit the BARE_DEAD_CODE_* tables under the same "Backwards-compat
-  // aliases" section header. If FLATTEN_DEDUPED_ALIASES had no
-  // backwards-compat entries, drop the header here so the section still
-  // gets one explanatory block before the first dead-code alias.
+  // Emit the schema-derived dead-code aliases under the same
+  // "Backwards-compat aliases" section header. If FLATTEN_DEDUPED_ALIASES had
+  // no backwards-compat entries, drop the header here so the section still gets
+  // one explanatory block before the first dead-code alias.
   if (!backwardsCompatHeaderEmitted) {
     out += BACKWARDS_COMPAT_ALIASES_HEADER;
     backwardsCompatHeaderEmitted = true;
   }
-  for (const alias of BARE_DEAD_CODE_ALIASES) {
+  for (const alias of deadCodeAliases.singles) {
     const description = bareDeadCodeAliasDescription(alias.name, alias.parent);
     out += `\n/**\n * ${description}\n */\nexport type ${alias.name} = ${alias.parent};\n`;
   }
-  for (const alias of BARE_DEAD_CODE_UNION_ALIASES) {
+  for (const alias of deadCodeAliases.unions) {
     const description = bareDeadCodeUnionAliasDescription(
       alias.name,
       alias.parents,
@@ -524,7 +515,7 @@ function appendDedupedFlattenAliases(contents) {
  * and `pnpm run lint` (tsc --noEmit) would fail; this assertion is
  * deliberately narrower so the failure surfaces at codegen time first.
  */
-function assertAliasesEmitted(contents) {
+function assertAliasesEmitted(contents, deadCodeAliases) {
   const assertAlias = (name, parents, table) => {
     const aliasRe = new RegExp(`^export type ${name}\\b`, "m");
     if (!aliasRe.test(contents)) {
@@ -547,17 +538,20 @@ function assertAliasesEmitted(contents) {
   for (const alias of FLATTEN_DEDUPED_ALIASES) {
     assertAlias(alias.name, [alias.parent], "FLATTEN_DEDUPED_ALIASES");
   }
-  for (const alias of BARE_DEAD_CODE_ALIASES) {
-    assertAlias(alias.name, [alias.parent], "BARE_DEAD_CODE_ALIASES");
+  for (const alias of deadCodeAliases.singles) {
+    assertAlias(alias.name, [alias.parent], "fallow schema ts_alias");
   }
-  for (const alias of BARE_DEAD_CODE_UNION_ALIASES) {
-    assertAlias(alias.name, alias.parents, "BARE_DEAD_CODE_UNION_ALIASES");
+  for (const alias of deadCodeAliases.unions) {
+    assertAlias(alias.name, alias.parents, "fallow schema ts_alias");
   }
 }
 
 async function generate() {
   const raw = await readFile(SCHEMA_PATH, "utf8");
   const parsed = JSON.parse(raw);
+  const deadCodeAliases = deadCodeAliasesFromCapabilitySchema(
+    await loadCapabilitySchema(),
+  );
   stripTitles(parsed);
   flattenRefSiblings(parsed);
   // With the root title stripped, jstt uses the second arg as the name of the
@@ -566,8 +560,9 @@ async function generate() {
   const version = await readRustSchemaVersion();
   const final = appendDedupedFlattenAliases(
     stripTrailingWhitespace(pinSchemaVersion(raw_ts, version)),
+    deadCodeAliases,
   );
-  assertAliasesEmitted(final);
+  assertAliasesEmitted(final, deadCodeAliases);
   return final;
 }
 


### PR DESCRIPTION
## Summary
- Moves published TypeScript compatibility alias policy for dead-code findings into the shared issue contract metadata.
- Exposes the policy through `fallow schema` as `ts_alias` rows.
- Generates `fallow/types` compatibility aliases from the live capability schema instead of a duplicated JS table.

## Verification
- `cargo test -p fallow-types issue_meta`
- `cargo test -p fallow-cli schema`
- `pnpm --dir editors/vscode run check:codegen`
- `npm run generate:all:check`
- `cargo check --workspace`
- `cargo clippy -p fallow-cli -p fallow-mcp -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run fmt:js:check`
- `git diff --check`
- `typos .`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `cargo test --workspace --lib --bins --tests`