### PR TITLE
refactor: move health section contracts to engine

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -252,11 +252,9 @@ pub struct ComplexityOptions {
     pub coverage_root: Option<PathBuf>,
 }
 
+pub use fallow_engine::{DerivedHealthSections, HealthSectionOptions, derive_health_sections};
+
 /// Derived section selection for programmatic health / complexity runs.
-///
-/// Owned by `fallow-api` so embedders and the remaining CLI-backed runtime path
-/// share the same defaulting rules while health execution moves behind the
-/// typed API boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DerivedComplexityOptions {
     pub any_section: bool,
@@ -269,91 +267,6 @@ pub struct DerivedComplexityOptions {
     pub force_full: bool,
     pub score_only_output: bool,
     pub score: bool,
-}
-
-/// Input for deriving effective health sections from command-neutral flags.
-#[derive(Debug, Clone)]
-pub struct HealthSectionOptions {
-    pub output: fallow_config::OutputFormat,
-    pub complexity: bool,
-    pub file_scores: bool,
-    pub coverage_gaps: bool,
-    pub hotspots: bool,
-    pub targets: bool,
-    pub css: bool,
-    pub score: bool,
-    pub score_gate: bool,
-    pub snapshot_requested: bool,
-    pub trend: bool,
-}
-
-/// Derived section selection for health runs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DerivedHealthSections {
-    pub any_section: bool,
-    pub complexity: bool,
-    pub file_scores: bool,
-    pub coverage_gaps: bool,
-    pub hotspots: bool,
-    pub targets: bool,
-    pub css: bool,
-    pub score: bool,
-    pub force_full: bool,
-    pub score_only_output: bool,
-}
-
-/// Derive effective health section flags for CLI and embedders.
-#[must_use]
-pub fn derive_health_sections(options: &HealthSectionOptions) -> DerivedHealthSections {
-    let score = options.score
-        || options.score_gate
-        || options.trend
-        || matches!(options.output, fallow_config::OutputFormat::Badge);
-    let any_section = options.complexity
-        || options.file_scores
-        || options.coverage_gaps
-        || options.hotspots
-        || options.targets
-        || score;
-    let effective_score = if any_section { score } else { true } || options.snapshot_requested;
-    let force_full = options.snapshot_requested || effective_score;
-
-    DerivedHealthSections {
-        any_section,
-        complexity: if any_section {
-            options.complexity
-        } else {
-            true
-        },
-        file_scores: if any_section {
-            options.file_scores
-        } else {
-            true
-        } || force_full,
-        coverage_gaps: if any_section {
-            options.coverage_gaps
-        } else {
-            false
-        },
-        hotspots: if any_section { options.hotspots } else { true }
-            || options.snapshot_requested
-            || options.trend,
-        targets: if any_section { options.targets } else { true },
-        css: options.css,
-        score: effective_score,
-        force_full,
-        score_only_output: is_health_score_only_output(options, score),
-    }
-}
-
-fn is_health_score_only_output(options: &HealthSectionOptions, score: bool) -> bool {
-    score
-        && !options.complexity
-        && !options.file_scores
-        && !options.coverage_gaps
-        && !options.hotspots
-        && !options.targets
-        && !options.trend
 }
 
 /// Derive effective programmatic health / complexity section flags.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5595,7 +5595,7 @@ fn dispatch_health(dispatch: &DispatchContext<'_>, args: HealthDispatchArgs<'_>)
         return code;
     }
     let targets = args.targets || args.effort.is_some();
