### PR TITLE
refactor: stop writing fluent chain new sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -617,7 +617,11 @@ use crate::MemberKind;
 ///
 /// Bumped to 198: fluent-chain member accesses are now persisted only as typed
 /// semantic facts, while legacy sentinels remain decode-only for older caches.
-pub(super) const CACHE_VERSION: u32 = 198;
+///
+/// Bumped to 199: constructor-rooted fluent-chain member accesses are now
+/// persisted only as typed semantic facts, while legacy sentinels remain
+/// decode-only for older caches.
+pub(super) const CACHE_VERSION: u32 = 199;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -5017,7 +5017,7 @@ fn new_expression_direct_member_access_recorded() {
 }
 
 #[test]
-fn new_expression_fluent_chain_emits_new_sentinel() {
+fn new_expression_fluent_chain_emits_typed_member_facts() {
     let info = parse(
         r"
         import { OptionBuilder } from './option-builder';
@@ -5033,23 +5033,11 @@ fn new_expression_fluent_chain_emits_new_sentinel() {
         info.member_accesses,
     );
     assert!(
-        info.member_accesses.iter().any(|a| a.object
-            == format!(
-                "{}OptionBuilder:addDefault",
-                crate::FLUENT_CHAIN_NEW_SENTINEL
-            )
-            && a.member == "addFromCli"),
-        "second chained call should encode the first method in the chain prefix, found: {:?}",
-        info.member_accesses,
-    );
-    assert!(
-        info.member_accesses.iter().any(|a| a.object
-            == format!(
-                "{}OptionBuilder:addDefault,addFromCli",
-                crate::FLUENT_CHAIN_NEW_SENTINEL
-            )
-            && a.member == "build"),
-        "terminal call should encode the full prior chain, found: {:?}",
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object.starts_with(crate::FLUENT_CHAIN_NEW_SENTINEL)),
+        "new-expression fluent chain should not emit legacy sentinel accesses, found: {:?}",
         info.member_accesses,
     );
     let fluent_new_facts: Vec<_> = info

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -888,21 +888,11 @@ impl ModuleInfoExtractor {
             {
                 chain_prefix_reversed.push(inner_member.property.name.to_string());
                 chain_prefix_reversed.reverse();
-                let chain_prefix = chain_prefix_reversed.join(",");
                 self.record_fluent_chain_new_member_fact(
                     class_id.name.to_string(),
                     chain_prefix_reversed,
                     this_method.to_string(),
                 );
-                self.member_accesses.push(MemberAccess {
-                    object: format!(
-                        "{}{}:{}",
-                        crate::FLUENT_CHAIN_NEW_SENTINEL,
-                        class_id.name,
-                        chain_prefix,
-                    ),
-                    member: this_method.to_string(),
-                });
                 return;
             }
             chain_prefix_reversed.push(inner_member.property.name.to_string());


### PR DESCRIPTION
## Summary
- Stop emitting legacy fluent-chain-new member-access sentinels from extraction.
- Keep core fallback decoding for older cached module data during migration.
- Bump the parse cache version and update the extractor test to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract new_expression_fluent_chain_emits_typed_member_facts
- cargo test -p fallow-core typed_fluent_chain_new_fact_credits_class_member
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
