### PR TITLE
refactor: move json path stripping to output crate

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -10,7 +10,7 @@ use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationSta
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
     CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, build_check_output,
-    build_dupes_output, check_meta,
+    build_dupes_output, check_meta, strip_root_prefix,
 };
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1305,27 +1305,6 @@ fn is_absolute_path_any_platform(path: &Path) -> bool {
         || s.starts_with('/')
         || s.starts_with("\\\\")
         || s.as_bytes().get(1) == Some(&b':')
-}
-
-fn strip_root_prefix(value: &mut serde_json::Value, prefix: &str) {
-    match value {
-        serde_json::Value::String(s) => {
-            if let Some(rest) = s.strip_prefix(prefix) {
-                *s = rest.to_string();
-            }
-        }
-        serde_json::Value::Array(items) => {
-            for item in items {
-                strip_root_prefix(item, prefix);
-            }
-        }
-        serde_json::Value::Object(map) => {
-            for value in map.values_mut() {
-                strip_root_prefix(value, prefix);
-            }
-        }
-        _ => {}
-    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -8,7 +8,9 @@ use fallow_core::duplicates::DuplicationReport;
 use fallow_core::results::AnalysisResults;
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
-use super::{emit_json, normalize_uri};
+use fallow_output::strip_root_prefix;
+
+use super::emit_json;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutputInput,
@@ -234,76 +236,6 @@ fn postprocess_check_json(output: &mut serde_json::Value, root: &Path) {
     let root_prefix = format!("{}/", root.display());
     strip_root_prefix(output, &root_prefix);
     harmonize_multi_kind_suppress_line_actions(output);
-}
-
-/// Recursively strip the root prefix from all string values in the JSON tree.
-///
-/// This converts absolute paths (e.g., `/home/runner/work/repo/repo/src/utils.ts`)
-/// to relative paths (`src/utils.ts`) for all output fields.
-pub fn strip_root_prefix(value: &mut serde_json::Value, prefix: &str) {
-    match value {
-        serde_json::Value::String(s) => {
-            if let Some(rest) = s.strip_prefix(prefix) {
-                *s = rest.to_string();
-            } else {
-                let normalized = normalize_uri(s);
-                let normalized_prefix = normalize_uri(prefix);
-                if let Some(rest) = normalized.strip_prefix(&normalized_prefix) {
-                    *s = rest.to_string();
-                } else if let Some(stripped) =
-                    strip_embedded_root_prefixes(&normalized, &normalized_prefix)
-                {
-                    *s = stripped;
-                }
-            }
-        }
-        serde_json::Value::Array(arr) => {
-            for item in arr {
-                strip_root_prefix(item, prefix);
-            }
-        }
-        serde_json::Value::Object(map) => {
-            for (_, v) in map.iter_mut() {
-                strip_root_prefix(v, prefix);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn strip_embedded_root_prefixes(value: &str, prefix: &str) -> Option<String> {
-    let mut output = String::with_capacity(value.len());
-    let mut changed = false;
-    let mut last = 0;
-    let mut search_from = 0;
-
-    while let Some(offset) = value[search_from..].find(prefix) {
-        let index = search_from + offset;
-        let can_strip = index > 0
-            && value[..index]
-                .chars()
-                .next_back()
-                .is_some_and(is_embedded_path_boundary);
-
-        if can_strip {
-            output.push_str(&value[last..index]);
-            last = index + prefix.len();
-            changed = true;
-        }
-
-        search_from = index + prefix.len();
-    }
-
-    if changed {
-        output.push_str(&value[last..]);
-        Some(output)
-    } else {
-        None
-    }
-}
-
-fn is_embedded_path_boundary(c: char) -> bool {
-    c.is_whitespace() || matches!(c, '"' | '\'' | '`' | '(' | '[' | '{' | ':' | '=')
 }
 
 type SuppressAnchor = (String, u64);

--- a/crates/cli/src/report/mod.rs
+++ b/crates/cli/src/report/mod.rs
@@ -25,13 +25,13 @@ use fallow_core::trace::{CloneTrace, DependencyTrace, ExportTrace, FileTrace, Pi
 
 use crate::report::sink::outln;
 
-pub use grouping::OwnershipResolver;
-pub use human::health::{render_health_score, render_health_trend};
 #[allow(
     unused_imports,
     reason = "used by binary crate modules (combined.rs, audit.rs)"
 )]
-pub use json::strip_root_prefix;
+pub use fallow_output::strip_root_prefix;
+pub use grouping::OwnershipResolver;
+pub use human::health::{render_health_score, render_health_trend};
 
 /// Shared context for all report dispatch functions.
 ///

--- a/crates/output/src/json_paths.rs
+++ b/crates/output/src/json_paths.rs
@@ -1,0 +1,127 @@
+//! Shared JSON path post-processing for output contracts.
+
+/// Recursively strip a project-root prefix from all string values in a JSON
+/// tree.
+///
+/// This keeps machine output relative to the analyzed root even when upstream
+/// analysis stages temporarily carry absolute paths.
+pub fn strip_root_prefix(value: &mut serde_json::Value, prefix: &str) {
+    match value {
+        serde_json::Value::String(s) => strip_root_prefix_from_string(s, prefix),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                strip_root_prefix(item, prefix);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for value in map.values_mut() {
+                strip_root_prefix(value, prefix);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn strip_root_prefix_from_string(value: &mut String, prefix: &str) {
+    if let Some(rest) = value.strip_prefix(prefix) {
+        *value = rest.to_string();
+        return;
+    }
+
+    let normalized = normalize_output_path(value);
+    let normalized_prefix = normalize_output_path(prefix);
+    if let Some(rest) = normalized.strip_prefix(&normalized_prefix) {
+        *value = rest.to_string();
+    } else if let Some(stripped) = strip_embedded_root_prefixes(&normalized, &normalized_prefix) {
+        *value = stripped;
+    }
+}
+
+fn normalize_output_path(path: &str) -> String {
+    path.replace('\\', "/")
+        .replace('[', "%5B")
+        .replace(']', "%5D")
+}
+
+fn strip_embedded_root_prefixes(value: &str, prefix: &str) -> Option<String> {
+    let mut output = String::with_capacity(value.len());
+    let mut changed = false;
+    let mut last = 0;
+    let mut search_from = 0;
+
+    while let Some(offset) = value[search_from..].find(prefix) {
+        let index = search_from + offset;
+        let can_strip = index > 0
+            && value[..index]
+                .chars()
+                .next_back()
+                .is_some_and(is_embedded_path_boundary);
+
+        if can_strip {
+            output.push_str(&value[last..index]);
+            last = index + prefix.len();
+            changed = true;
+        }
+
+        search_from = index + prefix.len();
+    }
+
+    if changed {
+        output.push_str(&value[last..]);
+        Some(output)
+    } else {
+        None
+    }
+}
+
+fn is_embedded_path_boundary(c: char) -> bool {
+    c.is_whitespace() || matches!(c, '"' | '\'' | '`' | '(' | '[' | '{' | ':' | '=')
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn strips_root_from_nested_strings() {
+        let mut value = json!({
+            "path": "/project/src/index.ts",
+            "items": ["/project/src/a.ts", { "path": "/project/src/b.ts" }]
+        });
+
+        strip_root_prefix(&mut value, "/project/");
+
+        assert_eq!(value["path"], "src/index.ts");
+        assert_eq!(value["items"][0], "src/a.ts");
+        assert_eq!(value["items"][1]["path"], "src/b.ts");
+    }
+
+    #[test]
+    fn normalizes_windows_separators_before_stripping() {
+        let mut value = json!("C:\\repo\\src\\index.ts");
+
+        strip_root_prefix(&mut value, "C:/repo/");
+
+        assert_eq!(value, json!("src/index.ts"));
+    }
+
+    #[test]
+    fn rewrites_embedded_path_strings() {
+        let mut value = json!("See /project/src/a.ts and /project/src/b.ts");
+
+        strip_root_prefix(&mut value, "/project/");
+
+        assert_eq!(value, json!("See src/a.ts and src/b.ts"));
+    }
+
+    #[test]
+    fn leaves_non_matching_strings_unchanged() {
+        let mut value = json!("src/index.ts");
+
+        strip_root_prefix(&mut value, "/project/");
+
+        assert_eq!(value, json!("src/index.ts"));
+    }
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -41,6 +41,7 @@ mod health_vital_signs;
 mod impact;
 mod inspect_envelopes;
 mod issue_contract;
+mod json_paths;
 mod list_envelopes;
 mod report_contract;
 mod review_envelopes;
@@ -166,6 +167,7 @@ pub use issue_contract::{
     CODECLIMATE_RESULT_CODES, IssueOutputContract, TsAliasMeta, check_meta, dead_code_docs_url,
     issue_output_contract_by_code, issue_output_contracts, rule_docs_url,
 };
+pub use json_paths::strip_root_prefix;
 pub use list_envelopes::{
     BoundariesListLogicalGroup, BoundariesListRule, BoundariesListZone, BoundariesListing,
     ListBoundariesOutput, WorkspaceInfo, WorkspacesOutput,


### PR DESCRIPTION
## Summary
- move JSON root-prefix stripping into fallow-output
- reuse the shared output helper from CLI JSON rendering and fallow-api runtime
- remove the duplicate API implementation while preserving CLI behavior

## Validation
- cargo check -p fallow-output -p fallow-api -p fallow-cli
- cargo test -p fallow-output json_paths
- cargo test -p fallow-cli report::json::tests::strip_root_prefix
- cargo test -p fallow-api
- cargo clippy -p fallow-output -p fallow-api -p fallow-cli --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check