### PR TITLE
refactor: stop writing playwright fixture alias sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -632,7 +632,11 @@ use crate::MemberKind;
 /// Bumped to 202: Playwright fixture-definition member accesses are now
 /// persisted only as typed semantic facts, while legacy sentinels remain
 /// decode-only for older caches.
-pub(super) const CACHE_VERSION: u32 = 202;
+///
+/// Bumped to 203: Playwright fixture-alias member accesses are now persisted
+/// only as typed semantic facts, while legacy sentinels remain decode-only for
+/// older caches.
+pub(super) const CACHE_VERSION: u32 = 203;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -93,6 +93,20 @@ fn has_playwright_fixture_definition_fact(
     })
 }
 
+fn has_playwright_fixture_alias_fact(
+    info: &crate::ModuleInfo,
+    test_name: &str,
+    base_name: &str,
+) -> bool {
+    info.semantic_facts.iter().any(|fact| {
+        matches!(
+            fact,
+            SemanticFact::PlaywrightFixtureAlias(access)
+                if access.test_name == test_name && access.base_name == base_name
+        )
+    })
+}
+
 #[test]
 fn pinia_option_store_harvests_state_getters_actions_keys() {
     let info = parse(
@@ -2607,43 +2621,19 @@ fn playwright_merge_tests_records_fixture_aliases() {
     );
 
     assert!(
-        info.member_accesses.iter().any(|a| {
-            a.object == format!("{}mergedTest:", crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL)
-                && a.member == "testPrimary"
-        }),
-        "Playwright mergeTests should record the first inherited fixture test, found: {:?}",
+        !info.member_accesses.iter().any(|a| a
+            .object
+            .starts_with(crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL)),
+        "Playwright fixture aliases should not emit legacy sentinels, found: {:?}",
         info.member_accesses
     );
     assert!(
-        info.member_accesses.iter().any(|a| {
-            a.object == format!("{}mergedTest:", crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL)
-                && a.member == "testSecondary"
-        }),
-        "Playwright mergeTests should record the second inherited fixture test, found: {:?}",
-        info.member_accesses
-    );
-    let fixture_alias_facts: Vec<_> = info
-        .semantic_facts
-        .iter()
-        .filter_map(|fact| {
-            if let SemanticFact::PlaywrightFixtureAlias(access) = fact {
-                Some(access)
-            } else {
-                None
-            }
-        })
-        .collect();
-    assert!(
-        fixture_alias_facts
-            .iter()
-            .any(|fact| fact.test_name == "mergedTest" && fact.base_name == "testPrimary"),
+        has_playwright_fixture_alias_fact(&info, "mergedTest", "testPrimary"),
         "Playwright mergeTests should emit a typed alias for testPrimary, found: {:?}",
         info.semantic_facts
     );
     assert!(
-        fixture_alias_facts
-            .iter()
-            .any(|fact| fact.test_name == "mergedTest" && fact.base_name == "testSecondary"),
+        has_playwright_fixture_alias_fact(&info, "mergedTest", "testSecondary"),
         "Playwright mergeTests should emit a typed alias for testSecondary, found: {:?}",
         info.semantic_facts
     );
@@ -2661,12 +2651,9 @@ fn playwright_aliased_merge_tests_records_fixture_aliases() {
     );
 
     assert!(
-        info.member_accesses.iter().any(|a| {
-            a.object == format!("{}mergedTest:", crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL)
-                && a.member == "testPrimary"
-        }),
-        "aliased Playwright mergeTests should record an inherited fixture test, found: {:?}",
-        info.member_accesses
+        has_playwright_fixture_alias_fact(&info, "mergedTest", "testPrimary"),
+        "aliased Playwright mergeTests should emit a typed inherited fixture test, found: {:?}",
+        info.semantic_facts
     );
 }
 
@@ -2681,12 +2668,9 @@ fn playwright_wrapper_extend_records_fixture_alias() {
     );
 
     assert!(
-        info.member_accesses.iter().any(|a| {
-            a.object == format!("{}extendedTest:", crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL)
-                && a.member == "testPrimary"
-        }),
-        "chained Playwright wrapper .extend should record an inherited fixture test, found: {:?}",
-        info.member_accesses
+        has_playwright_fixture_alias_fact(&info, "extendedTest", "testPrimary"),
+        "chained Playwright wrapper .extend should emit a typed inherited fixture test, found: {:?}",
+        info.semantic_facts
     );
 }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2402,10 +2402,6 @@ impl ModuleInfoExtractor {
 
     fn record_playwright_fixture_alias(&mut self, test_name: &str, base_name: &str) {
         self.record_playwright_fixture_alias_fact(test_name.to_string(), base_name.to_string());
-        self.member_accesses.push(MemberAccess {
-            object: format!("{}{}:", crate::PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL, test_name),
-            member: base_name.to_string(),
-        });
     }
 
     fn record_playwright_wrapper_aliases(&mut self, test_name: &str, call: &CallExpression<'_>) {


### PR DESCRIPTION
## Summary
- Stop emitting legacy Playwright fixture-alias member-access sentinels from extraction.
- Persist mergeTests and wrapper extend aliases as typed semantic facts only.
- Bump the parse cache version and update alias tests to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract playwright_merge_tests_records_fixture_aliases
- cargo test -p fallow-extract playwright_aliased_merge_tests_records_fixture_aliases
- cargo test -p fallow-extract playwright_wrapper_extend_records_fixture_alias
- cargo test -p fallow-core playwright_fixture
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
