### PR TITLE
refactor: route combined next steps through output contract

### DIFF
--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -22,7 +22,9 @@ use std::process::Command;
 
 use fallow_core::results::AnalysisResults;
 use fallow_output::{
-    DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
+    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
+    ImpactDigestCounts, TraceUnusedExportInput,
+    build_combined_next_steps as build_combined_next_steps_contract,
     build_dead_code_next_steps as build_dead_code_next_steps_contract,
     build_dupes_next_steps as build_dupes_next_steps_contract, impact_digest_summary,
 };
@@ -97,6 +99,21 @@ fn relative_command_path(path: &Path, root: &Path) -> String {
 /// Uses the lexicographically smallest `(path, name)` finding so the embedded
 /// command is deterministic across runs (independent of internal vec order).
 fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextStep> {
+    let target = trace_unused_export_input(results, root)?;
+    Some(next_step(
+        "trace-unused-export",
+        format!(
+            "fallow dead-code --trace {}:{}",
+            target.path, target.export_name
+        ),
+        "verify an export is truly unused before deleting",
+    ))
+}
+
+fn trace_unused_export_input(
+    results: &AnalysisResults,
+    root: &Path,
+) -> Option<TraceUnusedExportInput> {
     let target = results
         .unused_exports
         .iter()
@@ -107,29 +124,10 @@ fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextSte
             )
         })
         .min()?;
-    Some(next_step(
-        "trace-unused-export",
-        format!("fallow dead-code --trace {}:{}", target.0, target.1),
-        "verify an export is truly unused before deleting",
-    ))
-}
-
-/// `setup`: first-contact pointer for unconfigured projects. The command is the
-/// read-only capability manifest (`fallow schema`), whose `task_matrix` and
-/// commands list name the guided-setup surface (`init --agents`, the hooks
-/// installer); the mutating commands themselves are never embedded here (the
-/// read-only contract), the agent offers them to the user instead. Callers gate
-/// this via [`setup_pointer_applicable`] so CI runs, configured projects, and
-/// projects that declined onboarding never see it.
-fn setup_pointer(offer_setup: bool) -> Option<NextStep> {
-    if !offer_setup {
-        return None;
-    }
-    Some(next_step(
-        "setup",
-        "fallow schema".to_string(),
-        "fallow has no config here; the manifest lists guided-setup commands (agent guide, commit gate) to offer the user",
-    ))
+    Some(TraceUnusedExportInput {
+        path: target.0,
+        export_name: target.1,
+    })
 }
 
 /// Shared first-contact gate for the `setup` next-step and the human setup hint
