### PR TITLE
refactor: normalize complexity run options through engine

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -14,6 +14,8 @@
 
 use std::path::PathBuf;
 
+use fallow_config::EmailMode;
+use fallow_output::EffortEstimate;
 use serde::Serialize;
 
 pub mod dupes_output;
@@ -253,16 +255,45 @@ pub struct ComplexityOptions {
 }
 
 pub use fallow_engine::{
-    ComplexitySectionOptions, DerivedComplexityOptions, DerivedHealthSections,
-    HealthSectionOptions, derive_complexity_sections, derive_health_sections,
+    ComplexityRunOptions, ComplexitySectionOptions, DerivedComplexityOptions,
+    DerivedHealthSections, HealthSectionOptions, derive_complexity_sections,
+    derive_health_sections,
 };
 
 /// Derive effective programmatic health / complexity section flags.
 #[must_use]
 pub fn derive_complexity_options(options: &ComplexityOptions) -> DerivedComplexityOptions {
+    derive_complexity_sections(&complexity_section_options(options))
+}
+
+/// Normalize public API complexity options into engine-owned run contracts.
+#[must_use]
+pub fn derive_complexity_run_options(options: &ComplexityOptions) -> ComplexityRunOptions<'_> {
+    ComplexityRunOptions {
+        thresholds: fallow_engine::HealthThresholdOverrides {
+            max_cyclomatic: options.max_cyclomatic,
+            max_cognitive: options.max_cognitive,
+            max_crap: options.max_crap,
+        },
+        top: options.top,
+        sort: complexity_sort_to_engine(options.sort),
+        sections: derive_complexity_options(options),
+        ownership_emails: options.ownership_emails.map(ownership_email_mode_to_config),
+        effort: options.effort.map(target_effort_to_output),
+        css: options.css,
+        since: options.since.as_deref(),
+        min_commits: options.min_commits,
+        coverage_inputs: fallow_engine::HealthCoverageInputs {
+            coverage: options.coverage.as_deref(),
+            coverage_root: options.coverage_root.as_deref(),
+        },
+    }
+}
+
+fn complexity_section_options(options: &ComplexityOptions) -> ComplexitySectionOptions {
     let ownership = options.ownership || options.ownership_emails.is_some();
     let requested_targets = options.targets || options.effort.is_some();
-    derive_complexity_sections(&ComplexitySectionOptions {
+    ComplexitySectionOptions {
         complexity: options.complexity,
         file_scores: options.file_scores,
         coverage_gaps: options.coverage_gaps,
@@ -271,7 +302,33 @@ pub fn derive_complexity_options(options: &ComplexityOptions) -> DerivedComplexi
         targets: requested_targets,
         css: options.css,
         score: options.score,
-    })
+    }
+}
+
+const fn complexity_sort_to_engine(sort: ComplexitySort) -> fallow_engine::HealthSort {
+    match sort {
+        ComplexitySort::Severity => fallow_engine::HealthSort::Severity,
+        ComplexitySort::Cyclomatic => fallow_engine::HealthSort::Cyclomatic,
+        ComplexitySort::Cognitive => fallow_engine::HealthSort::Cognitive,
+        ComplexitySort::Lines => fallow_engine::HealthSort::Lines,
+    }
+}
+
+const fn ownership_email_mode_to_config(mode: OwnershipEmailMode) -> EmailMode {
+    match mode {
+        OwnershipEmailMode::Raw => EmailMode::Raw,
+        OwnershipEmailMode::Handle => EmailMode::Handle,
+        OwnershipEmailMode::Anonymized => EmailMode::Anonymized,
+        OwnershipEmailMode::Hash => EmailMode::Hash,
+    }
+}
+
+const fn target_effort_to_output(effort: TargetEffort) -> EffortEstimate {
+    match effort {
+        TargetEffort::Low => EffortEstimate::Low,
+        TargetEffort::Medium => EffortEstimate::Medium,
+        TargetEffort::High => EffortEstimate::High,
+    }
 }
 
 #[cfg(test)]
