### PR TITLE
refactor: move dupes envelope contract to output crate

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -8,11 +8,12 @@ use fallow_config::{
 };
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
-use fallow_output::{CHECK_SCHEMA_VERSION, CheckOutputInput, build_check_output, check_meta};
+use fallow_output::{
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, build_check_output, check_meta,
+};
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Serialize;
 
 use crate::{
     AnalysisOptions, DeadCodeFilters, DeadCodeOptions, DupesReportPayload, DuplicationMode,
@@ -23,17 +24,6 @@ const SCHEMA_VERSION: u32 = 1;
 const MAX_DIFF_BYTES: u64 = 10 * 1024 * 1024;
 
 type ProgrammaticResult<T> = Result<T, ProgrammaticError>;
-
-#[derive(Debug, Clone, Serialize)]
-struct DupesOutput {
-    schema_version: SchemaVersion,
-    version: ToolVersion,
-    elapsed_ms: ElapsedMs,
-    #[serde(flatten)]
-    report: DupesReportPayload,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    total_issues: Option<usize>,
-}
 
 struct ResolvedAnalysisOptions {
     root: PathBuf,
@@ -619,12 +609,17 @@ fn detect_duplication_inner(
     }
 
     let payload = DupesReportPayload::from_report(&report);
-    let envelope = DupesOutput {
+    let envelope: DupesOutput<DupesReportPayload, serde_json::Value> = DupesOutput {
         schema_version: SchemaVersion(SCHEMA_VERSION),
         version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
         elapsed_ms: ElapsedMs(start.elapsed().as_millis() as u64),
         report: payload,
+        grouped_by: None,
         total_issues: None,
+        groups: None,
+        meta: None,
+        workspace_diagnostics: Vec::new(),
+        next_steps: Vec::new(),
     };
     let mut output = serde_json::to_value(envelope).map_err(|err| {
         ProgrammaticError::new(format!("failed to serialize duplication report: {err}"), 2)

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub use fallow_output::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, CodeClimateIssue,
     CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation, CodeClimateOutput,
-    CodeClimateSeverity, GroupByMode, HealthOutput, WorkspaceDiagnosticOutput,
+    CodeClimateSeverity, DupesOutput, GroupByMode, HealthOutput, WorkspaceDiagnosticOutput,
     apply_config_fixable_to_duplicate_exports, build_check_output, build_check_summary,
 };
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, ToolVersion};
@@ -330,38 +330,6 @@ pub struct CoverageAnalyzeOutput {
     pub runtime_coverage: RuntimeCoverageReport,
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(title = "fallow dupes --format json"))]
-pub struct DupesOutput {
-    pub schema_version: SchemaVersion,
-    pub version: ToolVersion,
-    pub elapsed_ms: ElapsedMs,
-    #[serde(flatten)]
-    pub report: DupesReportPayload,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub grouped_by: Option<GroupByMode>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_issues: Option<usize>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub groups: Option<Vec<DuplicationGroup>>,
-    /// `_meta` block with metric / rule definitions, emitted when `--explain`
-    /// is passed (always present in MCP responses).
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Meta>,
-    /// Workspace-discovery diagnostics surfaced during config load
-    /// (issue #473). See [`CheckOutput::workspace_diagnostics`] for the full
-    /// contract; the same list is repeated on each top-level command's
-    /// envelope so single-command consumers see it without having to look at
-    /// a separate top-level field.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub workspace_diagnostics: Vec<fallow_config::WorkspaceDiagnostic>,
-    /// Read-only follow-up commands computed from this run's findings. See
-    /// [`CheckOutput::next_steps`] for the contract.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub next_steps: Vec<NextStep>,
 }
 
 /// Envelope emitted by `fallow explain <issue-type> --format json`.
@@ -977,7 +945,7 @@ pub enum FallowOutput {
     /// (typed wrapper payload carrying `clone_groups[]: CloneGroupFinding`
     /// and `clone_families[]: CloneFamilyFinding`).
     #[serde(rename = "dupes")]
-    Dupes(DupesOutput),
+    Dupes(DupesOutput<DupesReportPayload, DuplicationGroup>),
     /// `fallow dead-code --format json --group-by <mode>`. Required `grouped_by`
     /// plus a `groups` array.
     #[serde(rename = "dead-code-grouped")]

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -615,7 +615,7 @@ pub fn build_duplication_json(
         total_issues: None,
         groups: None,
         meta: explain.then(fallow_output::dupes_meta),
-        workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
         next_steps,
     };
     let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;
@@ -664,7 +664,7 @@ pub fn build_grouped_duplication_json(
         total_issues: Some(report.clone_groups.len()),
         groups: None,
         meta: explain.then(fallow_output::dupes_meta),
-        workspace_diagnostics: crate::runtime_support::workspace_diagnostics_for(root),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
         next_steps,
     };
     let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;

--- a/crates/output/src/dupes.rs
+++ b/crates/output/src/dupes.rs
@@ -5,7 +5,42 @@
 //! core-independent and are shared by CLI schema emission, JSON output, and
 //! future API/LSP consumers.
 
+use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, ToolVersion};
+use fallow_types::output::NextStep;
 use serde::Serialize;
+
+use crate::{GroupByMode, WorkspaceDiagnosticOutput};
+
+/// Envelope emitted by `fallow dupes --format json`.
+///
+/// `Report` and `Group` are generic so the envelope can live in
+/// `fallow-output` while duplication report wrappers and grouped output
+/// internals continue to migrate out of CLI/API-specific crates.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(title = "fallow dupes --format json"))]
+pub struct DupesOutput<Report, Group> {
+    pub schema_version: SchemaVersion,
+    pub version: ToolVersion,
+    pub elapsed_ms: ElapsedMs,
+    #[serde(flatten)]
+    pub report: Report,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grouped_by: Option<GroupByMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_issues: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<Group>>,
+    /// `_meta` block with metric / rule definitions, emitted when `--explain`
+    /// is passed.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    /// Read-only follow-up commands computed from this run's findings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_steps: Vec<NextStep>,
+}
 
 /// Inline suppression comment emitted for code duplication findings.
 pub const DUPES_SUPPRESS_COMMENT: &str = "// fallow-ignore-next-line code-duplication";

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -31,7 +31,8 @@ pub use codeclimate::{
 };
 pub use dupes::{
     CloneFamilyAction, CloneFamilyActionType, CloneGroupAction, CloneGroupActionType,
-    DUPES_SUPPRESS_COMMENT, DUPES_SUPPRESS_DESCRIPTION, clone_family_actions, clone_group_actions,
+    DUPES_SUPPRESS_COMMENT, DUPES_SUPPRESS_DESCRIPTION, DupesOutput, clone_family_actions,
+    clone_group_actions,
 };
 pub use fallow_types::envelope;
 pub use fallow_types::output;


### PR DESCRIPTION
## Summary
- move the duplication JSON envelope contract into fallow-output as a generic DupesOutput<Report, Group>
- re-export the contract from the CLI envelope module while grouped dupes internals continue migrating
- switch the programmatic API duplication output to the shared envelope contract

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-api -p fallow-cli
- cargo check -p fallow-cli --features schema
- cargo test -p fallow-output
- cargo test -p fallow-api detect_duplication
- cargo test -p fallow-cli report::json
- cargo clippy -p fallow-output -p fallow-api -p fallow-cli --all-targets -- -D warnings
- git diff --check