### PR TITLE
refactor: build health envelope in output crate

### DIFF
--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -13,8 +13,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub use fallow_output::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, CodeClimateIssue,
     CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation, CodeClimateOutput,
-    CodeClimateSeverity, DupesOutput, GroupByMode, HealthOutput, WorkspaceDiagnosticOutput,
-    apply_config_fixable_to_duplicate_exports, build_check_output, build_check_summary,
+    CodeClimateSeverity, DupesOutput, GroupByMode, HealthOutput, HealthOutputInput,
+    WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports, build_check_output,
+    build_check_summary, build_health_output,
 };
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, ToolVersion};
 use fallow_types::output::NextStep;

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -12,8 +12,9 @@ use super::{emit_json, normalize_uri};
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutput,
-    FallowOutput, GroupByMode, HealthOutput, WorkspaceDiagnosticOutput,
-    apply_config_fixable_to_duplicate_exports, build_check_output, serialize_root_output,
+    FallowOutput, GroupByMode, HealthOutputInput, WorkspaceDiagnosticOutput,
+    apply_config_fixable_to_duplicate_exports, build_check_output, build_health_output,
+    serialize_root_output,
 };
 use crate::report::grouping::{OwnershipResolver, ResultGroup};
 
@@ -496,10 +497,10 @@ pub fn build_health_json(
     elapsed: Duration,
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let envelope = HealthOutput {
-        schema_version: SchemaVersion(SCHEMA_VERSION),
-        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: ElapsedMs(elapsed.as_millis() as u64),
+    let envelope = build_health_output(HealthOutputInput {
+        schema_version: SCHEMA_VERSION,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        elapsed,
         report: report.clone(),
         grouped_by: None,
         groups: None,
@@ -511,7 +512,7 @@ pub fn build_health_json(
             crate::report::suggestions::setup_pointer_applicable(root),
             crate::report::suggestions::due_impact_digest(root),
         ),
-    };
+    });
     let mut output = serialize_root_output(FallowOutput::Health(envelope))?;
     let root_prefix = format!("{}/", root.display());
     strip_root_prefix(&mut output, &root_prefix);
@@ -541,10 +542,10 @@ pub fn build_grouped_health_json(
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
     let root_prefix = format!("{}/", root.display());
-    let envelope = HealthOutput {
-        schema_version: SchemaVersion(SCHEMA_VERSION),
-        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: ElapsedMs(elapsed.as_millis() as u64),
+    let envelope = build_health_output(HealthOutputInput {
+        schema_version: SCHEMA_VERSION,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        elapsed,
         report: report.clone(),
         grouped_by: Some(group_by_mode_from_label(grouping.mode)),
         groups: None,
@@ -556,7 +557,7 @@ pub fn build_grouped_health_json(
             crate::report::suggestions::setup_pointer_applicable(root),
             crate::report::suggestions::due_impact_digest(root),
         ),
-    };
+    });
     let mut output = serialize_root_output(FallowOutput::Health(envelope))?;
     strip_root_prefix(&mut output, &root_prefix);
 
@@ -860,10 +861,10 @@ mod tests {
             ..Default::default()
         };
 
-        let envelope: HealthOutput<
+        let envelope: crate::output_envelope::HealthOutput<
             crate::health_types::HealthReport,
             crate::health_types::HealthGroup,
-        > = HealthOutput {
+        > = crate::output_envelope::HealthOutput {
             schema_version: SchemaVersion(SCHEMA_VERSION),
             version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
             elapsed_ms: ElapsedMs(7),

--- a/crates/output/src/health.rs
+++ b/crates/output/src/health.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, ToolVersion};
 use fallow_types::output::NextStep;
 use serde::Serialize;
@@ -30,4 +32,37 @@ pub struct HealthOutput<Report, Group> {
     /// Read-only follow-up commands computed from this run's findings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_steps: Vec<NextStep>,
+}
+
+/// Inputs for constructing a [`HealthOutput`] without exposing envelope
+/// assembly details to callers.
+#[derive(Debug, Clone)]
+pub struct HealthOutputInput<Report, Group> {
+    pub schema_version: u32,
+    pub version: String,
+    pub elapsed: Duration,
+    pub report: Report,
+    pub grouped_by: Option<GroupByMode>,
+    pub groups: Option<Vec<Group>>,
+    pub meta: Option<Meta>,
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    pub next_steps: Vec<NextStep>,
+}
+
+/// Build a health JSON envelope from caller-owned report data.
+#[must_use]
+pub fn build_health_output<Report, Group>(
+    input: HealthOutputInput<Report, Group>,
+) -> HealthOutput<Report, Group> {
+    HealthOutput {
+        schema_version: SchemaVersion(input.schema_version),
+        version: ToolVersion(input.version),
+        elapsed_ms: ElapsedMs(input.elapsed.as_millis() as u64),
+        report: input.report,
+        grouped_by: input.grouped_by,
+        groups: input.groups,
+        meta: input.meta,
+        workspace_diagnostics: input.workspace_diagnostics,
+        next_steps: input.next_steps,
+    }
 }

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -39,7 +39,7 @@ pub use fallow_types::output;
 pub use fallow_types::output_dead_code;
 pub use fallow_types::output_health;
 pub use format::OutputFormat;
-pub use health::HealthOutput;
+pub use health::{HealthOutput, HealthOutputInput, build_health_output};
 pub use issue_contract::{
     ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION, ACTIONS_FIELD_DEFINITION, CHECK_DOCS,
     CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, check_meta, dead_code_docs_url,


### PR DESCRIPTION
## Summary
- add HealthOutputInput and build_health_output to fallow-output
- route CLI health JSON envelope construction through the output-layer builder
- keep health report internals in CLI while moving another top-level output contract boundary out of CLI

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo check -p fallow-cli --features schema
- cargo test -p fallow-output
- cargo test -p fallow-cli report::json
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check