### PR TITLE
refactor: move health shared parse contract to engine

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -2524,7 +2524,7 @@ fn build_audit_dupes_options<'a>(
 fn run_audit_health<'a>(
     opts: &'a AuditOptions<'a>,
     changed_since: Option<&'a str>,
-    shared_parse: Option<crate::health::SharedParseData>,
+    shared_parse: Option<fallow_engine::HealthSharedParseData>,
 ) -> Result<Option<HealthResult>, ExitCode> {
     let runtime_coverage = match opts.runtime_coverage {
         Some(path) => match crate::health::coverage::prepare_options(

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -320,7 +320,7 @@ pub struct CheckResult {
     pub baseline_matched: Option<(usize, usize)>,
     pub timings: Option<fallow_core::trace::PipelineTimings>,
     /// Retained parse data for sharing with health (only populated when retain_modules_for_health=true).
-    pub shared_parse: Option<crate::health::SharedParseData>,
+    pub shared_parse: Option<fallow_engine::HealthSharedParseData>,
     /// Impact closure for the review brief: the transitive
     /// affected-but-not-in-diff set plus coordination gaps. Populated by the
     /// audit brief path from the retained graph against the changed-file set;
@@ -590,7 +590,7 @@ fn build_shared_parse_data(
     retained_modules: Option<Vec<fallow_core::extract::ModuleInfo>>,
     retained_files: Option<Vec<fallow_core::discover::DiscoveredFile>>,
     script_used_packages: &rustc_hash::FxHashSet<String>,
-) -> Option<crate::health::SharedParseData> {
+) -> Option<fallow_engine::HealthSharedParseData> {
     let (Some(modules), Some(files)) = (retained_modules, retained_files) else {
         return None;
     };
@@ -603,7 +603,7 @@ fn build_shared_parse_data(
         script_used_packages: script_used_packages.clone(),
         file_hashes: rustc_hash::FxHashMap::default(),
     });
-    Some(crate::health::SharedParseData {
+    Some(fallow_engine::HealthSharedParseData {
         files,
         modules,
         analysis_output,

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 use fallow_config::{OutputFormat, PackageJson, ResolvedConfig, Severity};
-use fallow_engine::{HealthSort, RuntimeCoverageOptions};
+use fallow_engine::{HealthSharedParseData, HealthSort, RuntimeCoverageOptions};
 
 use crate::baseline::{HealthBaselineData, filter_new_health_findings, filter_new_health_targets};
 use crate::check::{get_changed_files, resolve_workspace_scope};
@@ -32,13 +32,6 @@ use runtime_filter::{
 };
 use scoring::compute_file_scores;
 
-/// Pre-parsed data from the dead-code pipeline, shared with health to avoid re-analysis.
-pub struct SharedParseData {
-    pub files: Vec<fallow_types::discover::DiscoveredFile>,
-    pub modules: Vec<fallow_types::extract::ModuleInfo>,
-    /// Full analysis output (graph + results) for file scoring.
-    pub analysis_output: Option<fallow_core::AnalysisOutput>,
-}
 use targets::{TargetAuxData, compute_refactoring_targets};
 
 /// Sort criteria for complexity output.
@@ -217,7 +210,7 @@ fn validate_churn_file(opts: &HealthOptions<'_>) -> Result<(), ExitCode> {
 /// Skips file discovery and parsing (saves ~1.9s on 21K-file projects).
 pub fn execute_health_with_shared_parse(
     opts: &HealthOptions<'_>,
-    shared: SharedParseData,
+    shared: HealthSharedParseData,
 ) -> Result<HealthResult, ExitCode> {
     scoring::validate_coverage_root_absolute(opts.coverage_root)
         .map_err(|e| emit_error(&e, 2, opts.output))?;

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -46,7 +46,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use crate::base_worktree::{BaseWorktree, git_rev_parse};
 use crate::error::emit_error;
-use crate::health::{HealthOptions, SharedParseData};
+use crate::health::HealthOptions;
 use crate::health_types::{
     RuntimeCoverageFinding, RuntimeCoverageHotPath, RuntimeCoverageReport, RuntimeCoverageVerdict,
 };
@@ -1117,7 +1117,7 @@ fn analyze_security_runtime(
     )?;
     let result = crate::health::execute_health_with_shared_parse(
         &security_runtime_health_options(opts, runtime_coverage),
-        SharedParseData {
+        fallow_engine::HealthSharedParseData {
             files,
             modules,
             analysis_output: Some(analysis_output),

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -33,6 +33,14 @@ pub struct RuntimeCoverageOptions {
     pub watermark: Option<RuntimeCoverageWatermark>,
 }
 
+/// Pre-parsed health input reused from another analysis in the same process.
+pub struct HealthSharedParseData {
+    pub files: Vec<fallow_types::discover::DiscoveredFile>,
+    pub modules: Vec<fallow_types::extract::ModuleInfo>,
+    /// Full analysis output (graph + results) for file scoring.
+    pub analysis_output: Option<fallow_core::AnalysisOutput>,
+}
+
 /// Typed health analysis result shared by CLI, API, NAPI, and future embedders.
 ///
 /// The health runner still lives in `fallow-cli` during the staged migration,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -66,7 +66,7 @@ pub use fallow_core::duplicates::{
 pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
-pub use health::{HealthAnalysisResult, HealthSort, RuntimeCoverageOptions};
+pub use health::{HealthAnalysisResult, HealthSharedParseData, HealthSort, RuntimeCoverageOptions};
 
 /// Result alias for typed engine operations.
 pub type EngineResult<T> = Result<T, EngineError>;


### PR DESCRIPTION
## Summary
- add engine-owned HealthSharedParseData for health runs that reuse parsed modules from check/audit
- keep the CLI runner implementation in place while removing the shared parse DTO from the CLI module
- update check, audit, security, and health callsites to pass the engine contract

## Validation
- cargo fmt --all -- --check
- cargo check -p fallow-engine -p fallow-cli -p fallow-api -p fallow-node
- cargo test -p fallow-cli shared_parse --lib
- cargo clippy -p fallow-engine -p fallow-cli -p fallow-api -p fallow-node --all-targets -- -D warnings
- git diff --check