### PR TITLE
refactor: move dupes meta to output contracts

### DIFF
--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -20,9 +20,6 @@ pub const CHECK_DOCS: &str = "https://docs.fallow.tools/cli/dead-code";
 /// Docs URL for the health command.
 pub const HEALTH_DOCS: &str = "https://docs.fallow.tools/cli/health";
 
-/// Docs URL for the dupes command.
-pub const DUPES_DOCS: &str = "https://docs.fallow.tools/cli/dupes";
-
 /// Docs URL for the runtime coverage setup command's agent-readable JSON.
 pub const COVERAGE_SETUP_DOCS: &str = "https://docs.fallow.tools/cli/coverage#agent-readable-json";
 
@@ -1614,49 +1611,10 @@ fn health_runtime_production_metrics() -> Value {
 /// Build the `_meta` object for `fallow dupes --format json --explain`.
 #[must_use]
 pub fn dupes_meta() -> Value {
-    json!({
-        "docs": DUPES_DOCS,
-        "field_definitions": {
-            "actions[]": ACTIONS_FIELD_DEFINITION,
-            "actions[].auto_fixable": ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION
-        },
-        "metrics": {
-            "duplication_percentage": {
-                "name": "Duplication Percentage",
-                "description": "Fraction of total source tokens that appear in at least one clone group. Computed over the full analyzed file set.",
-                "range": "[0, 100]",
-                "interpretation": "lower is better"
-            },
-            "token_count": {
-                "name": "Token Count",
-                "description": "Number of normalized source tokens in the clone group. Tokens are language-aware (keywords, identifiers, operators, punctuation). Higher token count = larger duplicate.",
-                "range": "[1, \u{221e})",
-                "interpretation": "larger clones have higher refactoring value"
-            },
-            "line_count": {
-                "name": "Line Count",
-                "description": "Number of source lines spanned by the clone instance. Approximation of clone size for human readability.",
-                "range": "[1, \u{221e})",
-                "interpretation": "larger clones are more impactful to deduplicate"
-            },
-            "clone_groups": {
-                "name": "Clone Groups",
-                "description": "A set of code fragments with identical or near-identical normalized token sequences. Each group has 2+ instances across different locations.",
-                "interpretation": "each group is a single refactoring opportunity"
-            },
-            "clone_groups_below_min_occurrences": {
-                "name": "Clone Groups Below minOccurrences",
-                "description": "Number of clone groups detected but hidden by the `duplicates.minOccurrences` filter. Always 0 (or absent) when the filter is at its default of 2. Pre-filter group count = `clone_groups + clone_groups_below_min_occurrences`.",
-                "range": "[0, \u{221e})",
-                "interpretation": "high values suggest noisy pair-only duplication; lower `minOccurrences` to inspect"
-            },
-            "clone_families": {
-                "name": "Clone Families",
-                "description": "Groups of clone groups that share the same set of files. Indicates systematic duplication patterns (e.g., mirrored directory structures).",
-                "interpretation": "families suggest extract-module refactoring opportunities"
-            }
-        }
-    })
+    match serde_json::to_value(fallow_output::dupes_meta()) {
+        Ok(value) => value,
+        Err(_) => json!({}),
+    }
 }
 
 /// Build the `_meta` object for `fallow security --format json --explain`.
@@ -2359,8 +2317,8 @@ mod tests {
 
     #[test]
     fn dupes_docs_url_valid() {
-        assert!(DUPES_DOCS.starts_with("https://"));
-        assert!(DUPES_DOCS.contains("dupes"));
+        assert!(fallow_output::DUPES_DOCS.starts_with("https://"));
+        assert!(fallow_output::DUPES_DOCS.contains("dupes"));
     }
 
     #[test]
@@ -2378,7 +2336,7 @@ mod tests {
     #[test]
     fn dupes_meta_docs_url_matches_constant() {
         let meta = dupes_meta();
-        assert_eq!(meta["docs"].as_str().unwrap(), DUPES_DOCS);
+        assert_eq!(meta["docs"].as_str().unwrap(), fallow_output::DUPES_DOCS);
     }
 
     #[test]

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -621,17 +621,13 @@ pub fn build_duplication_json(
         grouped_by: None,
         total_issues: None,
         groups: None,
-        meta: None,
+        meta: explain.then(fallow_output::dupes_meta),
         workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
         next_steps,
     };
     let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;
     let root_prefix = format!("{}/", root.display());
     strip_root_prefix(&mut output, &root_prefix);
-
-    if explain {
-        insert_meta(&mut output, explain::dupes_meta());
-    }
 
     Ok(output)
 }
@@ -674,7 +670,7 @@ pub fn build_grouped_duplication_json(
         grouped_by: Some(group_by_mode_from_label(grouping.mode)),
         total_issues: Some(report.clone_groups.len()),
         groups: None,
-        meta: None,
+        meta: explain.then(fallow_output::dupes_meta),
         workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
         next_steps,
     };
@@ -693,10 +689,6 @@ pub fn build_grouped_duplication_json(
 
     if let serde_json::Value::Object(ref mut map) = output {
         map.insert("groups".to_string(), serde_json::Value::Array(group_values));
-    }
-
-    if explain {
-        insert_meta(&mut output, explain::dupes_meta());
     }
 
     Ok(output)

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -17,6 +17,7 @@ mod codeclimate;
 mod dupes;
 mod format;
 mod issue_contract;
+mod report_contract;
 
 pub use check::{
     CHECK_SCHEMA_VERSION, CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput,
@@ -41,3 +42,4 @@ pub use issue_contract::{
     CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, check_meta, dead_code_docs_url,
     issue_output_contract_by_code, issue_output_contracts, rule_docs_url,
 };
+pub use report_contract::{DUPES_DOCS, dupes_meta};

--- a/crates/output/src/report_contract.rs
+++ b/crates/output/src/report_contract.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+
+use fallow_types::envelope::{Meta, MetaMetric};
+
+use crate::{ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION, ACTIONS_FIELD_DEFINITION};
+
+/// Docs URL for the duplication command.
+pub const DUPES_DOCS: &str = "https://docs.fallow.tools/cli/dupes";
+
+/// Build the `_meta` object for `fallow dupes --format json --explain`.
+#[must_use]
+pub fn dupes_meta() -> Meta {
+    Meta {
+        docs: Some(DUPES_DOCS.to_string()),
+        field_definitions: BTreeMap::from([
+            (
+                "actions[]".to_string(),
+                ACTIONS_FIELD_DEFINITION.to_string(),
+            ),
+            (
+                "actions[].auto_fixable".to_string(),
+                ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION.to_string(),
+            ),
+        ]),
+        metrics: BTreeMap::from([
+            (
+                "duplication_percentage".to_string(),
+                metric(
+                    "Duplication Percentage",
+                    "Fraction of total source tokens that appear in at least one clone group. Computed over the full analyzed file set.",
+                    Some("[0, 100]"),
+                    "lower is better",
+                ),
+            ),
+            (
+                "token_count".to_string(),
+                metric(
+                    "Token Count",
+                    "Number of normalized source tokens in the clone group. Tokens are language-aware (keywords, identifiers, operators, punctuation). Higher token count = larger duplicate.",
+                    Some("[1, ∞)"),
+                    "larger clones have higher refactoring value",
+                ),
+            ),
+            (
+                "line_count".to_string(),
+                metric(
+                    "Line Count",
+                    "Number of source lines spanned by the clone instance. Approximation of clone size for human readability.",
+                    Some("[1, ∞)"),
+                    "larger clones are more impactful to deduplicate",
+                ),
+            ),
+            (
+                "clone_groups".to_string(),
+                metric(
+                    "Clone Groups",
+                    "A set of code fragments with identical or near-identical normalized token sequences. Each group has 2+ instances across different locations.",
+                    None,
+                    "each group is a single refactoring opportunity",
+                ),
+            ),
+            (
+                "clone_groups_below_min_occurrences".to_string(),
+                metric(
+                    "Clone Groups Below minOccurrences",
+                    "Number of clone groups detected but hidden by the `duplicates.minOccurrences` filter. Always 0 (or absent) when the filter is at its default of 2. Pre-filter group count = `clone_groups + clone_groups_below_min_occurrences`.",
+                    Some("[0, ∞)"),
+                    "high values suggest noisy pair-only duplication; lower `minOccurrences` to inspect",
+                ),
+            ),
+            (
+                "clone_families".to_string(),
+                metric(
+                    "Clone Families",
+                    "Groups of clone groups that share the same set of files. Indicates systematic duplication patterns (e.g., mirrored directory structures).",
+                    None,
+                    "families suggest extract-module refactoring opportunities",
+                ),
+            ),
+        ]),
+        ..Meta::default()
+    }
+}
+
+fn metric(
+    name: impl Into<String>,
+    description: impl Into<String>,
+    range: Option<&str>,
+    interpretation: impl Into<String>,
+) -> MetaMetric {
+    MetaMetric {
+        name: Some(name.into()),
+        description: Some(description.into()),
+        range: range.map(str::to_string),
+        interpretation: Some(interpretation.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dupes_meta_uses_output_contract_shape() {
+        let meta = dupes_meta();
+        assert_eq!(meta.docs.as_deref(), Some(DUPES_DOCS));
+        assert!(meta.field_definitions.contains_key("actions[]"));
+        assert!(meta.metrics.contains_key("duplication_percentage"));
+        assert!(
+            meta.metrics
+                .contains_key("clone_groups_below_min_occurrences")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add output-owned dupes explain metadata in fallow-output
- wire dupes JSON envelopes to populate typed _meta before serialization
- keep the CLI explain helper as a compatibility wrapper around the shared contract

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo test -p fallow-output dupes_meta
- cargo test -p fallow-cli dupes_meta
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check