### PR TITLE
refactor: stop writing fluent chain sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -614,7 +614,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 197: factory-call member accesses are now persisted only as typed
 /// semantic facts, while legacy sentinels remain decode-only for older caches.
-pub(super) const CACHE_VERSION: u32 = 197;
+///
+/// Bumped to 198: fluent-chain member accesses are now persisted only as typed
+/// semantic facts, while legacy sentinels remain decode-only for older caches.
+pub(super) const CACHE_VERSION: u32 = 198;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -4949,7 +4949,7 @@ fn dotted_bound_receiver_preserves_suffix() {
 }
 
 #[test]
-fn fluent_chain_emits_sentinel_member_access() {
+fn fluent_chain_emits_typed_member_facts() {
     let info = parse(
         r#"
         import { EventBuilder } from './event-builder';
@@ -4958,30 +4958,11 @@ fn fluent_chain_emits_sentinel_member_access() {
     );
 
     assert!(
-        info.member_accesses.iter().any(|a| a.object
-            == format!("{}EventBuilder:create:", crate::FLUENT_CHAIN_SENTINEL)
-            && a.member == "setProcessId"),
-        "first chained call should emit sentinel with empty chain prefix, found: {:?}",
-        info.member_accesses,
-    );
-    assert!(
-        info.member_accesses.iter().any(|a| a.object
-            == format!(
-                "{}EventBuilder:create:setProcessId",
-                crate::FLUENT_CHAIN_SENTINEL
-            )
-            && a.member == "setSubject"),
-        "second chained call should encode intermediate method in chain prefix, found: {:?}",
-        info.member_accesses,
-    );
-    assert!(
-        info.member_accesses.iter().any(|a| a.object
-            == format!(
-                "{}EventBuilder:create:setProcessId,setSubject",
-                crate::FLUENT_CHAIN_SENTINEL
-            )
-            && a.member == "build"),
-        "terminal call should encode the full prior chain, found: {:?}",
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object.starts_with(crate::FLUENT_CHAIN_SENTINEL)),
+        "fluent chain should not emit legacy sentinel accesses, found: {:?}",
         info.member_accesses,
     );
     let fluent_facts: Vec<_> = info

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -855,7 +855,7 @@ impl ModuleInfoExtractor {
         }
     }
 
-    /// Emit a fluent-chain sentinel `MemberAccess` for chained calls.
+    /// Emit typed fluent-chain facts for chained calls.
     fn try_record_fluent_chain_access(&mut self, expr: &CallExpression<'_>) {
         let Expression::StaticMemberExpression(member) = &expr.callee else {
             return;
@@ -875,23 +875,12 @@ impl ModuleInfoExtractor {
             };
             if let Expression::Identifier(root_id) = &inner_member.object {
                 chain_prefix_reversed.reverse();
-                let chain_prefix = chain_prefix_reversed.join(",");
                 self.record_fluent_chain_member_fact(
                     root_id.name.to_string(),
                     inner_member.property.name.to_string(),
                     chain_prefix_reversed,
                     this_method.to_string(),
                 );
-                self.member_accesses.push(MemberAccess {
-                    object: format!(
-                        "{}{}:{}:{}",
-                        crate::FLUENT_CHAIN_SENTINEL,
-                        root_id.name,
-                        inner_member.property.name,
-                        chain_prefix,
-                    ),
-                    member: this_method.to_string(),
-                });
                 return;
             }
             if let Expression::NewExpression(new_expr) = &inner_member.object


### PR DESCRIPTION
## Summary
- Stop emitting legacy fluent-chain member-access sentinels from extraction.
- Keep core fallback decoding for older cached module data during migration.
- Bump the parse cache version and update the extractor test to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract fluent_chain_emits_typed_member_facts
- cargo test -p fallow-core typed_fluent_chain_fact_credits_class_member
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