@@ -345,6 +402,50 @@ mod tests {
         assert!(derived.hotspots);
         assert!(derived.ownership);
         assert!(!derived.targets);
+    }
+
+    #[test]
+    fn complexity_run_options_normalize_public_api_options() {
+        let options = ComplexityOptions {
+            max_cyclomatic: Some(42),
+            max_cognitive: Some(21),
+            max_crap: Some(18.5),
+            top: Some(7),
+            sort: ComplexitySort::Severity,
+            ownership_emails: Some(OwnershipEmailMode::Hash),
+            effort: Some(TargetEffort::High),
+            coverage: Some(PathBuf::from("coverage/coverage-final.json")),
+            coverage_root: Some(PathBuf::from("/ci/workspace")),
+            since: Some("30d".to_string()),
+            min_commits: Some(4),
+            ..ComplexityOptions::default()
+        };
+
+        let run = derive_complexity_run_options(&options);
+
+        assert_eq!(run.thresholds.max_cyclomatic, Some(42));
+        assert_eq!(run.thresholds.max_cognitive, Some(21));
+        assert_eq!(run.thresholds.max_crap, Some(18.5));
+        assert_eq!(run.top, Some(7));
+        assert!(matches!(run.sort, fallow_engine::HealthSort::Severity));
+        assert!(run.sections.hotspots);
+        assert!(run.sections.ownership);
+        assert!(run.sections.targets);
+        assert!(matches!(
+            run.ownership_emails,
+            Some(fallow_config::EmailMode::Hash)
+        ));
+        assert!(matches!(
+            run.effort,
+            Some(fallow_output::EffortEstimate::High)
+        ));
+        assert_eq!(run.since, Some("30d"));
+        assert_eq!(run.min_commits, Some(4));
+        assert_eq!(run.coverage_inputs.coverage, options.coverage.as_deref());
+        assert_eq!(
+            run.coverage_inputs.coverage_root,
+            options.coverage_root.as_deref()
+        );
     }
 
     #[test]

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -1,19 +1,18 @@
 use std::path::{Path, PathBuf};
 
-use fallow_config::{EmailMode, OutputFormat};
+use fallow_config::OutputFormat;
 use fallow_core::results::AnalysisResults;
 
 use crate::check::{CheckOptions, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions};
 use crate::health::HealthOptions;
-use crate::health_types::EffortEstimate;
 use crate::report::ci::diff_filter::{DiffIndex, LoadedDiff, MAX_DIFF_BYTES};
 use crate::report::{build_duplication_json, build_health_json};
 
 pub use fallow_api::{
     AnalysisOptions, COMMON_ANALYSIS_OPTION_FLAGS, ComplexityOptions, ComplexitySort,
     DeadCodeFilters, DeadCodeOptions, DuplicationMode, DuplicationOptions, OwnershipEmailMode,
-    ProgrammaticError, TargetEffort, derive_complexity_options,
+    ProgrammaticError, TargetEffort, derive_complexity_options, derive_complexity_run_options,
 };
 
 type ProgrammaticResult<T> = Result<T, ProgrammaticError>;
@@ -24,32 +23,6 @@ const fn duplication_mode_to_cli(mode: DuplicationMode) -> DupesMode {
         DuplicationMode::Mild => DupesMode::Mild,
         DuplicationMode::Weak => DupesMode::Weak,
         DuplicationMode::Semantic => DupesMode::Semantic,
-    }
-}
-
-const fn complexity_sort_to_engine(sort: ComplexitySort) -> fallow_engine::HealthSort {
-    match sort {
-        ComplexitySort::Severity => fallow_engine::HealthSort::Severity,
-        ComplexitySort::Cyclomatic => fallow_engine::HealthSort::Cyclomatic,
-        ComplexitySort::Cognitive => fallow_engine::HealthSort::Cognitive,
-        ComplexitySort::Lines => fallow_engine::HealthSort::Lines,
-    }
-}
-
-const fn ownership_email_mode_to_config(mode: OwnershipEmailMode) -> EmailMode {
-    match mode {
-        OwnershipEmailMode::Raw => EmailMode::Raw,
-        OwnershipEmailMode::Handle => EmailMode::Handle,
-        OwnershipEmailMode::Anonymized => EmailMode::Anonymized,
-        OwnershipEmailMode::Hash => EmailMode::Hash,
-    }
-}
-
-const fn target_effort_to_cli(effort: TargetEffort) -> EffortEstimate {
-    match effort {
-        TargetEffort::Low => EffortEstimate::Low,
-        TargetEffort::Medium => EffortEstimate::Medium,
-        TargetEffort::High => EffortEstimate::High,
     }
 }
 
@@ -623,7 +596,7 @@ fn build_complexity_options<'a>(
     resolved: &'a ResolvedAnalysisOptions,
     options: &'a ComplexityOptions,
 ) -> HealthOptions<'a> {
