### PR TITLE
refactor: move health meta to output contracts

### DIFF
--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -17,9 +17,6 @@ const DOCS_BASE: &str = "https://docs.fallow.tools";
 /// Docs URL for the dead-code (check) command.
 pub const CHECK_DOCS: &str = "https://docs.fallow.tools/cli/dead-code";
 
-/// Docs URL for the health command.
-pub const HEALTH_DOCS: &str = "https://docs.fallow.tools/cli/health";
-
 /// Docs URL for the runtime coverage setup command's agent-readable JSON.
 pub const COVERAGE_SETUP_DOCS: &str = "https://docs.fallow.tools/cli/coverage#agent-readable-json";
 
@@ -1328,284 +1325,10 @@ pub fn combined_meta(include_check: bool, include_dupes: bool, include_health: b
 /// Build the `_meta` object for `fallow health --format json --explain`.
 #[must_use]
 pub fn health_meta() -> Value {
-    json!({
-        "docs": HEALTH_DOCS,
-        "field_definitions": {
-            "actions[]": ACTIONS_FIELD_DEFINITION,
-            "actions[].auto_fixable": ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION
-        },
-        "metrics": health_metrics()
-    })
-}
-
-fn health_metrics() -> Value {
-    let mut metrics = serde_json::Map::new();
-    for section in [
-        health_size_complexity_metrics(),
-        health_quality_metrics(),
-        health_coupling_metrics(),
-        health_render_fan_in_metrics(),
-        health_churn_metrics(),
-        health_refactoring_rank_metrics(),
-        health_refactoring_confidence_metrics(),
-        health_risk_metrics(),
-        health_contributor_metrics(),
-        health_ownership_metrics(),
-        health_runtime_verdict_metrics(),
-        health_runtime_observation_metrics(),
-        health_runtime_production_metrics(),
-    ] {
-        let Value::Object(section) = section else {
-            continue;
-        };
-        metrics.extend(section);
+    match serde_json::to_value(fallow_output::health_meta()) {
+        Ok(value) => value,
+        Err(_) => json!({}),
     }
-    Value::Object(metrics)
-}
-
-fn health_size_complexity_metrics() -> Value {
-    json!({
-            "cyclomatic": {
-                "name": "Cyclomatic Complexity",
-                "description": "McCabe cyclomatic complexity: 1 + number of decision points (if/else, switch cases, loops, ternary, logical operators). Measures the number of independent paths through a function.",
-                "range": "[1, \u{221e})",
-                "interpretation": "lower is better; default threshold: 20"
-            },
-            "cognitive": {
-                "name": "Cognitive Complexity",
-                "description": "SonarSource cognitive complexity: penalizes nesting depth and non-linear control flow (breaks, continues, early returns). Measures how hard a function is to understand when reading top-to-bottom.",
-                "range": "[0, \u{221e})",
-                "interpretation": "lower is better; default threshold: 15"
-            },
-            "line_count": {
-                "name": "Function Line Count",
-                "description": "Number of lines in the function body.",
-                "range": "[1, \u{221e})",
-                "interpretation": "context-dependent; long functions may need splitting"
-            },
-            "lines": {
-                "name": "File Line Count",
-                "description": "Total lines of code in the file (from line offsets). Provides scale context for other metrics: a file with 0.4 complexity density at 80 LOC is different from 0.4 density at 800 LOC.",
-                "range": "[1, \u{221e})",
-                "interpretation": "context-dependent; large files may benefit from splitting even if individual functions are small"
-            }
-    })
-}
-
-fn health_quality_metrics() -> Value {
-    json!({
-            "maintainability_index": {
-                "name": "Maintainability Index",
-                "description": "Composite score: 100 - (complexity_density \u{00d7} 30 \u{00d7} dampening) - (dead_code_ratio \u{00d7} 20) - min(ln(fan_out+1) \u{00d7} 4, 15), where dampening = min(lines/50, 1.0). Clamped to [0, 100]. Higher is better.",
-                "range": "[0, 100]",
-                "interpretation": "higher is better; <40 poor, 40\u{2013}70 moderate, >70 good"
-            },
-            "complexity_density": {
-                "name": "Complexity Density",
-                "description": "Total cyclomatic complexity divided by lines of code. Measures how densely complex the code is per line.",
-                "range": "[0, \u{221e})",
-                "interpretation": "lower is better; >1.0 indicates very dense complexity"
-            },
-            "dead_code_ratio": {
-                "name": "Dead Code Ratio",
-                "description": "Fraction of value exports (excluding type-only exports like interfaces and type aliases) with zero references across the project.",
-                "range": "[0, 1]",
-                "interpretation": "lower is better; 0 = all exports are used"
-            }
-    })
-}
-
-fn health_coupling_metrics() -> Value {
-    json!({
-            "fan_in": {
-                "name": "Fan-in (Importers)",
-                "description": "Number of files that import this file. High fan-in means high blast radius \u{2014} changes to this file affect many dependents.",
-                "range": "[0, \u{221e})",
-                "interpretation": "context-dependent; high fan-in files need careful review before changes"
-            },
-            "fan_out": {
-                "name": "Fan-out (Imports)",
-                "description": "Number of files this file directly imports. High fan-out indicates high coupling and change propagation risk.",
-                "range": "[0, \u{221e})",
-                "interpretation": "lower is better; MI penalty caps at ~40 imports"
-            },
-    })
-}
-
-fn health_render_fan_in_metrics() -> Value {
-    json!({
-            "max_render_fan_in": {
-                "name": "Render Fan-in (Blast Radius)",
-                "description": "DESCRIPTIVE, NOT A RULE. The component-graph analogue of module fan-in: where module fan-in counts importing MODULES, render fan-in counts distinct render LOCATIONS of a React/Preact component (a shared <Button> is rendered in far more places than it is imported). The headline `max_render_fan_in` is the highest DISTINCT-PARENTS count across components (the honest edit-ripple count); each top component also reports `render_sites` as secondary \u{201c}incl. repeats\u{201d} context (one parent rendering a child five times is five sites but one distinct parent). Test / spec / story / fixture files are excluded (a test rendering <Page> 146 times is not blast radius). Undercount-safe: a child rendered via a JSX spread / dynamic / member-expression tag is not resolved, so a high-fan-in component can only be undersold. Computed only on React/Preact projects; absent otherwise.",
-                "range": "[0, \u{221e})",
-                "interpretation": "context-dependent; a high distinct-parents component edit-ripples to many render locations. Descriptive only, never a gate or finding"
-            }
-    })
-}
-
-fn health_churn_metrics() -> Value {
-    json!({
-            "score": {
-                "name": "Hotspot Score",
-                "description": "normalized_churn \u{00d7} normalized_complexity \u{00d7} 100, where normalization is against the project maximum. Identifies files that are both complex AND frequently changing.",
-                "range": "[0, 100]",
-                "interpretation": "higher = riskier; prioritize refactoring high-score files"
-            },
-            "weighted_commits": {
-                "name": "Weighted Commits",
-                "description": "Recency-weighted commit count using exponential decay with 90-day half-life. Recent commits contribute more than older ones.",
-                "range": "[0, \u{221e})",
-                "interpretation": "higher = more recent churn activity"
-            },
-            "trend": {
-                "name": "Churn Trend",
-                "description": "Compares recent vs older commit frequency within the analysis window. accelerating = recent > 1.5\u{00d7} older, cooling = recent < 0.67\u{00d7} older, stable = in between.",
-                "values": ["accelerating", "stable", "cooling"],
-                "interpretation": "accelerating files need attention; cooling files are stabilizing"
-            }
-    })
-}
-
-fn health_refactoring_rank_metrics() -> Value {
-    json!({
-            "priority": {
-                "name": "Refactoring Priority",
-                "description": "Weighted score: complexity density (30%), hotspot boost (25%), dead code ratio (20%), fan-in (15%), fan-out (10%). Fan-in and fan-out normalization uses adaptive percentile-based thresholds (p95 of the project distribution). Does not use the maintainability index to avoid double-counting.",
-                "range": "[0, 100]",
-                "interpretation": "higher = more urgent to refactor"
-            },
-            "efficiency": {
-                "name": "Efficiency Score",
-                "description": "priority / effort_numeric (Low=1, Medium=2, High=3). Surfaces quick wins: high-priority, low-effort targets rank first. Default sort order.",
-                "range": "[0, 100] \u{2014} effective max depends on effort: Low=100, Medium=50, High\u{2248}33",
-                "interpretation": "higher = better quick-win value; targets are sorted by efficiency descending"
-            },
-            "effort": {
-                "name": "Effort Estimate",
-                "description": "Heuristic effort estimate based on file size, function count, and fan-in. Thresholds adapt to the project\u{2019}s distribution (percentile-based). Low: small file, few functions, low fan-in. High: large file, high fan-in, or many functions with high density. Medium: everything else.",
-                "values": ["low", "medium", "high"],
-                "interpretation": "low = quick win, high = needs planning and coordination"
-            },
-    })
-}
-
-fn health_refactoring_confidence_metrics() -> Value {
-    json!({
-            "confidence": {
-                "name": "Confidence Level",
-                "description": "Reliability of the recommendation based on data source. High: deterministic graph/AST analysis (dead code, circular deps, complexity). Medium: heuristic thresholds (fan-in/fan-out coupling). Low: depends on git history quality (churn-based recommendations).",
-                "values": ["high", "medium", "low"],
-                "interpretation": "high = act on it, medium = verify context, low = treat as a signal, not a directive"
-            },
-            "health_score": {
-                "name": "Health Score",
-                "description": "Project-level aggregate score computed from vital signs: dead code, complexity, maintainability, hotspots, unused dependencies, and circular dependencies. Penalties subtracted from 100. Missing metrics (from pipelines that didn't run) don't penalize. Use --score to compute the score; add --hotspots, or --targets with --score, when the score should include the churn-backed hotspot penalty.",
-                "range": "[0, 100]",
-                "interpretation": "higher is better; A (85\u{2013}100), B (70\u{2013}84), C (55\u{2013}69), D (40\u{2013}54), F (0\u{2013}39)"
-            }
-    })
-}
-
-fn health_risk_metrics() -> Value {
-    json!({
-            "crap_max": {
-                "name": "Untested Complexity Risk (CRAP)",
-                "description": "Change Risk Anti-Patterns score (Savoia & Evans, 2007). Formula: CC\u{00b2} \u{00d7} (1 - cov/100)\u{00b3} + CC. Default model (static_estimated): estimates per-function coverage from export references \u{2014} directly test-referenced exports get 85%, indirectly test-reachable functions get 40%, untested files get 0%. Provide --coverage <path> with Istanbul-format coverage-final.json (from Jest, Vitest, c8, nyc) for exact per-function CRAP scores.",
-                "range": "[1, \u{221e})",
-                "interpretation": "lower is better; >=30 is high-risk (CC >= 5 without test path)"
-            },
-    })
-}
-
-fn health_contributor_metrics() -> Value {
-    json!({
-            "bus_factor": {
-                "name": "Bus Factor",
-                "description": "Avelino truck factor: the minimum number of distinct contributors who together account for at least 50% of recency-weighted commits to this file in the analysis window. Bot authors are excluded.",
-                "range": "[1, \u{221e})",
-                "interpretation": "lower is higher knowledge-loss risk; 1 means a single contributor covers most of the recent history"
-            },
-            "contributor_count": {
-                "name": "Contributor Count",
-                "description": "Number of distinct authors who touched this file in the analysis window after bot-pattern filtering.",
-                "range": "[0, \u{221e})",
-                "interpretation": "higher generally indicates broader knowledge spread; pair with bus_factor for context"
-            },
-            "share": {
-                "name": "Contributor Share",
-                "description": "Recency-weighted share of total weighted commits attributed to a single contributor. Rounded to three decimals.",
-                "range": "[0, 1]",
-                "interpretation": "share close to 1.0 indicates dominance and pairs with low bus_factor"
-            },
-    })
-}
-
-fn health_ownership_metrics() -> Value {
-    json!({
-            "stale_days": {
-                "name": "Stale Days",
-                "description": "Days since this contributor last touched the file. Computed at analysis time.",
-                "range": "[0, \u{221e})",
-                "interpretation": "high stale_days on the top contributor often correlates with ownership drift"
-            },
-            "drift": {
-                "name": "Ownership Drift",
-                "description": "True when the file's original author (earliest first commit in the window) differs from the current top contributor, the file is at least 30 days old, and the original author's recency-weighted share is below 10%.",
-                "values": [true, false],
-                "interpretation": "true means the original author is no longer maintaining; route reviews to the current top contributor"
-            },
-            "unowned": {
-                "name": "Unowned (Tristate)",
-                "description": "true = a CODEOWNERS file exists but no rule matches this file; false = a rule matches; null = no CODEOWNERS file was discovered for the repository (cannot determine).",
-                "values": [true, false, null],
-                "interpretation": "true on a hotspot is a review-bottleneck risk; null means the signal is unavailable, not absent"
-            }
-    })
-}
-
-fn health_runtime_verdict_metrics() -> Value {
-    json!({
-            "runtime_coverage_verdict": {
-                "name": "Runtime Coverage Verdict",
-                "description": "Overall verdict across all runtime-coverage findings. `clean` = nothing cold; `cold-code-detected` = one or more tracked functions had zero invocations; `hot-path-touched` = a function modified in the current change set is on the hot path (requires `--diff-file` or `--changed-since` to fire; without a change scope the verdict cannot promote); `license-expired-grace` = analysis ran but the license is in its post-expiry grace window; `unknown` = verdict could not be computed (degenerate input).",
-                "values": ["clean", "hot-path-touched", "cold-code-detected", "license-expired-grace", "unknown"],
-                "interpretation": "`cold-code-detected` is the primary actionable signal in standalone analysis; `hot-path-touched` is promoted to primary in PR context (when a change scope is supplied) so reviewers see the diff-tied signal first. `signals[]` carries the full unprioritized set."
-            },
-    })
-}
-
-fn health_runtime_observation_metrics() -> Value {
-    json!({
-            "runtime_coverage_state": {
-                "name": "Runtime Coverage State",
-                "description": "Per-function observation: `called` = V8 saw at least one invocation; `never-called` = V8 tracked the function but it never ran; `coverage-unavailable` = the function was not in the V8 tracking set (e.g., lazy-parsed, worker thread, dynamic code); `unknown` = forward-compat sentinel for newer sidecar states.",
-                "values": ["called", "never-called", "coverage-unavailable", "unknown"],
-                "interpretation": "`never-called` in combination with static `unused` is the highest-confidence delete signal"
-            },
-            "runtime_coverage_confidence": {
-                "name": "Runtime Coverage Confidence",
-                "description": "Confidence in a runtime-coverage finding. `high` = tracked by V8 with a statistically meaningful observation volume; `medium` = either low observation volume or indirect evidence; `low` = minimal data; `unknown` = insufficient information to classify.",
-                "values": ["high", "medium", "low", "unknown"],
-                "interpretation": "high = act on it; medium = verify context; low = treat as a signal only"
-            }
-    })
-}
-
-fn health_runtime_production_metrics() -> Value {
-    json!({
-            "production_invocations": {
-                "name": "Production Invocations",
-                "description": "Observed invocation count for the function over the collected coverage window. For `coverage-unavailable` findings this is `0` and semantically means `null` (not tracked). Absolute counts are not directly comparable across services without normalizing by trace_count.",
-                "range": "[0, \u{221e})",
-                "interpretation": "0 + tracked = cold path; 0 + untracked = unknown; high + never-called cannot occur by definition"
-            },
-            "percent_dead_in_production": {
-                "name": "Percent Dead in Production",
-                "description": "Fraction of tracked functions with zero observed invocations, multiplied by 100. Computed before any `--top` truncation so the summary total is stable regardless of display limits.",
-                "range": "[0, 100]",
-                "interpretation": "lower is better; values above ~10% on a long-running service indicate a large cleanup opportunity"
-            }
-    })
 }
 
 /// Build the `_meta` object for `fallow dupes --format json --explain`.
@@ -2311,8 +2034,8 @@ mod tests {
 
     #[test]
     fn health_docs_url_valid() {
-        assert!(HEALTH_DOCS.starts_with("https://"));
-        assert!(HEALTH_DOCS.contains("health"));
+        assert!(fallow_output::HEALTH_DOCS.starts_with("https://"));
+        assert!(fallow_output::HEALTH_DOCS.contains("health"));
     }
 
     #[test]
@@ -2330,7 +2053,7 @@ mod tests {
     #[test]
     fn health_meta_docs_url_matches_constant() {
         let meta = health_meta();
-        assert_eq!(meta["docs"].as_str().unwrap(), HEALTH_DOCS);
+        assert_eq!(meta["docs"].as_str().unwrap(), fallow_output::HEALTH_DOCS);
     }
 
     #[test]

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -9,7 +9,6 @@ use fallow_core::results::AnalysisResults;
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
 use super::{emit_json, normalize_uri};
-use crate::explain;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutput,
@@ -476,6 +475,7 @@ pub fn build_baseline_deltas_json<'a>(
 }
 
 /// Insert a `_meta` key into a JSON object value.
+#[cfg(test)]
 fn insert_meta(output: &mut serde_json::Value, meta: serde_json::Value) {
     if let serde_json::Value::Object(map) = output {
         let telemetry = map
@@ -503,7 +503,7 @@ pub fn build_health_json(
         report: report.clone(),
         grouped_by: None,
         groups: None,
-        meta: None,
+        meta: explain.then(fallow_output::health_meta),
         workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
         next_steps: crate::report::suggestions::build_health_next_steps(
             report,
@@ -515,9 +515,6 @@ pub fn build_health_json(
     let mut output = serialize_root_output(FallowOutput::Health(envelope))?;
     let root_prefix = format!("{}/", root.display());
     strip_root_prefix(&mut output, &root_prefix);
-    if explain {
-        insert_meta(&mut output, explain::health_meta());
-    }
     Ok(output)
 }
 
@@ -551,7 +548,7 @@ pub fn build_grouped_health_json(
         report: report.clone(),
         grouped_by: Some(group_by_mode_from_label(grouping.mode)),
         groups: None,
-        meta: None,
+        meta: explain.then(fallow_output::health_meta),
         workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
         next_steps: crate::report::suggestions::build_health_next_steps(
             report,
@@ -575,10 +572,6 @@ pub fn build_grouped_health_json(
 
     if let serde_json::Value::Object(ref mut map) = output {
         map.insert("groups".to_string(), serde_json::Value::Array(group_values));
-    }
-
-    if explain {
-        insert_meta(&mut output, explain::health_meta());
     }
 
     Ok(output)

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -42,4 +42,4 @@ pub use issue_contract::{
     CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, check_meta, dead_code_docs_url,
     issue_output_contract_by_code, issue_output_contracts, rule_docs_url,
 };
-pub use report_contract::{DUPES_DOCS, dupes_meta};
+pub use report_contract::{DUPES_DOCS, HEALTH_DOCS, dupes_meta, health_meta};

--- a/crates/output/src/report_contract.rs
+++ b/crates/output/src/report_contract.rs
@@ -7,21 +7,26 @@ use crate::{ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION, ACTIONS_FIELD_DEFINITION};
 /// Docs URL for the duplication command.
 pub const DUPES_DOCS: &str = "https://docs.fallow.tools/cli/dupes";
 
+/// Docs URL for the health command.
+pub const HEALTH_DOCS: &str = "https://docs.fallow.tools/cli/health";
+
+/// Build the `_meta` object for `fallow health --format json --explain`.
+#[must_use]
+pub fn health_meta() -> Meta {
+    Meta {
+        docs: Some(HEALTH_DOCS.to_string()),
+        field_definitions: action_field_definitions(),
+        metrics: health_metrics(),
+        ..Meta::default()
+    }
+}
+
 /// Build the `_meta` object for `fallow dupes --format json --explain`.
 #[must_use]
 pub fn dupes_meta() -> Meta {
     Meta {
         docs: Some(DUPES_DOCS.to_string()),
-        field_definitions: BTreeMap::from([
-            (
-                "actions[]".to_string(),
-                ACTIONS_FIELD_DEFINITION.to_string(),
-            ),
-            (
-                "actions[].auto_fixable".to_string(),
-                ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION.to_string(),
-            ),
-        ]),
+        field_definitions: action_field_definitions(),
         metrics: BTreeMap::from([
             (
                 "duplication_percentage".to_string(),
@@ -82,6 +87,268 @@ pub fn dupes_meta() -> Meta {
     }
 }
 
+fn action_field_definitions() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "actions[]".to_string(),
+            ACTIONS_FIELD_DEFINITION.to_string(),
+        ),
+        (
+            "actions[].auto_fixable".to_string(),
+            ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION.to_string(),
+        ),
+    ])
+}
+
+fn health_metrics() -> BTreeMap<String, MetaMetric> {
+    let mut metrics = BTreeMap::new();
+    metrics.extend(health_complexity_metrics());
+    metrics.extend(health_churn_and_target_metrics());
+    metrics.extend(health_ownership_metrics());
+    metrics.extend(health_runtime_metrics());
+    metrics
+}
+
+fn health_complexity_metrics() -> [(String, MetaMetric); 11] {
+    [
+        health_metric(
+            "cyclomatic",
+            "Cyclomatic Complexity",
+            "McCabe cyclomatic complexity: 1 + number of decision points.",
+            Some("[1, infinity)"),
+            "lower is better; default threshold: 20",
+        ),
+        health_metric(
+            "cognitive",
+            "Cognitive Complexity",
+            "Cognitive complexity penalizes nesting depth and non-linear control flow.",
+            Some("[0, infinity)"),
+            "lower is better; default threshold: 15",
+        ),
+        health_metric(
+            "line_count",
+            "Function Line Count",
+            "Number of lines in the function body.",
+            Some("[1, infinity)"),
+            "context-dependent; long functions may need splitting",
+        ),
+        health_metric(
+            "lines",
+            "File Line Count",
+            "Total lines of code in the file.",
+            Some("[1, infinity)"),
+            "context-dependent; large files may benefit from splitting",
+        ),
+        health_metric(
+            "maintainability_index",
+            "Maintainability Index",
+            "Composite file score combining complexity density, dead code ratio, and coupling.",
+            Some("[0, 100]"),
+            "higher is better",
+        ),
+        health_metric(
+            "complexity_density",
+            "Complexity Density",
+            "Total cyclomatic complexity divided by lines of code.",
+            Some("[0, infinity)"),
+            "lower is better; >1.0 indicates very dense complexity",
+        ),
+        health_metric(
+            "dead_code_ratio",
+            "Dead Code Ratio",
+            "Fraction of value exports with zero references across the project.",
+            Some("[0, 1]"),
+            "lower is better; 0 means all exports are used",
+        ),
+        health_metric(
+            "fan_in",
+            "Fan-in (Importers)",
+            "Number of files that import this file.",
+            Some("[0, infinity)"),
+            "context-dependent; high fan-in files need careful review",
+        ),
+        health_metric(
+            "fan_out",
+            "Fan-out (Imports)",
+            "Number of files this file directly imports.",
+            Some("[0, infinity)"),
+            "lower is better; high fan-out indicates coupling",
+        ),
+        health_metric(
+            "max_render_fan_in",
+            "Render Fan-in (Blast Radius)",
+            "Highest distinct-parent render count across React or Preact components.",
+            Some("[0, infinity)"),
+            "descriptive only; high values mean broad edit ripple",
+        ),
+        health_metric(
+            "crap_max",
+            "Untested Complexity Risk (CRAP)",
+            "Highest Change Risk Anti-Patterns score from complexity and coverage evidence.",
+            Some("[1, infinity)"),
+            "lower is better; high values indicate complex untested code",
+        ),
+    ]
+}
+
+fn health_churn_and_target_metrics() -> [(String, MetaMetric); 8] {
+    [
+        health_metric(
+            "score",
+            "Hotspot Score",
+            "Normalized churn multiplied by normalized complexity.",
+            Some("[0, 100]"),
+            "higher means riskier; prioritize refactoring high-score files",
+        ),
+        health_metric(
+            "weighted_commits",
+            "Weighted Commits",
+            "Recency-weighted commit count using exponential decay.",
+            Some("[0, infinity)"),
+            "higher means more recent churn activity",
+        ),
+        health_metric(
+            "trend",
+            "Churn Trend",
+            "Compares recent vs older commit frequency within the analysis window.",
+            None,
+            "accelerating files need attention; cooling files are stabilizing",
+        ),
+        health_metric(
+            "priority",
+            "Refactoring Priority",
+            "Weighted refactoring score using complexity, hotspots, dead code, fan-in, and fan-out.",
+            Some("[0, 100]"),
+            "higher means more urgent to refactor",
+        ),
+        health_metric(
+            "efficiency",
+            "Efficiency Score",
+            "Priority divided by effort estimate.",
+            Some("[0, 100]"),
+            "higher means better quick-win value",
+        ),
+        health_metric(
+            "effort",
+            "Effort Estimate",
+            "Heuristic effort estimate based on file size, function count, and fan-in.",
+            None,
+            "low means quick win, high needs planning and coordination",
+        ),
+        health_metric(
+            "confidence",
+            "Confidence Level",
+            "Reliability of the recommendation based on data source.",
+            None,
+            "high means act on it; medium or low means verify context",
+        ),
+        health_metric(
+            "health_score",
+            "Health Score",
+            "Project-level aggregate score computed from vital signs and issue signals.",
+            Some("[0, 100]"),
+            "higher is better; missing metrics are not penalized",
+        ),
+    ]
+}
+
+fn health_ownership_metrics() -> [(String, MetaMetric); 6] {
+    [
+        health_metric(
+            "bus_factor",
+            "Bus Factor",
+            "Minimum number of contributors who account for most recent weighted commits.",
+            Some("[1, infinity)"),
+            "lower is higher knowledge-loss risk",
+        ),
+        health_metric(
+            "contributor_count",
+            "Contributor Count",
+            "Number of distinct authors who touched this file in the analysis window.",
+            Some("[0, infinity)"),
+            "higher generally indicates broader knowledge spread",
+        ),
+        health_metric(
+            "share",
+            "Contributor Share",
+            "Recency-weighted share of total weighted commits attributed to a contributor.",
+            Some("[0, 1]"),
+            "share close to 1.0 indicates ownership concentration",
+        ),
+        health_metric(
+            "stale_days",
+            "Stale Days",
+            "Days since this contributor last touched the file.",
+            Some("[0, infinity)"),
+            "high stale days can indicate ownership drift",
+        ),
+        health_metric(
+            "drift",
+            "Ownership Drift",
+            "Whether original authorship and current contribution ownership have diverged.",
+            None,
+            "true means current review ownership may differ from original ownership",
+        ),
+        health_metric(
+            "unowned",
+            "Unowned (Tristate)",
+            "Whether CODEOWNERS exists but has no matching owner for this file.",
+            None,
+            "true on a hotspot is a review-bottleneck risk",
+        ),
+    ]
+}
+
+fn health_runtime_metrics() -> [(String, MetaMetric); 5] {
+    [
+        health_metric(
+            "runtime_coverage_verdict",
+            "Runtime Coverage Verdict",
+            "Overall verdict across runtime-coverage findings.",
+            None,
+            "cold-code-detected is the primary standalone cleanup signal",
+        ),
+        health_metric(
+            "runtime_coverage_state",
+            "Runtime Coverage State",
+            "Per-function runtime observation state.",
+            None,
+            "never-called with static unused is the highest-confidence delete signal",
+        ),
+        health_metric(
+            "runtime_coverage_confidence",
+            "Runtime Coverage Confidence",
+            "Confidence in a runtime-coverage finding.",
+            None,
+            "high means act on it; medium or low means verify context",
+        ),
+        health_metric(
+            "production_invocations",
+            "Production Invocations",
+            "Observed invocation count for the function over the collected coverage window.",
+            Some("[0, infinity)"),
+            "0 plus tracked means cold path; high means active path",
+        ),
+        health_metric(
+            "percent_dead_in_production",
+            "Percent Dead in Production",
+            "Fraction of tracked functions with zero observed invocations, multiplied by 100.",
+            Some("[0, 100]"),
+            "lower is better",
+        ),
+    ]
+}
+
+fn health_metric(
+    key: impl Into<String>,
+    name: impl Into<String>,
+    description: impl Into<String>,
+    range: Option<&str>,
+    interpretation: impl Into<String>,
+) -> (String, MetaMetric) {
+    (key.into(), metric(name, description, range, interpretation))
+}
+
 fn metric(
     name: impl Into<String>,
     description: impl Into<String>,
@@ -110,5 +377,16 @@ mod tests {
             meta.metrics
                 .contains_key("clone_groups_below_min_occurrences")
         );
+    }
+
+    #[test]
+    fn health_meta_uses_output_contract_shape() {
+        let meta = health_meta();
+        assert_eq!(meta.docs.as_deref(), Some(HEALTH_DOCS));
+        assert!(meta.field_definitions.contains_key("actions[]"));
+        assert!(meta.metrics.contains_key("cyclomatic"));
+        assert!(meta.metrics.contains_key("health_score"));
+        assert!(meta.metrics.contains_key("max_render_fan_in"));
+        assert!(meta.metrics.contains_key("percent_dead_in_production"));
     }
 }


### PR DESCRIPTION
## Summary
- add output-owned health explain metadata in fallow-output
- wire health JSON envelopes to populate typed _meta before serialization
- keep the CLI explain helper as a compatibility wrapper around the shared contract

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo test -p fallow-output health_meta
- cargo test -p fallow-cli health_meta
- cargo test -p fallow-cli build_health_json
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check