### PR TITLE
refactor: move health report contracts to output crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ name = "fallow-output"
 version = "2.102.0"
 dependencies = [
  "fallow-types",
+ "rustc-hash 2.1.2",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/cli/src/health_types/mod.rs
+++ b/crates/cli/src/health_types/mod.rs
@@ -6,8 +6,6 @@
 
 mod coverage;
 mod coverage_intelligence;
-mod finding;
-mod grouped;
 mod runtime_coverage;
 mod scores;
 mod targets;
@@ -21,181 +19,23 @@ pub use coverage_intelligence::*;
     reason = "report tests construct CSS actions through the health_types facade"
 )]
 pub use fallow_output::CssCandidateActionType;
+#[allow(
+    unused_imports,
+    reason = "CLI report tests exercise the compatibility facade for this output action builder"
+)]
+pub use fallow_output::build_health_finding_actions;
 pub use fallow_output::{
     CssAnalyticsReport, CssAnalyticsSummary, CssBlockOccurrence, CssCandidateAction,
     CssDuplicateBlock, CssFileAnalytics, CssNotationConsistency, CssNotationCount,
     FrameworkHealthDetector, FrameworkHealthDetectorStatus, FrameworkHealthDiagnostics,
-    HealthActionsMeta, HealthTimings, ScopedUnusedClasses, TailwindArbitraryValue,
-    UndefinedKeyframes, UnreferencedCssClass, UnreferencedKeyframes, UnresolvedClassReference,
-    UnusedAtRule, UnusedAtRuleKind, UnusedFontFace, UnusedThemeToken,
+    HealthActionContext, HealthActionOptions, HealthActionsMeta, HealthFinding, HealthGroup,
+    HealthGrouping, HealthReport, HealthTimings, HotspotFinding, RefactoringTargetFinding,
+    ScopedUnusedClasses, TailwindArbitraryValue, UndefinedKeyframes, UnreferencedCssClass,
+    UnreferencedKeyframes, UnresolvedClassReference, UnusedAtRule, UnusedAtRuleKind,
+    UnusedFontFace, UnusedThemeToken,
 };
-pub use finding::*;
-pub use grouped::*;
 pub use runtime_coverage::*;
 pub use scores::*;
 pub use targets::*;
 pub use trends::*;
 pub use vital_signs::*;
