### PR TITLE
refactor: route health JSON reports through api contract

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,8 +22,8 @@ pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
 pub use runtime::{
-    ProgrammaticHealthJsonInput, detect_boundary_violations, detect_circular_dependencies,
-    detect_dead_code, detect_duplication, serialize_programmatic_health_json,
+    HealthJsonReportInput, detect_boundary_violations, detect_circular_dependencies,
+    detect_dead_code, detect_duplication, serialize_health_report_json,
 };
 
 pub const COMMON_ANALYSIS_OPTION_FLAGS: &[&str] = &[

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -9,9 +9,10 @@ use fallow_config::{
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
-    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, HealthJsonOutputInput,
-    HealthOutputInput, HealthReport, RootEnvelopeMode, WorkspaceDiagnosticOutput, apply_root_kind,
-    build_check_output, build_dupes_output, check_meta, health_meta, strip_root_prefix,
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, GroupByMode,
+    HealthGroup, HealthJsonOutputInput, HealthOutputInput, HealthReport, RootEnvelopeMode,
+    WorkspaceDiagnosticOutput, apply_root_kind, build_check_output, build_dupes_output, check_meta,
+    health_meta, strip_root_prefix,
 };
 use fallow_types::output::NextStep;
 use globset::Glob;
@@ -28,12 +29,14 @@ const MAX_DIFF_BYTES: u64 = 10 * 1024 * 1024;
 
 type ProgrammaticResult<T> = Result<T, ProgrammaticError>;
 
-/// Inputs for serializing programmatic health / complexity output.
-pub struct ProgrammaticHealthJsonInput<'a> {
+/// Inputs for serializing health JSON output through the API boundary.
+pub struct HealthJsonReportInput<'a> {
     pub report: HealthReport,
     pub root: &'a Path,
     pub elapsed: std::time::Duration,
     pub explain: bool,
+    pub grouped_by: Option<GroupByMode>,
+    pub groups: Option<Vec<HealthGroup>>,
     pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
     pub next_steps: Vec<NextStep>,
     pub envelope_mode: RootEnvelopeMode,
@@ -114,8 +117,7 @@ pub fn detect_boundary_violations(
     resolved.install(|| detect_dead_code_inner(options, &resolved, keep_boundary_violations))
 }
 
-/// Serialize a programmatic health / complexity report into the stable JSON
-/// output contract.
+/// Serialize a health / complexity report into the stable JSON output contract.
 ///
 /// The health runner is still migrating out of the CLI crate, so callers pass
 /// the already assembled report plus CLI-owned suggestion and workspace
@@ -124,8 +126,8 @@ pub fn detect_boundary_violations(
 /// # Errors
 ///
 /// Returns a serde error when the report cannot be converted to JSON.
-pub fn serialize_programmatic_health_json(
-    input: ProgrammaticHealthJsonInput<'_>,
+pub fn serialize_health_report_json(
+    input: HealthJsonReportInput<'_>,
 ) -> Result<serde_json::Value, serde_json::Error> {
     let root_prefix = format!("{}/", input.root.display());
     fallow_output::serialize_health_json_output(HealthJsonOutputInput {
@@ -134,8 +136,8 @@ pub fn serialize_programmatic_health_json(
             version: env!("CARGO_PKG_VERSION").to_string(),
             elapsed: input.elapsed,
             report: input.report,
-            grouped_by: None,
-            groups: None::<Vec<fallow_output::HealthGroup>>,
+            grouped_by: input.grouped_by,
+            groups: input.groups,
             meta: input.explain.then(health_meta),
             workspace_diagnostics: input.workspace_diagnostics,
             next_steps: input.next_steps,
@@ -1368,13 +1370,15 @@ mod tests {
     }
 
     #[test]
-    fn serialize_programmatic_health_json_tags_meta_and_strips_paths() {
+    fn serialize_health_report_json_tags_meta_and_strips_paths() {
         let root = Path::new("/repo");
-        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+        let json = serialize_health_report_json(HealthJsonReportInput {
             report: HealthReport::default(),
             root,
             elapsed: std::time::Duration::ZERO,
             explain: true,
+            grouped_by: None,
+            groups: None,
             workspace_diagnostics: vec![WorkspaceDiagnosticOutput(serde_json::json!({
                 "path": "/repo/package.json"
             }))],
@@ -1395,12 +1399,14 @@ mod tests {
     }
 
     #[test]
-    fn serialize_programmatic_health_json_respects_legacy_envelope() {
-        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+    fn serialize_health_report_json_respects_legacy_envelope() {
+        let json = serialize_health_report_json(HealthJsonReportInput {
             report: HealthReport::default(),
             root: Path::new("/repo"),
             elapsed: std::time::Duration::ZERO,
             explain: false,
+            grouped_by: None,
+            groups: None,
             workspace_diagnostics: Vec::new(),
             next_steps: Vec::new(),
             envelope_mode: RootEnvelopeMode::Legacy,

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -686,24 +686,25 @@ pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<ser
                 crate::report::suggestions::due_impact_digest(&result.config.root),
             ),
         );
-        let mut output = fallow_api::serialize_programmatic_health_json(
-            fallow_api::ProgrammaticHealthJsonInput {
+        let mut output =
+            fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
                 report: result.report,
                 root: &result.config.root,
                 elapsed: result.elapsed,
                 explain: resolved.explain,
+                grouped_by: None,
+                groups: None,
                 workspace_diagnostics: workspace_diagnostics_for_programmatic_output(
                     &result.config.root,
                 ),
                 next_steps,
                 envelope_mode: programmatic_root_envelope_mode(&resolved),
-            },
-        )
-        .map_err(|err| {
-            ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
-                .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
-                .with_context("health")
-        })?;
+            })
+            .map_err(|err| {
+                ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
+                    .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
+                    .with_context("health")
+            })?;
         crate::output_envelope::attach_telemetry_meta(&mut output);
         Ok(output)
     })

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -8,13 +8,13 @@ use fallow_core::duplicates::DuplicationReport;
 use fallow_core::results::AnalysisResults;
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
-use fallow_output::{HealthJsonOutputInput, strip_root_prefix};
+use fallow_output::strip_root_prefix;
 
 use super::emit_json;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutputInput,
-    EnvelopeMode, FallowOutput, GroupByMode, HealthOutputInput, WorkspaceDiagnosticOutput,
+    EnvelopeMode, FallowOutput, GroupByMode, WorkspaceDiagnosticOutput,
     apply_config_fixable_to_duplicate_exports, build_check_output, build_dupes_output,
     serialize_root_output,
 };
@@ -429,27 +429,22 @@ pub fn build_health_json(
     elapsed: Duration,
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let root_prefix = format!("{}/", root.display());
-    let mut output = fallow_output::serialize_health_json_output(HealthJsonOutputInput {
-        output: HealthOutputInput {
-            schema_version: SCHEMA_VERSION,
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            elapsed,
-            report: report.clone(),
-            grouped_by: None,
-            groups: None::<Vec<crate::health_types::HealthGroup>>,
-            meta: explain.then(fallow_output::health_meta),
-            workspace_diagnostics: workspace_diagnostics_for_output(root),
-            next_steps: fallow_output::build_health_next_steps(
-                crate::report::suggestions::health_next_steps_input(
-                    report,
-                    root,
-                    crate::report::suggestions::setup_pointer_applicable(root),
-                    crate::report::suggestions::due_impact_digest(root),
-                ),
+    let mut output = fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
+        report: report.clone(),
+        root,
+        elapsed,
+        explain,
+        grouped_by: None,
+        groups: None,
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
+        next_steps: fallow_output::build_health_next_steps(
+            crate::report::suggestions::health_next_steps_input(
+                report,
+                root,
+                crate::report::suggestions::setup_pointer_applicable(root),
+                crate::report::suggestions::due_impact_digest(root),
             ),
-        },
-        root_prefix: Some(&root_prefix),
+        ),
         envelope_mode: EnvelopeMode::current().into(),
     })?;
     crate::output_envelope::attach_telemetry_meta(&mut output);
@@ -463,27 +458,22 @@ pub fn build_grouped_health_json(
     elapsed: Duration,
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let root_prefix = format!("{}/", root.display());
-    fallow_output::serialize_health_json_output(HealthJsonOutputInput {
-        output: HealthOutputInput {
-            schema_version: SCHEMA_VERSION,
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            elapsed,
-            report: report.clone(),
-            grouped_by: Some(group_by_mode_from_label(grouping.mode)),
-            groups: Some(grouping.groups.clone()),
-            meta: explain.then(fallow_output::health_meta),
-            workspace_diagnostics: workspace_diagnostics_for_output(root),
-            next_steps: fallow_output::build_health_next_steps(
-                crate::report::suggestions::health_next_steps_input(
-                    report,
-                    root,
-                    crate::report::suggestions::setup_pointer_applicable(root),
-                    crate::report::suggestions::due_impact_digest(root),
-                ),
+    fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
+        report: report.clone(),
+        root,
+        elapsed,
+        explain,
+        grouped_by: Some(group_by_mode_from_label(grouping.mode)),
+        groups: Some(grouping.groups.clone()),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
+        next_steps: fallow_output::build_health_next_steps(
+            crate::report::suggestions::health_next_steps_input(
+                report,
+                root,
+                crate::report::suggestions::setup_pointer_applicable(root),
+                crate::report::suggestions::due_impact_digest(root),
             ),
-        },
-        root_prefix: Some(&root_prefix),
+        ),
         envelope_mode: EnvelopeMode::current().into(),
     })
 }
@@ -839,7 +829,7 @@ mod tests {
     }
 
     #[test]
-    fn grouped_health_json_uses_output_serializer_for_group_paths() {
+    fn grouped_health_json_uses_api_contract_for_group_paths() {
         let root = PathBuf::from("/project");
         let grouping = crate::health_types::HealthGrouping {
             mode: "package",


### PR DESCRIPTION
## Summary
- Generalize the API-owned health JSON serializer.
- Route CLI standalone and grouped health JSON output through the same API contract as programmatic health.
- Preserve schema version, envelope mode, meta, path stripping, diagnostics, next steps, and telemetry.

## Plan
- Local plan: .plans/api-health-json-report-contract.md

## Verification
- [x] cargo test -p fallow-api serialize_health_report_json --lib
- [x] cargo test -p fallow-cli health_json --lib
- [x] cargo test -p fallow-cli compute_health --lib
- [x] cargo test -p fallow-cli compute_complexity --lib
- [x] cargo check -p fallow-api -p fallow-cli
- [x] cargo clippy -p fallow-api -p fallow-cli --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] em dash scan
