### PR TITLE
refactor: add typed fluent chain facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -1669,6 +1669,41 @@ fn parse_fluent_chain_sentinel(object: &str) -> Option<(&str, &str, Vec<&str>)> 
     Some((root, root_method, chain))
 }
 
+struct FluentChainAccess<'a> {
+    root_local: &'a str,
+    root_method: &'a str,
+    chain: Vec<&'a str>,
+    member: &'a str,
+}
+
+fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::FluentChainMemberAccess(access) = fact {
+            accesses.push(FluentChainAccess {
+                root_local: access.root_object.as_str(),
+                root_method: access.root_method.as_str(),
+                chain: access.chain.iter().map(String::as_str).collect(),
+                member: access.member.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((root_local, root_method, chain)) =
+            parse_fluent_chain_sentinel(access.object.as_str())
+        else {
+            continue;
+        };
+        accesses.push(FluentChainAccess {
+            root_local,
+            root_method,
+            chain,
+            member: access.member.as_str(),
+        });
+    }
+    accesses
+}
+
 /// Validate a fluent chain against a single class export.
 fn export_validates_fluent_chain(
     export: &crate::extract::ExportInfo,
@@ -1709,13 +1744,8 @@ fn propagate_fluent_chain_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in &resolved.member_accesses {
-            let Some((root_local, root_method, chain)) =
-                parse_fluent_chain_sentinel(access.object.as_str())
-            else {
-                continue;
-            };
-            let Some(seed_keys) = local_to_export_keys.get(root_local) else {
+        for access in fluent_chain_accesses(resolved) {
+            let Some(seed_keys) = local_to_export_keys.get(access.root_local) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1726,7 +1756,12 @@ fn propagate_fluent_chain_accesses(
                         continue;
                     };
                     let chain_valid = origin_module.exports.iter().any(|export| {
-                        export_validates_fluent_chain(export, &origin, root_method, &chain)
+                        export_validates_fluent_chain(
+                            export,
+                            &origin,
+                            access.root_method,
+                            &access.chain,
+                        )
                     });
                     if !chain_valid {
                         continue;
@@ -1734,7 +1769,7 @@ fn propagate_fluent_chain_accesses(
                     accessed_members
                         .entry(origin)
                         .or_default()
-                        .insert(access.member.clone());
+                        .insert(access.member.to_string());
                 }
             }
         }
@@ -1750,6 +1785,37 @@ fn parse_fluent_chain_new_sentinel(object: &str) -> Option<(&str, Vec<&str>)> {
         return None;
     }
     Some((class, chain_str.split(',').collect()))
+}
+
+struct FluentChainNewAccess<'a> {
+    class_local: &'a str,
+    chain: Vec<&'a str>,
+    member: &'a str,
+}
+
+fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::FluentChainNewMemberAccess(access) = fact {
+            accesses.push(FluentChainNewAccess {
+                class_local: access.class_name.as_str(),
+                chain: access.chain.iter().map(String::as_str).collect(),
+                member: access.member.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((class_local, chain)) = parse_fluent_chain_new_sentinel(access.object.as_str())
+        else {
+            continue;
+        };
+        accesses.push(FluentChainNewAccess {
+            class_local,
+            chain,
+            member: access.member.as_str(),
+        });
+    }
+    accesses
 }
 
 /// Validate a constructor-rooted fluent chain against a single class export.
@@ -1783,13 +1849,8 @@ fn propagate_fluent_chain_new_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in &resolved.member_accesses {
-            let Some((class_local, chain)) =
-                parse_fluent_chain_new_sentinel(access.object.as_str())
-            else {
-                continue;
-            };
-            let Some(seed_keys) = local_to_export_keys.get(class_local) else {
+        for access in fluent_chain_new_accesses(resolved) {
+            let Some(seed_keys) = local_to_export_keys.get(access.class_local) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1799,17 +1860,16 @@ fn propagate_fluent_chain_new_accesses(
                     let Some(origin_module) = module_by_id.get(&origin.file_id) else {
                         continue;
                     };
-                    let chain_valid = origin_module
-                        .exports
-                        .iter()
-                        .any(|export| export_validates_fluent_chain_new(export, &origin, &chain));
+                    let chain_valid = origin_module.exports.iter().any(|export| {
+                        export_validates_fluent_chain_new(export, &origin, &access.chain)
+                    });
                     if !chain_valid {
                         continue;
                     }
                     accessed_members
                         .entry(origin)
                         .or_default()
-                        .insert(access.member.clone());
+                        .insert(access.member.to_string());
                 }
             }
         }
@@ -2607,7 +2667,10 @@ mod tests {
     use crate::graph::{ExportSymbol, ModuleGraph, SymbolReference};
     use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
-    use fallow_types::extract::{ClassHeritageInfo, FactoryCallMemberAccessFact, SemanticFact};
+    use fallow_types::extract::{
+        ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
+        FluentChainNewMemberAccessFact, SemanticFact,
+    };
     use oxc_span::Span;
     use std::path::PathBuf;
 
@@ -2662,6 +2725,13 @@ mod tests {
     fn make_factory_member(name: &str) -> MemberInfo {
         MemberInfo {
             is_instance_returning_static: true,
+            ..make_member(name, MemberKind::ClassMethod)
+        }
+    }
+
+    fn make_self_member(name: &str) -> MemberInfo {
+        MemberInfo {
+            is_self_returning: true,
             ..make_member(name, MemberKind::ClassMethod)
         }
     }
@@ -2759,6 +2829,151 @@ mod tests {
             .get(&ExportKey::new(FileId(1), "MyClass"))
             .expect("factory target class should be credited");
         assert!(credited.contains("getData"));
+    }
+
+    #[test]
+    fn typed_fluent_chain_fact_credits_class_member() {
+        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/event-builder.ts", false)]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "EventBuilder",
+            vec![
+                make_factory_member("create"),
+                make_self_member("setProcessId"),
+                make_self_member("setSubject"),
+                make_member("build", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let class_export = ExportInfo {
+            name: ExportName::Named("EventBuilder".to_string()),
+            local_name: Some("EventBuilder".to_string()),
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: Span::new(0, 10),
+            members: vec![
+                make_factory_member("create"),
+                make_self_member("setProcessId"),
+                make_self_member("setSubject"),
+                make_member("build", MemberKind::ClassMethod),
+            ],
+            super_class: None,
+        };
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: PathBuf::from("/src/entry.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./event-builder".to_string(),
+                        imported_name: ImportedName::Named("EventBuilder".to_string()),
+                        local_name: "EventBuilder".to_string(),
+                        is_type_only: false,
+                        from_style: false,
+                        span: Span::new(0, 10),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                semantic_facts: vec![SemanticFact::FluentChainMemberAccess(
+                    FluentChainMemberAccessFact {
+                        root_object: "EventBuilder".to_string(),
+                        root_method: "create".to_string(),
+                        chain: vec!["setProcessId".to_string(), "setSubject".to_string()],
+                        member: "build".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: PathBuf::from("/src/event-builder.ts"),
+                exports: vec![class_export],
+                ..Default::default()
+            },
+        ];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_fluent_chain_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(1), "EventBuilder"))
+            .expect("fluent target class should be credited");
+        assert!(credited.contains("build"));
+    }
+
+    #[test]
+    fn typed_fluent_chain_new_fact_credits_class_member() {
+        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/option-builder.ts", false)]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "OptionBuilder",
+            vec![
+                make_self_member("addDefault"),
+                make_self_member("addFromCli"),
+                make_member("build", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let class_export = ExportInfo {
+            name: ExportName::Named("OptionBuilder".to_string()),
+            local_name: Some("OptionBuilder".to_string()),
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: Span::new(0, 10),
+            members: vec![
+                make_self_member("addDefault"),
+                make_self_member("addFromCli"),
+                make_member("build", MemberKind::ClassMethod),
+            ],
+            super_class: None,
+        };
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: PathBuf::from("/src/entry.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./option-builder".to_string(),
+                        imported_name: ImportedName::Named("OptionBuilder".to_string()),
+                        local_name: "OptionBuilder".to_string(),
+                        is_type_only: false,
+                        from_style: false,
+                        span: Span::new(0, 10),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                semantic_facts: vec![SemanticFact::FluentChainNewMemberAccess(
+                    FluentChainNewMemberAccessFact {
+                        class_name: "OptionBuilder".to_string(),
+                        chain: vec!["addDefault".to_string(), "addFromCli".to_string()],
+                        member: "build".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: PathBuf::from("/src/option-builder.ts"),
+                exports: vec![class_export],
+                ..Default::default()
+            },
+        ];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_fluent_chain_new_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(1), "OptionBuilder"))
+            .expect("fluent-new target class should be credited");
+        assert!(credited.contains("build"));
     }
 
     fn make_module_with_class_heritage(

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -989,6 +989,17 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 callee_method: "getInstance".to_string(),
                 member: "getData".to_string(),
             }),
+            SemanticFact::FluentChainMemberAccess(FluentChainMemberAccessFact {
+                root_object: "EventBuilder".to_string(),
+                root_method: "create".to_string(),
+                chain: vec!["setProcessId".to_string(), "setSubject".to_string()],
+                member: "build".to_string(),
+            }),
+            SemanticFact::FluentChainNewMemberAccess(FluentChainNewMemberAccessFact {
+                class_name: "OptionBuilder".to_string(),
+                chain: vec!["addDefault".to_string(), "addFromCli".to_string()],
+                member: "build".to_string(),
+            }),
         ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
@@ -1079,6 +1090,17 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 callee_object: "MyClass".to_string(),
                 callee_method: "getInstance".to_string(),
                 member: "getData".to_string(),
+            }),
+            SemanticFact::FluentChainMemberAccess(FluentChainMemberAccessFact {
+                root_object: "EventBuilder".to_string(),
+                root_method: "create".to_string(),
+                chain: vec!["setProcessId".to_string(), "setSubject".to_string()],
+                member: "build".to_string(),
+            }),
+            SemanticFact::FluentChainNewMemberAccess(FluentChainNewMemberAccessFact {
+                class_name: "OptionBuilder".to_string(),
+                chain: vec!["addDefault".to_string(), "addFromCli".to_string()],
+                member: "build".to_string(),
             }),
         ]
     );

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -593,7 +593,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 190: `SemanticFact` now includes typed static-factory call member
 /// access facts alongside the legacy factory-call sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 190;
+///
+/// Bumped to 191: `SemanticFact` now includes typed fluent-chain member access
+/// facts alongside the legacy fluent-chain sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 191;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.
@@ -661,7 +664,7 @@ assert_cached_type_size!(CachedReExport, 88);
 assert_cached_type_size!(CachedMember, 64);
 assert_cached_type_size!(CachedDynamicImportPattern, 56);
 assert_cached_type_size!(crate::MemberAccess, 48);
-assert_cached_type_size!(fallow_types::extract::SemanticFact, 72);
+assert_cached_type_size!(fallow_types::extract::SemanticFact, 96);
 assert_cached_type_size!(fallow_types::extract::CalleeUse, 32);
 assert_cached_type_size!(fallow_types::extract::MisplacedDirectiveSite, 8);
 assert_cached_type_size!(fallow_types::extract::SinkSite, 216);

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -53,10 +53,10 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 
 pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
-    ExportInfo, ExportName, FactoryCallMemberAccessFact, ImportInfo, ImportedName,
-    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
-    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
-    compute_line_offsets,
+    ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
+    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
+    MemberInfo, MemberKind, ModuleInfo, ParseResult, PublicSignatureTypeReference, ReExportInfo,
+    RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -13,8 +13,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::suppress::ParsedSuppressions;
 use crate::{
     AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
-    ExportName, FactoryCallMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo,
-    MemberKind, ModuleInfo, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
+    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
+    ModuleInfo, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -514,6 +515,40 @@ impl ModuleInfoExtractor {
                 FactoryCallMemberAccessFact {
                     callee_object,
                     callee_method,
+                    member,
+                },
+            ));
+    }
+
+    pub(crate) fn record_fluent_chain_member_fact(
+        &mut self,
+        root_object: String,
+        root_method: String,
+        chain: Vec<String>,
+        member: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::FluentChainMemberAccess(
+                FluentChainMemberAccessFact {
+                    root_object,
+                    root_method,
+                    chain,
+                    member,
+                },
+            ));
+    }
+
+    pub(crate) fn record_fluent_chain_new_member_fact(
+        &mut self,
+        class_name: String,
+        chain: Vec<String>,
+        member: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::FluentChainNewMemberAccess(
+                FluentChainNewMemberAccessFact {
+                    class_name,
+                    chain,
                     member,
                 },
             ));

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -4881,6 +4881,37 @@ fn fluent_chain_emits_sentinel_member_access() {
         "terminal call should encode the full prior chain, found: {:?}",
         info.member_accesses,
     );
+    let fluent_facts: Vec<_> = info
+        .semantic_facts
+        .iter()
+        .filter_map(|fact| {
+            if let SemanticFact::FluentChainMemberAccess(access) = fact {
+                Some(access)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert!(
+        fluent_facts
+            .iter()
+            .any(|fact| fact.root_object == "EventBuilder"
+                && fact.root_method == "create"
+                && fact.chain.is_empty()
+                && fact.member == "setProcessId"),
+        "first chained call should emit typed fluent fact, found: {:?}",
+        info.semantic_facts,
+    );
+    assert!(
+        fluent_facts
+            .iter()
+            .any(|fact| fact.root_object == "EventBuilder"
+                && fact.root_method == "create"
+                && fact.chain == vec!["setProcessId".to_string(), "setSubject".to_string()]
+                && fact.member == "build"),
+        "terminal call should emit typed fluent fact with full prior chain, found: {:?}",
+        info.semantic_facts,
+    );
 }
 
 #[test]
@@ -4936,6 +4967,35 @@ fn new_expression_fluent_chain_emits_new_sentinel() {
             && a.member == "build"),
         "terminal call should encode the full prior chain, found: {:?}",
         info.member_accesses,
+    );
+    let fluent_new_facts: Vec<_> = info
+        .semantic_facts
+        .iter()
+        .filter_map(|fact| {
+            if let SemanticFact::FluentChainNewMemberAccess(access) = fact {
+                Some(access)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert!(
+        fluent_new_facts
+            .iter()
+            .any(|fact| fact.class_name == "OptionBuilder"
+                && fact.chain == vec!["addDefault".to_string()]
+                && fact.member == "addFromCli"),
+        "second chained call should emit typed fluent-new fact, found: {:?}",
+        info.semantic_facts,
+    );
+    assert!(
+        fluent_new_facts
+            .iter()
+            .any(|fact| fact.class_name == "OptionBuilder"
+                && fact.chain == vec!["addDefault".to_string(), "addFromCli".to_string()]
+                && fact.member == "build"),
+        "terminal call should emit typed fluent-new fact, found: {:?}",
+        info.semantic_facts,
     );
 }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -876,6 +876,12 @@ impl ModuleInfoExtractor {
             if let Expression::Identifier(root_id) = &inner_member.object {
                 chain_prefix_reversed.reverse();
                 let chain_prefix = chain_prefix_reversed.join(",");
+                self.record_fluent_chain_member_fact(
+                    root_id.name.to_string(),
+                    inner_member.property.name.to_string(),
+                    chain_prefix_reversed,
+                    this_method.to_string(),
+                );
                 self.member_accesses.push(MemberAccess {
                     object: format!(
                         "{}{}:{}:{}",
@@ -894,6 +900,11 @@ impl ModuleInfoExtractor {
                 chain_prefix_reversed.push(inner_member.property.name.to_string());
                 chain_prefix_reversed.reverse();
                 let chain_prefix = chain_prefix_reversed.join(",");
+                self.record_fluent_chain_new_member_fact(
+                    class_id.name.to_string(),
+                    chain_prefix_reversed,
+                    this_method.to_string(),
+                );
                 self.member_accesses.push(MemberAccess {
                     object: format!(
                         "{}{}:{}",

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1354,6 +1354,10 @@ pub enum SemanticFact {
     AngularTemplateMemberAccess(AngularTemplateMemberAccessFact),
     /// A member access on a value returned by an imported static factory call.
     FactoryCallMemberAccess(FactoryCallMemberAccessFact),
+    /// A member access on a fluent chain rooted at an imported static factory.
+    FluentChainMemberAccess(FluentChainMemberAccessFact),
+    /// A member access on a fluent chain rooted at a `new` expression.
+    FluentChainNewMemberAccess(FluentChainNewMemberAccessFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1373,6 +1377,32 @@ pub struct FactoryCallMemberAccessFact {
     /// Static factory method invoked on the callee object.
     pub callee_method: String,
     /// Member accessed on the returned instance-like object.
+    pub member: String,
+}
+
+/// A member access on a fluent chain rooted at a static factory call.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FluentChainMemberAccessFact {
+    /// Local imported class or namespace object used as the chain root.
+    pub root_object: String,
+    /// Static factory method that starts the fluent chain.
+    pub root_method: String,
+    /// Intermediate fluent methods between the root method and final member.
+    pub chain: Vec<String>,
+    /// Member accessed at this chain step.
+    pub member: String,
+}
+
+/// A member access on a fluent chain rooted at a `new` expression.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FluentChainNewMemberAccessFact {
+    /// Local imported class constructed by the `new` expression.
+    pub class_name: String,
+    /// Intermediate fluent methods between construction and final member.
+    pub chain: Vec<String>,
+    /// Member accessed at this chain step.
     pub member: String,
 }
 
@@ -1849,7 +1879,7 @@ const _: () = assert!(std::mem::size_of::<ImportedName>() == 24);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<MemberAccess>() == 48);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<SemanticFact>() == 72);
+const _: () = assert!(std::mem::size_of::<SemanticFact>() == 96);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<SinkSite>() == 216);
 #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
## Summary
- Adds typed `SemanticFact` variants for fluent-chain member credits.
- Dual-writes fluent-chain and new-rooted fluent-chain facts plus legacy sentinel member accesses during migration.
- Migrates `unused_members` fluent propagation to typed facts with sentinel fallback.
- Bumps parse cache version for the new semantic fact variants.

## Verification
- cargo test -p fallow-extract fluent_chain
- cargo test -p fallow-core typed_fluent_chain
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- em dash scan clean