### PR TITLE
refactor: move coverage envelope contracts to output crate

### DIFF
--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -13,7 +13,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub use fallow_output::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, CodeClimateIssue,
     CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation, CodeClimateOutput,
-    CodeClimateSeverity, DupesOutput, DupesOutputInput, GroupByMode, HealthOutput,
+    CodeClimateSeverity, CoverageAnalyzeOutput, CoverageAnalyzeSchemaVersion,
+    CoverageSetupFileToEdit, CoverageSetupFramework, CoverageSetupMember, CoverageSetupOutput,
+    CoverageSetupPackageManager, CoverageSetupRuntimeTarget, CoverageSetupSchemaVersion,
+    CoverageSetupSnippet, DupesOutput, DupesOutputInput, GroupByMode, HealthOutput,
     HealthOutputInput, WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports,
     build_check_output, build_check_summary, build_dupes_output, build_health_output,
 };
@@ -22,7 +25,7 @@ use fallow_types::output::NextStep;
 use serde::Serialize;
 
 use crate::audit::{AuditAttribution, AuditSummary, AuditVerdict};
-use crate::health_types::{HealthGroup, HealthReport, RuntimeCoverageReport};
+use crate::health_types::{HealthGroup, HealthReport};
 use crate::output_dupes::DupesReportPayload;
 use crate::report::dupes_grouping::DuplicationGroup;
 
@@ -129,99 +132,6 @@ pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str) {
         );
     }
 }
