### PR TITLE
refactor: move health envelope contract to output crate

### DIFF
--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub use fallow_output::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, CodeClimateIssue,
     CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation, CodeClimateOutput,
-    CodeClimateSeverity, GroupByMode, WorkspaceDiagnosticOutput,
+    CodeClimateSeverity, GroupByMode, HealthOutput, WorkspaceDiagnosticOutput,
     apply_config_fixable_to_duplicate_exports, build_check_output, build_check_summary,
 };
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, ToolVersion};
@@ -356,40 +356,6 @@ pub struct DupesOutput {
     /// contract; the same list is repeated on each top-level command's
     /// envelope so single-command consumers see it without having to look at
     /// a separate top-level field.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub workspace_diagnostics: Vec<fallow_config::WorkspaceDiagnostic>,
-    /// Read-only follow-up commands computed from this run's findings. See
-    /// [`CheckOutput::next_steps`] for the contract.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_steps: Vec<NextStep>,
-}
-
-/// Envelope emitted by `fallow health --format json` (plus the `health` block
-/// inside the combined and audit envelopes).
-///
-/// The body is `HealthReport` flattened into the envelope so every report
-/// field (`findings`, `summary`, `vital_signs`, `hotspots`, `actions_meta`,
-/// ...) lives at the top level. Grouped runs populate `grouped_by` +
-/// `groups` with per-bucket recomputed metrics. The `actions_meta`
-/// breadcrumb is modeled on `HealthReport` as an `Option<HealthActionsMeta>`
-/// and is set at construction time by the report builder when the active
-/// `HealthActionContext` requests suppress-line omission, so the schema
-/// documents the field and serde populates it natively.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(title = "fallow health --format json"))]
-pub struct HealthOutput {
-    pub schema_version: SchemaVersion,
-    pub version: ToolVersion,
-    pub elapsed_ms: ElapsedMs,
-    #[serde(flatten)]
-    pub report: HealthReport,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub grouped_by: Option<GroupByMode>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub groups: Option<Vec<HealthGroup>>,
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Meta>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workspace_diagnostics: Vec<fallow_config::WorkspaceDiagnostic>,
     /// Read-only follow-up commands computed from this run's findings. See
@@ -1006,7 +972,7 @@ pub enum FallowOutput {
     Workspaces(WorkspacesOutput),
     /// `fallow health --format json`. Required `report: HealthReport`.
     #[serde(rename = "health")]
-    Health(HealthOutput),
+    Health(HealthOutput<HealthReport, HealthGroup>),
     /// `fallow dupes --format json`. Required `report: DupesReportPayload`
     /// (typed wrapper payload carrying `clone_groups[]: CloneGroupFinding`
     /// and `clone_families[]: CloneFamilyFinding`).

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -504,7 +504,7 @@ pub fn build_health_json(
         grouped_by: None,
         groups: None,
         meta: explain.then(fallow_output::health_meta),
-        workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
         next_steps: crate::report::suggestions::build_health_next_steps(
             report,
             root,
@@ -549,7 +549,7 @@ pub fn build_grouped_health_json(
         grouped_by: Some(group_by_mode_from_label(grouping.mode)),
         groups: None,
         meta: explain.then(fallow_output::health_meta),
-        workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
         next_steps: crate::report::suggestions::build_health_next_steps(
             report,
             root,
@@ -860,7 +860,10 @@ mod tests {
             ..Default::default()
         };
 
-        let envelope = HealthOutput {
+        let envelope: HealthOutput<
+            crate::health_types::HealthReport,
+            crate::health_types::HealthGroup,
+        > = HealthOutput {
             schema_version: SchemaVersion(SCHEMA_VERSION),
             version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
             elapsed_ms: ElapsedMs(7),

--- a/crates/output/src/health.rs
+++ b/crates/output/src/health.rs
@@ -1,0 +1,33 @@
+use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, ToolVersion};
+use fallow_types::output::NextStep;
+use serde::Serialize;
+
+use crate::{GroupByMode, WorkspaceDiagnosticOutput};
+
+/// Envelope emitted by `fallow health --format json`.
+///
+/// The health report body is flattened into the envelope so every report field
+/// lives at the top level. `Report` and `Group` are generic while health report
+/// internals are still moving out of the CLI crate; the envelope contract itself
+/// is owned here so CLI, API, and future embedders share one top-level shape.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(title = "fallow health --format json"))]
+pub struct HealthOutput<Report, Group> {
+    pub schema_version: SchemaVersion,
+    pub version: ToolVersion,
+    pub elapsed_ms: ElapsedMs,
+    #[serde(flatten)]
+    pub report: Report,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grouped_by: Option<GroupByMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<Group>>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    /// Read-only follow-up commands computed from this run's findings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_steps: Vec<NextStep>,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -16,6 +16,7 @@ mod check;
 mod codeclimate;
 mod dupes;
 mod format;
+mod health;
 mod issue_contract;
 mod report_contract;
 
@@ -37,6 +38,7 @@ pub use fallow_types::output;
 pub use fallow_types::output_dead_code;
 pub use fallow_types::output_health;
 pub use format::OutputFormat;
+pub use health::HealthOutput;
 pub use issue_contract::{
     ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION, ACTIONS_FIELD_DEFINITION, CHECK_DOCS,
     CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, check_meta, dead_code_docs_url,


### PR DESCRIPTION
## Summary
- move the health JSON envelope contract into fallow-output as a generic HealthOutput<Report, Group>
- re-export the contract from the CLI envelope module while health report internals continue migrating
- route health JSON workspace diagnostics through the output-layer transparent DTO

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output
- cargo check -p fallow-cli
- cargo check -p fallow-output --features schema
- cargo check -p fallow-cli --features schema
- cargo test -p fallow-output
- cargo test -p fallow-cli report::json
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check