### PR TITLE
refactor: route lsp result types through engine

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -19,6 +19,26 @@ use std::path::{Path, PathBuf};
 
 use fallow_config::{DuplicatesConfig, ResolvedConfig};
 
+/// Duplication result types exposed through the engine boundary.
+pub mod duplicates {
+    pub use fallow_core::duplicates::*;
+}
+
+/// Extracted semantic types exposed through the engine boundary.
+pub mod extract {
+    pub use fallow_types::extract::*;
+}
+
+/// Analysis result types exposed through the engine boundary.
+pub mod results {
+    pub use fallow_core::results::*;
+}
+
+/// Suppression helpers exposed for editor and embedding surfaces.
+pub mod suppress {
+    pub use fallow_core::suppress::{IssueKind, is_suppressed};
+}
+
 pub use fallow_core::duplicates::{
     CloneFamily, CloneGroup, CloneInstance, DuplicationReport, DuplicationStats, MirroredDirectory,
     RefactoringSuggestion,

--- a/crates/lsp/src/code_actions/quick_fix.rs
+++ b/crates/lsp/src/code_actions/quick_fix.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 #[allow(clippy::wildcard_imports, reason = "many LSP types used")]
 use ls_types::*;
 
-use fallow_core::results::AnalysisResults;
+use fallow_engine::results::AnalysisResults;
 
 use crate::diagnostics::FIRST_LINE_RANGE;
 
@@ -129,11 +129,12 @@ pub fn build_remove_export_actions(
     let types_iter = results.unused_types.iter().map(|f| &f.export);
     for (exports, msg_prefix) in [
         (
-            Box::new(exports_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedExport>>,
+            Box::new(exports_iter)
+                as Box<dyn Iterator<Item = &fallow_engine::results::UnusedExport>>,
             "Export",
         ),
         (
-            Box::new(types_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedExport>>,
+            Box::new(types_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedExport>>,
             "Type export",
         ),
     ] {
@@ -158,7 +159,7 @@ pub fn build_remove_export_actions(
     reason = "identifier/indent lengths are bounded by source size"
 )]
 fn remove_export_action(
-    export: &fallow_core::results::UnusedExport,
+    export: &fallow_engine::results::UnusedExport,
     msg_prefix: &str,
     file_path: &Path,
     uri: &Uri,
@@ -202,7 +203,7 @@ fn remove_export_action(
 }
 
 fn remove_export_span(
-    export: &fallow_core::results::UnusedExport,
+    export: &fallow_engine::results::UnusedExport,
     file_path: &Path,
     cursor_range: &Range,
     file_lines: &[&str],
@@ -242,7 +243,7 @@ fn export_prefix_to_remove(trimmed: &str) -> Option<&'static str> {
     reason = "identifier lengths are bounded by source size"
 )]
 fn remove_export_diagnostic(
-    export: &fallow_core::results::UnusedExport,
+    export: &fallow_engine::results::UnusedExport,
     msg_prefix: &str,
     export_line: u32,
 ) -> Diagnostic {
@@ -318,7 +319,7 @@ pub fn build_remove_catalog_entry_actions(
 }
 
 fn catalog_entry_delete_span(
-    entry: &fallow_core::results::UnusedCatalogEntry,
+    entry: &fallow_engine::results::UnusedCatalogEntry,
     root: &Path,
     uri: &Uri,
     cursor_range: &Range,
@@ -361,7 +362,7 @@ fn catalog_entry_delete_span(
     reason = "WorkspaceEdit.changes is typed as std::collections::HashMap by ls-types"
 )]
 fn remove_catalog_entry_action(
-    entry: &fallow_core::results::UnusedCatalogEntry,
+    entry: &fallow_engine::results::UnusedCatalogEntry,
     uri: &Uri,
     file_lines: &[&str],
     entry_line: u32,
@@ -409,7 +410,7 @@ fn remove_catalog_entry_action(
 
 /// Build the `unused-catalog-entry` diagnostic linked to the removal action.
 fn catalog_entry_diagnostic(
-    entry: &fallow_core::results::UnusedCatalogEntry,
+    entry: &fallow_engine::results::UnusedCatalogEntry,
     entry_line: u32,
 ) -> Diagnostic {
     Diagnostic {
@@ -432,7 +433,7 @@ fn catalog_entry_diagnostic(
     }
 }
 
-fn catalog_entry_action_title(entry: &fallow_core::results::UnusedCatalogEntry) -> String {
+fn catalog_entry_action_title(entry: &fallow_engine::results::UnusedCatalogEntry) -> String {
     if entry.catalog_name == "default" {
         format!("Remove unused catalog entry `{}`", entry.entry_name)
     } else {
@@ -443,7 +444,7 @@ fn catalog_entry_action_title(entry: &fallow_core::results::UnusedCatalogEntry) 
     }
 }
 
-fn catalog_entry_diagnostic_message(entry: &fallow_core::results::UnusedCatalogEntry) -> String {
+fn catalog_entry_diagnostic_message(entry: &fallow_engine::results::UnusedCatalogEntry) -> String {
     if entry.catalog_name == "default" {
         format!(
             "Unused catalog entry: '{}' is not referenced by any workspace package",
@@ -504,7 +505,7 @@ pub fn build_remove_empty_catalog_group_actions(
 /// Validate that an empty-catalog-group finding still anchors to a matching
 /// header line within the cursor range, returning the 0-based line to delete.
 fn empty_catalog_group_delete_line(
-    group: &fallow_core::results::EmptyCatalogGroup,
+    group: &fallow_engine::results::EmptyCatalogGroup,
     root: &Path,
     uri: &Uri,
     cursor_range: &Range,
@@ -540,7 +541,7 @@ fn empty_catalog_group_delete_line(
     reason = "WorkspaceEdit.changes is typed as std::collections::HashMap by ls-types"
 )]
 fn remove_empty_catalog_group_action(
-    group: &fallow_core::results::EmptyCatalogGroup,
+    group: &fallow_engine::results::EmptyCatalogGroup,
     uri: &Uri,
     group_line: u32,
 ) -> CodeActionOrCommand {
@@ -811,7 +812,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use fallow_core::results::{UnusedExport, UnusedFile, UnusedFileFinding, UnusedTypeFinding};
+    use fallow_engine::results::{UnusedExport, UnusedFile, UnusedFileFinding, UnusedTypeFinding};
 
     fn test_root() -> PathBuf {
         if cfg!(windows) {
@@ -839,8 +840,8 @@ mod tests {
         name: &str,
         line: u32,
         col: u32,
-    ) -> fallow_core::results::UnusedExportFinding {
-        fallow_core::results::UnusedExportFinding::with_actions(UnusedExport {
+    ) -> fallow_engine::results::UnusedExportFinding {
+        fallow_engine::results::UnusedExportFinding::with_actions(UnusedExport {
             path: path.to_path_buf(),
             export_name: name.to_string(),
             is_type_only: false,
@@ -1420,7 +1421,7 @@ mod tests {
         assert!(delete_ca.title.contains("Delete"));
     }
 
-    use fallow_core::results::{UnusedCatalogEntry, UnusedCatalogEntryFinding};
+    use fallow_engine::results::{UnusedCatalogEntry, UnusedCatalogEntryFinding};
 
     fn make_catalog_entry(
         name: &str,
@@ -1879,7 +1880,7 @@ mod tests {
         assert_eq!(compute_catalog_deletion_end(&lines, 1), 4);
     }
 
-    use fallow_core::results::{EmptyCatalogGroup, EmptyCatalogGroupFinding};
+    use fallow_engine::results::{EmptyCatalogGroup, EmptyCatalogGroupFinding};
 
     fn make_empty_group(name: &str, line: u32) -> EmptyCatalogGroupFinding {
         make_empty_group_in_file(name, PathBuf::from("pnpm-workspace.yaml"), line)

--- a/crates/lsp/src/code_actions/suppress.rs
+++ b/crates/lsp/src/code_actions/suppress.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use ls_types::*;
 use rustc_hash::FxHashSet;
 
-use fallow_core::results::{AnalysisResults, SecurityFindingKind};
+use fallow_engine::results::{AnalysisResults, SecurityFindingKind};
 
 use crate::diagnostics::security::{security_diagnostic, security_label, security_token};
 
@@ -140,7 +140,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use fallow_core::results::{SecurityFinding, SecurityFindingKind, SecuritySeverity};
+    use fallow_engine::results::{SecurityFinding, SecurityFindingKind, SecuritySeverity};
 
     fn test_root() -> PathBuf {
         if cfg!(windows) {
@@ -153,7 +153,7 @@ mod tests {
     fn sink(path: PathBuf, line: u32) -> SecurityFinding {
         SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
             kind: SecurityFindingKind::TaintedSink,
@@ -177,7 +177,7 @@ mod tests {
     fn leak(path: PathBuf, line: u32) -> SecurityFinding {
         SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
             kind: SecurityFindingKind::ClientServerLeak,

--- a/crates/lsp/src/code_lens.rs
+++ b/crates/lsp/src/code_lens.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use ls_types::{CodeLens, Command, Position, Range, Uri};
 
-use fallow_core::results::AnalysisResults;
+use fallow_engine::results::AnalysisResults;
 
 /// LSP-local inline complexity signal rendered as a code lens.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,7 +62,7 @@ fn react_component_code_lenses(results: &AnalysisResults, file_path: &Path) -> V
         .collect()
 }
 
-fn react_component_code_lens(intel: &fallow_core::results::ReactComponentIntel) -> CodeLens {
+fn react_component_code_lens(intel: &fallow_engine::results::ReactComponentIntel) -> CodeLens {
     let position = Position {
         line: intel.anchor_line.saturating_sub(1),
         character: intel.anchor_col,
@@ -87,7 +87,7 @@ fn react_component_code_lens(intel: &fallow_core::results::ReactComponentIntel) 
 /// honored (`1 prop`, `1 parent`). A component with no render sites, no props,
 /// and no hooks falls back to a bare `component` label so the lens is never
 /// empty.
-fn react_component_lens_title(intel: &fallow_core::results::ReactComponentIntel) -> String {
+fn react_component_lens_title(intel: &fallow_engine::results::ReactComponentIntel) -> String {
     let mut segments: Vec<String> = Vec::new();
 
     if intel.render_sites > 0 {
@@ -110,7 +110,7 @@ fn react_component_lens_title(intel: &fallow_core::results::ReactComponentIntel)
 
 /// Build the `N hooks (a state, b effect, ...)` segment, or `None` when the
 /// component uses no hooks. Each kind sub-count is omitted when zero.
-fn react_hook_segment(hooks: &fallow_core::results::ReactHookSummary) -> Option<String> {
+fn react_hook_segment(hooks: &fallow_engine::results::ReactHookSummary) -> Option<String> {
     let total = u32::from(hooks.state)
         + u32::from(hooks.effect)
         + u32::from(hooks.memo)
@@ -164,7 +164,7 @@ fn export_usage_code_lenses(
 }
 
 fn export_usage_code_lens(
-    usage: &fallow_core::results::ExportUsage,
+    usage: &fallow_engine::results::ExportUsage,
     document_uri: &Uri,
 ) -> CodeLens {
     let line = usage.line.saturating_sub(1);
@@ -200,7 +200,7 @@ fn export_usage_code_lens(
 }
 
 fn reference_location_payload(
-    loc: &fallow_core::results::ReferenceLocation,
+    loc: &fallow_engine::results::ReferenceLocation,
 ) -> Option<serde_json::Value> {
     let uri = Uri::from_file_path(&loc.path)?;
     let ref_line = loc.line.saturating_sub(1);
@@ -276,7 +276,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use fallow_core::results::{
+    use fallow_engine::results::{
         ExportUsage, ReactComponentIntel, ReactHookSummary, ReactPropIntel, ReferenceLocation,
     };
 

--- a/crates/lsp/src/diagnostics/mod.rs
+++ b/crates/lsp/src/diagnostics/mod.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use ls_types::{CodeDescription, Diagnostic, Position, Range, Uri};
 
-use fallow_core::duplicates::DuplicationReport;
-use fallow_core::results::AnalysisResults;
+use fallow_engine::duplicates::DuplicationReport;
+use fallow_engine::results::AnalysisResults;
 
 /// Base URL for diagnostic documentation links.
 const DOCS_BASE: &str = "https://docs.fallow.tools/explanations/dead-code#";
@@ -69,8 +69,8 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{DuplicationReport, DuplicationStats};
-    use fallow_core::results::{
+    use fallow_engine::duplicates::{DuplicationReport, DuplicationStats};
+    use fallow_engine::results::{
         AnalysisResults, SecuritySeverity, UnresolvedImport, UnresolvedImportFinding, UnusedExport,
         UnusedExportFinding, UnusedFile, UnusedFileFinding,
     };
@@ -205,12 +205,12 @@ mod tests {
         let mut results = AnalysisResults::default();
         results
             .security_findings
-            .push(fallow_core::results::SecurityFinding {
+            .push(fallow_engine::results::SecurityFinding {
                 finding_id: String::new(),
-                candidate: fallow_core::results::SecurityCandidate::default(),
+                candidate: fallow_engine::results::SecurityCandidate::default(),
                 taint_flow: None,
                 attack_surface: None,
-                kind: fallow_core::results::SecurityFindingKind::TaintedSink,
+                kind: fallow_engine::results::SecurityFindingKind::TaintedSink,
                 category: Some("dangerous-html".to_string()),
                 cwe: Some(79),
                 path: path.clone(),
@@ -272,7 +272,7 @@ mod tests {
 ///    in [`severity_gate_emits_expected_severity_per_kind`]) or a
 ///    destructured-and-ignored non-diagnostic field (metadata / counts /
 ///    advisory). `AnalysisResults` is NOT `#[non_exhaustive]` (defined in
-///    `fallow_types::results`, re-exported via `fallow_core::results`), so the
+///    `fallow_types::results`, re-exported via `fallow_engine::results`), so the
 ///    exhaustive destructure compiles cross-crate -- the preferred mechanism.
 ///
 /// 2. [`severity_gate_emits_expected_severity_per_kind`] builds a synthetic
@@ -289,8 +289,8 @@ mod severity_gate {
     use std::path::PathBuf;
 
     use fallow_config::{RulesConfig, Severity};
-    use fallow_core::duplicates::{DuplicationReport, DuplicationStats};
-    use fallow_core::results::AnalysisResults;
+    use fallow_engine::duplicates::{DuplicationReport, DuplicationStats};
+    use fallow_engine::results::AnalysisResults;
     use ls_types::DiagnosticSeverity;
 
     use crate::diagnostics::build_diagnostics;
@@ -472,8 +472,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unused_files
-                        .push(fallow_core::results::UnusedFileFinding::with_actions(
-                            fallow_core::results::UnusedFile {
+                        .push(fallow_engine::results::UnusedFileFinding::with_actions(
+                            fallow_engine::results::UnusedFile {
                                 path: root.join("a.ts"),
                             },
                         ));
@@ -483,9 +483,9 @@ mod severity_gate {
                 "unused-export",
                 S::HINT,
                 Box::new(|root, r| {
-                    r.unused_exports
-                        .push(fallow_core::results::UnusedExportFinding::with_actions(
-                            fallow_core::results::UnusedExport {
+                    r.unused_exports.push(
+                        fallow_engine::results::UnusedExportFinding::with_actions(
+                            fallow_engine::results::UnusedExport {
                                 path: root.join("a.ts"),
                                 export_name: "x".to_string(),
                                 is_type_only: false,
@@ -494,7 +494,8 @@ mod severity_gate {
                                 span_start: 0,
                                 is_re_export: false,
                             },
-                        ));
+                        ),
+                    );
                 }),
             ),
             (
@@ -507,8 +508,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_types
-                        .push(fallow_core::results::UnusedTypeFinding::with_actions(
-                            fallow_core::results::UnusedExport {
+                        .push(fallow_engine::results::UnusedTypeFinding::with_actions(
+                            fallow_engine::results::UnusedExport {
                                 path: root.join("a.ts"),
                                 export_name: "T".to_string(),
                                 is_type_only: true,
@@ -525,8 +526,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.private_type_leaks.push(
-                        fallow_core::results::PrivateTypeLeakFinding::with_actions(
-                            fallow_core::results::PrivateTypeLeak {
+                        fallow_engine::results::PrivateTypeLeakFinding::with_actions(
+                            fallow_engine::results::PrivateTypeLeak {
                                 path: root.join("a.ts"),
                                 export_name: "pub_fn".to_string(),
                                 type_name: "Secret".to_string(),
@@ -543,10 +544,10 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unused_dependencies.push(
-                        fallow_core::results::UnusedDependencyFinding::with_actions(
-                            fallow_core::results::UnusedDependency {
+                        fallow_engine::results::UnusedDependencyFinding::with_actions(
+                            fallow_engine::results::UnusedDependency {
                                 package_name: "dep".to_string(),
-                                location: fallow_core::results::DependencyLocation::Dependencies,
+                                location: fallow_engine::results::DependencyLocation::Dependencies,
                                 path: root.join("package.json"),
                                 line: 3,
                                 used_in_workspaces: Vec::new(),
@@ -560,10 +561,11 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unused_dev_dependencies.push(
-                        fallow_core::results::UnusedDevDependencyFinding::with_actions(
-                            fallow_core::results::UnusedDependency {
+                        fallow_engine::results::UnusedDevDependencyFinding::with_actions(
+                            fallow_engine::results::UnusedDependency {
                                 package_name: "dev-dep".to_string(),
-                                location: fallow_core::results::DependencyLocation::DevDependencies,
+                                location:
+                                    fallow_engine::results::DependencyLocation::DevDependencies,
                                 path: root.join("package.json"),
                                 line: 4,
                                 used_in_workspaces: Vec::new(),
@@ -577,11 +579,11 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unused_optional_dependencies.push(
-                        fallow_core::results::UnusedOptionalDependencyFinding::with_actions(
-                            fallow_core::results::UnusedDependency {
+                        fallow_engine::results::UnusedOptionalDependencyFinding::with_actions(
+                            fallow_engine::results::UnusedDependency {
                                 package_name: "opt-dep".to_string(),
                                 location:
-                                    fallow_core::results::DependencyLocation::OptionalDependencies,
+                                    fallow_engine::results::DependencyLocation::OptionalDependencies,
                                 path: root.join("package.json"),
                                 line: 5,
                                 used_in_workspaces: Vec::new(),
@@ -595,12 +597,12 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_enum_members.push(
-                        fallow_core::results::UnusedEnumMemberFinding::with_actions(
-                            fallow_core::results::UnusedMember {
+                        fallow_engine::results::UnusedEnumMemberFinding::with_actions(
+                            fallow_engine::results::UnusedMember {
                                 path: root.join("a.ts"),
                                 parent_name: "E".to_string(),
                                 member_name: "A".to_string(),
-                                kind: fallow_core::extract::MemberKind::EnumMember,
+                                kind: fallow_engine::extract::MemberKind::EnumMember,
                                 line: 6,
                                 col: 0,
                             },
@@ -613,12 +615,12 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_class_members.push(
-                        fallow_core::results::UnusedClassMemberFinding::with_actions(
-                            fallow_core::results::UnusedMember {
+                        fallow_engine::results::UnusedClassMemberFinding::with_actions(
+                            fallow_engine::results::UnusedMember {
                                 path: root.join("a.ts"),
                                 parent_name: "C".to_string(),
                                 member_name: "m".to_string(),
-                                kind: fallow_core::extract::MemberKind::ClassMethod,
+                                kind: fallow_engine::extract::MemberKind::ClassMethod,
                                 line: 7,
                                 col: 0,
                             },
@@ -631,12 +633,12 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_store_members.push(
-                        fallow_core::results::UnusedStoreMemberFinding::with_actions(
-                            fallow_core::results::UnusedMember {
+                        fallow_engine::results::UnusedStoreMemberFinding::with_actions(
+                            fallow_engine::results::UnusedMember {
                                 path: root.join("a.ts"),
                                 parent_name: "S".to_string(),
                                 member_name: "a".to_string(),
-                                kind: fallow_core::extract::MemberKind::StoreMember,
+                                kind: fallow_engine::extract::MemberKind::StoreMember,
                                 line: 8,
                                 col: 0,
                             },
@@ -649,8 +651,8 @@ mod severity_gate {
                 S::ERROR,
                 Box::new(|root, r| {
                     r.unresolved_imports.push(
-                        fallow_core::results::UnresolvedImportFinding::with_actions(
-                            fallow_core::results::UnresolvedImport {
+                        fallow_engine::results::UnresolvedImportFinding::with_actions(
+                            fallow_engine::results::UnresolvedImport {
                                 path: root.join("a.ts"),
                                 specifier: "./gone".to_string(),
                                 line: 1,
@@ -666,8 +668,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|_root, r| {
                     r.unlisted_dependencies.push(
-                        fallow_core::results::UnlistedDependencyFinding::with_actions(
-                            fallow_core::results::UnlistedDependency {
+                        fallow_engine::results::UnlistedDependencyFinding::with_actions(
+                            fallow_engine::results::UnlistedDependency {
                                 package_name: "unlisted".to_string(),
                                 imported_from: vec![],
                             },
@@ -680,10 +682,10 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.duplicate_exports.push(
-                        fallow_core::results::DuplicateExportFinding::with_actions(
-                            fallow_core::results::DuplicateExport {
+                        fallow_engine::results::DuplicateExportFinding::with_actions(
+                            fallow_engine::results::DuplicateExport {
                                 export_name: "dup".to_string(),
-                                locations: vec![fallow_core::results::DuplicateLocation {
+                                locations: vec![fallow_engine::results::DuplicateLocation {
                                     path: root.join("a.ts"),
                                     line: 1,
                                     col: 0,
@@ -698,8 +700,8 @@ mod severity_gate {
                 S::INFORMATION,
                 Box::new(|root, r| {
                     r.type_only_dependencies.push(
-                        fallow_core::results::TypeOnlyDependencyFinding::with_actions(
-                            fallow_core::results::TypeOnlyDependency {
+                        fallow_engine::results::TypeOnlyDependencyFinding::with_actions(
+                            fallow_engine::results::TypeOnlyDependency {
                                 package_name: "type-only".to_string(),
                                 path: root.join("package.json"),
                                 line: 9,
@@ -713,8 +715,8 @@ mod severity_gate {
                 S::INFORMATION,
                 Box::new(|root, r| {
                     r.test_only_dependencies.push(
-                        fallow_core::results::TestOnlyDependencyFinding::with_actions(
-                            fallow_core::results::TestOnlyDependency {
+                        fallow_engine::results::TestOnlyDependencyFinding::with_actions(
+                            fallow_engine::results::TestOnlyDependency {
                                 package_name: "test-only".to_string(),
                                 path: root.join("package.json"),
                                 line: 10,
@@ -733,8 +735,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.circular_dependencies.push(
-                        fallow_core::results::CircularDependencyFinding::with_actions(
-                            fallow_core::results::CircularDependency {
+                        fallow_engine::results::CircularDependencyFinding::with_actions(
+                            fallow_engine::results::CircularDependency {
                                 files: vec![root.join("a.ts"), root.join("b.ts")],
                                 length: 2,
                                 line: 1,
@@ -751,10 +753,10 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.re_export_cycles.push(
-                        fallow_core::results::ReExportCycleFinding::with_actions(
-                            fallow_core::results::ReExportCycle {
+                        fallow_engine::results::ReExportCycleFinding::with_actions(
+                            fallow_engine::results::ReExportCycle {
                                 files: vec![root.join("barrel.ts")],
-                                kind: fallow_core::results::ReExportCycleKind::SelfLoop,
+                                kind: fallow_engine::results::ReExportCycleKind::SelfLoop,
                             },
                         ),
                     );
@@ -769,8 +771,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.boundary_violations.push(
-                        fallow_core::results::BoundaryViolationFinding::with_actions(
-                            fallow_core::results::BoundaryViolation {
+                        fallow_engine::results::BoundaryViolationFinding::with_actions(
+                            fallow_engine::results::BoundaryViolation {
                                 from_path: root.join("a.ts"),
                                 to_path: root.join("b.ts"),
                                 from_zone: "ui".to_string(),
@@ -790,8 +792,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.boundary_coverage_violations.push(
-                        fallow_core::results::BoundaryCoverageViolationFinding::with_actions(
-                            fallow_core::results::BoundaryCoverageViolation {
+                        fallow_engine::results::BoundaryCoverageViolationFinding::with_actions(
+                            fallow_engine::results::BoundaryCoverageViolation {
                                 path: root.join("unzoned.ts"),
                                 line: 1,
                                 col: 0,
@@ -805,8 +807,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.boundary_call_violations.push(
-                        fallow_core::results::BoundaryCallViolationFinding::with_actions(
-                            fallow_core::results::BoundaryCallViolation {
+                        fallow_engine::results::BoundaryCallViolationFinding::with_actions(
+                            fallow_engine::results::BoundaryCallViolation {
                                 path: root.join("zoned.ts"),
                                 line: 1,
                                 col: 0,
@@ -826,16 +828,16 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.policy_violations.push(
-                        fallow_core::results::PolicyViolationFinding::with_actions(
-                            fallow_core::results::PolicyViolation {
+                        fallow_engine::results::PolicyViolationFinding::with_actions(
+                            fallow_engine::results::PolicyViolation {
                                 path: root.join("zoned.ts"),
                                 line: 1,
                                 col: 0,
                                 pack: "team-policy".to_string(),
                                 rule_id: "no-console".to_string(),
-                                kind: fallow_core::results::PolicyRuleKind::BannedCall,
+                                kind: fallow_engine::results::PolicyRuleKind::BannedCall,
                                 matched: "console.log".to_string(),
-                                severity: fallow_core::results::PolicyViolationSeverity::Warn,
+                                severity: fallow_engine::results::PolicyViolationSeverity::Warn,
                                 message: None,
                             },
                         ),
@@ -847,18 +849,18 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.stale_suppressions
-                        .push(fallow_core::results::StaleSuppression {
+                        .push(fallow_engine::results::StaleSuppression {
                             path: root.join("a.ts"),
                             line: 1,
                             col: 0,
-                            origin: fallow_core::results::SuppressionOrigin::Comment {
+                            origin: fallow_engine::results::SuppressionOrigin::Comment {
                                 issue_kind: None,
                                 reason: None,
                                 is_file_level: false,
                                 kind_known: true,
                             },
                             missing_reason: false,
-                            actions: fallow_core::results::StaleSuppression::actions_for(false),
+                            actions: fallow_engine::results::StaleSuppression::actions_for(false),
                         });
                 }),
             ),
@@ -867,8 +869,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unused_catalog_entries.push(
-                        fallow_core::results::UnusedCatalogEntryFinding::with_actions(
-                            fallow_core::results::UnusedCatalogEntry {
+                        fallow_engine::results::UnusedCatalogEntryFinding::with_actions(
+                            fallow_engine::results::UnusedCatalogEntry {
                                 entry_name: "react".to_string(),
                                 catalog_name: "default".to_string(),
                                 path: root.join("pnpm-workspace.yaml"),
@@ -884,8 +886,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.empty_catalog_groups.push(
-                        fallow_core::results::EmptyCatalogGroupFinding::with_actions(
-                            fallow_core::results::EmptyCatalogGroup {
+                        fallow_engine::results::EmptyCatalogGroupFinding::with_actions(
+                            fallow_engine::results::EmptyCatalogGroup {
                                 catalog_name: "ui".to_string(),
                                 path: root.join("pnpm-workspace.yaml"),
                                 line: 1,
@@ -899,8 +901,8 @@ mod severity_gate {
                 S::ERROR,
                 Box::new(|root, r| {
                     r.unresolved_catalog_references.push(
-                        fallow_core::results::UnresolvedCatalogReferenceFinding::with_actions(
-                            fallow_core::results::UnresolvedCatalogReference {
+                        fallow_engine::results::UnresolvedCatalogReferenceFinding::with_actions(
+                            fallow_engine::results::UnresolvedCatalogReference {
                                 entry_name: "vue".to_string(),
                                 catalog_name: "default".to_string(),
                                 path: root.join("package.json"),
@@ -916,15 +918,15 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unused_dependency_overrides.push(
-                        fallow_core::results::UnusedDependencyOverrideFinding::with_actions(
-                            fallow_core::results::UnusedDependencyOverride {
+                        fallow_engine::results::UnusedDependencyOverrideFinding::with_actions(
+                            fallow_engine::results::UnusedDependencyOverride {
                                 raw_key: "react".to_string(),
                                 target_package: "react".to_string(),
                                 parent_package: None,
                                 version_constraint: None,
                                 version_range: "18".to_string(),
                                 source:
-                                    fallow_core::results::DependencyOverrideSource::PnpmWorkspaceYaml,
+                                    fallow_engine::results::DependencyOverrideSource::PnpmWorkspaceYaml,
                                 path: root.join("pnpm-workspace.yaml"),
                                 line: 1,
                                 hint: None,
@@ -938,15 +940,15 @@ mod severity_gate {
                 S::ERROR,
                 Box::new(|root, r| {
                     r.misconfigured_dependency_overrides.push(
-                        fallow_core::results::MisconfiguredDependencyOverrideFinding::with_actions(
-                            fallow_core::results::MisconfiguredDependencyOverride {
+                        fallow_engine::results::MisconfiguredDependencyOverrideFinding::with_actions(
+                            fallow_engine::results::MisconfiguredDependencyOverride {
                                 raw_key: "bad>".to_string(),
                                 target_package: None,
                                 raw_value: String::new(),
                                 reason:
-                                    fallow_core::results::DependencyOverrideMisconfigReason::EmptyValue,
+                                    fallow_engine::results::DependencyOverrideMisconfigReason::EmptyValue,
                                 source:
-                                    fallow_core::results::DependencyOverrideSource::PnpmPackageJson,
+                                    fallow_engine::results::DependencyOverrideSource::PnpmPackageJson,
                                 path: root.join("package.json"),
                                 line: 1,
                             },
@@ -959,8 +961,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.invalid_client_exports.push(
-                        fallow_core::results::InvalidClientExportFinding::with_actions(
-                            fallow_core::results::InvalidClientExport {
+                        fallow_engine::results::InvalidClientExportFinding::with_actions(
+                            fallow_engine::results::InvalidClientExport {
                                 path: root.join("app/page.tsx"),
                                 export_name: "metadata".to_string(),
                                 directive: "use client".to_string(),
@@ -976,8 +978,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.mixed_client_server_barrels.push(
-                        fallow_core::results::MixedClientServerBarrelFinding::with_actions(
-                            fallow_core::results::MixedClientServerBarrel {
+                        fallow_engine::results::MixedClientServerBarrelFinding::with_actions(
+                            fallow_engine::results::MixedClientServerBarrel {
                                 path: root.join("app/index.ts"),
                                 client_origin: "./Button".to_string(),
                                 server_origin: "./fetchUser".to_string(),
@@ -993,8 +995,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.misplaced_directives.push(
-                        fallow_core::results::MisplacedDirectiveFinding::with_actions(
-                            fallow_core::results::MisplacedDirective {
+                        fallow_engine::results::MisplacedDirectiveFinding::with_actions(
+                            fallow_engine::results::MisplacedDirective {
                                 path: root.join("app/widget.tsx"),
                                 directive: "use client".to_string(),
                                 line: 1,
@@ -1009,8 +1011,8 @@ mod severity_gate {
                 S::WARNING,
                 Box::new(|root, r| {
                     r.unprovided_injects.push(
-                        fallow_core::results::UnprovidedInjectFinding::with_actions(
-                            fallow_core::results::UnprovidedInject {
+                        fallow_engine::results::UnprovidedInjectFinding::with_actions(
+                            fallow_engine::results::UnprovidedInject {
                                 path: root.join("Comp.vue"),
                                 key_name: "ApiKey".to_string(),
                                 framework: "vue".to_string(),
@@ -1026,8 +1028,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unrendered_components.push(
-                        fallow_core::results::UnrenderedComponentFinding::with_actions(
-                            fallow_core::results::UnrenderedComponent {
+                        fallow_engine::results::UnrenderedComponentFinding::with_actions(
+                            fallow_engine::results::UnrenderedComponent {
                                 path: root.join("Widget.vue"),
                                 component_name: "Widget".to_string(),
                                 framework: "vue".to_string(),
@@ -1044,8 +1046,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_component_props.push(
-                        fallow_core::results::UnusedComponentPropFinding::with_actions(
-                            fallow_core::results::UnusedComponentProp {
+                        fallow_engine::results::UnusedComponentPropFinding::with_actions(
+                            fallow_engine::results::UnusedComponentProp {
                                 path: root.join("Widget.vue"),
                                 component_name: "Widget".to_string(),
                                 prop_name: "size".to_string(),
@@ -1061,8 +1063,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_component_emits.push(
-                        fallow_core::results::UnusedComponentEmitFinding::with_actions(
-                            fallow_core::results::UnusedComponentEmit {
+                        fallow_engine::results::UnusedComponentEmitFinding::with_actions(
+                            fallow_engine::results::UnusedComponentEmit {
                                 path: root.join("Widget.vue"),
                                 component_name: "Widget".to_string(),
                                 emit_name: "change".to_string(),
@@ -1078,8 +1080,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_component_inputs.push(
-                        fallow_core::results::UnusedComponentInputFinding::with_actions(
-                            fallow_core::results::UnusedComponentInput {
+                        fallow_engine::results::UnusedComponentInputFinding::with_actions(
+                            fallow_engine::results::UnusedComponentInput {
                                 path: root.join("widget.component.ts"),
                                 component_name: "WidgetComponent".to_string(),
                                 input_name: "size".to_string(),
@@ -1095,8 +1097,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_component_outputs.push(
-                        fallow_core::results::UnusedComponentOutputFinding::with_actions(
-                            fallow_core::results::UnusedComponentOutput {
+                        fallow_engine::results::UnusedComponentOutputFinding::with_actions(
+                            fallow_engine::results::UnusedComponentOutput {
                                 path: root.join("widget.component.ts"),
                                 component_name: "WidgetComponent".to_string(),
                                 output_name: "change".to_string(),
@@ -1112,8 +1114,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_svelte_events.push(
-                        fallow_core::results::UnusedSvelteEventFinding::with_actions(
-                            fallow_core::results::UnusedSvelteEvent {
+                        fallow_engine::results::UnusedSvelteEventFinding::with_actions(
+                            fallow_engine::results::UnusedSvelteEvent {
                                 path: root.join("Child.svelte"),
                                 component_name: "Child".to_string(),
                                 event_name: "dead".to_string(),
@@ -1129,8 +1131,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_server_actions.push(
-                        fallow_core::results::UnusedServerActionFinding::with_actions(
-                            fallow_core::results::UnusedServerAction {
+                        fallow_engine::results::UnusedServerActionFinding::with_actions(
+                            fallow_engine::results::UnusedServerAction {
                                 path: root.join("app/actions.ts"),
                                 action_name: "createUser".to_string(),
                                 line: 1,
@@ -1145,8 +1147,8 @@ mod severity_gate {
                 S::HINT,
                 Box::new(|root, r| {
                     r.unused_load_data_keys.push(
-                        fallow_core::results::UnusedLoadDataKeyFinding::with_actions(
-                            fallow_core::results::UnusedLoadDataKey {
+                        fallow_engine::results::UnusedLoadDataKeyFinding::with_actions(
+                            fallow_engine::results::UnusedLoadDataKey {
                                 path: root.join("src/routes/blog/+page.server.ts"),
                                 key_name: "posts".to_string(),
                                 line: 1,
@@ -1163,8 +1165,8 @@ mod severity_gate {
                 S::ERROR,
                 Box::new(|root, r| {
                     r.route_collisions.push(
-                        fallow_core::results::RouteCollisionFinding::with_actions(
-                            fallow_core::results::RouteCollision {
+                        fallow_engine::results::RouteCollisionFinding::with_actions(
+                            fallow_engine::results::RouteCollision {
                                 path: root.join("app/(a)/about/page.tsx"),
                                 url: "/about".to_string(),
                                 conflicting_paths: vec![root.join("app/(b)/about/page.tsx")],
@@ -1181,8 +1183,8 @@ mod severity_gate {
                 S::ERROR,
                 Box::new(|root, r| {
                     r.dynamic_segment_name_conflicts.push(
-                        fallow_core::results::DynamicSegmentNameConflictFinding::with_actions(
-                            fallow_core::results::DynamicSegmentNameConflict {
+                        fallow_engine::results::DynamicSegmentNameConflictFinding::with_actions(
+                            fallow_engine::results::DynamicSegmentNameConflict {
                                 path: root.join("app/blog/[id]/page.tsx"),
                                 position: "/blog".to_string(),
                                 conflicting_segments: vec![

--- a/crates/lsp/src/diagnostics/quality.rs
+++ b/crates/lsp/src/diagnostics/quality.rs
@@ -5,8 +5,8 @@ use ls_types::{
     Location, NumberOrString, Position, Range, Uri,
 };
 
-use fallow_core::duplicates::DuplicationReport;
-use fallow_core::results::AnalysisResults;
+use fallow_engine::duplicates::DuplicationReport;
+use fallow_engine::results::AnalysisResults;
 
 use super::doc_link;
 
@@ -94,8 +94,8 @@ pub fn push_duplication_diagnostics(
 )]
 fn push_duplication_instance_diagnostic(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    group: &fallow_core::duplicates::CloneGroup,
-    instance: &fallow_core::duplicates::CloneInstance,
+    group: &fallow_engine::duplicates::CloneGroup,
+    instance: &fallow_engine::duplicates::CloneInstance,
 ) {
     let Some(inst_uri) = Uri::from_file_path(&instance.file) else {
         return;
@@ -145,8 +145,8 @@ fn push_duplication_instance_diagnostic(
     reason = "line/col numbers are bounded by source size"
 )]
 fn duplication_related_info(
-    group: &fallow_core::duplicates::CloneGroup,
-    instance: &fallow_core::duplicates::CloneInstance,
+    group: &fallow_engine::duplicates::CloneGroup,
+    instance: &fallow_engine::duplicates::CloneInstance,
 ) -> Vec<DiagnosticRelatedInformation> {
     group
         .instances
@@ -215,8 +215,10 @@ pub fn push_stale_suppression_diagnostics(
 mod tests {
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{CloneGroup, CloneInstance, DuplicationReport, DuplicationStats};
-    use fallow_core::results::{
+    use fallow_engine::duplicates::{
+        CloneGroup, CloneInstance, DuplicationReport, DuplicationStats,
+    };
+    use fallow_engine::results::{
         AnalysisResults, DuplicateExport, DuplicateExportFinding, DuplicateLocation, UnusedExport,
         UnusedExportFinding, UnusedTypeFinding,
     };
@@ -476,16 +478,16 @@ mod tests {
             }));
         results
             .unused_files
-            .push(fallow_core::results::UnusedFileFinding::with_actions(
-                fallow_core::results::UnusedFile { path: path.clone() },
+            .push(fallow_engine::results::UnusedFileFinding::with_actions(
+                fallow_engine::results::UnusedFile { path: path.clone() },
             ));
         results.unused_enum_members.push(
-            fallow_core::results::UnusedEnumMemberFinding::with_actions(
-                fallow_core::results::UnusedMember {
+            fallow_engine::results::UnusedEnumMemberFinding::with_actions(
+                fallow_engine::results::UnusedMember {
                     path: path.clone(),
                     parent_name: "E".to_string(),
                     member_name: "A".to_string(),
-                    kind: fallow_core::extract::MemberKind::EnumMember,
+                    kind: fallow_engine::extract::MemberKind::EnumMember,
                     line: 3,
                     col: 0,
                 },

--- a/crates/lsp/src/diagnostics/security.rs
+++ b/crates/lsp/src/diagnostics/security.rs
@@ -17,7 +17,7 @@ use ls_types::{
     CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Uri,
 };
 
-use fallow_core::results::{AnalysisResults, SecurityFinding, SecurityFindingKind};
+use fallow_engine::results::{AnalysisResults, SecurityFinding, SecurityFindingKind};
 
 /// Documentation page for the security candidate surface. The dead-code
 /// `DOCS_BASE` in `super` points at the dead-code explanation; security has its
@@ -141,7 +141,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use fallow_core::results::{
+    use fallow_engine::results::{
         SecurityFinding, SecurityFindingKind, SecurityReachability, SecuritySeverity,
         TaintConfidence,
     };
@@ -157,7 +157,7 @@ mod tests {
     fn tainted_sink(path: PathBuf) -> SecurityFinding {
         SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
             kind: SecurityFindingKind::TaintedSink,
@@ -189,7 +189,7 @@ mod tests {
     fn client_server_leak(path: PathBuf) -> SecurityFinding {
         SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
             kind: SecurityFindingKind::ClientServerLeak,

--- a/crates/lsp/src/diagnostics/structural.rs
+++ b/crates/lsp/src/diagnostics/structural.rs
@@ -5,7 +5,7 @@ use ls_types::{
     Position, Range, Uri,
 };
 
-use fallow_core::results::AnalysisResults;
+use fallow_engine::results::AnalysisResults;
 
 use super::{FIRST_LINE_RANGE, doc_link};
 
@@ -45,7 +45,7 @@ fn cycle_fingerprint(files: &[std::path::PathBuf]) -> String {
 /// the first file, with the other members listed as related info at line 0.
 fn push_legacy_circular_diagnostic(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    cycle: &fallow_core::results::CircularDependency,
+    cycle: &fallow_engine::results::CircularDependency,
     names: &[String],
 ) {
     let Some(first_file) = cycle.files.first() else {
@@ -124,7 +124,7 @@ pub fn push_circular_dep_diagnostics(
 /// `edges` anchors, anchored at the import edge pointing to the next file.
 fn push_circular_cycle_edge_diagnostics(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    cycle: &fallow_core::results::CircularDependency,
+    cycle: &fallow_engine::results::CircularDependency,
 ) {
     // Names are derived from the EDGES (not `files`) so all the rotated
     // message and related-info index math below stays in bounds even if a
@@ -193,7 +193,7 @@ fn push_circular_cycle_edge_diagnostics(
 /// Build the related-information hops for the edge at index `i`, pointing at
 /// every OTHER hop's real location.
 fn circular_cycle_related_info(
-    cycle: &fallow_core::results::CircularDependency,
+    cycle: &fallow_engine::results::CircularDependency,
     names: &[String],
     i: usize,
     n: usize,
@@ -240,14 +240,14 @@ pub fn push_re_export_cycle_diagnostics(
 
 /// Format the shared `re-export-cycle` message: kind, file count, the chain,
 /// and the kind-appropriate fix hint.
-fn re_export_cycle_message(cycle: &fallow_core::results::ReExportCycle) -> String {
+fn re_export_cycle_message(cycle: &fallow_engine::results::ReExportCycle) -> String {
     let chain: Vec<String> = cycle.files.iter().map(|f| cycle_file_name(f)).collect();
     let (kind_label, fix_hint) = match cycle.kind {
-        fallow_core::results::ReExportCycleKind::SelfLoop => (
+        fallow_engine::results::ReExportCycleKind::SelfLoop => (
             "Self-loop",
             "Remove the `export * from './'` (or equivalent) inside this file.",
         ),
-        fallow_core::results::ReExportCycleKind::MultiNode => (
+        fallow_engine::results::ReExportCycleKind::MultiNode => (
             "Cycle",
             "Remove one `export * from` statement on any one member to break the cycle.",
         ),
@@ -266,7 +266,7 @@ fn re_export_cycle_message(cycle: &fallow_core::results::ReExportCycle) -> Strin
 /// the other members linked as related info.
 fn push_re_export_member_diagnostic(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    cycle: &fallow_core::results::ReExportCycle,
+    cycle: &fallow_engine::results::ReExportCycle,
     member_path: &std::path::Path,
     idx: usize,
     message: &str,
@@ -445,7 +445,7 @@ pub fn push_policy_violation_diagnostics(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
     results: &AnalysisResults,
 ) {
-    use fallow_core::results::PolicyViolationSeverity;
+    use fallow_engine::results::PolicyViolationSeverity;
 
     for v in &results.policy_violations {
         let Some(uri) = Uri::from_file_path(&v.violation.path) else {
@@ -730,8 +730,8 @@ pub fn push_dynamic_segment_name_conflict_diagnostics(
 mod tests {
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{DuplicationReport, DuplicationStats};
-    use fallow_core::results::{
+    use fallow_engine::duplicates::{DuplicationReport, DuplicationStats};
+    use fallow_engine::results::{
         AnalysisResults, BoundaryViolation, BoundaryViolationFinding, CircularDependency,
         CircularDependencyEdge, CircularDependencyFinding,
     };
@@ -1023,7 +1023,7 @@ mod tests {
 
     #[test]
     fn re_export_cycle_multi_node_emits_one_diagnostic_per_member() {
-        use fallow_core::results::{ReExportCycle, ReExportCycleFinding, ReExportCycleKind};
+        use fallow_engine::results::{ReExportCycle, ReExportCycleFinding, ReExportCycleKind};
 
         let root = test_root();
         let file_a = root.join("src/api/index.ts");
@@ -1082,7 +1082,7 @@ mod tests {
 
     #[test]
     fn re_export_cycle_self_loop_emits_self_loop_message_and_no_related_info() {
-        use fallow_core::results::{ReExportCycle, ReExportCycleFinding, ReExportCycleKind};
+        use fallow_engine::results::{ReExportCycle, ReExportCycleFinding, ReExportCycleKind};
 
         let root = test_root();
         let file = root.join("src/utils/index.ts");
@@ -1159,8 +1159,8 @@ mod tests {
 
         let mut results = AnalysisResults::default();
         results.boundary_call_violations.push(
-            fallow_core::results::BoundaryCallViolationFinding::with_actions(
-                fallow_core::results::BoundaryCallViolation {
+            fallow_engine::results::BoundaryCallViolationFinding::with_actions(
+                fallow_engine::results::BoundaryCallViolation {
                     path: file.clone(),
                     line: 5,
                     col: 2,
@@ -1200,21 +1200,21 @@ mod tests {
         let file = root.join("src/app.ts");
 
         let mut results = AnalysisResults::default();
-        results
-            .policy_violations
-            .push(fallow_core::results::PolicyViolationFinding::with_actions(
-                fallow_core::results::PolicyViolation {
+        results.policy_violations.push(
+            fallow_engine::results::PolicyViolationFinding::with_actions(
+                fallow_engine::results::PolicyViolation {
                     path: file.clone(),
                     line: 7,
                     col: 2,
                     pack: "team-policy".to_string(),
                     rule_id: "no-moment".to_string(),
-                    kind: fallow_core::results::PolicyRuleKind::BannedImport,
+                    kind: fallow_engine::results::PolicyRuleKind::BannedImport,
                     matched: "moment".to_string(),
-                    severity: fallow_core::results::PolicyViolationSeverity::Error,
+                    severity: fallow_engine::results::PolicyViolationSeverity::Error,
                     message: Some("Use date-fns.".to_string()),
                 },
-            ));
+            ),
+        );
 
         let duplication = empty_duplication();
         let diags = build_diagnostics(&results, &duplication, &root);
@@ -1244,8 +1244,8 @@ mod tests {
 
         let mut results = AnalysisResults::default();
         results.invalid_client_exports.push(
-            fallow_core::results::InvalidClientExportFinding::with_actions(
-                fallow_core::results::InvalidClientExport {
+            fallow_engine::results::InvalidClientExportFinding::with_actions(
+                fallow_engine::results::InvalidClientExport {
                     path: file.clone(),
                     export_name: "metadata".to_string(),
                     directive: "use client".to_string(),
@@ -1284,8 +1284,8 @@ mod tests {
         let mut results = AnalysisResults::default();
         results
             .route_collisions
-            .push(fallow_core::results::RouteCollisionFinding::with_actions(
-                fallow_core::results::RouteCollision {
+            .push(fallow_engine::results::RouteCollisionFinding::with_actions(
+                fallow_engine::results::RouteCollision {
                     path: file.clone(),
                     url: "/about".to_string(),
                     conflicting_paths: vec![root.join("app/(b)/about/page.tsx")],
@@ -1321,8 +1321,8 @@ mod tests {
 
         let mut results = AnalysisResults::default();
         results.dynamic_segment_name_conflicts.push(
-            fallow_core::results::DynamicSegmentNameConflictFinding::with_actions(
-                fallow_core::results::DynamicSegmentNameConflict {
+            fallow_engine::results::DynamicSegmentNameConflictFinding::with_actions(
+                fallow_engine::results::DynamicSegmentNameConflict {
                     path: file.clone(),
                     position: "/blog".to_string(),
                     conflicting_segments: vec!["[id]".to_string(), "[slug]".to_string()],
@@ -1361,8 +1361,8 @@ mod tests {
 
         let mut results = AnalysisResults::default();
         results.mixed_client_server_barrels.push(
-            fallow_core::results::MixedClientServerBarrelFinding::with_actions(
-                fallow_core::results::MixedClientServerBarrel {
+            fallow_engine::results::MixedClientServerBarrelFinding::with_actions(
+                fallow_engine::results::MixedClientServerBarrel {
                     path: file.clone(),
                     client_origin: "./Button".to_string(),
                     server_origin: "./fetchUser".to_string(),
@@ -1402,8 +1402,8 @@ mod tests {
 
         let mut results = AnalysisResults::default();
         results.misplaced_directives.push(
-            fallow_core::results::MisplacedDirectiveFinding::with_actions(
-                fallow_core::results::MisplacedDirective {
+            fallow_engine::results::MisplacedDirectiveFinding::with_actions(
+                fallow_engine::results::MisplacedDirective {
                     path: file.clone(),
                     directive: "use client".to_string(),
                     line: 3,

--- a/crates/lsp/src/diagnostics/unused.rs
+++ b/crates/lsp/src/diagnostics/unused.rs
@@ -4,7 +4,7 @@ use ls_types::{
     Diagnostic, DiagnosticSeverity, DiagnosticTag, NumberOrString, Position, Range, Uri,
 };
 
-use fallow_core::results::AnalysisResults;
+use fallow_engine::results::AnalysisResults;
 
 use super::{FIRST_LINE_RANGE, doc_link};
 
@@ -16,13 +16,14 @@ pub fn push_export_diagnostics(
     let types_iter = results.unused_types.iter().map(|f| &f.export);
     for (exports, code, anchor, msg_prefix) in [
         (
-            Box::new(exports_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedExport>>,
+            Box::new(exports_iter)
+                as Box<dyn Iterator<Item = &fallow_engine::results::UnusedExport>>,
             "unused-export",
             "unused-exports",
             "Export" as &str,
         ),
         (
-            Box::new(types_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedExport>>,
+            Box::new(types_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedExport>>,
             "unused-type",
             "unused-types",
             "Type export",
@@ -43,7 +44,7 @@ pub fn push_export_diagnostics(
 )]
 fn push_unused_export_diagnostic(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    export: &fallow_core::results::UnusedExport,
+    export: &fallow_engine::results::UnusedExport,
     code: &str,
     anchor: &str,
     msg_prefix: &str,
@@ -168,7 +169,7 @@ pub fn push_dep_diagnostics(
     package_json_uri: Option<&Uri>,
     root: &std::path::Path,
 ) {
-    type DepIter<'a> = Box<dyn Iterator<Item = &'a fallow_core::results::UnusedDependency> + 'a>;
+    type DepIter<'a> = Box<dyn Iterator<Item = &'a fallow_engine::results::UnusedDependency> + 'a>;
     let groups: [(DepIter<'_>, &str, &str, &str); 3] = [
         (
             Box::new(results.unused_dependencies.iter().map(|f| &f.dep)),
@@ -210,7 +211,7 @@ pub fn push_dep_diagnostics(
 /// Push one full-line WARNING diagnostic for an unused dependency group entry.
 fn push_unused_dependency_diagnostic(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    dep: &fallow_core::results::UnusedDependency,
+    dep: &fallow_engine::results::UnusedDependency,
     code: &str,
     anchor: &str,
     msg_prefix: &str,
@@ -324,7 +325,7 @@ fn push_unused_catalog_entry_diagnostics(
     }
 }
 
-fn unused_catalog_entry_message(entry: &fallow_core::results::UnusedCatalogEntry) -> String {
+fn unused_catalog_entry_message(entry: &fallow_engine::results::UnusedCatalogEntry) -> String {
     if entry.catalog_name == "default" {
         format!(
             "Unused catalog entry: '{}' is not referenced by any workspace package",
@@ -518,19 +519,19 @@ pub fn push_member_diagnostics(
     let store_iter = results.unused_store_members.iter().map(|f| &f.member);
     for (members, code, anchor, kind_label) in [
         (
-            Box::new(enum_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedMember>>,
+            Box::new(enum_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedMember>>,
             "unused-enum-member",
             "unused-enum-members",
             "Enum member" as &str,
         ),
         (
-            Box::new(class_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedMember>>,
+            Box::new(class_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedMember>>,
             "unused-class-member",
             "unused-class-members",
             "Class member",
         ),
         (
-            Box::new(store_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedMember>>,
+            Box::new(store_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedMember>>,
             "unused-store-member",
             "unused-store-members",
             "Store member",
@@ -554,7 +555,7 @@ pub fn push_member_diagnostics(
 /// Push one HINT diagnostic for an unused enum / class / store member.
 fn push_unused_member_diagnostic(
     map: &mut FxHashMap<Uri, Vec<Diagnostic>>,
-    member: &fallow_core::results::UnusedMember,
+    member: &fallow_engine::results::UnusedMember,
     code: &str,
     anchor: &str,
     kind_label: &str,
@@ -881,9 +882,9 @@ fn push_unused_server_action_diagnostics(
 mod tests {
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{DuplicationReport, DuplicationStats};
-    use fallow_core::extract::MemberKind;
-    use fallow_core::results::{
+    use fallow_engine::duplicates::{DuplicationReport, DuplicationStats};
+    use fallow_engine::extract::MemberKind;
+    use fallow_engine::results::{
         AnalysisResults, DependencyLocation, EmptyCatalogGroup, EmptyCatalogGroupFinding,
         ImportSite, TestOnlyDependency, TestOnlyDependencyFinding, TypeOnlyDependency,
         TypeOnlyDependencyFinding, UnlistedDependency, UnlistedDependencyFinding,
@@ -1544,7 +1545,7 @@ mod tests {
 
     #[test]
     fn unused_dependency_override_produces_warning_diagnostic_with_absolute_uri() {
-        use fallow_core::results::{
+        use fallow_engine::results::{
             DependencyOverrideSource, UnusedDependencyOverride, UnusedDependencyOverrideFinding,
         };
 
@@ -1595,7 +1596,7 @@ mod tests {
 
     #[test]
     fn misconfigured_dependency_override_produces_error_diagnostic() {
-        use fallow_core::results::{
+        use fallow_engine::results::{
             DependencyOverrideMisconfigReason, DependencyOverrideSource,
             MisconfiguredDependencyOverride, MisconfiguredDependencyOverrideFinding,
         };

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use ls_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position, Range};
 
-use fallow_core::duplicates::DuplicationReport;
-use fallow_core::results::{AnalysisResults, SecurityFindingKind};
+use fallow_engine::duplicates::DuplicationReport;
+use fallow_engine::results::{AnalysisResults, SecurityFindingKind};
 
 use crate::diagnostics::security::security_label;
 use crate::markdown::format_inline_code;
@@ -148,7 +148,7 @@ fn check_security(
 
 /// Build the confidence-first triage markdown body for a security candidate.
 fn security_hover_markdown(
-    finding: &fallow_core::results::SecurityFinding,
+    finding: &fallow_engine::results::SecurityFinding,
     file_path: &Path,
 ) -> String {
     let label = security_label(finding);
@@ -203,7 +203,7 @@ fn security_hover_markdown(
 }
 
 /// Kind-appropriate "Next:" guidance line for a security candidate.
-fn security_next_step(finding: &fallow_core::results::SecurityFinding) -> &'static str {
+fn security_next_step(finding: &fallow_engine::results::SecurityFinding) -> &'static str {
     match finding.kind {
         SecurityFindingKind::ClientServerLeak => {
             "Next: check whether the import is type-only, server-only, or behind a build-time \
@@ -257,12 +257,12 @@ fn check_unused_export(
     for (exports, kind_label) in [
         (
             Box::new(unused_exports_iter)
-                as Box<dyn Iterator<Item = &fallow_core::results::UnusedExport>>,
+                as Box<dyn Iterator<Item = &fallow_engine::results::UnusedExport>>,
             "Export",
         ),
         (
             Box::new(unused_types_iter)
-                as Box<dyn Iterator<Item = &fallow_core::results::UnusedExport>>,
+                as Box<dyn Iterator<Item = &fallow_engine::results::UnusedExport>>,
             "Type export",
         ),
     ] {
@@ -356,7 +356,7 @@ fn check_used_export(
 
 /// Build the reference-count markdown body for a used export, listing up to
 /// ten reference locations and a "... and N more" overflow line.
-fn used_export_hover_markdown(usage: &fallow_core::results::ExportUsage) -> String {
+fn used_export_hover_markdown(usage: &fallow_engine::results::ExportUsage) -> String {
     let ref_word = if usage.reference_count == 1 {
         "file"
     } else {
@@ -411,15 +411,15 @@ fn check_unused_member(
     let store_iter = results.unused_store_members.iter().map(|f| &f.member);
     for (members, kind_label) in [
         (
-            Box::new(enum_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedMember>>,
+            Box::new(enum_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedMember>>,
             "Enum member",
         ),
         (
-            Box::new(class_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedMember>>,
+            Box::new(class_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedMember>>,
             "Class member",
         ),
         (
-            Box::new(store_iter) as Box<dyn Iterator<Item = &fallow_core::results::UnusedMember>>,
+            Box::new(store_iter) as Box<dyn Iterator<Item = &fallow_engine::results::UnusedMember>>,
             "Store member",
         ),
     ] {
@@ -1007,7 +1007,7 @@ fn check_react_component_intel(
 /// Build the component summary line for the hover, matching the code-lens
 /// title format: `rendered 12x (8 parents) · 5 props · 9 hooks (4 state, ...)`.
 /// Zero segments are omitted; singular/plural is honored.
-fn react_component_summary(intel: &fallow_core::results::ReactComponentIntel) -> String {
+fn react_component_summary(intel: &fallow_engine::results::ReactComponentIntel) -> String {
     let mut segments: Vec<String> = Vec::new();
     if intel.render_sites > 0 {
         let parents = intel_pluralize(intel.distinct_parents, "parent");
@@ -1027,7 +1027,7 @@ fn react_component_summary(intel: &fallow_core::results::ReactComponentIntel) ->
 
 /// `N hooks (a state, b effect, ...)` or `None` when the component uses no
 /// hooks (kind sub-counts omitted when zero).
-fn intel_hook_segment(hooks: &fallow_core::results::ReactHookSummary) -> Option<String> {
+fn intel_hook_segment(hooks: &fallow_engine::results::ReactHookSummary) -> Option<String> {
     let total = u32::from(hooks.state)
         + u32::from(hooks.effect)
         + u32::from(hooks.memo)
@@ -1163,8 +1163,8 @@ fn check_duplication(
 /// Build the markdown body for a duplication hover: the block size plus up to
 /// ten other instance locations and a "... and N more" overflow line.
 fn duplication_hover_markdown(
-    group: &fallow_core::duplicates::CloneGroup,
-    instance: &fallow_core::duplicates::CloneInstance,
+    group: &fallow_engine::duplicates::CloneGroup,
+    instance: &fallow_engine::duplicates::CloneInstance,
 ) -> String {
     let other_count = group.instances.len() - 1;
     let instance_word = if other_count == 1 {
@@ -1217,9 +1217,9 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{CloneGroup, CloneInstance, DuplicationStats};
-    use fallow_core::extract::MemberKind;
-    use fallow_core::results::{
+    use fallow_engine::duplicates::{CloneGroup, CloneInstance, DuplicationStats};
+    use fallow_engine::extract::MemberKind;
+    use fallow_engine::results::{
         ExportUsage, ReactComponentIntel, ReactHookSummary, ReactPropDrill, ReactPropIntel,
         ReferenceLocation, SecuritySeverity, UnresolvedImport, UnresolvedImportFinding,
         UnusedClassMemberFinding, UnusedEnumMemberFinding, UnusedExport, UnusedExportFinding,
@@ -2206,13 +2206,13 @@ mod tests {
         assert!(build_hover(&results, &duplication, &path_b, pos).is_none());
     }
 
-    fn tainted_sink_finding(path: PathBuf) -> fallow_core::results::SecurityFinding {
-        fallow_core::results::SecurityFinding {
+    fn tainted_sink_finding(path: PathBuf) -> fallow_engine::results::SecurityFinding {
+        fallow_engine::results::SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
-            kind: fallow_core::results::SecurityFindingKind::TaintedSink,
+            kind: fallow_engine::results::SecurityFindingKind::TaintedSink,
             category: Some("dangerous-html".to_string()),
             cwe: Some(79),
             path,
@@ -2225,7 +2225,7 @@ mod tests {
             trace: vec![],
             actions: vec![],
             dead_code: None,
-            reachability: Some(fallow_core::results::SecurityReachability {
+            reachability: Some(fallow_engine::results::SecurityReachability {
                 reachable_from_entry: true,
                 reachable_from_untrusted_source: false,
                 taint_confidence: None,
@@ -2326,8 +2326,8 @@ mod tests {
         let path = root.join("src/components/MyCard.vue");
         let mut results = AnalysisResults::default();
         results.unrendered_components.push(
-            fallow_core::results::UnrenderedComponentFinding::with_actions(
-                fallow_core::results::UnrenderedComponent {
+            fallow_engine::results::UnrenderedComponentFinding::with_actions(
+                fallow_engine::results::UnrenderedComponent {
                     path: path.clone(),
                     component_name: "MyCard".to_string(),
                     framework: "vue".to_string(),
@@ -2359,8 +2359,8 @@ mod tests {
         let path = root.join("src/components/MyCard.vue");
         let mut results = AnalysisResults::default();
         results.unrendered_components.push(
-            fallow_core::results::UnrenderedComponentFinding::with_actions(
-                fallow_core::results::UnrenderedComponent {
+            fallow_engine::results::UnrenderedComponentFinding::with_actions(
+                fallow_engine::results::UnrenderedComponent {
                     path: path.clone(),
                     component_name: "MyCard".to_string(),
                     framework: "vue".to_string(),
@@ -2384,8 +2384,8 @@ mod tests {
         let path = root.join("src/components/MyCard.vue");
         let mut results = AnalysisResults::default();
         results.unrendered_components.push(
-            fallow_core::results::UnrenderedComponentFinding::with_actions(
-                fallow_core::results::UnrenderedComponent {
+            fallow_engine::results::UnrenderedComponentFinding::with_actions(
+                fallow_engine::results::UnrenderedComponent {
                     path: path.clone(),
                     component_name: "MyCard".to_string(),
                     framework: "vue".to_string(),
@@ -2417,8 +2417,8 @@ mod tests {
         let path = root.join("src/components/Button.vue");
         let mut results = AnalysisResults::default();
         results.unused_component_props.push(
-            fallow_core::results::UnusedComponentPropFinding::with_actions(
-                fallow_core::results::UnusedComponentProp {
+            fallow_engine::results::UnusedComponentPropFinding::with_actions(
+                fallow_engine::results::UnusedComponentProp {
                     path: path.clone(),
                     component_name: "Button".to_string(),
                     prop_name: "variant".to_string(),
@@ -2449,8 +2449,8 @@ mod tests {
         let path = root.join("src/components/Button.vue");
         let mut results = AnalysisResults::default();
         results.unused_component_props.push(
-            fallow_core::results::UnusedComponentPropFinding::with_actions(
-                fallow_core::results::UnusedComponentProp {
+            fallow_engine::results::UnusedComponentPropFinding::with_actions(
+                fallow_engine::results::UnusedComponentProp {
                     path: path.clone(),
                     component_name: "Button".to_string(),
                     prop_name: "variant".to_string(),
@@ -2481,8 +2481,8 @@ mod tests {
         let path = root.join("src/components/Form.vue");
         let mut results = AnalysisResults::default();
         results.unused_component_emits.push(
-            fallow_core::results::UnusedComponentEmitFinding::with_actions(
-                fallow_core::results::UnusedComponentEmit {
+            fallow_engine::results::UnusedComponentEmitFinding::with_actions(
+                fallow_engine::results::UnusedComponentEmit {
                     path: path.clone(),
                     component_name: "Form".to_string(),
                     emit_name: "submit".to_string(),
@@ -2513,8 +2513,8 @@ mod tests {
         let path = root.join("src/components/Form.vue");
         let mut results = AnalysisResults::default();
         results.unused_component_emits.push(
-            fallow_core::results::UnusedComponentEmitFinding::with_actions(
-                fallow_core::results::UnusedComponentEmit {
+            fallow_engine::results::UnusedComponentEmitFinding::with_actions(
+                fallow_engine::results::UnusedComponentEmit {
                     path: path.clone(),
                     component_name: "Form".to_string(),
                     emit_name: "submit".to_string(),
@@ -2545,8 +2545,8 @@ mod tests {
         let path = root.join("src/app/card/card.component.ts");
         let mut results = AnalysisResults::default();
         results.unused_component_inputs.push(
-            fallow_core::results::UnusedComponentInputFinding::with_actions(
-                fallow_core::results::UnusedComponentInput {
+            fallow_engine::results::UnusedComponentInputFinding::with_actions(
+                fallow_engine::results::UnusedComponentInput {
                     path: path.clone(),
                     component_name: "CardComponent".to_string(),
                     input_name: "title".to_string(),
@@ -2577,8 +2577,8 @@ mod tests {
         let path = root.join("src/app/card/card.component.ts");
         let mut results = AnalysisResults::default();
         results.unused_component_inputs.push(
-            fallow_core::results::UnusedComponentInputFinding::with_actions(
-                fallow_core::results::UnusedComponentInput {
+            fallow_engine::results::UnusedComponentInputFinding::with_actions(
+                fallow_engine::results::UnusedComponentInput {
                     path: path.clone(),
                     component_name: "CardComponent".to_string(),
                     input_name: "title".to_string(),
@@ -2609,8 +2609,8 @@ mod tests {
         let path = root.join("src/app/counter/counter.component.ts");
         let mut results = AnalysisResults::default();
         results.unused_component_outputs.push(
-            fallow_core::results::UnusedComponentOutputFinding::with_actions(
-                fallow_core::results::UnusedComponentOutput {
+            fallow_engine::results::UnusedComponentOutputFinding::with_actions(
+                fallow_engine::results::UnusedComponentOutput {
                     path: path.clone(),
                     component_name: "CounterComponent".to_string(),
                     output_name: "changed".to_string(),
@@ -2641,8 +2641,8 @@ mod tests {
         let path = root.join("src/app/counter/counter.component.ts");
         let mut results = AnalysisResults::default();
         results.unused_component_outputs.push(
-            fallow_core::results::UnusedComponentOutputFinding::with_actions(
-                fallow_core::results::UnusedComponentOutput {
+            fallow_engine::results::UnusedComponentOutputFinding::with_actions(
+                fallow_engine::results::UnusedComponentOutput {
                     path: path.clone(),
                     component_name: "CounterComponent".to_string(),
                     output_name: "changed".to_string(),
@@ -2673,8 +2673,8 @@ mod tests {
         let path = root.join("src/lib/Notification.svelte");
         let mut results = AnalysisResults::default();
         results.unused_svelte_events.push(
-            fallow_core::results::UnusedSvelteEventFinding::with_actions(
-                fallow_core::results::UnusedSvelteEvent {
+            fallow_engine::results::UnusedSvelteEventFinding::with_actions(
+                fallow_engine::results::UnusedSvelteEvent {
                     path: path.clone(),
                     component_name: "Notification".to_string(),
                     event_name: "close".to_string(),
@@ -2705,8 +2705,8 @@ mod tests {
         let path = root.join("src/lib/Notification.svelte");
         let mut results = AnalysisResults::default();
         results.unused_svelte_events.push(
-            fallow_core::results::UnusedSvelteEventFinding::with_actions(
-                fallow_core::results::UnusedSvelteEvent {
+            fallow_engine::results::UnusedSvelteEventFinding::with_actions(
+                fallow_engine::results::UnusedSvelteEvent {
                     path: path.clone(),
                     component_name: "Notification".to_string(),
                     event_name: "close".to_string(),
@@ -2737,8 +2737,8 @@ mod tests {
         let path = root.join("src/app/actions.ts");
         let mut results = AnalysisResults::default();
         results.unused_server_actions.push(
-            fallow_core::results::UnusedServerActionFinding::with_actions(
-                fallow_core::results::UnusedServerAction {
+            fallow_engine::results::UnusedServerActionFinding::with_actions(
+                fallow_engine::results::UnusedServerAction {
                     path: path.clone(),
                     action_name: "deleteUser".to_string(),
                     line: 8,
@@ -2769,8 +2769,8 @@ mod tests {
         let path = root.join("src/app/actions.ts");
         let mut results = AnalysisResults::default();
         results.unused_server_actions.push(
-            fallow_core::results::UnusedServerActionFinding::with_actions(
-                fallow_core::results::UnusedServerAction {
+            fallow_engine::results::UnusedServerActionFinding::with_actions(
+                fallow_engine::results::UnusedServerAction {
                     path: path.clone(),
                     action_name: "deleteUser".to_string(),
                     line: 8,
@@ -2800,8 +2800,8 @@ mod tests {
         let path = root.join("src/routes/blog/+page.server.ts");
         let mut results = AnalysisResults::default();
         results.unused_load_data_keys.push(
-            fallow_core::results::UnusedLoadDataKeyFinding::with_actions(
-                fallow_core::results::UnusedLoadDataKey {
+            fallow_engine::results::UnusedLoadDataKeyFinding::with_actions(
+                fallow_engine::results::UnusedLoadDataKey {
                     path: path.clone(),
                     key_name: "posts".to_string(),
                     line: 12,
@@ -2833,8 +2833,8 @@ mod tests {
         let path = root.join("src/routes/blog/+page.server.ts");
         let mut results = AnalysisResults::default();
         results.unused_load_data_keys.push(
-            fallow_core::results::UnusedLoadDataKeyFinding::with_actions(
-                fallow_core::results::UnusedLoadDataKey {
+            fallow_engine::results::UnusedLoadDataKeyFinding::with_actions(
+                fallow_engine::results::UnusedLoadDataKey {
                     path: path.clone(),
                     key_name: "posts".to_string(),
                     line: 12,
@@ -2857,8 +2857,8 @@ mod tests {
         let path = root.join("src/routes/blog/+page.server.ts");
         let mut results = AnalysisResults::default();
         results.unused_load_data_keys.push(
-            fallow_core::results::UnusedLoadDataKeyFinding::with_actions(
-                fallow_core::results::UnusedLoadDataKey {
+            fallow_engine::results::UnusedLoadDataKeyFinding::with_actions(
+                fallow_engine::results::UnusedLoadDataKey {
                     path: path.clone(),
                     key_name: "posts".to_string(),
                     line: 12,
@@ -2883,12 +2883,12 @@ mod tests {
     fn hover_on_client_server_leak_security_candidate() {
         let root = test_root();
         let path = root.join("src/client/Secrets.tsx");
-        let finding = fallow_core::results::SecurityFinding {
+        let finding = fallow_engine::results::SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
-            kind: fallow_core::results::SecurityFindingKind::ClientServerLeak,
+            kind: fallow_engine::results::SecurityFindingKind::ClientServerLeak,
             category: None,
             cwe: None,
             path: path.clone(),
@@ -2897,7 +2897,7 @@ mod tests {
             evidence: "process.env.SECRET_KEY imported into client bundle".to_string(),
             source_backed: false,
             source_read: None,
-            severity: fallow_core::results::SecuritySeverity::High,
+            severity: fallow_engine::results::SecuritySeverity::High,
             trace: vec![],
             actions: vec![],
             dead_code: None,
@@ -2926,8 +2926,8 @@ mod tests {
         let root = test_root();
         let path = root.join("src/utils/xss.ts");
         let mut finding = tainted_sink_finding(path.clone());
-        finding.dead_code = Some(fallow_core::results::SecurityDeadCodeContext {
-            kind: fallow_core::results::SecurityDeadCodeKind::UnusedExport,
+        finding.dead_code = Some(fallow_engine::results::SecurityDeadCodeContext {
+            kind: fallow_engine::results::SecurityDeadCodeKind::UnusedExport,
             export_name: Some("renderHtml".to_string()),
             line: Some(8),
             guidance: "Verify the dead-code finding and delete the code if safe before hardening."
@@ -3008,8 +3008,8 @@ mod tests {
                 path: path.clone(),
             }));
         results.unrendered_components.push(
-            fallow_core::results::UnrenderedComponentFinding::with_actions(
-                fallow_core::results::UnrenderedComponent {
+            fallow_engine::results::UnrenderedComponentFinding::with_actions(
+                fallow_engine::results::UnrenderedComponent {
                     path: path.clone(),
                     component_name: "Dead".to_string(),
                     framework: "vue".to_string(),
@@ -3421,8 +3421,8 @@ mod tests {
         let path = root.join("src/Card.tsx");
         let mut results = AnalysisResults::default();
         results.unused_component_props.push(
-            fallow_core::results::UnusedComponentPropFinding::with_actions(
-                fallow_core::results::UnusedComponentProp {
+            fallow_engine::results::UnusedComponentPropFinding::with_actions(
+                fallow_engine::results::UnusedComponentProp {
                     path: path.clone(),
                     component_name: "Card".to_string(),
                     prop_name: "subtitle".to_string(),

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -500,10 +500,10 @@ fn collect_inline_complexity(
         }
 
         for function in &module.complexity {
-            if fallow_core::suppress::is_suppressed(
+            if fallow_engine::suppress::is_suppressed(
                 &module.suppressions,
                 function.line,
-                fallow_core::suppress::IssueKind::Complexity,
+                fallow_engine::suppress::IssueKind::Complexity,
             ) {
                 continue;
             }
@@ -915,7 +915,7 @@ impl LanguageServer for FallowLspServer {
         let position = params.text_document_position_params.position;
 
         let duplication = self.duplication.read().await;
-        let empty_report = fallow_core::duplicates::DuplicationReport::default();
+        let empty_report = fallow_engine::duplicates::DuplicationReport::default();
         let duplication_ref = duplication.as_ref().unwrap_or(&empty_report);
 
         Ok(hover::build_hover(
@@ -1549,8 +1549,8 @@ fn merge_duplication(target: &mut DuplicationReport, source: DuplicationReport) 
 mod tests {
     use super::*;
 
-    use fallow_core::duplicates::{CloneGroup, CloneInstance, DuplicationStats};
-    use fallow_core::results::{
+    use fallow_engine::duplicates::{CloneGroup, CloneInstance, DuplicationStats};
+    use fallow_engine::results::{
         BoundaryViolation, BoundaryViolationFinding, CircularDependency, CircularDependencyFinding,
         ExportUsage, SecuritySeverity, TestOnlyDependency, TestOnlyDependencyFinding,
         TypeOnlyDependency, UnlistedDependency, UnlistedDependencyFinding,
@@ -1638,8 +1638,8 @@ mod tests {
                 col: 0,
             })],
             boundary_coverage_violations: vec![
-                fallow_core::results::BoundaryCoverageViolationFinding::with_actions(
-                    fallow_core::results::BoundaryCoverageViolation {
+                fallow_engine::results::BoundaryCoverageViolationFinding::with_actions(
+                    fallow_engine::results::BoundaryCoverageViolation {
                         path: "/unzoned.ts".into(),
                         line: 2,
                         col: 0,
@@ -1647,8 +1647,8 @@ mod tests {
                 ),
             ],
             boundary_call_violations: vec![
-                fallow_core::results::BoundaryCallViolationFinding::with_actions(
-                    fallow_core::results::BoundaryCallViolation {
+                fallow_engine::results::BoundaryCallViolationFinding::with_actions(
+                    fallow_engine::results::BoundaryCallViolation {
                         path: "/domain.ts".into(),
                         line: 3,
                         col: 0,
@@ -2506,8 +2506,8 @@ export function choose(value: number): string {
                 path: "/a.ts".into(),
             }));
         source_a.unresolved_imports.push(
-            fallow_core::results::UnresolvedImportFinding::with_actions(
-                fallow_core::results::UnresolvedImport {
+            fallow_engine::results::UnresolvedImportFinding::with_actions(
+                fallow_engine::results::UnresolvedImport {
                     path: "/a.ts".into(),
                     specifier: "./missing".to_string(),
                     line: 1,
@@ -2562,7 +2562,7 @@ export function choose(value: number): string {
 
     fn merge_test_unused_dependency(
         package_name: &str,
-        location: fallow_core::results::DependencyLocation,
+        location: fallow_engine::results::DependencyLocation,
         line: u32,
     ) -> UnusedDependency {
         UnusedDependency {
@@ -2577,7 +2577,7 @@ export function choose(value: number): string {
     fn merge_test_unused_member(
         parent_name: &str,
         member_name: &str,
-        kind: fallow_core::extract::MemberKind,
+        kind: fallow_engine::extract::MemberKind,
         line: u32,
     ) -> UnusedMember {
         UnusedMember {
@@ -2608,32 +2608,37 @@ export function choose(value: number): string {
             unused_dependencies: vec![UnusedDependencyFinding::with_actions(
                 merge_test_unused_dependency(
                     "dep",
-                    fallow_core::results::DependencyLocation::Dependencies,
+                    fallow_engine::results::DependencyLocation::Dependencies,
                     3,
                 ),
             )],
             unused_dev_dependencies: vec![UnusedDevDependencyFinding::with_actions(
                 merge_test_unused_dependency(
                     "dev-dep",
-                    fallow_core::results::DependencyLocation::DevDependencies,
+                    fallow_engine::results::DependencyLocation::DevDependencies,
                     4,
                 ),
             )],
             unused_optional_dependencies: vec![UnusedOptionalDependencyFinding::with_actions(
                 merge_test_unused_dependency(
                     "opt-dep",
-                    fallow_core::results::DependencyLocation::OptionalDependencies,
+                    fallow_engine::results::DependencyLocation::OptionalDependencies,
                     5,
                 ),
             )],
             unused_enum_members: vec![UnusedEnumMemberFinding::with_actions(
-                merge_test_unused_member("E", "A", fallow_core::extract::MemberKind::EnumMember, 6),
+                merge_test_unused_member(
+                    "E",
+                    "A",
+                    fallow_engine::extract::MemberKind::EnumMember,
+                    6,
+                ),
             )],
             unused_class_members: vec![UnusedClassMemberFinding::with_actions(
                 merge_test_unused_member(
                     "C",
                     "m",
-                    fallow_core::extract::MemberKind::ClassMethod,
+                    fallow_engine::extract::MemberKind::ClassMethod,
                     7,
                 ),
             )],
@@ -2641,37 +2646,43 @@ export function choose(value: number): string {
                 merge_test_unused_member(
                     "S",
                     "a",
-                    fallow_core::extract::MemberKind::StoreMember,
+                    fallow_engine::extract::MemberKind::StoreMember,
                     7,
                 ),
             )],
-            unresolved_imports: vec![fallow_core::results::UnresolvedImportFinding::with_actions(
-                fallow_core::results::UnresolvedImport {
-                    path: "/f.ts".into(),
-                    specifier: "./gone".to_string(),
-                    line: 8,
-                    col: 0,
-                    specifier_col: 10,
-                },
-            )],
+            unresolved_imports: vec![
+                fallow_engine::results::UnresolvedImportFinding::with_actions(
+                    fallow_engine::results::UnresolvedImport {
+                        path: "/f.ts".into(),
+                        specifier: "./gone".to_string(),
+                        line: 8,
+                        col: 0,
+                        specifier_col: 10,
+                    },
+                ),
+            ],
             unlisted_dependencies: vec![UnlistedDependencyFinding::with_actions(
                 UnlistedDependency {
                     package_name: "unlisted".to_string(),
                     imported_from: vec![],
                 },
             )],
-            duplicate_exports: vec![fallow_core::results::DuplicateExportFinding::with_actions(
-                fallow_core::results::DuplicateExport {
-                    export_name: "dup".to_string(),
-                    locations: vec![],
-                },
-            )],
+            duplicate_exports: vec![
+                fallow_engine::results::DuplicateExportFinding::with_actions(
+                    fallow_engine::results::DuplicateExport {
+                        export_name: "dup".to_string(),
+                        locations: vec![],
+                    },
+                ),
+            ],
             type_only_dependencies: vec![
-                fallow_core::results::TypeOnlyDependencyFinding::with_actions(TypeOnlyDependency {
-                    package_name: "type-only".to_string(),
-                    path: "/pkg.json".into(),
-                    line: 9,
-                }),
+                fallow_engine::results::TypeOnlyDependencyFinding::with_actions(
+                    TypeOnlyDependency {
+                        package_name: "type-only".to_string(),
+                        path: "/pkg.json".into(),
+                        line: 9,
+                    },
+                ),
             ],
             circular_dependencies: vec![CircularDependencyFinding::with_actions(
                 CircularDependency {
@@ -2700,8 +2711,8 @@ export function choose(value: number): string {
                 col: 0,
             })],
             boundary_coverage_violations: vec![
-                fallow_core::results::BoundaryCoverageViolationFinding::with_actions(
-                    fallow_core::results::BoundaryCoverageViolation {
+                fallow_engine::results::BoundaryCoverageViolationFinding::with_actions(
+                    fallow_engine::results::BoundaryCoverageViolation {
                         path: "/unzoned.ts".into(),
                         line: 13,
                         col: 0,
@@ -2709,8 +2720,8 @@ export function choose(value: number): string {
                 ),
             ],
             boundary_call_violations: vec![
-                fallow_core::results::BoundaryCallViolationFinding::with_actions(
-                    fallow_core::results::BoundaryCallViolation {
+                fallow_engine::results::BoundaryCallViolationFinding::with_actions(
+                    fallow_engine::results::BoundaryCallViolation {
                         path: "/zoned.ts".into(),
                         line: 14,
                         col: 0,
@@ -2720,19 +2731,21 @@ export function choose(value: number): string {
                     },
                 ),
             ],
-            policy_violations: vec![fallow_core::results::PolicyViolationFinding::with_actions(
-                fallow_core::results::PolicyViolation {
-                    path: "/zoned.ts".into(),
-                    line: 15,
-                    col: 0,
-                    pack: "team-policy".to_string(),
-                    rule_id: "no-console".to_string(),
-                    kind: fallow_core::results::PolicyRuleKind::BannedCall,
-                    matched: "console.log".to_string(),
-                    severity: fallow_core::results::PolicyViolationSeverity::Warn,
-                    message: None,
-                },
-            )],
+            policy_violations: vec![
+                fallow_engine::results::PolicyViolationFinding::with_actions(
+                    fallow_engine::results::PolicyViolation {
+                        path: "/zoned.ts".into(),
+                        line: 15,
+                        col: 0,
+                        pack: "team-policy".to_string(),
+                        rule_id: "no-console".to_string(),
+                        kind: fallow_engine::results::PolicyRuleKind::BannedCall,
+                        matched: "console.log".to_string(),
+                        severity: fallow_engine::results::PolicyViolationSeverity::Warn,
+                        message: None,
+                    },
+                ),
+            ],
             export_usages: vec![ExportUsage {
                 path: "/f.ts".into(),
                 export_name: "used".to_string(),
@@ -2741,38 +2754,40 @@ export function choose(value: number): string {
                 reference_count: 3,
                 reference_locations: vec![],
             }],
-            private_type_leaks: vec![fallow_core::results::PrivateTypeLeakFinding::with_actions(
-                fallow_core::results::PrivateTypeLeak {
-                    path: "/f.ts".into(),
-                    export_name: "pub_fn".to_string(),
-                    type_name: "Secret".to_string(),
-                    line: 14,
-                    col: 0,
-                    span_start: 0,
-                },
-            )],
-            re_export_cycles: vec![fallow_core::results::ReExportCycleFinding::with_actions(
-                fallow_core::results::ReExportCycle {
+            private_type_leaks: vec![
+                fallow_engine::results::PrivateTypeLeakFinding::with_actions(
+                    fallow_engine::results::PrivateTypeLeak {
+                        path: "/f.ts".into(),
+                        export_name: "pub_fn".to_string(),
+                        type_name: "Secret".to_string(),
+                        line: 14,
+                        col: 0,
+                        span_start: 0,
+                    },
+                ),
+            ],
+            re_export_cycles: vec![fallow_engine::results::ReExportCycleFinding::with_actions(
+                fallow_engine::results::ReExportCycle {
                     files: vec!["/barrel.ts".into()],
-                    kind: fallow_core::results::ReExportCycleKind::SelfLoop,
+                    kind: fallow_engine::results::ReExportCycleKind::SelfLoop,
                 },
             )],
-            stale_suppressions: vec![fallow_core::results::StaleSuppression {
+            stale_suppressions: vec![fallow_engine::results::StaleSuppression {
                 path: "/f.ts".into(),
                 line: 15,
                 col: 0,
-                origin: fallow_core::results::SuppressionOrigin::Comment {
+                origin: fallow_engine::results::SuppressionOrigin::Comment {
                     issue_kind: None,
                     reason: None,
                     is_file_level: false,
                     kind_known: true,
                 },
                 missing_reason: false,
-                actions: fallow_core::results::StaleSuppression::actions_for(false),
+                actions: fallow_engine::results::StaleSuppression::actions_for(false),
             }],
             unused_catalog_entries: vec![
-                fallow_core::results::UnusedCatalogEntryFinding::with_actions(
-                    fallow_core::results::UnusedCatalogEntry {
+                fallow_engine::results::UnusedCatalogEntryFinding::with_actions(
+                    fallow_engine::results::UnusedCatalogEntry {
                         entry_name: "react".to_string(),
                         catalog_name: "default".to_string(),
                         path: "/pnpm-workspace.yaml".into(),
@@ -2782,8 +2797,8 @@ export function choose(value: number): string {
                 ),
             ],
             empty_catalog_groups: vec![
-                fallow_core::results::EmptyCatalogGroupFinding::with_actions(
-                    fallow_core::results::EmptyCatalogGroup {
+                fallow_engine::results::EmptyCatalogGroupFinding::with_actions(
+                    fallow_engine::results::EmptyCatalogGroup {
                         catalog_name: "ui".to_string(),
                         path: "/pnpm-workspace.yaml".into(),
                         line: 17,
@@ -2791,8 +2806,8 @@ export function choose(value: number): string {
                 ),
             ],
             unresolved_catalog_references: vec![
-                fallow_core::results::UnresolvedCatalogReferenceFinding::with_actions(
-                    fallow_core::results::UnresolvedCatalogReference {
+                fallow_engine::results::UnresolvedCatalogReferenceFinding::with_actions(
+                    fallow_engine::results::UnresolvedCatalogReference {
                         entry_name: "vue".to_string(),
                         catalog_name: "default".to_string(),
                         path: "/pkg.json".into(),
@@ -2802,14 +2817,14 @@ export function choose(value: number): string {
                 ),
             ],
             unused_dependency_overrides: vec![
-                fallow_core::results::UnusedDependencyOverrideFinding::with_actions(
-                    fallow_core::results::UnusedDependencyOverride {
+                fallow_engine::results::UnusedDependencyOverrideFinding::with_actions(
+                    fallow_engine::results::UnusedDependencyOverride {
                         raw_key: "react".to_string(),
                         target_package: "react".to_string(),
                         parent_package: None,
                         version_constraint: None,
                         version_range: "18".to_string(),
-                        source: fallow_core::results::DependencyOverrideSource::PnpmWorkspaceYaml,
+                        source: fallow_engine::results::DependencyOverrideSource::PnpmWorkspaceYaml,
                         path: "/pnpm-workspace.yaml".into(),
                         line: 19,
                         hint: None,
@@ -2817,21 +2832,22 @@ export function choose(value: number): string {
                 ),
             ],
             misconfigured_dependency_overrides: vec![
-                fallow_core::results::MisconfiguredDependencyOverrideFinding::with_actions(
-                    fallow_core::results::MisconfiguredDependencyOverride {
+                fallow_engine::results::MisconfiguredDependencyOverrideFinding::with_actions(
+                    fallow_engine::results::MisconfiguredDependencyOverride {
                         raw_key: "bad>".to_string(),
                         target_package: None,
                         raw_value: String::new(),
-                        reason: fallow_core::results::DependencyOverrideMisconfigReason::EmptyValue,
-                        source: fallow_core::results::DependencyOverrideSource::PnpmPackageJson,
+                        reason:
+                            fallow_engine::results::DependencyOverrideMisconfigReason::EmptyValue,
+                        source: fallow_engine::results::DependencyOverrideSource::PnpmPackageJson,
                         path: "/pkg.json".into(),
                         line: 20,
                     },
                 ),
             ],
             invalid_client_exports: vec![
-                fallow_core::results::InvalidClientExportFinding::with_actions(
-                    fallow_core::results::InvalidClientExport {
+                fallow_engine::results::InvalidClientExportFinding::with_actions(
+                    fallow_engine::results::InvalidClientExport {
                         path: "/app/page.tsx".into(),
                         export_name: "metadata".to_string(),
                         directive: "use client".to_string(),
@@ -2841,8 +2857,8 @@ export function choose(value: number): string {
                 ),
             ],
             mixed_client_server_barrels: vec![
-                fallow_core::results::MixedClientServerBarrelFinding::with_actions(
-                    fallow_core::results::MixedClientServerBarrel {
+                fallow_engine::results::MixedClientServerBarrelFinding::with_actions(
+                    fallow_engine::results::MixedClientServerBarrel {
                         path: "/app/components/index.ts".into(),
                         client_origin: "./Button".to_string(),
                         server_origin: "./fetchUser".to_string(),
@@ -2852,8 +2868,8 @@ export function choose(value: number): string {
                 ),
             ],
             misplaced_directives: vec![
-                fallow_core::results::MisplacedDirectiveFinding::with_actions(
-                    fallow_core::results::MisplacedDirective {
+                fallow_engine::results::MisplacedDirectiveFinding::with_actions(
+                    fallow_engine::results::MisplacedDirective {
                         path: "/app/widget.tsx".into(),
                         directive: "use client".to_string(),
                         line: 24,
@@ -2874,8 +2890,8 @@ export function choose(value: number): string {
             prop_drilling_chains: vec![],
             thin_wrappers: vec![],
             duplicate_prop_shapes: vec![],
-            route_collisions: vec![fallow_core::results::RouteCollisionFinding::with_actions(
-                fallow_core::results::RouteCollision {
+            route_collisions: vec![fallow_engine::results::RouteCollisionFinding::with_actions(
+                fallow_engine::results::RouteCollision {
                     path: "/app/(a)/about/page.tsx".into(),
                     url: "/about".to_string(),
                     conflicting_paths: vec!["/app/(b)/about/page.tsx".into()],
@@ -2884,8 +2900,8 @@ export function choose(value: number): string {
                 },
             )],
             dynamic_segment_name_conflicts: vec![
-                fallow_core::results::DynamicSegmentNameConflictFinding::with_actions(
-                    fallow_core::results::DynamicSegmentNameConflict {
+                fallow_engine::results::DynamicSegmentNameConflictFinding::with_actions(
+                    fallow_engine::results::DynamicSegmentNameConflict {
                         path: "/app/shop/[id]/page.tsx".into(),
                         position: "/shop".to_string(),
                         conflicting_segments: vec!["[id]".to_string(), "[slug]".to_string()],
@@ -2897,11 +2913,11 @@ export function choose(value: number): string {
             ],
             suppression_count: 1,
             active_suppressions: Vec::new(),
-            feature_flags: vec![fallow_core::results::FeatureFlag {
+            feature_flags: vec![fallow_engine::results::FeatureFlag {
                 path: "/f.ts".into(),
                 flag_name: "ENABLE_X".to_string(),
-                kind: fallow_core::results::FlagKind::EnvironmentVariable,
-                confidence: fallow_core::results::FlagConfidence::High,
+                kind: fallow_engine::results::FlagKind::EnvironmentVariable,
+                confidence: fallow_engine::results::FlagConfidence::High,
                 line: 21,
                 col: 0,
                 guard_span_start: None,
@@ -2911,16 +2927,16 @@ export function choose(value: number): string {
                 guard_line_end: None,
                 guarded_dead_exports: vec![],
             }],
-            entry_point_summary: Some(fallow_core::results::EntryPointSummary {
+            entry_point_summary: Some(fallow_engine::results::EntryPointSummary {
                 total: 0,
                 by_source: vec![],
             }),
-            security_findings: vec![fallow_core::results::SecurityFinding {
+            security_findings: vec![fallow_engine::results::SecurityFinding {
                 finding_id: String::new(),
-                candidate: fallow_core::results::SecurityCandidate::default(),
+                candidate: fallow_engine::results::SecurityCandidate::default(),
                 taint_flow: None,
                 attack_surface: None,
-                kind: fallow_core::results::SecurityFindingKind::ClientServerLeak,
+                kind: fallow_engine::results::SecurityFindingKind::ClientServerLeak,
                 category: None,
                 cwe: None,
                 path: "/client.tsx".into(),
@@ -2939,17 +2955,17 @@ export function choose(value: number): string {
             security_unresolved_edge_files: 2,
             security_unresolved_callee_sites: 0,
             security_unresolved_callee_diagnostics: vec![
-                fallow_core::results::SecurityUnresolvedCalleeDiagnostic {
+                fallow_engine::results::SecurityUnresolvedCalleeDiagnostic {
                     path: "/client.tsx".into(),
                     line: 2,
                     col: 0,
-                    reason: fallow_core::extract::SkippedSecurityCalleeReason::DynamicDispatch,
+                    reason: fallow_engine::extract::SkippedSecurityCalleeReason::DynamicDispatch,
                     expression_kind:
-                        fallow_core::extract::SkippedSecurityCalleeExpressionKind::Other,
+                        fallow_engine::extract::SkippedSecurityCalleeExpressionKind::Other,
                 },
             ],
-            render_fan_in: Some(fallow_core::results::RenderFanInMetric {
-                per_component: vec![fallow_core::results::RenderFanInComponent {
+            render_fan_in: Some(fallow_engine::results::RenderFanInMetric {
+                per_component: vec![fallow_engine::results::RenderFanInComponent {
                     file: "/Button.tsx".into(),
                     component: "Button".to_string(),
                     render_sites: 6,
@@ -2959,7 +2975,7 @@ export function choose(value: number): string {
                 high_pct: Some(0.0),
                 max_distinct_parents: Some(3),
             }),
-            react_component_intel: vec![fallow_core::results::ReactComponentIntel {
+            react_component_intel: vec![fallow_engine::results::ReactComponentIntel {
                 path: "/Button.tsx".into(),
                 component_name: "Button".to_string(),
                 anchor_line: 1,
@@ -2967,7 +2983,7 @@ export function choose(value: number): string {
                 render_sites: 6,
                 distinct_parents: 3,
                 prop_count: 1,
-                hooks: fallow_core::results::ReactHookSummary::default(),
+                hooks: fallow_engine::results::ReactHookSummary::default(),
                 props: Vec::new(),
             }],
         }
@@ -3826,12 +3842,12 @@ export function choose(value: number): string {
         install_document(backend, &uri, 1, "doRender();").await;
         let snapshot = snapshot_for(&uri, 1);
 
-        let finding = fallow_core::results::SecurityFinding {
+        let finding = fallow_engine::results::SecurityFinding {
             finding_id: String::new(),
-            candidate: fallow_core::results::SecurityCandidate::default(),
+            candidate: fallow_engine::results::SecurityCandidate::default(),
             taint_flow: None,
             attack_surface: None,
-            kind: fallow_core::results::SecurityFindingKind::TaintedSink,
+            kind: fallow_engine::results::SecurityFindingKind::TaintedSink,
             category: Some("dangerous-html".to_string()),
             cwe: Some(79),
             path: std::path::PathBuf::from("/render.ts"),


### PR DESCRIPTION
## Summary
- Expose result, duplication, extract, and suppression namespaces from fallow-engine.
- Route LSP result, diagnostic, hover, code action, and code lens type references through fallow-engine instead of fallow-core.
- Leave non-result LSP core integration points for a later engine-session slice.

## Verification
- cargo test -p fallow-lsp
- cargo check -p fallow-engine -p fallow-lsp
- cargo clippy -p fallow-engine -p fallow-lsp --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check