### PR TITLE
refactor: type playwright fixture use helper

### DIFF
--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -4135,20 +4135,11 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.react_record_hook_call(expr);
 
         if let Some(test_name) = playwright_test_callee_name(&expr.callee) {
-            let fixture_uses =
-                collect_playwright_fixture_member_uses(test_name.as_str(), &expr.arguments);
+            let fixture_uses = collect_playwright_fixture_member_uses(&expr.arguments);
             for access in &fixture_uses {
-                let Some(fixture_name) = access
-                    .object
-                    .strip_prefix(crate::PLAYWRIGHT_FIXTURE_USE_SENTINEL)
-                    .and_then(|payload| payload.strip_prefix(test_name.as_str()))
-                    .and_then(|payload| payload.strip_prefix(':'))
-                else {
-                    continue;
-                };
                 self.record_playwright_fixture_use_fact(
                     test_name.clone(),
-                    fixture_name.to_string(),
+                    access.fixture_name.clone(),
                     access.member.clone(),
                 );
             }

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -915,10 +915,14 @@ pub(super) fn extract_arrow_return_call<'a, 'b>(
     extract_function_body_final_return_call(&arrow.body)
 }
 
+pub(super) struct PlaywrightFixtureMemberUse {
+    pub(super) fixture_name: String,
+    pub(super) member: String,
+}
+
 pub(super) fn collect_playwright_fixture_member_uses(
-    test_name: &str,
     arguments: &[Argument<'_>],
-) -> Vec<MemberAccess> {
+) -> Vec<PlaywrightFixtureMemberUse> {
     let Some(callback) = arguments.iter().find_map(|arg| match arg {
         Argument::ArrowFunctionExpression(arrow) => {
             Some((arrow.params.items.first()?, arrow.body.as_ref()))
@@ -944,13 +948,8 @@ pub(super) fn collect_playwright_fixture_member_uses(
     collector
         .accesses
         .into_iter()
-        .map(|access| MemberAccess {
-            object: format!(
-                "{}{}:{}",
-                crate::PLAYWRIGHT_FIXTURE_USE_SENTINEL,
-                test_name,
-                access.object
-            ),
+        .map(|access| PlaywrightFixtureMemberUse {
+            fixture_name: access.object,
             member: access.member,
         })
         .collect()


### PR DESCRIPTION
## Summary
- Replace the internal Playwright fixture-use helper sentinel payload with a typed helper result.
- Stop parsing `PLAYWRIGHT_FIXTURE_USE_SENTINEL` inside `visit_call_expression`.
- Keep persisted output behavior unchanged: fixture uses are still emitted as typed semantic facts only.

## Verification
- cargo test -p fallow-extract playwright_test_callback_records_fixture_member_uses
- cargo test -p fallow-extract playwright_fixture_destructure_with_default_value_records_binding
- cargo test -p fallow-core playwright_fixture
- cargo test -p fallow-types -p fallow-extract -p fallow-graph -p fallow-core --no-run
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
