### PR TITLE
refactor: stop writing angular template sentinels

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -640,7 +640,11 @@ use crate::MemberKind;
 /// Bumped to 204: Playwright fixture-type member accesses are now persisted
 /// only as typed semantic facts, while legacy sentinels remain decode-only for
 /// older caches.
-pub(super) const CACHE_VERSION: u32 = 204;
+///
+/// Bumped to 205: Angular template member accesses are now persisted only as
+/// typed semantic facts, while legacy template sentinels remain decode-only for
+/// older caches.
+pub(super) const CACHE_VERSION: u32 = 205;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/html.rs
+++ b/crates/extract/src/html.rs
@@ -5,8 +5,7 @@
 //! transitive imports) are reachable from the HTML entry point.
 //!
 //! Also scans for Angular template syntax (`{{ }}`, `[prop]`, `(event)`, `@if`, etc.)
-//! and stores referenced identifiers as typed semantic facts, while also emitting
-//! legacy sentinel `MemberAccess` entries during the migration.
+//! and stores referenced identifiers as typed semantic facts.
 
 use std::path::Path;
 use std::sync::LazyLock;
@@ -14,7 +13,7 @@ use std::sync::LazyLock;
 use oxc_span::Span;
 
 use crate::asset_url::normalize_asset_url;
-use crate::sfc_template::angular::{self, ANGULAR_TPL_SENTINEL};
+use crate::sfc_template::angular;
 use crate::{
     AngularTemplateMemberAccessFact, ImportInfo, ImportedName, MemberAccess, ModuleInfo,
     SemanticFact,
@@ -197,14 +196,7 @@ fn collect_html_module_parts(source: &str, need_complexity: bool) -> HtmlModuleP
             SemanticFact::AngularTemplateMemberAccess(AngularTemplateMemberAccessFact { member })
         })
         .collect();
-    let mut member_accesses: Vec<MemberAccess> = identifiers
-        .into_iter()
-        .map(|member| MemberAccess {
-            object: ANGULAR_TPL_SENTINEL.to_string(),
-            member,
-        })
-        .collect();
-    member_accesses.extend(template_member_accesses);
+    let member_accesses = template_member_accesses;
 
     // Angular external template (`templateUrl`): harvest the custom element
     // selector tags rendered here so the Angular `unrendered-component` detector
@@ -778,22 +770,6 @@ mod tests {
              <button (click)=\"onButtonClick()\">Toggle</button>",
             0,
         );
-        let names: rustc_hash::FxHashSet<&str> = info
-            .member_accesses
-            .iter()
-            .filter(|a| a.object == ANGULAR_TPL_SENTINEL)
-            .map(|a| a.member.as_str())
-            .collect();
-        assert!(names.contains("title"), "should contain 'title'");
-        assert!(
-            names.contains("isHighlighted"),
-            "should contain 'isHighlighted'"
-        );
-        assert!(names.contains("greeting"), "should contain 'greeting'");
-        assert!(
-            names.contains("onButtonClick"),
-            "should contain 'onButtonClick'"
-        );
         let fact_names: rustc_hash::FxHashSet<&str> = info
             .semantic_facts
             .iter()
@@ -814,6 +790,13 @@ mod tests {
         assert!(
             fact_names.contains("onButtonClick"),
             "should contain 'onButtonClick'"
+        );
+        assert!(
+            info.member_accesses
+                .iter()
+                .all(|access| access.object != angular::ANGULAR_TPL_SENTINEL),
+            "Angular template refs should not emit legacy sentinels: {:?}",
+            info.member_accesses
         );
     }
 

--- a/crates/extract/src/sfc_template/mod.rs
+++ b/crates/extract/src/sfc_template/mod.rs
@@ -17,9 +17,9 @@
 //!   external `.html` siblings (`templateUrl`). The scanner is invoked
 //!   directly from `crate::visitor::visit_impl::visit_class` for inline
 //!   templates and from `crate::html::parse_html_to_module_with_complexity`
-//!   for external templates. Bare identifier references use an
-//!   `ANGULAR_TPL_SENTINEL` object name so the analysis phase can bridge
-//!   them to the importing component's class members.
+//!   for external templates. Bare identifier references are persisted as typed
+//!   semantic facts so the analysis phase can bridge them to the importing
+//!   component's class members.
 //!
 //! - **Glimmer (`glimmer`)**: Ember `.gts` / `.gjs` single-file components.
 //!   The host file IS valid JS once `<template>...</template>` blocks are

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -59,6 +59,12 @@ fn angular_template_fact_members(info: &crate::ModuleInfo) -> Vec<&str> {
         .collect()
 }
 
