### PR TITLE
refactor: add typed instance export facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -1406,16 +1406,12 @@ fn build_instance_export_targets(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in &resolved.member_accesses {
-            let Some(instance_export_name) = access.object.strip_prefix(INSTANCE_EXPORT_SENTINEL)
-            else {
-                continue;
-            };
-            let Some(target_keys) = local_to_export_keys.get(access.member.as_str()) else {
+        for access in instance_export_binding_accesses(resolved) {
+            let Some(target_keys) = local_to_export_keys.get(access.target_local) else {
                 continue;
             };
 
-            let instance_key = ExportKey::new(resolved.file_id, instance_export_name);
+            let instance_key = ExportKey::new(resolved.file_id, access.export_name);
             let instance_targets = targets_by_instance.entry(instance_key).or_default();
             for target_key in target_keys {
                 for key in export_key_with_origins(graph, target_key) {
@@ -1426,6 +1422,35 @@ fn build_instance_export_targets(
     }
 
     targets_by_instance
+}
+
+struct InstanceExportBindingAccess<'a> {
+    export_name: &'a str,
+    target_local: &'a str,
+}
+
+fn instance_export_binding_accesses(
+    module: &ResolvedModule,
+) -> Vec<InstanceExportBindingAccess<'_>> {
+    let mut accesses = Vec::new();
+    for fact in &module.semantic_facts {
+        if let SemanticFact::InstanceExportBinding(access) = fact {
+            accesses.push(InstanceExportBindingAccess {
+                export_name: access.export_name.as_str(),
+                target_local: access.target_name.as_str(),
+            });
+        }
+    }
+    for access in &module.member_accesses {
+        let Some(export_name) = access.object.strip_prefix(INSTANCE_EXPORT_SENTINEL) else {
+            continue;
+        };
+        accesses.push(InstanceExportBindingAccess {
+            export_name,
+            target_local: access.member.as_str(),
+        });
+    }
+    accesses
 }
 
 fn propagate_accesses_through_instance_exports(
@@ -2772,7 +2797,7 @@ mod tests {
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
     use fallow_types::extract::{
         ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-        FluentChainNewMemberAccessFact, PlaywrightFixtureAliasFact,
+        FluentChainNewMemberAccessFact, InstanceExportBindingFact, PlaywrightFixtureAliasFact,
         PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
         SemanticFact,
     };
@@ -3111,6 +3136,35 @@ mod tests {
             .get(&ExportKey::new(FileId(3), "AdminPage"))
             .expect("nested fixture target class should be credited");
         assert!(credited.contains("assertGreeting"));
+    }
+
+    #[test]
+    fn typed_instance_export_binding_fact_builds_target_map() {
+        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/service.ts", false)]);
+        graph.modules[0].exports = vec![make_export_with_members("service", vec![], Some(0))];
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members("Service", vec![], Some(0))];
+
+        let resolved_modules = vec![ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/src/entry.ts"),
+            resolved_imports: vec![make_resolved_import("./service", "Service", "Service", 1)],
+            exports: vec![make_export_info("service", None)],
+            semantic_facts: vec![SemanticFact::InstanceExportBinding(
+                InstanceExportBindingFact {
+                    export_name: "service".to_string(),
+                    target_name: "Service".to_string(),
+                },
+            )],
+            ..Default::default()
+        }];
+
+        let instance_targets = build_instance_export_targets(&graph, &resolved_modules);
+
+        assert_eq!(
+            instance_targets.get(&ExportKey::new(FileId(0), "service")),
+            Some(&vec![ExportKey::new(FileId(1), "Service")])
+        );
     }
 
     #[test]

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1019,6 +1019,10 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 fixture_name: "adminPage".to_string(),
                 type_name: "AdminPage".to_string(),
             }),
+            SemanticFact::InstanceExportBinding(InstanceExportBindingFact {
+                export_name: "service".to_string(),
+                target_name: "Service".to_string(),
+            }),
         ],
         whole_object_uses: vec![],
         dynamic_import_patterns: vec![],
@@ -1139,6 +1143,10 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 alias_name: "Pages".to_string(),
                 fixture_name: "adminPage".to_string(),
                 type_name: "AdminPage".to_string(),
+            }),
+            SemanticFact::InstanceExportBinding(InstanceExportBindingFact {
+                export_name: "service".to_string(),
+                target_name: "Service".to_string(),
             }),
         ]
     );

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -608,7 +608,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 195: `SemanticFact` now includes typed Playwright fixture type
 /// facts alongside the legacy fixture-type sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 195;
