### PR TITLE
refactor: type extractor binding targets

### DIFF
--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -125,14 +125,13 @@ pub const PLAYWRIGHT_FIXTURE_USE_SENTINEL: &str = "__fallow_playwright_fixture_u
 /// fixture generic imports an object type alias from another module.
 pub const PLAYWRIGHT_FIXTURE_TYPE_SENTINEL: &str = "__fallow_playwright_fixture_type__:";
 
-/// Synthetic member-access object prefix for static-factory call returns.
+/// Legacy member-access object prefix for static-factory call returns.
 ///
 /// `MemberAccess { object: format!("{FACTORY_CALL_SENTINEL}{callee}:{method}"), member }`
-/// means a local binding was assigned from `<callee>.<method>()` and a member
-/// is accessed on the result. The analyze layer resolves `callee` through the
-/// consumer module's imports to a class export and credits `member` on the
-/// class when the matching method carries `is_instance_returning_static`.
-/// See issue #346.
+/// was the pre-typed-fact representation for a local binding assigned from
+/// `<callee>.<method>()` with a member access on the result. New extraction uses
+/// `SemanticFact::FactoryCallMemberAccess`; the prefix remains decode-only for
+/// older cache entries. See issue #346.
 pub const FACTORY_CALL_SENTINEL: &str = "__fallow_factory_call__:";
 
 /// Synthetic member-access object prefix for fluent-builder chain credit.

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -700,7 +700,11 @@ fn harvest_template_visible_bindings(
             .binding_target_names()
             .iter()
             .filter(|(local, _)| !local.starts_with("this."))
-            .map(|(local, target)| (local.clone(), target.clone())),
+            .filter_map(|(local, target)| {
+                target
+                    .class_name()
+                    .map(|class_name| (local.clone(), class_name.to_string()))
+            }),
     );
 }
 

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -87,6 +87,29 @@ pub(crate) struct FactoryCallCandidate {
     pub(crate) callee_method: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BindingTarget {
+    Class(String),
+    FactoryCall {
+        callee_object: String,
+        callee_method: String,
+    },
+}
+
+impl BindingTarget {
+    pub(crate) fn class_name(&self) -> Option<&str> {
+        match self {
+            Self::Class(name) => Some(name),
+            Self::FactoryCall { .. } => None,
+        }
+    }
+
+    fn class_with_suffix(&self, suffix: &str) -> Option<String> {
+        self.class_name()
+            .map(|class_name| format!("{class_name}.{suffix}"))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct PendingPlaywrightFactory {
     pub(crate) test_name: String,
@@ -146,7 +169,7 @@ pub(crate) struct ModuleInfoExtractor {
     handled_require_spans: FxHashSet<Span>,
     handled_import_spans: FxHashSet<Span>,
     namespace_binding_names: Vec<String>,
-    binding_target_names: FxHashMap<String, String>,
+    binding_target_names: FxHashMap<String, BindingTarget>,
     interface_property_types: FxHashMap<String, FxHashMap<String, String>>,
     pending_typed_destructures: Vec<(String, String, String)>,
     iterable_element_types: FxHashMap<String, String>,
@@ -495,8 +518,19 @@ impl ModuleInfoExtractor {
         );
     }
 
-    pub(crate) fn binding_target_names(&self) -> &FxHashMap<String, String> {
+    pub(crate) fn binding_target_names(&self) -> &FxHashMap<String, BindingTarget> {
         &self.binding_target_names
+    }
+
+    fn insert_class_binding_target(&mut self, binding: String, target: String) {
+        self.binding_target_names
+            .insert(binding, BindingTarget::Class(target));
+    }
+
+    fn insert_class_binding_target_if_absent(&mut self, binding: String, target: String) {
+        self.binding_target_names
+            .entry(binding)
+            .or_insert(BindingTarget::Class(target));
     }
 
     pub(crate) fn record_angular_template_member_fact(&mut self, member: String) {
@@ -941,11 +975,15 @@ impl ModuleInfoExtractor {
             let Some(local_name) = export.local_name.as_deref() else {
                 continue;
             };
-            let Some(target_name) = self.binding_target_names.get(local_name).cloned() else {
+            let Some(target_name) = self
+                .binding_target_names
+                .get(local_name)
+                .and_then(BindingTarget::class_name)
+            else {
                 continue;
             };
             let export_name = export.name.to_string();
-            self.record_instance_export_binding_fact(export_name, target_name);
+            self.record_instance_export_binding_fact(export_name, target_name.to_string());
         }
     }
 
@@ -1054,7 +1092,7 @@ impl ModuleInfoExtractor {
                         && m.name == callee_method
                 })
             {
-                self.binding_target_names.insert(local_name, callee_object);
+                self.insert_class_binding_target(local_name, callee_object);
                 continue;
             }
 
@@ -1063,11 +1101,13 @@ impl ModuleInfoExtractor {
                 .iter()
                 .any(|import| import.local_name == callee_object);
             if has_import {
-                let sentinel = format!(
-                    "{}{callee_object}:{callee_method}",
-                    crate::FACTORY_CALL_SENTINEL,
+                self.binding_target_names.insert(
+                    local_name,
+                    BindingTarget::FactoryCall {
+                        callee_object,
+                        callee_method,
+                    },
                 );
-                self.binding_target_names.insert(local_name, sentinel);
             }
         }
     }
@@ -1084,13 +1124,11 @@ impl ModuleInfoExtractor {
             let Some(class_name) = properties.get(&property_key) else {
                 continue;
             };
-            self.binding_target_names
-                .entry(local)
-                .or_insert_with(|| class_name.clone());
+            self.insert_class_binding_target_if_absent(local, class_name.clone());
         }
     }
 
-    fn resolve_bound_object_name(&self, object: &str) -> Option<String> {
+    fn resolve_bound_object_name(&self, object: &str) -> Option<BindingTarget> {
         if let Some(target_name) = self.binding_target_names.get(object) {
             return Some(target_name.clone());
         }
@@ -1099,10 +1137,9 @@ impl ModuleInfoExtractor {
             .iter()
             .filter_map(|(binding, target_name)| {
                 let suffix = object.strip_prefix(binding.as_str())?.strip_prefix('.')?;
-                if target_name.starts_with(crate::FACTORY_CALL_SENTINEL) {
-                    return None;
-                }
-                Some((binding.len(), format!("{target_name}.{suffix}")))
+                target_name
+                    .class_with_suffix(suffix)
+                    .map(|object_name| (binding.len(), BindingTarget::Class(object_name)))
             })
             .max_by_key(|(len, _)| *len)
             .map(|(_, object_name)| object_name)
@@ -1115,29 +1152,31 @@ impl ModuleInfoExtractor {
         let mut additional_accesses = Vec::new();
         let mut additional_facts = Vec::new();
         for access in &self.member_accesses {
-            let Some(object) = self.resolve_bound_object_name(&access.object) else {
+            let Some(target) = self.resolve_bound_object_name(&access.object) else {
                 continue;
             };
-            if let Some((callee_object, callee_method)) =
-                parse_factory_call_bound_target(object.as_str())
-            {
-                additional_facts.push((
-                    callee_object.to_string(),
-                    callee_method.to_string(),
-                    access.member.clone(),
-                ));
-                continue;
+            match target {
+                BindingTarget::Class(object) => additional_accesses.push(MemberAccess {
+                    object,
+                    member: access.member.clone(),
+                }),
+                BindingTarget::FactoryCall {
+                    callee_object,
+                    callee_method,
+                } => additional_facts.push((callee_object, callee_method, access.member.clone())),
             }
-            additional_accesses.push(MemberAccess {
-                object,
-                member: access.member.clone(),
-            });
         }
         let additional_whole: Vec<String> = self
             .whole_object_uses
             .iter()
             .filter_map(|name| self.resolve_bound_object_name(name))
-            .filter(|target| !target.starts_with(crate::FACTORY_CALL_SENTINEL))
+            .filter_map(|target| {
+                if let BindingTarget::Class(name) = target {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
             .collect();
         self.member_accesses.extend(additional_accesses);
         for (callee_object, callee_method, member) in additional_facts {
@@ -1190,8 +1229,8 @@ impl ModuleInfoExtractor {
             StructuralCallArgument::Binding(binding) => self
                 .binding_target_names
                 .get(binding.as_str())
-                .filter(|target| !target.starts_with(crate::FACTORY_CALL_SENTINEL))
-                .cloned(),
+                .and_then(BindingTarget::class_name)
+                .map(str::to_string),
         }
     }
 
@@ -1219,6 +1258,9 @@ impl ModuleInfoExtractor {
         }
         let mut aliases = Vec::new();
         for (binding_path, target_name) in &self.binding_target_names {
+            let Some(target_name) = target_name.class_name() else {
+                continue;
+            };
             if !self
                 .namespace_binding_names
                 .iter()
@@ -1240,7 +1282,7 @@ impl ModuleInfoExtractor {
                 aliases.push(fallow_types::extract::NamespaceObjectAlias {
                     via_export_name: canonical_name,
                     suffix: suffix.to_string(),
-                    namespace_local: target_name.clone(),
+                    namespace_local: target_name.to_string(),
                 });
             }
         }
@@ -1709,12 +1751,6 @@ fn extract_member_names_from_object(
         }
     }
     if names.is_empty() { None } else { Some(names) }
-}
-
-fn parse_factory_call_bound_target(object: &str) -> Option<(&str, &str)> {
-    object
-        .strip_prefix(crate::FACTORY_CALL_SENTINEL)
-        .and_then(|payload| payload.split_once(':'))
 }
 
 #[cfg(all(test, not(miri)))]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -36,7 +36,7 @@ use super::helpers::{
     ts_import_type_qualifier_root,
 };
 use super::{
-    ModuleInfoExtractor, PendingLocalExportSpecifier, SecurityPathSinkBinding,
+    BindingTarget, ModuleInfoExtractor, PendingLocalExportSpecifier, SecurityPathSinkBinding,
     SideEffectRegistrationTarget, try_extract_arrow_wrapped_import, try_extract_dynamic_import,
     try_extract_import_then_callback, try_extract_property_callback_import, try_extract_require,
 };
@@ -578,16 +578,14 @@ impl ModuleInfoExtractor {
         if let Some(type_name) = extract_type_annotation_name(type_annotation)
             && let Some(resolved) = self.resolve_class_type_param(&type_name)
         {
-            self.binding_target_names
-                .insert(binding_name.to_string(), resolved);
+            self.insert_class_binding_target(binding_name.to_string(), resolved);
         }
 
         for (property_path, type_name) in extract_nested_type_bindings(type_annotation) {
             let Some(resolved) = self.resolve_class_type_param(&type_name) else {
                 continue;
             };
-            self.binding_target_names
-                .insert(format!("{binding_name}.{property_path}"), resolved);
+            self.insert_class_binding_target(format!("{binding_name}.{property_path}"), resolved);
         }
     }
 
@@ -605,9 +603,7 @@ impl ModuleInfoExtractor {
             let properties = collect_object_type_property_types(&type_lit.members);
             for (local, key) in bindings {
                 if let Some(class_name) = properties.get(&key) {
-                    self.binding_target_names
-                        .entry(local)
-                        .or_insert_with(|| class_name.clone());
+                    self.insert_class_binding_target_if_absent(local, class_name.clone());
                 }
             }
         } else if let Some(type_name) = extract_type_annotation_name(type_annotation) {
@@ -940,7 +936,7 @@ impl ModuleInfoExtractor {
             _ => None,
         };
         if let Some(name) = param_name {
-            self.binding_target_names.insert(name, element_type);
+            self.insert_class_binding_target(name, element_type);
         }
     }
 
@@ -2030,7 +2026,7 @@ impl ModuleInfoExtractor {
     fn copy_nested_binding_targets(&mut self, source_binding: &str, target_binding: &str) -> bool {
         let source_prefix = format!("{source_binding}.");
         let target_prefix = format!("{target_binding}.");
-        let copied: Vec<(String, String)> = self
+        let copied: Vec<(String, BindingTarget)> = self
             .binding_target_names
             .iter()
             .filter_map(|(binding, target)| {
@@ -2047,7 +2043,7 @@ impl ModuleInfoExtractor {
         changed
     }
 
-    fn insert_binding_target(&mut self, binding: String, target: String) -> bool {
+    fn insert_binding_target(&mut self, binding: String, target: BindingTarget) -> bool {
         if self.binding_target_names.get(&binding) == Some(&target) {
             return false;
         }
@@ -2067,7 +2063,7 @@ impl ModuleInfoExtractor {
         {
             changed |= self.insert_binding_target(
                 candidate.binding_path.clone(),
-                candidate.source_name.clone(),
+                BindingTarget::Class(candidate.source_name.clone()),
             );
         } else if let Some(target_name) = self
             .binding_target_names
@@ -3372,15 +3368,13 @@ impl<'a> ModuleInfoExtractor {
             && let BindingPattern::BindingIdentifier(id) = &declarator.id
             && !super::helpers::is_builtin_constructor(callee.name.as_str())
         {
-            self.binding_target_names
-                .insert(id.name.to_string(), callee.name.to_string());
+            self.insert_class_binding_target(id.name.to_string(), callee.name.to_string());
         }
 
         if let BindingPattern::BindingIdentifier(id) = &declarator.id
             && let Some(class_name) = Self::svelte_derived_new_class(init)
         {
-            self.binding_target_names
-                .insert(id.name.to_string(), class_name);
+            self.insert_class_binding_target(id.name.to_string(), class_name);
         }
 
         if let Expression::CallExpression(call) = init
@@ -3388,8 +3382,7 @@ impl<'a> ModuleInfoExtractor {
             && let Some(Some(BindingPattern::BindingIdentifier(id))) = arr_pat.elements.first()
             && let Some(class_name) = super::helpers::try_extract_factory_new_class(&call.arguments)
         {
-            self.binding_target_names
-                .insert(id.name.to_string(), class_name);
+            self.insert_class_binding_target(id.name.to_string(), class_name);
         }
 
         // `const svc = useMemo(() => new Svc())`: useMemo returns the factory's
@@ -3402,9 +3395,7 @@ impl<'a> ModuleInfoExtractor {
             && is_value_returning_memo_callee(&call.callee)
             && let Some(class_name) = super::helpers::try_extract_factory_new_class(&call.arguments)
         {
-            self.binding_target_names
-                .entry(id.name.to_string())
-                .or_insert(class_name);
+            self.insert_class_binding_target_if_absent(id.name.to_string(), class_name);
         }
 
         if let Expression::CallExpression(call) = init
@@ -3563,7 +3554,7 @@ impl<'a> ModuleInfoExtractor {
             && let Expression::Identifier(callee) = &new_expr.callee
             && !super::helpers::is_builtin_constructor(callee.name.as_str())
         {
-            self.binding_target_names.insert(
+            self.insert_class_binding_target(
                 format!("this.{}", member.property.name),
                 callee.name.to_string(),
             );
@@ -3783,15 +3774,13 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 && let Expression::Identifier(callee) = &new_expr.callee
                 && !super::helpers::is_builtin_constructor(callee.name.as_str())
             {
-                self.binding_target_names
-                    .insert(format!("this.{name}"), callee.name.to_string());
+                self.insert_class_binding_target(format!("this.{name}"), callee.name.to_string());
             }
 
             if let Some(Expression::CallExpression(call)) = &prop.value
                 && let Some(type_name) = self.extract_angular_inject_target(call)
             {
-                self.binding_target_names
-                    .insert(format!("this.{name}"), type_name);
+                self.insert_class_binding_target(format!("this.{name}"), type_name);
             }
 
             if let Some(value) = prop.value.as_ref()
@@ -3801,7 +3790,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 if query.plural {
                     self.iterable_element_types.insert(call_key, query.type_arg);
                 } else {
-                    self.binding_target_names.insert(call_key, query.type_arg);
+                    self.insert_class_binding_target(call_key, query.type_arg);
                 }
             }
 
@@ -4399,7 +4388,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         let mut narrowings = Vec::new();
         collect_instanceof_narrowings(&stmt.test, &mut narrowings);
         for (local, class_name) in narrowings {
-            self.binding_target_names.entry(local).or_insert(class_name);
+            self.insert_class_binding_target_if_absent(local, class_name);
         }
         walk::walk_if_statement(self, stmt);
     }
@@ -7017,9 +7006,10 @@ impl ModuleInfoExtractor {
             && let Expression::Identifier(callee) = &call.callee
             && self.is_store_factory_call(callee.name.as_str())
         {
-            self.binding_target_names
-                .entry(id.name.to_string())
-                .or_insert_with(|| callee.name.to_string());
+            self.insert_class_binding_target_if_absent(
+                id.name.to_string(),
+                callee.name.to_string(),
+            );
             self.store_instance_locals.insert(id.name.to_string());
             return;
         }


### PR DESCRIPTION
## Summary
- replace extractor binding-target string encoding with a typed BindingTarget enum
- keep factory-call bindings typed internally until they emit FactoryCallMemberAccess facts
- filter non-class binding targets out of SFC template-visible binding and namespace alias exports

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-extract -p fallow-core
- cargo test -p fallow-extract static_factory
- cargo test -p fallow-core typed_factory_call_fact_credits_class_member
- cargo clippy -p fallow-extract -p fallow-core --all-targets -- -D warnings
- git diff --check