### PR TITLE
refactor: stop writing instance export sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -621,7 +621,10 @@ use crate::MemberKind;
 /// Bumped to 199: constructor-rooted fluent-chain member accesses are now
 /// persisted only as typed semantic facts, while legacy sentinels remain
 /// decode-only for older caches.
-pub(super) const CACHE_VERSION: u32 = 199;
+///
+/// Bumped to 200: instance export bindings are now persisted only as typed
+/// semantic facts, while legacy sentinels remain decode-only for older caches.
+pub(super) const CACHE_VERSION: u32 = 200;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -940,11 +940,7 @@ impl ModuleInfoExtractor {
                 continue;
             };
             let export_name = export.name.to_string();
-            self.record_instance_export_binding_fact(export_name.clone(), target_name.clone());
-            self.member_accesses.push(MemberAccess {
-                object: format!("{}{}", crate::INSTANCE_EXPORT_SENTINEL, export_name),
-                member: target_name,
-            });
+            self.record_instance_export_binding_fact(export_name, target_name);
         }
     }
 

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2058,10 +2058,11 @@ fn exported_instance_binding_is_recorded() {
     );
 
     assert!(
-        info.member_accesses.iter().any(|a| {
-            a.object == format!("{}box", crate::INSTANCE_EXPORT_SENTINEL) && a.member == "Box"
-        }),
-        "exported instance binding should be recorded, found: {:?}",
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object.starts_with(crate::INSTANCE_EXPORT_SENTINEL)),
+        "exported instance binding should not emit legacy sentinel access, found: {:?}",
         info.member_accesses
     );
     assert!(


### PR DESCRIPTION
## Summary
- Stop emitting legacy instance-export member-access sentinels from extraction.
- Keep core fallback decoding for older cached module data during migration.
- Bump the parse cache version and update the extractor test to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract exported_instance_binding_is_recorded
- cargo test -p fallow-core typed_instance_export_binding_fact_builds_target_map
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
