### PR TITLE
refactor: move health next steps to output

### DIFF
--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -21,6 +21,10 @@ use std::path::Path;
 use std::process::Command;
 
 use fallow_core::results::AnalysisResults;
+use fallow_output::{
+    HealthNextStepsInput, ImpactDigestCounts,
+    build_health_next_steps as build_health_next_steps_contract, impact_digest_summary,
+};
 use fallow_types::output::NextStep;
 
 use crate::health_types::HealthReport;
@@ -165,27 +169,15 @@ fn impact_digest_step(digest: Option<crate::impact::ImpactDigest>) -> Option<Nex
 
 /// Real-counter summary fragment shared by the next-step reason and the human
 /// one-liner (the placeholder-free contract: numbers come from the store).
+fn impact_counts(digest: crate::impact::ImpactDigest) -> ImpactDigestCounts {
+    ImpactDigestCounts {
+        containment_count: digest.containment_count,
+        resolved_total: digest.resolved_total,
+    }
+}
+
 fn digest_summary(digest: crate::impact::ImpactDigest) -> String {
-    let mut parts = Vec::new();
-    if digest.containment_count > 0 {
-        parts.push(format!(
-            "{} commit{} contained at the gate",
-            digest.containment_count,
-            if digest.containment_count == 1 {
-                ""
-            } else {
-                "s"
-            }
-        ));
-    }
-    if digest.resolved_total > 0 {
-        parts.push(format!(
-            "{} finding{} resolved",
-            digest.resolved_total,
-            if digest.resolved_total == 1 { "" } else { "s" }
-        ));
-    }
-    parts.join(", ")
+    impact_digest_summary(impact_counts(digest))
 }
 
 /// One-line human counterpart of the `impact-report` next-step, printed with