@@ -149,27 +147,8 @@ pub fn setup_pointer_applicable(root: &Path) -> bool {
 /// Worded as an offer, not a deficiency: zero-config is a supported happy path.
 pub const SETUP_HINT: &str = "Setup: `fallow init --agents` writes an agent guide; `fallow hooks install --target agent` adds a commit gate (hide this hint: `fallow init --decline`).";
 
-/// `impact-report`: the periodic local value digest. Emitted at most once per
-/// week per project (the cadence stamp lives in the impact store, not the
-/// agent, so it is consistent across agents and sessions), only when impact
-/// tracking is enabled and has non-zero value to report, never in CI. Unlike
-/// every other trigger this one may surface on a CLEAN run: a clean project
-/// after a period of gate containment is exactly the moment the value report
-/// is informative.
-fn impact_digest_step(digest: Option<crate::impact::ImpactDigest>) -> Option<NextStep> {
-    let digest = digest?;
-    Some(next_step(
-        "impact-report",
-        "fallow impact".to_string(),
-        &format!(
-            "local value report: {}; share the non-zero numbers with the user",
-            digest_summary(digest)
-        ),
-    ))
-}
-
 /// Real-counter summary fragment shared by the next-step reason and the human
-/// one-liner (the placeholder-free contract: numbers come from the store).
+/// one-liner. The output crate owns the `impact-report` command contract.
 fn impact_counts(digest: crate::impact::ImpactDigest) -> ImpactDigestCounts {
     ImpactDigestCounts {
         containment_count: digest.containment_count,
@@ -203,21 +182,6 @@ pub fn due_impact_digest(root: &Path) -> Option<crate::impact::ImpactDigest> {
     crate::impact::take_due_digest(root)
 }
 
-/// `trace-clone`: see sibling locations and an extract-function suggestion for a
-/// duplicated block. Uses the smallest fingerprint for run-to-run determinism.
-fn trace_clone(payload: &DupesReportPayload) -> Option<NextStep> {
-    let fingerprint = payload
-        .clone_groups
-        .iter()
-        .map(|group| group.fingerprint.as_str())
-        .min()?;
-    Some(next_step(
-        "trace-clone",
-        format!("fallow dupes --trace {fingerprint}"),
-        "see sibling locations and an extract-function suggestion",
-    ))
-}
-
 /// `complexity-breakdown`: see the per-decision-point contributions behind a
 /// high-complexity finding.
 fn complexity_breakdown(report: &HealthReport) -> Option<NextStep> {
@@ -228,18 +192,6 @@ fn complexity_breakdown(report: &HealthReport) -> Option<NextStep> {
         "complexity-breakdown",
         "fallow health --complexity-breakdown".to_string(),
         "see per-decision-point contributions for a hotspot",
-    ))
-}
-
-/// `scope-workspaces`: scope a monorepo run to the packages touched since the
-/// default branch. Emitted only when the project is a monorepo AND a concrete
-/// default ref resolves, so the embedded ref is real (never a placeholder).
-fn scope_workspaces(root: &Path) -> Option<NextStep> {
-    let reference = default_workspace_ref_for_next_step(root)?;
-    Some(next_step(
-        "scope-workspaces",
-        format!("fallow dead-code --changed-workspaces {reference}"),
-        "scope a monorepo run to the packages your branch touched",
     ))
 }
 
@@ -398,29 +350,27 @@ pub fn build_combined_next_steps(
     offer_setup: bool,
     digest: Option<crate::impact::ImpactDigest>,
 ) -> Vec<NextStep> {
-    if !suggestions_enabled() {
-        return Vec::new();
-    }
-    let has_findings = results.is_some_and(|r| r.total_issues() > 0)
-        || dupes.is_some_and(|d| !d.clone_groups.is_empty())
-        || health.is_some_and(|h| !h.findings.is_empty());
-    if !has_findings {
-        return impact_digest_step(digest).into_iter().collect();
-    }
-    let mut steps: Vec<NextStep> = [
-        setup_pointer(offer_setup),
-        impact_digest_step(digest),
-        results.and_then(|r| trace_unused_export(r, root)),
-        scope_workspaces(root),
-        dupes.and_then(trace_clone),
-        health.and_then(complexity_breakdown),
-        audit_changed(root),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-    steps.truncate(MAX_NEXT_STEPS);
-    steps
+    let workspace_ref = default_workspace_ref_for_next_step(root);
+    let clone_fingerprints = dupes
+        .map(|payload| {
+            payload
+                .clone_groups
+                .iter()
+                .map(|group| group.fingerprint.as_str())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    build_combined_next_steps_contract(&CombinedNextStepsInput {
+        suggestions_enabled: suggestions_enabled(),
+        has_dead_code_findings: results.is_some_and(|r| r.total_issues() > 0),
+        trace_unused_export: results.and_then(|r| trace_unused_export_input(r, root)),
+        workspace_ref: workspace_ref.as_deref(),
+        clone_fingerprints: &clone_fingerprints,
+        has_complexity_findings: health.is_some_and(|h| !h.findings.is_empty()),
+        offer_setup,
+        impact_digest: digest.map(impact_counts),
+        audit_changed: audit_changed(root).is_some(),
+    })
 }
 
 /// Next-steps for `fallow audit`. No `audit-changed` (audit IS the changed
@@ -610,15 +560,6 @@ mod tests {
     }
 
     #[test]
-    fn setup_pointer_emits_only_when_applicable() {
-        assert!(setup_pointer(false).is_none());
-        let step = setup_pointer(true).expect("step");
-        assert_eq!(step.id, "setup");
-        assert_eq!(step.command, "fallow schema");
-        assert_valid(&step);
-    }
-
-    #[test]
     fn setup_pointer_gate_ignores_nonexistent_roots() {
         assert!(!setup_pointer_applicable(Path::new(
             "/fallow-test-project-does-not-exist"
@@ -649,20 +590,6 @@ mod tests {
             containment_count: containment,
             resolved_total: resolved,
         }
-    }
-
-    #[test]
-    fn impact_digest_step_carries_real_counters() {
-        assert!(impact_digest_step(None).is_none());
-        let step = impact_digest_step(Some(digest(4, 12))).expect("step");
-        assert_eq!(step.id, "impact-report");
-        assert_eq!(step.command, "fallow impact");
-        assert!(step.reason.contains("4 commits contained at the gate"));
-        assert!(step.reason.contains("12 findings resolved"));
-        assert_valid(&step);
-        let singular = impact_digest_step(Some(digest(1, 0))).expect("step");
-        assert!(singular.reason.contains("1 commit contained at the gate"));
-        assert!(!singular.reason.contains("resolved"));
     }
 
     #[test]
@@ -734,6 +661,33 @@ mod tests {
     }
 
     #[test]
+    fn combined_next_steps_route_payload_facts_to_output_contract() {
+        let root = PathBuf::from("/project");
+        let results = results_with_exports(vec![
+            unused_export("/project/src/b.ts", "beta"),
+            unused_export("/project/src/a.ts", "alpha"),
+        ]);
+        let payload = dupes_payload();
+        let report = health_report_with_finding();
+
+        let steps = build_combined_next_steps(
+            Some(&results),
+            Some(&payload),
+            Some(&report),
+            &root,
+            true,
+            Some(digest(2, 1)),
+        );
+        let ids: Vec<&str> = steps.iter().map(|s| s.id.as_str()).collect();
+
+        assert_eq!(ids, ["setup", "impact-report", "trace-unused-export"]);
+        assert_eq!(steps[2].command, "fallow dead-code --trace src/a.ts:alpha");
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
     fn impact_digest_line_renders_counters() {
         let line = impact_digest_line(digest(2, 1));
         assert_eq!(
@@ -777,7 +731,7 @@ mod tests {
             "fallow dupes --trace dup:abcd1234".to_string(),
             "x",
         ));
-        all.extend(setup_pointer(true));
+        all.push(next_step("setup", "fallow schema".to_string(), "x"));
         assert!(!all.is_empty());
         for step in &all {
             assert_valid(step);

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -177,7 +177,8 @@ pub use list_envelopes::{
     ListBoundariesOutput, WorkspaceInfo, WorkspacesOutput,
 };
 pub use next_steps::{
-    DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
+    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
+    ImpactDigestCounts, TraceUnusedExportInput, build_combined_next_steps,
     build_dead_code_next_steps, build_dupes_next_steps, build_health_next_steps,
     impact_digest_summary,
 };

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -40,6 +40,27 @@ pub struct DupesNextStepsInput<'a> {
     pub audit_changed: bool,
 }
 
+/// Deterministic unused-export trace target selected by the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceUnusedExportInput {
+    pub path: String,
+    pub export_name: String,
+}
+
+/// Runtime-independent inputs for bare `fallow` combined next steps.
+#[derive(Debug, Clone)]
+pub struct CombinedNextStepsInput<'a> {
+    pub suggestions_enabled: bool,
+    pub has_dead_code_findings: bool,
+    pub trace_unused_export: Option<TraceUnusedExportInput>,
+    pub workspace_ref: Option<&'a str>,
+    pub clone_fingerprints: &'a [&'a str],
+    pub has_complexity_findings: bool,
+    pub offer_setup: bool,
+    pub impact_digest: Option<ImpactDigestCounts>,
+    pub audit_changed: bool,
+}
+
 /// Runtime-independent inputs for standalone health next steps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HealthNextStepsInput {
@@ -152,6 +173,37 @@ pub fn build_dupes_next_steps(input: DupesNextStepsInput<'_>) -> Vec<NextStep> {
     steps
 }
 
+/// Aggregated next-steps for bare `fallow` combined output.
+#[must_use]
+pub fn build_combined_next_steps(input: &CombinedNextStepsInput<'_>) -> Vec<NextStep> {
+    if !input.suggestions_enabled {
+        return Vec::new();
+    }
+    let has_findings = input.has_dead_code_findings
+        || !input.clone_fingerprints.is_empty()
+        || input.has_complexity_findings;
+    if !has_findings {
+        return impact_digest_step(input.impact_digest)
+            .into_iter()
+            .collect();
+    }
+
+    let mut steps: Vec<NextStep> = [
+        setup_pointer(input.offer_setup),
+        impact_digest_step(input.impact_digest),
+        trace_unused_export_from_input(input.trace_unused_export.as_ref()),
+        scope_workspaces(input.workspace_ref),
+        trace_clone(input.clone_fingerprints),
+        complexity_breakdown(input.has_complexity_findings),
+        audit_changed(input.audit_changed),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    steps.truncate(MAX_NEXT_STEPS);
+    steps
+}
+
 fn relative_command_path(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -173,6 +225,18 @@ fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextSte
     Some(next_step(
         "trace-unused-export",
         format!("fallow dead-code --trace {}:{}", target.0, target.1),
+        "verify an export is truly unused before deleting",
+    ))
+}
+
+fn trace_unused_export_from_input(target: Option<&TraceUnusedExportInput>) -> Option<NextStep> {
+    let target = target?;
+    Some(next_step(
+        "trace-unused-export",
+        format!(
+            "fallow dead-code --trace {}:{}",
+            target.path, target.export_name
+        ),
         "verify an export is truly unused before deleting",
     ))
 }
@@ -315,6 +379,20 @@ mod tests {
         }
     }
 
+    fn combined_input<'a>(clone_fingerprints: &'a [&'a str]) -> CombinedNextStepsInput<'a> {
+        CombinedNextStepsInput {
+            suggestions_enabled: true,
+            has_dead_code_findings: false,
+            trace_unused_export: None,
+            workspace_ref: None,
+            clone_fingerprints,
+            has_complexity_findings: false,
+            offer_setup: false,
+            impact_digest: None,
+            audit_changed: false,
+        }
+    }
+
     fn assert_valid(step: &NextStep) {
         assert!(
             !step.command.contains('<') && !step.command.contains('>'),
@@ -439,6 +517,87 @@ mod tests {
 
         assert_eq!(steps.len(), 1);
         assert_eq!(steps[0].id, "impact-report");
+    }
+
+    #[test]
+    fn combined_steps_are_empty_when_suggestions_are_disabled() {
+        let fingerprints = ["dup:aaaaaaaa"];
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            suggestions_enabled: false,
+            has_dead_code_findings: true,
+            trace_unused_export: Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            }),
+            workspace_ref: Some("origin/main"),
+            clone_fingerprints: &fingerprints,
+            has_complexity_findings: true,
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+        });
+
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn clean_combined_run_emits_only_due_impact_digest() {
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..combined_input(&[])
+        });
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "impact-report");
+    }
+
+    #[test]
+    fn combined_steps_order_and_cap_all_signals() {
+        let fingerprints = ["dup:bbbbbbbb", "dup:aaaaaaaa"];
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            has_dead_code_findings: true,
+            trace_unused_export: Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            }),
+            workspace_ref: Some("origin/main"),
+            has_complexity_findings: true,
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..combined_input(&fingerprints)
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["setup", "impact-report", "trace-unused-export"]);
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
+    fn combined_steps_keep_workspace_before_clone_and_complexity() {
+        let fingerprints = ["dup:aaaaaaaa"];
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            has_dead_code_findings: true,
+            workspace_ref: Some("origin/main"),
+            has_complexity_findings: true,
+            audit_changed: true,
+            ..combined_input(&fingerprints)
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ids,
+            ["scope-workspaces", "trace-clone", "complexity-breakdown"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Routes bare combined-mode next_steps through fallow-output.
- Leaves fallow-cli responsible for runtime probes and fact selection only.
- Preserves existing ordering, cap, and command text contracts.

## Plan
- Local plan: .plans/output-combined-next-steps-contract.md

## Verification
- [x] cargo fmt --all -- --check
- [x] cargo test -p fallow-output next_steps --lib
- [x] cargo test -p fallow-cli combined_next_steps --lib
- [x] cargo check -p fallow-output -p fallow-cli
- [x] cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- [x] git diff --check
- [x] em dash scan over touched files