### PR TITLE
refactor: move review brief support contracts to output crate

### DIFF
--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -25,9 +25,9 @@ use rustc_hash::FxHashSet;
 use crate::audit::AuditResult;
 
 pub type ReviewBriefOutput = fallow_output::ReviewBriefOutput<
-    crate::audit_focus::FocusMap,
-    crate::audit::weakening::WeakeningSignal,
-    crate::audit::routing::RoutingFacts,
+    fallow_output::FocusMap,
+    fallow_output::WeakeningSignal,
+    fallow_output::RoutingFacts,
     crate::audit_decision_surface::DecisionSurface,
 >;
 

--- a/crates/cli/src/audit_decision_surface.rs
+++ b/crates/cli/src/audit_decision_surface.rs
@@ -44,8 +44,8 @@ pub use fallow_output::{
 };
 use xxhash_rust::xxh3::xxh3_64;
 
-use crate::audit::routing::RoutingFacts;
 use crate::audit_brief::ReviewDeltas;
+use fallow_output::RoutingFacts;
 
 /// Default decision-surface cap (the working-memory limit). The surface holds at
 /// most this many ranked decisions; the rest collapse into a truncation note.

--- a/crates/cli/src/audit_focus.rs
+++ b/crates/cli/src/audit_focus.rs
@@ -33,9 +33,8 @@
 //! components are summed. No runtime field, no runtime read, no runtime gate here:
 //! free mode is the complete surface.
 
-use serde::Serialize;
-
 use fallow_core::graph::FocusFileFactsPaths;
+pub use fallow_output::{ConfidenceFlag, FocusLabel, FocusMap, FocusScore, FocusUnit};
 
 /// A unit's score at or above this threshold is labeled [`FocusLabel::ReviewHere`];
 /// below it, [`FocusLabel::NotPrioritized`]. Tuned so a unit with any non-trivial
@@ -58,124 +57,6 @@ const RISK_ZONE_WEIGHT: u32 = 2;
 const CHANGE_SHAPE_WEIGHT: u32 = 2;
 /// Points added when a unit sits on a security source -> sink taint trace.
 const SECURITY_TAINT_WEIGHT: u32 = 3;
-
-/// The focus label for a review unit. EXACTLY two variants: `Skip` is NOT
-/// representable, so the type system is the guarantee that free mode never emits
-/// a `skip` label (safe explicit-skip is paid, runtime-backed only). Mirrors
-/// the decision surface's "cut category not representable" structural posture.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum FocusLabel {
-    /// Review this unit: its composite attention score is at or above the line.
-    ReviewHere,
-    /// Not prioritized: below the line. NEVER "skip" (the reviewer is free to
-    /// review it anyway; the escape hatch enumerates every such unit).
-    NotPrioritized,
-}
-
-impl FocusLabel {
-    /// The wire token. The no-skip done-condition test asserts no label's token
-    /// is ever `"skip"`.
-    #[must_use]
-    pub const fn token(self) -> &'static str {
-        match self {
-            Self::ReviewHere => "review-here",
-            Self::NotPrioritized => "not-prioritized",
-        }
-    }
-}
-
-/// A per-unit confidence flag. The EXACT panel-decided strings: a dynamically-
-/// wired or re-export-heavy unit carries one so its static-reachability signal is
-/// not trusted as complete (the anti-silent-de-prioritization guard). The flag
-/// NEVER lowers the score; it is advisory provenance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum ConfidenceFlag {
-    /// The unit is dynamically wired (DI / decorators / plugin-loader / lazy
-    /// patterns the static graph cannot fully resolve).
-    DynamicDispatch,
-    /// The unit's reachability runs through re-export barrels.
-    ReExportIndirection,
-}
-
-impl ConfidenceFlag {
-    /// The EXACT panel-decided wire string for this flag.
-    #[must_use]
-    pub const fn message(self) -> &'static str {
-        match self {
-            Self::DynamicDispatch => "low: dynamic dispatch detected",
-            Self::ReExportIndirection => "low: re-export indirection",
-        }
-    }
-}
-
-/// The composite attention score, with the four deterministic component
-/// sub-scores kept on the wire so the runtime seam can re-weight `total`
-/// without recomputing the signals.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct FocusScore {
-    /// Fan-in/out blast-radius component.
-    pub fan_io: u32,
-    /// Security source -> sink taint-touch component (0 until a security pass is
-    /// threaded onto the brief path; the seam is built and tested).
-    pub security_taint: u32,
-    /// Risk-zone component (boundary / public-API / security-sensitive).
-    pub risk_zone: u32,
-    /// Change-shape component (new/widened export, signature change proxy).
-    pub change_shape: u32,
-    /// The summed total. The paid runtime layer multiplies a runtime hot/cold weight in here.
-    pub total: u32,
-}
-
-/// One review unit on the focus map: its file, composite score, label, human
-/// reason, and any confidence flags.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct FocusUnit {
-    /// Root-relative path of the changed file this unit covers.
-    pub file: String,
-    /// The composite attention score and its component breakdown.
-    pub score: FocusScore,
-    /// The focus label (`review-here` / `not-prioritized`; NEVER `skip`).
-    pub label: FocusLabel,
-    /// A human-readable reason for the label, built from the present signals.
-    pub reason: String,
-    /// Confidence flags (advisory; never lower the score). Sorted, deduped.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub confidence: Vec<ConfidenceFlag>,
-}
-
-/// The weighted focus map: the ranked `review-here` units plus the FULL
-/// `deprioritized` escape-hatch list, so nothing is hidden.
-///
-/// Completeness invariant (the escape-hatch done-condition): the two lists
-/// partition the unit set, so `review_here.len() + deprioritized.len()` equals
-/// the total unit count by construction.
-#[derive(Debug, Clone, Default, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct FocusMap {
-    /// Units labeled `review-here`, ranked by composite score (descending), ties
-    /// broken by path for determinism.
-    pub review_here: Vec<FocusUnit>,
-    /// EVERY `not-prioritized` unit (the escape hatch). Always present and fully
-    /// enumerated so a reviewer can always "show me what you de-prioritized"; the
-    /// human brief collapses it by default and re-expands under
-    /// `--show-deprioritized`.
-    pub deprioritized: Vec<FocusUnit>,
-}
-
-impl FocusMap {
-    /// Total number of units (review-here + deprioritized). The escape-hatch
-    /// completeness invariant: this equals the input unit count.
-    #[must_use]
-    pub fn total_units(&self) -> usize {
-        self.review_here.len() + self.deprioritized.len()
-    }
-}
 
 /// A boundary-zone signal for a unit: the unit's file introduced a new cross-zone
 /// edge (it is the `from_file` of an introduced boundary edge).

