### PR TITLE
refactor: centralize semantic fact legacy compatibility

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -13,7 +13,7 @@ use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
     SemanticFact, is_legacy_semantic_member_access_object, is_legacy_semantic_whole_object_use,
-    legacy_member_access_to_semantic_fact,
+    semantic_facts_with_legacy_member_accesses,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -1366,21 +1366,13 @@ struct InstanceExportBindingAccess {
 
 fn instance_export_binding_accesses(module: &ResolvedModule) -> Vec<InstanceExportBindingAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::InstanceExportBinding(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::InstanceExportBinding(access) = fact.as_fact() {
             accesses.push(InstanceExportBindingAccess {
                 export_name: access.export_name.clone(),
                 target_local: access.target_name.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::InstanceExportBinding(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(InstanceExportBindingAccess {
-                export_name: fact.export_name,
-                target_local: fact.target_name,
             });
         }
     }
@@ -1633,23 +1625,14 @@ struct FactoryCallAccess {
 
 fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::FactoryCallMemberAccess(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::FactoryCallMemberAccess(access) = fact.as_fact() {
             accesses.push(FactoryCallAccess {
                 callee_object: access.callee_object.clone(),
                 callee_method: access.callee_method.clone(),
                 member: access.member.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::FactoryCallMemberAccess(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(FactoryCallAccess {
-                callee_object: fact.callee_object,
-                callee_method: fact.callee_method,
-                member: fact.member,
             });
         }
     }
@@ -1711,25 +1694,15 @@ struct FluentChainAccess {
 
 fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::FluentChainMemberAccess(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::FluentChainMemberAccess(access) = fact.as_fact() {
             accesses.push(FluentChainAccess {
                 root_local: access.root_object.clone(),
                 root_method: access.root_method.clone(),
                 chain: access.chain.clone(),
                 member: access.member.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::FluentChainMemberAccess(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(FluentChainAccess {
-                root_local: fact.root_object,
-                root_method: fact.root_method,
-                chain: fact.chain,
-                member: fact.member,
             });
         }
     }
@@ -1817,23 +1790,14 @@ struct FluentChainNewAccess {
 
 fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::FluentChainNewMemberAccess(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::FluentChainNewMemberAccess(access) = fact.as_fact() {
             accesses.push(FluentChainNewAccess {
                 class_local: access.class_name.clone(),
                 chain: access.chain.clone(),
                 member: access.member.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::FluentChainNewMemberAccess(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(FluentChainNewAccess {
-                class_local: fact.class_name,
-                chain: fact.chain,
-                member: fact.member,
             });
         }
     }
@@ -5198,8 +5162,16 @@ mod tests {
     #[test]
     fn malformed_legacy_member_access_is_skip_only() {
         let malformed = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:");
+        let member_accesses = vec![crate::extract::MemberAccess {
+            object: malformed.clone(),
+            member: "value".to_string(),
+        }];
 
         assert!(is_legacy_member_access_object(&malformed));
-        assert!(legacy_member_access_to_semantic_fact(&malformed, "value").is_none());
+        assert!(
+            semantic_facts_with_legacy_member_accesses(&[], &member_accesses)
+                .next()
+                .is_none()
+        );
     }
 }

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1588,6 +1588,44 @@ pub fn legacy_member_access_to_semantic_fact(object: &str, member: &str) -> Opti
     })
 }
 
+/// A semantic fact yielded from current typed extraction or decoded from an
+/// older sentinel-backed cache entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemanticFactCompat<'a> {
+    /// Fact borrowed from a module's typed semantic facts.
+    Borrowed(&'a SemanticFact),
+    /// Fact decoded from a legacy `MemberAccess` sentinel.
+    Owned(SemanticFact),
+}
+
+impl SemanticFactCompat<'_> {
+    /// View the semantic fact regardless of whether it was borrowed or decoded.
+    #[must_use]
+    pub const fn as_fact(&self) -> &SemanticFact {
+        match self {
+            Self::Borrowed(fact) => fact,
+            Self::Owned(fact) => fact,
+        }
+    }
+}
+
+/// Iterate over typed semantic facts plus decoded legacy member-access facts.
+///
+/// New extraction persists typed facts directly. The legacy path exists only so
+/// older parse-cache entries still feed the same typed analysis code.
+pub fn semantic_facts_with_legacy_member_accesses<'a>(
+    semantic_facts: &'a [SemanticFact],
+    member_accesses: &'a [MemberAccess],
+) -> impl Iterator<Item = SemanticFactCompat<'a>> + 'a {
+    semantic_facts
+        .iter()
+        .map(SemanticFactCompat::Borrowed)
+        .chain(member_accesses.iter().filter_map(|access| {
+            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
+                .map(SemanticFactCompat::Owned)
+        }))
+}
+
 /// A member name referenced from an Angular template surface.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -2406,6 +2444,49 @@ mod tests {
                 chain: vec!["next".to_string(), "finish".to_string()],
                 member: "value".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn semantic_fact_compat_iterator_yields_typed_and_legacy_facts() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::FactoryCallMemberAccess(
+                FactoryCallMemberAccessFact {
+                    callee_object: "Svc".to_string(),
+                    callee_method: "make".to_string(),
+                    member: "run".to_string(),
+                },
+            ));
+        module.member_accesses.push(MemberAccess {
+            object: format!("{INSTANCE_EXPORT_SENTINEL}exported"),
+            member: "target".to_string(),
+        });
+
+        let facts = semantic_facts_with_legacy_member_accesses(
+            &module.semantic_facts,
+            &module.member_accesses,
+        )
+        .collect::<Vec<_>>();
+
+        assert!(matches!(facts[0], SemanticFactCompat::Borrowed(_)));
+        assert_eq!(
+            facts[0].as_fact(),
+            &SemanticFact::FactoryCallMemberAccess(FactoryCallMemberAccessFact {
+                callee_object: "Svc".to_string(),
+                callee_method: "make".to_string(),
+                member: "run".to_string(),
+            })
+        );
+        assert_eq!(
+            facts[1],
+            SemanticFactCompat::Owned(SemanticFact::InstanceExportBinding(
+                InstanceExportBindingFact {
+                    export_name: "exported".to_string(),
+                    target_name: "target".to_string(),
+                }
+            ))
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds a fallow-types compatibility iterator for typed semantic facts plus decoded legacy member-access facts.
- Migrates unused_members family collectors to consume the iterator instead of decoding legacy sentinels directly.
- Keeps legacy parse-cache compatibility while moving the string protocol behind the type boundary.

## Plan
- Local plan: .plans/semantic-fact-compat-iterator.md

## Verification
- [x] cargo fmt --all -- --check
- [x] cargo test -p fallow-types semantic_fact --lib
- [x] cargo test -p fallow-core typed_ --lib
- [x] cargo test -p fallow-core legacy_member_access --lib
- [x] cargo check -p fallow-types -p fallow-core
- [x] cargo clippy -p fallow-types -p fallow-core --all-targets -- -D warnings
- [x] git diff --check
- [x] em dash scan over touched files