### PR TITLE
fix(extract): credit inline useStore().member store access

### DIFF
--- a/crates/core/tests/integration_test/unused_store_members.rs
+++ b/crates/core/tests/integration_test/unused_store_members.rs
@@ -96,6 +96,33 @@ fn credits_consumed_store_members() {
 }
 
 #[test]
+fn credits_inline_store_call_members_and_flags_dead_ones() {
+    // Issue #1489 case 1: a member consumed only through an inline
+    // `useCounterStore().member` (no bound local) must be credited, while a
+    // genuinely unaccessed member on the same store still flags.
+    let root = fixture_path("pinia-inline-store-member");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let names: Vec<String> = store_members(&results, &root)
+        .into_iter()
+        .map(|(_, m)| m)
+        .collect();
+
+    for credited in ["count", "increment"] {
+        assert!(
+            !names.contains(&credited.to_string()),
+            "{credited} consumed via inline useCounterStore().{credited} must be credited: {names:?}"
+        );
+    }
+    for dead in ["deadState", "deadAction"] {
+        assert!(
+            names.contains(&dead.to_string()),
+            "{dead} is never accessed and should still flag: {names:?}"
+        );
+    }
+}
+
+#[test]
 fn abstains_on_whole_object_dynamic_and_map_helpers() {
     let root = fixture_path("pinia-store-members-abstain");
     let config = create_config(root.clone());

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -587,7 +587,12 @@ use crate::MemberKind;
 /// Bumped to 188: `HookUse` now carries the enclosing `component` name, so the
 /// descriptive per-component hook summary stays exact in multi-component files.
 /// A warm cache from 187 lacks the attribution field on persisted `hook_uses`.
-pub(super) const CACHE_VERSION: u32 = 188;
+///
+/// Bumped to 189 (issue #1489): an inline `useFooStore().member` receiver now
+/// emits a member access against the store factory, so a warm cache from 188
+/// lacks that credit and would surface the member as a false
+/// `unused-store-member`.
+pub(super) const CACHE_VERSION: u32 = 189;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -127,6 +127,66 @@ fn pinia_credits_inline_to_refs_store_members() {
 }
 
 #[test]
+fn pinia_credits_inline_store_call_member_access() {
+    // `useCounterStore().count` / `useCounterStore().increment()` with no bound
+    // local must credit the member on the store factory, mirroring the bound
+    // `const s = useCounterStore(); s.member` path. Regression for issue #1489
+    // case 1.
+    let info = parse(
+        "import { useCounterStore } from './counter'\nconst n = useCounterStore().count\nuseCounterStore().increment()\nvoid n",
+    );
+    let accesses = store_member_accesses(&info);
+    assert!(
+        accesses.contains(&("useCounterStore".to_string(), "count".to_string())),
+        "inline store call should credit a property read on the factory: {accesses:?}"
+    );
+    assert!(
+        accesses.contains(&("useCounterStore".to_string(), "increment".to_string())),
+        "inline store call should credit a method call on the factory: {accesses:?}"
+    );
+}
+
+#[test]
+fn pinia_credits_auto_imported_inline_store_call_member() {
+    // Nuxt auto-import: `useCounterStore` follows the `use<Name>Store` convention
+    // with no explicit import, so the inline path credits `.count` by name alone.
+    let info = parse("const n = useCounterStore().count\nvoid n");
+    let accesses = store_member_accesses(&info);
+    assert!(
+        accesses.contains(&("useCounterStore".to_string(), "count".to_string())),
+        "auto-imported inline store call should credit the member: {accesses:?}"
+    );
+}
+
+#[test]
+fn pinia_credits_inline_store_call_with_argument() {
+    // `useFooStore(pinia).count` (passing the pinia instance outside setup) is a
+    // valid inline form; the member must still be credited (parity with the bound
+    // `const s = useFooStore(pinia)` path).
+    let info = parse(
+        "import { useFooStore } from './store'\nimport { pinia } from './pinia'\nconst n = useFooStore(pinia).count\nvoid n",
+    );
+    let accesses = store_member_accesses(&info);
+    assert!(
+        accesses.contains(&("useFooStore".to_string(), "count".to_string())),
+        "inline store call with an argument should still credit the member: {accesses:?}"
+    );
+}
+
+#[test]
+fn inline_non_store_call_does_not_credit_member_on_import() {
+    // `makeThing().foo` on an imported NON-store name must NOT credit `makeThing.foo`:
+    // the inline path is gated on the `use*Store` convention, so an imported class
+    // or enum can never mask a real `unused-class-member` / `unused-enum-member`.
+    let info = parse("import { makeThing } from './lib'\nconst x = makeThing().foo\nvoid x");
+    let accesses = store_member_accesses(&info);
+    assert!(
+        !accesses.contains(&("makeThing".to_string(), "foo".to_string())),
+        "non-store inline call must not credit a member on the import: {accesses:?}"
+    );
+}
+
+#[test]
 fn pinia_credits_original_key_for_aliased_inline_store_to_refs_member() {
     let info = parse(
         "import { storeToRefs } from 'pinia'\nimport { useCounterStore } from './counter'\nconst { count: localCount } = storeToRefs(useCounterStore())\nvoid localCount",

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -4344,7 +4344,16 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 member: expr.property.name.to_string(),
             });
         }
