### PR TITLE
refactor: move review reconcile contracts to output crate

### DIFF
--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -23,9 +23,10 @@ pub use fallow_output::{
     InspectSectionStatus, InspectSymbolIdentity, InspectTargetDescriptor, MARKER_REGEX_FLAGS_V2,
     MARKER_REGEX_V2, ReviewCheckConclusion, ReviewComment, ReviewEnvelopeEvent, ReviewEnvelopeMeta,
     ReviewEnvelopeOutput, ReviewEnvelopeSchema, ReviewEnvelopeSummary, ReviewProvider,
-    WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports, build_check_output,
-    build_check_summary, build_dupes_output, build_health_output, default_marker_regex,
-    default_marker_regex_flags, is_false,
+    ReviewReconcileOutput, ReviewReconcileSchema, WorkspaceDiagnosticOutput,
+    apply_config_fixable_to_duplicate_exports, build_check_output, build_check_summary,
+    build_dupes_output, build_health_output, default_marker_regex, default_marker_regex_flags,
+    is_false,
 };
 use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, ToolVersion};
 use fallow_types::output::NextStep;
@@ -226,48 +227,6 @@ pub struct CombinedMeta {
     pub health: Option<Meta>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry: Option<TelemetryMeta>,
-}
-
-/// Envelope emitted by `fallow ci reconcile-review --format json`. Used by
-/// CI integrations to drive comment carry-over and stale-comment cleanup
-/// across PR / MR revisions.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "schema",
-    schemars(title = "fallow ci reconcile-review --format json")
-)]
-pub struct ReviewReconcileOutput {
-    pub schema: ReviewReconcileSchema,
-    pub provider: ReviewProvider,
-    pub target: Option<String>,
-    pub dry_run: bool,
-    pub comments: u32,
-    pub current_fingerprints: u32,
-    pub existing_fingerprints: u32,
-    pub new_fingerprints: u32,
-    pub stale_fingerprints: u32,
-    pub new: Vec<String>,
-    pub stale: Vec<String>,
-    pub provider_warning: Option<String>,
-    pub resolution_comments_posted: u32,
-    pub threads_resolved: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub apply_hint: Option<String>,
-    pub apply_errors: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub failed_fingerprints: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub unapplied_fingerprints: Vec<String>,
-}
-
-/// Schema-version discriminator for the review reconcile envelope.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub enum ReviewReconcileSchema {
-    /// First release of the review reconcile format.
-    #[serde(rename = "fallow-review-reconcile/v1")]
-    V1,
 }
 
 /// Envelope emitted by `fallow list --boundaries --format json`. Surfaces

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -141,6 +141,6 @@ pub use review_envelopes::{
     GitHubReviewComment, GitHubReviewSide, GitLabReviewComment, GitLabReviewPosition,
     GitLabReviewPositionType, MARKER_REGEX_FLAGS_V2, MARKER_REGEX_V2, ReviewCheckConclusion,
     ReviewComment, ReviewEnvelopeEvent, ReviewEnvelopeMeta, ReviewEnvelopeOutput,
-    ReviewEnvelopeSchema, ReviewEnvelopeSummary, ReviewProvider, default_marker_regex,
-    default_marker_regex_flags, is_false,
+    ReviewEnvelopeSchema, ReviewEnvelopeSummary, ReviewProvider, ReviewReconcileOutput,
+    ReviewReconcileSchema, default_marker_regex, default_marker_regex_flags, is_false,
 };

--- a/crates/output/src/review_envelopes.rs
+++ b/crates/output/src/review_envelopes.rs
@@ -194,3 +194,43 @@ pub enum ReviewCheckConclusion {
     /// At least one finding gated as failure.
     Failure,
 }
+
+/// Envelope emitted by `fallow ci reconcile-review --format json`.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    schemars(title = "fallow ci reconcile-review --format json")
+)]
+pub struct ReviewReconcileOutput {
+    pub schema: ReviewReconcileSchema,
+    pub provider: ReviewProvider,
+    pub target: Option<String>,
+    pub dry_run: bool,
+    pub comments: u32,
+    pub current_fingerprints: u32,
+    pub existing_fingerprints: u32,
+    pub new_fingerprints: u32,
+    pub stale_fingerprints: u32,
+    pub new: Vec<String>,
+    pub stale: Vec<String>,
+    pub provider_warning: Option<String>,
+    pub resolution_comments_posted: u32,
+    pub threads_resolved: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub apply_hint: Option<String>,
+    pub apply_errors: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_fingerprints: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unapplied_fingerprints: Vec<String>,
+}
+
+/// Schema-version discriminator for the review reconcile envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ReviewReconcileSchema {
+    /// First release of the review reconcile format.
+    #[serde(rename = "fallow-review-reconcile/v1")]
+    V1,
+}


### PR DESCRIPTION
## Summary
- Moved review reconcile JSON envelope DTOs from fallow-cli to fallow-output.
- Reused the shared ReviewProvider contract now owned by fallow-output.
- Kept crates/cli/src/output_envelope as the compatibility reexport and serialization-state surface.

## Verification
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-output -p fallow-cli
- [x] cargo check -p fallow-output -p fallow-cli --features schema
- [x] cargo test -p fallow-output
- [x] cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- [x] git diff --check
- [x] hidden unicode dash check on touched files