### PR TITLE
refactor: move check output contracts to output

### DIFF
--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -6,19 +6,16 @@
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use fallow_core::results::AnalysisResults;
 #[allow(
     unused_imports,
     reason = "compatibility re-export while CodeClimate output contracts move to fallow-output"
 )]
 pub use fallow_output::{
-    CodeClimateIssue, CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation,
-    CodeClimateOutput, CodeClimateSeverity,
+    CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CodeClimateIssue, CodeClimateIssueKind,
+    CodeClimateLines, CodeClimateLocation, CodeClimateOutput, CodeClimateSeverity, GroupByMode,
+    WorkspaceDiagnosticOutput,
 };
-use fallow_types::envelope::{
-    BaselineDeltas, BaselineMatch, CheckSummary, ElapsedMs, EntryPoints, Meta, RegressionResult,
-    SchemaVersion, TelemetryMeta, ToolVersion,
-};
+use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, ToolVersion};
 use fallow_types::output::NextStep;
 use serde::Serialize;
 
@@ -364,91 +361,6 @@ pub struct DupesOutput {
     /// [`CheckOutput::next_steps`] for the contract.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_steps: Vec<NextStep>,
-}
-
-/// Envelope emitted by `fallow dead-code --format json` (plus the `check`
-/// block inside the combined and audit envelopes).
-///
-/// The body is the full `AnalysisResults` flattened into the envelope so
-/// every issue array (`unused_files`, `unused_exports`, ...) lives at the
-/// top level, matching the existing wire shape. `entry_points` lifts the
-/// otherwise `#[serde(skip)]`'d `AnalysisResults::entry_point_summary` back
-/// into the JSON output. `summary` carries the per-category counts the
-/// JSON layer always emits.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(title = "fallow dead-code --format json"))]
-pub struct CheckOutput {
-    pub schema_version: SchemaVersion,
-    pub version: ToolVersion,
-    pub elapsed_ms: ElapsedMs,
-    pub total_issues: usize,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub entry_points: Option<EntryPoints>,
-    pub summary: CheckSummary,
-    #[serde(flatten)]
-    pub results: AnalysisResults,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub baseline_deltas: Option<BaselineDeltas>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub baseline: Option<BaselineMatch>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub regression: Option<RegressionResult>,
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Meta>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub workspace_diagnostics: Vec<fallow_config::WorkspaceDiagnostic>,
-    /// Read-only follow-up commands computed from this run's findings, emitted
-    /// at the JSON root so an agent acting on the output is pointed at fallow's
-    /// adjacent verification capabilities (trace, complexity breakdown, audit,
-    /// workspace scoping). Each command is runnable as-is and never mutating;
-    /// see [`NextStep`] for both contracts. Omitted when empty or when
-    /// `FALLOW_SUGGESTIONS=off`; does NOT contribute to `total_issues`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_steps: Vec<NextStep>,
-}
-
-/// Envelope emitted by `fallow dead-code --group-by ... --format json`.
-///
-/// Issues are partitioned into resolver buckets (CODEOWNERS team, directory
-/// prefix, workspace package, or GitLab CODEOWNERS section) instead of flat
-/// arrays. Each bucket carries the same issue-array shape as the ungrouped
-/// `CheckOutput` body, plus per-group `key` / `owners` / `total_issues`.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "schema",
-    schemars(
-        title = "fallow dead-code --group-by <owner|directory|package|section> --format json"
-    )
-)]
-pub struct CheckGroupedOutput {
-    pub schema_version: SchemaVersion,
-    pub version: ToolVersion,
-    pub elapsed_ms: ElapsedMs,
-    pub grouped_by: GroupByMode,
-    pub total_issues: usize,
-    pub groups: Vec<CheckGroupedEntry>,
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Meta>,
-    /// Read-only follow-up commands computed from the full (ungrouped) findings.
-    /// See [`CheckOutput::next_steps`] for the contract.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_steps: Vec<NextStep>,
-}
-
-/// Single resolver bucket inside `CheckGroupedOutput`. Carries the group's
-/// identifier, optional section owners, and a per-group flattened
-/// `AnalysisResults`.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct CheckGroupedEntry {
-    pub key: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub owners: Option<Vec<String>>,
-    pub total_issues: usize,
-    #[serde(flatten)]
-    pub results: AnalysisResults,
 }
 
 /// Envelope emitted by `fallow health --format json` (plus the `health` block
