### PR TITLE
refactor: add typed playwright fixture type facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -975,6 +975,41 @@ struct PlaywrightFixtureAliasAccess<'a> {
     base_local: &'a str,
 }
 
+struct PlaywrightFixtureTypeAccess<'a> {
+    alias_local: &'a str,
+    fixture: &'a str,
+    type_local: &'a str,
+}
+
+fn playwright_fixture_type_accesses(
+    module: &ResolvedModule,
+) -> Vec<PlaywrightFixtureTypeAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::PlaywrightFixtureType(access) = fact {
+            accesses.push(PlaywrightFixtureTypeAccess {
+                alias_local: access.alias_name.as_str(),
+                fixture: access.fixture_name.as_str(),
+                type_local: access.type_name.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some((alias_name, fixture_name)) = parse_playwright_fixture_sentinel(
+            access.object.as_str(),
+            PLAYWRIGHT_FIXTURE_TYPE_SENTINEL,
+        ) else {
+            continue;
+        };
+        accesses.push(PlaywrightFixtureTypeAccess {
+            alias_local: alias_name,
+            fixture: fixture_name,
+            type_local: access.member.as_str(),
+        });
+    }
+    accesses
+}
+
 fn playwright_fixture_alias_accesses(
     module: &ResolvedModule,
 ) -> Vec<PlaywrightFixtureAliasAccess<'_>> {
@@ -1305,23 +1340,17 @@ fn build_playwright_fixture_type_targets(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in &resolved.member_accesses {
-            let Some((alias_name, fixture_name)) = parse_playwright_fixture_sentinel(
-                access.object.as_str(),
-                PLAYWRIGHT_FIXTURE_TYPE_SENTINEL,
-            ) else {
+        for access in playwright_fixture_type_accesses(resolved) {
+            let Some(alias_keys) = local_to_export_keys.get(access.alias_local) else {
                 continue;
             };
-            let Some(alias_keys) = local_to_export_keys.get(alias_name) else {
-                continue;
-            };
-            let Some(target_keys) = local_to_export_keys.get(access.member.as_str()) else {
+            let Some(target_keys) = local_to_export_keys.get(access.type_local) else {
                 continue;
             };
 
             for alias_key in alias_keys {
                 let alias_targets = targets_by_alias.entry(alias_key.clone()).or_default();
-                let fixture_targets = alias_targets.entry(fixture_name.to_string()).or_default();
+                let fixture_targets = alias_targets.entry(access.fixture.to_string()).or_default();
                 for target_key in target_keys {
                     for key in export_key_with_origins(graph, target_key) {
                         push_export_key(fixture_targets, key);
@@ -2744,7 +2773,8 @@ mod tests {
     use fallow_types::extract::{
         ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
         FluentChainNewMemberAccessFact, PlaywrightFixtureAliasFact,
-        PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact, SemanticFact,
+        PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
+        SemanticFact,
     };
     use oxc_span::Span;
     use std::path::PathBuf;
@@ -3009,6 +3039,77 @@ mod tests {
         let credited = accessed_members
             .get(&ExportKey::new(FileId(3), "AdminPage"))
             .expect("aliased fixture target class should be credited");
+        assert!(credited.contains("assertGreeting"));
+    }
+
+    #[test]
+    fn typed_playwright_fixture_type_fact_expands_nested_fixture_targets() {
+        let mut graph = build_graph(&[
+            ("/src/spec.ts", true),
+            ("/src/fixtures.ts", false),
+            ("/src/pages.ts", false),
+            ("/src/admin-page.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members("test", vec![], Some(0))];
+        graph.modules[2].set_reachable(true);
+        graph.modules[2].exports = vec![make_export_with_members("Pages", vec![], Some(0))];
+        graph.modules[3].set_reachable(true);
+        graph.modules[3].exports = vec![make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(2),
+        )];
+
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: PathBuf::from("/src/spec.ts"),
+                resolved_imports: vec![
+                    make_resolved_import("./fixtures", "test", "test", 1),
+                    make_resolved_import("./pages", "Pages", "Pages", 2),
+                ],
+                semantic_facts: vec![
+                    SemanticFact::PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact {
+                        test_name: "test".to_string(),
+                        fixture_name: "pages".to_string(),
+                        type_name: "Pages".to_string(),
+                    }),
+                    SemanticFact::PlaywrightFixtureUse(PlaywrightFixtureUseFact {
+                        test_name: "test".to_string(),
+                        fixture_name: "pages.adminPage".to_string(),
+                        member: "assertGreeting".to_string(),
+                    }),
+                ],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: PathBuf::from("/src/pages.ts"),
+                resolved_imports: vec![make_resolved_import(
+                    "./admin-page",
+                    "AdminPage",
+                    "AdminPage",
+                    3,
+                )],
+                exports: vec![make_export_info("Pages", None)],
+                semantic_facts: vec![SemanticFact::PlaywrightFixtureType(
+                    PlaywrightFixtureTypeFact {
+                        alias_name: "Pages".to_string(),
+                        fixture_name: "adminPage".to_string(),
+                        type_name: "AdminPage".to_string(),
+                    },
+                )],
+                ..Default::default()
+            },
+        ];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_playwright_fixture_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(3), "AdminPage"))
+            .expect("nested fixture target class should be credited");
         assert!(credited.contains("assertGreeting"));
     }
 

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1014,6 +1014,11 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 test_name: "mergedTest".to_string(),
                 base_name: "test".to_string(),
             }),
+            SemanticFact::PlaywrightFixtureType(PlaywrightFixtureTypeFact {
+                alias_name: "Pages".to_string(),
+                fixture_name: "adminPage".to_string(),
+                type_name: "AdminPage".to_string(),
+            }),
         ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
@@ -1129,6 +1134,11 @@ fn module_to_cached_roundtrip_dynamic_imports() {
             SemanticFact::PlaywrightFixtureAlias(PlaywrightFixtureAliasFact {
                 test_name: "mergedTest".to_string(),
                 base_name: "test".to_string(),
+            }),
+            SemanticFact::PlaywrightFixtureType(PlaywrightFixtureTypeFact {
+                alias_name: "Pages".to_string(),
+                fixture_name: "adminPage".to_string(),
+                type_name: "AdminPage".to_string(),
             }),
         ]
     );

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -605,7 +605,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 194: `SemanticFact` now includes typed Playwright fixture alias
 /// facts alongside the legacy fixture-alias sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 194;
+///
+/// Bumped to 195: `SemanticFact` now includes typed Playwright fixture type
+/// facts alongside the legacy fixture-type sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 195;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -56,8 +56,9 @@ pub use fallow_types::extract::{
     ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
     MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureAliasFact,
-    PlaywrightFixtureDefinitionFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
-    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
+    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
+    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -16,7 +16,8 @@ use crate::{
     ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
     FluentChainNewMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
     ModuleInfo, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo,
+    SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -596,6 +597,22 @@ impl ModuleInfoExtractor {
                 PlaywrightFixtureAliasFact {
                     test_name,
                     base_name,
+                },
+            ));
+    }
+
+    pub(crate) fn record_playwright_fixture_type_fact(
+        &mut self,
+        alias_name: String,
+        fixture_name: String,
+        type_name: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::PlaywrightFixtureType(
+                PlaywrightFixtureTypeFact {
+                    alias_name,
+                    fixture_name,
+                    type_name,
                 },
             ));
     }

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -3000,6 +3000,19 @@ fn playwright_fixture_type_alias_records_nested_type_bindings() {
         "Playwright fixture type alias should record nested type bindings, found: {:?}",
         info.member_accesses
     );
+    assert!(
+        info.semantic_facts.iter().any(|fact| {
+            matches!(
+                fact,
+                SemanticFact::PlaywrightFixtureType(access)
+                    if access.alias_name == "AppFixture"
+                        && access.fixture_name == "assert.messageChecks"
+                        && access.type_name == "MessageChecks"
+            )
+        }),
+        "Playwright fixture type alias should emit a typed fixture type fact, found: {:?}",
+        info.semantic_facts
+    );
 }
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2373,20 +2373,22 @@ impl ModuleInfoExtractor {
         if !bindings.is_empty() {
             self.playwright_fixture_types
                 .insert(alias.id.name.to_string(), bindings.clone());
-            self.member_accesses
-                .extend(
-                    bindings
-                        .into_iter()
-                        .map(|(fixture_name, type_name)| MemberAccess {
-                            object: format!(
-                                "{}{}:{}",
-                                crate::PLAYWRIGHT_FIXTURE_TYPE_SENTINEL,
-                                alias.id.name,
-                                fixture_name
-                            ),
-                            member: type_name,
-                        }),
+            for (fixture_name, type_name) in bindings {
+                self.record_playwright_fixture_type_fact(
+                    alias.id.name.to_string(),
+                    fixture_name.clone(),
+                    type_name.clone(),
                 );
+                self.member_accesses.push(MemberAccess {
+                    object: format!(
+                        "{}{}:{}",
+                        crate::PLAYWRIGHT_FIXTURE_TYPE_SENTINEL,
+                        alias.id.name,
+                        fixture_name
+                    ),
+                    member: type_name,
+                });
+            }
         }
     }
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1364,6 +1364,8 @@ pub enum SemanticFact {
     PlaywrightFixtureDefinition(PlaywrightFixtureDefinitionFact),
     /// A Playwright fixture wrapper alias declared by `mergeTests` or `.extend`.
     PlaywrightFixtureAlias(PlaywrightFixtureAliasFact),
+    /// A nested Playwright fixture binding declared by a fixture type alias.
+    PlaywrightFixtureType(PlaywrightFixtureTypeFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1444,6 +1446,18 @@ pub struct PlaywrightFixtureAliasFact {
     pub test_name: String,
     /// Local test function or wrapper inherited by `test_name`.
     pub base_name: String,
+}
+
+/// A nested Playwright fixture binding declared by a fixture type alias.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PlaywrightFixtureTypeFact {
+    /// Local type alias containing the nested fixture binding.
+    pub alias_name: String,
+    /// Fixture name or dotted fixture path declared inside the type alias.
+    pub fixture_name: String,
+    /// Local type symbol used as the nested fixture target.
+    pub type_name: String,
 }
 
 /// A statically flattenable callee path invoked in a module (e.g. `execSync`,


### PR DESCRIPTION
## Summary
- Add a typed Playwright fixture type-alias semantic fact next to the legacy fixture-type sentinel.
- Move nested fixture type target collection to typed facts first, with legacy sentinel fallback during migration.
- Bump the parse cache version and extend extractor, cache, and core tests for nested fixture propagation.

## Verification
- cargo test -p fallow-extract playwright_fixture_type_alias_records_nested_type_bindings
- cargo test -p fallow-core typed_playwright_fixture_type_fact_expands_nested_fixture_targets
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