+fn has_no_angular_template_sentinel(info: &crate::ModuleInfo) -> bool {
+    info.member_accesses
+        .iter()
+        .all(|access| access.object != crate::sfc_template::angular::ANGULAR_TPL_SENTINEL)
+}
+
 fn has_playwright_fixture_use_fact(
     info: &crate::ModuleInfo,
     test_name: &str,
@@ -5917,7 +5923,7 @@ fn non_component_decorator_ignored() {
 }
 
 #[test]
-fn angular_inline_template_emits_sentinel_member_accesses() {
+fn angular_inline_template_emits_typed_member_facts() {
     let info = parse(
         r#"
         import { Component, signal } from '@angular/core';
@@ -5932,18 +5938,14 @@ fn angular_inline_template_emits_sentinel_member_accesses() {
         }
         "#,
     );
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
-    let sentinel_refs: Vec<&str> = info
-        .member_accesses
-        .iter()
-        .filter(|a| a.object == sentinel)
-        .map(|a| a.member.as_str())
-        .collect();
-    assert!(sentinel_refs.contains(&"message"));
-    assert!(sentinel_refs.contains(&"onClick"));
     let fact_refs = angular_template_fact_members(&info);
     assert!(fact_refs.contains(&"message"));
     assert!(fact_refs.contains(&"onClick"));
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "inline template should not emit legacy sentinels, found: {:?}",
+        info.member_accesses
+    );
 }
 
 #[test]
@@ -5961,12 +5963,13 @@ fn angular_inline_template_backtick_scanned() {
         }
         ",
     );
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
-    let has_title = info
-        .member_accesses
-        .iter()
-        .any(|a| a.object == sentinel && a.member == "title");
-    assert!(has_title);
+    let fact_refs = angular_template_fact_members(&info);
+    assert!(fact_refs.contains(&"title"));
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "backtick template should not emit legacy sentinels, found: {:?}",
+        info.member_accesses
+    );
 }
 
 #[test]
@@ -6056,7 +6059,7 @@ export class A {}\n",
 }
 
 #[test]
-fn angular_host_bindings_emit_sentinel_accesses() {
+fn angular_host_bindings_emit_typed_member_facts() {
     let info = parse(
         r"
         import { Component } from '@angular/core';
@@ -6079,22 +6082,16 @@ fn angular_host_bindings_emit_sentinel_accesses() {
         }
         ",
     );
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
-    let host_refs: Vec<&str> = info
-        .member_accesses
-        .iter()
-        .filter(|a| a.object == sentinel)
-        .map(|a| a.member.as_str())
-        .collect();
-    assert!(host_refs.contains(&"hostClass"));
-    assert!(host_refs.contains(&"isActive"));
-    assert!(host_refs.contains(&"onHostClick"));
-    assert!(host_refs.contains(&"customColor"));
     let fact_refs = angular_template_fact_members(&info);
     assert!(fact_refs.contains(&"hostClass"));
     assert!(fact_refs.contains(&"isActive"));
     assert!(fact_refs.contains(&"onHostClick"));
     assert!(fact_refs.contains(&"customColor"));
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "host bindings should not emit legacy sentinels, found: {:?}",
+        info.member_accesses
+    );
 }
 
 #[test]
@@ -6114,19 +6111,20 @@ fn angular_host_binding_skips_keywords() {
         export class App {}
         ",
     );
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
     assert!(
+        angular_template_fact_members(&info).is_empty(),
+        "keyword-only host bindings should not emit template facts, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "keyword-only host bindings should not emit legacy sentinels, found: {:?}",
         info.member_accesses
-            .iter()
-            .filter(|a| a.object == sentinel)
-            .map(|a| a.member.as_str())
-            .next()
-            .is_none()
     );
 }
 
 #[test]
-fn angular_inputs_outputs_metadata_emit_sentinel_accesses() {
+fn angular_inputs_outputs_metadata_emit_typed_member_facts() {
     let info = parse(
         r"
         import { Component } from '@angular/core';
@@ -6144,20 +6142,19 @@ fn angular_inputs_outputs_metadata_emit_sentinel_accesses() {
         }
         ",
     );
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
-    let refs: Vec<&str> = info
-        .member_accesses
-        .iter()
-        .filter(|a| a.object == sentinel)
-        .map(|a| a.member.as_str())
-        .collect();
+    let refs = angular_template_fact_members(&info);
     assert!(refs.contains(&"bankName"));
     assert!(refs.contains(&"id"));
     assert!(refs.contains(&"clicked"));
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "inputs/outputs metadata should not emit legacy sentinels, found: {:?}",
+        info.member_accesses
+    );
 }
 
 #[test]