@@ -889,20 +801,6 @@ pub enum ReviewReconcileSchema {
     V1,
 }
 
-/// Resolver mode label for grouped envelopes (dead-code, dupes, health).
-///
-/// `owner` groups by CODEOWNERS team, `directory` groups by top-level
-/// directory prefix, `package` groups by workspace package name, `section`
-/// groups by GitLab CODEOWNERS `[Section]` header name.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum GroupByMode {
-    Owner,
-    Directory,
-    Package,
-    Section,
-}
 /// Envelope emitted by `fallow list --boundaries --format json`. Surfaces
 /// the architecture boundary zones, rules, and (issue #373) the user's
 /// pre-expansion `autoDiscover` logical groups so consumers can render

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -13,7 +13,7 @@ use crate::explain;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, DupesOutput, FallowOutput, GroupByMode,
-    HealthOutput, serialize_root_output,
+    HealthOutput, WorkspaceDiagnosticOutput, serialize_root_output,
 };
 use crate::report::grouping::{OwnershipResolver, ResultGroup};
 
@@ -229,12 +229,20 @@ fn build_check_output(
         baseline: None,
         regression: None,
         meta: None,
-        workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
         // Populated only at the standalone-command entry points; the combined
         // and audit envelopes reuse this struct as a sub-block and aggregate
         // their own `next_steps` at the top level, so it stays empty here.
         next_steps: Vec::new(),
     }
+}
+
+fn workspace_diagnostics_for_output(root: &Path) -> Vec<WorkspaceDiagnosticOutput> {
+    crate::runtime_support::workspace_diagnostics_for(root)
+        .into_iter()
+        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
+        .map(WorkspaceDiagnosticOutput)
+        .collect()
 }
 
 fn postprocess_check_json(output: &mut serde_json::Value, root: &Path) {

--- a/crates/output/Cargo.toml
+++ b/crates/output/Cargo.toml
@@ -14,13 +14,11 @@ readme = "../../README.md"
 [dependencies]
 fallow-types = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 schemars = { workspace = true, optional = true }
 
 [features]
 schema = ["dep:schemars", "fallow-types/schema"]
-
-[dev-dependencies]
-serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/output/src/check.rs
+++ b/crates/output/src/check.rs
@@ -1,0 +1,117 @@
+use fallow_types::envelope::{
+    BaselineDeltas, BaselineMatch, CheckSummary, ElapsedMs, EntryPoints, Meta, RegressionResult,
+    SchemaVersion, ToolVersion,
+};
+use fallow_types::output::NextStep;
+use fallow_types::results::AnalysisResults;
+use serde::Serialize;
+
+/// Serialized workspace-discovery diagnostic surfaced on check output.
+///
+/// The runtime diagnostic type currently lives in `fallow-config`, which is
+/// upstream of `fallow-output`. This transparent DTO keeps the wire contract in
+/// the output layer without introducing a crate cycle.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct WorkspaceDiagnosticOutput(pub serde_json::Value);
+
+/// Envelope emitted by `fallow dead-code --format json` (plus the `check`
+/// block inside the combined and audit envelopes).
+///
+/// The body is the full `AnalysisResults` flattened into the envelope so
+/// every issue array (`unused_files`, `unused_exports`, ...) lives at the
+/// top level, matching the existing wire shape. `entry_points` lifts the
+/// otherwise `#[serde(skip)]`'d `AnalysisResults::entry_point_summary` back
+/// into the JSON output. `summary` carries the per-category counts the
+/// JSON layer always emits.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(title = "fallow dead-code --format json"))]
+pub struct CheckOutput {
+    pub schema_version: SchemaVersion,
+    pub version: ToolVersion,
+    pub elapsed_ms: ElapsedMs,
+    pub total_issues: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry_points: Option<EntryPoints>,
+    pub summary: CheckSummary,
+    #[serde(flatten)]
+    pub results: AnalysisResults,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline_deltas: Option<BaselineDeltas>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<BaselineMatch>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regression: Option<RegressionResult>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    /// Read-only follow-up commands computed from this run's findings, emitted
+    /// at the JSON root so an agent acting on the output is pointed at fallow's
+    /// adjacent verification capabilities (trace, complexity breakdown, audit,
+    /// workspace scoping). Each command is runnable as-is and never mutating;
+    /// see [`NextStep`] for both contracts. Omitted when empty or when
+    /// `FALLOW_SUGGESTIONS=off`; does NOT contribute to `total_issues`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_steps: Vec<NextStep>,
+}
+
+/// Envelope emitted by `fallow dead-code --group-by ... --format json`.
+///
+/// Issues are partitioned into resolver buckets (CODEOWNERS team, directory
+/// prefix, workspace package, or GitLab CODEOWNERS section) instead of flat
+/// arrays. Each bucket carries the same issue-array shape as the ungrouped
+/// `CheckOutput` body, plus per-group `key` / `owners` / `total_issues`.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    schemars(
+        title = "fallow dead-code --group-by <owner|directory|package|section> --format json"
+    )
+)]
+pub struct CheckGroupedOutput {
+    pub schema_version: SchemaVersion,
+    pub version: ToolVersion,
+    pub elapsed_ms: ElapsedMs,
+    pub grouped_by: GroupByMode,
+    pub total_issues: usize,
+    pub groups: Vec<CheckGroupedEntry>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+    /// Read-only follow-up commands computed from the full (ungrouped) findings.
+    /// See [`CheckOutput::next_steps`] for the contract.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_steps: Vec<NextStep>,
+}
+
+/// Single resolver bucket inside `CheckGroupedOutput`. Carries the group's
+/// identifier, optional section owners, and a per-group flattened
+/// `AnalysisResults`.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CheckGroupedEntry {
+    pub key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owners: Option<Vec<String>>,
+    pub total_issues: usize,
+    #[serde(flatten)]
+    pub results: AnalysisResults,
+}
+
+/// Resolver mode label for grouped envelopes (dead-code, dupes, health).
+///
+/// `owner` groups by CODEOWNERS team, `directory` groups by top-level
+/// directory prefix, `package` groups by workspace package name, `section`
+/// groups by GitLab CODEOWNERS `[Section]` header name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum GroupByMode {
+    Owner,
+    Directory,
+    Package,
+    Section,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -12,11 +12,15 @@
     )
 )]
 
