### PR TITLE
refactor: add typed playwright fixture definition facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -964,6 +964,41 @@ struct PlaywrightFixtureUseAccess<'a> {
     member: &'a str,
 }
 
+struct PlaywrightFixtureDefinitionAccess<'a> {
+    test_local: &'a str,
+    fixture: &'a str,
+    type_local: &'a str,
+}
+
+fn playwright_fixture_definition_accesses(
+    module: &ResolvedModule,
+) -> Vec<PlaywrightFixtureDefinitionAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::PlaywrightFixtureDefinition(access) = fact {
+            accesses.push(PlaywrightFixtureDefinitionAccess {
+                test_local: access.test_name.as_str(),
+                fixture: access.fixture_name.as_str(),
+                type_local: access.type_name.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((test_local_name, fixture_name)) = parse_playwright_fixture_sentinel(
+            access.object.as_str(),
+            PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
+        ) else {
+            continue;
+        };
+        accesses.push(PlaywrightFixtureDefinitionAccess {
+            test_local: test_local_name,
+            fixture: fixture_name,
+            type_local: access.member.as_str(),
+        });
+    }
+    accesses
+}
+
 fn playwright_fixture_use_accesses(module: &ResolvedModule) -> Vec<PlaywrightFixtureUseAccess<'_>> {
     let mut accesses = Vec::new();
     for fact in &module.semantic_facts {
@@ -1005,13 +1040,10 @@ fn push_playwright_test_key(keys: &mut Vec<PlaywrightTestKey>, key: PlaywrightTe
 
 fn collect_playwright_local_test_names(resolved: &ResolvedModule) -> FxHashSet<&str> {
     let mut names = FxHashSet::default();
+    for access in playwright_fixture_definition_accesses(resolved) {
+        names.insert(access.test_local);
+    }
     for access in &resolved.member_accesses {
-        if let Some((test_local_name, _)) = parse_playwright_fixture_sentinel(
-            access.object.as_str(),
-            PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
-        ) {
-            names.insert(test_local_name);
-        }
         if let Some((test_local_name, _)) = parse_playwright_fixture_sentinel(
             access.object.as_str(),
             PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL,
@@ -1094,20 +1126,14 @@ fn collect_playwright_fixture_def_targets(
     type_targets: &FxHashMap<ExportKey, FxHashMap<String, Vec<ExportKey>>>,
     targets_by_test: &mut FxHashMap<PlaywrightTestKey, FxHashMap<String, Vec<ExportKey>>>,
 ) {
-    for access in &resolved.member_accesses {
-        let Some((test_local_name, fixture_name)) = parse_playwright_fixture_sentinel(
-            access.object.as_str(),
-            PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
-        ) else {
-            continue;
-        };
+    for access in playwright_fixture_definition_accesses(resolved) {
         let test_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
             resolved.file_id,
-            test_local_name,
+            access.test_local,
         );
-        let Some(target_keys) = local_to_export_keys.get(access.member.as_str()) else {
+        let Some(target_keys) = local_to_export_keys.get(access.type_local) else {
             continue;
         };
 
@@ -1118,7 +1144,7 @@ fn collect_playwright_fixture_def_targets(
                     graph,
                     type_targets,
                     fixture_targets,
-                    fixture_name,
+                    access.fixture,
                     target_key,
                 );
             }
@@ -2696,7 +2722,8 @@ mod tests {
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
     use fallow_types::extract::{
         ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-        FluentChainNewMemberAccessFact, PlaywrightFixtureUseFact, SemanticFact,
+        FluentChainNewMemberAccessFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact,
+        SemanticFact,
     };
     use oxc_span::Span;
     use std::path::PathBuf;
@@ -2834,17 +2861,18 @@ mod tests {
                     target: ResolveResult::InternalModule(FileId(2)),
                 },
             ],
-            member_accesses: vec![MemberAccess {
-                object: format!("{PLAYWRIGHT_FIXTURE_DEF_SENTINEL}test:adminPage"),
-                member: "AdminPage".to_string(),
-            }],
-            semantic_facts: vec![SemanticFact::PlaywrightFixtureUse(
-                PlaywrightFixtureUseFact {
+            semantic_facts: vec![
+                SemanticFact::PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "adminPage".to_string(),
+                    type_name: "AdminPage".to_string(),
+                }),
+                SemanticFact::PlaywrightFixtureUse(PlaywrightFixtureUseFact {
                     test_name: "test".to_string(),
                     fixture_name: "adminPage".to_string(),
                     member: "assertGreeting".to_string(),
-                },
-            )],
+                }),
+            ],
             ..Default::default()
         }];
 

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1005,6 +1005,11 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 fixture_name: "adminPage".to_string(),
                 member: "assertGreeting".to_string(),
             }),
+            SemanticFact::PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact {
+                test_name: "test".to_string(),
+                fixture_name: "adminPage".to_string(),
+                type_name: "AdminPage".to_string(),
+            }),
         ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
@@ -1111,6 +1116,11 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 test_name: "test".to_string(),
                 fixture_name: "adminPage".to_string(),
                 member: "assertGreeting".to_string(),
+            }),
+            SemanticFact::PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact {
+                test_name: "test".to_string(),
+                fixture_name: "adminPage".to_string(),
+                type_name: "AdminPage".to_string(),
             }),
         ]
     );

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -599,7 +599,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 192: `SemanticFact` now includes typed Playwright fixture-use facts
 /// alongside the legacy fixture-use sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 192;