@@ -362,23 +354,13 @@ pub fn build_health_next_steps(
     offer_setup: bool,
     digest: Option<crate::impact::ImpactDigest>,
 ) -> Vec<NextStep> {
-    if !suggestions_enabled() {
-        return Vec::new();
-    }
-    if report.findings.is_empty() {
-        return impact_digest_step(digest).into_iter().collect();
-    }
-    let mut steps: Vec<NextStep> = [
-        setup_pointer(offer_setup),
-        impact_digest_step(digest),
-        complexity_breakdown(report),
-        audit_changed(root),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-    steps.truncate(MAX_NEXT_STEPS);
-    steps
+    build_health_next_steps_contract(HealthNextStepsInput {
+        suggestions_enabled: suggestions_enabled(),
+        has_findings: !report.findings.is_empty(),
+        offer_setup,
+        impact_digest: digest.map(impact_counts),
+        audit_changed: audit_changed(root).is_some(),
+    })
 }
 
 /// Next-steps for standalone `fallow dupes`. See [`build_dead_code_next_steps`]
@@ -495,6 +477,9 @@ pub fn top_combined_next_step(
 mod tests {
     use std::path::PathBuf;
 
+    use crate::health_types::{
+        ComplexityViolation, ExceededThreshold, FindingSeverity, HealthFinding, HealthReport,
+    };
     use fallow_types::output_dead_code::UnusedExportFinding;
     use fallow_types::results::{AnalysisResults, UnusedExport};
 
@@ -516,6 +501,37 @@ mod tests {
         AnalysisResults {
             unused_exports: exports,
             ..AnalysisResults::default()
+        }
+    }
+
+    fn health_report_with_finding() -> HealthReport {
+        HealthReport {
+            findings: vec![HealthFinding::from(ComplexityViolation {
+                path: PathBuf::from("/project/src/hot.ts"),
+                name: "hot".to_string(),
+                line: 1,
+                col: 0,
+                cyclomatic: 21,
+                cognitive: 16,
+                line_count: 42,
+                param_count: 0,
+                react_hook_count: 0,
+                react_jsx_max_depth: 0,
+                react_prop_count: 0,
+                react_hook_profile: None,
+                exceeded: ExceededThreshold::Both,
+                severity: FindingSeverity::High,
+                crap: None,
+                coverage_pct: None,
+                coverage_tier: None,
+                coverage_source: None,
+                inherited_from: None,
+                component_rollup: None,
+                contributions: Vec::new(),
+                effective_thresholds: None,
+                threshold_source: None,
+            })],
+            ..HealthReport::default()
         }
     }
 
@@ -642,6 +658,16 @@ mod tests {
         let ids: Vec<&str> = steps.iter().map(|s| s.id.as_str()).collect();
         assert_eq!(ids[0], "setup");
         assert_eq!(ids[1], "impact-report");
+    }
+
+    #[test]
+    fn health_steps_keep_complexity_breakdown_from_output_contract() {
+        let report = health_report_with_finding();
+        let steps = build_health_next_steps(&report, Path::new("/project"), false, None);
+        let ids: Vec<&str> = steps.iter().map(|s| s.id.as_str()).collect();
+
+        assert_eq!(ids, ["complexity-breakdown"]);
+        assert_valid(&steps[0]);
     }
 
     #[test]

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -43,6 +43,7 @@ mod inspect_envelopes;
 mod issue_contract;
 mod json_paths;
 mod list_envelopes;
+mod next_steps;
 mod report_contract;
 mod review_envelopes;
 mod root_envelopes;
@@ -174,6 +175,9 @@ pub use json_paths::strip_root_prefix;
 pub use list_envelopes::{
     BoundariesListLogicalGroup, BoundariesListRule, BoundariesListZone, BoundariesListing,
     ListBoundariesOutput, WorkspaceInfo, WorkspacesOutput,
+};
+pub use next_steps::{
+    HealthNextStepsInput, ImpactDigestCounts, build_health_next_steps, impact_digest_summary,
 };
 pub use report_contract::{
     COVERAGE_ANALYZE_DOCS, COVERAGE_SETUP_DOCS, DUPES_DOCS, HEALTH_DOCS, SECURITY_DOCS,

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -1,0 +1,252 @@
+//! Pure builders for JSON `next_steps[]` entries.
+//!
+//! Runtime probes stay with callers. This module owns the stable command,
+//! ordering, capping, and read-only contracts once a caller has already decided
+//! which signals apply.
+
+use fallow_types::output::NextStep;
+
+const MAX_NEXT_STEPS: usize = 3;
+const MUTATING_VERBS: [&str; 5] = ["fix", "init", "hooks", "migrate", "setup-hooks"];
+
+/// Local impact digest counters used to render the `impact-report` next step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImpactDigestCounts {
+    pub containment_count: usize,
+    pub resolved_total: usize,
+}
+
+/// Runtime-independent inputs for standalone health next steps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HealthNextStepsInput {
+    pub suggestions_enabled: bool,
+    pub has_findings: bool,
+    pub offer_setup: bool,
+    pub impact_digest: Option<ImpactDigestCounts>,
+    pub audit_changed: bool,
+}
+
+/// Render the human-readable impact counter summary shared by JSON and human
+/// output surfaces.
+#[must_use]
+pub fn impact_digest_summary(digest: ImpactDigestCounts) -> String {
+    let mut parts = Vec::new();
+    if digest.containment_count > 0 {
+        parts.push(format!(
+            "{} commit{} contained at the gate",
+            digest.containment_count,
+            if digest.containment_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ));
+    }
+    if digest.resolved_total > 0 {
+        parts.push(format!(
+            "{} finding{} resolved",
+            digest.resolved_total,
+            if digest.resolved_total == 1 { "" } else { "s" }
+        ));
+    }
+    parts.join(", ")
+}
+
+/// Next-steps for standalone `fallow health`.
+#[must_use]
+pub fn build_health_next_steps(input: HealthNextStepsInput) -> Vec<NextStep> {
+    if !input.suggestions_enabled {
+        return Vec::new();
+    }
+    if !input.has_findings {
+        return impact_digest_step(input.impact_digest)
+            .into_iter()
+            .collect();
+    }
+
+    let mut steps: Vec<NextStep> = [
+        setup_pointer(input.offer_setup),
+        impact_digest_step(input.impact_digest),
+        complexity_breakdown(input.has_findings),
+        audit_changed(input.audit_changed),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    steps.truncate(MAX_NEXT_STEPS);
+    steps
+}
+
+fn next_step(id: &str, command: String, reason: &str) -> NextStep {
+    debug_assert!(
+        !command.contains('<') && !command.contains('>'),
+        "next-step command must be runnable (no placeholder): {command}"
+    );
+    debug_assert!(
+        !command
+            .split_whitespace()
+            .any(|token| MUTATING_VERBS.contains(&token)),
+        "next-step command must be read-only (no mutating verb): {command}"
+    );
+    NextStep {
+        id: id.to_string(),
+        command,
+        reason: reason.to_string(),
+    }
+}
+
+fn setup_pointer(offer_setup: bool) -> Option<NextStep> {
+    if !offer_setup {
+        return None;
+    }
+    Some(next_step(
+        "setup",
+        "fallow schema".to_string(),
+        "fallow has no config here; the manifest lists guided-setup commands (agent guide, commit gate) to offer the user",
+    ))
+}
+
+fn impact_digest_step(digest: Option<ImpactDigestCounts>) -> Option<NextStep> {
+    let digest = digest?;
+    Some(next_step(
+        "impact-report",
+        "fallow impact".to_string(),
+        &format!(
+            "local value report: {}; share the non-zero numbers with the user",
+            impact_digest_summary(digest)
+        ),
+    ))
+}
+
+fn complexity_breakdown(has_findings: bool) -> Option<NextStep> {
+    if !has_findings {
+        return None;
+    }
+    Some(next_step(
+        "complexity-breakdown",
+        "fallow health --complexity-breakdown".to_string(),
+        "see per-decision-point contributions for a hotspot",
+    ))
+}
+
+fn audit_changed(applicable: bool) -> Option<NextStep> {
+    if !applicable {
+        return None;
+    }
+    Some(next_step(
+        "audit-changed",
+        "fallow audit".to_string(),
+        "gate only the files your branch changed (auto-detects the base)",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(containment_count: usize, resolved_total: usize) -> ImpactDigestCounts {
+        ImpactDigestCounts {
+            containment_count,
+            resolved_total,
+        }
+    }
+
+    fn dirty_input() -> HealthNextStepsInput {
+        HealthNextStepsInput {
+            suggestions_enabled: true,
+            has_findings: true,
+            offer_setup: false,
+            impact_digest: None,
+            audit_changed: false,
+        }
+    }
+
+    fn assert_valid(step: &NextStep) {
+        assert!(
+            !step.command.contains('<') && !step.command.contains('>'),
+            "command must be placeholder-free: {}",
+            step.command
+        );
+        assert!(
+            !step
+                .command
+                .split_whitespace()
+                .any(|token| MUTATING_VERBS.contains(&token)),
+            "command must be read-only: {}",
+            step.command
+        );
+    }
+
+    #[test]
+    fn health_steps_are_empty_when_suggestions_are_disabled() {
+        let steps = build_health_next_steps(HealthNextStepsInput {
+            suggestions_enabled: false,
+            has_findings: true,
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+        });
+
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn clean_health_run_emits_only_due_impact_digest() {
+        let steps = build_health_next_steps(HealthNextStepsInput {
+            suggestions_enabled: true,
+            has_findings: false,
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+        });
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "impact-report");
+        assert_valid(&steps[0]);
+    }
+
+    #[test]
+    fn dirty_health_run_orders_setup_impact_complexity_then_audit() {
+        let steps = build_health_next_steps(HealthNextStepsInput {
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..dirty_input()
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["setup", "impact-report", "complexity-breakdown"]);
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
+    fn dirty_health_run_uses_complexity_when_setup_and_impact_are_absent() {
+        let steps = build_health_next_steps(HealthNextStepsInput {
+            audit_changed: true,
+            ..dirty_input()
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["complexity-breakdown", "audit-changed"]);
+    }
+
+    #[test]
+    fn impact_digest_summary_pluralizes_real_counters() {
+        assert_eq!(
+            impact_digest_summary(digest(1, 1)),
+            "1 commit contained at the gate, 1 finding resolved"
+        );
+        assert_eq!(
+            impact_digest_summary(digest(2, 3)),
+            "2 commits contained at the gate, 3 findings resolved"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- move the pure standalone health next_steps ordering and command contract into fallow-output
- keep CLI runtime probes for suggestions, setup, impact cadence, and git availability at the CLI edge
- add output-level contract tests plus a CLI adapter test for health complexity-breakdown next steps

## Validation
- cargo fmt --all -- --check
- cargo test -p fallow-output next_steps
- cargo test -p fallow-cli health_steps_keep_complexity_breakdown_from_output_contract --lib
- cargo test -p fallow-cli impact_digest_line_renders_counters --lib
- cargo check -p fallow-output -p fallow-cli
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- git diff --check