### PR TITLE
refactor: add typed lsp diagnostic input

### DIFF
--- a/crates/lsp/src/diagnostics/mod.rs
+++ b/crates/lsp/src/diagnostics/mod.rs
@@ -33,11 +33,35 @@ pub const FIRST_LINE_RANGE: Range = Range {
 };
 
 /// Build all LSP diagnostics from analysis results and duplication report, keyed by file URI.
-pub fn build_diagnostics(
-    results: &AnalysisResults,
-    duplication: &DuplicationReport,
-    root: &Path,
-) -> FxHashMap<Uri, Vec<Diagnostic>> {
+#[derive(Clone, Copy)]
+pub struct DiagnosticInput<'a> {
+    pub results: &'a AnalysisResults,
+    pub duplication: &'a DuplicationReport,
+    pub root: &'a Path,
+}
+
+impl<'a> DiagnosticInput<'a> {
+    #[must_use]
+    pub const fn new(
+        results: &'a AnalysisResults,
+        duplication: &'a DuplicationReport,
+        root: &'a Path,
+    ) -> Self {
+        Self {
+            results,
+            duplication,
+            root,
+        }
+    }
+}
+
+/// Build all LSP diagnostics from a typed editor analysis input, keyed by file URI.
+pub fn build_diagnostics(input: DiagnosticInput<'_>) -> FxHashMap<Uri, Vec<Diagnostic>> {
+    let DiagnosticInput {
+        results,
+        duplication,
+        root,
+    } = input;
     let mut map: FxHashMap<Uri, Vec<Diagnostic>> = FxHashMap::default();
     let package_json_uri = Uri::from_file_path(root.join("package.json"));
 
@@ -62,6 +86,15 @@ pub fn build_diagnostics(
     security::push_security_diagnostics(&mut map, results);
 
     map
+}
+
+#[cfg(test)]
+fn build_diagnostics_for_test(
+    results: &AnalysisResults,
+    duplication: &DuplicationReport,
+    root: &Path,
+) -> FxHashMap<Uri, Vec<Diagnostic>> {
+    build_diagnostics(DiagnosticInput::new(results, duplication, root))
 }
 
 #[cfg(test)]
@@ -109,7 +142,7 @@ mod tests {
         let duplication = empty_duplication();
         let root = test_root();
 
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
         assert!(diags.is_empty());
     }
 
@@ -151,7 +184,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&path).unwrap();
         let file_diags = &diags[&uri];
@@ -189,7 +222,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         for file_diags in diags.values() {
             for d in file_diags {
@@ -228,7 +261,7 @@ mod tests {
             });
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
         let uri = Uri::from_file_path(&path).unwrap();
         let file_diags = diags.get(&uri).expect("security diagnostic present");
         assert!(file_diags.iter().any(|d| matches!(
@@ -293,7 +326,7 @@ mod severity_gate {
     use fallow_engine::results::AnalysisResults;
     use ls_types::DiagnosticSeverity;
 
-    use crate::diagnostics::build_diagnostics;
+    use crate::diagnostics::build_diagnostics_for_test;
 
     fn test_root() -> PathBuf {
         if cfg!(windows) {
@@ -425,7 +458,7 @@ mod severity_gate {
         let root = test_root();
         let mut results = AnalysisResults::default();
         build(&root, &mut results);
-        let diags = build_diagnostics(&results, &empty_duplication(), &root);
+        let diags = build_diagnostics_for_test(&results, &empty_duplication(), &root);
         let all: Vec<_> = diags.values().flatten().collect();
         assert_eq!(
             all.len(),

--- a/crates/lsp/src/diagnostics/quality.rs
+++ b/crates/lsp/src/diagnostics/quality.rs
@@ -224,7 +224,7 @@ mod tests {
     };
     use ls_types::{DiagnosticSeverity, NumberOrString, Uri};
 
-    use crate::diagnostics::build_diagnostics;
+    use crate::diagnostics::build_diagnostics_for_test;
 
     fn test_root() -> PathBuf {
         if cfg!(windows) {
@@ -284,7 +284,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri_utils = Uri::from_file_path(&utils_path).unwrap();
         let uri_helpers = Uri::from_file_path(&helpers_path).unwrap();
@@ -352,7 +352,7 @@ mod tests {
             },
         };
 
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri_a = Uri::from_file_path(root.join("src/a.ts")).unwrap();
         let diags_a = &diags[&uri_a];
@@ -416,7 +416,7 @@ mod tests {
             },
         };
 
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
         let uri = Uri::from_file_path(root.join("src/only.ts")).unwrap();
         let d = &diags[&uri][0];
 
@@ -441,7 +441,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&path).unwrap();
         let d = &diags[&uri][0];
@@ -495,7 +495,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&path).unwrap();
         let file_diags = &diags[&uri];

--- a/crates/lsp/src/diagnostics/structural.rs
+++ b/crates/lsp/src/diagnostics/structural.rs
@@ -737,7 +737,7 @@ mod tests {
     };
     use ls_types::{DiagnosticSeverity, NumberOrString, Uri};
 
-    use crate::diagnostics::build_diagnostics;
+    use crate::diagnostics::build_diagnostics_for_test;
 
     fn test_root() -> PathBuf {
         if cfg!(windows) {
@@ -789,7 +789,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri_a = Uri::from_file_path(&file_a).unwrap();
         let file_diags = &diags[&uri_a];
@@ -842,7 +842,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file_a).unwrap();
         let d = &diags[&uri][0];
@@ -867,7 +867,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
         assert!(diags.is_empty());
     }
 
@@ -909,7 +909,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri_a = Uri::from_file_path(&file_a).unwrap();
         let uri_b = Uri::from_file_path(&file_b).unwrap();
@@ -1012,7 +1012,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         // file_a (absolute) still renders; the relative hop is silently
         // skipped from rendering only.
@@ -1038,7 +1038,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri_a = Uri::from_file_path(&file_a).unwrap();
         let uri_b = Uri::from_file_path(&file_b).unwrap();
@@ -1096,7 +1096,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let d = &diags[&uri][0];
@@ -1130,7 +1130,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&from_file).unwrap();
         let file_diags = &diags[&uri];
@@ -1172,7 +1172,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1217,7 +1217,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1256,7 +1256,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1295,7 +1295,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1334,7 +1334,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1373,7 +1373,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1413,7 +1413,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&file).unwrap();
         let file_diags = diags
@@ -1452,7 +1452,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&from_file).unwrap();
         let d = &diags[&uri][0];
@@ -1480,7 +1480,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&from_file).unwrap();
         let d = &diags[&uri][0];
@@ -1525,7 +1525,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&from_file).unwrap();
         let file_diags = &diags[&uri];
@@ -1541,7 +1541,7 @@ mod tests {
         let results = AnalysisResults::default();
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
         assert!(diags.is_empty());
     }
 }

--- a/crates/lsp/src/diagnostics/unused.rs
+++ b/crates/lsp/src/diagnostics/unused.rs
@@ -897,7 +897,7 @@ mod tests {
     };
     use ls_types::{DiagnosticSeverity, DiagnosticTag, NumberOrString, Uri};
 
-    use crate::diagnostics::{FIRST_LINE_RANGE, build_diagnostics};
+    use crate::diagnostics::{FIRST_LINE_RANGE, build_diagnostics_for_test};
 
     fn test_root() -> PathBuf {
         if cfg!(windows) {
@@ -948,7 +948,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/utils.ts")).unwrap();
         let file_diags = diags.get(&uri).expect("should have diagnostics for file");
@@ -985,7 +985,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/types.ts")).unwrap();
         let file_diags = &diags[&uri];
@@ -1011,7 +1011,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/dead.ts")).unwrap();
         let file_diags = &diags[&uri];
@@ -1046,7 +1046,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/app.ts")).unwrap();
         let file_diags = &diags[&uri];
@@ -1078,7 +1078,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("package.json")).unwrap();
         let file_diags = &diags[&uri];
@@ -1105,7 +1105,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("package.json")).unwrap();
         let file_diags = &diags[&uri];
@@ -1134,7 +1134,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("package.json")).unwrap();
         let file_diags = &diags[&uri];
