### PR TITLE
refactor: centralize root envelope serialization

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -9,8 +9,8 @@ use fallow_config::{
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
-    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, build_check_output,
-    build_dupes_output, check_meta, strip_root_prefix,
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, RootEnvelopeMode,
+    apply_root_kind, build_check_output, build_dupes_output, check_meta, strip_root_prefix,
 };
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -136,14 +136,11 @@ fn detect_dead_code_inner(
             .with_code("FALLOW_SERIALIZE_DEAD_CODE_REPORT")
             .with_context("dead-code")
     })?;
-    if let serde_json::Value::Object(map) = &mut output
-        && !resolved.legacy_envelope
-    {
-        map.insert(
-            "kind".to_string(),
-            serde_json::Value::String("dead_code".to_string()),
-        );
-    }
+    apply_root_kind(
+        &mut output,
+        "dead_code",
+        root_envelope_mode(resolved.legacy_envelope),
+    );
     let root_prefix = format!("{}/", session.root().display());
     strip_root_prefix(&mut output, &root_prefix);
     Ok(output)
@@ -627,14 +624,11 @@ fn detect_duplication_inner(
             .with_code("FALLOW_SERIALIZE_DUPLICATION_REPORT")
             .with_context("dupes")
     })?;
-    if let serde_json::Value::Object(map) = &mut output
-        && !resolved.legacy_envelope
-    {
-        map.insert(
-            "kind".to_string(),
-            serde_json::Value::String("dupes".to_string()),
-        );
-    }
+    apply_root_kind(
+        &mut output,
+        "dupes",
+        root_envelope_mode(resolved.legacy_envelope),
+    );
     let root_prefix = format!("{}/", session.root().display());
     strip_root_prefix(&mut output, &root_prefix);
     Ok(output)
@@ -1305,6 +1299,14 @@ fn is_absolute_path_any_platform(path: &Path) -> bool {
         || s.starts_with('/')
         || s.starts_with("\\\\")
         || s.as_bytes().get(1) == Some(&b':')
+}
+
+const fn root_envelope_mode(legacy_envelope: bool) -> RootEnvelopeMode {
+    if legacy_envelope {
+        RootEnvelopeMode::Legacy
+    } else {
+        RootEnvelopeMode::Tagged
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -78,21 +78,14 @@ pub fn serialize_root_output(output: FallowOutput) -> Result<serde_json::Value, 
 pub fn serialize_root_output_without_telemetry(
     output: FallowOutput,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let mut value = serde_json::to_value(output)?;
-    if EnvelopeMode::current() == EnvelopeMode::Legacy {
-        remove_root_kind(&mut value);
-    }
-    Ok(value)
+    fallow_output::serialize_json_root_output(output, EnvelopeMode::current().into())
 }
 
 pub fn serialize_root_output_with_mode(
     output: FallowOutput,
     mode: EnvelopeMode,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let mut value = serde_json::to_value(output)?;
-    if mode == EnvelopeMode::Legacy {
-        remove_root_kind(&mut value);
-    }
+    let mut value = fallow_output::serialize_json_root_output(output, mode.into())?;
     attach_telemetry_meta(&mut value);
     Ok(value)
 }
@@ -118,23 +111,16 @@ pub fn attach_telemetry_meta(value: &mut serde_json::Value) {
     }
 }
 
-/// Remove only the document-root discriminator for the one-cycle
-/// compatibility mode. Nested objects may carry their own meaningful `kind`
-/// fields, so this intentionally does not recurse.
-pub fn remove_root_kind(value: &mut serde_json::Value) {
-    if let serde_json::Value::Object(map) = value {
-        map.remove("kind");
-    }
+pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str) {
+    fallow_output::apply_root_kind(value, kind, EnvelopeMode::current().into());
 }
 
-pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str) {
-    if EnvelopeMode::current() == EnvelopeMode::Tagged
-        && let serde_json::Value::Object(map) = value
-    {
-        map.insert(
-            "kind".to_string(),
-            serde_json::Value::String(kind.to_string()),
-        );
+impl From<EnvelopeMode> for fallow_output::RootEnvelopeMode {
+    fn from(mode: EnvelopeMode) -> Self {
+        match mode {
+            EnvelopeMode::Tagged => Self::Tagged,
+            EnvelopeMode::Legacy => Self::Legacy,
+        }
     }
 }
 pub type AuditOutput = fallow_output::AuditOutput<
@@ -277,7 +263,7 @@ mod tests {
                 "kind": "suppress"
             }
         });
