### PR TITLE
refactor: stop writing playwright fixture type sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -636,7 +636,11 @@ use crate::MemberKind;
 /// Bumped to 203: Playwright fixture-alias member accesses are now persisted
 /// only as typed semantic facts, while legacy sentinels remain decode-only for
 /// older caches.
-pub(super) const CACHE_VERSION: u32 = 203;
+///
+/// Bumped to 204: Playwright fixture-type member accesses are now persisted
+/// only as typed semantic facts, while legacy sentinels remain decode-only for
+/// older caches.
+pub(super) const CACHE_VERSION: u32 = 204;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -107,6 +107,23 @@ fn has_playwright_fixture_alias_fact(
     })
 }
 
+fn has_playwright_fixture_type_fact(
+    info: &crate::ModuleInfo,
+    alias_name: &str,
+    fixture_name: &str,
+    type_name: &str,
+) -> bool {
+    info.semantic_facts.iter().any(|fact| {
+        matches!(
+            fact,
+            SemanticFact::PlaywrightFixtureType(access)
+                if access.alias_name == alias_name
+                    && access.fixture_name == fixture_name
+                    && access.type_name == type_name
+        )
+    })
+}
+
 #[test]
 fn pinia_option_store_harvests_state_getters_actions_keys() {
     let info = parse(
@@ -2930,27 +2947,19 @@ fn playwright_fixture_type_alias_records_nested_type_bindings() {
     );
 
     assert!(
-        info.member_accesses.iter().any(|a| {
-            a.object
-                == format!(
-                    "{}AppFixture:assert.messageChecks",
-                    crate::PLAYWRIGHT_FIXTURE_TYPE_SENTINEL
-                )
-                && a.member == "MessageChecks"
-        }),
-        "Playwright fixture type alias should record nested type bindings, found: {:?}",
+        !info.member_accesses.iter().any(|a| a
+            .object
+            .starts_with(crate::PLAYWRIGHT_FIXTURE_TYPE_SENTINEL)),
+        "Playwright fixture type aliases should not emit legacy sentinels, found: {:?}",
         info.member_accesses
     );
     assert!(
-        info.semantic_facts.iter().any(|fact| {
-            matches!(
-                fact,
-                SemanticFact::PlaywrightFixtureType(access)
-                    if access.alias_name == "AppFixture"
-                        && access.fixture_name == "assert.messageChecks"
-                        && access.type_name == "MessageChecks"
-            )
-        }),
+        has_playwright_fixture_type_fact(
+            &info,
+            "AppFixture",
+            "assert.messageChecks",
+            "MessageChecks"
+        ),
         "Playwright fixture type alias should emit a typed fixture type fact, found: {:?}",
         info.semantic_facts
     );

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2356,17 +2356,8 @@ impl ModuleInfoExtractor {
                 self.record_playwright_fixture_type_fact(
                     alias.id.name.to_string(),
                     fixture_name.clone(),
-                    type_name.clone(),
+                    type_name,
                 );
-                self.member_accesses.push(MemberAccess {
-                    object: format!(
-                        "{}{}:{}",
-                        crate::PLAYWRIGHT_FIXTURE_TYPE_SENTINEL,
-                        alias.id.name,
-                        fixture_name
-                    ),
-                    member: type_name,
-                });
             }
         }
     }


### PR DESCRIPTION
## Summary
- Stop emitting legacy Playwright fixture-type member-access sentinels from extraction.
- Persist fixture type-alias bindings as typed semantic facts only.
- Bump the parse cache version and update fixture-type tests to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract playwright_fixture_type_alias_records_nested_type_bindings
- cargo test -p fallow-core playwright_fixture
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
