### PR TITLE
refactor: centralize dynamic element render facts

### DIFF
--- a/crates/core/src/analyze/unrendered_component.rs
+++ b/crates/core/src/analyze/unrendered_component.rs
@@ -37,7 +37,8 @@ use std::path::Path;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::extract::{
-    AngularComponentSelector, ExportName, ImportedName, ModuleInfo, SemanticFact,
+    AngularComponentSelector, ExportName, ImportedName, ModuleInfo,
+    has_dynamic_custom_element_render,
 };
 
 use crate::discover::FileId;
@@ -571,17 +572,10 @@ pub fn find_unrendered_lit_elements(input: &LitUnrenderedInput<'_>) -> Vec<Unren
     // parse caches conservative.
     let mut rendered_tags: FxHashSet<&str> = FxHashSet::default();
     for module in modules {
-        if module
-            .semantic_facts
-            .iter()
-            .any(|fact| matches!(fact, SemanticFact::DynamicCustomElementRender(_)))
-        {
+        if has_dynamic_custom_element_render(module) {
             return Vec::new();
         }
         for tag in &module.used_custom_element_tags {
-            if tag == fallow_types::extract::DYNAMIC_CUSTOM_ELEMENT_TAG {
-                return Vec::new();
-            }
             rendered_tags.insert(tag.as_str());
         }
     }

--- a/crates/extract/src/sfc_template/angular.rs
+++ b/crates/extract/src/sfc_template/angular.rs
@@ -9,8 +9,9 @@
 //! - `@let name = expr;` template-local variables (Angular 18+)
 //! - `| pipeName` pipe references
 //!
-//! Referenced identifiers are stored as `MemberAccess` entries with a sentinel object name
-//! so the analysis phase can bridge them to the importing component's class members.
+//! Referenced bare identifiers are persisted as typed semantic facts, while
+//! member-access chains keep their real object/member shape for typed-instance
+//! propagation.
 
 use std::sync::LazyLock;
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1534,6 +1534,23 @@ pub fn is_legacy_template_or_semantic_whole_object_use(object: &str) -> bool {
         || is_legacy_semantic_whole_object_use(object)
 }
 
+/// Return true when a module contains a dynamic custom-element render.
+///
+/// Current extraction writes [`SemanticFact::DynamicCustomElementRender`].
+/// The tag fallback is decode-only compatibility for older parse caches that
+/// persisted [`DYNAMIC_CUSTOM_ELEMENT_TAG`] in `used_custom_element_tags`.
+#[must_use]
+pub fn has_dynamic_custom_element_render(module: &ModuleInfo) -> bool {
+    module
+        .semantic_facts
+        .iter()
+        .any(|fact| matches!(fact, SemanticFact::DynamicCustomElementRender(_)))
+        || module
+            .used_custom_element_tags
+            .iter()
+            .any(|tag| tag == DYNAMIC_CUSTOM_ELEMENT_TAG)
+}
+
 /// Decode an older sentinel-backed member access into the semantic fact shape
 /// used by current extraction.
 #[must_use]
@@ -3939,6 +3956,28 @@ mod tests {
             svelte_listened_events: Vec::new(),
             has_dynamic_dispatch: false,
         }
+    }
+
+    #[test]
+    fn dynamic_custom_element_render_helper_prefers_typed_fact() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::DynamicCustomElementRender(
+                DynamicCustomElementRenderFact,
+            ));
+
+        assert!(has_dynamic_custom_element_render(&module));
+    }
+
+    #[test]
+    fn dynamic_custom_element_render_helper_decodes_legacy_tag() {
+        let mut module = minimal_module_info();
+        module
+            .used_custom_element_tags
+            .push(DYNAMIC_CUSTOM_ELEMENT_TAG.to_string());
+
+        assert!(has_dynamic_custom_element_render(&module));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a `fallow-types::extract` compat helper for dynamic custom-element render facts.
- Keep legacy `<dynamic>` cache handling inside the extraction contract layer.
- Route the Lit unrendered-component analysis through the typed helper instead of reading the legacy sentinel directly.
- Refresh Angular template scanner docs to describe typed semantic facts rather than sentinel member accesses.

## Verification
- [x] cargo test -p fallow-types dynamic_custom_element_render_helper --lib
- [x] cargo test -p fallow-core unrendered_component --lib
- [x] cargo check -p fallow-types -p fallow-extract -p fallow-core
- [x] cargo clippy -p fallow-types -p fallow-extract -p fallow-core --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] em dash scan
