### PR TITLE
refactor: move health actions meta to output crate

### DIFF
--- a/crates/cli/src/health_types/mod.rs
+++ b/crates/cli/src/health_types/mod.rs
@@ -16,6 +16,7 @@ mod vital_signs;
 
 pub use coverage::*;
 pub use coverage_intelligence::*;
+pub use fallow_output::HealthActionsMeta;
 pub use finding::*;
 pub use grouped::*;
 pub use runtime_coverage::*;
@@ -52,33 +53,6 @@ pub struct HealthTimings {
     /// the cost is attributed to the `Pipeline Performance` table instead.
     /// The renderer shows those two stages as `(measured above)`.
     pub shared_parse: bool,
-}
-
-/// Auditable breadcrumb recording when health-finding `suppress-line`
-/// action hints were omitted from the report.
-///
-/// Set at construction time on [`HealthReport::actions_meta`] (and on
-/// each [`HealthGroup::actions_meta`](crate::health_types::HealthGroup)
-/// when grouped) by the report builder, derived from the active
-/// [`HealthActionContext`]. Lets consumers see "where did the
-/// suppress-line hints go?" without having to grep the config or CLI
-/// history.
-///
-/// Stable `reason` codes:
-/// - `baseline-active`: a baseline is active and inline ignores would
-///   become dead annotations once the baseline regenerates.
-/// - `config-disabled`: `health.suggestInlineSuppression` is `false`.
-/// - `unspecified`: the caller did not record a reason.
-#[derive(Debug, Clone, serde::Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct HealthActionsMeta {
-    /// Always `true` when the breadcrumb is emitted. Absent from the wire
-    /// when no suppression occurred.
-    pub suppression_hints_omitted: bool,
-    /// Stable code describing why the suppression occurred.
-    pub reason: String,
-    /// Scope of the omission. Always `"health-findings"` today.
-    pub scope: String,
 }
 
 /// Structural CSS analytics surfaced by `fallow health --css`.

--- a/crates/output/src/health_actions.rs
+++ b/crates/output/src/health_actions.rs
@@ -1,0 +1,19 @@
+/// Auditable breadcrumb recording when health-finding `suppress-line`
+/// action hints were omitted from the report.
+///
+/// Stable `reason` codes:
+/// - `baseline-active`: a baseline is active and inline ignores would become
+///   dead annotations once the baseline regenerates.
+/// - `config-disabled`: `health.suggestInlineSuppression` is `false`.
+/// - `unspecified`: the caller did not record a reason.
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct HealthActionsMeta {
+    /// Always `true` when the breadcrumb is emitted. Absent from the wire when
+    /// no suppression occurred.
+    pub suppression_hints_omitted: bool,
+    /// Stable code describing why the suppression occurred.
+    pub reason: String,
+    /// Scope of the omission. Always `"health-findings"` today.
+    pub scope: String,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -17,6 +17,7 @@ mod codeclimate;
 mod dupes;
 mod format;
 mod health;
+mod health_actions;
 mod health_coverage;
 mod health_coverage_gaps;
 mod health_targets;
@@ -45,6 +46,7 @@ pub use fallow_types::output_dead_code;
 pub use fallow_types::output_health;
 pub use format::OutputFormat;
 pub use health::{HealthOutput, HealthOutputInput, build_health_output};
+pub use health_actions::HealthActionsMeta;
 pub use health_coverage::CoverageModel;
 pub use health_coverage_gaps::{
     CoverageGapSummary, CoverageGaps, UntestedExport, UntestedExportFinding, UntestedFile,


### PR DESCRIPTION
## Summary
- move HealthActionsMeta into fallow-output
- re-export the type through CLI health_types for compatibility
- keep the health action breadcrumb owned by the output contract layer

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo check -p fallow-output -p fallow-cli --features schema
- cargo test -p fallow-output
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check