-    let sections = fallow_api::derive_health_sections(&fallow_api::HealthSectionOptions {
+    let sections = fallow_engine::derive_health_sections(&fallow_engine::HealthSectionOptions {
         output,
         complexity: args.complexity,
         file_scores: args.file_scores,
@@ -5645,7 +5645,7 @@ fn dispatch_health(dispatch: &DispatchContext<'_>, args: HealthDispatchArgs<'_>)
 /// builder. Borrows the section flags and coverage inputs; owns the resolved
 /// runtime-coverage options.
 struct ResolvedHealthDispatch<'a> {
-    sections: &'a fallow_api::DerivedHealthSections,
+    sections: &'a fallow_engine::DerivedHealthSections,
     runtime_coverage: Option<fallow_engine::RuntimeCoverageOptions>,
     production: bool,
     coverage_inputs: &'a ResolvedHealthCoverageInputs,

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use fallow_config::ResolvedConfig;
+use fallow_config::{OutputFormat, ResolvedConfig};
 use fallow_output::{
     FindingSeverity, HealthGrouping, HealthReport, HealthTimings, RuntimeCoverageWatermark,
 };
@@ -43,6 +43,91 @@ pub struct HealthGateOptions {
     pub min_severity: Option<FindingSeverity>,
     /// Render the score and findings but never fail CI on a health gate.
     pub report_only: bool,
+}
+
+/// Input for deriving effective health sections from command-neutral flags.
+#[derive(Debug, Clone)]
+pub struct HealthSectionOptions {
+    pub output: OutputFormat,
+    pub complexity: bool,
+    pub file_scores: bool,
+    pub coverage_gaps: bool,
+    pub hotspots: bool,
+    pub targets: bool,
+    pub css: bool,
+    pub score: bool,
+    pub score_gate: bool,
+    pub snapshot_requested: bool,
+    pub trend: bool,
+}
+
+/// Derived section selection for health runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DerivedHealthSections {
+    pub any_section: bool,
+    pub complexity: bool,
+    pub file_scores: bool,
+    pub coverage_gaps: bool,
+    pub hotspots: bool,
+    pub targets: bool,
+    pub css: bool,
+    pub score: bool,
+    pub force_full: bool,
+    pub score_only_output: bool,
+}
+
+/// Derive effective health section flags for CLI and embedders.
+#[must_use]
+pub fn derive_health_sections(options: &HealthSectionOptions) -> DerivedHealthSections {
+    let score = options.score
+        || options.score_gate
+        || options.trend
+        || matches!(options.output, OutputFormat::Badge);
+    let any_section = options.complexity
+        || options.file_scores
+        || options.coverage_gaps
+        || options.hotspots
+        || options.targets
+        || score;
+    let effective_score = if any_section { score } else { true } || options.snapshot_requested;
+    let force_full = options.snapshot_requested || effective_score;
+
+    DerivedHealthSections {
+        any_section,
+        complexity: if any_section {
+            options.complexity
+        } else {
+            true
+        },
+        file_scores: if any_section {
+            options.file_scores
+        } else {
+            true
+        } || force_full,
+        coverage_gaps: if any_section {
+            options.coverage_gaps
+        } else {
+            false
+        },
+        hotspots: if any_section { options.hotspots } else { true }
+            || options.snapshot_requested
+            || options.trend,
+        targets: if any_section { options.targets } else { true },
+        css: options.css,
+        score: effective_score,
+        force_full,
+        score_only_output: is_health_score_only_output(options, score),
+    }
+}
+
+fn is_health_score_only_output(options: &HealthSectionOptions, score: bool) -> bool {
+    score
+        && !options.complexity
+        && !options.file_scores
+        && !options.coverage_gaps
+        && !options.hotspots
+        && !options.targets
+        && !options.trend
 }
 
 /// Command-neutral runtime coverage input for health analysis.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -67,8 +67,9 @@ pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
 pub use health::{
-    HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions, HealthSharedParseData,
-    HealthSort, HealthThresholdOverrides, RuntimeCoverageOptions,
+    DerivedHealthSections, HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions,
+    HealthSectionOptions, HealthSharedParseData, HealthSort, HealthThresholdOverrides,
+    RuntimeCoverageOptions, derive_health_sections,
 };
 
 /// Result alias for typed engine operations.


### PR DESCRIPTION
## Summary
- move HealthSectionOptions, DerivedHealthSections, and derive_health_sections into fallow-engine
- keep fallow-api compatibility by re-exporting the engine-owned contracts
- update CLI health dispatch to derive section defaults through fallow-engine directly

## Validation
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node
- [x] cargo test -p fallow-api health_sections --lib
- [x] cargo test -p fallow-cli health --lib
- [x] cargo clippy -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings
- [x] git diff --check