### PR TITLE
refactor: move health sort contract to engine

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -14,7 +14,7 @@ use crate::base_worktree::{
 use crate::check::{CheckOptions, CheckResult, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions, DupesResult};
 use crate::error::emit_error;
-use crate::health::{HealthOptions, HealthResult, SortBy};
+use crate::health::{HealthOptions, HealthResult};
 
 const AUDIT_BASE_SNAPSHOT_CACHE_VERSION: u8 = 3;
 const MAX_AUDIT_BASE_SNAPSHOT_CACHE_SIZE: usize = 16 * 1024 * 1024;
@@ -2570,7 +2570,7 @@ fn build_audit_health_options<'a>(
         max_cognitive: None,
         max_crap: opts.max_crap,
         top: None,
-        sort: SortBy::Cyclomatic,
+        sort: fallow_engine::HealthSort::Cyclomatic,
         production: opts.production_health.unwrap_or(opts.production),
         production_override: opts.production_health,
         changed_since,

--- a/crates/cli/src/combined/mod.rs
+++ b/crates/cli/src/combined/mod.rs
@@ -5,7 +5,7 @@ use fallow_config::{DuplicatesConfig, OutputFormat};
 
 use crate::check::{CheckOptions, CheckResult, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions, DupesResult};
-use crate::health::{HealthOptions, HealthResult, SortBy};
+use crate::health::{HealthOptions, HealthResult};
 use crate::regression;
 use crate::report;
 use crate::{AnalysisKind, load_config_for_analysis};
@@ -381,7 +381,7 @@ fn build_health_opts<'a>(opts: &'a CombinedOptions<'a>) -> HealthOptions<'a> {
         max_cognitive: None,
         max_crap: None,
         top: None,
-        sort: SortBy::Cyclomatic,
+        sort: fallow_engine::HealthSort::Cyclomatic,
         production: opts.production_health.unwrap_or(opts.production),
         production_override: opts.production_health,
         changed_since: opts.changed_since,

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -16,7 +16,7 @@ use crate::coverage::cloud_client::{
     CloudTrackingState, fetch_runtime_context,
 };
 use crate::error::emit_error;
-use crate::health::{HealthOptions, SortBy};
+use crate::health::HealthOptions;
 use crate::health_types::{
     RuntimeCoverageAction, RuntimeCoverageCaptureQuality, RuntimeCoverageConfidence,
     RuntimeCoverageDataSource, RuntimeCoverageEvidence, RuntimeCoverageFinding,
@@ -164,7 +164,7 @@ fn local_health_options<'a>(
         max_cognitive: None,
         max_crap: None,
         top: args.top,
-        sort: SortBy::Cyclomatic,
+        sort: fallow_engine::HealthSort::Cyclomatic,
         production: args.production,
         production_override: Some(args.production),
         changed_since: None,

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 use fallow_config::{OutputFormat, PackageJson, ResolvedConfig, Severity};
+use fallow_engine::HealthSort;
 
 use crate::baseline::{HealthBaselineData, filter_new_health_findings, filter_new_health_targets};
 use crate::check::{get_changed_files, resolve_workspace_scope};
@@ -65,6 +66,17 @@ pub enum SortBy {
     Lines,
 }
 
+impl From<SortBy> for HealthSort {
+    fn from(sort: SortBy) -> Self {
+        match sort {
+            SortBy::Severity => Self::Severity,
+            SortBy::Cyclomatic => Self::Cyclomatic,
+            SortBy::Cognitive => Self::Cognitive,
+            SortBy::Lines => Self::Lines,
+        }
+    }
+}
+
 pub struct HealthOptions<'a> {
     pub root: &'a std::path::Path,
     pub config_path: &'a Option<std::path::PathBuf>,
@@ -78,7 +90,7 @@ pub struct HealthOptions<'a> {
     /// meeting or exceeding this score are reported as complexity findings.
     pub max_crap: Option<f64>,
     pub top: Option<usize>,
-    pub sort: SortBy,
+    pub sort: HealthSort,
     pub production: bool,
     pub production_override: Option<bool>,
     pub changed_since: Option<&'a str>,
@@ -3858,7 +3870,7 @@ fn finalize_health_findings(
     if let Some(diff_index) = diff_index {
         filter_complexity_findings_by_diff(findings, diff_index, &config.root);
     }
-    sort_findings(findings, &opts.sort);
+    sort_findings(findings, opts.sort);
     let total_above_threshold = findings.len();
     let (sev_critical, sev_high, sev_moderate) = count_finding_severities(findings);
     let loaded_baseline = apply_health_baseline_and_top(opts, config, findings)?;
@@ -5396,9 +5408,9 @@ fn apply_duplication_metrics(
 }
 
 /// Sort findings by the specified criteria.
-fn sort_findings(findings: &mut [ComplexityViolation], sort: &SortBy) {
+fn sort_findings(findings: &mut [ComplexityViolation], sort: HealthSort) {
     match sort {
-        SortBy::Severity => findings.sort_by_key(|f| {
+        HealthSort::Severity => findings.sort_by_key(|f| {
             std::cmp::Reverse((
                 exceeded_priority(f.exceeded),
                 severity_priority(f.severity),
@@ -5408,9 +5420,9 @@ fn sort_findings(findings: &mut [ComplexityViolation], sort: &SortBy) {
                 f.line_count,
             ))
         }),
-        SortBy::Cyclomatic => findings.sort_by_key(|f| std::cmp::Reverse(f.cyclomatic)),
-        SortBy::Cognitive => findings.sort_by_key(|f| std::cmp::Reverse(f.cognitive)),
-        SortBy::Lines => findings.sort_by_key(|f| std::cmp::Reverse(f.line_count)),
+        HealthSort::Cyclomatic => findings.sort_by_key(|f| std::cmp::Reverse(f.cyclomatic)),
+        HealthSort::Cognitive => findings.sort_by_key(|f| std::cmp::Reverse(f.cognitive)),
+        HealthSort::Lines => findings.sort_by_key(|f| std::cmp::Reverse(f.line_count)),
     }
 }
 
@@ -7307,7 +7319,7 @@ mod tests {
             make_finding("all", ExceededThreshold::All),
         ];
 
-        sort_findings(&mut findings, &SortBy::Severity);
+        sort_findings(&mut findings, HealthSort::Severity);
 
         let names = findings
             .iter()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5675,7 +5675,7 @@ fn run_health_dispatch(
         max_cognitive: args.max_cognitive,
         max_crap: args.max_crap,
         top: args.top,
-        sort: args.sort,
+        sort: args.sort.into(),
         production,
         production_override: Some(production),
         changed_since: cli.changed_since.as_deref(),

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -5,7 +5,7 @@ use fallow_core::results::AnalysisResults;
 
 use crate::check::{CheckOptions, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions};
-use crate::health::{HealthOptions, SortBy};
+use crate::health::HealthOptions;
 use crate::health_types::EffortEstimate;
 use crate::report::ci::diff_filter::{DiffIndex, LoadedDiff, MAX_DIFF_BYTES};
 use crate::report::{build_duplication_json, build_health_json};
@@ -27,12 +27,12 @@ const fn duplication_mode_to_cli(mode: DuplicationMode) -> DupesMode {
     }
 }
 
-const fn complexity_sort_to_cli(sort: ComplexitySort) -> SortBy {
+const fn complexity_sort_to_engine(sort: ComplexitySort) -> fallow_engine::HealthSort {
     match sort {
-        ComplexitySort::Severity => SortBy::Severity,
-        ComplexitySort::Cyclomatic => SortBy::Cyclomatic,
-        ComplexitySort::Cognitive => SortBy::Cognitive,
-        ComplexitySort::Lines => SortBy::Lines,
+        ComplexitySort::Severity => fallow_engine::HealthSort::Severity,
+        ComplexitySort::Cyclomatic => fallow_engine::HealthSort::Cyclomatic,
+        ComplexitySort::Cognitive => fallow_engine::HealthSort::Cognitive,
+        ComplexitySort::Lines => fallow_engine::HealthSort::Lines,
     }
 }
 
@@ -636,7 +636,7 @@ fn build_complexity_options<'a>(
         max_cognitive: options.max_cognitive,
         max_crap: options.max_crap,
         top: options.top,
-        sort: complexity_sort_to_cli(options.sort),
+        sort: complexity_sort_to_engine(options.sort),
         production: resolved.production_override.unwrap_or(false),
         production_override: resolved.production_override,
         changed_since: resolved.changed_since.as_deref(),

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -46,7 +46,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use crate::base_worktree::{BaseWorktree, git_rev_parse};
 use crate::error::emit_error;
-use crate::health::{HealthOptions, SharedParseData, SortBy};
+use crate::health::{HealthOptions, SharedParseData};
 use crate::health_types::{
     RuntimeCoverageFinding, RuntimeCoverageHotPath, RuntimeCoverageReport, RuntimeCoverageVerdict,
 };
@@ -1143,7 +1143,7 @@ fn security_runtime_health_options<'a>(
         max_cognitive: None,
         max_crap: None,
         top: None,
-        sort: SortBy::Cyclomatic,
+        sort: fallow_engine::HealthSort::Cyclomatic,
         production: true,
         production_override: Some(true),
         changed_since: opts.changed_since,

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -5,6 +5,15 @@ use std::time::Duration;
 use fallow_config::ResolvedConfig;
 use fallow_output::{HealthGrouping, HealthReport, HealthTimings};
 
+/// Command-neutral sort criteria for health complexity findings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthSort {
+    Severity,
+    Cyclomatic,
+    Cognitive,
+    Lines,
+}
+
 /// Typed health analysis result shared by CLI, API, NAPI, and future embedders.
 ///
 /// The health runner still lives in `fallow-cli` during the staged migration,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -66,7 +66,7 @@ pub use fallow_core::duplicates::{
 pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
-pub use health::HealthAnalysisResult;
+pub use health::{HealthAnalysisResult, HealthSort};
 
 /// Result alias for typed engine operations.
 pub type EngineResult<T> = Result<T, EngineError>;


### PR DESCRIPTION
## Summary
- add engine-owned HealthSort for command-neutral health runner options
- keep CLI SortBy as the clap-facing parser and convert it at the HealthOptions boundary
- update programmatic, combined, audit, coverage, security, and standalone health callsites to pass HealthSort

## Validation
- cargo fmt --all -- --check
- cargo check -p fallow-engine -p fallow-cli -p fallow-api -p fallow-node
- cargo test -p fallow-cli sort_findings_by_severity_surfaces_crap_before_single_metric_findings --lib
- cargo test -p fallow-api
- cargo clippy -p fallow-engine -p fallow-cli -p fallow-api -p fallow-node --all-targets -- -D warnings
- git diff --check