### PR TITLE
refactor: expose programmatic health output through api

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,7 +22,8 @@ pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
 pub use runtime::{
-    detect_boundary_violations, detect_circular_dependencies, detect_dead_code, detect_duplication,
+    ProgrammaticHealthJsonInput, detect_boundary_violations, detect_circular_dependencies,
+    detect_dead_code, detect_duplication, serialize_programmatic_health_json,
 };
 
 pub const COMMON_ANALYSIS_OPTION_FLAGS: &[&str] = &[

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -9,9 +9,11 @@ use fallow_config::{
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
-    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, RootEnvelopeMode,
-    apply_root_kind, build_check_output, build_dupes_output, check_meta, strip_root_prefix,
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, HealthJsonOutputInput,
+    HealthOutputInput, HealthReport, RootEnvelopeMode, WorkspaceDiagnosticOutput, apply_root_kind,
+    build_check_output, build_dupes_output, check_meta, health_meta, strip_root_prefix,
 };
+use fallow_types::output::NextStep;
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -21,9 +23,21 @@ use crate::{
 };
 
 const SCHEMA_VERSION: u32 = 1;
+const HEALTH_SCHEMA_VERSION: u32 = 7;
 const MAX_DIFF_BYTES: u64 = 10 * 1024 * 1024;
 
 type ProgrammaticResult<T> = Result<T, ProgrammaticError>;
+
+/// Inputs for serializing programmatic health / complexity output.
+pub struct ProgrammaticHealthJsonInput<'a> {
+    pub report: HealthReport,
+    pub root: &'a Path,
+    pub elapsed: std::time::Duration,
+    pub explain: bool,
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    pub next_steps: Vec<NextStep>,
+    pub envelope_mode: RootEnvelopeMode,
+}
 
 struct ResolvedAnalysisOptions {
     root: PathBuf,
@@ -98,6 +112,37 @@ pub fn detect_boundary_violations(
 ) -> ProgrammaticResult<serde_json::Value> {
     let resolved = resolve_analysis_options(&options.analysis)?;
     resolved.install(|| detect_dead_code_inner(options, &resolved, keep_boundary_violations))
+}
+
+/// Serialize a programmatic health / complexity report into the stable JSON
+/// output contract.
+///
+/// The health runner is still migrating out of the CLI crate, so callers pass
+/// the already assembled report plus CLI-owned suggestion and workspace
+/// diagnostics policy as explicit typed inputs.
+///
+/// # Errors
+///
+/// Returns a serde error when the report cannot be converted to JSON.
+pub fn serialize_programmatic_health_json(
+    input: ProgrammaticHealthJsonInput<'_>,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let root_prefix = format!("{}/", input.root.display());
+    fallow_output::serialize_health_json_output(HealthJsonOutputInput {
+        output: HealthOutputInput {
+            schema_version: HEALTH_SCHEMA_VERSION,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            elapsed: input.elapsed,
+            report: input.report,
+            grouped_by: None,
+            groups: None::<Vec<fallow_output::HealthGroup>>,
+            meta: input.explain.then(health_meta),
+            workspace_diagnostics: input.workspace_diagnostics,
+            next_steps: input.next_steps,
+        },
+        root_prefix: Some(&root_prefix),
+        envelope_mode: input.envelope_mode,
+    })
 }
 
 fn detect_dead_code_inner(
@@ -1320,6 +1365,49 @@ mod tests {
             root: Some(root.to_path_buf()),
             ..AnalysisOptions::default()
         }
+    }
+
+    #[test]
+    fn serialize_programmatic_health_json_tags_meta_and_strips_paths() {
+        let root = Path::new("/repo");
+        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+            report: HealthReport::default(),
+            root,
+            elapsed: std::time::Duration::ZERO,
+            explain: true,
+            workspace_diagnostics: vec![WorkspaceDiagnosticOutput(serde_json::json!({
+                "path": "/repo/package.json"
+            }))],
+            next_steps: vec![NextStep {
+                id: "inspect-health".to_string(),
+                command: "fallow health --format json".to_string(),
+                reason: "inspect health details".to_string(),
+            }],
+            envelope_mode: RootEnvelopeMode::Tagged,
+        })
+        .expect("health JSON serializes");
+
+        assert_eq!(json["kind"], "health");
+        assert_eq!(json["schema_version"], HEALTH_SCHEMA_VERSION);
+        assert!(json["_meta"].is_object());
+        assert_eq!(json["workspace_diagnostics"][0]["path"], "package.json");
+        assert_eq!(json["next_steps"][0]["id"], "inspect-health");
+    }
+
+    #[test]
+    fn serialize_programmatic_health_json_respects_legacy_envelope() {
+        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+            report: HealthReport::default(),
+            root: Path::new("/repo"),
+            elapsed: std::time::Duration::ZERO,
+            explain: false,
+            workspace_diagnostics: Vec::new(),
+            next_steps: Vec::new(),
+            envelope_mode: RootEnvelopeMode::Legacy,
+        })
+        .expect("health JSON serializes");
+
+        assert!(json.get("kind").is_none());
     }
 
     #[test]

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -6,8 +6,8 @@ use fallow_core::results::AnalysisResults;
 use crate::check::{CheckOptions, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions};
 use crate::health::HealthOptions;
