### PR TITLE
refactor: move complexity section contracts to engine

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -252,55 +252,26 @@ pub struct ComplexityOptions {
     pub coverage_root: Option<PathBuf>,
 }
 
-pub use fallow_engine::{DerivedHealthSections, HealthSectionOptions, derive_health_sections};
-
-/// Derived section selection for programmatic health / complexity runs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DerivedComplexityOptions {
-    pub any_section: bool,
-    pub complexity: bool,
-    pub file_scores: bool,
-    pub coverage_gaps: bool,
-    pub hotspots: bool,
-    pub ownership: bool,
-    pub targets: bool,
-    pub force_full: bool,
-    pub score_only_output: bool,
-    pub score: bool,
-}
+pub use fallow_engine::{
+    ComplexitySectionOptions, DerivedComplexityOptions, DerivedHealthSections,
+    HealthSectionOptions, derive_complexity_sections, derive_health_sections,
+};
 
 /// Derive effective programmatic health / complexity section flags.
 #[must_use]
 pub fn derive_complexity_options(options: &ComplexityOptions) -> DerivedComplexityOptions {
     let ownership = options.ownership || options.ownership_emails.is_some();
-    let requested_hotspots = options.hotspots || ownership;
     let requested_targets = options.targets || options.effort.is_some();
-    let sections = derive_health_sections(&HealthSectionOptions {
-        output: fallow_config::OutputFormat::Human,
+    derive_complexity_sections(&ComplexitySectionOptions {
         complexity: options.complexity,
         file_scores: options.file_scores,
         coverage_gaps: options.coverage_gaps,
-        hotspots: requested_hotspots,
+        hotspots: options.hotspots,
+        ownership,
         targets: requested_targets,
         css: options.css,
         score: options.score,
-        score_gate: false,
-        snapshot_requested: false,
-        trend: false,
-    });
-
-    DerivedComplexityOptions {
-        any_section: sections.any_section,
-        complexity: sections.complexity,
-        file_scores: sections.file_scores,
-        coverage_gaps: sections.coverage_gaps,
-        hotspots: sections.hotspots,
-        ownership: ownership && sections.hotspots,
-        targets: sections.targets,
-        force_full: sections.force_full,
-        score_only_output: sections.score_only_output,
-        score: sections.score,
-    }
+    })
 }
 
 #[cfg(test)]

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -130,6 +130,66 @@ fn is_health_score_only_output(options: &HealthSectionOptions, score: bool) -> b
         && !options.trend
 }
 
+/// Input for deriving effective programmatic complexity sections.
+#[derive(Debug, Clone)]
+pub struct ComplexitySectionOptions {
+    pub complexity: bool,
+    pub file_scores: bool,
+    pub coverage_gaps: bool,
+    pub hotspots: bool,
+    pub ownership: bool,
+    pub targets: bool,
+    pub css: bool,
+    pub score: bool,
+}
+
+/// Derived section selection for programmatic health / complexity runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DerivedComplexityOptions {
+    pub any_section: bool,
+    pub complexity: bool,
+    pub file_scores: bool,
+    pub coverage_gaps: bool,
+    pub hotspots: bool,
+    pub ownership: bool,
+    pub targets: bool,
+    pub force_full: bool,
+    pub score_only_output: bool,
+    pub score: bool,
+}
+
+/// Derive effective programmatic health / complexity section flags.
+#[must_use]
+pub fn derive_complexity_sections(options: &ComplexitySectionOptions) -> DerivedComplexityOptions {
+    let requested_hotspots = options.hotspots || options.ownership;
+    let sections = derive_health_sections(&HealthSectionOptions {
+        output: OutputFormat::Human,
+        complexity: options.complexity,
+        file_scores: options.file_scores,
+        coverage_gaps: options.coverage_gaps,
+        hotspots: requested_hotspots,
+        targets: options.targets,
+        css: options.css,
+        score: options.score,
+        score_gate: false,
+        snapshot_requested: false,
+        trend: false,
+    });
+
+    DerivedComplexityOptions {
+        any_section: sections.any_section,
+        complexity: sections.complexity,
+        file_scores: sections.file_scores,
+        coverage_gaps: sections.coverage_gaps,
+        hotspots: sections.hotspots,
+        ownership: options.ownership && sections.hotspots,
+        targets: sections.targets,
+        force_full: sections.force_full,
+        score_only_output: sections.score_only_output,
+        score: sections.score,
+    }
+}
+
 /// Command-neutral runtime coverage input for health analysis.
 #[derive(Debug, Clone)]
 pub struct RuntimeCoverageOptions {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -67,9 +67,10 @@ pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
 pub use health::{
-    DerivedHealthSections, HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions,
-    HealthSectionOptions, HealthSharedParseData, HealthSort, HealthThresholdOverrides,
-    RuntimeCoverageOptions, derive_health_sections,
+    ComplexitySectionOptions, DerivedComplexityOptions, DerivedHealthSections,
+    HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions, HealthSectionOptions,
+    HealthSharedParseData, HealthSort, HealthThresholdOverrides, RuntimeCoverageOptions,
+    derive_complexity_sections, derive_health_sections,
 };
 
 /// Result alias for typed engine operations.


### PR DESCRIPTION
## Summary
- add engine-owned ComplexitySectionOptions and DerivedComplexityOptions
- move programmatic complexity section derivation into fallow-engine
- keep fallow-api compatibility by translating public ComplexityOptions into the engine contract

## Validation
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node
- [x] cargo test -p fallow-api complexity_options --lib
- [x] cargo test -p fallow-cli health --lib
- [x] cargo clippy -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings
- [x] git diff --check