### PR TITLE
refactor: type dynamic render extraction facts

### DIFF
--- a/crates/core/src/analyze/unrendered_component.rs
+++ b/crates/core/src/analyze/unrendered_component.rs
@@ -36,7 +36,9 @@ use std::path::Path;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use fallow_types::extract::{AngularComponentSelector, ExportName, ImportedName, ModuleInfo};
+use fallow_types::extract::{
+    AngularComponentSelector, ExportName, ImportedName, ModuleInfo, SemanticFact,
+};
 
 use crate::discover::FileId;
 use crate::graph::{ModuleGraph, ModuleNode};
@@ -565,9 +567,17 @@ pub fn find_unrendered_lit_elements(input: &LitUnrenderedInput<'_>) -> Vec<Unren
         modules.iter().map(|m| (m.file_id, m)).collect();
 
     // Pass 1: project-wide rendered-tag union, built LIBERALLY. A dynamic-render
-    // sentinel abstains on the whole project.
+    // fact abstains on the whole project. The legacy sentinel path keeps older
+    // parse caches conservative.
     let mut rendered_tags: FxHashSet<&str> = FxHashSet::default();
     for module in modules {
+        if module
+            .semantic_facts
+            .iter()
+            .any(|fact| matches!(fact, SemanticFact::DynamicCustomElementRender(_)))
+        {
+            return Vec::new();
+        }
         for tag in &module.used_custom_element_tags {
             if tag == fallow_types::extract::DYNAMIC_CUSTOM_ELEMENT_TAG {
                 return Vec::new();

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -647,7 +647,11 @@ use crate::MemberKind;
 /// Bumped to 206: Angular `{ ...this }` spread abstains are now persisted as
 /// typed semantic facts, while the legacy spread sentinel remains decode-only
 /// for older caches.
-pub(super) const CACHE_VERSION: u32 = 206;
+///
+/// Bumped to 207: dynamic custom-element render abstains are now persisted as
+/// typed semantic facts, while the legacy `<dynamic>` tag sentinel remains
+/// decode-only for older caches.
+pub(super) const CACHE_VERSION: u32 = 207;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -52,13 +52,14 @@ use cache::CacheStore;
 use fallow_types::discover::{DiscoveredFile, FileId};
 
 pub use fallow_types::extract::{
-    AngularTemplateMemberAccessFact, AngularThisSpreadFact, ClassHeritageInfo, DynamicImportInfo,
-    DynamicImportPattern, ExportInfo, ExportName, FactoryCallMemberAccessFact,
-    FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
-    InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, ParseResult, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
-    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
+    AngularTemplateMemberAccessFact, AngularThisSpreadFact, ClassHeritageInfo,
+    DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
+    ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
+    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
+    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
+    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+    PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
+    SemanticFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/tests/js_ts/html_tagged_template.rs
+++ b/crates/extract/src/tests/js_ts/html_tagged_template.rs
@@ -5,7 +5,7 @@
 //! components emit HTML via a tagged template whose tag is the identifier
 //! `html`. See issue #105 (till's follow-up comment).
 
-use fallow_types::extract::ImportedName;
+use fallow_types::extract::{DYNAMIC_CUSTOM_ELEMENT_TAG, ImportedName, SemanticFact};
 
 use crate::tests::parse_ts;
 
@@ -307,15 +307,23 @@ fn document_create_element_credits_custom_element_tag() {
 }
 
 #[test]
-fn dynamic_html_tag_records_dynamic_sentinel() {
+fn dynamic_html_tag_records_typed_dynamic_render_fact() {
     let info = parse_ts(
         r#"import { html } from "lit";
 export const render = (tag) => html`<${tag}></${tag}>`;"#,
     );
     assert!(
-        info.used_custom_element_tags
-            .contains(&"<dynamic>".to_string()),
-        "a `<${{tag}}>` dynamic render must record the dynamic sentinel: {:?}",
+        info.semantic_facts
+            .iter()
+            .any(|fact| matches!(fact, SemanticFact::DynamicCustomElementRender(_))),
+        "a `<${{tag}}>` dynamic render must record a typed semantic fact: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        !info
+            .used_custom_element_tags
+            .contains(&DYNAMIC_CUSTOM_ELEMENT_TAG.to_string()),
+        "new extraction must not persist the legacy dynamic sentinel: {:?}",
         info.used_custom_element_tags
     );
 }

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -12,8 +12,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::suppress::ParsedSuppressions;
 use crate::{
-    AngularTemplateMemberAccessFact, AngularThisSpreadFact, DynamicImportInfo,
-    DynamicImportPattern, ExportInfo, ExportName, FactoryCallMemberAccessFact,
+    AngularTemplateMemberAccessFact, AngularThisSpreadFact, DynamicCustomElementRenderFact,
+    DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, FactoryCallMemberAccessFact,
     FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
     InstanceExportBindingFact, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
     PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
@@ -543,6 +543,13 @@ impl ModuleInfoExtractor {
     pub(crate) fn record_angular_this_spread_fact(&mut self) {
         self.semantic_facts
             .push(SemanticFact::AngularThisSpread(AngularThisSpreadFact));
+    }
+
+    pub(crate) fn record_dynamic_custom_element_render_fact(&mut self) {
+        self.semantic_facts
+            .push(SemanticFact::DynamicCustomElementRender(
+                DynamicCustomElementRenderFact,
+            ));
     }
 
     fn record_instance_export_binding_fact(&mut self, export_name: String, target_name: String) {

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -4485,8 +4485,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     .as_ref()
                     .map_or_else(|| quasi.value.raw.as_str(), |c| c.as_str());
                 if text.ends_with('<') || text.ends_with("</") {
-                    self.used_custom_element_tags
-                        .insert(fallow_types::extract::DYNAMIC_CUSTOM_ELEMENT_TAG.to_string());
+                    self.record_dynamic_custom_element_render_fact();
                 }
             }
         }

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1371,6 +1371,8 @@ pub enum SemanticFact {
     PlaywrightFixtureType(PlaywrightFixtureTypeFact),
     /// An exported value whose runtime instance targets a local class or interface.
     InstanceExportBinding(InstanceExportBindingFact),
+    /// A dynamic custom-element tag render that makes static Lit tag credit opaque.
+    DynamicCustomElementRender(DynamicCustomElementRenderFact),
 }
 
 /// A member name referenced from an Angular template surface.
@@ -1479,6 +1481,11 @@ pub struct InstanceExportBindingFact {
     /// Local class or interface symbol used as the instance target.
     pub target_name: String,
 }
+
+/// Opaque marker for a dynamic custom-element render site.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DynamicCustomElementRenderFact;
 
 /// A statically flattenable callee path invoked in a module (e.g. `execSync`,
 /// `child_process.exec`, `console.log`). One entry per unique `callee_path`
@@ -1673,12 +1680,9 @@ pub struct AngularComponentSelector {
     pub class_name: String,
 }
 
-/// Sentinel pushed into `ModuleInfo.used_custom_element_tags` when an `html`
-/// template renders a DYNAMIC tag (`` html`<${tag}>` ``, the lit `static-html`
-/// form). It contains `<`/`>` so it can never collide with a real (hyphenated,
-/// no-angle-bracket) custom-element tag. When present project-wide, the Lit
-/// `unrendered-component` arm abstains on EVERY element (a dynamic render could
-/// instantiate any of them), mirroring `unprovided-inject`'s `has_dynamic_provide`.
+/// Legacy sentinel decoded from older parse caches when an `html` template
+/// renders a dynamic tag. New extraction persists
+/// `SemanticFact::DynamicCustomElementRender` instead.
 pub const DYNAMIC_CUSTOM_ELEMENT_TAG: &str = "<dynamic>";
 
 /// A Lit / web-component custom element registered in a module via


### PR DESCRIPTION
## Summary
- persist dynamic custom-element render abstains as typed semantic facts
- keep the legacy dynamic tag sentinel as a conservative fallback for older parse caches
- bump the parse cache version and update extraction coverage

## Validation
- cargo fmt --all -- --check
- cargo check -p fallow-types -p fallow-extract -p fallow-core
- cargo test -p fallow-extract dynamic_html_tag
- cargo test -p fallow-core unrendered_component
- cargo clippy -p fallow-types -p fallow-extract -p fallow-core --all-targets -- -D warnings
- git diff --check
- cargo run -p fallow-cli --features schema-emit --bin fallow-schema-emit