-        if let Some(object_name) = static_member_object_name(&expr.object) {
+        if let Some(store_factory) = Self::inline_store_factory_receiver(&expr.object) {
+            // `useFooStore().member` with no bound local: the generic receiver
+            // name would be the inert `useFooStore()` string. Credit the member on
+            // the factory import directly, mirroring the bound
+            // `const s = useFooStore(); s.member` path (see `record_pinia_store`).
+            self.member_accesses.push(MemberAccess {
+                object: store_factory,
+                member: expr.property.name.to_string(),
+            });
+        } else if let Some(object_name) = static_member_object_name(&expr.object) {
             self.member_accesses.push(MemberAccess {
                 object: object_name,
                 member: expr.property.name.to_string(),
@@ -7496,6 +7505,28 @@ impl ModuleInfoExtractor {
     fn is_store_factory_call(&self, name: &str) -> bool {
         self.imports.iter().any(|i| i.local_name == name)
             || (name.starts_with("use") && name.ends_with("Store"))
+    }
+
+    /// For an inline `useFooStore().member` receiver (a store-factory call never
+    /// bound to a local), return the factory's name so the member is credited on
+    /// the store export directly; `None` otherwise, leaving the generic
+    /// `static_member_object_name` path untouched.
+    ///
+    /// Gated on the `use<Name>Store` naming convention, not the broader
+    /// `is_store_factory_call` (any import): without a bound local there is no
+    /// store-instance signal, so an inline non-store call like `makeThing().foo`
+    /// on an imported class must not credit `foo` and mask a real
+    /// `unused-class-member` (the analyzer credits by member name regardless of
+    /// kind). A non-conventional store alias is the documented bind-to-a-const case.
+    fn inline_store_factory_receiver(object: &Expression<'_>) -> Option<String> {
+        let Expression::CallExpression(call) = object else {
+            return None;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            return None;
+        };
+        let name = callee.name.as_str();
+        (name.starts_with("use") && name.ends_with("Store")).then(|| name.to_string())
     }
 
     fn store_name_from_refs_arg<'a>(&self, arg: &'a Argument<'_>) -> Option<&'a str> {

--- a/tests/fixtures/pinia-inline-store-member/package.json
+++ b/tests/fixtures/pinia-inline-store-member/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pinia-inline-store-member-fixture",
+  "version": "1.0.0",
+  "dependencies": { "pinia": "^2.1.0", "vue": "^3.4.0" }
+}

--- a/tests/fixtures/pinia-inline-store-member/src/main.ts
+++ b/tests/fixtures/pinia-inline-store-member/src/main.ts
@@ -1,0 +1,7 @@
+import { useCounterStore } from './stores/counter'
+
+// Inline `useStore().member` consumption with no bound local (issue #1489 case 1):
+// a property read and a method call directly on the store-factory call result.
+const n = useCounterStore().count
+useCounterStore().increment()
+void n

--- a/tests/fixtures/pinia-inline-store-member/src/stores/counter.ts
+++ b/tests/fixtures/pinia-inline-store-member/src/stores/counter.ts
@@ -1,0 +1,9 @@
+import { defineStore } from 'pinia'
+
+export const useCounterStore = defineStore('counter', {
+  state: () => ({ count: 0, deadState: 99 }),
+  actions: {
+    increment() { this.count++ },
+    deadAction() { return 0 },
+  },
+})

--- a/tests/fixtures/pinia-inline-store-member/tsconfig.json
+++ b/tests/fixtures/pinia-inline-store-member/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target": "ESNext", "module": "ESNext", "moduleResolution": "bundler", "strict": true } }


### PR DESCRIPTION
## Problem

A Pinia store member consumed **only** through an inline `useFooStore().member` (no variable bound to the store) was falsely reported as `unused-store-member`.

The bound form is already credited: `const s = useFooStore(); s.member` sets `binding_target_names[s] = useFooStore`, which the analyzer maps onto the store export's members. But an inline call receiver yielded the inert object name `useFooStore()` (from `static_member_object_name`), which matches no import/local, so the access was dropped.

## Fix

In `visit_static_member_expression`, before the generic `static_member_object_name` push, detect a store-factory call receiver via a new `inline_store_factory_receiver` and record `MemberAccess { object: <factory name>, member }` directly — mirroring the bound path so the analyzer credit fires identically. Covers property reads and method calls, with or without an argument (`useFooStore(pinia).x`).

The receiver is gated on the **`use<Name>Store` naming convention** rather than the broader any-import `is_store_factory_call`. Without a bound local there is no store-instance signal, so an inline non-store call such as `makeThing().foo` on an imported **class** must not credit `foo` and mask a real `unused-class-member` (the analyzer credits by member name regardless of kind). A class or enum can never match `use*Store`; an inline store call under a non-conventional alias is the documented bind-to-a-const case.

## Tests

Extract-level: imported factory (read + method call), Nuxt auto-imported `use*Store` (no import), argument form, and a negative asserting an imported non-store `makeThing().foo` is **not** credited. Integration: a new `pinia-inline-store-member` fixture where `count`/`increment` are consumed only inline (credited) while `deadState`/`deadAction` still flag.

## Cache

`CACHE_VERSION` 188 → 189: the emitted `member_accesses` change for files with inline store calls.

`cargo fmt --check`, `clippy -D warnings`, and the full `fallow-extract` + `fallow-core` integration suites pass.

Closes #1489 (case 1 — inline `useStore().member`).

> The typed-param case 2 (`props.store: ReturnType<typeof useStore>`) is type-driven and deferred; the bind-to-a-const workaround applies.