+///
+/// Bumped to 196: `SemanticFact` now includes typed instance export binding
+/// facts alongside the legacy instance-export sentinel entries.
+pub(super) const CACHE_VERSION: u32 = 196;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -54,11 +54,11 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
     ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, LocalTypeDeclaration, MemberAccess,
-    MemberInfo, MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureAliasFact,
-    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
-    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
-    compute_line_offsets,
+    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
+    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
+    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+    PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
+    SemanticFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -14,10 +14,10 @@ use crate::suppress::ParsedSuppressions;
 use crate::{
     AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
     ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo,
-    SemanticFact, VisibilityTag,
+    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
+    MemberAccess, MemberInfo, MemberKind, ModuleInfo, PlaywrightFixtureAliasFact,
+    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
+    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -506,6 +506,16 @@ impl ModuleInfoExtractor {
             ));
     }
 
+    fn record_instance_export_binding_fact(&mut self, export_name: String, target_name: String) {
+        self.semantic_facts
+            .push(SemanticFact::InstanceExportBinding(
+                InstanceExportBindingFact {
+                    export_name,
+                    target_name,
+                },
+            ));
+    }
+
     fn record_factory_call_member_fact(
         &mut self,
         callee_object: String,
@@ -922,20 +932,20 @@ impl ModuleInfoExtractor {
             return;
         }
 
-        let additional_accesses: Vec<MemberAccess> = self
-            .exports
-            .iter()
-            .filter_map(|export| {
-                let local_name = export.local_name.as_deref()?;
-                let target_name = self.binding_target_names.get(local_name)?;
-                Some(MemberAccess {
-                    object: format!("{}{}", crate::INSTANCE_EXPORT_SENTINEL, export.name),
-                    member: target_name.clone(),
-                })
-            })
-            .collect();
-
-        self.member_accesses.extend(additional_accesses);
+        for export in self.exports.clone() {
+            let Some(local_name) = export.local_name.as_deref() else {
+                continue;
+            };
+            let Some(target_name) = self.binding_target_names.get(local_name).cloned() else {
+                continue;
+            };
+            let export_name = export.name.to_string();
+            self.record_instance_export_binding_fact(export_name.clone(), target_name.clone());
+            self.member_accesses.push(MemberAccess {
+                object: format!("{}{}", crate::INSTANCE_EXPORT_SENTINEL, export_name),
+                member: target_name,
+            });
+        }
     }
 
     fn map_local_signature_refs_to_exports(&mut self) {

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2064,6 +2064,17 @@ fn exported_instance_binding_is_recorded() {
         "exported instance binding should be recorded, found: {:?}",
         info.member_accesses
     );
+    assert!(
+        info.semantic_facts.iter().any(|fact| {
+            matches!(
+                fact,
+                SemanticFact::InstanceExportBinding(access)
+                    if access.export_name == "box" && access.target_name == "Box"
+            )
+        }),
+        "exported instance binding should emit a typed fact, found: {:?}",
+        info.semantic_facts
+    );
 }
 
 #[test]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1366,6 +1366,8 @@ pub enum SemanticFact {
     PlaywrightFixtureAlias(PlaywrightFixtureAliasFact),
     /// A nested Playwright fixture binding declared by a fixture type alias.
     PlaywrightFixtureType(PlaywrightFixtureTypeFact),
+    /// An exported value whose runtime instance targets a local class or interface.
+    InstanceExportBinding(InstanceExportBindingFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1458,6 +1460,16 @@ pub struct PlaywrightFixtureTypeFact {
     pub fixture_name: String,
     /// Local type symbol used as the nested fixture target.
     pub type_name: String,
+}
+
+/// An exported value whose runtime instance targets a local class or interface.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct InstanceExportBindingFact {
+    /// Exported binding name.
+    pub export_name: String,
+    /// Local class or interface symbol used as the instance target.
+    pub target_name: String,
 }
 
 /// A statically flattenable callee path invoked in a module (e.g. `execSync`,


### PR DESCRIPTION
## Summary
- Add a typed instance export binding semantic fact next to the legacy instance-export sentinel.
- Move instance export target collection to typed facts first, with legacy sentinel fallback during migration.
- Bump the parse cache version and extend extractor, cache, and core tests for the new fact.

## Verification
- cargo test -p fallow-extract exported_instance_binding_is_recorded
- cargo test -p fallow-core typed_instance_export_binding_fact_builds_target_map
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
