### PR TITLE
refactor: add typed playwright fixture alias facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -970,6 +970,38 @@ struct PlaywrightFixtureDefinitionAccess<'a> {
     type_local: &'a str,
 }
 
+struct PlaywrightFixtureAliasAccess<'a> {
+    test_local: &'a str,
+    base_local: &'a str,
+}
+
+fn playwright_fixture_alias_accesses(
+    module: &ResolvedModule,
+) -> Vec<PlaywrightFixtureAliasAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::PlaywrightFixtureAlias(access) = fact {
+            accesses.push(PlaywrightFixtureAliasAccess {
+                test_local: access.test_name.as_str(),
+                base_local: access.base_name.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((test_local_name, _)) = parse_playwright_fixture_sentinel(
+            access.object.as_str(),
+            PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL,
+        ) else {
+            continue;
+        };
+        accesses.push(PlaywrightFixtureAliasAccess {
+            test_local: test_local_name,
+            base_local: access.member.as_str(),
+        });
+    }
+    accesses
+}
+
 fn playwright_fixture_definition_accesses(
     module: &ResolvedModule,
 ) -> Vec<PlaywrightFixtureDefinitionAccess<'_>> {
@@ -1043,13 +1075,8 @@ fn collect_playwright_local_test_names(resolved: &ResolvedModule) -> FxHashSet<&
     for access in playwright_fixture_definition_accesses(resolved) {
         names.insert(access.test_local);
     }
-    for access in &resolved.member_accesses {
-        if let Some((test_local_name, _)) = parse_playwright_fixture_sentinel(
-            access.object.as_str(),
-            PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL,
-        ) {
-            names.insert(test_local_name);
-        }
+    for access in playwright_fixture_alias_accesses(resolved) {
+        names.insert(access.test_local);
     }
     names
 }
@@ -1161,24 +1188,18 @@ fn collect_playwright_fixture_aliases(
     local_playwright_test_names: &FxHashSet<&str>,
     aliases_by_test: &mut FxHashMap<PlaywrightTestKey, Vec<PlaywrightTestKey>>,
 ) {
-    for access in &resolved.member_accesses {
-        let Some((test_local_name, _)) = parse_playwright_fixture_sentinel(
-            access.object.as_str(),
-            PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL,
-        ) else {
-            continue;
-        };
+    for access in playwright_fixture_alias_accesses(resolved) {
         let test_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
             resolved.file_id,
-            test_local_name,
+            access.test_local,
         );
         let base_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
             resolved.file_id,
-            access.member.as_str(),
+            access.base_local,
         );
 
         for test_key in test_keys {
@@ -2722,8 +2743,8 @@ mod tests {
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
     use fallow_types::extract::{
         ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-        FluentChainNewMemberAccessFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact,
-        SemanticFact,
+        FluentChainNewMemberAccessFact, PlaywrightFixtureAliasFact,
+        PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact, SemanticFact,
     };
     use oxc_span::Span;
     use std::path::PathBuf;
@@ -2787,6 +2808,26 @@ mod tests {
         MemberInfo {
             is_self_returning: true,
             ..make_member(name, MemberKind::ClassMethod)
+        }
+    }
+
+    fn make_resolved_import(
+        source: &str,
+        imported: &str,
+        local: &str,
+        target: u32,
+    ) -> ResolvedImport {
+        ResolvedImport {
+            info: ImportInfo {
+                source: source.to_string(),
+                imported_name: ImportedName::Named(imported.to_string()),
+                local_name: local.to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: Span::new(0, 10),
+                source_span: Span::default(),
+            },
+            target: ResolveResult::InternalModule(FileId(target)),
         }
     }
 
@@ -2882,6 +2923,92 @@ mod tests {
         let credited = accessed_members
             .get(&ExportKey::new(FileId(2), "AdminPage"))
             .expect("fixture target class should be credited");
+        assert!(credited.contains("assertGreeting"));
+    }
+
+    #[test]
+    fn typed_playwright_fixture_alias_fact_expands_fixture_targets() {
+        let mut graph = build_graph(&[
+            ("/src/spec.ts", true),
+            ("/src/fixtures.ts", false),
+            ("/src/wrapped-fixtures.ts", false),
+            ("/src/admin-page.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members("testPrimary", vec![], Some(2))];
+        graph.modules[2].set_reachable(true);
+        graph.modules[2].exports = vec![make_export_with_members("mergedTest", vec![], Some(0))];
+        graph.modules[3].set_reachable(true);
+        graph.modules[3].exports = vec![make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(1),
+        )];
+
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: PathBuf::from("/src/spec.ts"),
+                resolved_imports: vec![make_resolved_import(
+                    "./wrapped-fixtures",
+                    "mergedTest",
+                    "mergedTest",
+                    2,
+                )],
+                semantic_facts: vec![SemanticFact::PlaywrightFixtureUse(
+                    PlaywrightFixtureUseFact {
+                        test_name: "mergedTest".to_string(),
+                        fixture_name: "adminPage".to_string(),
+                        member: "assertGreeting".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: PathBuf::from("/src/fixtures.ts"),
+                resolved_imports: vec![make_resolved_import(
+                    "./admin-page",
+                    "AdminPage",
+                    "AdminPage",
+                    3,
+                )],
+                exports: vec![make_export_info("testPrimary", None)],
+                semantic_facts: vec![SemanticFact::PlaywrightFixtureDefinition(
+                    PlaywrightFixtureDefinitionFact {
+                        test_name: "testPrimary".to_string(),
+                        fixture_name: "adminPage".to_string(),
+                        type_name: "AdminPage".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: PathBuf::from("/src/wrapped-fixtures.ts"),
+                resolved_imports: vec![make_resolved_import(
+                    "./fixtures",
+                    "testPrimary",
+                    "testPrimary",
+                    1,
+                )],
+                exports: vec![make_export_info("mergedTest", None)],
+                semantic_facts: vec![SemanticFact::PlaywrightFixtureAlias(
+                    PlaywrightFixtureAliasFact {
+                        test_name: "mergedTest".to_string(),
+                        base_name: "testPrimary".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+        ];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_playwright_fixture_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(3), "AdminPage"))
+            .expect("aliased fixture target class should be credited");
         assert!(credited.contains("assertGreeting"));
     }
 

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1010,6 +1010,10 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 fixture_name: "adminPage".to_string(),
                 type_name: "AdminPage".to_string(),
             }),
+            SemanticFact::PlaywrightFixtureAlias(PlaywrightFixtureAliasFact {
+                test_name: "mergedTest".to_string(),
+                base_name: "test".to_string(),
+            }),
         ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
@@ -1121,6 +1125,10 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 test_name: "test".to_string(),
                 fixture_name: "adminPage".to_string(),
                 type_name: "AdminPage".to_string(),
+            }),
+            SemanticFact::PlaywrightFixtureAlias(PlaywrightFixtureAliasFact {
+                test_name: "mergedTest".to_string(),
+                base_name: "test".to_string(),
             }),
         ]
     );

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -602,7 +602,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 193: `SemanticFact` now includes typed Playwright fixture definition
 /// facts alongside the legacy fixture-definition sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 193;
+///
+/// Bumped to 194: `SemanticFact` now includes typed Playwright fixture alias
+/// facts alongside the legacy fixture-alias sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 194;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -55,9 +55,9 @@ pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
     ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
-    MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
-    SemanticFact, VisibilityTag, compute_line_offsets,
+    MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureAliasFact,
+    PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
+    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -15,8 +15,8 @@ use crate::{
     AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
     ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact, ReExportInfo,
-    RequireCallInfo, SemanticFact, VisibilityTag,
+    ModuleInfo, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
+    PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -582,6 +582,20 @@ impl ModuleInfoExtractor {
                     test_name,
                     fixture_name,
                     type_name,
+                },
+            ));
+    }
+
+    pub(crate) fn record_playwright_fixture_alias_fact(
+        &mut self,
+        test_name: String,
+        base_name: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::PlaywrightFixtureAlias(
+                PlaywrightFixtureAliasFact {
+                    test_name,
+                    base_name,
                 },
             ));
     }

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2603,6 +2603,31 @@ fn playwright_merge_tests_records_fixture_aliases() {
         "Playwright mergeTests should record the second inherited fixture test, found: {:?}",
         info.member_accesses
     );
+    let fixture_alias_facts: Vec<_> = info
+        .semantic_facts
+        .iter()
+        .filter_map(|fact| {
+            if let SemanticFact::PlaywrightFixtureAlias(access) = fact {
+                Some(access)
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert!(
+        fixture_alias_facts
+            .iter()
+            .any(|fact| fact.test_name == "mergedTest" && fact.base_name == "testPrimary"),
+        "Playwright mergeTests should emit a typed alias for testPrimary, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        fixture_alias_facts
+            .iter()
+            .any(|fact| fact.test_name == "mergedTest" && fact.base_name == "testSecondary"),
+        "Playwright mergeTests should emit a typed alias for testSecondary, found: {:?}",
+        info.semantic_facts
+    );
 }
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2429,6 +2429,7 @@ impl ModuleInfoExtractor {
     }
 
     fn record_playwright_fixture_alias(&mut self, test_name: &str, base_name: &str) {
+        self.record_playwright_fixture_alias_fact(test_name.to_string(), base_name.to_string());
         self.member_accesses.push(MemberAccess {
             object: format!("{}{}:", crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL, test_name),
             member: base_name.to_string(),

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1362,6 +1362,8 @@ pub enum SemanticFact {
     PlaywrightFixtureUse(PlaywrightFixtureUseFact),
     /// A Playwright fixture definition declared by a typed `test.extend<T>()`.
     PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact),
+    /// A Playwright fixture wrapper alias declared by `mergeTests` or `.extend`.
+    PlaywrightFixtureAlias(PlaywrightFixtureAliasFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1432,6 +1434,16 @@ pub struct PlaywrightFixtureDefinitionFact {
     pub fixture_name: String,
     /// Local type symbol used as the fixture target.
     pub type_name: String,
+}
+
+/// A Playwright fixture wrapper alias declared by `mergeTests` or `.extend`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PlaywrightFixtureAliasFact {
+    /// Local test function or wrapper that inherits fixture definitions.
+    pub test_name: String,
+    /// Local test function or wrapper inherited by `test_name`.
+    pub base_name: String,
 }
 
 /// A statically flattenable callee path invoked in a module (e.g. `execSync`,


### PR DESCRIPTION
## Summary
- Add a typed Playwright fixture-alias semantic fact next to the legacy alias sentinel.
- Move alias expansion to typed facts first, with legacy sentinel fallback during migration.
- Bump the parse cache version and extend extractor, cache, and core tests for alias propagation.

## Verification
- cargo test -p fallow-extract playwright_merge_tests_records_fixture_aliases
- cargo test -p fallow-core typed_playwright_fixture_alias_fact_expands_fixture_targets
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