+use crate::report::build_duplication_json;
 use crate::report::ci::diff_filter::{DiffIndex, LoadedDiff, MAX_DIFF_BYTES};
-use crate::report::{build_duplication_json, build_health_json};
 
 pub use fallow_api::{
     AnalysisOptions, COMMON_ANALYSIS_OPTION_FLAGS, ComplexityOptions, ComplexitySort,
@@ -249,6 +249,26 @@ fn apply_programmatic_envelope_options(
     if resolved.legacy_envelope {
         fallow_output::remove_root_kind(output);
     }
+}
+
+fn programmatic_root_envelope_mode(
+    resolved: &ResolvedAnalysisOptions,
+) -> fallow_output::RootEnvelopeMode {
+    if resolved.legacy_envelope {
+        fallow_output::RootEnvelopeMode::Legacy
+    } else {
+        fallow_output::RootEnvelopeMode::Tagged
+    }
+}
+
+fn workspace_diagnostics_for_programmatic_output(
+    root: &Path,
+) -> Vec<fallow_output::WorkspaceDiagnosticOutput> {
+    crate::runtime_support::workspace_diagnostics_for(root)
+        .into_iter()
+        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
+        .map(fallow_output::WorkspaceDiagnosticOutput)
+        .collect()
 }
 
 fn build_dead_code_json(
@@ -658,18 +678,33 @@ pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<ser
         let health_options = build_complexity_options(&resolved, options);
         let result = crate::health::execute_health(&health_options)
             .map_err(|_| generic_analysis_error("health"))?;
-        let mut output = build_health_json(
-            &result.report,
-            &result.config.root,
-            result.elapsed,
-            resolved.explain,
+        let next_steps = fallow_output::build_health_next_steps(
+            crate::report::suggestions::health_next_steps_input(
+                &result.report,
+                &result.config.root,
+                crate::report::suggestions::setup_pointer_applicable(&result.config.root),
+                crate::report::suggestions::due_impact_digest(&result.config.root),
+            ),
+        );
+        let mut output = fallow_api::serialize_programmatic_health_json(
+            fallow_api::ProgrammaticHealthJsonInput {
+                report: result.report,
+                root: &result.config.root,
+                elapsed: result.elapsed,
+                explain: resolved.explain,
+                workspace_diagnostics: workspace_diagnostics_for_programmatic_output(
+                    &result.config.root,
+                ),
+                next_steps,
+                envelope_mode: programmatic_root_envelope_mode(&resolved),
+            },
         )
         .map_err(|err| {
             ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
                 .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
                 .with_context("health")
         })?;
-        apply_programmatic_envelope_options(&mut output, &resolved);
+        crate::output_envelope::attach_telemetry_meta(&mut output);
         Ok(output)
     })
 }


### PR DESCRIPTION
## Summary
- Add a fallow-api owned programmatic health JSON serialization contract.
- Route fallow-cli::programmatic health output through that API helper while keeping the CLI-owned runner in place.
- Preserve health schema version, root envelope mode, meta, path stripping, workspace diagnostics, telemetry, and next-step behavior.

## Plan
- Local plan: .plans/napi-health-api-runtime-boundary.md

## Verification
- [x] cargo test -p fallow-api programmatic_health --lib
- [x] cargo test -p fallow-cli compute_health --lib
- [x] cargo test -p fallow-cli compute_complexity --lib
- [x] cargo test -p fallow-node compute_complexity --lib
- [x] cargo check -p fallow-api -p fallow-cli -p fallow-node
- [x] cargo clippy -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] em dash scan on changed files