### PR TITLE
refactor: add typed angular this-spread facts

### DIFF
--- a/crates/core/src/analyze/unused_component_input.rs
+++ b/crates/core/src/analyze/unused_component_input.rs
@@ -196,14 +196,17 @@ fn component_has_extends(module: &ModuleInfo) -> bool {
             .any(|h| h.super_class.is_some())
 }
 
-/// Whether the module spreads `this` into an object literal (`{ ...this }`),
-/// recorded by the extractor as an `ANGULAR_THIS_SPREAD_SENTINEL` member access.
+/// Whether the module spreads `this` into an object literal (`{ ...this }`).
 /// Every input/output is then consumed opaquely, so the whole component abstains.
 pub(super) fn component_spreads_this(module: &ModuleInfo) -> bool {
     module
-        .member_accesses
+        .semantic_facts
         .iter()
-        .any(|a| a.object == ANGULAR_THIS_SPREAD_SENTINEL)
+        .any(|fact| matches!(fact, SemanticFact::AngularThisSpread(_)))
+        || module
+            .member_accesses
+            .iter()
+            .any(|a| a.object == ANGULAR_THIS_SPREAD_SENTINEL)
 }
 
 /// The `.ts` modules reached from `from` by a `SideEffect`-shaped edge that hold
@@ -294,8 +297,8 @@ pub(super) fn is_js_reserved_word(name: &str) -> bool {
 mod tests {
     use fallow_types::discover::FileId;
     use fallow_types::extract::{
-        AngularInputMember, AngularTemplateMemberAccessFact, ClassHeritageInfo, MemberAccess,
-        SemanticFact,
+        AngularInputMember, AngularTemplateMemberAccessFact, AngularThisSpreadFact,
+        ClassHeritageInfo, MemberAccess, SemanticFact,
     };
     use rustc_hash::FxHashSet;
 
@@ -320,6 +323,10 @@ mod tests {
         SemanticFact::AngularTemplateMemberAccess(AngularTemplateMemberAccessFact {
             member: member.to_string(),
         })
+    }
+
+    fn this_spread_fact() -> SemanticFact {
+        SemanticFact::AngularThisSpread(AngularThisSpreadFact)
     }
 
     fn this_access(member: &str) -> MemberAccess {
@@ -430,6 +437,19 @@ mod tests {
         assert!(
             !component_has_extends(&component),
             "a component with no heritage `extends` does not abstain"
+        );
+    }
+
+    #[test]
+    fn typed_this_spread_fact_abstains_component() {
+        let component = ModuleInfo {
+            angular_inputs: vec![input("label", 10)],
+            semantic_facts: vec![this_spread_fact()],
+            ..empty_module()
+        };
+        assert!(
+            component_spreads_this(&component),
+            "a typed Angular this-spread fact abstains the whole component"
         );
     }
 

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -461,11 +461,10 @@ use crate::MemberKind;
 /// Bumped to 171 (feat/angular): Angular input/output IR
 /// (`angular_inputs` / `angular_outputs` on `ModuleInfo`) plus the
 /// `unused-component-input` / `unused-component-output` suppression tokens, and
-/// the Angular `{ ...this }` spread now records an
-/// `ANGULAR_THIS_SPREAD_SENTINEL` member access (whole-component abstain for the
-/// input/output detectors); a warm cache from 170 lacks the Angular IR and the
-/// sentinel and would report zero input/output findings or false-flag
-/// spread-forwarded inputs/outputs.
+/// the Angular `{ ...this }` spread now records a whole-component abstain marker
+/// for the input/output detectors; a warm cache from 170 lacks the Angular IR
+/// and the abstain marker and would report zero input/output findings or
+/// false-flag spread-forwarded inputs/outputs.
 ///
 /// Bumped to 172 (feat/vue-options-api-prop-emit): the Vue Options API
 /// (`export default { props, emits, ... }` / `defineComponent({ ... })`) in a
@@ -644,7 +643,11 @@ use crate::MemberKind;
 /// Bumped to 205: Angular template member accesses are now persisted only as
 /// typed semantic facts, while legacy template sentinels remain decode-only for
 /// older caches.
-pub(super) const CACHE_VERSION: u32 = 205;
+///
+/// Bumped to 206: Angular `{ ...this }` spread abstains are now persisted as
+/// typed semantic facts, while the legacy spread sentinel remains decode-only
+/// for older caches.
+pub(super) const CACHE_VERSION: u32 = 206;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -52,13 +52,13 @@ use cache::CacheStore;
 use fallow_types::discover::{DiscoveredFile, FileId};
 
 pub use fallow_types::extract::{
-    AngularTemplateMemberAccessFact, ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern,
-    ExportInfo, ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
-    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
-    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
-    PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
-    SemanticFact, VisibilityTag, compute_line_offsets,
+    AngularTemplateMemberAccessFact, AngularThisSpreadFact, ClassHeritageInfo, DynamicImportInfo,
+    DynamicImportPattern, ExportInfo, ExportName, FactoryCallMemberAccessFact,
+    FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
+    InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind,
+    ModuleInfo, ParseResult, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
+    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
+    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -12,12 +12,12 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::suppress::ParsedSuppressions;
 use crate::{
-    AngularTemplateMemberAccessFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
-    ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
-    MemberAccess, MemberInfo, MemberKind, ModuleInfo, PlaywrightFixtureAliasFact,
-    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
-    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    AngularTemplateMemberAccessFact, AngularThisSpreadFact, DynamicImportInfo,
+    DynamicImportPattern, ExportInfo, ExportName, FactoryCallMemberAccessFact,
+    FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
+    InstanceExportBindingFact, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
+    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+    PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -504,6 +504,11 @@ impl ModuleInfoExtractor {
             .push(SemanticFact::AngularTemplateMemberAccess(
                 AngularTemplateMemberAccessFact { member },
             ));
+    }
+
+    pub(crate) fn record_angular_this_spread_fact(&mut self) {
+        self.semantic_facts
+            .push(SemanticFact::AngularThisSpread(AngularThisSpreadFact));
     }
 
     fn record_instance_export_binding_fact(&mut self, export_name: String, target_name: String) {

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -6184,6 +6184,33 @@ fn angular_queries_metadata_emit_typed_member_facts() {
 }
 
 #[test]
+fn angular_this_spread_emits_typed_abstain_fact() {
+    let info = parse(
+        r"
+        export class App {
+            createBehavior() {
+                return { ...this, role: 'button' };
+            }
+        }
+        ",
+    );
+    assert!(
+        info.semantic_facts
+            .iter()
+            .any(|fact| matches!(fact, SemanticFact::AngularThisSpread(_))),
+        "spread-this should emit a typed Angular abstain fact, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        !info.member_accesses.iter().any(|access| {
+            access.object == crate::sfc_template::angular::ANGULAR_THIS_SPREAD_SENTINEL
+        }),
+        "spread-this should not emit a legacy sentinel, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
 fn angular_signal_input_marks_member_as_decorated() {
     let info = parse(
         r"

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -4420,14 +4420,9 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             }
             // `{ ...this }` forwards every member opaquely (the Angular "headless
             // pattern" convention spreads `this` into a behavior pattern). Record
-            // a sentinel member access so the Angular input/output detectors
-            // abstain the whole component instead of false-flagging spread inputs.
-            Expression::ThisExpression(_) => {
-                self.member_accesses.push(MemberAccess {
-                    object: crate::sfc_template::angular::ANGULAR_THIS_SPREAD_SENTINEL.to_string(),
-                    member: String::new(),
-                });
-            }
+            // a typed fact so the Angular input/output detectors abstain the
+            // whole component instead of false-flagging spread inputs.
+            Expression::ThisExpression(_) => self.record_angular_this_spread_fact(),
             _ => {}
         }
         walk::walk_spread_element(self, elem);

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1352,6 +1352,9 @@ pub enum SemanticFact {
     /// A class member referenced from an Angular template, host binding, or
     /// component metadata entry.
     AngularTemplateMemberAccess(AngularTemplateMemberAccessFact),
+    /// An Angular component spreads `this` into an object literal, so component
+    /// input/output usage is opaque.
+    AngularThisSpread(AngularThisSpreadFact),
     /// A member access on a value returned by an imported static factory call.
     FactoryCallMemberAccess(FactoryCallMemberAccessFact),
     /// A member access on a fluent chain rooted at an imported static factory.
@@ -1377,6 +1380,11 @@ pub struct AngularTemplateMemberAccessFact {
     /// Referenced class member name.
     pub member: String,
 }
+
+/// Opaque Angular `{ ...this }` forwarding marker.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AngularThisSpreadFact;
 
 /// A member access on a static factory call result.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]


### PR DESCRIPTION
## Summary
- Add a typed Angular this-spread semantic fact for `{ ...this }` component abstains.
- Stop emitting the legacy Angular this-spread member-access sentinel from extraction.
- Keep core fallback decoding for older cached module data and bump the parse cache version.

## Verification
- cargo test -p fallow-extract angular_this_spread_emits_typed_abstain_fact
- cargo test -p fallow-core typed_this_spread_fact_abstains_component
- cargo test -p fallow-core unused_component_io_angular
- cargo test -p fallow-extract module_to_cached_roundtrip_dynamic_imports
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