-        remove_root_kind(&mut nested);
+        fallow_output::remove_root_kind(&mut nested);
         assert!(nested.get("kind").is_none());
         assert_eq!(nested["action"]["kind"], "suppress");
     }

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -274,7 +274,7 @@ fn apply_programmatic_envelope_options(
     resolved: &ResolvedAnalysisOptions,
 ) {
     if resolved.legacy_envelope {
-        crate::output_envelope::remove_root_kind(output);
+        fallow_output::remove_root_kind(output);
     }
 }
 

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -184,7 +184,10 @@ pub use review_envelopes::{
     ReviewEnvelopeSchema, ReviewEnvelopeSummary, ReviewProvider, ReviewReconcileOutput,
     ReviewReconcileSchema, default_marker_regex, default_marker_regex_flags, is_false,
 };
-pub use root_envelopes::{AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput};
+pub use root_envelopes::{
+    AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
+    apply_root_kind, remove_root_kind, serialize_json_root_output,
+};
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,
     SecurityBlindSpotsSchemaVersion, SecurityBlindSpotsSummary, SecurityGate, SecurityGateVerdict,

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -4,6 +4,52 @@ use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, TelemetryMeta, Tool
 use fallow_types::output::NextStep;
 use serde::Serialize;
 
+/// Whether a JSON root envelope keeps the top-level `kind` discriminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootEnvelopeMode {
+    Tagged,
+    Legacy,
+}
+
+/// Serialize a typed fallow root envelope with the requested discriminator
+/// mode.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_json_root_output<T: Serialize>(
+    output: T,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let mut value = serde_json::to_value(output)?;
+    if mode == RootEnvelopeMode::Legacy {
+        remove_root_kind(&mut value);
+    }
+    Ok(value)
+}
+
+/// Remove only the document-root discriminator. Nested objects may carry their
+/// own meaningful `kind` fields, so this intentionally does not recurse.
+pub fn remove_root_kind(value: &mut serde_json::Value) {
+    if let serde_json::Value::Object(map) = value {
+        map.remove("kind");
+    }
+}
+
+/// Apply a document-root discriminator unless the caller requested the legacy
+/// envelope shape.
+pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str, mode: RootEnvelopeMode) {
+    if mode == RootEnvelopeMode::Tagged
+        && let serde_json::Value::Object(map) = value
+    {
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(kind.to_string()),
+        );
+    }
+}
+
 /// `fallow audit --format json` envelope.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -210,4 +256,59 @@ pub enum FallowOutput<
     /// `fallow review --walkthrough-file --format json`.
     #[serde(rename = "review-walkthrough-validation")]
     WalkthroughValidation(WalkthroughValidation),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn legacy_mode_removes_only_root_kind() {
+        let mut value = json!({
+            "kind": "root",
+            "action": {
+                "kind": "suppress"
+            }
+        });
+
+        remove_root_kind(&mut value);
+
+        assert!(value.get("kind").is_none());
+        assert_eq!(value["action"]["kind"], "suppress");
+    }
+
+    #[test]
+    fn apply_root_kind_respects_legacy_mode() {
+        let mut value = json!({});
+
+        apply_root_kind(&mut value, "dead_code", RootEnvelopeMode::Legacy);
+
+        assert!(value.get("kind").is_none());
+    }
+
+    #[test]
+    fn apply_root_kind_sets_tagged_mode() {
+        let mut value = json!({});
+
+        apply_root_kind(&mut value, "dead_code", RootEnvelopeMode::Tagged);
+
+        assert_eq!(value["kind"], "dead_code");
+    }
+
+    #[test]
+    fn serialize_json_root_output_removes_root_kind_in_legacy_mode() {
+        let value = serialize_json_root_output(
+            json!({
+                "kind": "combined",
+                "schema_version": 1
+            }),
+            RootEnvelopeMode::Legacy,
+        )
+        .expect("root should serialize");
+
+        assert!(value.get("kind").is_none());
+        assert_eq!(value["schema_version"], 1);
+    }
 }


### PR DESCRIPTION
## Summary
- add output-owned root envelope mode and serializer helpers
- keep CLI telemetry attachment in the CLI layer while sharing discriminator handling
- reuse the shared root-kind helper from fallow-api runtime paths

## Validation
- cargo check -p fallow-output -p fallow-api -p fallow-cli
- cargo test -p fallow-output root_envelopes
- cargo test -p fallow-api legacy_envelope_removes_root_kind
- cargo test -p fallow-cli output_envelope::tests
- cargo clippy -p fallow-output -p fallow-api -p fallow-cli --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check