--- a/crates/cli/src/audit_routing.rs
+++ b/crates/cli/src/audit_routing.rs
@@ -11,8 +11,8 @@
 
 use std::path::{Path, PathBuf};
 
+pub use fallow_output::{RoutingFacts, RoutingUnit};
 use rustc_hash::FxHashSet;
-use serde::Serialize;
 
 use crate::codeowners::CodeOwners;
 use crate::health::ownership::{OwnershipContext, compile_bot_globs, compute_ownership};
@@ -22,30 +22,6 @@ use fallow_core::churn::{self, SinceDuration};
 /// Default churn window for routing: one year of history is enough to identify
 /// the per-file experts without an unbounded `git log`.
 const ROUTING_CHURN_WINDOW: &str = "1 year ago";
-
-/// One routed unit (a changed file) with its experts and bus-factor flag.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct RoutingUnit {
-    /// Root-relative path of the changed file.
-    pub file: String,
-    /// The routed expert(s): the CODEOWNERS declared owner when present, else the
-    /// top git-blame / recency contributor; empty when no signal is available.
-    pub expert: Vec<String>,
-    /// Whether the only qualified owner is a single contributor (bus-factor-1):
-    /// a knowledge-concentration risk worth a second reviewer.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub bus_factor_one: bool,
-}
-
-/// The full routing section: one unit per changed source file with a routable
-/// signal. Files with no ownership signal are omitted (no noise).
-#[derive(Debug, Clone, Default, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct RoutingFacts {
-    /// Per-changed-file routing units, sorted by file path.
-    pub units: Vec<RoutingUnit>,
-}
 
 /// Compute the routing section for the changed files. Best-effort: returns an
 /// empty `RoutingFacts` when churn is unavailable (non-git repo, shallow clone

--- a/crates/cli/src/audit_walkthrough.rs
+++ b/crates/cli/src/audit_walkthrough.rs
@@ -36,13 +36,12 @@ pub use fallow_output::{
     AcceptedJudgment, AgentWalkthrough, ChangeAnchor, DirectionUnit, INJECTION_NOTE,
     RejectedJudgment, ReviewDirection, WalkthroughValidation, agent_schema,
 };
+use fallow_output::{FocusMap, RoutingFacts};
 use rustc_hash::{FxHashMap, FxHashSet};
 use xxhash_rust::xxh3::xxh3_64;
 
-use crate::audit::routing::RoutingFacts;
 use crate::audit_brief::{ReviewBriefOutput, ReviewBriefSchemaVersion, build_brief_output};
 use crate::audit_decision_surface::DecisionSurface;
-use crate::audit_focus::FocusMap;
 use crate::report::ci::diff_filter::parse_new_hunk_start;
 
 #[cfg(test)]

