### PR TITLE
fix(config): normalize leading dot ignore patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ignorePatterns` now accepts a leading `./`.** Entries such as
+  `./src/generated/**` now match the same project-root-relative files as
+  `src/generated/**`, instead of silently leaving those files in the analysis.
+  The same normalization applies to `ignoreUnresolvedImports`. (Closes
+  [#1385](https://github.com/fallow-rs/fallow/issues/1385))
+
 ## [2.102.0] - 2026-06-23
 
 ### Added

--- a/crates/config/src/config/resolution.rs
+++ b/crates/config/src/config/resolution.rs
@@ -256,6 +256,10 @@ fn resolve_cache_dir(root: &Path, configured: Option<PathBuf>) -> PathBuf {
     }
 }
 
+fn normalize_user_glob_pattern(pattern: &str) -> &str {
+    pattern.strip_prefix("./").unwrap_or(pattern)
+}
+
 #[expect(
     clippy::expect_used,
     reason = "user glob patterns are validated before config resolution"
@@ -263,8 +267,9 @@ fn resolve_cache_dir(root: &Path, configured: Option<PathBuf>) -> PathBuf {
 fn compile_ignore_patterns(ignore_patterns: &[String]) -> GlobSet {
     let mut ignore_builder = GlobSetBuilder::new();
     for pattern in ignore_patterns {
+        let normalized = normalize_user_glob_pattern(pattern);
         ignore_builder.add(
-            Glob::new(pattern).expect("ignorePatterns entry was validated at config load time"),
+            Glob::new(normalized).expect("ignorePatterns entry was validated at config load time"),
         );
     }
 
@@ -294,7 +299,8 @@ fn compile_ignore_unresolved_imports(patterns: &[String]) -> Vec<GlobMatcher> {
     patterns
         .iter()
         .map(|pattern| {
-            Glob::new(pattern)
+            let normalized = normalize_user_glob_pattern(pattern);
+            Glob::new(normalized)
                 .expect("ignoreUnresolvedImports entry was validated at config load time")
                 .compile_matcher()
         })
@@ -1335,6 +1341,54 @@ mod tests {
                 .is_match("src/__generated__/types.ts")
         );
         assert!(resolved.ignore_patterns.is_match("node_modules/foo/bar.js"));
+    }
+
+    #[test]
+    fn resolve_normalizes_leading_dot_ignore_patterns() {
+        let mut config = make_config(false);
+        config.ignore_patterns = vec!["./src/generated/**".to_string()];
+        let resolved = config.resolve(
+            PathBuf::from("/project"),
+            OutputFormat::Human,
+            1,
+            true,
+            true,
+            None,
+        );
+
+        assert!(resolved.ignore_patterns.is_match("src/generated/client.ts"));
+        assert!(
+            !resolved
+                .ignore_patterns
+                .is_match("./src/generated/client.ts")
+        );
+    }
+
+    #[test]
+    fn resolve_normalizes_leading_dot_ignore_unresolved_imports() {
+        let mut config = make_config(false);
+        config.ignore_unresolved_imports = vec!["./src/generated/**".to_string()];
+        let resolved = config.resolve(
+            PathBuf::from("/project"),
+            OutputFormat::Human,
+            1,
+            true,
+            true,
+            None,
+        );
+
+        assert!(
+            resolved
+                .ignore_unresolved_imports
+                .iter()
+                .any(|matcher| matcher.is_match("src/generated/client"))
+        );
+        assert!(
+            !resolved
+                .ignore_unresolved_imports
+                .iter()
+                .any(|matcher| matcher.is_match("./src/generated/client"))
+        );
     }
 
     #[test]

--- a/crates/core/src/discover/walk.rs
+++ b/crates/core/src/discover/walk.rs
@@ -1386,6 +1386,27 @@ mod tests {
         }
 
         #[test]
+        fn leading_dot_ignore_patterns_exclude_matching_files() {
+            let dir = tempfile::tempdir().expect("create temp dir");
+
+            let generated = dir.path().join("src").join("generated");
+            std::fs::create_dir_all(&generated).unwrap();
+            std::fs::write(generated.join("client.ts"), "export const api = {};").unwrap();
+
+            let src = dir.path().join("src");
+            std::fs::write(src.join("index.ts"), "export const x = 1;").unwrap();
+
+            let config = make_config_with_ignores(
+                dir.path().to_path_buf(),
+                vec!["./src/generated/**".to_string()],
+            );
+            let files = discover_files(&config);
+            let names = file_names(&files, dir.path());
+
+            assert_eq!(names, vec!["src/index.ts"]);
+        }
+
+        #[test]
         fn default_ignore_patterns_exclude_node_modules_and_dist() {
             let dir = tempfile::tempdir().expect("create temp dir");
 


### PR DESCRIPTION
## Summary
- Normalize leading ./ on ignore pattern config before glob compilation.
- Cover both ignorePatterns and ignoreUnresolvedImports.
- Add regression coverage for resolved matchers and the source walker.

## Issue
Closes #1385

## Verification
- [x] cargo check --workspace
- [x] cargo test -p fallow-config resolve_normalizes_leading_dot --lib
- [x] cargo test -p fallow-core leading_dot_ignore_patterns_exclude_matching_files --lib
- [x] cargo test --workspace --lib --bins --tests
- [x] cargo check --workspace --benches
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items
- [x] ./target/debug/fallow audit --format json --quiet
- [x] Minimal repro with ignorePatterns ["./src/generated/**"]
- [x] Real-project smoke: zod fixture with --no-cache