-    let state = derive_complexity_options(options);
+    let run = derive_complexity_run_options(options);
 
     HealthOptions {
         root: &resolved.root,
@@ -632,13 +605,9 @@ fn build_complexity_options<'a>(
         no_cache: resolved.no_cache,
         threads: resolved.threads,
         quiet: true,
-        thresholds: fallow_engine::HealthThresholdOverrides {
-            max_cyclomatic: options.max_cyclomatic,
-            max_cognitive: options.max_cognitive,
-            max_crap: options.max_crap,
-        },
-        top: options.top,
-        sort: complexity_sort_to_engine(options.sort),
+        thresholds: run.thresholds,
+        top: run.top,
+        sort: run.sort,
         production: resolved.production_override.unwrap_or(false),
         production_override: resolved.production_override,
         changed_since: resolved.changed_since.as_deref(),
@@ -648,33 +617,30 @@ fn build_complexity_options<'a>(
         changed_workspaces: resolved.changed_workspaces.as_deref(),
         baseline: None,
         save_baseline: None,
-        complexity: state.complexity,
+        complexity: run.sections.complexity,
         complexity_breakdown: false,
-        file_scores: state.file_scores,
-        coverage_gaps: state.coverage_gaps,
-        config_activates_coverage_gaps: !state.any_section,
-        hotspots: state.hotspots,
-        ownership: state.ownership,
-        ownership_emails: options.ownership_emails.map(ownership_email_mode_to_config),
-        targets: state.targets,
-        css: options.css,
-        force_full: state.force_full,
-        score_only_output: state.score_only_output,
+        file_scores: run.sections.file_scores,
+        coverage_gaps: run.sections.coverage_gaps,
+        config_activates_coverage_gaps: !run.sections.any_section,
+        hotspots: run.sections.hotspots,
+        ownership: run.sections.ownership,
+        ownership_emails: run.ownership_emails,
+        targets: run.sections.targets,
+        css: run.css,
+        force_full: run.sections.force_full,
+        score_only_output: run.sections.score_only_output,
         enforce_coverage_gap_gate: true,
-        effort: options.effort.map(target_effort_to_cli),
-        score: state.score,
+        effort: run.effort,
+        score: run.sections.score,
         gates: fallow_engine::HealthGateOptions::default(),
-        since: options.since.as_deref(),
-        min_commits: options.min_commits,
+        since: run.since,
+        min_commits: run.min_commits,
         explain: resolved.explain,
         summary: false,
         save_snapshot: None,
         trend: false,
         group_by: None,
-        coverage_inputs: fallow_engine::HealthCoverageInputs {
-            coverage: options.coverage.as_deref(),
-            coverage_root: options.coverage_root.as_deref(),
-        },
+        coverage_inputs: run.coverage_inputs,
         performance: false,
         runtime_coverage: None,
         // The programmatic facade has no churn-file knob; embedders that want

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -3,9 +3,10 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use fallow_config::{OutputFormat, ResolvedConfig};
+use fallow_config::{EmailMode, OutputFormat, ResolvedConfig};
 use fallow_output::{
-    FindingSeverity, HealthGrouping, HealthReport, HealthTimings, RuntimeCoverageWatermark,
+    EffortEstimate, FindingSeverity, HealthGrouping, HealthReport, HealthTimings,
+    RuntimeCoverageWatermark,
 };
 
 /// Command-neutral sort criteria for health complexity findings.
@@ -188,6 +189,22 @@ pub fn derive_complexity_sections(options: &ComplexitySectionOptions) -> Derived
         score_only_output: sections.score_only_output,
         score: sections.score,
     }
+}
+
+/// Normalized programmatic complexity / health inputs shared by API, NAPI, and
+/// the CLI-backed runner during the engine migration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComplexityRunOptions<'a> {
+    pub thresholds: HealthThresholdOverrides,
+    pub top: Option<usize>,
+    pub sort: HealthSort,
+    pub sections: DerivedComplexityOptions,
+    pub ownership_emails: Option<EmailMode>,
+    pub effort: Option<EffortEstimate>,
+    pub css: bool,
+    pub since: Option<&'a str>,
+    pub min_commits: Option<u32>,
+    pub coverage_inputs: HealthCoverageInputs<'a>,
 }
 
 /// Command-neutral runtime coverage input for health analysis.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -67,10 +67,10 @@ pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
 pub use health::{
-    ComplexitySectionOptions, DerivedComplexityOptions, DerivedHealthSections,
-    HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions, HealthSectionOptions,
-    HealthSharedParseData, HealthSort, HealthThresholdOverrides, RuntimeCoverageOptions,
-    derive_complexity_sections, derive_health_sections,
+    ComplexityRunOptions, ComplexitySectionOptions, DerivedComplexityOptions,
+    DerivedHealthSections, HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions,
+    HealthSectionOptions, HealthSharedParseData, HealthSort, HealthThresholdOverrides,
+    RuntimeCoverageOptions, derive_complexity_sections, derive_health_sections,
 };
 
 /// Result alias for typed engine operations.


### PR DESCRIPTION
## Summary
- add engine-owned ComplexityRunOptions for normalized programmatic health inputs
- move threshold, sort, ownership email, effort, section, and coverage normalization into fallow-api plus engine contracts
- simplify the CLI-backed programmatic health runner to consume the normalized engine run options while keeping public reexports intact

## Validation
- [x] cargo fmt --all -- --check
- [x] cargo check -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node
- [x] cargo test -p fallow-api complexity_run_options --lib
- [x] cargo test -p fallow-cli programmatic --lib
- [x] cargo clippy -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings
- [x] git diff --check