-
-use fallow_types::output_dead_code::PropDrillingChainFinding;
-
-/// Result of complexity analysis for reporting.
-#[derive(Debug, Clone, serde::Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct HealthReport {
-    /// Functions and synthetic template entries exceeding complexity
-    /// thresholds, sorted by the --sort criteria. Each entry wraps its
-    /// inner [`ComplexityViolation`] payload (flattened on the wire) with
-    /// the typed `actions` list and an optional audit-mode `introduced`
-    /// flag.
-    pub findings: Vec<HealthFinding>,
-    /// Summary statistics.
-    pub summary: HealthSummary,
-    /// Configured threshold override states. Entries are emitted for active
-    /// exceptions, stale exceptions, and full-run no-match cleanup hints.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub threshold_overrides: Vec<ThresholdOverrideState>,
-    /// Project-wide vital signs (always computed from available data).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vital_signs: Option<VitalSigns>,
-    /// Project-wide health score (only populated with `--score`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub health_score: Option<HealthScore>,
-    /// Per-file health scores. Only present when --file-scores is used. Sorted
-    /// by risk-aware triage concern, combining low maintainability and high
-    /// CRAP risk. Zero-function files (barrels) are excluded by default.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub file_scores: Vec<FileHealthScore>,
-    /// Static coverage gaps.
-    ///
-    /// Populated when coverage gaps are explicitly requested, or when the
-    /// top-level `health` command allows config severity to surface them in the
-    /// default report.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub coverage_gaps: Option<CoverageGaps>,
-    /// Located prop-drilling chains (React/Preact props forwarded unchanged
-    /// through 3+ pass-through components). Only present when the opt-in
-    /// `prop-drilling` rule is enabled (it defaults to off). Each entry carries
-    /// the source, every pass-through hop, and the consumer with file + line +
-    /// component, so CI / an agent can act. Surfaced alongside hotspots as a
-    /// graph-derived health signal.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub prop_drilling_chains: Vec<PropDrillingChainFinding>,
-    /// Hotspot entries combining git churn with complexity. Only present when
-    /// --hotspots is used. Sorted by score descending (highest risk first).
-    /// Each entry wraps its inner [`HotspotEntry`] payload (flattened on the
-    /// wire) with a typed `actions` list.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub hotspots: Vec<HotspotFinding>,
-    /// Hotspot analysis summary (only set with `--hotspots`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hotspot_summary: Option<HotspotSummary>,
-    /// Runtime coverage findings from the paid sidecar (only populated with
-    /// `--runtime-coverage`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runtime_coverage: Option<RuntimeCoverageReport>,
-    /// Combined coverage, runtime, complexity, and change-scope verdicts.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub coverage_intelligence: Option<CoverageIntelligenceReport>,
-    /// Functions exceeding 60 LOC (very high risk). Only present when unit size
-    /// very-high-risk bin >= 3%. Sorted by line count descending.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub large_functions: Vec<LargeFunctionEntry>,
-    /// Ranked refactoring recommendations. Only present when --targets is used.
-    /// Sorted by efficiency (priority/effort) descending. Each entry wraps
-    /// its inner [`RefactoringTarget`] payload (flattened on the wire) with
-    /// a typed `actions` list.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub targets: Vec<RefactoringTargetFinding>,
-    /// Adaptive thresholds used for target scoring (only set with `--targets`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub target_thresholds: Option<TargetThresholds>,
-    /// Health trend comparison against a previous snapshot (only set with `--trend`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub health_trend: Option<HealthTrend>,
-    /// Audit breadcrumb explaining systemic action-array adjustments. Present
-    /// only when at least one adjustment was made (e.g., health finding
-    /// suppression hints omitted because a baseline is active). When --group-by
-    /// is active, each entry of `groups` may carry its own `actions_meta`
-    /// describing the same omission so per-group consumers do not need to walk
-    /// back to the report root.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub actions_meta: Option<HealthActionsMeta>,
-    /// Optional framework-specific detector coverage. Present only when the
-    /// health run already needed the dead-code analysis output.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub framework_health: Option<FrameworkHealthDiagnostics>,
-    /// Structural CSS analytics (specificity hotspots, `!important` density,
-    /// over-complex selectors, deep nesting). Present only with `--css`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub css_analytics: Option<CssAnalyticsReport>,
-    /// Per-file top render fan-in for the descriptive human drill-down only:
-    /// maps a component file's absolute path to its highest-fan-in component
-    /// `(component name, render SITES)`. Drives the `rendered in N places`
-    /// blast-radius line on the React hotspot/complexity surface. INTERNAL: the
-    /// public render-fan-in surface is the `VitalSigns` aggregate, so this is
-    /// `#[serde(skip)]` and never widens the JSON contract.
-    #[serde(skip)]
-    pub render_fan_in_top: rustc_hash::FxHashMap<std::path::PathBuf, (String, u32)>,
-}
-
-#[cfg(test)]
-#[expect(
-    clippy::derivable_impls,
-    reason = "test-only Default with custom HealthSummary thresholds (20/15)"
-)]
-impl Default for HealthReport {
-    fn default() -> Self {
-        Self {
-            findings: vec![],
-            summary: HealthSummary::default(),
-            threshold_overrides: vec![],
-            vital_signs: None,
-            health_score: None,
-            file_scores: vec![],
-            coverage_gaps: None,
-            prop_drilling_chains: vec![],
-            hotspots: vec![],
-            hotspot_summary: None,
-            runtime_coverage: None,
-            coverage_intelligence: None,
-            large_functions: vec![],
-            targets: vec![],
-            target_thresholds: None,
-            health_trend: None,
-            actions_meta: None,
-            framework_health: None,
-            css_analytics: None,
-            render_fan_in_top: rustc_hash::FxHashMap::default(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn health_report_skips_empty_collections() {
-        let report = HealthReport::default();
-        let json = serde_json::to_string(&report).unwrap();
-        assert!(!json.contains("file_scores"));
-        assert!(!json.contains("hotspots"));
-        assert!(!json.contains("hotspot_summary"));
-        assert!(!json.contains("runtime_coverage"));
-        assert!(!json.contains("coverage_intelligence"));
-        assert!(!json.contains("large_functions"));
-        assert!(!json.contains("targets"));
-        assert!(!json.contains("threshold_overrides"));
-        assert!(!json.contains("vital_signs"));
-        assert!(!json.contains("health_score"));
-        assert!(!json.contains("framework_health"));
-    }
-
-    #[test]
-    fn health_score_none_skipped_in_report() {
-        let report = HealthReport::default();
-        let json = serde_json::to_string(&report).unwrap();
-        assert!(!json.contains("health_score"));
-    }
-}

--- a/crates/output/Cargo.toml
+++ b/crates/output/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../../README.md"
 fallow-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 
 [features]

--- a/crates/output/src/health_findings.rs
+++ b/crates/output/src/health_findings.rs
@@ -10,10 +10,10 @@ use fallow_types::output_health::{
 use std::ops::Deref;
 use std::path::Path;
 
-use crate::health_types::scores::{
-    ComplexityViolation, CoverageTier, HotspotEntry, OwnershipState,
+use crate::{
+    ComplexityViolation, CoverageTier, ExceededThreshold, HotspotEntry, OwnershipMetrics,
+    OwnershipState, RecommendationCategory, RefactoringTarget,
 };
-use crate::health_types::targets::{RecommendationCategory, RefactoringTarget};
 
 /// Options controlling how the action builder populates `actions`.
 #[derive(Debug, Clone, Copy, Default)]
@@ -115,7 +115,7 @@ pub fn build_health_finding_actions(
     let name = violation.name.as_str();
     let exceeded = violation.exceeded;
     let includes_crap = exceeded.includes_crap();
-    let crap_only = matches!(exceeded, crate::health_types::ExceededThreshold::Crap);
+    let crap_only = matches!(exceeded, ExceededThreshold::Crap);
     let cyclomatic = violation.cyclomatic;
     let cognitive = violation.cognitive;
     let max_cyclomatic_threshold = violation
@@ -481,7 +481,7 @@ fn base_hotspot_actions(path: &str) -> Vec<HotspotAction> {
 
 fn append_ownership_hotspot_actions(
     actions: &mut Vec<HotspotAction>,
-    ownership: &crate::health_types::OwnershipMetrics,
+    ownership: &OwnershipMetrics,
     path: &str,
 ) {
     if ownership.bus_factor == 1 {
@@ -497,10 +497,7 @@ fn append_ownership_hotspot_actions(
     }
 }
 
-fn low_bus_factor_action(
-    ownership: &crate::health_types::OwnershipMetrics,
-    path: &str,
-) -> HotspotAction {
+fn low_bus_factor_action(ownership: &OwnershipMetrics, path: &str) -> HotspotAction {
     let top = &ownership.top_contributor;
     let owner = top.identifier.as_str();
     HotspotAction {
@@ -515,7 +512,7 @@ fn low_bus_factor_action(
     }
 }
 
-fn low_bus_factor_note(ownership: &crate::health_types::OwnershipMetrics) -> Option<String> {
+fn low_bus_factor_note(ownership: &OwnershipMetrics) -> Option<String> {
     let suggested: Vec<&str> = ownership
         .suggested_reviewers
         .iter()
@@ -550,10 +547,7 @@ fn unowned_hotspot_action(path: &str) -> HotspotAction {
     }
 }
 
-fn ownership_drift_action(
-    ownership: &crate::health_types::OwnershipMetrics,
-    path: &str,
-) -> HotspotAction {
+fn ownership_drift_action(ownership: &OwnershipMetrics, path: &str) -> HotspotAction {
     let reason = ownership
         .drift_reason
         .as_deref()
@@ -715,10 +709,11 @@ const fn category_snake_case(cat: &RecommendationCategory) -> &'static str {
 #[cfg(test)]
 mod hotspot_target_tests {
     use super::*;
-    use crate::health_types::scores::{
-        ContributorEntry, ContributorIdentifierFormat, OwnershipMetrics, OwnershipState,
+    use crate::{
+        Confidence, ContributorEntry, ContributorIdentifierFormat, EffortEstimate,
+        EvidenceFunction, OwnershipMetrics, OwnershipState, TargetEvidence,
     };
-    use fallow_core::churn::ChurnTrend;
+    use fallow_types::churn::ChurnTrend;
     use std::path::PathBuf;
 
     fn sample_entry(path: &str) -> HotspotEntry {
@@ -754,8 +749,8 @@ mod hotspot_target_tests {
             efficiency: 75.0,
             recommendation: "Extract `handleRequest` into helpers".to_string(),
             category: RecommendationCategory::ExtractComplexFunctions,
-            effort: crate::health_types::EffortEstimate::Low,
-            confidence: crate::health_types::Confidence::High,
+            effort: EffortEstimate::Low,
+            confidence: Confidence::High,
             factors: Vec::new(),
             evidence: None,
         }
@@ -765,8 +760,10 @@ mod hotspot_target_tests {
     fn hotspot_finding_flattens_inner_fields_at_top_level() {
         let entry = sample_entry("/root/src/api.ts");
         let finding = HotspotFinding::with_actions(entry, Path::new("/root"));
-        let json = serde_json::to_value(&finding).unwrap();
-        let obj = json.as_object().unwrap();
+        let json = serde_json::to_value(&finding).expect("hotspot finding should serialize");
+        let obj = json
+            .as_object()
+            .expect("hotspot finding should serialize as object");
         assert!(obj.contains_key("score"));
         assert!(obj.contains_key("commits"));
         assert!(obj.contains_key("weighted_commits"));
@@ -959,8 +956,11 @@ mod hotspot_target_tests {
     fn refactoring_target_finding_flattens_inner_fields_at_top_level() {
         let target = sample_target();
         let finding = RefactoringTargetFinding::with_actions(target);
-        let json = serde_json::to_value(&finding).unwrap();
-        let obj = json.as_object().unwrap();
+        let json =
+            serde_json::to_value(&finding).expect("refactoring target finding should serialize");
+        let obj = json
+            .as_object()
+            .expect("refactoring target finding should serialize as object");
         assert!(obj.contains_key("priority"));
         assert!(obj.contains_key("efficiency"));
         assert!(obj.contains_key("recommendation"));
@@ -992,9 +992,9 @@ mod hotspot_target_tests {
     #[test]
     fn refactoring_target_actions_append_suppress_when_evidence_present() {
         let mut target = sample_target();
-        target.evidence = Some(crate::health_types::TargetEvidence {
+        target.evidence = Some(TargetEvidence {
             unused_exports: Vec::new(),
-            complex_functions: vec![crate::health_types::EvidenceFunction {
+            complex_functions: vec![EvidenceFunction {
                 name: "handleRequest".to_string(),
                 line: 12,
                 cognitive: 30,
@@ -1052,8 +1052,10 @@ mod hotspot_target_tests {
             RecommendationCategory::AddTestCoverage,
         ];
         for cat in &variants {
-            let via_serde = serde_json::to_value(cat).unwrap();
-            let serde_str = via_serde.as_str().unwrap();
+            let via_serde = serde_json::to_value(cat).expect("category should serialize");
+            let serde_str = via_serde
+                .as_str()
+                .expect("category should serialize as string");
             assert_eq!(
                 serde_str,
                 category_snake_case(cat),

--- a/crates/output/src/health_grouped.rs
+++ b/crates/output/src/health_grouped.rs
@@ -9,7 +9,7 @@
 
 use serde::Serialize;
 
-use crate::health_types::{
+use crate::{
     CoverageSourceConsistency, FileHealthScore, HealthActionsMeta, HealthFinding, HealthScore,
     HotspotFinding, LargeFunctionEntry, RefactoringTargetFinding, VitalSigns,
 };
@@ -24,7 +24,7 @@ use crate::health_types::{
 /// files in the group, so they answer "what is the health of workspace X" in
 /// a single invocation. `files_analyzed` and `functions_above_threshold`
 /// summarise the subset for parity with the project-level
-/// [`crate::health_types::HealthSummary`].
+/// [`HealthSummary`].
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct HealthGroup {
@@ -61,7 +61,7 @@ pub struct HealthGroup {
     pub health_score: Option<HealthScore>,
     /// Findings restricted to files in this group. Each entry is the typed
     /// [`HealthFinding`] wrapper around a
-    /// [`ComplexityViolation`](crate::health_types::ComplexityViolation)
+    /// [`ComplexityViolation`](ComplexityViolation)
     /// payload.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub findings: Vec<HealthFinding>,
@@ -70,7 +70,7 @@ pub struct HealthGroup {
     pub file_scores: Vec<FileHealthScore>,
     /// Hotspots restricted to files in this group. Each entry is the typed
     /// [`HotspotFinding`] wrapper around a
-    /// [`HotspotEntry`](crate::health_types::HotspotEntry) payload.
+    /// [`HotspotEntry`](HotspotEntry) payload.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hotspots: Vec<HotspotFinding>,
     /// Large functions in files belonging to this group.
@@ -78,14 +78,14 @@ pub struct HealthGroup {
     pub large_functions: Vec<LargeFunctionEntry>,
     /// Refactoring targets in files belonging to this group. Each entry is
     /// the typed [`RefactoringTargetFinding`] wrapper around a
-    /// [`RefactoringTarget`](crate::health_types::RefactoringTarget)
+    /// [`RefactoringTarget`](RefactoringTarget)
     /// payload.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub targets: Vec<RefactoringTargetFinding>,
     /// Auditable breadcrumb recording why `suppress-line` action hints
     /// were omitted from this group's findings. Mirrors the project-level
     /// `HealthReport.actions_meta`; populated at construction time when the
-    /// per-group [`HealthActionContext`](crate::health_types::HealthActionContext)
+    /// per-group [`HealthActionContext`](HealthActionContext)
     /// suppresses inline hints.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actions_meta: Option<HealthActionsMeta>,

--- a/crates/output/src/health_report.rs
+++ b/crates/output/src/health_report.rs
@@ -1,0 +1,103 @@
+//! Top-level health report contract.
+
+use crate::{
+    CoverageGaps, CoverageIntelligenceReport, CssAnalyticsReport, FileHealthScore,
+    FrameworkHealthDiagnostics, HealthActionsMeta, HealthFinding, HealthScore, HealthSummary,
+    HealthTrend, HotspotFinding, HotspotSummary, LargeFunctionEntry, RefactoringTargetFinding,
+    RuntimeCoverageReport, TargetThresholds, ThresholdOverrideState, VitalSigns,
+};
+use fallow_types::output_dead_code::PropDrillingChainFinding;
+
+/// Result of complexity analysis for reporting.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct HealthReport {
+    /// Functions and synthetic template entries exceeding complexity
+    /// thresholds, sorted by the --sort criteria.
+    pub findings: Vec<HealthFinding>,
+    /// Summary statistics.
+    pub summary: HealthSummary,
+    /// Configured threshold override states.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub threshold_overrides: Vec<ThresholdOverrideState>,
+    /// Project-wide vital signs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vital_signs: Option<VitalSigns>,
+    /// Project-wide health score.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health_score: Option<HealthScore>,
+    /// Per-file health scores.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_scores: Vec<FileHealthScore>,
+    /// Static coverage gaps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_gaps: Option<CoverageGaps>,
+    /// Located prop-drilling chains.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prop_drilling_chains: Vec<PropDrillingChainFinding>,
+    /// Hotspot entries combining git churn with complexity.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hotspots: Vec<HotspotFinding>,
+    /// Hotspot analysis summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hotspot_summary: Option<HotspotSummary>,
+    /// Runtime coverage findings from the paid sidecar.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_coverage: Option<RuntimeCoverageReport>,
+    /// Combined coverage, runtime, complexity, and change-scope verdicts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_intelligence: Option<CoverageIntelligenceReport>,
+    /// Functions exceeding 60 LOC.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub large_functions: Vec<LargeFunctionEntry>,
+    /// Ranked refactoring recommendations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<RefactoringTargetFinding>,
+    /// Adaptive thresholds used for target scoring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_thresholds: Option<TargetThresholds>,
+    /// Health trend comparison against a previous snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health_trend: Option<HealthTrend>,
+    /// Audit breadcrumb explaining systemic action-array adjustments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actions_meta: Option<HealthActionsMeta>,
+    /// Optional framework-specific detector coverage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub framework_health: Option<FrameworkHealthDiagnostics>,
+    /// Structural CSS analytics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub css_analytics: Option<CssAnalyticsReport>,
+    /// Per-file top render fan-in for the descriptive human drill-down only.
+    #[serde(skip)]
+    pub render_fan_in_top: rustc_hash::FxHashMap<std::path::PathBuf, (String, u32)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_report_skips_empty_collections() {
+        let report = HealthReport::default();
+        let json = serde_json::to_string(&report).expect("health report should serialize");
+        assert!(!json.contains("file_scores"));
+        assert!(!json.contains("hotspots"));
+        assert!(!json.contains("hotspot_summary"));
+        assert!(!json.contains("runtime_coverage"));
+        assert!(!json.contains("coverage_intelligence"));
+        assert!(!json.contains("large_functions"));
+        assert!(!json.contains("targets"));
+        assert!(!json.contains("threshold_overrides"));
+        assert!(!json.contains("vital_signs"));
+        assert!(!json.contains("health_score"));
+        assert!(!json.contains("framework_health"));
+    }
+
+    #[test]
+    fn health_score_none_skipped_in_report() {
+        let report = HealthReport::default();
+        let json = serde_json::to_string(&report).expect("health report should serialize");
+        assert!(!json.contains("health_score"));
+    }
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -23,6 +23,9 @@ mod health_coverage_gaps;
 mod health_coverage_intelligence;
 mod health_css;
 mod health_diagnostics;
+mod health_findings;
+mod health_grouped;
+mod health_report;
 mod health_runtime_coverage;
 mod health_scores;
 mod health_targets;
@@ -75,6 +78,12 @@ pub use health_diagnostics::{
     FrameworkHealthDetector, FrameworkHealthDetectorStatus, FrameworkHealthDiagnostics,
     HealthTimings,
 };
+pub use health_findings::{
+    HealthActionContext, HealthActionOptions, HealthFinding, HotspotFinding,
+    RefactoringTargetFinding, build_health_finding_actions,
+};
+pub use health_grouped::{HealthGroup, HealthGrouping};
+pub use health_report::HealthReport;
 pub use health_runtime_coverage::{
     RuntimeCoverageAction, RuntimeCoverageBlastRadiusEntry, RuntimeCoverageCaptureQuality,
     RuntimeCoverageConfidence, RuntimeCoverageDataSource, RuntimeCoverageEvidence,


### PR DESCRIPTION
## Summary
- Moved health finding, hotspot, refactoring target, grouped health, and HealthReport contracts from fallow-cli to fallow-output.
- Kept crates/cli/src/health_types as a compatibility facade for existing report builders.
- Removed CLI/core/clap coupling from the moved output contracts.

## Verification
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-output -p fallow-cli
- [x] cargo check -p fallow-output -p fallow-cli --features schema
- [x] cargo test -p fallow-output
- [x] cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- [x] git diff --check
- [x] hidden unicode dash check on touched files