### PR TITLE
refactor: build dupes envelope in output crate

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -9,9 +9,9 @@ use fallow_config::{
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
-    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, build_check_output, check_meta,
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, build_check_output,
+    build_dupes_output, check_meta,
 };
-use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -609,18 +609,19 @@ fn detect_duplication_inner(
     }
 
     let payload = DupesReportPayload::from_report(&report);
-    let envelope: DupesOutput<DupesReportPayload, serde_json::Value> = DupesOutput {
-        schema_version: SchemaVersion(SCHEMA_VERSION),
-        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: ElapsedMs(start.elapsed().as_millis() as u64),
-        report: payload,
-        grouped_by: None,
-        total_issues: None,
-        groups: None,
-        meta: None,
-        workspace_diagnostics: Vec::new(),
-        next_steps: Vec::new(),
-    };
+    let envelope: DupesOutput<DupesReportPayload, serde_json::Value> =
+        build_dupes_output(DupesOutputInput {
+            schema_version: SCHEMA_VERSION,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            elapsed: start.elapsed(),
+            report: payload,
+            grouped_by: None,
+            total_issues: None,
+            groups: None,
+            meta: None,
+            workspace_diagnostics: Vec::new(),
+            next_steps: Vec::new(),
+        });
     let mut output = serde_json::to_value(envelope).map_err(|err| {
         ProgrammaticError::new(format!("failed to serialize duplication report: {err}"), 2)
             .with_code("FALLOW_SERIALIZE_DUPLICATION_REPORT")

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -13,9 +13,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub use fallow_output::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, CodeClimateIssue,
     CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation, CodeClimateOutput,
-    CodeClimateSeverity, DupesOutput, GroupByMode, HealthOutput, HealthOutputInput,
-    WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports, build_check_output,
-    build_check_summary, build_health_output,
+    CodeClimateSeverity, DupesOutput, DupesOutputInput, GroupByMode, HealthOutput,
+    HealthOutputInput, WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports,
+    build_check_output, build_check_summary, build_dupes_output, build_health_output,
 };
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, ToolVersion};
 use fallow_types::output::NextStep;

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -11,10 +11,10 @@ use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 use super::{emit_json, normalize_uri};
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
-    CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutput,
+    CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutputInput,
     FallowOutput, GroupByMode, HealthOutputInput, WorkspaceDiagnosticOutput,
-    apply_config_fixable_to_duplicate_exports, build_check_output, build_health_output,
-    serialize_root_output,
+    apply_config_fixable_to_duplicate_exports, build_check_output, build_dupes_output,
+    build_health_output, serialize_root_output,
 };
 use crate::report::grouping::{OwnershipResolver, ResultGroup};
 
@@ -607,10 +607,10 @@ pub fn build_duplication_json(
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
     );
-    let envelope = DupesOutput {
-        schema_version: SchemaVersion(SCHEMA_VERSION),
-        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: ElapsedMs(elapsed.as_millis() as u64),
+    let envelope = build_dupes_output(DupesOutputInput {
+        schema_version: SCHEMA_VERSION,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        elapsed,
         report: payload,
         grouped_by: None,
         total_issues: None,
@@ -618,7 +618,7 @@ pub fn build_duplication_json(
         meta: explain.then(fallow_output::dupes_meta),
         workspace_diagnostics: workspace_diagnostics_for_output(root),
         next_steps,
-    };
+    });
     let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;
     let root_prefix = format!("{}/", root.display());
     strip_root_prefix(&mut output, &root_prefix);
@@ -656,10 +656,10 @@ pub fn build_grouped_duplication_json(
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
     );
-    let envelope = DupesOutput {
-        schema_version: SchemaVersion(SCHEMA_VERSION),
-        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: ElapsedMs(elapsed.as_millis() as u64),
+    let envelope = build_dupes_output(DupesOutputInput {
+        schema_version: SCHEMA_VERSION,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        elapsed,
         report: payload,
         grouped_by: Some(group_by_mode_from_label(grouping.mode)),
         total_issues: Some(report.clone_groups.len()),
@@ -667,7 +667,7 @@ pub fn build_grouped_duplication_json(
         meta: explain.then(fallow_output::dupes_meta),
         workspace_diagnostics: workspace_diagnostics_for_output(root),
         next_steps,
-    };
+    });
     let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;
     strip_root_prefix(&mut output, &root_prefix);
 

--- a/crates/output/src/dupes.rs
+++ b/crates/output/src/dupes.rs
@@ -5,6 +5,8 @@
 //! core-independent and are shared by CLI schema emission, JSON output, and
 //! future API/LSP consumers.
 
+use std::time::Duration;
+
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, ToolVersion};
 use fallow_types::output::NextStep;
 use serde::Serialize;
@@ -40,6 +42,41 @@ pub struct DupesOutput<Report, Group> {
     /// Read-only follow-up commands computed from this run's findings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub next_steps: Vec<NextStep>,
+}
+
+/// Inputs for constructing a [`DupesOutput`] without exposing envelope assembly
+/// details to callers.
+#[derive(Debug, Clone)]
+pub struct DupesOutputInput<Report, Group> {
+    pub schema_version: u32,
+    pub version: String,
+    pub elapsed: Duration,
+    pub report: Report,
+    pub grouped_by: Option<GroupByMode>,
+    pub total_issues: Option<usize>,
+    pub groups: Option<Vec<Group>>,
+    pub meta: Option<Meta>,
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    pub next_steps: Vec<NextStep>,
+}
+
+/// Build a duplication JSON envelope from caller-owned report data.
+#[must_use]
+pub fn build_dupes_output<Report, Group>(
+    input: DupesOutputInput<Report, Group>,
+) -> DupesOutput<Report, Group> {
+    DupesOutput {
+        schema_version: SchemaVersion(input.schema_version),
+        version: ToolVersion(input.version),
+        elapsed_ms: ElapsedMs(input.elapsed.as_millis() as u64),
+        report: input.report,
+        grouped_by: input.grouped_by,
+        total_issues: input.total_issues,
+        groups: input.groups,
+        meta: input.meta,
+        workspace_diagnostics: input.workspace_diagnostics,
+        next_steps: input.next_steps,
+    }
 }
 
 /// Inline suppression comment emitted for code duplication findings.

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -31,8 +31,8 @@ pub use codeclimate::{
 };
 pub use dupes::{
     CloneFamilyAction, CloneFamilyActionType, CloneGroupAction, CloneGroupActionType,
-    DUPES_SUPPRESS_COMMENT, DUPES_SUPPRESS_DESCRIPTION, DupesOutput, clone_family_actions,
-    clone_group_actions,
+    DUPES_SUPPRESS_COMMENT, DUPES_SUPPRESS_DESCRIPTION, DupesOutput, DupesOutputInput,
+    build_dupes_output, clone_family_actions, clone_group_actions,
 };
 pub use fallow_types::envelope;
 pub use fallow_types::output;


### PR DESCRIPTION
## Summary
- add DupesOutputInput and build_dupes_output to fallow-output
- route CLI duplication JSON envelope construction through the output-layer builder
- route programmatic API duplication output through the same shared builder

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-api -p fallow-cli
- cargo check -p fallow-cli --features schema
- cargo test -p fallow-output
- cargo test -p fallow-api detect_duplication
- cargo test -p fallow-cli report::json
- cargo clippy -p fallow-output -p fallow-api -p fallow-cli --all-targets -- -D warnings
- git diff --check