+///
+/// Bumped to 193: `SemanticFact` now includes typed Playwright fixture definition
+/// facts alongside the legacy fixture-definition sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 193;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -55,9 +55,9 @@ pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
     ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
-    MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureUseFact,
-    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
-    compute_line_offsets,
+    MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureDefinitionFact,
+    PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
+    SemanticFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -15,8 +15,8 @@ use crate::{
     AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
     ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo, SemanticFact,
-    VisibilityTag,
+    ModuleInfo, PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact, ReExportInfo,
+    RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -568,6 +568,22 @@ impl ModuleInfoExtractor {
                 member,
             },
         ));
+    }
+
+    pub(crate) fn record_playwright_fixture_definition_fact(
+        &mut self,
+        test_name: String,
+        fixture_name: String,
+        type_name: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::PlaywrightFixtureDefinition(
+                PlaywrightFixtureDefinitionFact {
+                    test_name,
+                    fixture_name,
+                    type_name,
+                },
+            ));
     }
 
     pub(crate) fn record_local_declaration_name(&mut self, name: &str) {

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2519,6 +2519,35 @@ fn playwright_extend_type_alias_records_fixture_definitions() {
         "typed Playwright fixture userPage should be recorded, found: {:?}",
         info.member_accesses
     );
+    let fixture_definition_facts: Vec<_> = info
+        .semantic_facts
+        .iter()
+        .filter_map(|fact| {
+            if let SemanticFact::PlaywrightFixtureDefinition(access) = fact {
+                Some(access)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert!(
+        fixture_definition_facts
+            .iter()
+            .any(|fact| fact.test_name == "test"
+                && fact.fixture_name == "adminPage"
+                && fact.type_name == "AdminPage"),
+        "typed Playwright fixture adminPage should emit a fixture definition fact, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        fixture_definition_facts
+            .iter()
+            .any(|fact| fact.test_name == "test"
+                && fact.fixture_name == "userPage"
+                && fact.type_name == "UserPage"),
+        "typed Playwright fixture userPage should emit a fixture definition fact, found: {:?}",
+        info.semantic_facts
+    );
 }
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2410,20 +2410,22 @@ impl ModuleInfoExtractor {
         }
         bindings.sort_unstable();
         bindings.dedup();
-        self.member_accesses
-            .extend(
-                bindings
-                    .into_iter()
-                    .map(|(fixture_name, type_name)| MemberAccess {
-                        object: format!(
-                            "{}{}:{}",
-                            crate::PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
-                            test_name,
-                            fixture_name
-                        ),
-                        member: type_name,
-                    }),
+        for (fixture_name, type_name) in bindings {
+            self.record_playwright_fixture_definition_fact(
+                test_name.to_string(),
+                fixture_name.clone(),
+                type_name.clone(),
             );
+            self.member_accesses.push(MemberAccess {
+                object: format!(
+                    "{}{}:{}",
+                    crate::PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
+                    test_name,
+                    fixture_name
+                ),
+                member: type_name,
+            });
+        }
     }
 
     fn record_playwright_fixture_alias(&mut self, test_name: &str, base_name: &str) {

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -832,7 +832,7 @@ pub fn compute_line_offsets(source: &str) -> Vec<u32> {
         if byte == b'\n' {
             debug_assert!(
                 u32::try_from(i + 1).is_ok(),
-                "source file exceeds u32::MAX bytes — line offsets would overflow"
+                "source file exceeds u32::MAX bytes: line offsets would overflow"
             );
             offsets.push((i + 1) as u32);
         }
@@ -1360,6 +1360,8 @@ pub enum SemanticFact {
     FluentChainNewMemberAccess(FluentChainNewMemberAccessFact),
     /// A member access on a Playwright fixture object inside a test callback.
     PlaywrightFixtureUse(PlaywrightFixtureUseFact),
+    /// A Playwright fixture definition declared by a typed `test.extend<T>()`.
+    PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1418,6 +1420,18 @@ pub struct PlaywrightFixtureUseFact {
     pub fixture_name: String,
     /// Member accessed on the fixture target.
     pub member: String,
+}
+
+/// A Playwright fixture definition declared by a typed `test.extend<T>()`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PlaywrightFixtureDefinitionFact {
+    /// Local test function or wrapper receiving the fixture definition.
+    pub test_name: String,
+    /// Fixture name or dotted fixture path declared by the fixture type.
+    pub fixture_name: String,
+    /// Local type symbol used as the fixture target.
+    pub type_name: String,
 }
 
 /// A statically flattenable callee path invoked in a module (e.g. `execSync`,


### PR DESCRIPTION
## Summary
- Add a typed Playwright fixture-definition semantic fact next to the legacy fixture-definition sentinel.
- Move the unused-member fixture target builder to typed facts first, with legacy sentinel fallback during migration.
- Bump the parse cache version and extend cache, extractor, and core coverage for the new fact.

## Verification
- cargo test -p fallow-extract playwright_extend_type_alias_records_fixture_definitions
- cargo test -p fallow-core typed_playwright_fixture_use_fact_credits_fixture_member
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
