### PR TITLE
refactor: bridge legacy sentinels to typed semantic facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -12,8 +12,8 @@ use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
-    LegacySemanticMemberAccess, SemanticFact, is_legacy_semantic_member_access_object,
-    is_legacy_semantic_whole_object_use, parse_legacy_semantic_member_access,
+    SemanticFact, is_legacy_semantic_member_access_object, is_legacy_semantic_whole_object_use,
+    legacy_member_access_to_semantic_fact,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -1342,11 +1342,11 @@ fn build_instance_export_targets(
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
         for access in instance_export_binding_accesses(resolved) {
-            let Some(target_keys) = local_to_export_keys.get(access.target_local) else {
+            let Some(target_keys) = local_to_export_keys.get(access.target_local.as_str()) else {
                 continue;
             };
 
-            let instance_key = ExportKey::new(resolved.file_id, access.export_name);
+            let instance_key = ExportKey::new(resolved.file_id, access.export_name.clone());
             let instance_targets = targets_by_instance.entry(instance_key).or_default();
             for target_key in target_keys {
                 for key in export_key_with_origins(graph, target_key) {
@@ -1359,32 +1359,28 @@ fn build_instance_export_targets(
     targets_by_instance
 }
 
-struct InstanceExportBindingAccess<'a> {
-    export_name: &'a str,
-    target_local: &'a str,
+struct InstanceExportBindingAccess {
+    export_name: String,
+    target_local: String,
 }
 
-fn instance_export_binding_accesses(
-    module: &ResolvedModule,
-) -> Vec<InstanceExportBindingAccess<'_>> {
+fn instance_export_binding_accesses(module: &ResolvedModule) -> Vec<InstanceExportBindingAccess> {
     let mut accesses = Vec::new();
     for fact in &module.semantic_facts {
         if let SemanticFact::InstanceExportBinding(access) = fact {
             accesses.push(InstanceExportBindingAccess {
-                export_name: access.export_name.as_str(),
-                target_local: access.target_name.as_str(),
+                export_name: access.export_name.clone(),
+                target_local: access.target_name.clone(),
             });
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacySemanticMemberAccess::InstanceExportBinding {
-            export_name,
-            target_local,
-        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
+        if let Some(SemanticFact::InstanceExportBinding(fact)) =
+            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
         {
             accesses.push(InstanceExportBindingAccess {
-                export_name,
-                target_local,
+                export_name: fact.export_name,
+                target_local: fact.target_name,
             });
         }
     }
@@ -1629,34 +1625,31 @@ fn is_legacy_whole_object_use(object: &str) -> bool {
     object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_whole_object_use(object)
 }
 
-struct FactoryCallAccess<'a> {
-    callee_object: &'a str,
-    callee_method: &'a str,
-    member: &'a str,
+struct FactoryCallAccess {
+    callee_object: String,
+    callee_method: String,
+    member: String,
 }
 
-fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess<'_>> {
+fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess> {
     let mut accesses = Vec::new();
     for fact in &module.semantic_facts {
         if let SemanticFact::FactoryCallMemberAccess(access) = fact {
             accesses.push(FactoryCallAccess {
-                callee_object: access.callee_object.as_str(),
-                callee_method: access.callee_method.as_str(),
-                member: access.member.as_str(),
+                callee_object: access.callee_object.clone(),
+                callee_method: access.callee_method.clone(),
+                member: access.member.clone(),
             });
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacySemanticMemberAccess::FactoryCall {
-            callee_object,
-            callee_method,
-            member,
-        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
+        if let Some(SemanticFact::FactoryCallMemberAccess(fact)) =
+            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
         {
             accesses.push(FactoryCallAccess {
-                callee_object,
-                callee_method,
-                member,
+                callee_object: fact.callee_object,
+                callee_method: fact.callee_method,
+                member: fact.member,
             });
         }
     }
@@ -1678,7 +1671,7 @@ fn propagate_factory_call_accesses(
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
         for access in factory_call_accesses(resolved) {
-            let Some(seed_keys) = local_to_export_keys.get(access.callee_object) else {
+            let Some(seed_keys) = local_to_export_keys.get(access.callee_object.as_str()) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1702,45 +1695,41 @@ fn propagate_factory_call_accesses(
                     accessed_members
                         .entry(origin)
                         .or_default()
-                        .insert(access.member.to_string());
+                        .insert(access.member.clone());
                 }
             }
         }
     }
 }
 
-struct FluentChainAccess<'a> {
-    root_local: &'a str,
-    root_method: &'a str,
-    chain: Vec<&'a str>,
-    member: &'a str,
+struct FluentChainAccess {
+    root_local: String,
+    root_method: String,
+    chain: Vec<String>,
+    member: String,
 }
 
-fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess<'_>> {
+fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess> {
     let mut accesses = Vec::new();
     for fact in &module.semantic_facts {
         if let SemanticFact::FluentChainMemberAccess(access) = fact {
             accesses.push(FluentChainAccess {
-                root_local: access.root_object.as_str(),
-                root_method: access.root_method.as_str(),
-                chain: access.chain.iter().map(String::as_str).collect(),
-                member: access.member.as_str(),
+                root_local: access.root_object.clone(),
+                root_method: access.root_method.clone(),
+                chain: access.chain.clone(),
+                member: access.member.clone(),
             });
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacySemanticMemberAccess::FluentChain {
-            root_local,
-            root_method,
-            chain,
-            member,
-        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
+        if let Some(SemanticFact::FluentChainMemberAccess(fact)) =
+            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
         {
             accesses.push(FluentChainAccess {
-                root_local,
-                root_method,
-                chain,
-                member,
+                root_local: fact.root_object,
+                root_method: fact.root_method,
+                chain: fact.chain,
+                member: fact.member,
             });
         }
     }
@@ -1788,7 +1777,7 @@ fn propagate_fluent_chain_accesses(
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
         for access in fluent_chain_accesses(resolved) {
-            let Some(seed_keys) = local_to_export_keys.get(access.root_local) else {
+            let Some(seed_keys) = local_to_export_keys.get(access.root_local.as_str()) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1798,12 +1787,13 @@ fn propagate_fluent_chain_accesses(
                     let Some(origin_module) = module_by_id.get(&origin.file_id) else {
                         continue;
                     };
+                    let chain = access.chain.iter().map(String::as_str).collect::<Vec<_>>();
                     let chain_valid = origin_module.exports.iter().any(|export| {
                         export_validates_fluent_chain(
                             export,
                             &origin,
-                            access.root_method,
-                            &access.chain,
+                            access.root_method.as_str(),
+                            &chain,
                         )
                     });
                     if !chain_valid {
@@ -1812,41 +1802,38 @@ fn propagate_fluent_chain_accesses(
                     accessed_members
                         .entry(origin)
                         .or_default()
-                        .insert(access.member.to_string());
+                        .insert(access.member.clone());
                 }
             }
         }
     }
 }
 
-struct FluentChainNewAccess<'a> {
-    class_local: &'a str,
-    chain: Vec<&'a str>,
-    member: &'a str,
+struct FluentChainNewAccess {
+    class_local: String,
+    chain: Vec<String>,
+    member: String,
 }
 
-fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAccess<'_>> {
+fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAccess> {
     let mut accesses = Vec::new();
     for fact in &module.semantic_facts {
         if let SemanticFact::FluentChainNewMemberAccess(access) = fact {
             accesses.push(FluentChainNewAccess {
-                class_local: access.class_name.as_str(),
-                chain: access.chain.iter().map(String::as_str).collect(),
-                member: access.member.as_str(),
+                class_local: access.class_name.clone(),
+                chain: access.chain.clone(),
+                member: access.member.clone(),
             });
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacySemanticMemberAccess::FluentChainNew {
-            class_local,
-            chain,
-            member,
-        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
+        if let Some(SemanticFact::FluentChainNewMemberAccess(fact)) =
+            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
         {
             accesses.push(FluentChainNewAccess {
-                class_local,
-                chain,
-                member,
+                class_local: fact.class_name,
+                chain: fact.chain,
+                member: fact.member,
             });
         }
     }
@@ -1885,7 +1872,7 @@ fn propagate_fluent_chain_new_accesses(
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
         for access in fluent_chain_new_accesses(resolved) {
-            let Some(seed_keys) = local_to_export_keys.get(access.class_local) else {
+            let Some(seed_keys) = local_to_export_keys.get(access.class_local.as_str()) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1895,16 +1882,18 @@ fn propagate_fluent_chain_new_accesses(
                     let Some(origin_module) = module_by_id.get(&origin.file_id) else {
                         continue;
                     };
-                    let chain_valid = origin_module.exports.iter().any(|export| {
-                        export_validates_fluent_chain_new(export, &origin, &access.chain)
-                    });
+                    let chain = access.chain.iter().map(String::as_str).collect::<Vec<_>>();
+                    let chain_valid = origin_module
+                        .exports
+                        .iter()
+                        .any(|export| export_validates_fluent_chain_new(export, &origin, &chain));
                     if !chain_valid {
                         continue;
                     }
                     accessed_members
                         .entry(origin)
                         .or_default()
-                        .insert(access.member.to_string());
+                        .insert(access.member.clone());
                 }
             }
         }
@@ -5211,6 +5200,6 @@ mod tests {
         let malformed = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:");
 
         assert!(is_legacy_member_access_object(&malformed));
-        assert!(parse_legacy_semantic_member_access(&malformed, "value").is_none());
+        assert!(legacy_member_access_to_semantic_fact(&malformed, "value").is_none());
     }
 }

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1544,6 +1544,50 @@ pub fn parse_legacy_semantic_member_access<'a>(
     None
 }
 
+/// Decode an older sentinel-backed member access into the owned typed
+/// semantic fact emitted by current extraction.
+#[must_use]
+pub fn legacy_member_access_to_semantic_fact(object: &str, member: &str) -> Option<SemanticFact> {
+    Some(match parse_legacy_semantic_member_access(object, member)? {
+        LegacySemanticMemberAccess::InstanceExportBinding {
+            export_name,
+            target_local,
+        } => SemanticFact::InstanceExportBinding(InstanceExportBindingFact {
+            export_name: export_name.to_string(),
+            target_name: target_local.to_string(),
+        }),
+        LegacySemanticMemberAccess::FactoryCall {
+            callee_object,
+            callee_method,
+            member,
+        } => SemanticFact::FactoryCallMemberAccess(FactoryCallMemberAccessFact {
+            callee_object: callee_object.to_string(),
+            callee_method: callee_method.to_string(),
+            member: member.to_string(),
+        }),
+        LegacySemanticMemberAccess::FluentChain {
+            root_local,
+            root_method,
+            chain,
+            member,
+        } => SemanticFact::FluentChainMemberAccess(FluentChainMemberAccessFact {
+            root_object: root_local.to_string(),
+            root_method: root_method.to_string(),
+            chain: chain.into_iter().map(str::to_string).collect(),
+            member: member.to_string(),
+        }),
+        LegacySemanticMemberAccess::FluentChainNew {
+            class_local,
+            chain,
+            member,
+        } => SemanticFact::FluentChainNewMemberAccess(FluentChainNewMemberAccessFact {
+            class_name: class_local.to_string(),
+            chain: chain.into_iter().map(str::to_string).collect(),
+            member: member.to_string(),
+        }),
+    })
+}
+
 /// A member name referenced from an Angular template surface.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -2304,6 +2348,65 @@ mod tests {
 
         assert!(is_legacy_semantic_member_access_object(&malformed));
         assert!(parse_legacy_semantic_member_access(&malformed, "value").is_none());
+    }
+
+    #[test]
+    fn legacy_semantic_member_access_converts_to_owned_typed_facts() {
+        let instance = legacy_member_access_to_semantic_fact(
+            &format!("{INSTANCE_EXPORT_SENTINEL}exported"),
+            "target",
+        )
+        .expect("instance fact");
+        assert_eq!(
+            instance,
+            SemanticFact::InstanceExportBinding(InstanceExportBindingFact {
+                export_name: "exported".to_string(),
+                target_name: "target".to_string(),
+            })
+        );
+
+        let factory = legacy_member_access_to_semantic_fact(
+            &format!("{FACTORY_CALL_SENTINEL}Svc:create"),
+            "run",
+        )
+        .expect("factory fact");
+        assert_eq!(
+            factory,
+            SemanticFact::FactoryCallMemberAccess(FactoryCallMemberAccessFact {
+                callee_object: "Svc".to_string(),
+                callee_method: "create".to_string(),
+                member: "run".to_string(),
+            })
+        );
+
+        let fluent = legacy_member_access_to_semantic_fact(
+            &format!("{FLUENT_CHAIN_SENTINEL}Builder:start:next,finish"),
+            "value",
+        )
+        .expect("fluent fact");
+        assert_eq!(
+            fluent,
+            SemanticFact::FluentChainMemberAccess(FluentChainMemberAccessFact {
+                root_object: "Builder".to_string(),
+                root_method: "start".to_string(),
+                chain: vec!["next".to_string(), "finish".to_string()],
+                member: "value".to_string(),
+            })
+        );
+
+        let fluent_new = legacy_member_access_to_semantic_fact(
+            &format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:next,finish"),
+            "value",
+        )
+        .expect("new fluent fact");
+        assert_eq!(
+            fluent_new,
+            SemanticFact::FluentChainNewMemberAccess(FluentChainNewMemberAccessFact {
+                class_name: "Builder".to_string(),
+                chain: vec!["next".to_string(), "finish".to_string()],
+                member: "value".to_string(),
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keep legacy sentinel decoding inside `fallow-types`.
- Route unused-member analysis through typed semantic facts for legacy cache entries.
- Preserve older parse-cache compatibility while moving core away from string protocol matching.

## Plan
- Local plan: `.plans/semantic-fact-legacy-bridge.md`

## Verification
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p fallow-types legacy_semantic --lib`
- [x] `cargo test -p fallow-core typed_ --lib`
- [x] `cargo test -p fallow-core malformed_legacy_member_access_is_skip_only --lib`
- [x] `cargo check -p fallow-types -p fallow-core`
- [x] `cargo clippy -p fallow-types -p fallow-core --all-targets -- -D warnings`
- [x] `git diff --check`
- [x] em dash scan on touched files
- [x] pre-commit fast guard
- [x] pre-push fast guard