### PR TITLE
refactor: expose health result from engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ version = "2.102.0"
 dependencies = [
  "fallow-config",
  "fallow-core",
+ "fallow-output",
  "fallow-types",
  "rustc-hash 2.1.2",
  "tempfile",

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -6731,27 +6731,8 @@ pub fn run_health(opts: &HealthOptions<'_>) -> ExitCode {
 }
 
 /// Result of executing health analysis without printing.
-pub struct HealthResult {
-    pub report: HealthReport,
-    /// Per-group health output when `--group-by` is active.
-    ///
-    /// `None` for the default run; `Some` for any
-    /// `--group-by package|owner|directory|section` invocation. The top-level
-    /// `report` reflects the active run scope (for example, after
-    /// `--workspace`); consumers that want per-group metrics read from
-    /// `grouping.groups`.
-    pub grouping: Option<crate::health_types::HealthGrouping>,
-    /// Resolver retained alongside `grouping` so per-result formats
-    /// (SARIF, CodeClimate) can tag findings with the active group key
-    /// without re-discovering CODEOWNERS or workspace info at print time.
-    /// Always `None` when `grouping` is `None`.
-    pub group_resolver: Option<crate::report::OwnershipResolver>,
-    pub config: ResolvedConfig,
-    pub elapsed: Duration,
-    pub timings: Option<HealthTimings>,
-    pub coverage_gaps_has_findings: bool,
-    pub should_fail_on_coverage_gaps: bool,
-}
+pub type HealthResult =
+    fallow_engine::health::HealthAnalysisResult<crate::report::OwnershipResolver>;
 
 /// Print health results and return appropriate exit code.
 ///

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -14,11 +14,12 @@ readme = "../../README.md"
 [dependencies]
 fallow-config = { workspace = true }
 fallow-core = { workspace = true }
+fallow-output = { workspace = true }
 fallow-types = { workspace = true }
 rustc-hash = { workspace = true }
 
 [features]
-schema = ["fallow-core/schema", "fallow-types/schema"]
+schema = ["fallow-core/schema", "fallow-output/schema", "fallow-types/schema"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -1,0 +1,30 @@
+//! Typed health result contracts exposed through the engine boundary.
+
+use std::time::Duration;
+
+use fallow_config::ResolvedConfig;
+use fallow_output::{HealthGrouping, HealthReport, HealthTimings};
+
+/// Typed health analysis result shared by CLI, API, NAPI, and future embedders.
+///
+/// The health runner still lives in `fallow-cli` during the staged migration,
+/// but the result contract belongs at the engine boundary so downstream callers
+/// can depend on a command-neutral shape.
+#[derive(Debug)]
+pub struct HealthAnalysisResult<GroupResolver = ()> {
+    pub report: HealthReport,
+    /// Per-group health output when grouping is active.
+    ///
+    /// `None` for the default run; `Some` for any grouped invocation. The
+    /// top-level report reflects the active run scope; consumers that want
+    /// per-group metrics read from `grouping.groups`.
+    pub grouping: Option<HealthGrouping>,
+    /// Optional grouping resolver retained by callers that need to tag findings
+    /// after analysis without rediscovering ownership or package metadata.
+    pub group_resolver: Option<GroupResolver>,
+    pub config: ResolvedConfig,
+    pub elapsed: Duration,
+    pub timings: Option<HealthTimings>,
+    pub coverage_gaps_has_findings: bool,
+    pub should_fail_on_coverage_gaps: bool,
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -28,6 +28,7 @@ pub mod duplicates {
 }
 
 pub mod dead_code;
+pub mod health;
 
 /// Extracted semantic types exposed through the engine boundary.
 pub mod extract {
@@ -65,6 +66,7 @@ pub use fallow_core::duplicates::{
 pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
+pub use health::HealthAnalysisResult;
 
 /// Result alias for typed engine operations.
 pub type EngineResult<T> = Result<T, EngineError>;


### PR DESCRIPTION
## Summary
- add a typed fallow-engine health result contract backed by fallow-output DTOs
- keep the CLI health runner in place while making its public HealthResult a command-neutral engine type alias
- wire fallow-engine to fallow-output with schema feature parity for future API and NAPI migration

## Validation
- cargo fmt --all -- --check
- cargo test -p fallow-engine
- cargo test -p fallow-cli health_steps_keep_complexity_breakdown_from_output_contract --lib
- cargo check -p fallow-engine -p fallow-cli -p fallow-api -p fallow-node
- cargo clippy -p fallow-engine -p fallow-cli -p fallow-api -p fallow-node --all-targets -- -D warnings
- git diff --check