### PR TITLE
refactor: introduce fallow-engine lsp facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallow-engine"
+version = "2.102.0"
+dependencies = [
+ "fallow-config",
+ "fallow-core",
+ "fallow-types",
+]
+
+[[package]]
 name = "fallow-extract"
 version = "2.102.0"
 dependencies = [
@@ -1182,6 +1191,7 @@ version = "2.102.0"
 dependencies = [
  "fallow-config",
  "fallow-core",
+ "fallow-engine",
  "fallow-types",
  "futures",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ fallow-api = { version = "2.102.0", path = "crates/api" }
 fallow-core = { version = "2.102.0", path = "crates/core" }
 fallow-config = { version = "2.102.0", path = "crates/config" }
 fallow-extract = { version = "2.102.0", path = "crates/extract" }
+fallow-engine = { version = "2.102.0", path = "crates/engine" }
 fallow-graph = { version = "2.102.0", path = "crates/graph" }
 fallow-output = { version = "2.102.0", path = "crates/output" }
 fallow-types = { version = "2.102.0", path = "crates/types" }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fallow-engine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Typed analysis engine facade for fallow consumers"
+readme = "../../README.md"
+
+[dependencies]
+fallow-config = { workspace = true }
+fallow-core = { workspace = true }
+fallow-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,0 +1,185 @@
+//! Typed analysis engine facade for fallow consumers.
+//!
+//! `fallow-core` remains the internal orchestration backend. This crate owns
+//! the typed boundary that editor, API, and embedding surfaces can depend on
+//! without calling deprecated core entry points directly.
+
+#![cfg_attr(not(test), deny(clippy::disallowed_methods))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "tests use unwrap and expect to keep fixture setup concise"
+    )
+)]
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use fallow_config::{DuplicatesConfig, ResolvedConfig};
+
+pub use fallow_core::duplicates::{
+    CloneFamily, CloneGroup, CloneInstance, DuplicationReport, DuplicationStats, MirroredDirectory,
+    RefactoringSuggestion,
+};
+pub use fallow_types::discover::{DiscoveredFile, FileId};
+pub use fallow_types::extract::ModuleInfo;
+pub use fallow_types::results::AnalysisResults;
+
+/// Result alias for typed engine operations.
+pub type EngineResult<T> = Result<T, EngineError>;
+
+/// Error type exposed by the typed engine boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineError {
+    message: String,
+}
+
+impl EngineError {
+    /// Create an engine error from a user-facing message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// User-facing error message from the backend.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for EngineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for EngineError {}
+
+fn engine_error(err: impl fmt::Display) -> EngineError {
+    EngineError::new(err.to_string())
+}
+
+/// Resolved project config plus the config file path when one was loaded.
+#[derive(Debug)]
+pub struct ProjectConfig {
+    pub config: ResolvedConfig,
+    pub path: Option<PathBuf>,
+}
+
+/// Typed dead-code analysis result.
+#[derive(Debug)]
+pub struct DeadCodeAnalysis {
+    pub results: AnalysisResults,
+}
+
+/// Typed dead-code analysis result with retained parser artifacts.
+#[derive(Debug)]
+pub struct DeadCodeAnalysisOutput {
+    pub results: AnalysisResults,
+    pub modules: Option<Vec<ModuleInfo>>,
+    pub files: Option<Vec<DiscoveredFile>>,
+}
+
+/// Resolve the analysis config for a project.
+///
+/// # Errors
+///
+/// Returns an error when an explicit config cannot be loaded or automatic
+/// config discovery finds an invalid config.
+pub fn config_for_project(root: &Path, config_path: Option<&Path>) -> EngineResult<ProjectConfig> {
+    fallow_core::config_for_project(root, config_path)
+        .map(|(config, path)| ProjectConfig { config, path })
+        .map_err(engine_error)
+}
+
+/// Run dead-code analysis on a project directory with export usage collection.
+///
+/// # Errors
+///
+/// Returns an error if config loading, file discovery, parsing, or analysis
+/// fails.
+pub fn analyze_project(root: &Path) -> EngineResult<DeadCodeAnalysis> {
+    #[expect(
+        deprecated,
+        reason = "fallow-engine is the typed migration boundary over the internal core backend"
+    )]
+    fallow_core::analyze_project(root)
+        .map(|results| DeadCodeAnalysis { results })
+        .map_err(engine_error)
+}
+
+/// Run dead-code analysis with export usage collection for a resolved config.
+///
+/// # Errors
+///
+/// Returns an error if file discovery, parsing, or analysis fails.
+pub fn analyze_with_usages(config: &ResolvedConfig) -> EngineResult<DeadCodeAnalysis> {
+    #[expect(
+        deprecated,
+        reason = "fallow-engine is the typed migration boundary over the internal core backend"
+    )]
+    fallow_core::analyze_with_usages(config)
+        .map(|results| DeadCodeAnalysis { results })
+        .map_err(engine_error)
+}
+
+/// Run dead-code analysis with export usage and retained complexity artifacts.
+///
+/// # Errors
+///
+/// Returns an error if file discovery, parsing, or analysis fails.
+pub fn analyze_with_usages_and_complexity(
+    config: &ResolvedConfig,
+) -> EngineResult<DeadCodeAnalysisOutput> {
+    #[expect(
+        deprecated,
+        reason = "fallow-engine is the typed migration boundary over the internal core backend"
+    )]
+    fallow_core::analyze_with_usages_and_complexity(config)
+        .map(|output| DeadCodeAnalysisOutput {
+            results: output.results,
+            modules: output.modules,
+            files: output.files,
+        })
+        .map_err(engine_error)
+}
+
+/// Discover source files for a resolved config, including plugin scopes.
+#[must_use]
+pub fn discover_files_with_plugin_scopes(config: &ResolvedConfig) -> Vec<DiscoveredFile> {
+    fallow_core::discover::discover_files_with_plugin_scopes(config)
+}
+
+/// Run duplication detection on a discovered file set.
+#[must_use]
+pub fn find_duplicates(
+    root: &Path,
+    files: &[DiscoveredFile],
+    config: &DuplicatesConfig,
+) -> DuplicationReport {
+    fallow_core::duplicates::find_duplicates(root, files, config)
+}
+
+/// Run duplication detection on a project directory.
+#[must_use]
+pub fn find_duplicates_in_project(root: &Path, config: &DuplicatesConfig) -> DuplicationReport {
+    fallow_core::duplicates::find_duplicates_in_project(root, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_error_displays_message() {
+        let err = EngineError::new("config failed");
+
+        assert_eq!(err.message(), "config failed");
+        assert_eq!(err.to_string(), "config failed");
+    }
+}

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 fallow-core = { workspace = true }
 fallow-config = { workspace = true }
+fallow-engine = { workspace = true }
 fallow-types = { workspace = true }
 globset = { workspace = true }
 ls-types = { workspace = true }

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -32,8 +32,7 @@ use fallow_core::changed_files::{
     filter_duplication_by_changed_files, filter_results_by_changed_files, resolve_git_toplevel,
     try_get_changed_files_with_toplevel,
 };
-use fallow_core::duplicates::DuplicationReport;
-use fallow_core::results::AnalysisResults;
+use fallow_engine::{AnalysisResults, DuplicationReport};
 use fallow_types::issue_meta::{IssueKindMeta, diagnostic_issue_metas};
 
 use crate::code_lens::{InlineComplexityExceeded, InlineComplexityFinding};
@@ -207,22 +206,20 @@ struct BlockingAnalysisOutput {
 }
 
 fn analyze_project_root(input: &mut ProjectRootAnalysisInput<'_>) {
-    let load = fallow_core::config_for_project(input.project_root, input.config_path);
+    let load = fallow_engine::config_for_project(input.project_root, input.config_path);
     let (mut config, message) = match load {
-        Ok((config, Some(path))) => (
-            config,
+        Ok(project_config) => (
+            project_config.config,
             (
                 MessageType::INFO,
-                format!("loaded config: {}", path.display()),
-            ),
-        ),
-        Ok((config, None)) => (
-            config,
-            (
-                MessageType::INFO,
-                format!(
-                    "no config file found for {}, using defaults",
-                    input.project_root.display()
+                project_config.path.map_or_else(
+                    || {
+                        format!(
+                            "no config file found for {}, using defaults",
+                            input.project_root.display()
+                        )
+                    },
+                    |path| format!("loaded config: {}", path.display()),
                 ),
             ),
         ),
@@ -244,13 +241,13 @@ fn analyze_project_root(input: &mut ProjectRootAnalysisInput<'_>) {
 
     run_typed_dead_code_analysis(input, &config);
 
-    let files = fallow_core::discover::discover_files_with_plugin_scopes(&config);
+    let files = fallow_engine::discover_files_with_plugin_scopes(&config);
     let duplicates_config = input.duplication_options.map_or_else(
         || config.duplicates.clone(),
         |options| options.merge_with(&config.duplicates),
     );
     let duplication =
-        fallow_core::duplicates::find_duplicates(input.project_root, &files, &duplicates_config);
+        fallow_engine::find_duplicates(input.project_root, &files, &duplicates_config);
     merge_duplication(input.merged_duplication, duplication);
 }
 
@@ -266,17 +263,11 @@ fn analyze_project_root_config_fallback(
     if input.config_path.is_some() {
         return;
     }
-    #[expect(
-        deprecated,
-        reason = "ADR-008 deprecates fallow_core::analyze_project externally; the LSP still uses the workspace path dependency"
-    )]
-    if let Ok(results) = fallow_core::analyze_project(input.project_root) {
-        merge_results(input.merged_results, results);
+    if let Ok(analysis) = fallow_engine::analyze_project(input.project_root) {
+        merge_results(input.merged_results, analysis.results);
     }
-    let duplication = fallow_core::duplicates::find_duplicates_in_project(
-        input.project_root,
-        &DuplicatesConfig::default(),
-    );
+    let duplication =
+        fallow_engine::find_duplicates_in_project(input.project_root, &DuplicatesConfig::default());
     merge_duplication(input.merged_duplication, duplication);
 }
 
@@ -288,24 +279,14 @@ fn run_typed_dead_code_analysis(
     config: &fallow_config::ResolvedConfig,
 ) {
     if input.inline_complexity_enabled {
-        #[expect(
-            deprecated,
-            reason = "ADR-008 deprecates fallow_core typed analysis externally; the LSP still uses the workspace path dependency"
-        )]
-        if let Ok(output) = fallow_core::analyze_with_usages_and_complexity(config) {
+        if let Ok(output) = fallow_engine::analyze_with_usages_and_complexity(config) {
             input
                 .merged_inline_complexity
                 .extend(collect_inline_complexity(config, &output));
             merge_results(input.merged_results, output.results);
         }
-    } else {
-        #[expect(
-            deprecated,
-            reason = "ADR-008 deprecates fallow_core::analyze_with_usages externally; the LSP still uses the workspace path dependency"
-        )]
-        if let Ok(results) = fallow_core::analyze_with_usages(config) {
-            merge_results(input.merged_results, results);
-        }
+    } else if let Ok(analysis) = fallow_engine::analyze_with_usages(config) {
+        merge_results(input.merged_results, analysis.results);
     }
 }
 
@@ -493,7 +474,7 @@ fn build_health_ignore_set(patterns: &[String]) -> Option<globset::GlobSet> {
 
 fn collect_inline_complexity(
     config: &fallow_config::ResolvedConfig,
-    output: &fallow_core::AnalysisOutput,
+    output: &fallow_engine::DeadCodeAnalysisOutput,
 ) -> Vec<InlineComplexityFinding> {
     let Some(modules) = output.modules.as_ref() else {
         return Vec::new();

--- a/docs/fallow-core-migration.md
+++ b/docs/fallow-core-migration.md
@@ -7,16 +7,21 @@ warnings. The next minor release (target `2.77.0`, no earlier than 2026-Q3)
 will flip `publish = false` on `fallow-core` so the crate is no longer
 fetchable from crates.io.
 
-Use the supported embedder API in `fallow_cli::programmatic` instead. The
-programmatic API returns `Result<serde_json::Value, ProgrammaticError>` whose
-JSON shape matches the matching CLI command with `--format json`; it does not
-return typed `AnalysisResults` or the bare finding structs from `fallow-core`.
+Use the supported embedder API in `fallow_cli::programmatic` for CLI-shaped
+JSON output. The programmatic API returns
+`Result<serde_json::Value, ProgrammaticError>` whose JSON shape matches the
+matching CLI command with `--format json`.
+
+Use `fallow_engine` for in-process consumers that need typed analysis results.
+It owns the migration boundary over the internal `fallow-core` backend and is
+where editor, API, and embedding surfaces should move before depending on
+typed `AnalysisResults`.
 
 ## Function mapping
 
 | Deprecated `fallow_core` function | Replacement |
 | --- | --- |
-| `fallow_core::analyze`, `analyze_with_usages`, `analyze_with_trace`, `analyze_retaining_modules`, `analyze_with_parse_result`, `analyze_project` | `fallow_cli::programmatic::detect_dead_code` (or `compute_health` / `detect_duplication` for those slices) |
+| `fallow_core::analyze`, `analyze_with_usages`, `analyze_with_trace`, `analyze_retaining_modules`, `analyze_with_parse_result`, `analyze_project` | `fallow_cli::programmatic::detect_dead_code` for CLI-shaped JSON, or `fallow_engine` for typed in-process analysis |
 | `fallow_core::analyze::find_dead_code_full` | `fallow_cli::programmatic::detect_dead_code` |
 | `find_unused_files` | `fallow_cli::programmatic::detect_dead_code` |
 | `find_unused_exports` | `fallow_cli::programmatic::detect_dead_code` |
@@ -55,10 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 The JSON contract is documented in `docs/output-schema.json`. Consumers that
-previously matched Rust structs should now narrow typed envelopes by the
-top-level `kind` field and deserialize into their own local DTOs if they need
-typed access. Set `AnalysisOptions::legacy_envelope` only while migrating
-consumers that still expect the previous root shape without `kind`.
+want CLI parity should narrow typed envelopes by the top-level `kind` field and
+deserialize into their own local DTOs if they need typed access. Set
+`AnalysisOptions::legacy_envelope` only while migrating consumers that still
+expect the previous root shape without `kind`.
 
 ## Semantic differences vs. the typed Rust API
 


### PR DESCRIPTION
## Summary
- Introduces the new fallow-engine crate as the typed analysis facade over internal fallow-core orchestration.
- Migrates the LSP analysis path to call fallow-engine for config loading, typed dead-code analysis, retained complexity artifacts, and duplication scans.
- Updates the fallow-core migration note so typed consumers point at fallow-engine instead of direct core calls.

## Plan
- Local plan: .plans/fallow-engine-lsp-facade.md

## Verification
- [x] cargo test -p fallow-engine
- [x] cargo test -p fallow-lsp
- [x] cargo check --workspace
- [x] cargo clippy -p fallow-engine -p fallow-lsp --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo doc -p fallow-engine -p fallow-lsp --no-deps --document-private-items
- [x] git diff --check
- [x] diff grep: no em dash introduced

## Review
- rust-review: APPROVE, no correctness or boundary blockers found.
- lsp-review: APPROVE, no protocol, diagnostic-code, code-action, or lifecycle behavior change.