-fn angular_queries_metadata_emit_sentinel_accesses() {
+fn angular_queries_metadata_emit_typed_member_facts() {
     let info = parse(
         r"
         import { Component, ViewChild, ContentChild, ElementRef } from '@angular/core';
@@ -6176,15 +6173,14 @@ fn angular_queries_metadata_emit_sentinel_accesses() {
         }
         ",
     );
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
-    let refs: Vec<&str> = info
-        .member_accesses
-        .iter()
-        .filter(|a| a.object == sentinel)
-        .map(|a| a.member.as_str())
-        .collect();
+    let refs = angular_template_fact_members(&info);
     assert!(refs.contains(&"header"));
     assert!(refs.contains(&"footer"));
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "queries metadata should not emit legacy sentinels, found: {:?}",
+        info.member_accesses
+    );
 }
 
 #[test]
@@ -6451,17 +6447,16 @@ fn angular_component_all_metadata_combined() {
         .any(|i| i.source == "./app.html" && matches!(i.imported_name, ImportedName::SideEffect));
     assert!(has_html_import);
 
-    let sentinel = crate::sfc_template::angular::ANGULAR_TPL_SENTINEL;
-    let refs: Vec<&str> = info
-        .member_accesses
-        .iter()
-        .filter(|a| a.object == sentinel)
-        .map(|a| a.member.as_str())
-        .collect();
+    let refs = angular_template_fact_members(&info);
     assert!(refs.contains(&"greeting"));
     assert!(refs.contains(&"handleClick"));
     assert!(refs.contains(&"externalInput"));
     assert!(refs.contains(&"externalOutput"));
+    assert!(
+        has_no_angular_template_sentinel(&info),
+        "external template should not emit legacy sentinels, found: {:?}",
+        info.member_accesses
+    );
 
     let app_export = info
         .exports

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -3700,10 +3700,6 @@ impl<'a> ModuleInfoExtractor {
         let refs = crate::sfc_template::angular::collect_angular_template_refs(template);
         for name in refs.identifiers {
             self.record_angular_template_member_fact(name.clone());
-            self.member_accesses.push(MemberAccess {
-                object: crate::sfc_template::angular::ANGULAR_TPL_SENTINEL.to_string(),
-                member: name,
-            });
         }
         self.member_accesses.extend(refs.member_accesses);
         let template_offset = meta
@@ -3724,21 +3720,13 @@ impl<'a> ModuleInfoExtractor {
     }
 
     /// Record Angular `host:` binding and `inputs:` / `outputs:` member refs as
-    /// template-sentinel member accesses.
+    /// typed template member facts.
     fn record_angular_template_members(&mut self, meta: &super::helpers::AngularComponentMetadata) {
         for name in &meta.host_member_refs {
             self.record_angular_template_member_fact(name.clone());
-            self.member_accesses.push(MemberAccess {
-                object: crate::sfc_template::angular::ANGULAR_TPL_SENTINEL.to_string(),
-                member: name.clone(),
-            });
         }
         for name in &meta.input_output_members {
             self.record_angular_template_member_fact(name.clone());
-            self.member_accesses.push(MemberAccess {
-                object: crate::sfc_template::angular::ANGULAR_TPL_SENTINEL.to_string(),
-                member: name.clone(),
-            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Stop emitting legacy Angular template member-access sentinels from HTML and inline-template extraction.
- Persist Angular template identifiers as typed semantic facts only while keeping real template member chains as normal member accesses.
- Bump the parse cache version and update Angular extraction tests to assert typed facts instead of sentinel output.

## Verification
- cargo test -p fallow-extract angular_inline_template_emits_typed_member_facts
- cargo test -p fallow-extract angular_host_bindings_emit_typed_member_facts
- cargo test -p fallow-extract angular_template_extracts_member_refs
- cargo test -p fallow-extract angular_inputs_outputs_metadata_emit_typed_member_facts
- cargo test -p fallow-extract angular_queries_metadata_emit_typed_member_facts
- cargo test -p fallow-extract angular_component_all_metadata_combined
- cargo test -p fallow-core angular
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
