### PR TITLE
refactor: move coverage model contract to output crate

### DIFF
--- a/crates/cli/src/health_types/scores.rs
+++ b/crates/cli/src/health_types/scores.rs
@@ -1,5 +1,7 @@
 //! Score types, grade boundaries, file health metrics, and findings.
 
+pub use fallow_output::CoverageModel;
+
 pub const HOTSPOT_SCORE_THRESHOLD: f64 = 50.0;
 
 pub const COGNITIVE_EXTRACTION_THRESHOLD: u16 = 30;
@@ -582,20 +584,6 @@ pub struct FileHealthScore {
     pub lines: u32,
     pub crap_max: f64,
     pub crap_above_threshold: usize,
-}
-
-/// Coverage model used for CRAP score computation.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum CoverageModel {
-    #[allow(
-        dead_code,
-        reason = "retained for backwards-compatible JSON deserialization"
-    )]
-    StaticBinary,
-    StaticEstimated,
-    Istanbul,
 }
 
 /// A hotspot: a file that is both complex and frequently changing.

--- a/crates/output/src/health_coverage.rs
+++ b/crates/output/src/health_coverage.rs
@@ -1,0 +1,13 @@
+/// Coverage model used for CRAP score computation.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageModel {
+    #[allow(
+        dead_code,
+        reason = "retained for backwards-compatible JSON deserialization"
+    )]
+    StaticBinary,
+    StaticEstimated,
+    Istanbul,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -17,6 +17,7 @@ mod codeclimate;
 mod dupes;
 mod format;
 mod health;
+mod health_coverage;
 mod health_targets;
 mod issue_contract;
 mod report_contract;
@@ -41,6 +42,7 @@ pub use fallow_types::output_dead_code;
 pub use fallow_types::output_health;
 pub use format::OutputFormat;
 pub use health::{HealthOutput, HealthOutputInput, build_health_output};
+pub use health_coverage::CoverageModel;
 pub use health_targets::{
     CloneSiblingEvidence, Confidence, ContributingFactor, DirectCallerEvidence,
     DirectCallerSymbolEvidence, EffortEstimate, EvidenceFunction, RecommendationCategory,


### PR DESCRIPTION
## Summary
- move the CoverageModel wire enum into fallow-output
- re-export it through the CLI health types for compatibility
- keep serialization and schema derivation owned by the output contract crate

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo check -p fallow-output -p fallow-cli --features schema
- cargo test -p fallow-output
- cargo test -p fallow-cli coverage_model_serializes_as_snake_case
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check