### PR TITLE
refactor: move complexity input validation to api boundary

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -290,6 +290,39 @@ pub fn derive_complexity_run_options(options: &ComplexityOptions) -> ComplexityR
     }
 }
 
+/// Validate programmatic complexity / health inputs before invoking a concrete
+/// runner.
+///
+/// The runner still lives in `fallow-cli` during the migration, but these
+/// option contracts belong to the API boundary because NAPI and future Rust
+/// embedders construct the same [`ComplexityOptions`] type.
+///
+/// # Errors
+///
+/// Returns a structured programmatic error when a coverage path does not exist
+/// or when `coverage_root` is not an absolute prefix from the coverage data.
+pub fn validate_complexity_options(options: &ComplexityOptions) -> Result<(), ProgrammaticError> {
+    if let Some(path) = &options.coverage
+        && !path.exists()
+    {
+        return Err(ProgrammaticError::new(
+            format!("coverage path does not exist: {}", path.display()),
+            2,
+        )
+        .with_code("FALLOW_INVALID_COVERAGE_PATH")
+        .with_context("health.coverage"));
+    }
+    if let Err(message) =
+        fallow_engine::validate_coverage_root_absolute(options.coverage_root.as_deref())
+    {
+        return Err(ProgrammaticError::new(message, 2)
+            .with_code("FALLOW_INVALID_COVERAGE_ROOT")
+            .with_context("health.coverage_root"));
+    }
+
+    Ok(())
+}
+
 fn complexity_section_options(options: &ComplexityOptions) -> ComplexitySectionOptions {
     let ownership = options.ownership || options.ownership_emails.is_some();
     let requested_targets = options.targets || options.effort.is_some();
@@ -446,6 +479,47 @@ mod tests {
             run.coverage_inputs.coverage_root,
             options.coverage_root.as_deref()
         );
+    }
+
+    #[test]
+    fn complexity_options_validation_accepts_existing_coverage_path_and_absolute_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let coverage = dir.path().join("coverage-final.json");
+        std::fs::write(&coverage, "{}").expect("coverage fixture");
+
+        let result = validate_complexity_options(&ComplexityOptions {
+            coverage: Some(coverage),
+            coverage_root: Some(PathBuf::from("/ci/workspace")),
+            ..ComplexityOptions::default()
+        });
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn complexity_options_validation_keeps_missing_coverage_error_contract() {
+        let err = validate_complexity_options(&ComplexityOptions {
+            coverage: Some(PathBuf::from("/missing/coverage-final.json")),
+            ..ComplexityOptions::default()
+        })
+        .expect_err("missing coverage path should fail");
+
+        assert_eq!(err.exit_code, 2);
+        assert_eq!(err.code.as_deref(), Some("FALLOW_INVALID_COVERAGE_PATH"));
+        assert_eq!(err.context.as_deref(), Some("health.coverage"));
+    }
+
+    #[test]
+    fn complexity_options_validation_keeps_relative_coverage_root_error_contract() {
+        let err = validate_complexity_options(&ComplexityOptions {
+            coverage_root: Some(PathBuf::from("coverage")),
+            ..ComplexityOptions::default()
+        })
+        .expect_err("relative coverage root should fail");
+
+        assert_eq!(err.exit_code, 2);
+        assert_eq!(err.code.as_deref(), Some("FALLOW_INVALID_COVERAGE_ROOT"));
+        assert_eq!(err.context.as_deref(), Some("health.coverage_root"));
     }
 
     #[test]

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -2629,7 +2629,7 @@ pub use output::{
 /// clears. The marker only affects the local Impact store; it never changes
 /// the verdict, exit code, or output.
 pub fn run_audit(opts: &AuditOptions<'_>, gate_marker: Option<&str>) -> ExitCode {
-    if let Err(e) = crate::health::scoring::validate_coverage_root_absolute(opts.coverage_root) {
+    if let Err(e) = fallow_engine::validate_coverage_root_absolute(opts.coverage_root) {
         return emit_error(&e, 2, opts.output);
     }
     let coverage_resolved = opts

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -202,7 +202,7 @@ pub fn execute_health_with_shared_parse(
     opts: &HealthOptions<'_>,
     shared: HealthSharedParseData,
 ) -> Result<HealthResult, ExitCode> {
-    scoring::validate_coverage_root_absolute(opts.coverage_inputs.coverage_root)
+    fallow_engine::validate_coverage_root_absolute(opts.coverage_inputs.coverage_root)
         .map_err(|e| emit_error(&e, 2, opts.output))?;
     validate_churn_file(opts)?;
     let t = Instant::now();
@@ -240,7 +240,7 @@ pub fn execute_health_with_shared_parse(
 }
 
 pub fn execute_health(opts: &HealthOptions<'_>) -> Result<HealthResult, ExitCode> {
-    scoring::validate_coverage_root_absolute(opts.coverage_inputs.coverage_root)
+    fallow_engine::validate_coverage_root_absolute(opts.coverage_inputs.coverage_root)
         .map_err(|e| emit_error(&e, 2, opts.output))?;
     validate_churn_file(opts)?;
     let t = Instant::now();

--- a/crates/cli/src/health/scoring.rs
+++ b/crates/cli/src/health/scoring.rs
@@ -899,20 +899,6 @@ pub fn resolve_relative_to_root(
     }
 }
 
-pub fn validate_coverage_root_absolute(
-    coverage_root: Option<&std::path::Path>,
-) -> Result<(), String> {
-    if let Some(path) = coverage_root
-        && !path.has_root()
-    {
-        return Err(format!(
-            "--coverage-root expects an absolute path prefix from the coverage data, got '{}'. Use the checkout prefix from the machine that generated coverage, for example '/home/runner/work/myapp'.",
-            path.display()
-        ));
-    }
-    Ok(())
-}
-
 /// If `path` is a directory, looks for `coverage-final.json` inside it.
 /// Parses the Istanbul JSON format and pre-computes per-function statement
 /// coverage percentages for efficient lookup during CRAP scoring.
@@ -929,7 +915,7 @@ pub(super) fn load_istanbul_coverage(
     coverage_root: Option<&std::path::Path>,
     project_root: Option<&std::path::Path>,
 ) -> Result<IstanbulCoverage, String> {
-    validate_coverage_root_absolute(coverage_root)?;
+    fallow_engine::validate_coverage_root_absolute(coverage_root)?;
     let resolved = resolve_relative_to_root(path, project_root);
     let file_path = if resolved.is_dir() {
         let candidate = resolved.join("coverage-final.json");
@@ -4778,52 +4764,5 @@ mod tests {
         let (max, above) = compute_crap_scores_binary(&funcs, false);
         assert!((max - 72.0).abs() < f64::EPSILON);
         assert_eq!(above, 1);
-    }
-
-    #[test]
-    fn validate_coverage_root_accepts_posix_absolute() {
-        assert!(
-            validate_coverage_root_absolute(Some(std::path::Path::new("/ci/workspace"))).is_ok()
-        );
-        assert!(
-            validate_coverage_root_absolute(Some(std::path::Path::new("/home/runner/work/myapp")))
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn validate_coverage_root_rejects_truly_relative() {
-        assert!(validate_coverage_root_absolute(Some(std::path::Path::new("src"))).is_err());
-        assert!(validate_coverage_root_absolute(Some(std::path::Path::new("./coverage"))).is_err());
-        assert!(validate_coverage_root_absolute(Some(std::path::Path::new("a/b/c"))).is_err());
-    }
-
-    #[test]
-    fn validate_coverage_root_accepts_none() {
-        assert!(validate_coverage_root_absolute(None).is_ok());
-    }
-
-    /// Regression for issue #561: `Path::is_absolute` on Windows requires a
-    /// drive letter, so a POSIX-style `--coverage-root /ci/workspace` (the
-    /// shape Linux-CI-generated Istanbul data uses) was rejected with exit 2
-    /// when fallow ran on Windows. The prefix-strip in `load_istanbul_coverage`
-    /// is component-wise and works on root-anchored POSIX paths regardless of
-    /// host OS, so the validator must accept `has_root` rather than
-    /// `is_absolute`.
-    #[cfg(windows)]
-    #[test]
-    fn validate_coverage_root_accepts_posix_absolute_on_windows() {
-        assert!(
-            validate_coverage_root_absolute(Some(std::path::Path::new(r"/ci/workspace"))).is_ok(),
-            "POSIX-absolute prefix must be accepted on Windows: coverage data from Linux CI uses this exact shape"
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn validate_coverage_root_accepts_windows_absolute() {
-        assert!(
-            validate_coverage_root_absolute(Some(std::path::Path::new(r"C:\ci\workspace"))).is_ok()
-        );
     }
 }

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -652,23 +652,7 @@ fn build_complexity_options<'a>(
 /// Run the health / complexity analysis and return the CLI JSON contract as a value.
 pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<serde_json::Value> {
     let resolved = resolve_analysis_options(&options.analysis)?;
-    if let Some(path) = &options.coverage
-        && !path.exists()
-    {
-        return Err(ProgrammaticError::new(
-            format!("coverage path does not exist: {}", path.display()),
-            2,
-        )
-        .with_code("FALLOW_INVALID_COVERAGE_PATH")
-        .with_context("health.coverage"));
-    }
-    if let Err(message) =
-        crate::health::scoring::validate_coverage_root_absolute(options.coverage_root.as_deref())
-    {
-        return Err(ProgrammaticError::new(message, 2)
-            .with_code("FALLOW_INVALID_COVERAGE_ROOT")
-            .with_context("health.coverage_root"));
-    }
+    fallow_api::validate_complexity_options(options)?;
 
     resolved.install(|| {
         let health_options = build_complexity_options(&resolved, options);

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -8,6 +8,7 @@ use fallow_output::{
     EffortEstimate, FindingSeverity, HealthGrouping, HealthReport, HealthTimings,
     RuntimeCoverageWatermark,
 };
+use fallow_types::path_util::is_absolute_path_any_platform;
 
 /// Command-neutral sort criteria for health complexity findings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +36,24 @@ pub struct HealthCoverageInputs<'a> {
     /// Absolute coverage-path prefix to strip before rebasing files onto the
     /// project root.
     pub coverage_root: Option<&'a Path>,
+}
+
+/// Validate that a coverage-data root is absolute under Unix or Windows path
+/// conventions.
+///
+/// Istanbul coverage paths often come from a Linux CI runner even when fallow
+/// is invoked on another host, so POSIX-rooted paths and Windows drive paths
+/// are both accepted on every platform.
+pub fn validate_coverage_root_absolute(coverage_root: Option<&Path>) -> Result<(), String> {
+    if let Some(path) = coverage_root
+        && !is_absolute_path_any_platform(path)
+    {
+        return Err(format!(
+            "--coverage-root expects an absolute path prefix from the coverage data, got '{}'. Use the checkout prefix from the machine that generated coverage, for example '/home/runner/work/myapp'.",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 /// Command-neutral health exit gate options.
@@ -418,5 +437,30 @@ mod tests {
 
         assert!(run.sections.score);
         assert_eq!(run.gates.min_score, Some(90.0));
+    }
+
+    #[test]
+    fn coverage_root_accepts_posix_absolute() {
+        assert!(validate_coverage_root_absolute(Some(Path::new("/ci/workspace"))).is_ok());
+        assert!(
+            validate_coverage_root_absolute(Some(Path::new("/home/runner/work/myapp"))).is_ok()
+        );
+    }
+
+    #[test]
+    fn coverage_root_rejects_relative() {
+        assert!(validate_coverage_root_absolute(Some(Path::new("src"))).is_err());
+        assert!(validate_coverage_root_absolute(Some(Path::new("./coverage"))).is_err());
+        assert!(validate_coverage_root_absolute(Some(Path::new("a/b/c"))).is_err());
+    }
+
+    #[test]
+    fn coverage_root_accepts_none() {
+        assert!(validate_coverage_root_absolute(None).is_ok());
+    }
+
+    #[test]
+    fn coverage_root_accepts_windows_absolute_on_all_hosts() {
+        assert!(validate_coverage_root_absolute(Some(Path::new(r"C:\ci\workspace"))).is_ok());
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -71,7 +71,7 @@ pub use health::{
     DerivedHealthSections, HealthAnalysisResult, HealthCoverageInputs, HealthGateOptions,
     HealthRunOptions, HealthRunOptionsInput, HealthSectionOptions, HealthSharedParseData,
     HealthSort, HealthThresholdOverrides, RuntimeCoverageOptions, derive_complexity_sections,
-    derive_health_run_options, derive_health_sections,
+    derive_health_run_options, derive_health_sections, validate_coverage_root_absolute,
 };
 
 /// Result alias for typed engine operations.


### PR DESCRIPTION
## Summary
- Move command-neutral coverage-root validation to the engine boundary.
- Add API-owned programmatic complexity / health preflight validation.
- Keep the health runtime in CLI for this slice while reducing CLI-owned contract logic.

## Plan
- Local plan: `.plans/api-complexity-input-contract.md`

## Verification
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p fallow-engine coverage_root --lib`
- [x] `cargo test -p fallow-api complexity --lib`
- [x] `cargo test -p fallow-cli programmatic --lib`
- [x] `cargo test -p fallow-node compute_complexity --lib`
- [x] `cargo check -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node`
- [x] `cargo clippy -p fallow-engine -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] em dash scan on touched files
- [x] pre-commit fast guard
- [x] pre-push fast guard