### PR TITLE
refactor: centralize root envelope mode mapping

### DIFF
--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -1349,11 +1349,7 @@ fn is_absolute_path_any_platform(path: &Path) -> bool {
 }
 
 const fn root_envelope_mode(legacy_envelope: bool) -> RootEnvelopeMode {
-    if legacy_envelope {
-        RootEnvelopeMode::Legacy
-    } else {
-        RootEnvelopeMode::Tagged
-    }
+    RootEnvelopeMode::from_legacy(legacy_envelope)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -254,11 +254,7 @@ fn apply_programmatic_envelope_options(
 fn programmatic_root_envelope_mode(
     resolved: &ResolvedAnalysisOptions,
 ) -> fallow_output::RootEnvelopeMode {
-    if resolved.legacy_envelope {
-        fallow_output::RootEnvelopeMode::Legacy
-    } else {
-        fallow_output::RootEnvelopeMode::Tagged
-    }
+    fallow_output::RootEnvelopeMode::from_legacy(resolved.legacy_envelope)
 }
 
 fn workspace_diagnostics_for_programmatic_output(

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -11,6 +11,18 @@ pub enum RootEnvelopeMode {
     Legacy,
 }
 
+impl RootEnvelopeMode {
+    /// Convert a legacy-envelope flag into the root envelope mode.
+    #[must_use]
+    pub const fn from_legacy(legacy_envelope: bool) -> Self {
+        if legacy_envelope {
+            Self::Legacy
+        } else {
+            Self::Tagged
+        }
+    }
+}
+
 /// Serialize a typed fallow root envelope with the requested discriminator
 /// mode.
 ///
@@ -285,6 +297,18 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn root_envelope_mode_maps_legacy_flag() {
+        assert_eq!(
+            RootEnvelopeMode::from_legacy(false),
+            RootEnvelopeMode::Tagged
+        );
+        assert_eq!(
+            RootEnvelopeMode::from_legacy(true),
+            RootEnvelopeMode::Legacy
+        );
+    }
 
     #[test]
     fn legacy_mode_removes_only_root_kind() {


### PR DESCRIPTION
## Summary
- Add an output-owned RootEnvelopeMode::from_legacy constructor.
- Route API and CLI programmatic envelope mode selection through the shared contract.
- Keep JSON envelope behavior unchanged.

## Verification
- [x] cargo test -p fallow-output root_envelope --lib
- [x] cargo test -p fallow-api legacy_envelope --lib
- [x] cargo test -p fallow-cli legacy_envelope --lib
- [x] cargo check -p fallow-output -p fallow-api -p fallow-cli
- [x] cargo clippy -p fallow-output -p fallow-api -p fallow-cli --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] git diff --check
- [x] changed-file em dash scan
- [x] pre-commit guard
- [x] pre-push guard