### PR TITLE
refactor: move health diagnostics contracts to output crate

### DIFF
--- a/crates/cli/src/health_types/mod.rs
+++ b/crates/cli/src/health_types/mod.rs
@@ -16,7 +16,10 @@ mod vital_signs;
 
 pub use coverage::*;
 pub use coverage_intelligence::*;
-pub use fallow_output::HealthActionsMeta;
+pub use fallow_output::{
+    FrameworkHealthDetector, FrameworkHealthDetectorStatus, FrameworkHealthDiagnostics,
+    HealthActionsMeta, HealthTimings,
+};
 pub use finding::*;
 pub use grouped::*;
 pub use runtime_coverage::*;
@@ -26,34 +29,6 @@ pub use trends::*;
 pub use vital_signs::*;
 
 use fallow_types::output_dead_code::PropDrillingChainFinding;
-
-/// Detailed timing breakdown for the health pipeline.
-///
-/// Only populated when `--performance` is passed.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct HealthTimings {
-    pub config_ms: f64,
-    pub discover_ms: f64,
-    pub parse_ms: f64,
-    /// Summed wall-clock time of the actual AST parses across all rayon
-    /// workers (the parse stage's CPU cost). `parse_ms` is the stage's
-    /// wall-clock time. Observational and non-deterministic; do not assert
-    /// against it. `0.0` when `shared_parse` is true (parse was reused).
-    pub parse_cpu_ms: f64,
-    pub complexity_ms: f64,
-    pub file_scores_ms: f64,
-    pub git_churn_ms: f64,
-    pub git_churn_cache_hit: bool,
-    pub hotspots_ms: f64,
-    pub duplication_ms: f64,
-    pub targets_ms: f64,
-    pub total_ms: f64,
-    /// True when discover + parse were reused from the upstream dead-code
-    /// (check) pass in combined mode, so their timings are `0.0` here and
-    /// the cost is attributed to the `Pipeline Performance` table instead.
-    /// The renderer shows those two stages as `(measured above)`.
-    pub shared_parse: bool,
-}
 
 /// Structural CSS analytics surfaced by `fallow health --css`.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -779,43 +754,6 @@ pub struct CssAnalyticsSummary {
     /// truncated at the per-file cap, so a consumer knows the per-rule detail is
     /// incomplete without walking every file.
     pub notable_truncated_files: u32,
-}
-
-/// Framework-specific health detector coverage surfaced for agent consumers.
-#[derive(Debug, Clone, serde::Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct FrameworkHealthDiagnostics {
-    /// Detected framework IDs, sorted and deduplicated.
-    pub detected_frameworks: Vec<String>,
-    /// Detector coverage for the detected frameworks.
-    pub detectors: Vec<FrameworkHealthDetector>,
-}
-
-/// Status for one framework-specific health detector.
-#[derive(Debug, Clone, serde::Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct FrameworkHealthDetector {
-    /// Rule or detector ID, matching fallow's stable rule names where possible.
-    pub id: String,
-    /// Framework ID that made this detector relevant.
-    pub framework: String,
-    /// Whether the detector ran, was disabled, abstained, or could not be checked.
-    pub status: FrameworkHealthDetectorStatus,
-    /// Stable reason code for non-active statuses.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
-}
-
-/// Detector status codes for framework health observability.
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum FrameworkHealthDetectorStatus {
-    Active,
-    DisabledByConfig,
-    Abstained,
-    #[allow(dead_code, reason = "reserved for analysis paths that skip a detector")]
-    NotChecked,
 }
 
 /// Result of complexity analysis for reporting.

--- a/crates/output/src/health_diagnostics.rs
+++ b/crates/output/src/health_diagnostics.rs
@@ -1,0 +1,64 @@
+/// Detailed timing breakdown for the health pipeline.
+///
+/// Only populated when `--performance` is passed.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct HealthTimings {
+    pub config_ms: f64,
+    pub discover_ms: f64,
+    pub parse_ms: f64,
+    /// Summed wall-clock time of the actual AST parses across all rayon
+    /// workers (the parse stage's CPU cost). `parse_ms` is the stage's
+    /// wall-clock time. Observational and non-deterministic; do not assert
+    /// against it. `0.0` when `shared_parse` is true (parse was reused).
+    pub parse_cpu_ms: f64,
+    pub complexity_ms: f64,
+    pub file_scores_ms: f64,
+    pub git_churn_ms: f64,
+    pub git_churn_cache_hit: bool,
+    pub hotspots_ms: f64,
+    pub duplication_ms: f64,
+    pub targets_ms: f64,
+    pub total_ms: f64,
+    /// True when discover + parse were reused from the upstream dead-code
+    /// (check) pass in combined mode, so their timings are `0.0` here and
+    /// the cost is attributed to the `Pipeline Performance` table instead.
+    /// The renderer shows those two stages as `(measured above)`.
+    pub shared_parse: bool,
+}
+
+/// Framework-specific health detector coverage surfaced for agent consumers.
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FrameworkHealthDiagnostics {
+    /// Detected framework IDs, sorted and deduplicated.
+    pub detected_frameworks: Vec<String>,
+    /// Detector coverage for the detected frameworks.
+    pub detectors: Vec<FrameworkHealthDetector>,
+}
+
+/// Status for one framework-specific health detector.
+#[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FrameworkHealthDetector {
+    /// Rule or detector ID, matching fallow's stable rule names where possible.
+    pub id: String,
+    /// Framework ID that made this detector relevant.
+    pub framework: String,
+    /// Whether the detector ran, was disabled, abstained, or could not be checked.
+    pub status: FrameworkHealthDetectorStatus,
+    /// Stable reason code for non-active statuses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Detector status codes for framework health observability.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum FrameworkHealthDetectorStatus {
+    Active,
+    DisabledByConfig,
+    Abstained,
+    #[allow(dead_code, reason = "reserved for analysis paths that skip a detector")]
+    NotChecked,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -21,6 +21,7 @@ mod health_actions;
 mod health_coverage;
 mod health_coverage_gaps;
 mod health_coverage_intelligence;
+mod health_diagnostics;
 mod health_runtime_coverage;
 mod health_targets;
 mod health_trends;
@@ -60,6 +61,10 @@ pub use health_coverage_intelligence::{
     CoverageIntelligenceRecommendation, CoverageIntelligenceReport,
     CoverageIntelligenceSchemaVersion, CoverageIntelligenceSignal, CoverageIntelligenceSummary,
     CoverageIntelligenceVerdict,
+};
+pub use health_diagnostics::{
+    FrameworkHealthDetector, FrameworkHealthDetectorStatus, FrameworkHealthDiagnostics,
+    HealthTimings,
 };
 pub use health_runtime_coverage::{
     RuntimeCoverageAction, RuntimeCoverageBlastRadiusEntry, RuntimeCoverageCaptureQuality,


### PR DESCRIPTION
## Summary
- Move health timing and framework-health diagnostics DTOs from fallow-cli to fallow-output.
- Keep CLI compatibility through health_types re-exports.

## Plan
- Local plan: .plans/output-health-diagnostics-contracts.md

## Verification
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-output -p fallow-cli
- [x] cargo check -p fallow-output -p fallow-cli --features schema
- [x] cargo test -p fallow-output
- [x] cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- [x] git diff --check