-/// `fallow coverage setup --json` envelope.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(title = "fallow coverage setup --json"))]
-pub struct CoverageSetupOutput {
-    pub schema_version: CoverageSetupSchemaVersion,
-    pub framework_detected: CoverageSetupFramework,
-    pub package_manager: Option<CoverageSetupPackageManager>,
-    pub runtime_targets: Vec<CoverageSetupRuntimeTarget>,
-    pub members: Vec<CoverageSetupMember>,
-    pub config_written: Option<serde_json::Value>,
-    pub commands: Vec<String>,
-    pub files_to_edit: Vec<CoverageSetupFileToEdit>,
-    pub snippets: Vec<CoverageSetupSnippet>,
-    pub dockerfile_snippet: Option<String>,
-    pub next_steps: Vec<String>,
-    pub warnings: Vec<String>,
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub enum CoverageSetupSchemaVersion {
-    #[serde(rename = "1")]
-    V1,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "snake_case")]
-pub enum CoverageSetupFramework {
-    #[serde(rename = "nextjs")]
-    NextJs,
-    #[serde(rename = "nestjs")]
-    NestJs,
-    Nuxt,
-    #[serde(rename = "sveltekit")]
-    SvelteKit,
-    Astro,
-    Remix,
-    Vite,
-    PlainNode,
-    Unknown,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum CoverageSetupPackageManager {
-    Npm,
-    Pnpm,
-    Yarn,
-    Bun,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum CoverageSetupRuntimeTarget {
-    Node,
-    Browser,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct CoverageSetupMember {
-    pub name: String,
-    pub path: String,
-    pub framework_detected: CoverageSetupFramework,
-    pub package_manager: Option<CoverageSetupPackageManager>,
-    pub runtime_targets: Vec<CoverageSetupRuntimeTarget>,
-    pub files_to_edit: Vec<CoverageSetupFileToEdit>,
-    pub snippets: Vec<CoverageSetupSnippet>,
-    pub dockerfile_snippet: Option<String>,
-    pub warnings: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct CoverageSetupFileToEdit {
-    pub path: String,
-    pub reason: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct CoverageSetupSnippet {
-    pub label: String,
-    pub path: String,
-    pub content: String,
-}
-
 /// `fallow audit --format json` envelope.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -309,28 +219,6 @@ pub struct CombinedMeta {
     pub health: Option<Meta>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry: Option<TelemetryMeta>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub enum CoverageAnalyzeSchemaVersion {
-    #[serde(rename = "1")]
-    V1,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "schema",
-    schemars(title = "fallow coverage analyze --format json")
-)]
-pub struct CoverageAnalyzeOutput {
-    pub schema_version: CoverageAnalyzeSchemaVersion,
-    pub version: ToolVersion,
-    pub elapsed_ms: ElapsedMs,
-    pub runtime_coverage: RuntimeCoverageReport,
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Meta>,
 }
 
 /// Envelope emitted by `fallow explain <issue-type> --format json`.

--- a/crates/output/src/coverage_envelopes.rs
+++ b/crates/output/src/coverage_envelopes.rs
@@ -1,0 +1,120 @@
+//! Coverage command output envelopes.
+
+use crate::RuntimeCoverageReport;
+use fallow_types::envelope::{ElapsedMs, Meta, ToolVersion};
+use serde::Serialize;
+
+/// `fallow coverage setup --json` envelope.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(title = "fallow coverage setup --json"))]
+pub struct CoverageSetupOutput {
+    pub schema_version: CoverageSetupSchemaVersion,
+    pub framework_detected: CoverageSetupFramework,
+    pub package_manager: Option<CoverageSetupPackageManager>,
+    pub runtime_targets: Vec<CoverageSetupRuntimeTarget>,
+    pub members: Vec<CoverageSetupMember>,
+    pub config_written: Option<serde_json::Value>,
+    pub commands: Vec<String>,
+    pub files_to_edit: Vec<CoverageSetupFileToEdit>,
+    pub snippets: Vec<CoverageSetupSnippet>,
+    pub dockerfile_snippet: Option<String>,
+    pub next_steps: Vec<String>,
+    pub warnings: Vec<String>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CoverageSetupSchemaVersion {
+    #[serde(rename = "1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageSetupFramework {
+    #[serde(rename = "nextjs")]
+    NextJs,
+    #[serde(rename = "nestjs")]
+    NestJs,
+    Nuxt,
+    #[serde(rename = "sveltekit")]
+    SvelteKit,
+    Astro,
+    Remix,
+    Vite,
+    PlainNode,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum CoverageSetupPackageManager {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum CoverageSetupRuntimeTarget {
+    Node,
+    Browser,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CoverageSetupMember {
+    pub name: String,
+    pub path: String,
+    pub framework_detected: CoverageSetupFramework,
+    pub package_manager: Option<CoverageSetupPackageManager>,
+    pub runtime_targets: Vec<CoverageSetupRuntimeTarget>,
+    pub files_to_edit: Vec<CoverageSetupFileToEdit>,
+    pub snippets: Vec<CoverageSetupSnippet>,
+    pub dockerfile_snippet: Option<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CoverageSetupFileToEdit {
+    pub path: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CoverageSetupSnippet {
+    pub label: String,
+    pub path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CoverageAnalyzeSchemaVersion {
+    #[serde(rename = "1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    schemars(title = "fallow coverage analyze --format json")
+)]
+pub struct CoverageAnalyzeOutput {
+    pub schema_version: CoverageAnalyzeSchemaVersion,
+    pub version: ToolVersion,
+    pub elapsed_ms: ElapsedMs,
+    pub runtime_coverage: RuntimeCoverageReport,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod check;
 mod codeclimate;
+mod coverage_envelopes;
 mod dupes;
 mod format;
 mod health;
@@ -42,6 +43,11 @@ pub use check::{
 pub use codeclimate::{
     CodeClimateIssue, CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation,
     CodeClimateOutput, CodeClimateSeverity,
+};
+pub use coverage_envelopes::{
+    CoverageAnalyzeOutput, CoverageAnalyzeSchemaVersion, CoverageSetupFileToEdit,
+    CoverageSetupFramework, CoverageSetupMember, CoverageSetupOutput, CoverageSetupPackageManager,
+    CoverageSetupRuntimeTarget, CoverageSetupSchemaVersion, CoverageSetupSnippet,
 };
 pub use dupes::{
     CloneFamilyAction, CloneFamilyActionType, CloneGroupAction, CloneGroupActionType,


### PR DESCRIPTION
## Summary
- Moved coverage setup and coverage analyze JSON envelope DTOs from fallow-cli to fallow-output.
- Kept crates/cli/src/output_envelope as a compatibility reexport surface for existing callers and schema emission.
- Left CLI envelope serialization state in fallow-cli.

## Verification
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-output -p fallow-cli
- [x] cargo check -p fallow-output -p fallow-cli --features schema
- [x] cargo test -p fallow-output
- [x] cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- [x] git diff --check
- [x] hidden unicode dash check on touched files