### PR TITLE
refactor: share source fingerprint cache contract

### DIFF
--- a/crates/core/src/duplicates/cache.rs
+++ b/crates/core/src/duplicates/cache.rs
@@ -1,10 +1,10 @@
 //! Persistent token cache for duplication analysis.
 
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 use bitcode::{Decode, Encode};
 use fallow_config::ResolvedNormalization;
+use fallow_types::source_fingerprint::SourceFingerprint;
 use fallow_types::suppress::{PolicyRuleSuppression, SuppressionTarget};
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
@@ -133,10 +133,20 @@ impl TokenCache {
         metadata: &std::fs::Metadata,
         mode: TokenCacheMode,
     ) -> Option<TokenCacheEntry> {
+        self.get_by_fingerprint(path, SourceFingerprint::from_metadata(metadata), mode)
+    }
+
+    fn get_by_fingerprint(
+        &self,
+        path: &Path,
+        fingerprint: SourceFingerprint,
+        mode: TokenCacheMode,
+    ) -> Option<TokenCacheEntry> {
+        if !fingerprint.has_known_mtime() {
+            return None;
+        }
         let entry = self.store.entries.get(&cache_key(path))?;
-        let (mtime_ns, file_size) = metadata_key(metadata);
-        if entry.mtime_ns != mtime_ns
-            || entry.file_size != file_size
+        if SourceFingerprint::new(entry.mtime_ns, entry.file_size) != fingerprint
             || entry.normalization_hash != mode.hash
         {
             return None;
@@ -151,12 +161,11 @@ impl TokenCache {
         mode: TokenCacheMode,
         payload: &TokenPayload<'_>,
     ) {
-        let (mtime_ns, file_size) = metadata_key(metadata);
+        let fingerprint = SourceFingerprint::from_metadata(metadata);
         self.store.entries.insert(
             cache_key(path),
             CachedTokenFile::from_tokens(
-                mtime_ns,
-                file_size,
+                fingerprint,
                 mode.hash,
                 payload.hashed_tokens,
                 payload.file_tokens,
@@ -220,16 +229,15 @@ impl CacheStore {
 
 impl CachedTokenFile {
     fn from_tokens(
-        mtime_ns: u64,
-        file_size: u64,
+        fingerprint: SourceFingerprint,
         normalization_hash: u64,
         hashed_tokens: &[HashedToken],
         file_tokens: &FileTokens,
         suppressions: &[Suppression],
     ) -> Self {
         Self {
-            mtime_ns,
-            file_size,
+            mtime_ns: fingerprint.mtime_ns,
+            file_size: fingerprint.file_size,
             normalization_hash,
             hashed_tokens: hashed_tokens
                 .iter()
@@ -352,19 +360,6 @@ fn cached_suppression(suppression: &Suppression) -> CachedSuppression {
 
 fn cache_key(path: &Path) -> String {
     path.to_string_lossy().into_owned()
-}
-
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "filesystem mtimes used for cache invalidation fit in u64 nanoseconds for supported dates"
-)]
-fn metadata_key(metadata: &std::fs::Metadata) -> (u64, u64) {
-    let mtime_ns = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
-        .map_or(0, |duration| duration.as_nanos() as u64);
-    (mtime_ns, metadata.len())
 }
 
 #[cfg(test)]
@@ -530,8 +525,7 @@ mod tests {
         store.entries.insert(
             cache_key(&file),
             CachedTokenFile::from_tokens(
-                metadata_key(&metadata).0,
-                metadata.len(),
+                SourceFingerprint::from_metadata(&metadata),
                 mode().hash,
                 &entry.hashed_tokens,
                 &entry.file_tokens,
@@ -542,5 +536,50 @@ mod tests {
 
         let loaded = TokenCache::load(dir.path());
         assert!(loaded.get(&file, &metadata, mode()).is_none());
+    }
+
+    #[test]
+    fn token_cache_misses_when_cached_mtime_changes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let file = dir.path().join("src.ts");
+        std::fs::write(&file, "const value = 1;\n").expect("write source");
+        let metadata = std::fs::metadata(&file).expect("metadata");
+
+        let mut cache = TokenCache::load(dir.path());
+        let entry = entry("const value = 1;\n");
+        insert_entry(&mut cache, &file, &metadata, mode(), &entry);
+        let cached = cache
+            .store
+            .entries
+            .get_mut(&cache_key(&file))
+            .expect("cached token entry");
+        cached.mtime_ns = cached.mtime_ns.saturating_add(1);
+
+        assert!(cache.get(&file, &metadata, mode()).is_none());
+    }
+
+    #[test]
+    fn token_cache_misses_when_mtime_is_unknown() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let file = dir.path().join("src.ts");
+        std::fs::write(&file, "const value = 1;\n").expect("write source");
+        let metadata = std::fs::metadata(&file).expect("metadata");
+
+        let mut cache = TokenCache::load(dir.path());
+        let entry = entry("const value = 1;\n");
+        insert_entry(&mut cache, &file, &metadata, mode(), &entry);
+        let cached = cache
+            .store
+            .entries
+            .get_mut(&cache_key(&file))
+            .expect("cached token entry");
+        cached.mtime_ns = 0;
+
+        let unknown_mtime = SourceFingerprint::new(0, metadata.len());
+        assert!(
+            cache
+                .get_by_fingerprint(&file, unknown_mtime, mode())
+                .is_none()
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -176,19 +176,30 @@ fn update_cache(
 ) {
     for module in modules {
         if let Some(file) = files.get(module.file_id.0 as usize) {
-            let (mt, sz) = file_mtime_and_size(&file.path);
+            let fingerprint = file_fingerprint(&file.path);
             if let Some(cached) = store.get_by_path_only(&file.path)
                 && cached.content_hash == module.content_hash
             {
-                if cached.mtime_secs != mt || cached.file_size != sz {
+                let cached_fingerprint = fallow_types::source_fingerprint::SourceFingerprint::new(
+                    cached.mtime_secs,
+                    cached.file_size,
+                );
+                if cached_fingerprint != fingerprint {
                     let preserved_last_access = cached.last_access_secs;
-                    let mut refreshed = cache::module_to_cached(module, mt, sz);
+                    let mut refreshed = cache::module_to_cached(
+                        module,
+                        fingerprint.mtime_ns,
+                        fingerprint.file_size,
+                    );
                     refreshed.last_access_secs = preserved_last_access;
                     store.insert(&file.path, refreshed);
                 }
                 continue;
             }
-            store.insert(&file.path, cache::module_to_cached(module, mt, sz));
+            store.insert(
+                &file.path,
+                cache::module_to_cached(module, fingerprint.mtime_ns, fingerprint.file_size),
+            );
         }
     }
     store.retain_paths(files);
@@ -210,16 +221,12 @@ pub fn resolve_cache_max_size_bytes(config: &ResolvedConfig) -> usize {
         })
 }
 
-/// Extract mtime (seconds since epoch) and file size from a path.
-fn file_mtime_and_size(path: &std::path::Path) -> (u64, u64) {
-    std::fs::metadata(path).map_or((0, 0), |m| {
-        let mt = m
-            .modified()
-            .ok()
-            .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-            .map_or(0, |d| d.as_secs());
-        (mt, m.len())
-    })
+/// Extract source fingerprint metadata from a path.
+fn file_fingerprint(path: &std::path::Path) -> fallow_types::source_fingerprint::SourceFingerprint {
+    std::fs::metadata(path).map_or(
+        fallow_types::source_fingerprint::SourceFingerprint::new(0, 0),
+        |metadata| fallow_types::source_fingerprint::SourceFingerprint::from_metadata(&metadata),
+    )
 }
 
 fn format_undeclared_workspace_warning(

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -550,7 +550,8 @@ pub fn cached_to_module_opts(
 ///
 /// `mtime_secs` and `file_size` come from `std::fs::metadata()` at parse time
 /// and enable fast cache validation on subsequent runs (skip file read when
-/// mtime+size match).
+/// mtime+size match). Despite the legacy field name, callers now pass the
+/// shared source-fingerprint mtime value.
 #[must_use]
 pub fn module_to_cached(
     module: &crate::ModuleInfo,

--- a/crates/extract/src/cache/store.rs
+++ b/crates/extract/src/cache/store.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use fallow_types::source_fingerprint::SourceFingerprint;
 use rustc_hash::FxHashMap;
 
 use bitcode::{Decode, Encode};
@@ -180,12 +181,12 @@ impl CacheStore {
     pub fn get_by_metadata(
         &self,
         path: &Path,
-        mtime_secs: u64,
-        file_size: u64,
+        fingerprint: SourceFingerprint,
     ) -> Option<&CachedModule> {
         let key = path.to_string_lossy();
         let entry = self.entries.get(key.as_ref())?;
-        if entry.mtime_secs == mtime_secs && entry.file_size == file_size && mtime_secs > 0 {
+        let cached = SourceFingerprint::new(entry.mtime_secs, entry.file_size);
+        if cached == fingerprint && fingerprint.has_known_mtime() {
             Some(entry)
         } else {
             None

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -7,6 +7,7 @@ use oxc_span::Span;
 use crate::*;
 use fallow_types::discover::FileId;
 use fallow_types::extract::{SkippedSecurityCalleeExpressionKind, SkippedSecurityCalleeReason};
+use fallow_types::source_fingerprint::SourceFingerprint;
 
 use super::*;
 
@@ -1837,7 +1838,7 @@ fn get_by_metadata_returns_entry_on_match() {
     };
     store.insert(Path::new("test.ts"), module);
 
-    let result = store.get_by_metadata(Path::new("test.ts"), 1000, 500);
+    let result = store.get_by_metadata(Path::new("test.ts"), SourceFingerprint::new(1000, 500));
     assert!(result.is_some());
     assert_eq!(result.unwrap().content_hash, 42);
 }
@@ -1922,7 +1923,7 @@ fn get_by_metadata_returns_none_on_mtime_mismatch() {
 
     assert!(
         store
-            .get_by_metadata(Path::new("test.ts"), 2000, 500)
+            .get_by_metadata(Path::new("test.ts"), SourceFingerprint::new(2000, 500))
             .is_none()
     );
 }
@@ -2007,7 +2008,7 @@ fn get_by_metadata_returns_none_on_size_mismatch() {
 
     assert!(
         store
-            .get_by_metadata(Path::new("test.ts"), 1000, 999)
+            .get_by_metadata(Path::new("test.ts"), SourceFingerprint::new(1000, 999))
             .is_none()
     );
 }
@@ -2092,7 +2093,7 @@ fn get_by_metadata_returns_none_for_zero_mtime() {
 
     assert!(
         store
-            .get_by_metadata(Path::new("test.ts"), 0, 500)
+            .get_by_metadata(Path::new("test.ts"), SourceFingerprint::new(0, 500))
             .is_none()
     );
 }
@@ -2102,7 +2103,10 @@ fn get_by_metadata_returns_none_for_missing_file() {
     let store = CacheStore::new();
     assert!(
         store
-            .get_by_metadata(Path::new("nonexistent.ts"), 1000, 500)
+            .get_by_metadata(
+                Path::new("nonexistent.ts"),
+                SourceFingerprint::new(1000, 500)
+            )
             .is_none()
     );
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -669,7 +669,7 @@ assert_cached_type_size!(fallow_types::extract::LoadReturnKey, 32);
 pub struct CachedModule {
     /// xxh3 hash of the file content.
     pub content_hash: u64,
-    /// File modification time (seconds since epoch) for fast cache validation.
+    /// File modification time for fast cache validation.
     /// When mtime+size match the on-disk file, we skip reading file content entirely.
     pub mtime_secs: u64,
     /// File size in bytes for fast cache validation.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -251,9 +251,9 @@ fn parse_single_file_cached(
     if let Some(store) = cache
         && let Ok(metadata) = std::fs::metadata(&file.path)
     {
-        let mt = mtime_secs(&metadata);
-        let sz = metadata.len();
-        if let Some(cached) = store.get_by_metadata(&file.path, mt, sz)
+        let fingerprint =
+            fallow_types::source_fingerprint::SourceFingerprint::from_metadata(&metadata);
+        if let Some(cached) = store.get_by_metadata(&file.path, fingerprint)
             && (!need_complexity || !cached.complexity.is_empty())
         {
             cache_hits.fetch_add(1, Ordering::Relaxed);
@@ -289,16 +289,6 @@ fn parse_single_file_cached(
         Ordering::Relaxed,
     );
     Some(module)
-}
-
-/// Extract mtime (seconds since epoch) from file metadata.
-/// Returns 0 if mtime cannot be determined (pre-epoch, unsupported OS, etc.).
-fn mtime_secs(metadata: &std::fs::Metadata) -> u64 {
-    metadata
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-        .map_or(0, |d| d.as_secs())
 }
 
 /// Parse a single file and extract module information (without complexity).

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -62,5 +62,7 @@ pub mod path_util;
 pub mod results;
 /// Custom serde serializers for cross-platform path output.
 pub mod serde_path;
+/// Shared source-file freshness metadata used by cache invalidation.
+pub mod source_fingerprint;
 /// Inline suppression comment types and issue kind definitions.
 pub mod suppress;

--- a/crates/types/src/source_fingerprint.rs
+++ b/crates/types/src/source_fingerprint.rs
@@ -1,0 +1,87 @@
+//! Shared source-file fingerprint inputs for cache invalidation.
+
+use std::fs::Metadata;
+use std::time::SystemTime;
+
+/// File metadata used to decide whether a source-derived cache entry is fresh.
+///
+/// This is intentionally metadata-only. Callers that need content validation
+/// can combine it with their existing content hash, while cheap caches can use
+/// the same freshness shape without inventing their own `(mtime, size)` tuple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SourceFingerprint {
+    /// Source file modification time as nanoseconds since the Unix epoch.
+    ///
+    /// A value of `0` means the timestamp could not be read. Fast metadata-only
+    /// cache hits should treat that as unknown and miss conservatively.
+    pub mtime_ns: u64,
+    /// Source file size in bytes.
+    pub file_size: u64,
+}
+
+impl SourceFingerprint {
+    /// Build a fingerprint from explicit metadata parts.
+    #[must_use]
+    pub const fn new(mtime_ns: u64, file_size: u64) -> Self {
+        Self {
+            mtime_ns,
+            file_size,
+        }
+    }
+
+    /// Build a fingerprint from filesystem metadata.
+    #[must_use]
+    pub fn from_metadata(metadata: &Metadata) -> Self {
+        Self {
+            mtime_ns: metadata_mtime_ns(metadata),
+            file_size: metadata.len(),
+        }
+    }
+
+    /// Returns true when the modification time is known.
+    #[must_use]
+    pub const fn has_known_mtime(self) -> bool {
+        self.mtime_ns > 0
+    }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "filesystem mtimes used for cache invalidation fit in u64 nanoseconds for supported dates"
+)]
+fn metadata_mtime_ns(metadata: &Metadata) -> u64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map_or(0, |duration| duration.as_nanos() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_fingerprint_preserves_explicit_parts() {
+        let fingerprint = SourceFingerprint::new(123, 456);
+        assert_eq!(fingerprint.mtime_ns, 123);
+        assert_eq!(fingerprint.file_size, 456);
+        assert!(fingerprint.has_known_mtime());
+    }
+
+    #[test]
+    fn source_fingerprint_zero_mtime_is_unknown() {
+        let fingerprint = SourceFingerprint::new(0, 456);
+        assert!(!fingerprint.has_known_mtime());
+    }
+
+    #[test]
+    fn source_fingerprint_from_metadata_sets_size() {
+        let exe = std::env::current_exe().expect("current executable");
+        let metadata = std::fs::metadata(exe).expect("metadata");
+
+        let fingerprint = SourceFingerprint::from_metadata(&metadata);
+
+        assert_eq!(fingerprint.file_size, metadata.len());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a shared `SourceFingerprint` type for source-derived cache freshness checks.
- Uses the shared fingerprint in parse cache and duplication token cache metadata paths.
- Preserves user-facing output behavior while making unknown mtimes miss conservatively in both caches.

## Verification
- `cargo test -p fallow-types source_fingerprint`
- `cargo test -p fallow-extract cache`
- `cargo test -p fallow-core duplicates::cache`
- `cargo check --workspace`
- `cargo clippy -p fallow-types -p fallow-extract -p fallow-core -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos .`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p fallow-types -p fallow-extract -p fallow-core --no-deps --document-private-items`
- `cargo test --workspace --lib --bins --tests`