### PR TITLE
refactor: add typed playwright fixture use facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -958,6 +958,39 @@ fn parse_playwright_fixture_sentinel<'a>(
     object.strip_prefix(prefix)?.split_once(':')
 }
 
+struct PlaywrightFixtureUseAccess<'a> {
+    test_local_name: &'a str,
+    fixture_name: &'a str,
+    member: &'a str,
+}
+
+fn playwright_fixture_use_accesses(module: &ResolvedModule) -> Vec<PlaywrightFixtureUseAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::PlaywrightFixtureUse(access) = fact {
+            accesses.push(PlaywrightFixtureUseAccess {
+                test_local_name: access.test_name.as_str(),
+                fixture_name: access.fixture_name.as_str(),
+                member: access.member.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((test_local_name, fixture_name)) = parse_playwright_fixture_sentinel(
+            access.object.as_str(),
+            PLAYWRIGHT_FIXTURE_USE_SENTINEL,
+        ) else {
+            continue;
+        };
+        accesses.push(PlaywrightFixtureUseAccess {
+            test_local_name,
+            fixture_name,
+            member: access.member.as_str(),
+        });
+    }
+    accesses
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum PlaywrightTestKey {
     Export(ExportKey),
@@ -1266,14 +1299,8 @@ fn propagate_playwright_fixture_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in &resolved.member_accesses {
-            let Some((test_local_name, fixture_name)) = parse_playwright_fixture_sentinel(
-                access.object.as_str(),
-                PLAYWRIGHT_FIXTURE_USE_SENTINEL,
-            ) else {
-                continue;
-            };
-            let Some(test_keys) = local_to_export_keys.get(test_local_name) else {
+        for access in playwright_fixture_use_accesses(resolved) {
+            let Some(test_keys) = local_to_export_keys.get(access.test_local_name) else {
                 continue;
             };
 
@@ -1281,14 +1308,14 @@ fn propagate_playwright_fixture_accesses(
                 let Some(fixture_targets) = targets_by_test.get(test_key) else {
                     continue;
                 };
-                let Some(target_keys) = fixture_targets.get(fixture_name) else {
+                let Some(target_keys) = fixture_targets.get(access.fixture_name) else {
                     continue;
                 };
                 for target_key in target_keys {
                     accessed_members
                         .entry(target_key.clone())
                         .or_default()
-                        .insert(access.member.clone());
+                        .insert(access.member.to_string());
                 }
             }
         }
@@ -2669,7 +2696,7 @@ mod tests {
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
     use fallow_types::extract::{
         ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-        FluentChainNewMemberAccessFact, SemanticFact,
+        FluentChainNewMemberAccessFact, PlaywrightFixtureUseFact, SemanticFact,
     };
     use oxc_span::Span;
     use std::path::PathBuf;
@@ -2760,6 +2787,74 @@ mod tests {
             references,
             members,
         }
+    }
+
+    #[test]
+    fn typed_playwright_fixture_use_fact_credits_fixture_member() {
+        let mut graph = build_graph(&[
+            ("/src/spec.ts", true),
+            ("/src/fixtures.ts", false),
+            ("/src/admin-page.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members("test", vec![], Some(0))];
+        graph.modules[2].set_reachable(true);
+        graph.modules[2].exports = vec![make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(0),
+        )];
+
+        let resolved_modules = vec![ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/src/spec.ts"),
+            resolved_imports: vec![
+                ResolvedImport {
+                    info: ImportInfo {
+                        source: "./fixtures".to_string(),
+                        imported_name: ImportedName::Named("test".to_string()),
+                        local_name: "test".to_string(),
+                        is_type_only: false,
+                        from_style: false,
+                        span: Span::new(0, 10),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                },
+                ResolvedImport {
+                    info: ImportInfo {
+                        source: "./admin-page".to_string(),
+                        imported_name: ImportedName::Named("AdminPage".to_string()),
+                        local_name: "AdminPage".to_string(),
+                        is_type_only: false,
+                        from_style: false,
+                        span: Span::new(11, 20),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(2)),
+                },
+            ],
+            member_accesses: vec![MemberAccess {
+                object: format!("{PLAYWRIGHT_FIXTURE_DEF_SENTINEL}test:adminPage"),
+                member: "AdminPage".to_string(),
+            }],
+            semantic_facts: vec![SemanticFact::PlaywrightFixtureUse(
+                PlaywrightFixtureUseFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "adminPage".to_string(),
+                    member: "assertGreeting".to_string(),
+                },
+            )],
+            ..Default::default()
+        }];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_playwright_fixture_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(2), "AdminPage"))
+            .expect("fixture target class should be credited");
+        assert!(credited.contains("assertGreeting"));
     }
 
     #[test]

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1000,6 +1000,11 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 chain: vec!["addDefault".to_string(), "addFromCli".to_string()],
                 member: "build".to_string(),
             }),
+            SemanticFact::PlaywrightFixtureUse(PlaywrightFixtureUseFact {
+                test_name: "test".to_string(),
+                fixture_name: "adminPage".to_string(),
+                member: "assertGreeting".to_string(),
+            }),
         ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
@@ -1101,6 +1106,11 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 class_name: "OptionBuilder".to_string(),
                 chain: vec!["addDefault".to_string(), "addFromCli".to_string()],
                 member: "build".to_string(),
+            }),
+            SemanticFact::PlaywrightFixtureUse(PlaywrightFixtureUseFact {
+                test_name: "test".to_string(),
+                fixture_name: "adminPage".to_string(),
+                member: "assertGreeting".to_string(),
             }),
         ]
     );

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -596,7 +596,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 191: `SemanticFact` now includes typed fluent-chain member access
 /// facts alongside the legacy fluent-chain sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 191;
