### PR TITLE
refactor: stop writing factory call sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -611,7 +611,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 196: `SemanticFact` now includes typed instance export binding
 /// facts alongside the legacy instance-export sentinel entries.
-pub(super) const CACHE_VERSION: u32 = 196;
+///
+/// Bumped to 197: factory-call member accesses are now persisted only as typed
+/// semantic facts, while legacy sentinels remain decode-only for older caches.
+pub(super) const CACHE_VERSION: u32 = 197;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/classes.rs
+++ b/crates/extract/src/tests/js_ts/classes.rs
@@ -1174,22 +1174,19 @@ fn instance_method_with_new_this_return_not_flagged() {
 }
 
 #[test]
-fn static_factory_binding_emits_sentinel_member_access() {
+fn static_factory_binding_emits_typed_member_fact() {
     let info = parse_source(
         r"import { MyClass } from './my-class';
         const myInstance = MyClass.getInstance();
         myInstance.getData();",
     );
-    let sentinel_access = info
-        .member_accesses
-        .iter()
-        .find(|a| a.object.starts_with(crate::FACTORY_CALL_SENTINEL))
-        .expect("sentinel-prefixed access should be emitted for the factory call result");
-    assert_eq!(sentinel_access.member, "getData");
     assert!(
-        sentinel_access.object.ends_with("MyClass:getInstance"),
-        "sentinel should encode the call shape, got: {}",
-        sentinel_access.object
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object.starts_with(crate::FACTORY_CALL_SENTINEL)),
+        "factory call result should not emit a legacy sentinel access: {:?}",
+        info.member_accesses
     );
     let fact = info
         .semantic_facts

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -1129,6 +1129,7 @@ impl ModuleInfoExtractor {
                     callee_method.to_string(),
                     access.member.clone(),
                 ));
+                continue;
             }
             additional_accesses.push(MemberAccess {
                 object,
@@ -1139,6 +1140,7 @@ impl ModuleInfoExtractor {
             .whole_object_uses
             .iter()
             .filter_map(|name| self.resolve_bound_object_name(name))
+            .filter(|target| !target.starts_with(crate::FACTORY_CALL_SENTINEL))
             .collect();
         self.member_accesses.extend(additional_accesses);
         for (callee_object, callee_method, member) in additional_facts {


### PR DESCRIPTION
## Summary
- Stop emitting legacy factory-call member-access sentinels from extraction.
- Keep core fallback decoding for older cached module data during migration.
- Bump the parse cache version and update the extractor test to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract static_factory_binding_emits_typed_member_fact
- cargo test -p fallow-core typed_factory_call_fact_credits_class_member
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
