### PR TITLE
fix(extract): match </template> close tag with interior whitespace

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -587,7 +587,12 @@ use crate::MemberKind;
 /// Bumped to 188: `HookUse` now carries the enclosing `component` name, so the
 /// descriptive per-component hook summary stays exact in multi-component files.
 /// A warm cache from 187 lacks the attribution field on persisted `hook_uses`.
-pub(super) const CACHE_VERSION: u32 = 188;
+///
+/// Bumped to 189 (issue #1439): the Vue SFC template scanner now recognizes a
+/// `</template >` close tag with interior whitespace, so a warm cache from 188
+/// that dropped such a template's body recorded too few template-credited
+/// `member_accesses` / prop uses and must be re-extracted.
+pub(super) const CACHE_VERSION: u32 = 189;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/sfc_template/vue.rs
+++ b/crates/extract/src/sfc_template/vue.rs
@@ -105,7 +105,7 @@ fn find_template_body_end(source: &str, body_start: usize) -> Option<usize> {
             && let Some((tag, next_index)) = scan_html_tag(source, index)
         {
             let trimmed = tag.trim();
-            if trimmed.eq_ignore_ascii_case("</template>") {
+            if is_template_close_tag(trimmed) {
                 depth -= 1;
                 if depth == 0 {
                     return Some(index);
@@ -135,6 +135,20 @@ fn is_template_open_tag(tag: &str) -> bool {
             .chars()
             .next()
             .is_none_or(|c| c.is_whitespace() || c == '>' || c == '/')
+}
+
+/// Whether `tag` (a full `<...>` tag string) is a `</template>` closing tag
+/// (case-insensitive), tolerating interior whitespace before `>` such as the
+/// `</template >` Prettier emits for slot blocks. Guards against `</templatefoo>`
+/// via the post-name remainder check.
+fn is_template_close_tag(tag: &str) -> bool {
+    let Some(rest) = tag.strip_prefix("</") else {
+        return false;
+    };
+    let Some(after) = rest.get(..8) else {
+        return false;
+    };
+    after.eq_ignore_ascii_case("template") && rest[8..].trim() == ">"
 }
 
 fn scan_template_body(
@@ -595,6 +609,54 @@ mod tests {
             assert!(
                 usage.used_bindings.contains(name),
                 "{name} should be credited across nested slot templates"
+            );
+        }
+    }
+
+    #[test]
+    fn closing_template_tag_with_interior_whitespace_is_matched() {
+        // Prettier emits `</template >` (space before `>`) for slot blocks. The
+        // root close must still be recognized so `find_template_body_end` does not
+        // return `None` and drop the whole body, falsely reporting every
+        // template-only binding unused. Regression for issue #1439.
+        for source in [
+            "<template><Content /></template >",
+            "<template><Content /></template\n>",
+        ] {
+            let usage = collect_template_usage(source, &imported(&["Content"]));
+            assert!(
+                usage.used_bindings.contains("Content"),
+                "component must stay credited when the root close tag has interior whitespace: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_slot_close_with_whitespace_does_not_truncate_root_body() {
+        // A `</template >` closing a nested slot must decrement depth like the
+        // exact form, so the trailing component after it stays credited.
+        let usage = collect_template_usage(
+            "<template><Header><template #logo>x</template ></Header><Content /></template >",
+            &imported(&["Header", "Content"]),
+        );
+        assert!(usage.used_bindings.contains("Header"));
+        assert!(usage.used_bindings.contains("Content"));
+    }
+
+    #[test]
+    fn whitespace_close_inside_comment_or_attribute_does_not_truncate() {
+        // A `</template >` appearing in an HTML comment or a quoted attribute must
+        // not be treated as the root close: comments are skipped and `scan_html_tag`
+        // is quote-aware, so the real close still ends the body and trailing
+        // bindings stay credited.
+        for source in [
+            "<template><!-- </template > --><Content /></template >",
+            "<template><div title=\"</template >\"></div><Content /></template >",
+        ] {
+            let usage = collect_template_usage(source, &imported(&["Content"]));
+            assert!(
+                usage.used_bindings.contains("Content"),
+                "spurious whitespace close must not truncate the body: {source:?}"
             );
         }
     }


### PR DESCRIPTION
## Problem

A Vue SFC whose root `</template>` close tag carries interior whitespace — `</template >` (Prettier emits this for slot blocks) — has its **entire template body dropped**, so every template-only prop/component usage is falsely reported as unused (`unused-component-prop`, `unrendered-component`, etc.).

## Root cause

`find_template_body_end` (`crates/extract/src/sfc_template/vue.rs`) matched the close tag with an exact-string compare:

```rust
if trimmed.eq_ignore_ascii_case("</template>") { depth -= 1; ... }
```

`scan_html_tag` preserves interior whitespace, so `</template >` never equals `</template>` → `depth` never reaches 0 → `find_template_body_end` returns `None` → the body is discarded.

## Fix

Match the close tag by parsed name via a new `is_template_close_tag` helper that strips `</`, checks the next 8 bytes are `template` (case-insensitive), and requires the remainder to trim to `>` — tolerating interior whitespace while still rejecting `</templatefoo>`. Mirrors the existing `is_template_open_tag` helper directly above it.

## Tests

Three regression tests: root close with space and newline (`</template >`, `</template\n>`); a nested slot close with whitespace (depth still decrements); and a guard that a `</template >` inside an HTML comment or quoted attribute does not truncate the body.

## Cache

`CACHE_VERSION` 188 → 189: template-usage crediting changes the extracted `member_accesses` / prop uses, so a warm cache from 188 that dropped such a body must re-extract.

`cargo fmt --check`, `clippy -D warnings`, and the full `fallow-extract` suite pass.

Closes #1439

> Note: the Glimmer `.gts`/`.gjs` path (`glimmer.rs` / `sfc_template/glimmer.rs`) uses the same exact-string `</template>` compare and would share this bug if its tooling emits interior whitespace — left out of scope here (different framework, no repro).