@@ -1166,7 +1166,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/enums.ts")).unwrap();
         let file_diags = &diags[&uri];
@@ -1200,7 +1200,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/service.ts")).unwrap();
         let file_diags = &diags[&uri];
@@ -1231,7 +1231,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/store.ts")).unwrap();
         let file_diags = &diags[&uri];
@@ -1263,7 +1263,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("package.json")).unwrap();
         let file_diags = &diags[&uri];
@@ -1298,7 +1298,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("package.json")).unwrap();
         let file_diags = &diags[&uri];
@@ -1333,7 +1333,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("package.json")).unwrap();
         let file_diags = &diags[&uri];
@@ -1370,7 +1370,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("src/edge.ts")).unwrap();
         let d = &diags[&uri][0];
@@ -1394,7 +1394,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("pnpm-workspace.yaml")).unwrap();
         let file_diags = diags
@@ -1430,7 +1430,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("pnpm-workspace.yaml")).unwrap();
         let d = &diags[&uri][0];
@@ -1455,7 +1455,7 @@ mod tests {
             }));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(root.join("pnpm-workspace.yaml")).unwrap();
         let file_diags = diags
@@ -1491,7 +1491,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&abs_path).unwrap();
         let file_diags = diags
@@ -1528,7 +1528,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&abs_path).unwrap();
         let d = &diags[&uri][0];
@@ -1569,7 +1569,7 @@ mod tests {
             ));
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&yaml_path).unwrap();
         let file_diags = diags
@@ -1617,7 +1617,7 @@ mod tests {
         );
 
         let duplication = empty_duplication();
-        let diags = build_diagnostics(&results, &duplication, &root);
+        let diags = build_diagnostics_for_test(&results, &duplication, &root);
 
         let uri = Uri::from_file_path(&json_path).unwrap();
         let d = &diags[&uri][0];

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -1188,8 +1188,9 @@ impl FallowLspServer {
             self.client.log_message(level, msg).await;
         }
 
-        let mut all_diagnostics =
-            diagnostics::build_diagnostics(&output.results, &output.duplication, root);
+        let mut all_diagnostics = diagnostics::build_diagnostics(
+            diagnostics::DiagnosticInput::new(&output.results, &output.duplication, root),
+        );
         attach_changed_since_data(&mut all_diagnostics, changed_since_for_data);
         self.publish_collected_diagnostics(all_diagnostics, version_snapshot)
             .await;


### PR DESCRIPTION
## Summary
- introduce a typed DiagnosticInput for LSP diagnostic fan-out
- route production diagnostic publishing through the typed input
- keep test call sites on a test-only wrapper while module internals migrate

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-lsp
- cargo test -p fallow-lsp
- cargo clippy -p fallow-lsp --all-targets -- -D warnings
- git diff --check