### PR TITLE
refactor: share health json output contract

### DIFF
--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -8,13 +8,13 @@ use fallow_core::duplicates::DuplicationReport;
 use fallow_core::results::AnalysisResults;
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
-use fallow_output::strip_root_prefix;
+use fallow_output::{HealthJsonOutputInput, strip_root_prefix};
 
 use super::emit_json;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutputInput,
-    FallowOutput, GroupByMode, HealthOutputInput, WorkspaceDiagnosticOutput,
+    EnvelopeMode, FallowOutput, GroupByMode, HealthOutputInput, WorkspaceDiagnosticOutput,
     apply_config_fixable_to_duplicate_exports, build_check_output, build_dupes_output,
     build_health_output, serialize_root_output,
 };
@@ -429,41 +429,29 @@ pub fn build_health_json(
     elapsed: Duration,
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let envelope = build_health_output(HealthOutputInput {
-        schema_version: SCHEMA_VERSION,
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        elapsed,
-        report: report.clone(),
-        grouped_by: None,
-        groups: None,
-        meta: explain.then(fallow_output::health_meta),
-        workspace_diagnostics: workspace_diagnostics_for_output(root),
-        next_steps: crate::report::suggestions::build_health_next_steps(
-            report,
-            root,
-            crate::report::suggestions::setup_pointer_applicable(root),
-            crate::report::suggestions::due_impact_digest(root),
-        ),
-    });
-    let mut output = serialize_root_output(FallowOutput::Health(envelope))?;
     let root_prefix = format!("{}/", root.display());
-    strip_root_prefix(&mut output, &root_prefix);
+    let mut output = fallow_output::serialize_health_json_output(HealthJsonOutputInput {
+        output: HealthOutputInput {
+            schema_version: SCHEMA_VERSION,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            elapsed,
+            report: report.clone(),
+            grouped_by: None,
+            groups: None::<Vec<crate::health_types::HealthGroup>>,
+            meta: explain.then(fallow_output::health_meta),
+            workspace_diagnostics: workspace_diagnostics_for_output(root),
+            next_steps: crate::report::suggestions::build_health_next_steps(
+                report,
+                root,
+                crate::report::suggestions::setup_pointer_applicable(root),
+                crate::report::suggestions::due_impact_digest(root),
+            ),
+        },
+        root_prefix: Some(&root_prefix),
+        envelope_mode: EnvelopeMode::current().into(),
+    })?;
+    crate::output_envelope::attach_telemetry_meta(&mut output);
     Ok(output)
-}
-
-pub(super) fn print_health_json(
-    report: &crate::health_types::HealthReport,
-    root: &Path,
-    elapsed: Duration,
-    explain: bool,
-) -> ExitCode {
-    match build_health_json(report, root, elapsed, explain) {
-        Ok(output) => emit_json(&output, "JSON"),
-        Err(e) => {
-            eprintln!("Error: failed to serialize health report: {e}");
-            ExitCode::from(2)
-        }
-    }
 }
 
 pub fn build_grouped_health_json(
@@ -508,6 +496,21 @@ pub fn build_grouped_health_json(
     }
 
     Ok(output)
+}
+
+pub(super) fn print_health_json(
+    report: &crate::health_types::HealthReport,
+    root: &Path,
+    elapsed: Duration,
+    explain: bool,
+) -> ExitCode {
+    match build_health_json(report, root, elapsed, explain) {
+        Ok(output) => emit_json(&output, "JSON"),
+        Err(e) => {
+            eprintln!("Error: failed to serialize health report: {e}");
+            ExitCode::from(2)
+        }
+    }
 }
 
 pub(super) fn print_grouped_health_json(

--- a/crates/output/src/health.rs
+++ b/crates/output/src/health.rs
@@ -4,7 +4,9 @@ use fallow_types::envelope::{ElapsedMs, Meta, SchemaVersion, ToolVersion};
 use fallow_types::output::NextStep;
 use serde::Serialize;
 
-use crate::{GroupByMode, WorkspaceDiagnosticOutput};
+use crate::{
+    GroupByMode, RootEnvelopeMode, WorkspaceDiagnosticOutput, apply_root_kind, strip_root_prefix,
+};
 
 /// Envelope emitted by `fallow health --format json`.
 ///
@@ -49,6 +51,14 @@ pub struct HealthOutputInput<Report, Group> {
     pub next_steps: Vec<NextStep>,
 }
 
+/// Inputs for serializing a health report into the root JSON contract.
+#[derive(Debug, Clone)]
+pub struct HealthJsonOutputInput<'a, Report, Group> {
+    pub output: HealthOutputInput<Report, Group>,
+    pub root_prefix: Option<&'a str>,
+    pub envelope_mode: RootEnvelopeMode,
+}
+
 /// Build a health JSON envelope from caller-owned report data.
 #[must_use]
 pub fn build_health_output<Report, Group>(
@@ -64,5 +74,82 @@ pub fn build_health_output<Report, Group>(
         meta: input.meta,
         workspace_diagnostics: input.workspace_diagnostics,
         next_steps: input.next_steps,
+    }
+}
+
+/// Build and serialize a health root JSON envelope.
+///
+/// This keeps the health contract serialization in `fallow-output` while
+/// callers still own report assembly, workspace diagnostics, and follow-up
+/// suggestion policy.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided report or group payload cannot be
+/// converted to JSON.
+pub fn serialize_health_json_output<Report, Group>(
+    input: HealthJsonOutputInput<'_, Report, Group>,
+) -> Result<serde_json::Value, serde_json::Error>
+where
+    Report: Serialize,
+    Group: Serialize,
+{
+    let envelope = build_health_output(input.output);
+    let mut output = serde_json::to_value(envelope)?;
+    apply_root_kind(&mut output, "health", input.envelope_mode);
+    if let Some(root_prefix) = input.root_prefix {
+        strip_root_prefix(&mut output, root_prefix);
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_health_json_output_tags_and_strips_root_paths() {
+        let output = serialize_health_json_output(HealthJsonOutputInput {
+            output: HealthOutputInput {
+                schema_version: 7,
+                version: "test".to_string(),
+                elapsed: Duration::ZERO,
+                report: serde_json::json!({ "findings": [{ "path": "/repo/src/a.ts" }] }),
+                grouped_by: None,
+                groups: None::<Vec<serde_json::Value>>,
+                meta: None,
+                workspace_diagnostics: Vec::new(),
+                next_steps: Vec::new(),
+            },
+            root_prefix: Some("/repo/"),
+            envelope_mode: RootEnvelopeMode::Tagged,
+        })
+        .expect("health output should serialize");
+
+        assert_eq!(output["kind"], "health");
+        assert_eq!(output["findings"][0]["path"], "src/a.ts");
+    }
+
+    #[test]
+    fn serialize_health_json_output_can_keep_legacy_root_shape() {
+        let output = serialize_health_json_output(HealthJsonOutputInput {
+            output: HealthOutputInput {
+                schema_version: 7,
+                version: "test".to_string(),
+                elapsed: Duration::ZERO,
+                report: serde_json::json!({ "summary": {} }),
+                grouped_by: None,
+                groups: None::<Vec<serde_json::Value>>,
+                meta: None,
+                workspace_diagnostics: Vec::new(),
+                next_steps: Vec::new(),
+            },
+            root_prefix: None,
+            envelope_mode: RootEnvelopeMode::Legacy,
+        })
+        .expect("health output should serialize");
+
+        assert!(output.get("kind").is_none());
+        assert_eq!(output["schema_version"], 7);
     }
 }

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -91,7 +91,10 @@ pub use fallow_types::output;
 pub use fallow_types::output_dead_code;
 pub use fallow_types::output_health;
 pub use format::OutputFormat;
-pub use health::{HealthOutput, HealthOutputInput, build_health_output};
+pub use health::{
+    HealthJsonOutputInput, HealthOutput, HealthOutputInput, build_health_output,
+    serialize_health_json_output,
+};
 pub use health_actions::HealthActionsMeta;
 pub use health_coverage::CoverageModel;
 pub use health_coverage_gaps::{


### PR DESCRIPTION
## Summary
- add a fallow-output helper for serializing health root JSON envelopes
- keep CLI-owned health suggestions and telemetry outside the output crate
- route the CLI health JSON builder through the shared output-contract path

## Validation
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo test -p fallow-output serialize_health_json_output
- cargo test -p fallow-cli health --lib
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check