+mod check;
 mod codeclimate;
 mod dupes;
 mod format;
 mod issue_contract;
 
+pub use check::{
+    CheckGroupedEntry, CheckGroupedOutput, CheckOutput, GroupByMode, WorkspaceDiagnosticOutput,
+};
 pub use codeclimate::{
     CodeClimateIssue, CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation,
     CodeClimateOutput, CodeClimateSeverity,

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -795,7 +795,7 @@
         "workspace_diagnostics": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WorkspaceDiagnostic"
+            "$ref": "#/definitions/WorkspaceDiagnosticOutput"
           }
         },
         "next_steps": {
@@ -2417,7 +2417,7 @@
           "items": {
             "$ref": "#/definitions/CloneFamilyFinding"
           },
-          "description": "Clone families, each wrapped with typed actions. Inner `groups`\ninside each [`CloneFamilyFinding`] are themselves wrapped as\n[`CloneGroupFinding`] entries carrying their own `actions[]` (and\noptional audit-mode `introduced` flag), so JSON-Schema strict\nconsumers and TS consumers reading `clone_families[].groups[]` see\nthe same shape as the top-level `clone_groups[]` array (preserves\nthe issue #393 regression contract)."
+          "description": "Clone families, each wrapped with typed actions."
         },
         "mirrored_directories": {
           "type": "array",
@@ -2489,7 +2489,7 @@
         "clone_families",
         "stats"
       ],