--- a/crates/cli/src/audit_weakening.rs
+++ b/crates/cli/src/audit_weakening.rs
@@ -12,40 +12,7 @@
 //! signal is an attention pointer ("the diff weakened a guardrail here"), framed
 //! so a reviewer decides.
 
-use serde::Serialize;
-
-/// The category of a single weakening signal.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum WeakeningKind {
-    /// A test was removed (a net-removed `it(`/`test(`/`describe(` callsite) or
-    /// skipped (`it.skip`/`xit`/`describe.skip` added, or a `.only` narrowing
-    /// that silently excludes sibling tests).
-    TestWeakened,
-    /// A coverage or quality threshold was lowered (a numeric config key whose
-    /// value decreased between base and head).
-    ThresholdLowered,
-    /// A suppression was added (a net-new `fallow-ignore` / `eslint-disable` /
-    /// `@ts-ignore` / `@ts-expect-error` in the diff).
-    SuppressionAdded,
-    /// A security check / step was removed from CI (a net-removed line invoking
-    /// a security scanner or audit step).
-    SecurityCheckRemoved,
-}
-
-/// One weakening signal: a category, the file it was detected in, and a short
-/// human-readable evidence string. Reviewer-private; never gates.
-#[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct WeakeningSignal {
-    /// What kind of guardrail was weakened.
-    pub kind: WeakeningKind,
-    /// Root-relative path of the changed file the signal was detected in.
-    pub file: String,
-    /// Short evidence string (e.g. the offending token or the threshold delta).
-    pub evidence: String,
-}
+pub use fallow_output::{WeakeningKind, WeakeningSignal};
 
 /// Detect skipped-test additions: an `it.skip` / `xit` / `describe.skip` /
 /// `.only` token present in head but not base. `.only` narrows the run to a

--- a/crates/cli/src/bin/schema_emit.rs
+++ b/crates/cli/src/bin/schema_emit.rs
@@ -28,7 +28,6 @@ use serde_json::{Map, Value};
 use fallow_cli::audit_brief::{
     DiffTriage, GraphFacts, ReviewBriefOutput, ReviewBriefSchemaVersion, ReviewEffort, RiskClass,
 };
-use fallow_cli::audit_focus::{ConfidenceFlag, FocusLabel, FocusMap, FocusScore, FocusUnit};
 use fallow_cli::audit_walkthrough::{WalkthroughGuide, WalkthroughValidation};
 use fallow_cli::health_types::{
     ComplexityViolation, ContributorEntry, ContributorIdentifierFormat, CoverageGapSummary,
@@ -80,9 +79,10 @@ use fallow_core::duplicates::{
     RefactoringKind, RefactoringSuggestion,
 };
 use fallow_output::{
-    AcceptedJudgment, AgentSchema, ChangeAnchor, Decision, DecisionAction, DecisionActionType,
-    DecisionCategory, DecisionSurface, DecisionSurfaceOutput, DecisionSurfaceSchemaVersion,
-    DecisionWithActions, DirectionUnit, RejectedJudgment, ReviewDirection, TruncationNote,
+    AcceptedJudgment, AgentSchema, ChangeAnchor, ConfidenceFlag, Decision, DecisionAction,
+    DecisionActionType, DecisionCategory, DecisionSurface, DecisionSurfaceOutput,
+    DecisionSurfaceSchemaVersion, DecisionWithActions, DirectionUnit, FocusLabel, FocusMap,
+    FocusScore, FocusUnit, RejectedJudgment, ReviewDirection, TruncationNote,
 };
 use fallow_output::{
     CloneFamilyAction, CloneFamilyActionType, CloneGroupAction, CloneGroupActionType,

--- a/crates/output/src/audit_focus.rs
+++ b/crates/output/src/audit_focus.rs
@@ -1,0 +1,98 @@
+//! Audit focus-map output contracts.
+
+use serde::Serialize;
+
+/// The focus label for a review unit. There is no `Skip` variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum FocusLabel {
+    /// Review this unit.
+    ReviewHere,
+    /// Not prioritized, but still visible in the escape-hatch list.
+    NotPrioritized,
+}
+
+impl FocusLabel {
+    /// The wire token.
+    #[must_use]
+    pub const fn token(self) -> &'static str {
+        match self {
+            Self::ReviewHere => "review-here",
+            Self::NotPrioritized => "not-prioritized",
+        }
+    }
+}
+
+/// A per-unit confidence flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ConfidenceFlag {
+    /// The unit is dynamically wired.
+    DynamicDispatch,
+    /// The unit's reachability runs through re-export barrels.
+    ReExportIndirection,
+}
+
+impl ConfidenceFlag {
+    /// The wire message for this flag.
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::DynamicDispatch => "low: dynamic dispatch detected",
+            Self::ReExportIndirection => "low: re-export indirection",
+        }
+    }
+}
+
+/// The composite attention score and component breakdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FocusScore {
+    /// Fan-in/out blast-radius component.
+    pub fan_io: u32,
+    /// Security source to sink taint-touch component.
+    pub security_taint: u32,
+    /// Risk-zone component.
+    pub risk_zone: u32,
+    /// Change-shape component.
+    pub change_shape: u32,
+    /// The summed total.
+    pub total: u32,
+}
+
+/// One review unit on the focus map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FocusUnit {
+    /// Root-relative path of the changed file this unit covers.
+    pub file: String,
+    /// The composite attention score and its component breakdown.
+    pub score: FocusScore,
+    /// The focus label.
+    pub label: FocusLabel,
+    /// Human-readable reason for the label.
+    pub reason: String,
+    /// Confidence flags.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub confidence: Vec<ConfidenceFlag>,
+}
+
+/// The weighted focus map.
+#[derive(Debug, Clone, Default, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FocusMap {
+    /// Units labeled `review-here`.
+    pub review_here: Vec<FocusUnit>,
+    /// Every `not-prioritized` unit.
+    pub deprioritized: Vec<FocusUnit>,
+}
+
+impl FocusMap {
+    /// Total number of units.
+    #[must_use]
+    pub fn total_units(&self) -> usize {
+        self.review_here.len() + self.deprioritized.len()
+    }
+}

