### PR TITLE
refactor: route napi dead-code helpers through api

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -19,7 +19,9 @@ use serde::Serialize;
 pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
-pub use runtime::{detect_dead_code, detect_duplication};
+pub use runtime::{
+    detect_boundary_violations, detect_circular_dependencies, detect_dead_code, detect_duplication,
+};
 
 pub const COMMON_ANALYSIS_OPTION_FLAGS: &[&str] = &[
     "root",

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -76,12 +76,44 @@ pub fn detect_duplication(options: &DuplicationOptions) -> ProgrammaticResult<se
 /// or serialization failures.
 pub fn detect_dead_code(options: &DeadCodeOptions) -> ProgrammaticResult<serde_json::Value> {
     let resolved = resolve_analysis_options(&options.analysis)?;
-    resolved.install(|| detect_dead_code_inner(options, &resolved))
+    resolved.install(|| detect_dead_code_inner(options, &resolved, |_| {}))
+}
+
+/// Run circular-dependency analysis and return the dead-code JSON envelope.
+///
+/// This is a convenience wrapper over the typed dead-code runtime. It keeps the
+/// envelope shape stable while narrowing results to `circular_dependencies`.
+///
+/// # Errors
+///
+/// Returns the same structured errors as [`detect_dead_code`].
+pub fn detect_circular_dependencies(
+    options: &DeadCodeOptions,
+) -> ProgrammaticResult<serde_json::Value> {
+    let resolved = resolve_analysis_options(&options.analysis)?;
+    resolved.install(|| detect_dead_code_inner(options, &resolved, keep_circular_dependencies))
+}
+
+/// Run boundary-family analysis and return the dead-code JSON envelope.
+///
+/// This is a convenience wrapper over the typed dead-code runtime. It keeps
+/// `boundary_violations`, `boundary_coverage_violations`, and
+/// `boundary_call_violations`.
+///
+/// # Errors
+///
+/// Returns the same structured errors as [`detect_dead_code`].
+pub fn detect_boundary_violations(
+    options: &DeadCodeOptions,
+) -> ProgrammaticResult<serde_json::Value> {
+    let resolved = resolve_analysis_options(&options.analysis)?;
+    resolved.install(|| detect_dead_code_inner(options, &resolved, keep_boundary_violations))
 }
 
 fn detect_dead_code_inner(
     options: &DeadCodeOptions,
     resolved: &ResolvedAnalysisOptions,
+    post_filter: impl FnOnce(&mut AnalysisResults),
 ) -> ProgrammaticResult<serde_json::Value> {
     validate_dead_code_runtime_options(options, resolved)?;
     let start = Instant::now();
@@ -95,6 +127,7 @@ fn detect_dead_code_inner(
 
     apply_dead_code_scope(options, resolved, &session, &mut results)?;
     apply_dead_code_filters(&options.filters, &mut results);
+    post_filter(&mut results);
 
     let envelope = build_check_output(CheckOutputInput {
         schema_version: CHECK_SCHEMA_VERSION,
@@ -121,6 +154,26 @@ fn detect_dead_code_inner(
     let root_prefix = format!("{}/", session.root().display());
     strip_root_prefix(&mut output, &root_prefix);
     Ok(output)
+}
+
+fn keep_circular_dependencies(results: &mut AnalysisResults) {
+    let entry_point_summary = results.entry_point_summary.take();
+    let circular_dependencies = std::mem::take(&mut results.circular_dependencies);
+    *results = AnalysisResults::default();
+    results.entry_point_summary = entry_point_summary;
+    results.circular_dependencies = circular_dependencies;
+}
+
+fn keep_boundary_violations(results: &mut AnalysisResults) {
+    let entry_point_summary = results.entry_point_summary.take();
+    let boundary_violations = std::mem::take(&mut results.boundary_violations);
+    let boundary_coverage_violations = std::mem::take(&mut results.boundary_coverage_violations);
+    let boundary_call_violations = std::mem::take(&mut results.boundary_call_violations);
+    *results = AnalysisResults::default();
+    results.entry_point_summary = entry_point_summary;
+    results.boundary_violations = boundary_violations;
+    results.boundary_coverage_violations = boundary_coverage_violations;
+    results.boundary_call_violations = boundary_call_violations;
 }
 
 fn validate_dead_code_runtime_options(
@@ -1243,6 +1296,40 @@ mod tests {
         .expect("dead-code succeeds");
 
         assert_eq!(unused_export_names(&json), vec!["deadA"]);
+    }
+
+    #[test]
+    fn detect_circular_dependencies_keeps_dead_code_envelope_but_filters_other_findings() {
+        let project = dead_code_project();
+        let root = project.path();
+
+        let json = detect_circular_dependencies(&DeadCodeOptions {
+            analysis: analysis_at(root),
+            ..DeadCodeOptions::default()
+        })
+        .expect("circular helper succeeds");
+
+        assert_eq!(json["kind"], "dead_code");
+        assert_eq!(json["total_issues"], 0);
+        assert!(json["circular_dependencies"].as_array().is_some());
+        assert!(json["unused_exports"].as_array().is_none_or(Vec::is_empty));
+    }
+
+    #[test]
+    fn detect_boundary_violations_keeps_only_boundary_family() {
+        let project = dead_code_project();
+        let root = project.path();
+
+        let json = detect_boundary_violations(&DeadCodeOptions {
+            analysis: analysis_at(root),
+            ..DeadCodeOptions::default()
+        })
+        .expect("boundary helper succeeds");
+
+        assert_eq!(json["kind"], "dead_code");
+        assert_eq!(json["total_issues"], 0);
+        assert!(json["boundary_violations"].as_array().is_some());
+        assert!(json["unused_exports"].as_array().is_none_or(Vec::is_empty));
     }
 
     #[test]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -509,6 +509,30 @@ fn detect_dead_code_with_api_fallback(
     }
 }
 
+fn detect_circular_dependencies_with_api_fallback(
+    options: &api::DeadCodeOptions,
+) -> Result<serde_json::Value, api::ProgrammaticError> {
+    match api::detect_circular_dependencies(options) {
+        Ok(output) => Ok(output),
+        Err(error) if is_dead_code_api_fallback_error(&error) => {
+            programmatic::detect_circular_dependencies(options)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn detect_boundary_violations_with_api_fallback(
+    options: &api::DeadCodeOptions,
+) -> Result<serde_json::Value, api::ProgrammaticError> {
+    match api::detect_boundary_violations(options) {
+        Ok(output) => Ok(output),
+        Err(error) if is_dead_code_api_fallback_error(&error) => {
+            programmatic::detect_boundary_violations(options)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 fn is_dead_code_api_fallback_error(error: &api::ProgrammaticError) -> bool {
     matches!(
         error.code.as_deref(),
@@ -532,7 +556,7 @@ pub fn detect_circular_dependencies(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::DeadCodeOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        programmatic::detect_circular_dependencies(&options)
+        detect_circular_dependencies_with_api_fallback(&options)
     })))
 }
 
@@ -542,7 +566,7 @@ pub fn detect_boundary_violations(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::DeadCodeOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        programmatic::detect_boundary_violations(&options)
+        detect_boundary_violations_with_api_fallback(&options)
     })))
 }
 
@@ -728,6 +752,39 @@ mod tests {
 
         assert!(json["_meta"].is_object());
         assert_eq!(unused_export_names(&json), vec!["dead"]);
+    }
+
+    #[test]
+    fn dead_code_family_helpers_use_api_filtered_envelopes() {
+        let project = tiny_dead_code_project();
+        let root = project.path();
+        let options = api::DeadCodeOptions {
+            analysis: api::AnalysisOptions {
+                root: Some(root.to_path_buf()),
+                ..api::AnalysisOptions::default()
+            },
+            ..api::DeadCodeOptions::default()
+        };
+
+        let circular =
+            detect_circular_dependencies_with_api_fallback(&options).expect("circular helper");
+        let boundary =
+            detect_boundary_violations_with_api_fallback(&options).expect("boundary helper");
+
+        assert_eq!(circular["kind"], "dead_code");
+        assert_eq!(circular["total_issues"], 0);
+        assert!(
+            circular["unused_exports"]
+                .as_array()
+                .is_none_or(Vec::is_empty)
+        );
+        assert_eq!(boundary["kind"], "dead_code");
+        assert_eq!(boundary["total_issues"], 0);
+        assert!(
+            boundary["unused_exports"]
+                .as_array()
+                .is_none_or(Vec::is_empty)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `fallow_api::detect_circular_dependencies` and `fallow_api::detect_boundary_violations` as typed dead-code runtime wrappers.
- Routes the matching NAPI helpers through the API runtime.
- Keeps the existing legacy fallback for `diff_file` and `explain` until those contracts move out of CLI.

## Verification
- `cargo test -p fallow-api -p fallow-node`
- `cargo check -p fallow-api -p fallow-node`
- `cargo clippy -p fallow-api -p fallow-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `fallow audit --base feat/napi-dead-code-api-runtime --format json --quiet`