-      "description": "Wire-shape payload for `fallow dupes --format json` (the body that\nflattens into [`crate::output_envelope::DupesOutput`] and is also\nemitted under the `dupes` / `duplication` key inside the combined and\naudit envelopes).\n\nMirrors [`DuplicationReport`] field-for-field, except `clone_groups`\nand `clone_families` carry the typed wrapper envelopes instead of bare\nfindings, so the schema (and any TS / agent consumer) sees the typed\n`actions[]` natively.",
+      "description": "Wire-shape payload for `fallow dupes --format json`.",
       "title": "fallow dupes --format json"
     },
     "DuplicationGroup": {
@@ -4032,7 +4032,7 @@
         },
         "auto_fixable": {
           "type": "boolean",
-          "description": "Whether `fallow fix` can auto-apply this action. All three variants\nare manual today."
+          "description": "Whether `fallow fix` can auto-apply this action."
         },
         "description": {
           "type": "string",
@@ -4043,14 +4043,14 @@
             "string",
             "null"
           ],
-          "description": "Additional context. Present on `extract-shared` (explaining that\nthe family's clone groups share the same files); absent otherwise."
+          "description": "Additional context for the action."
         },
         "comment": {
           "type": [
             "string",
             "null"
           ],
-          "description": "The inline comment to insert (e.g.,\n`// fallow-ignore-next-line code-duplication`). Present on\n`suppress-line` only."
+          "description": "Inline comment to insert for suppression actions."
         }
       },
       "required": [
@@ -4058,7 +4058,7 @@
         "auto_fixable",
         "description"
       ],
-      "description": "Per-action wire shape attached to each [`CloneFamilyFinding`]. Mirrors\nthe action types previously emitted by\n`build_clone_family_actions`: `extract-shared`, one `apply-suggestion`\nper [`RefactoringSuggestion`] on the family, and a trailing\n`suppress-line`."
+      "description": "Per-action wire shape attached to each clone family finding."
     },
     "CloneGroupAction": {
       "type": "object",
@@ -4069,7 +4069,7 @@
         },
         "auto_fixable": {
           "type": "boolean",
-          "description": "Whether `fallow fix` can auto-apply this action. Both variants are\nmanual today; the field is non-singleton so a future auto-applier\ndoes not need a schema change."
+          "description": "Whether `fallow fix` can auto-apply this action."
         },
         "description": {
           "type": "string",
@@ -4080,7 +4080,7 @@
             "string",
             "null"
           ],
-          "description": "The inline comment to insert (e.g.,\n`// fallow-ignore-next-line code-duplication`). Present on\n`suppress-line`; absent on `extract-shared`."
+          "description": "Inline comment to insert for suppression actions."
         }
       },
       "required": [
@@ -4088,7 +4088,7 @@
         "auto_fixable",
         "description"
       ],
-      "description": "Per-action wire shape attached to each [`CloneGroupFinding`] and\n[`AttributedCloneGroupFinding`]. Mirrors the action types previously\nemitted by `inject_dupes_actions::build_clone_group_actions` in\n`crates/cli/src/report/json.rs`: `extract-shared` plus `suppress-line`."
+      "description": "Per-action wire shape attached to each clone group finding."
     },
     "UnusedFile": {
       "type": "object",
@@ -9954,7 +9954,7 @@
         },
         "fingerprint": {
           "type": "string",
-          "description": "Stable content fingerprint, usually `dup:<8hex>` and widened on rare\nreport collisions. Addressable via `fallow dupes --trace dup:<fp>`.\nComputed from the group's instances, so it matches the top-level\n`clone_groups[].fingerprint` for the same clone."
+          "description": "Stable content fingerprint, usually `dup:<8hex>`."
         },
         "actions": {
           "type": "array",
@@ -9972,7 +9972,7 @@
         "fingerprint",
         "actions"
       ],
