### PR TITLE
refactor: move check meta into output contracts

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -133,7 +133,10 @@ fn detect_dead_code_inner(
         version: env!("CARGO_PKG_VERSION").to_string(),
         elapsed: start.elapsed(),
         results,
-        config_fixable: false,
+        config_fixable: fallow_config::is_config_fixable(
+            &resolved.root,
+            resolved.config_path.as_ref(),
+        ),
         meta: options.analysis.explain.then(check_meta),
         workspace_diagnostics: Vec::new(),
         next_steps: Vec::new(),
@@ -1451,6 +1454,52 @@ mod tests {
     }
 
     #[test]
+    fn detect_dead_code_marks_duplicate_export_config_action_fixable() {
+        let project = duplicate_export_project();
+        let root = project.path();
+
+        let json = detect_dead_code(&DeadCodeOptions {
+            analysis: analysis_at(root),
+            filters: DeadCodeFilters {
+                duplicate_exports: true,
+                ..DeadCodeFilters::default()
+            },
+            ..DeadCodeOptions::default()
+        })
+        .expect("dead-code succeeds");
+
+        let action = &json["duplicate_exports"][0]["actions"][0];
+        assert_eq!(action["type"], "add-to-config");
+        assert_eq!(action["auto_fixable"], true);
+    }
+
+    #[test]
+    fn detect_dead_code_keeps_duplicate_export_config_action_blocked_in_subpackage() {
+        let workspace = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            workspace.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\n",
+        )
+        .expect("workspace");
+        let root = workspace.path().join("packages/app");
+        duplicate_export_project_at(&root);
+
+        let json = detect_dead_code(&DeadCodeOptions {
+            analysis: analysis_at(&root),
+            filters: DeadCodeFilters {
+                duplicate_exports: true,
+                ..DeadCodeFilters::default()
+            },
+            ..DeadCodeOptions::default()
+        })
+        .expect("dead-code succeeds");
+
+        let action = &json["duplicate_exports"][0]["actions"][0];
+        assert_eq!(action["type"], "add-to-config");
+        assert_eq!(action["auto_fixable"], false);
+    }
+
+    #[test]
     fn detect_dead_code_file_filter_scopes_source_findings() {
         let project = dead_code_project();
         let root = project.path();
@@ -1653,6 +1702,23 @@ mod tests {
         std::fs::write(root.join("src/a.ts"), "export const deadA = 1;\n").expect("a");
         std::fs::write(root.join("src/b.ts"), "export const deadB = 1;\n").expect("b");
         project
+    }
+
+    fn duplicate_export_project() -> tempfile::TempDir {
+        let project = tempfile::tempdir().expect("temp dir");
+        duplicate_export_project_at(project.path());
+        project
+    }
+
+    fn duplicate_export_project_at(root: &Path) {
+        std::fs::create_dir_all(root.join("src")).expect("src dir");
+        write_json(
+            root.join("package.json"),
+            r#"{"name":"api-duplicate-export","main":"src/index.ts"}"#,
+        );
+        std::fs::write(root.join("src/index.ts"), "import './a';\nimport './b';\n").expect("entry");
+        std::fs::write(root.join("src/a.ts"), "export const Button = 1;\n").expect("a");
+        std::fs::write(root.join("src/b.ts"), "export const Button = 2;\n").expect("b");
     }
 
     fn unused_export_names(json: &serde_json::Value) -> Vec<&str> {

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -8,7 +8,7 @@ use fallow_config::{
 };
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
-use fallow_output::{CHECK_SCHEMA_VERSION, CheckOutputInput, build_check_output};
+use fallow_output::{CHECK_SCHEMA_VERSION, CheckOutputInput, build_check_output, check_meta};
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -115,7 +115,6 @@ fn detect_dead_code_inner(
     resolved: &ResolvedAnalysisOptions,
     post_filter: impl FnOnce(&mut AnalysisResults),
 ) -> ProgrammaticResult<serde_json::Value> {
-    validate_dead_code_runtime_options(options, resolved)?;
     let start = Instant::now();
     let session = load_dead_code_session(options, resolved)?;
     let analysis = session.analyze_dead_code().map_err(|err| {
@@ -135,6 +134,7 @@ fn detect_dead_code_inner(
         elapsed: start.elapsed(),
         results,
         config_fixable: false,
+        meta: options.analysis.explain.then(check_meta),
         workspace_diagnostics: Vec::new(),
         next_steps: Vec::new(),
     });
@@ -174,22 +174,6 @@ fn keep_boundary_violations(results: &mut AnalysisResults) {
     results.boundary_violations = boundary_violations;
     results.boundary_coverage_violations = boundary_coverage_violations;
     results.boundary_call_violations = boundary_call_violations;
-}
-
-fn validate_dead_code_runtime_options(
-    options: &DeadCodeOptions,
-    _resolved: &ResolvedAnalysisOptions,
-) -> ProgrammaticResult<()> {
-    if options.analysis.explain {
-        return Err(ProgrammaticError::new(
-            "`explain` is not supported by the API dead-code runtime yet",
-            2,
-        )
-        .with_code("FALLOW_UNSUPPORTED_DEAD_CODE_EXPLAIN")
-        .with_context("analysis.explain")
-        .with_help("Use the CLI dead-code JSON output for `_meta` until the metadata contract moves out of fallow-cli"));
-    }
-    Ok(())
 }
 
 fn load_dead_code_session(
@@ -1438,6 +1422,32 @@ mod tests {
         .expect("dead-code succeeds");
 
         assert!(json.get("kind").is_none());
+    }
+
+    #[test]
+    fn detect_dead_code_explain_includes_output_owned_meta() {
+        let project = dead_code_project();
+        let root = project.path();
+
+        let json = detect_dead_code(&DeadCodeOptions {
+            analysis: AnalysisOptions {
+                explain: true,
+                ..analysis_at(root)
+            },
+            filters: DeadCodeFilters {
+                unused_exports: true,
+                ..DeadCodeFilters::default()
+            },
+            ..DeadCodeOptions::default()
+        })
+        .expect("dead-code succeeds");
+
+        assert_eq!(json["kind"], "dead_code");
+        assert_eq!(
+            json["_meta"]["docs"].as_str(),
+            Some(fallow_output::CHECK_DOCS)
+        );
+        assert!(json["_meta"]["rules"]["unused-export"].is_object());
     }
 
     #[test]

--- a/crates/cli/src/fix/config.rs
+++ b/crates/cli/src/fix/config.rs
@@ -35,74 +35,14 @@ use std::fmt::Write as _;
 use std::path::{Component, Path, PathBuf};
 
 use fallow_config::{
-    FallowConfig, IgnoreExportRule, OutputFormat, add_ignore_exports_rule_to_string,
+    ConfigFixPlan as ResolvedConfigPlan, IgnoreExportRule, OutputFormat,
+    add_ignore_exports_rule_to_string, classify_config_fix_plan as classify_plan,
 };
 use fallow_core::results::{AnalysisResults, DuplicateExportFinding};
 use rustc_hash::FxHashSet;
 
 use super::io::atomic_write;
 use crate::init;
-
-/// Classification of whether `fallow fix` can apply config edits at `root`.
-///
-/// Separated from the apply path so the same classification feeds the
-/// dry-run preview, the apply branch, and the JSON-layer `auto_fixable`
-/// computation. The `ResolvedConfigPlan` distinguishes the three real
-/// outcomes the orchestrator must dispatch on.
-#[derive(Debug, Clone)]
-pub enum ResolvedConfigPlan {
-    /// A fallow config file exists; append entries in place.
-    Edit { config_path: PathBuf },
-    /// No fallow config exists, but a workspace marker sits above `root`,
-    /// so creating one inside this subpackage would fragment the monorepo.
-    /// `fallow fix` refuses; the user must run `fallow init` at
-    /// `workspace_root` instead.
-    BlockedMonorepo { workspace_root: PathBuf },
-    /// No fallow config exists and `--no-create-config` was passed.
-    BlockedNoCreate { target: PathBuf },
-    /// No fallow config exists; the writer will create one at `target`.
-    Create { target: PathBuf },
-}
-
-/// Classify how `fallow fix` should behave for `root` given the user's
-/// explicit `--config <path>` (if any) and `--no-create-config` flag.
-///
-/// This is the single source of truth for both the apply path and the
-/// JSON-layer `auto_fixable` field. Keep them aligned: a wire `auto_fixable: true`
-/// MUST mean the next `fallow fix --yes` invocation will not refuse.
-pub fn classify_plan(
-    root: &Path,
-    explicit: Option<&PathBuf>,
-    no_create_config: bool,
-) -> ResolvedConfigPlan {
-    if let Some(existing) = resolve_existing_config_path(root, explicit) {
-        return ResolvedConfigPlan::Edit {
-            config_path: existing,
-        };
-    }
-    let target = root.join(".fallowrc.json");
-    if let Some(workspace_root) = find_workspace_root_above(root) {
-        return ResolvedConfigPlan::BlockedMonorepo { workspace_root };
-    }
-    if no_create_config {
-        return ResolvedConfigPlan::BlockedNoCreate { target };
-    }
-    ResolvedConfigPlan::Create { target }
-}
-
-/// Whether `fallow fix --yes` (with the default `--no-create-config=false`)
-/// could apply config edits at `root`. Drives the JSON `auto_fixable` bool.
-///
-/// Aligned with [`classify_plan`]: returns `true` for `Edit` and `Create`,
-/// `false` for `BlockedMonorepo`. (`BlockedNoCreate` cannot happen here
-/// because that branch only fires when the user passes `--no-create-config`
-/// to `fallow fix`, which doesn't propagate to non-fix commands.)
-pub fn is_config_fixable(root: &Path, explicit: Option<&PathBuf>) -> bool {
-    matches!(
-        classify_plan(root, explicit, false),
-        ResolvedConfigPlan::Edit { .. } | ResolvedConfigPlan::Create { .. }
-    )
-}
 
 /// Inputs for [`apply_config_fixes`], bundled so the entry point takes one
 /// parameter struct instead of seven (mirrors the `*FixInput` convention used
@@ -445,67 +385,6 @@ fn render_unified_diff(path_display: &str, current: &str, proposed: &str) -> Str
     let unified = diff.unified_diff().context_radius(3).to_string();
     out.push_str(&unified);
     out
-}
-
-fn resolve_existing_config_path(root: &Path, explicit: Option<&PathBuf>) -> Option<PathBuf> {
-    if let Some(path) = explicit {
-        let absolute = if path.is_absolute() {
-            path.clone()
-        } else {
-            std::env::current_dir().map_or_else(|_| path.clone(), |cwd| cwd.join(path))
-        };
-        if absolute.exists() {
-            return Some(absolute);
-        }
-        return None;
-    }
-    FallowConfig::find_config_path(root)
-}
-
-/// Walk strictly upward from `start` (skipping `start` itself) looking for
-/// workspace markers. Returns `Some(ancestor)` when found, `None` otherwise.
-///
-/// Markers, in order of detection cost (cheapest first):
-/// - `pnpm-workspace.yaml`
-/// - `turbo.json`
-/// - `lerna.json`
-/// - `rush.json`
-/// - `package.json` with a `workspaces` key (yarn/npm classic + bun)
-fn find_workspace_root_above(start: &Path) -> Option<PathBuf> {
-    let mut current = start.parent()?;
-    loop {
-        if has_workspace_marker(current) {
-            return Some(current.to_path_buf());
-        }
-        current = current.parent()?;
-    }
-}
-
-fn has_workspace_marker(dir: &Path) -> bool {
-    const SENTINELS: &[&str] = &[
-        "pnpm-workspace.yaml",
-        "turbo.json",
-        "lerna.json",
-        "rush.json",
-    ];
-    for name in SENTINELS {
-        if dir.join(name).exists() {
-            return true;
-        }
-    }
-    let pkg_path = dir.join("package.json");
-    if !pkg_path.exists() {
-        return false;
-    }
-    let Ok(content) = std::fs::read_to_string(&pkg_path) else {
-        return false;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return false;
-    };
-    value
-        .get("workspaces")
-        .is_some_and(|v| v.is_array() || v.is_object())
 }
 
 fn ignore_export_entries(
@@ -1033,13 +912,13 @@ mod tests {
         fn is_config_fixable_true_when_config_exists() {
             let dir = tempfile::tempdir().unwrap();
             std::fs::write(dir.path().join(".fallowrc.json"), "{}\n").unwrap();
-            assert!(is_config_fixable(dir.path(), None));
+            assert!(fallow_config::is_config_fixable(dir.path(), None));
         }
 
         #[test]
         fn is_config_fixable_true_when_can_create_at_root() {
             let dir = tempfile::tempdir().unwrap();
-            assert!(is_config_fixable(dir.path(), None));
+            assert!(fallow_config::is_config_fixable(dir.path(), None));
         }
 
         #[test]
@@ -1048,7 +927,7 @@ mod tests {
             std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n").unwrap();
             let sub = dir.path().join("packages/ui");
             std::fs::create_dir_all(&sub).unwrap();
-            assert!(!is_config_fixable(&sub, None));
+            assert!(!fallow_config::is_config_fixable(&sub, None));
         }
     }
 }

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -14,7 +14,7 @@ mod exports;
 mod io;
 mod plan;
 
-pub use config::is_config_fixable;
+pub use fallow_config::is_config_fixable;
 
 use plan::{CapturedHashes, CommitOutcome, FixPlan, SkippedFile};
 

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -36,7 +36,13 @@ pub(super) fn print_json(input: &PrintJsonInput<'_>) -> ExitCode {
     let regression = input.regression;
     let baseline_matched = input.baseline_matched;
     let config_fixable = input.config_fixable;
-    match build_json_with_config_fixable(results, root, elapsed, config_fixable) {
+    match build_json_with_config_fixable_and_meta(
+        results,
+        root,
+        elapsed,
+        config_fixable,
+        explain.then(fallow_output::check_meta),
+    ) {
         Ok(mut output) => {
             if let Some(outcome) = regression
                 && let serde_json::Value::Object(ref mut map) = output
@@ -53,9 +59,6 @@ pub(super) fn print_json(input: &PrintJsonInput<'_>) -> ExitCode {
                         "matched": matched,
                     }),
                 );
-            }
-            if explain {
-                insert_meta(&mut output, explain::check_meta());
             }
             emit_json(&output, "JSON")
         }
@@ -106,7 +109,7 @@ pub(super) fn print_grouped_json(input: &PrintGroupedJsonInput<'_>) -> ExitCode 
         grouped_by: group_by_mode_from_label(resolver.mode_label()),
         total_issues: original.total_issues(),
         groups: entries,
-        meta: None,
+        meta: explain.then(fallow_output::check_meta),
         next_steps: crate::report::suggestions::build_dead_code_next_steps(
             original,
             root,
@@ -129,10 +132,6 @@ pub(super) fn print_grouped_json(input: &PrintGroupedJsonInput<'_>) -> ExitCode 
             strip_root_prefix(entry, &root_prefix);
             harmonize_multi_kind_suppress_line_actions(entry);
         }
-    }
-
-    if explain {
-        insert_meta(&mut output, explain::check_meta());
     }
 
     emit_json(&output, "JSON")
@@ -167,7 +166,17 @@ pub fn build_json_with_config_fixable(
     elapsed: Duration,
     config_fixable: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let mut envelope = build_cli_check_output(results, root, elapsed, config_fixable);
+    build_json_with_config_fixable_and_meta(results, root, elapsed, config_fixable, None)
+}
+
+fn build_json_with_config_fixable_and_meta(
+    results: &AnalysisResults,
+    root: &Path,
+    elapsed: Duration,
+    config_fixable: bool,
+    meta: Option<fallow_types::envelope::Meta>,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let mut envelope = build_cli_check_output(results, root, elapsed, config_fixable, meta);
     envelope.next_steps = crate::report::suggestions::build_dead_code_next_steps(
         results,
         root,
@@ -185,7 +194,7 @@ pub fn build_check_json_payload_with_config_fixable(
     elapsed: Duration,
     config_fixable: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let envelope = build_cli_check_output(results, root, elapsed, config_fixable);
+    let envelope = build_cli_check_output(results, root, elapsed, config_fixable, None);
     let mut output = serde_json::to_value(&envelope)?;
     postprocess_check_json(&mut output, root);
     Ok(output)
@@ -196,6 +205,7 @@ fn build_cli_check_output(
     root: &Path,
     elapsed: Duration,
     config_fixable: bool,
+    meta: Option<fallow_types::envelope::Meta>,
 ) -> CheckOutput {
     build_check_output(CheckOutputInput {
         schema_version: SCHEMA_VERSION,
@@ -203,6 +213,7 @@ fn build_cli_check_output(
         elapsed,
         results: results.clone(),
         config_fixable,
+        meta,
         workspace_diagnostics: workspace_diagnostics_for_output(root),
         // Populated only at the standalone-command entry points; the combined
         // and audit envelopes reuse this struct as a sub-block and aggregate
@@ -1905,7 +1916,10 @@ mod tests {
         let results = AnalysisResults::default();
         let elapsed = Duration::from_millis(0);
         let mut output = build_json(&results, &root, elapsed).expect("should serialize");
-        insert_meta(&mut output, crate::explain::check_meta());
+        insert_meta(
+            &mut output,
+            serde_json::to_value(fallow_output::check_meta()).unwrap(),
+        );
 
         assert!(output["_meta"]["docs"].is_string());
         assert!(output["_meta"]["rules"].is_object());

--- a/crates/config/src/fixability.rs
+++ b/crates/config/src/fixability.rs
@@ -1,0 +1,132 @@
+use std::path::{Path, PathBuf};
+
+use crate::FallowConfig;
+
+/// Classification of whether fallow can apply config edits at `root`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigFixPlan {
+    /// A fallow config file exists; append entries in place.
+    Edit { config_path: PathBuf },
+    /// No fallow config exists, but a workspace marker sits above `root`,
+    /// so creating one inside this subpackage would fragment the monorepo.
+    BlockedMonorepo { workspace_root: PathBuf },
+    /// No fallow config exists and config creation was disabled.
+    BlockedNoCreate { target: PathBuf },
+    /// No fallow config exists; the writer can create one at `target`.
+    Create { target: PathBuf },
+}
+
+/// Classify how config-editing fixes should behave for `root`.
+#[must_use]
+pub fn classify_config_fix_plan(
+    root: &Path,
+    explicit: Option<&PathBuf>,
+    no_create_config: bool,
+) -> ConfigFixPlan {
+    if let Some(existing) = resolve_existing_config_path(root, explicit) {
+        return ConfigFixPlan::Edit {
+            config_path: existing,
+        };
+    }
+    let target = root.join(".fallowrc.json");
+    if let Some(workspace_root) = find_workspace_root_above(root) {
+        return ConfigFixPlan::BlockedMonorepo { workspace_root };
+    }
+    if no_create_config {
+        return ConfigFixPlan::BlockedNoCreate { target };
+    }
+    ConfigFixPlan::Create { target }
+}
+
+/// Whether `fallow fix --yes` can apply config edits at `root` with default
+/// config-creation behavior. Drives JSON `auto_fixable` for config actions.
+#[must_use]
+pub fn is_config_fixable(root: &Path, explicit: Option<&PathBuf>) -> bool {
+    matches!(
+        classify_config_fix_plan(root, explicit, false),
+        ConfigFixPlan::Edit { .. } | ConfigFixPlan::Create { .. }
+    )
+}
+
+fn resolve_existing_config_path(root: &Path, explicit: Option<&PathBuf>) -> Option<PathBuf> {
+    if let Some(path) = explicit {
+        let absolute = if path.is_absolute() {
+            path.clone()
+        } else {
+            std::env::current_dir().map_or_else(|_| path.clone(), |cwd| cwd.join(path))
+        };
+        if absolute.exists() {
+            return Some(absolute);
+        }
+        return None;
+    }
+    FallowConfig::find_config_path(root)
+}
+
+fn find_workspace_root_above(start: &Path) -> Option<PathBuf> {
+    let mut current = start.parent()?;
+    loop {
+        if has_workspace_marker(current) {
+            return Some(current.to_path_buf());
+        }
+        current = current.parent()?;
+    }
+}
+
+fn has_workspace_marker(dir: &Path) -> bool {
+    const SENTINELS: &[&str] = &[
+        "pnpm-workspace.yaml",
+        "turbo.json",
+        "lerna.json",
+        "rush.json",
+    ];
+    for name in SENTINELS {
+        if dir.join(name).exists() {
+            return true;
+        }
+    }
+    let pkg_path = dir.join("package.json");
+    if !pkg_path.exists() {
+        return false;
+    }
+    let Ok(content) = std::fs::read_to_string(&pkg_path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    value
+        .get("workspaces")
+        .is_some_and(|v| v.is_array() || v.is_object())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_fixable_true_when_config_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".fallowrc.json"), "{}").unwrap();
+        assert!(is_config_fixable(dir.path(), None));
+    }
+
+    #[test]
+    fn config_fixable_true_when_can_create_at_root() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(is_config_fixable(dir.path(), None));
+    }
+
+    #[test]
+    fn config_fixable_false_when_monorepo_subpackage() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\n",
+        )
+        .unwrap();
+        let sub = dir.path().join("packages/app");
+        std::fs::create_dir_all(&sub).unwrap();
+        assert!(!is_config_fixable(&sub, None));
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -10,6 +10,7 @@
 mod config;
 mod config_writer;
 mod external_plugin;
+mod fixability;
 mod jsonc;
 pub mod levenshtein;
 mod rule_pack;
@@ -18,5 +19,6 @@ mod workspace;
 pub use config::*;
 pub use config_writer::*;
 pub use external_plugin::*;
+pub use fixability::*;
 pub use rule_pack::*;
 pub use workspace::*;

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -534,10 +534,8 @@ fn detect_boundary_violations_with_api_fallback(
 }
 
 fn is_dead_code_api_fallback_error(error: &api::ProgrammaticError) -> bool {
-    matches!(
-        error.code.as_deref(),
-        Some("FALLOW_UNSUPPORTED_DEAD_CODE_EXPLAIN")
-    )
+    let _ = error;
+    false
 }
 
 #[napi(js_name = "detectDeadCode")]
@@ -732,7 +730,7 @@ mod tests {
     }
 
     #[test]
-    fn dead_code_fallback_preserves_legacy_explain_meta() {
+    fn dead_code_explain_uses_api_runtime_meta() {
         let project = tiny_dead_code_project();
         let root = project.path();
 
@@ -748,7 +746,7 @@ mod tests {
             },
             ..api::DeadCodeOptions::default()
         })
-        .expect("legacy fallback succeeds");
+        .expect("api runtime succeeds");
 
         assert!(json["_meta"].is_object());
         assert_eq!(unused_export_names(&json), vec!["dead"]);
@@ -816,7 +814,7 @@ mod tests {
     }
 
     #[test]
-    fn dead_code_api_fallback_is_limited_to_known_contract_gaps() {
+    fn dead_code_api_fallback_has_no_known_contract_gaps() {
         let diff_error = api::ProgrammaticError::new("unsupported", 2)
             .with_code("FALLOW_UNSUPPORTED_DEAD_CODE_DIFF_FILE");
         let explain_error = api::ProgrammaticError::new("unsupported", 2)
@@ -825,7 +823,7 @@ mod tests {
             api::ProgrammaticError::new("bad config", 2).with_code("FALLOW_CONFIG_LOAD_FAILED");
 
         assert!(!is_dead_code_api_fallback_error(&diff_error));
-        assert!(is_dead_code_api_fallback_error(&explain_error));
+        assert!(!is_dead_code_api_fallback_error(&explain_error));
         assert!(!is_dead_code_api_fallback_error(&config_error));
     }
 

--- a/crates/output/src/check.rs
+++ b/crates/output/src/check.rs
@@ -128,6 +128,7 @@ pub struct CheckOutputInput {
     pub elapsed: Duration,
     pub results: AnalysisResults,
     pub config_fixable: bool,
+    pub meta: Option<Meta>,
     pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
     pub next_steps: Vec<NextStep>,
 }
@@ -158,7 +159,7 @@ pub fn build_check_output(input: CheckOutputInput) -> CheckOutput {
         baseline_deltas: None,
         baseline: None,
         regression: None,
-        meta: None,
+        meta: input.meta,
         workspace_diagnostics: input.workspace_diagnostics,
         next_steps: input.next_steps,
     }
@@ -246,6 +247,7 @@ mod tests {
             elapsed: Duration::from_millis(42),
             results,
             config_fixable: false,
+            meta: None,
             workspace_diagnostics: Vec::new(),
             next_steps: Vec::new(),
         });

--- a/crates/output/src/issue_contract.rs
+++ b/crates/output/src/issue_contract.rs
@@ -1,4 +1,19 @@
+use std::collections::BTreeMap;
+
+use fallow_types::envelope::{Meta, MetaRule};
 use fallow_types::issue_meta::{IssueResultMeta, issue_result_meta_by_code, result_issue_metas};
+
+const DOCS_BASE: &str = "https://docs.fallow.tools";
+
+/// Docs URL for the dead-code/check command.
+pub const CHECK_DOCS: &str = "https://docs.fallow.tools/cli/dead-code";
+
+/// `_meta` description for the per-finding `actions[]` array shared across
+/// JSON output.
+pub const ACTIONS_FIELD_DEFINITION: &str = "Per-finding fix and suppression suggestions. Each entry carries a `type` discriminant (kebab-case) plus a per-action `auto_fixable` bool. Consumers dispatch on `type` to choose the remediation and filter on `auto_fixable` of each individual entry.";
+
+/// `_meta` description for the per-action `auto_fixable` bool.
+pub const ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION: &str = "Evaluated PER FINDING, not per action type. The same `type` may carry `auto_fixable: true` on one finding and `auto_fixable: false` on another when per-instance guards in the `fallow fix` applier discriminate. Filter on this bool of each individual action, not on `type` alone. Current per-instance flips: (1) `remove-catalog-entry` is `true` only when the finding's `hardcoded_consumers` array is empty (else fallow fix skips the entry to avoid breaking `pnpm install`); (2) the primary dependency action flips between `remove-dependency` (`auto_fixable: true`) and `move-dependency` (`auto_fixable: false`) based on `used_in_workspaces`; (3) `add-to-config` for `ignoreExports` is `true` when fallow fix can safely apply the action, which means EITHER a fallow config file already exists OR no config exists and the working directory is NOT inside a monorepo subpackage (the applier then creates `.fallowrc.json` using `fallow init`'s framework-aware scaffolding and layers the new rules on top); `false` inside a monorepo subpackage with no workspace-root config because the applier refuses to fragment per-package configs; (4) `update-catalog-reference` is always `false` today (catalog-switching applier not yet wired). All `suppress-line` and `suppress-file` actions are uniformly `false`.";
 
 /// TypeScript backwards-compat alias emitted for a dead-code result row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,6 +37,12 @@ pub struct IssueOutputContract {
     pub summary_label: &'static str,
     /// Documentation anchor used by CI summary tables.
     pub summary_docs_anchor: &'static str,
+    /// Human-readable name emitted in dead-code `_meta.rules`.
+    pub meta_name: &'static str,
+    /// Explanation emitted in dead-code `_meta.rules`.
+    pub meta_description: &'static str,
+    /// Documentation path emitted in dead-code `_meta.rules`.
+    pub meta_docs_path: &'static str,
     /// SARIF rule ids used by the CLI SARIF formatter for this result row.
     pub sarif_rule_ids: Vec<String>,
     /// CodeClimate check names used by the CodeClimate formatter.
@@ -39,11 +60,64 @@ impl IssueOutputContract {
             counts_in_total: meta.counts_in_total,
             summary_label: issue_summary_label(meta.code)?,
             summary_docs_anchor: issue_summary_docs_anchor(meta.code)?,
+            meta_name: issue_meta_name(meta.code)?,
+            meta_description: issue_meta_description(meta.code)?,
+            meta_docs_path: issue_meta_docs_path(meta.code)?,
             sarif_rule_ids: sarif_rule_ids(meta.code),
             codeclimate_check_names: codeclimate_check_names(meta.code),
             ts_alias: ts_alias(meta.code),
         })
     }
+}
+
+/// Build the `_meta` object for `fallow dead-code --format json --explain`.
+#[must_use]
+pub fn check_meta() -> Meta {
+    let mut rules = BTreeMap::new();
+    for contract in issue_output_contracts() {
+        rules.insert(
+            contract.code.to_string(),
+            MetaRule {
+                name: Some(contract.meta_name.to_string()),
+                description: Some(contract.meta_description.to_string()),
+                docs: Some(rule_docs_url(contract.meta_docs_path)),
+            },
+        );
+    }
+    rules.insert(
+        "missing-suppression-reason".to_string(),
+        MetaRule {
+            name: Some("Missing Suppression Reason".to_string()),
+            description: Some("A fallow-ignore-next-line or fallow-ignore-file suppression omits the explanatory reason required by the requireSuppressionReason rule. Add a short reason after the suppression token, or remove the suppression if the issue is no longer intentional.".to_string()),
+            docs: Some(rule_docs_url("explanations/dead-code#stale-suppressions")),
+        },
+    );
+
+    Meta {
+        docs: Some(CHECK_DOCS.to_string()),
+        field_definitions: BTreeMap::from([
+            (
+                "actions[]".to_string(),
+                ACTIONS_FIELD_DEFINITION.to_string(),
+            ),
+            (
+                "actions[].auto_fixable".to_string(),
+                ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION.to_string(),
+            ),
+        ]),
+        rules,
+        ..Meta::default()
+    }
+}
+
+#[must_use]
+pub fn dead_code_docs_url(anchor: &str) -> String {
+    format!("{DOCS_BASE}/explanations/dead-code#{anchor}")
+}
+
+#[must_use]
+pub fn rule_docs_url(docs_path: &str) -> String {
+    format!("{DOCS_BASE}/{docs_path}")
 }
 
 /// Output-facing dead-code result contracts in stable registry order.
@@ -267,6 +341,232 @@ fn issue_summary_docs_anchor(code: &str) -> Option<&'static str> {
     })
 }
 
+fn issue_meta_name(code: &str) -> Option<&'static str> {
+    Some(match code {
+        "unused-file" => "Unused Files",
+        "unused-export" => "Unused Exports",
+        "unused-type" => "Unused Type Exports",
+        "private-type-leak" => "Private Type Leaks",
+        "unused-dependency" => "Unused Dependencies",
+        "unused-dev-dependency" => "Unused Dev Dependencies",
+        "unused-optional-dependency" => "Unused Optional Dependencies",
+        "unused-enum-member" => "Unused Enum Members",
+        "unused-class-member" => "Unused Class Members",
+        "unused-store-member" => "Unused Store Members",
+        "unresolved-import" => "Unresolved Imports",
+        "unlisted-dependency" => "Unlisted Dependencies",
+        "duplicate-export" => "Duplicate Exports",
+        "type-only-dependency" => "Type-only Dependencies",
+        "test-only-dependency" => "Test-only Dependencies",
+        "circular-dependency" => "Circular Dependencies",
+        "re-export-cycle" => "Re-Export Cycles",
+        "boundary-violation" => "Boundary Violations",
+        "boundary-coverage" => "Boundary Coverage",
+        "boundary-call-violation" => "Boundary Call Violation",
+        "policy-violation" => "Policy Violation",
+        "invalid-client-export" => "Invalid client export",
+        "mixed-client-server-barrel" => "Mixed client/server barrel",
+        "misplaced-directive" => "Misplaced directive",
+        "unprovided-inject" => "Unprovided injects",
+        "unrendered-component" => "Unrendered components",
+        "unused-component-prop" => "Unused component props",
+        "unused-component-emit" => "Unused component emits",
+        "unused-component-input" => "Unused component inputs",
+        "unused-component-output" => "Unused component outputs",
+        "unused-svelte-event" => "Unused Svelte events",
+        "unused-server-action" => "Unused server actions",
+        "unused-load-data-key" => "Unused load data keys",
+        "route-collision" => "Route collision",
+        "dynamic-segment-name-conflict" => "Dynamic segment name conflict",
+        "stale-suppression" => "Stale Suppressions",
+        "unused-catalog-entry" => "Unused catalog entry",
+        "empty-catalog-group" => "Empty catalog group",
+        "unresolved-catalog-reference" => "Unresolved catalog reference",
+        "unused-dependency-override" => "Unused pnpm dependency override",
+        "misconfigured-dependency-override" => "Misconfigured pnpm dependency override",
+        "prop-drilling" => "Prop drilling",
+        "thin-wrapper" => "Thin wrapper",
+        "duplicate-prop-shape" => "Duplicate prop shape",
+        _ => return None,
+    })
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "dead-code meta prose is intentionally kept in one lookup table"
+)]
+fn issue_meta_description(code: &str) -> Option<&'static str> {
+    Some(match code {
+        "unused-file" => {
+            "Source files that are not imported by any other module and are not entry points. Detection uses graph reachability from configured entry points."
+        }
+        "unused-export" => {
+            "Named exports that are never imported by any other module in the project, including direct exports and re-exports through barrel files."
+        }
+        "unused-type" => {
+            "Type-only exports that are never imported. These do not generate runtime code but add maintenance burden."
+        }
+        "private-type-leak" => {
+            "Exported values or types whose public TypeScript signature references a same-file type declaration that is not exported."
+        }
+        "unused-dependency" => {
+            "Packages listed in dependencies that are never imported or required by any source file."
+        }
+        "unused-dev-dependency" => {
+            "Packages listed in devDependencies that are never imported by test files, config files, or scripts."
+        }
+        "unused-optional-dependency" => {
+            "Packages listed in optionalDependencies that are never imported."
+        }
+        "unused-enum-member" => "Enum members that are never referenced in the codebase.",
+        "unused-class-member" => {
+            "Class methods and properties that are never referenced outside the class."
+        }
+        "unused-store-member" => {
+            "Pinia store members declared but never accessed by any consumer project-wide."
+        }
+        "unresolved-import" => "Import specifiers that could not be resolved to a file on disk.",
+        "unlisted-dependency" => "Packages imported in source code but not listed in package.json.",
+        "duplicate-export" => "The same export name is defined in multiple modules.",
+        "type-only-dependency" => {
+            "Production dependencies that are only imported via type-only imports."
+        }
+        "test-only-dependency" => "Production dependencies that are only imported from test files.",
+        "circular-dependency" => "A cycle in the module import graph.",
+        "re-export-cycle" => {
+            "A barrel file re-exports from another barrel that ultimately re-exports back."
+        }
+        "boundary-violation" => {
+            "A module imports from a zone that its configured boundary rules do not allow."
+        }
+        "boundary-coverage" => {
+            "A reachable source file is not assigned to any configured boundary zone while boundary coverage is required."
+        }
+        "boundary-call-violation" => {
+            "A file classified into a boundary zone calls a callee matching one of the zone's forbidden call patterns."
+        }
+        "policy-violation" => {
+            "A call site, import, or catalogue-derived effect matched a configured rule pack rule."
+        }
+        "invalid-client-export" => {
+            "A file carrying the use client directive also exports a Next.js server-only or route-segment config name."
+        }
+        "mixed-client-server-barrel" => {
+            "A barrel file forwards a name from a use client module alongside a name from a server-only module."
+        }
+        "misplaced-directive" => {
+            "A use client or use server directive string appears after a non-directive statement and is ignored."
+        }
+        "unprovided-inject" => {
+            "A Vue inject or Svelte getContext reads a dependency-injection key that no matching provider supplies."
+        }
+        "unrendered-component" => {
+            "A Vue or Svelte single-file component is reachable through the graph but rendered nowhere in the project."
+        }
+        "unused-component-prop" => {
+            "A declared Vue, Svelte, React, or Preact component prop is referenced nowhere inside its own component."
+        }
+        "unused-component-emit" => {
+            "A Vue script setup defineEmits event is emitted nowhere in its own component."
+        }
+        "unused-component-input" => "An Angular input is read nowhere in its own component.",
+        "unused-component-output" => "An Angular output is emitted nowhere in its own component.",
+        "unused-svelte-event" => {
+            "A Svelte component dispatches a custom event whose name is listened to nowhere in the analyzed project."
+        }
+        "unused-server-action" => {
+            "A Next.js Server Action exported from a use server file is referenced by no code in the project."
+        }
+        "unused-load-data-key" => {
+            "A SvelteKit load return-object key is read by no route or project-wide consumer."
+        }
+        "route-collision" => {
+            "Two or more Next.js App Router route files resolve to the same URL within one app root."
+        }
+        "dynamic-segment-name-conflict" => {
+            "Sibling Next.js dynamic route segments use different slug names at the same position."
+        }
+        "stale-suppression" => {
+            "A fallow suppression comment or tag no longer matches any active issue."
+        }
+        "unused-catalog-entry" => {
+            "A package manager catalog entry is not referenced by any workspace package.json."
+        }
+        "empty-catalog-group" => "A named package manager catalog group has no package entries.",
+        "unresolved-catalog-reference" => {
+            "A workspace package.json uses a catalog protocol reference that no catalog declares."
+        }
+        "unused-dependency-override" => {
+            "A pnpm dependency override targets a package not declared by any workspace package and not present in the lockfile."
+        }
+        "misconfigured-dependency-override" => {
+            "A pnpm dependency override key or value does not parse as a valid override spec."
+        }
+        "prop-drilling" => {
+            "A React or Preact prop is forwarded unchanged through multiple pass-through components to a distant consumer."
+        }
+        "thin-wrapper" => {
+            "A React or Preact component is structural indirection around a single spread-forwarded child render."
+        }
+        "duplicate-prop-shape" => {
+            "Multiple React or Preact components declare an identical significant prop-name set."
+        }
+        _ => return None,
+    })
+}
+
+fn issue_meta_docs_path(code: &str) -> Option<&'static str> {
+    Some(match code {
+        "unused-file" => "explanations/dead-code#unused-files",
+        "unused-export" => "explanations/dead-code#unused-exports",
+        "unused-type" => "explanations/dead-code#unused-types",
+        "private-type-leak" => "explanations/dead-code#private-type-leaks",
+        "unused-dependency" => "explanations/dead-code#unused-dependencies",
+        "unused-dev-dependency" => "explanations/dead-code#unused-devdependencies",
+        "unused-optional-dependency" => "explanations/dead-code#unused-optionaldependencies",
+        "type-only-dependency" => "explanations/dead-code#type-only-dependencies",
+        "test-only-dependency" => "explanations/dead-code#test-only-dependencies",
+        "unused-enum-member" => "explanations/dead-code#unused-enum-members",
+        "unused-class-member" => "explanations/dead-code#unused-class-members",
+        "unused-store-member" => "explanations/dead-code#unused-store-members",
+        "unresolved-import" => "explanations/dead-code#unresolved-imports",
+        "unlisted-dependency" => "explanations/dead-code#unlisted-dependencies",
+        "duplicate-export" => "explanations/dead-code#duplicate-exports",
+        "circular-dependency" => "explanations/dead-code#circular-dependencies",
+        "re-export-cycle" => "explanations/dead-code#re-export-cycles",
+        "boundary-violation" | "boundary-coverage" | "boundary-call-violation" => {
+            "explanations/dead-code#boundary-violations"
+        }
+        "policy-violation" => "explanations/dead-code#policy-violations",
+        "stale-suppression" => "explanations/dead-code#stale-suppressions",
+        "unused-catalog-entry" => "explanations/dead-code#unused-catalog-entries",
+        "empty-catalog-group" => "explanations/dead-code#empty-catalog-groups",
+        "unresolved-catalog-reference" => "explanations/dead-code#unresolved-catalog-references",
+        "unused-dependency-override" => "explanations/dead-code#unused-dependency-overrides",
+        "misconfigured-dependency-override" => {
+            "explanations/dead-code#misconfigured-dependency-overrides"
+        }
+        "invalid-client-export" => "explanations/dead-code#invalid-client-exports",
+        "mixed-client-server-barrel" => "explanations/dead-code#mixed-client-server-barrels",
+        "misplaced-directive" => "explanations/dead-code#misplaced-directives",
+        "unprovided-inject" => "explanations/dead-code#unprovided-injects",
+        "unrendered-component" => "explanations/dead-code#unrendered-components",
+        "unused-component-prop" => "explanations/dead-code#unused-component-props",
+        "unused-component-emit" => "explanations/dead-code#unused-component-emits",
+        "unused-component-input" => "explanations/dead-code#unused-component-inputs",
+        "unused-component-output" => "explanations/dead-code#unused-component-outputs",
+        "unused-svelte-event" => "explanations/dead-code#unused-svelte-events",
+        "unused-server-action" => "explanations/dead-code#unused-server-actions",
+        "unused-load-data-key" => "explanations/dead-code#unused-load-data-keys",
+        "prop-drilling" => "explanations/dead-code#prop-drilling",
+        "thin-wrapper" => "explanations/dead-code#thin-wrapper",
+        "duplicate-prop-shape" => "explanations/dead-code#duplicate-prop-shape",
+        "route-collision" => "explanations/dead-code#route-collisions",
+        "dynamic-segment-name-conflict" => "explanations/dead-code#dynamic-segment-name-conflicts",
+        _ => return None,
+    })
+}
+
 /// Result issue codes emitted by the dead-code CodeClimate formatter.
 pub const CODECLIMATE_RESULT_CODES: &[&str] = &[
     "unused-file",
@@ -332,7 +632,26 @@ mod tests {
         for contract in issue_output_contracts() {
             assert!(!contract.summary_label.is_empty());
             assert!(!contract.summary_docs_anchor.is_empty());
+            assert!(!contract.meta_name.is_empty());
+            assert!(!contract.meta_description.is_empty());
+            assert!(!contract.meta_docs_path.is_empty());
         }
+    }
+
+    #[test]
+    fn check_meta_uses_output_contracts() {
+        let meta = check_meta();
+        assert_eq!(meta.docs.as_deref(), Some(CHECK_DOCS));
+        assert!(
+            meta.field_definitions["actions[].auto_fixable"].contains("PER FINDING"),
+            "auto_fixable definition should preserve per-finding guidance"
+        );
+        assert!(meta.rules.contains_key("unused-export"));
+        assert!(meta.rules.contains_key("missing-suppression-reason"));
+        assert_eq!(
+            meta.rules["unused-dev-dependency"].docs.as_deref(),
+            Some("https://docs.fallow.tools/explanations/dead-code#unused-devdependencies")
+        );
     }
 
     #[test]

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -37,6 +37,7 @@ pub use fallow_types::output_dead_code;
 pub use fallow_types::output_health;
 pub use format::OutputFormat;
 pub use issue_contract::{
-    CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, issue_output_contract_by_code,
-    issue_output_contracts,
+    ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION, ACTIONS_FIELD_DEFINITION, CHECK_DOCS,
+    CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, check_meta, dead_code_docs_url,
+    issue_output_contract_by_code, issue_output_contracts, rule_docs_url,
 };


### PR DESCRIPTION
## Summary
- Move dead-code check meta construction into fallow-output.
- Let CheckOutputInput carry typed meta instead of CLI JSON post-processing.
- Enable fallow-api and NAPI dead-code explain output through the typed API runtime.

## Verification
- cargo test -p fallow-output -p fallow-api -p fallow-node
- cargo test -p fallow-cli --lib
- cargo check -p fallow-output -p fallow-api -p fallow-node
- cargo clippy -p fallow-output -p fallow-api -p fallow-node --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- fallow audit --base feat/napi-dead-code-family-api-runtime --format json --quiet