### PR TITLE
refactor: route dupes execution through engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "fallow-config",
  "fallow-core",
  "fallow-cov-protocol",
+ "fallow-engine",
  "fallow-license",
  "fallow-output",
  "fallow-types",
@@ -1129,6 +1130,7 @@ dependencies = [
  "fallow-config",
  "fallow-core",
  "fallow-types",
+ "rustc-hash 2.1.2",
  "tempfile",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -54,6 +54,7 @@ schema-emit = [
 [dependencies]
 fallow-api = { workspace = true }
 fallow-core = { workspace = true }
+fallow-engine = { workspace = true }
 fallow-config = { workspace = true }
 fallow-output = { workspace = true }
 fallow-types = { workspace = true }

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -567,37 +567,20 @@ fn run_duplication_analysis(
     dupes_config: &fallow_config::DuplicatesConfig,
     changed_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
 ) -> (DuplicationReport, DefaultIgnoreSkips) {
-    if let Some(changed_files) = changed_files {
-        if opts.no_cache {
-            fallow_core::duplicates::find_duplicates_touching_files_with_default_ignore_skips(
-                &config.root,
-                files,
-                dupes_config,
-                changed_files,
-            )
-        } else {
-            fallow_core::duplicates::find_duplicates_touching_files_cached_with_default_ignore_skips(
-                &config.root,
-                files,
-                dupes_config,
-                changed_files,
-                &config.cache_dir,
-            )
-        }
-    } else if opts.no_cache {
-        fallow_core::duplicates::find_duplicates_with_default_ignore_skips(
+    let cache_dir = (!opts.no_cache).then_some(config.cache_dir.as_path());
+    let analysis = if let Some(changed_files) = changed_files {
+        let changed_files = changed_files.iter().cloned().collect::<Vec<_>>();
+        fallow_engine::find_duplicates_touching_files_with_defaults(
             &config.root,
             files,
             dupes_config,
+            &changed_files,
+            cache_dir,
         )
     } else {
-        fallow_core::duplicates::find_duplicates_cached_with_default_ignore_skips(
-            &config.root,
-            files,
-            dupes_config,
-            &config.cache_dir,
-        )
-    }
+        fallow_engine::find_duplicates_with_defaults(&config.root, files, dupes_config, cache_dir)
+    };
+    (analysis.report, analysis.default_ignore_skips)
 }
 
 /// Print duplication results and return appropriate exit code.

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../../README.md"
 fallow-config = { workspace = true }
 fallow-core = { workspace = true }
 fallow-types = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use fallow_config::{DuplicatesConfig, ResolvedConfig};
+use rustc_hash::FxHashSet;
 
 /// Duplication result types exposed through the engine boundary.
 pub mod duplicates {
@@ -40,8 +41,8 @@ pub mod suppress {
 }
 
 pub use fallow_core::duplicates::{
-    CloneFamily, CloneGroup, CloneInstance, DuplicationReport, DuplicationStats, MirroredDirectory,
-    RefactoringSuggestion,
+    CloneFamily, CloneGroup, CloneInstance, DefaultIgnoreSkips, DuplicationReport,
+    DuplicationStats, MirroredDirectory, RefactoringSuggestion,
 };
 pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
@@ -103,6 +104,13 @@ pub struct DeadCodeAnalysisOutput {
     pub results: AnalysisResults,
     pub modules: Option<Vec<ModuleInfo>>,
     pub files: Option<Vec<DiscoveredFile>>,
+}
+
+/// Typed duplication analysis result.
+#[derive(Debug)]
+pub struct DuplicationAnalysis {
+    pub report: DuplicationReport,
+    pub default_ignore_skips: DefaultIgnoreSkips,
 }
 
 /// Reusable engine session for one resolved project.
@@ -208,6 +216,33 @@ impl AnalysisSession {
     pub fn find_duplicates_with(&self, config: &DuplicatesConfig) -> DuplicationReport {
         find_duplicates(&self.config.root, &self.files, config)
     }
+
+    /// Run duplication detection and return report sidecar metadata.
+    #[must_use]
+    pub fn find_duplicates_with_defaults(
+        &self,
+        config: &DuplicatesConfig,
+        cache_dir: Option<&Path>,
+    ) -> DuplicationAnalysis {
+        find_duplicates_with_defaults(&self.config.root, &self.files, config, cache_dir)
+    }
+
+    /// Run focused duplication detection for a changed-file set.
+    #[must_use]
+    pub fn find_duplicates_touching_files_with_defaults(
+        &self,
+        config: &DuplicatesConfig,
+        changed_files: &[PathBuf],
+        cache_dir: Option<&Path>,
+    ) -> DuplicationAnalysis {
+        find_duplicates_touching_files_with_defaults(
+            &self.config.root,
+            &self.files,
+            config,
+            changed_files,
+            cache_dir,
+        )
+    }
 }
 
 /// Resolve the analysis config for a project.
@@ -296,6 +331,59 @@ pub fn find_duplicates_in_project(root: &Path, config: &DuplicatesConfig) -> Dup
     fallow_core::duplicates::find_duplicates_in_project(root, config)
 }
 
+/// Run duplication detection and include metadata about built-in ignored files.
+#[must_use]
+pub fn find_duplicates_with_defaults(
+    root: &Path,
+    files: &[DiscoveredFile],
+    config: &DuplicatesConfig,
+    cache_dir: Option<&Path>,
+) -> DuplicationAnalysis {
+    let (report, default_ignore_skips) = if let Some(cache_dir) = cache_dir {
+        fallow_core::duplicates::find_duplicates_cached_with_default_ignore_skips(
+            root, files, config, cache_dir,
+        )
+    } else {
+        fallow_core::duplicates::find_duplicates_with_default_ignore_skips(root, files, config)
+    };
+    DuplicationAnalysis {
+        report,
+        default_ignore_skips,
+    }
+}
+
+/// Run focused duplication detection and include metadata about built-in ignored files.
+#[must_use]
+pub fn find_duplicates_touching_files_with_defaults(
+    root: &Path,
+    files: &[DiscoveredFile],
+    config: &DuplicatesConfig,
+    changed_files: &[PathBuf],
+    cache_dir: Option<&Path>,
+) -> DuplicationAnalysis {
+    let changed_files = changed_files.iter().cloned().collect::<FxHashSet<_>>();
+    let (report, default_ignore_skips) = if let Some(cache_dir) = cache_dir {
+        fallow_core::duplicates::find_duplicates_touching_files_cached_with_default_ignore_skips(
+            root,
+            files,
+            config,
+            &changed_files,
+            cache_dir,
+        )
+    } else {
+        fallow_core::duplicates::find_duplicates_touching_files_with_default_ignore_skips(
+            root,
+            files,
+            config,
+            &changed_files,
+        )
+    };
+    DuplicationAnalysis {
+        report,
+        default_ignore_skips,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,5 +435,29 @@ mod tests {
             .collect();
         assert!(relative_paths.contains(&Path::new("src/index.ts")));
         assert!(!relative_paths.contains(&Path::new("src/index.test.ts")));
+    }
+
+    #[test]
+    fn analysis_session_runs_duplication_with_default_skip_metadata() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let src = temp.path().join("src");
+        let generated = temp.path().join("storybook-static");
+        std::fs::create_dir(&src).expect("src dir");
+        std::fs::create_dir(&generated).expect("generated dir");
+        let repeated =
+            "export function repeated() {\n  return ['alpha', 'beta', 'gamma'].join(',');\n}\n";
+        std::fs::write(src.join("a.ts"), repeated).expect("source file");
+        std::fs::write(src.join("b.ts"), repeated).expect("source file");
+        std::fs::write(generated.join("generated.ts"), repeated).expect("generated file");
+
+        let session = AnalysisSession::load(temp.path(), None).expect("session loads");
+        let mut config = session.config().duplicates.clone();
+        config.min_tokens = 1;
+        config.min_lines = 1;
+
+        let analysis = session.find_duplicates_with_defaults(&config, None);
+
+        assert!(!analysis.report.clone_groups.is_empty());
+        assert!(analysis.default_ignore_skips.total > 0);
     }
 }


### PR DESCRIPTION
## Summary
- expose typed duplication execution results from fallow-engine, including default-ignore skip metadata
- route CLI duplication execution through the engine boundary instead of calling fallow-core directly
- keep CLI-specific filtering and output behavior unchanged for this slice

## Verification
- cargo test -p fallow-engine
- cargo test -p fallow-cli dupes
- cargo check -p fallow-engine -p fallow-cli
- cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check