-      "description": "Wire-shape envelope for an [`AttributedCloneGroup`] finding (per-bucket\nduplication attribution emitted under `fallow dupes --group-by`).\nFlattens the attributed group and carries the same typed\n`CloneGroupAction` array as [`CloneGroupFinding`]; no `introduced`\nfield because `fallow audit` does not run on grouped output."
+      "description": "Wire-shape envelope for an [`AttributedCloneGroup`] finding."
     },
     "CloneFamilyActionType": {
       "oneOf": [
@@ -9984,12 +9984,12 @@
         {
           "type": "string",
           "const": "apply-suggestion",
-          "description": "Apply one of the family's [`RefactoringSuggestion`]s. One action\nper suggestion entry on the bare family."
+          "description": "Apply one of the family's refactoring suggestions."
         },
         {
           "type": "string",
           "const": "suppress-line",
-          "description": "Suppress with an inline `// fallow-ignore-next-line code-duplication`\ncomment above the duplicated code."
+          "description": "Suppress with an inline comment above the duplicated code."
         }
       ],
       "description": "Discriminant for [`CloneFamilyAction::kind`]."
@@ -10002,14 +10002,14 @@
           "items": {
             "type": "string"
           },
-          "description": "The files involved in this family (sorted for stable output)."
+          "description": "The files involved in this family."
         },
         "groups": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/CloneGroupFinding"
           },
-          "description": "Clone groups belonging to this family, each wrapped with typed\n`actions[]` so consumers that read `clone_families[].groups[]`\ndirectly see the same shape as the top-level `clone_groups[]`."
+          "description": "Clone groups belonging to this family."
         },
         "total_duplicated_lines": {
           "type": "integer",
@@ -10031,7 +10031,7 @@
           "items": {
             "$ref": "#/definitions/CloneFamilyAction"
           },
-          "description": "Suggested next steps: an `extract-shared` primary, one\n`apply-suggestion` per [`RefactoringSuggestion`] on the family, and\na trailing `suppress-line`. Always emitted (possibly empty for\nforward-compat)."
+          "description": "Suggested next steps."
         }
       },
       "required": [
@@ -10042,7 +10042,7 @@
         "suggestions",
         "actions"
       ],
-      "description": "Wire-shape envelope for a [`CloneFamily`] finding.\n\nUnlike most `*Finding` wrappers this one is NOT `#[serde(flatten)]` over\nthe bare [`CloneFamily`], because the family's nested\n`groups: Vec<CloneGroup>` field needs to carry the typed\n[`CloneGroupFinding`] wrapper too (so every nested clone group gets its\nown `actions[]` array, matching the legacy post-pass behavior; see issue\n#393 regression test). The wire shape stays byte-identical to the\nprevious post-pass output. No `introduced` field because `fallow audit`\nattributes clone groups (not families) when running against a base ref."
+      "description": "Wire-shape envelope for a clone family finding."
     },
     "CloneGroupActionType": {
       "oneOf": [
@@ -10054,10 +10054,10 @@
         {
           "type": "string",
           "const": "suppress-line",
-          "description": "Suppress the finding with an inline `// fallow-ignore-next-line\ncode-duplication` comment above the duplicated code."
+          "description": "Suppress the finding with an inline comment above the duplicated code."
         }
       ],
-      "description": "Discriminant for [`CloneGroupAction::kind`]. Mirrors the action types\nemitted by the legacy `build_clone_group_actions` walker."
+      "description": "Discriminant for [`CloneGroupAction::kind`]."
     },
     "CloneGroupFinding": {
       "type": "object",
@@ -10079,21 +10079,21 @@
         },
         "fingerprint": {
           "type": "string",
-          "description": "Stable content fingerprint, usually `dup:<8hex>` and widened on rare\nreport collisions. Addressable via `fallow dupes --trace dup:<fp>` (and\nthe `trace_clone` MCP tool) to deep-dive this group; shown alongside\neach group in the human listing."
+          "description": "Stable content fingerprint, usually `dup:<8hex>`."
         },
         "suggested_name": {
           "type": [
             "string",
             "null"
           ],
-          "description": "Best-effort human-readable name for the clone: the dominant repeated\nidentifier across the duplicated fragment (e.g. a shared `parseCsv`\nfunction). `None` when the clone has no clear dominant name (generic or\ntied identifiers); consumers then fall back to a file-based label. Lets\neditors and agents label a clone by what it is rather than an opaque\nordinal."
+          "description": "Best-effort human-readable name for the clone."
         },
         "actions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/CloneGroupAction"
           },
-          "description": "Suggested next steps: an `extract-shared` primary and a\n`suppress-line` secondary. Always emitted (possibly empty for\nforward-compat)."
+          "description": "Suggested next steps."
         },
         "introduced": {
           "anyOf": [
@@ -10104,7 +10104,7 @@
               "type": "null"
             }
           ],
