### PR TITLE
refactor: add stable file key contract

### DIFF
--- a/crates/graph/src/project.rs
+++ b/crates/graph/src/project.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 
 use fallow_config::WorkspaceInfo;
 
-use fallow_types::discover::{DiscoveredFile, FileId};
+use fallow_types::discover::{DiscoveredFile, FileId, StableFileKey};
 
 /// Centralized project state owning the file registry and workspace metadata.
 ///
@@ -61,6 +61,22 @@ impl ProjectState {
     #[must_use]
     pub fn id_for_path(&self, path: &Path) -> Option<FileId> {
         self.path_to_id.get(path).copied()
+    }
+
+    /// Stable file key for a `FileId`, root-relative where possible.
+    #[must_use]
+    pub fn stable_key_for_file(&self, root: &Path, id: FileId) -> Option<StableFileKey> {
+        let file = self.file_by_id(id)?;
+        Some(StableFileKey::from_root_relative(root, &file.path))
+    }
+
+    /// Look up the current in-memory `FileId` for a stable root-relative key.
+    #[must_use]
+    pub fn id_for_stable_key(&self, root: &Path, key: &StableFileKey) -> Option<FileId> {
+        self.files
+            .iter()
+            .find(|file| StableFileKey::from_root_relative(root, &file.path) == *key)
+            .map(|file| file.id)
     }
 
     /// Find which workspace a file belongs to, if any.
@@ -123,6 +139,47 @@ mod tests {
             Some(FileId(1))
         );
         assert_eq!(state.id_for_path(Path::new("/project/missing.ts")), None);
+    }
+
+    #[test]
+    fn stable_key_for_file_is_root_relative() {
+        let files = vec![make_file(0, "/project/src/a.ts")];
+        let state = ProjectState::new(files, vec![]);
+
+        let key = state
+            .stable_key_for_file(Path::new("/project"), FileId(0))
+            .unwrap();
+
+        assert_eq!(key.as_str(), "src/a.ts");
+        assert_eq!(
+            state.id_for_stable_key(Path::new("/project"), &key),
+            Some(FileId(0))
+        );
+    }
+
+    #[test]
+    fn stable_key_survives_file_id_shift() {
+        let before = ProjectState::new(
+            vec![
+                make_file(0, "/project/src/a.ts"),
+                make_file(1, "/project/src/c.ts"),
+            ],
+            vec![],
+        );
+        let after = ProjectState::new(
+            vec![
+                make_file(0, "/project/src/a.ts"),
+                make_file(1, "/project/src/b.ts"),
+                make_file(2, "/project/src/c.ts"),
+            ],
+            vec![],
+        );
+        let root = Path::new("/project");
+        let key = before.stable_key_for_file(root, FileId(1)).unwrap();
+
+        assert_eq!(key.as_str(), "src/c.ts");
+        assert_eq!(before.id_for_stable_key(root, &key), Some(FileId(1)));
+        assert_eq!(after.id_for_stable_key(root, &key), Some(FileId(2)));
     }
 
     #[test]

--- a/crates/types/src/discover.rs
+++ b/crates/types/src/discover.rs
@@ -1,6 +1,6 @@
 //! File discovery types: discovered files, file IDs, and entry points.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// A discovered source file on disk.
 ///
@@ -51,6 +51,40 @@ pub struct FileId(pub u32);
 const _: () = assert!(std::mem::size_of::<FileId>() == 4);
 #[cfg(all(target_pointer_width = "64", unix))]
 const _: () = assert!(std::mem::size_of::<DiscoveredFile>() == 40);
+
+/// Persistable file identity for cache entries that need to survive `FileId`
+/// churn across runs.
+///
+/// `FileId` remains a dense in-memory index. This key is path-derived, root
+/// relative where possible, and uses `/` separators so graph-cache metadata can
+/// compare file identity without relying on platform path display quirks.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StableFileKey(String);
+
+impl StableFileKey {
+    /// Build a stable key from an absolute path and the analysis root.
+    #[must_use]
+    pub fn from_root_relative(root: &Path, path: &Path) -> Self {
+        let relative = path.strip_prefix(root).unwrap_or(path);
+        Self(normalize_path(relative))
+    }
+
+    /// Build a stable key from an already-root-relative path.
+    #[must_use]
+    pub fn from_relative(path: &Path) -> Self {
+        Self(normalize_path(path))
+    }
+
+    /// Stable string used in persisted cache manifests.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
 
 /// An entry point into the module graph.
 #[derive(Debug, Clone)]
@@ -107,6 +141,36 @@ pub enum EntryPointSource {
     InfrastructureConfig,
     /// Declared in `dynamicallyLoaded` config as a runtime-loaded file.
     DynamicallyLoaded,
+}
+
+#[cfg(test)]
+mod stable_file_key_tests {
+    use super::*;
+
+    #[test]
+    fn stable_file_key_strips_root_prefix() {
+        let key = StableFileKey::from_root_relative(
+            Path::new("/project"),
+            Path::new("/project/src/index.ts"),
+        );
+
+        assert_eq!(key.as_str(), "src/index.ts");
+    }
+
+    #[test]
+    fn stable_file_key_keeps_path_when_outside_root() {
+        let key =
+            StableFileKey::from_root_relative(Path::new("/project"), Path::new("/other/file.ts"));
+
+        assert_eq!(key.as_str(), "/other/file.ts");
+    }
+
+    #[test]
+    fn stable_file_key_normalizes_windows_separators() {
+        let key = StableFileKey::from_relative(Path::new(r"src\feature\file.ts"));
+
+        assert_eq!(key.as_str(), "src/feature/file.ts");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add a StableFileKey contract for persisted cache identities that should survive dense FileId churn.
- Add ProjectState helpers to translate between current FileId values and stable root-relative keys.
- Keep persisted graph caching disabled; this is the prerequisite identity layer only.

## Verification
- cargo test -p fallow-types stable_file_key
- cargo test -p fallow-graph stable_key
- cargo check -p fallow-types -p fallow-graph
- cargo clippy -p fallow-types -p fallow-graph --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check