### PR TITLE
refactor: move health section derivation to api

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -271,6 +271,91 @@ pub struct DerivedComplexityOptions {
     pub score: bool,
 }
 
+/// Input for deriving effective health sections from command-neutral flags.
+#[derive(Debug, Clone)]
+pub struct HealthSectionOptions {
+    pub output: fallow_config::OutputFormat,
+    pub complexity: bool,
+    pub file_scores: bool,
+    pub coverage_gaps: bool,
+    pub hotspots: bool,
+    pub targets: bool,
+    pub css: bool,
+    pub score: bool,
+    pub score_gate: bool,
+    pub snapshot_requested: bool,
+    pub trend: bool,
+}
+
+/// Derived section selection for health runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DerivedHealthSections {
+    pub any_section: bool,
+    pub complexity: bool,
+    pub file_scores: bool,
+    pub coverage_gaps: bool,
+    pub hotspots: bool,
+    pub targets: bool,
+    pub css: bool,
+    pub score: bool,
+    pub force_full: bool,
+    pub score_only_output: bool,
+}
+
+/// Derive effective health section flags for CLI and embedders.
+#[must_use]
+pub fn derive_health_sections(options: &HealthSectionOptions) -> DerivedHealthSections {
+    let score = options.score
+        || options.score_gate
+        || options.trend
+        || matches!(options.output, fallow_config::OutputFormat::Badge);
+    let any_section = options.complexity
+        || options.file_scores
+        || options.coverage_gaps
+        || options.hotspots
+        || options.targets
+        || score;
+    let effective_score = if any_section { score } else { true } || options.snapshot_requested;
+    let force_full = options.snapshot_requested || effective_score;
+
+    DerivedHealthSections {
+        any_section,
+        complexity: if any_section {
+            options.complexity
+        } else {
+            true
+        },
+        file_scores: if any_section {
+            options.file_scores
+        } else {
+            true
+        } || force_full,
+        coverage_gaps: if any_section {
+            options.coverage_gaps
+        } else {
+            false
+        },
+        hotspots: if any_section { options.hotspots } else { true }
+            || options.snapshot_requested
+            || options.trend,
+        targets: if any_section { options.targets } else { true },
+        css: options.css,
+        score: effective_score,
+        force_full,
+        score_only_output: is_health_score_only_output(options, score),
+    }
+}
+
+fn is_health_score_only_output(options: &HealthSectionOptions, score: bool) -> bool {
+    score
+        && !options.complexity
+        && !options.file_scores
+        && !options.coverage_gaps
+        && !options.hotspots
+        && !options.targets
+        && !options.trend
+}
+
 /// Derive effective programmatic health / complexity section flags.
 #[must_use]
 pub fn derive_complexity_options(options: &ComplexityOptions) -> DerivedComplexityOptions {
@@ -400,5 +485,82 @@ mod tests {
         assert!(derived.hotspots);
         assert!(derived.ownership);
         assert!(!derived.targets);
+    }
+
+    #[test]
+    fn default_health_sections_match_full_health_output() {
+        let derived = derive_health_sections(&HealthSectionOptions {
+            output: fallow_config::OutputFormat::Human,
+            complexity: false,
+            file_scores: false,
+            coverage_gaps: false,
+            hotspots: false,
+            targets: false,
+            css: false,
+            score: false,
+            score_gate: false,
+            snapshot_requested: false,
+            trend: false,
+        });
+
+        assert!(!derived.any_section);
+        assert!(derived.complexity);
+        assert!(derived.file_scores);
+        assert!(!derived.coverage_gaps);
+        assert!(derived.hotspots);
+        assert!(derived.targets);
+        assert!(derived.score);
+        assert!(derived.force_full);
+        assert!(!derived.score_only_output);
+    }
+
+    #[test]
+    fn health_score_gate_requests_score_only_output() {
+        let derived = derive_health_sections(&HealthSectionOptions {
+            output: fallow_config::OutputFormat::Human,
+            complexity: false,
+            file_scores: false,
+            coverage_gaps: false,
+            hotspots: false,
+            targets: false,
+            css: false,
+            score: false,
+            score_gate: true,
+            snapshot_requested: false,
+            trend: false,
+        });
+
+        assert!(derived.any_section);
+        assert!(!derived.complexity);
+        assert!(derived.file_scores);
+        assert!(!derived.hotspots);
+        assert!(!derived.targets);
+        assert!(derived.score);
+        assert!(derived.force_full);
+        assert!(derived.score_only_output);
+    }
+
+    #[test]
+    fn health_snapshot_keeps_full_hidden_inputs_without_section_request() {
+        let derived = derive_health_sections(&HealthSectionOptions {
+            output: fallow_config::OutputFormat::Human,
+            complexity: false,
+            file_scores: false,
+            coverage_gaps: false,
+            hotspots: false,
+            targets: false,
+            css: true,
+            score: false,
+            score_gate: false,
+            snapshot_requested: true,
+            trend: false,
+        });
+
+        assert!(!derived.any_section);
+        assert!(derived.css);
+        assert!(derived.file_scores);
+        assert!(derived.hotspots);
+        assert!(derived.score);
+        assert!(derived.force_full);
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5595,7 +5595,7 @@ fn dispatch_health(dispatch: &DispatchContext<'_>, args: HealthDispatchArgs<'_>)
         return code;
     }
     let targets = args.targets || args.effort.is_some();
-    let sections = effective_health_sections(&EffectiveHealthSectionInput {
+    let sections = fallow_api::derive_health_sections(&fallow_api::HealthSectionOptions {
         output,
         complexity: args.complexity,
         file_scores: args.file_scores,
@@ -5604,8 +5604,8 @@ fn dispatch_health(dispatch: &DispatchContext<'_>, args: HealthDispatchArgs<'_>)
         targets,
         css: args.css,
         score: args.score,
-        min_score: args.min_score,
-        save_snapshot: args.save_snapshot,
+        score_gate: args.min_score.is_some(),
+        snapshot_requested: args.save_snapshot.is_some(),
         trend: args.trend,
     });
     let runtime_coverage = match resolve_runtime_coverage_options(
@@ -5645,7 +5645,7 @@ fn dispatch_health(dispatch: &DispatchContext<'_>, args: HealthDispatchArgs<'_>)
 /// builder. Borrows the section flags and coverage inputs; owns the resolved
 /// runtime-coverage options.
 struct ResolvedHealthDispatch<'a> {
-    sections: &'a EffectiveHealthSections,
+    sections: &'a fallow_api::DerivedHealthSections,
     runtime_coverage: Option<health::RuntimeCoverageOptions>,
     production: bool,
     coverage_inputs: &'a ResolvedHealthCoverageInputs,
@@ -5718,77 +5718,6 @@ fn run_health_dispatch(
         runtime_coverage: resolved.runtime_coverage,
         churn_file: cli.churn_file.as_deref(),
     })
-}
-
-struct EffectiveHealthSectionInput<'a> {
-    output: fallow_config::OutputFormat,
-    complexity: bool,
-    file_scores: bool,
-    coverage_gaps: bool,
-    hotspots: bool,
-    targets: bool,
-    css: bool,
-    score: bool,
-    min_score: Option<f64>,
-    save_snapshot: Option<&'a Option<String>>,
-    trend: bool,
-}
-
-struct EffectiveHealthSections {
-    any_section: bool,
-    complexity: bool,
-    file_scores: bool,
-    coverage_gaps: bool,
-    hotspots: bool,
-    targets: bool,
-    css: bool,
-    score: bool,
-    force_full: bool,
-    score_only_output: bool,
-}
-
-fn effective_health_sections(input: &EffectiveHealthSectionInput<'_>) -> EffectiveHealthSections {
-    let score = input.score
-        || input.min_score.is_some()
-        || input.trend
-        || matches!(input.output, fallow_config::OutputFormat::Badge);
-    let snapshot_requested = input.save_snapshot.is_some();
-    let any_section = input.complexity
-        || input.file_scores
-        || input.coverage_gaps
-        || input.hotspots
-        || input.targets
-        || score;
-    let eff_score = if any_section { score } else { true } || snapshot_requested;
-    let force_full = snapshot_requested || eff_score;
-    EffectiveHealthSections {
-        any_section,
-        complexity: if any_section { input.complexity } else { true },
-        file_scores: if any_section { input.file_scores } else { true } || force_full,
-        coverage_gaps: if any_section {
-            input.coverage_gaps
-        } else {
-            false
-        },
-        hotspots: if any_section { input.hotspots } else { true }
-            || snapshot_requested
-            || input.trend,
-        targets: if any_section { input.targets } else { true },
-        css: input.css,
-        score: eff_score,
-        force_full,
-        score_only_output: is_health_score_only_output(input, score),
-    }
-}
-
-fn is_health_score_only_output(input: &EffectiveHealthSectionInput<'_>, score: bool) -> bool {
-    score
-        && !input.complexity
-        && !input.file_scores
-        && !input.coverage_gaps
-        && !input.hotspots
-        && !input.targets
-        && !input.trend
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add API-owned HealthSectionOptions and DerivedHealthSections contracts
- move standalone CLI health section defaulting out of main.rs
- keep existing score, badge, snapshot, trend, and section selection behavior covered by API tests

## Validation
- cargo fmt --all -- --check
- cargo check -p fallow-api -p fallow-cli -p fallow-node
- cargo test -p fallow-api
- cargo clippy -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings
- git diff --check