--- a/crates/output/src/audit_routing.rs
+++ b/crates/output/src/audit_routing.rs
@@ -1,0 +1,24 @@
+//! Audit reviewer-routing output contracts.
+
+use serde::Serialize;
+
+/// One routed unit with its experts and bus-factor flag.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RoutingUnit {
+    /// Root-relative path of the changed file.
+    pub file: String,
+    /// Routed expert(s), when ownership signals are available.
+    pub expert: Vec<String>,
+    /// Whether the only qualified owner is a single contributor.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub bus_factor_one: bool,
+}
+
+/// The full routing section.
+#[derive(Debug, Clone, Default, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RoutingFacts {
+    /// Per-changed-file routing units, sorted by file path.
+    pub units: Vec<RoutingUnit>,
+}

--- a/crates/output/src/audit_weakening.rs
+++ b/crates/output/src/audit_weakening.rs
@@ -1,0 +1,30 @@
+//! Audit weakening-signal output contracts.
+
+use serde::Serialize;
+
+/// The category of a single weakening signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum WeakeningKind {
+    /// A test was removed or skipped.
+    TestWeakened,
+    /// A coverage or quality threshold was lowered.
+    ThresholdLowered,
+    /// A suppression was added.
+    SuppressionAdded,
+    /// A security check or step was removed from CI.
+    SecurityCheckRemoved,
+}
+
+/// One weakening signal.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct WeakeningSignal {
+    /// What kind of guardrail was weakened.
+    pub kind: WeakeningKind,
+    /// Root-relative changed file path.
+    pub file: String,
+    /// Short evidence string.
+    pub evidence: String,
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -14,7 +14,10 @@
 
 mod audit_brief;
 mod audit_decision_surface;
+mod audit_focus;
+mod audit_routing;
 mod audit_walkthrough;
+mod audit_weakening;
 mod check;
 mod codeclimate;
 mod coverage_envelopes;
@@ -55,11 +58,14 @@ pub use audit_decision_surface::{
     DecisionWithActions, TruncationNote, build_decision_surface_output, decision_actions,
     suppress_comment,
 };
+pub use audit_focus::{ConfidenceFlag, FocusLabel, FocusMap, FocusScore, FocusUnit};
+pub use audit_routing::{RoutingFacts, RoutingUnit};
 pub use audit_walkthrough::{
     AcceptedJudgment, AgentJudgment, AgentSchema, AgentWalkthrough, ChangeAnchor, DirectionUnit,
     INJECTION_NOTE, RejectedJudgment, ReviewDirection, WalkthroughGuide, WalkthroughValidation,
     agent_schema,
 };
+pub use audit_weakening::{WeakeningKind, WeakeningSignal};
 pub use check::{
     CHECK_SCHEMA_VERSION, CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput,
     GroupByMode, WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports,


### PR DESCRIPTION
## Summary
- Move audit focus-map wire contracts into fallow-output
- Move audit weakening and reviewer-routing wire contracts into fallow-output
- Point review brief schema registration at the shared contract types

## Validation
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo check -p fallow-output -p fallow-cli --features schema
- cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit
- cargo test -p fallow-output
- cargo test -p fallow-cli audit_focus
- cargo test -p fallow-cli audit::weakening
- cargo test -p fallow-cli audit::routing
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check