+///
+/// Bumped to 192: `SemanticFact` now includes typed Playwright fixture-use facts
+/// alongside the legacy fixture-use sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 192;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -55,8 +55,9 @@ pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
     ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
-    MemberInfo, MemberKind, ModuleInfo, ParseResult, PublicSignatureTypeReference, ReExportInfo,
-    RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
+    MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureUseFact,
+    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -15,7 +15,8 @@ use crate::{
     AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
     ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    ModuleInfo, PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo, SemanticFact,
+    VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -552,6 +553,21 @@ impl ModuleInfoExtractor {
                     member,
                 },
             ));
+    }
+
+    pub(crate) fn record_playwright_fixture_use_fact(
+        &mut self,
+        test_name: String,
+        fixture_name: String,
+        member: String,
+    ) {
+        self.semantic_facts.push(SemanticFact::PlaywrightFixtureUse(
+            PlaywrightFixtureUseFact {
+                test_name,
+                fixture_name,
+                member,
+            },
+        ));
     }
 
     pub(crate) fn record_local_declaration_name(&mut self, name: &str) {

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2669,6 +2669,31 @@ fn playwright_test_callback_records_fixture_member_uses() {
         "aliased userPage.assertGreeting should be recorded as a Playwright fixture use, found: {:?}",
         info.member_accesses
     );
+    let fixture_use_facts: Vec<_> = info
+        .semantic_facts
+        .iter()
+        .filter_map(|fact| {
+            if let SemanticFact::PlaywrightFixtureUse(access) = fact {
+                Some(access)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert!(
+        fixture_use_facts.iter().any(|fact| fact.test_name == "test"
+            && fact.fixture_name == "adminPage"
+            && fact.member == "assertGreeting"),
+        "adminPage.assertGreeting should emit a typed Playwright fixture use, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        fixture_use_facts.iter().any(|fact| fact.test_name == "test"
+            && fact.fixture_name == "userPage"
+            && fact.member == "assertGreeting"),
+        "aliased userPage.assertGreeting should emit a typed Playwright fixture use, found: {:?}",
+        info.semantic_facts
+    );
 }
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -4185,11 +4185,24 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.react_record_hook_call(expr);
 
         if let Some(test_name) = playwright_test_callee_name(&expr.callee) {
-            self.member_accesses
-                .extend(collect_playwright_fixture_member_uses(
-                    test_name.as_str(),
-                    &expr.arguments,
-                ));
+            let fixture_uses =
+                collect_playwright_fixture_member_uses(test_name.as_str(), &expr.arguments);
+            for access in &fixture_uses {
+                let Some(fixture_name) = access
+                    .object
+                    .strip_prefix(crate::PLAYWRIGHT_FIXTURE_USE_SENTINEL)
+                    .and_then(|payload| payload.strip_prefix(test_name.as_str()))
+                    .and_then(|payload| payload.strip_prefix(':'))
+                else {
+                    continue;
+                };
+                self.record_playwright_fixture_use_fact(
+                    test_name.clone(),
+                    fixture_name.to_string(),
+                    access.member.clone(),
+                );
+            }
+            self.member_accesses.extend(fixture_uses);
         }
 
         if let Some((tag, class_name)) = extract_custom_elements_define(expr) {

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1358,6 +1358,8 @@ pub enum SemanticFact {
     FluentChainMemberAccess(FluentChainMemberAccessFact),
     /// A member access on a fluent chain rooted at a `new` expression.
     FluentChainNewMemberAccess(FluentChainNewMemberAccessFact),
+    /// A member access on a Playwright fixture object inside a test callback.
+    PlaywrightFixtureUse(PlaywrightFixtureUseFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1403,6 +1405,18 @@ pub struct FluentChainNewMemberAccessFact {
     /// Intermediate fluent methods between construction and final member.
     pub chain: Vec<String>,
     /// Member accessed at this chain step.
+    pub member: String,
+}
+
+/// A member access on a Playwright fixture object inside a test callback.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PlaywrightFixtureUseFact {
+    /// Local test function or wrapper used as the callback callee.
+    pub test_name: String,
+    /// Fixture name or dotted fixture path referenced in the callback.
+    pub fixture_name: String,
+    /// Member accessed on the fixture target.
     pub member: String,
 }
 


### PR DESCRIPTION
## Summary
- Adds typed `SemanticFact::PlaywrightFixtureUse` for Playwright fixture member credits.
- Dual-writes fixture-use facts plus legacy `PLAYWRIGHT_FIXTURE_USE_SENTINEL` member accesses during migration.
- Migrates `unused_members` fixture-use propagation to typed facts with sentinel fallback.
- Bumps parse cache version for the new semantic fact variant.

## Verification
- cargo test -p fallow-extract playwright_test_callback_records_fixture_member_uses
- cargo test -p fallow-core typed_playwright_fixture_use_fact_credits_fixture_member
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- em dash scan clean