-          "description": "Set by the audit pass when this clone group is introduced relative\nto the merge-base. `None` when serialized directly from Rust."
+          "description": "Audit-mode introduced flag, populated by audit post-processing."
         }
       },
       "required": [
@@ -10114,7 +10114,7 @@
         "fingerprint",
         "actions"
       ],
-      "description": "Wire-shape envelope for a [`CloneGroup`] finding. Flattens the bare\ngroup via `#[serde(flatten)]` and carries a typed `actions` array plus\nthe optional audit-mode `introduced` flag. Replaces the legacy\npost-pass injection in `crates/cli/src/report/json.rs::inject_dupes_actions`."
+      "description": "Wire-shape envelope for a clone group finding."
     },
     "DupesReportPayload": {
       "type": "object",
@@ -10131,7 +10131,7 @@
           "items": {
             "$ref": "#/definitions/CloneFamilyFinding"
           },
-          "description": "Clone families, each wrapped with typed actions. Inner `groups`\ninside each [`CloneFamilyFinding`] are themselves wrapped as\n[`CloneGroupFinding`] entries carrying their own `actions[]` (and\noptional audit-mode `introduced` flag), so JSON-Schema strict\nconsumers and TS consumers reading `clone_families[].groups[]` see\nthe same shape as the top-level `clone_groups[]` array (preserves\nthe issue #393 regression contract)."
+          "description": "Clone families, each wrapped with typed actions."
         },
         "mirrored_directories": {
           "type": "array",
@@ -10150,7 +10150,7 @@
         "clone_families",
         "stats"
       ],
-      "description": "Wire-shape payload for `fallow dupes --format json` (the body that\nflattens into [`crate::output_envelope::DupesOutput`] and is also\nemitted under the `dupes` / `duplication` key inside the combined and\naudit envelopes).\n\nMirrors [`DuplicationReport`] field-for-field, except `clone_groups`\nand `clone_families` carry the typed wrapper envelopes instead of bare\nfindings, so the schema (and any TS / agent consumer) sees the typed\n`actions[]` natively."
+      "description": "Wire-shape payload for `fallow dupes --format json`."
     },
     "CoverageAnalyzeSchemaVersion": {
       "type": "string",
@@ -17120,6 +17120,9 @@
         "line_count"
       ],
       "description": "One stable per-hunk CHANGE ANCHOR: a changed region the agent may cite as a\njudgment anchor IN ADDITION to a `signal_id`. Where a `signal_id` anchors a\ngraph FINDING (\"fallow emitted this exact finding\"), a change_anchor anchors\nonly a changed REGION (\"fallow confirms this region changed\") , a strictly\nweaker guarantee, surfaced as `anchor_kind` on the accepted judgment so a\nconsumer can tell the two apart. Graph/diff-derived; NEVER from prose."
+    },
+    "WorkspaceDiagnosticOutput": {
+      "description": "Serialized workspace-discovery diagnostic surfaced on check output.\n\nThe runtime diagnostic type currently lives in `fallow-config`, which is\nupstream of `fallow-output`. This transparent DTO keeps the wire contract in\nthe output layer without introducing a crate cycle."
     }
   }
 }


### PR DESCRIPTION
## Summary
- move dead-code check JSON envelope contracts and grouped mode labels into fallow-output
- keep a compatibility re-export from the CLI output envelope while callers migrate
- convert check workspace diagnostics at the CLI JSON boundary to avoid a fallow-output -> fallow-config dependency cycle
- regenerate the output schema from the Rust source of truth

## Verification
- cargo fmt --all -- --check
- CARGO_INCREMENTAL=0 cargo check -p fallow-output -p fallow-cli
- CARGO_INCREMENTAL=0 cargo check -p fallow-cli --features schema
- CARGO_INCREMENTAL=0 cargo test -p fallow-output
- CARGO_INCREMENTAL=0 cargo test -p fallow-cli --test schema_tests
- CARGO_INCREMENTAL=0 cargo test -p fallow-cli --test snapshot_tests json_workspace_dep_snapshot
- CARGO_INCREMENTAL=0 cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit
- CARGO_INCREMENTAL=0 cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check