### PR TITLE
refactor: add typed factory call facts

### DIFF
--- a/crates/core/src/analyze/unused_component_input.rs
+++ b/crates/core/src/analyze/unused_component_input.rs
@@ -163,8 +163,9 @@ pub(super) fn insert_angular_template_members<'a>(
     out: &mut FxHashSet<&'a str>,
 ) {
     for fact in &module.semantic_facts {
-        let SemanticFact::AngularTemplateMemberAccess(access) = fact;
-        out.insert(access.member.as_str());
+        if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
+            out.insert(access.member.as_str());
+        }
     }
     for access in &module.member_accesses {
         if access.object == ANGULAR_TPL_SENTINEL {

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -620,9 +620,12 @@ fn angular_template_member_refs(module: &ResolvedModule) -> Vec<&str> {
     module
         .semantic_facts
         .iter()
-        .map(|fact| {
-            let SemanticFact::AngularTemplateMemberAccess(access) = fact;
-            access.member.as_str()
+        .filter_map(|fact| {
+            if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
+                Some(access.member.as_str())
+            } else {
+                None
+            }
         })
         .chain(
             module
@@ -1574,6 +1577,38 @@ fn parse_factory_call_sentinel(object: &str) -> Option<(&str, &str)> {
         .and_then(|payload| payload.split_once(':'))
 }
 
+struct FactoryCallAccess<'a> {
+    callee_object: &'a str,
+    callee_method: &'a str,
+    member: &'a str,
+}
+
+fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::FactoryCallMemberAccess(access) = fact {
+            accesses.push(FactoryCallAccess {
+                callee_object: access.callee_object.as_str(),
+                callee_method: access.callee_method.as_str(),
+                member: access.member.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((callee_object, callee_method)) =
+            parse_factory_call_sentinel(access.object.as_str())
+        else {
+            continue;
+        };
+        accesses.push(FactoryCallAccess {
+            callee_object,
+            callee_method,
+            member: access.member.as_str(),
+        });
+    }
+    accesses
+}
+
 /// Credit member accesses produced by static-factory call bindings on the
 /// originating class export.
 fn propagate_factory_call_accesses(
@@ -1588,13 +1623,8 @@ fn propagate_factory_call_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in &resolved.member_accesses {
-            let Some((callee_object, callee_method)) =
-                parse_factory_call_sentinel(access.object.as_str())
-            else {
-                continue;
-            };
-            let Some(seed_keys) = local_to_export_keys.get(callee_object) else {
+        for access in factory_call_accesses(resolved) {
+            let Some(seed_keys) = local_to_export_keys.get(access.callee_object) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1609,7 +1639,7 @@ fn propagate_factory_call_accesses(
                             && export.members.iter().any(|member| {
                                 member.is_instance_returning_static
                                     && member.kind == MemberKind::ClassMethod
-                                    && member.name == callee_method
+                                    && member.name == access.callee_method
                             })
                     });
                     if !matches_factory {
@@ -1618,7 +1648,7 @@ fn propagate_factory_call_accesses(
                     accessed_members
                         .entry(origin)
                         .or_default()
-                        .insert(access.member.clone());
+                        .insert(access.member.to_string());
                 }
             }
         }
@@ -2577,7 +2607,7 @@ mod tests {
     use crate::graph::{ExportSymbol, ModuleGraph, SymbolReference};
     use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
-    use fallow_types::extract::ClassHeritageInfo;
+    use fallow_types::extract::{ClassHeritageInfo, FactoryCallMemberAccessFact, SemanticFact};
     use oxc_span::Span;
     use std::path::PathBuf;
 
@@ -2629,6 +2659,13 @@ mod tests {
         }
     }
 
+    fn make_factory_member(name: &str) -> MemberInfo {
+        MemberInfo {
+            is_instance_returning_static: true,
+            ..make_member(name, MemberKind::ClassMethod)
+        }
+    }
+
     fn make_export_with_members(
         name: &str,
         members: Vec<MemberInfo>,
@@ -2653,6 +2690,75 @@ mod tests {
             references,
             members,
         }
+    }
+
+    #[test]
+    fn typed_factory_call_fact_credits_class_member() {
+        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/my-class.ts", false)]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "MyClass",
+            vec![
+                make_factory_member("getInstance"),
+                make_member("getData", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let class_export = ExportInfo {
+            name: ExportName::Named("MyClass".to_string()),
+            local_name: Some("MyClass".to_string()),
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: Span::new(0, 10),
+            members: vec![
+                make_factory_member("getInstance"),
+                make_member("getData", MemberKind::ClassMethod),
+            ],
+            super_class: None,
+        };
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: PathBuf::from("/src/entry.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./my-class".to_string(),
+                        imported_name: ImportedName::Named("MyClass".to_string()),
+                        local_name: "MyClass".to_string(),
+                        is_type_only: false,
+                        from_style: false,
+                        span: Span::new(0, 10),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                semantic_facts: vec![SemanticFact::FactoryCallMemberAccess(
+                    FactoryCallMemberAccessFact {
+                        callee_object: "MyClass".to_string(),
+                        callee_method: "getInstance".to_string(),
+                        member: "getData".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: PathBuf::from("/src/my-class.ts"),
+                exports: vec![class_export],
+                ..Default::default()
+            },
+        ];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_factory_call_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(1), "MyClass"))
+            .expect("factory target class should be credited");
+        assert!(credited.contains("getData"));
     }
 
     fn make_module_with_class_heritage(

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -176,11 +176,7 @@ fn cache_store_hash_mismatch_returns_none() {
         require_calls: vec![],
         package_path_references: vec![],
         member_accesses: vec![],
-        semantic_facts: vec![SemanticFact::AngularTemplateMemberAccess(
-            AngularTemplateMemberAccessFact {
-                member: "title".to_string(),
-            },
-        )],
+        semantic_facts: Vec::new(),
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
         has_cjs_exports: false,
@@ -984,11 +980,16 @@ fn module_to_cached_roundtrip_dynamic_imports() {
             object: "Status".to_string(),
             member: "Active".to_string(),
         }],
-        semantic_facts: vec![SemanticFact::AngularTemplateMemberAccess(
-            AngularTemplateMemberAccessFact {
+        semantic_facts: vec![
+            SemanticFact::AngularTemplateMemberAccess(AngularTemplateMemberAccessFact {
                 member: "title".to_string(),
-            },
-        )],
+            }),
+            SemanticFact::FactoryCallMemberAccess(FactoryCallMemberAccessFact {
+                callee_object: "MyClass".to_string(),
+                callee_method: "getInstance".to_string(),
+                member: "getData".to_string(),
+            }),
+        ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
         has_cjs_exports: true,
@@ -1070,11 +1071,16 @@ fn module_to_cached_roundtrip_dynamic_imports() {
     assert_eq!(restored.member_accesses[0].member, "Active");
     assert_eq!(
         restored.semantic_facts,
-        vec![SemanticFact::AngularTemplateMemberAccess(
-            AngularTemplateMemberAccessFact {
+        vec![
+            SemanticFact::AngularTemplateMemberAccess(AngularTemplateMemberAccessFact {
                 member: "title".to_string(),
-            }
-        )]
+            }),
+            SemanticFact::FactoryCallMemberAccess(FactoryCallMemberAccessFact {
+                callee_object: "MyClass".to_string(),
+                callee_method: "getInstance".to_string(),
+                member: "getData".to_string(),
+            }),
+        ]
     );
     assert!(restored.has_cjs_exports);
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -590,7 +590,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 189: `ModuleInfo`/`CachedModule` now carry typed semantic facts for
 /// Angular template member accesses alongside the legacy sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 189;
+///
+/// Bumped to 190: `SemanticFact` now includes typed static-factory call member
+/// access facts alongside the legacy factory-call sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 190;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.
@@ -658,7 +661,7 @@ assert_cached_type_size!(CachedReExport, 88);
 assert_cached_type_size!(CachedMember, 64);
 assert_cached_type_size!(CachedDynamicImportPattern, 56);
 assert_cached_type_size!(crate::MemberAccess, 48);
-assert_cached_type_size!(fallow_types::extract::SemanticFact, 24);
+assert_cached_type_size!(fallow_types::extract::SemanticFact, 72);
 assert_cached_type_size!(fallow_types::extract::CalleeUse, 32);
 assert_cached_type_size!(fallow_types::extract::MisplacedDirectiveSite, 8);
 assert_cached_type_size!(fallow_types::extract::SinkSite, 216);

--- a/crates/extract/src/html.rs
+++ b/crates/extract/src/html.rs
@@ -797,9 +797,12 @@ mod tests {
         let fact_names: rustc_hash::FxHashSet<&str> = info
             .semantic_facts
             .iter()
-            .map(|fact| {
-                let SemanticFact::AngularTemplateMemberAccess(access) = fact;
-                access.member.as_str()
+            .filter_map(|fact| {
+                if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
+                    Some(access.member.as_str())
+                } else {
+                    None
+                }
             })
             .collect();
         assert!(fact_names.contains("title"), "should contain 'title'");

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -53,9 +53,10 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 
 pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
-    ExportInfo, ExportName, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
-    MemberInfo, MemberKind, ModuleInfo, ParseResult, PublicSignatureTypeReference, ReExportInfo,
-    RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
+    ExportInfo, ExportName, FactoryCallMemberAccessFact, ImportInfo, ImportedName,
+    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
+    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/tests/js_ts/classes.rs
+++ b/crates/extract/src/tests/js_ts/classes.rs
@@ -1,4 +1,4 @@
-use fallow_types::extract::{ExportName, MemberKind};
+use fallow_types::extract::{ExportName, MemberKind, SemanticFact};
 
 use crate::tests::parse_ts as parse_source;
 
@@ -1191,6 +1191,20 @@ fn static_factory_binding_emits_sentinel_member_access() {
         "sentinel should encode the call shape, got: {}",
         sentinel_access.object
     );
+    let fact = info
+        .semantic_facts
+        .iter()
+        .find_map(|fact| {
+            if let SemanticFact::FactoryCallMemberAccess(access) = fact {
+                Some(access)
+            } else {
+                None
+            }
+        })
+        .expect("typed factory call fact should be emitted");
+    assert_eq!(fact.callee_object, "MyClass");
+    assert_eq!(fact.callee_method, "getInstance");
+    assert_eq!(fact.member, "getData");
 }
 
 #[test]

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -13,8 +13,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::suppress::ParsedSuppressions;
 use crate::{
     AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
-    ExportName, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
-    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    ExportName, FactoryCallMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo,
+    MemberKind, ModuleInfo, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -500,6 +500,22 @@ impl ModuleInfoExtractor {
         self.semantic_facts
             .push(SemanticFact::AngularTemplateMemberAccess(
                 AngularTemplateMemberAccessFact { member },
+            ));
+    }
+
+    fn record_factory_call_member_fact(
+        &mut self,
+        callee_object: String,
+        callee_method: String,
+        member: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::FactoryCallMemberAccess(
+                FactoryCallMemberAccessFact {
+                    callee_object,
+                    callee_method,
+                    member,
+                },
             ));
     }
 
@@ -991,23 +1007,35 @@ impl ModuleInfoExtractor {
         if self.binding_target_names.is_empty() {
             return;
         }
-        let additional_accesses: Vec<MemberAccess> = self
-            .member_accesses
-            .iter()
-            .filter_map(|access| {
-                self.resolve_bound_object_name(&access.object)
-                    .map(|object| MemberAccess {
-                        object,
-                        member: access.member.clone(),
-                    })
-            })
-            .collect();
+        let mut additional_accesses = Vec::new();
+        let mut additional_facts = Vec::new();
+        for access in &self.member_accesses {
+            let Some(object) = self.resolve_bound_object_name(&access.object) else {
+                continue;
+            };
+            if let Some((callee_object, callee_method)) =
+                parse_factory_call_bound_target(object.as_str())
+            {
+                additional_facts.push((
+                    callee_object.to_string(),
+                    callee_method.to_string(),
+                    access.member.clone(),
+                ));
+            }
+            additional_accesses.push(MemberAccess {
+                object,
+                member: access.member.clone(),
+            });
+        }
         let additional_whole: Vec<String> = self
             .whole_object_uses
             .iter()
             .filter_map(|name| self.resolve_bound_object_name(name))
             .collect();
         self.member_accesses.extend(additional_accesses);
+        for (callee_object, callee_method, member) in additional_facts {
+            self.record_factory_call_member_fact(callee_object, callee_method, member);
+        }
         self.whole_object_uses.extend(additional_whole);
     }
 
@@ -1574,6 +1602,12 @@ fn extract_member_names_from_object(
         }
     }
     if names.is_empty() { None } else { Some(names) }
+}
+
+fn parse_factory_call_bound_target(object: &str) -> Option<(&str, &str)> {
+    object
+        .strip_prefix(crate::FACTORY_CALL_SENTINEL)
+        .and_then(|payload| payload.split_once(':'))
 }
 
 #[cfg(all(test, not(miri)))]

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -49,9 +49,12 @@ fn store_member_accesses(info: &crate::ModuleInfo) -> Vec<(String, String)> {
 fn angular_template_fact_members(info: &crate::ModuleInfo) -> Vec<&str> {
     info.semantic_facts
         .iter()
-        .map(|fact| {
-            let SemanticFact::AngularTemplateMemberAccess(access) = fact;
-            access.member.as_str()
+        .filter_map(|fact| {
+            if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
+                Some(access.member.as_str())
+            } else {
+                None
+            }
         })
         .collect()
 }

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1352,6 +1352,8 @@ pub enum SemanticFact {
     /// A class member referenced from an Angular template, host binding, or
     /// component metadata entry.
     AngularTemplateMemberAccess(AngularTemplateMemberAccessFact),
+    /// A member access on a value returned by an imported static factory call.
+    FactoryCallMemberAccess(FactoryCallMemberAccessFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1359,6 +1361,18 @@ pub enum SemanticFact {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct AngularTemplateMemberAccessFact {
     /// Referenced class member name.
+    pub member: String,
+}
+
+/// A member access on a static factory call result.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FactoryCallMemberAccessFact {
+    /// Local imported class or namespace object used as the factory callee.
+    pub callee_object: String,
+    /// Static factory method invoked on the callee object.
+    pub callee_method: String,
+    /// Member accessed on the returned instance-like object.
     pub member: String,
 }
 
@@ -1835,7 +1849,7 @@ const _: () = assert!(std::mem::size_of::<ImportedName>() == 24);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<MemberAccess>() == 48);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<SemanticFact>() == 24);
+const _: () = assert!(std::mem::size_of::<SemanticFact>() == 72);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<SinkSite>() == 216);
 #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
## Summary
- Adds `SemanticFact::FactoryCallMemberAccess` for static factory call member credits.
- Dual-writes typed factory facts plus legacy `FACTORY_CALL_SENTINEL` member accesses during migration.
- Migrates `unused_members` factory-call propagation to typed facts with sentinel fallback.
- Bumps parse cache version for the new semantic fact variant.

## Verification
- cargo test -p fallow-extract static_factory_binding_emits_sentinel_member_access
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-core typed_factory_call_fact_credits_class_member
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- em dash scan clean