### PR TITLE
refactor: centralize angular template fact helpers

### DIFF
--- a/crates/core/src/analyze/unused_component_input.rs
+++ b/crates/core/src/analyze/unused_component_input.rs
@@ -39,8 +39,8 @@ use std::path::Path;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::extract::{
-    ModuleInfo, SemanticFact, is_legacy_angular_template_member_access_object,
-    is_legacy_angular_this_spread_object,
+    ModuleInfo, angular_template_member_names, has_angular_template_members,
+    has_angular_this_spread,
 };
 
 use crate::discover::FileId;
@@ -164,27 +164,7 @@ pub(super) fn insert_angular_template_members<'a>(
     module: &'a ModuleInfo,
     out: &mut FxHashSet<&'a str>,
 ) {
-    for fact in &module.semantic_facts {
-        if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
-            out.insert(access.member.as_str());
-        }
-    }
-    for access in &module.member_accesses {
-        if is_legacy_angular_template_member_access_object(&access.object) {
-            out.insert(access.member.as_str());
-        }
-    }
-}
-
-pub(super) fn has_angular_template_members(module: &ModuleInfo) -> bool {
-    module
-        .semantic_facts
-        .iter()
-        .any(|fact| matches!(fact, SemanticFact::AngularTemplateMemberAccess(_)))
-        || module
-            .member_accesses
-            .iter()
-            .any(|a| is_legacy_angular_template_member_access_object(&a.object))
+    out.extend(angular_template_member_names(module));
 }
 
 /// Whether the component declares an `extends` heritage clause anywhere in its
@@ -201,14 +181,7 @@ fn component_has_extends(module: &ModuleInfo) -> bool {
 /// Whether the module spreads `this` into an object literal (`{ ...this }`).
 /// Every input/output is then consumed opaquely, so the whole component abstains.
 pub(super) fn component_spreads_this(module: &ModuleInfo) -> bool {
-    module
-        .semantic_facts
-        .iter()
-        .any(|fact| matches!(fact, SemanticFact::AngularThisSpread(_)))
-        || module
-            .member_accesses
-            .iter()
-            .any(|a| is_legacy_angular_this_spread_object(&a.object))
+    has_angular_this_spread(module)
 }
 
 /// The `.ts` modules reached from `from` by a `SideEffect`-shaped edge that hold

--- a/crates/core/src/analyze/unused_component_output.rs
+++ b/crates/core/src/analyze/unused_component_output.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use fallow_types::extract::ModuleInfo;
+use fallow_types::extract::{ModuleInfo, has_angular_template_members};
 
 use crate::discover::FileId;
 use crate::graph::{ModuleGraph, ModuleNode};
@@ -183,7 +183,7 @@ fn external_template_modules<'a>(
         let Some(target_module) = modules_by_id.get(&target) else {
             continue;
         };
-        if super::unused_component_input::has_angular_template_members(target_module) {
+        if has_angular_template_members(target_module) {
             out.push(*target_module);
         }
     }

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -12,8 +12,8 @@ use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
-    SemanticFact, is_legacy_angular_template_member_access_object,
-    is_legacy_template_or_semantic_member_access_object,
+    SemanticFact, angular_template_member_names_from_parts,
+    has_angular_template_members_from_parts, is_legacy_template_or_semantic_member_access_object,
     is_legacy_template_or_semantic_whole_object_use, semantic_facts_with_legacy_member_accesses,
 };
 
@@ -574,7 +574,11 @@ fn build_angular_template_refs(
     resolved_modules
         .iter()
         .filter_map(|module| {
-            let refs = angular_template_member_refs(module);
+            let refs: Vec<&str> = angular_template_member_names_from_parts(
+                &module.semantic_facts,
+                &module.member_accesses,
+            )
+            .collect();
             if refs.is_empty() {
                 None
             } else {
@@ -590,7 +594,10 @@ fn build_angular_template_chain_accesses(
     resolved_modules
         .iter()
         .filter_map(|module| {
-            if !has_angular_template_member_refs(module) {
+            if !has_angular_template_members_from_parts(
+                &module.semantic_facts,
+                &module.member_accesses,
+            ) {
                 return None;
             }
             let chains: Vec<(&str, &str)> = module
@@ -609,38 +616,6 @@ fn build_angular_template_chain_accesses(
             }
         })
         .collect()
-}
-
-fn angular_template_member_refs(module: &ResolvedModule) -> Vec<&str> {
-    module
-        .semantic_facts
-        .iter()
-        .filter_map(|fact| {
-            if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
-                Some(access.member.as_str())
-            } else {
-                None
-            }
-        })
-        .chain(
-            module
-                .member_accesses
-                .iter()
-                .filter(|access| is_legacy_angular_template_member_access_object(&access.object))
-                .map(|access| access.member.as_str()),
-        )
-        .collect()
-}
-
-fn has_angular_template_member_refs(module: &ResolvedModule) -> bool {
-    module
-        .semantic_facts
-        .iter()
-        .any(|fact| matches!(fact, SemanticFact::AngularTemplateMemberAccess(_)))
-        || module
-            .member_accesses
-            .iter()
-            .any(|access| is_legacy_angular_template_member_access_object(&access.object))
 }
 
 struct AngularTemplateRefContext<'a, 'b> {

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1534,6 +1534,45 @@ pub fn is_legacy_template_or_semantic_whole_object_use(object: &str) -> bool {
         || is_legacy_semantic_whole_object_use(object)
 }
 
+/// Iterate Angular template member names from typed facts plus decoded legacy
+/// template member-access sentinels.
+pub fn angular_template_member_names(module: &ModuleInfo) -> impl Iterator<Item = &str> {
+    let typed = module.semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
+            Some(access.member.as_str())
+        } else {
+            None
+        }
+    });
+    let legacy = module.member_accesses.iter().filter_map(|access| {
+        if is_legacy_angular_template_member_access_object(&access.object) {
+            Some(access.member.as_str())
+        } else {
+            None
+        }
+    });
+    typed.chain(legacy)
+}
+
+/// Return true when the module contains any Angular template member reference.
+#[must_use]
+pub fn has_angular_template_members(module: &ModuleInfo) -> bool {
+    angular_template_member_names(module).next().is_some()
+}
+
+/// Return true when a module spreads `this` in Angular template context.
+#[must_use]
+pub fn has_angular_this_spread(module: &ModuleInfo) -> bool {
+    module
+        .semantic_facts
+        .iter()
+        .any(|fact| matches!(fact, SemanticFact::AngularThisSpread(_)))
+        || module
+            .member_accesses
+            .iter()
+            .any(|access| is_legacy_angular_this_spread_object(&access.object))
+}
+
 /// Return true when a module contains a dynamic custom-element render.
 ///
 /// Current extraction writes [`SemanticFact::DynamicCustomElementRender`].
@@ -2469,6 +2508,44 @@ mod tests {
         )));
         assert!(!is_legacy_template_or_semantic_member_access_object("this"));
         assert!(!is_legacy_template_or_semantic_whole_object_use("this"));
+    }
+
+    #[test]
+    fn angular_template_member_names_include_typed_and_legacy_facts() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::AngularTemplateMemberAccess(
+                AngularTemplateMemberAccessFact {
+                    member: "typed".to_string(),
+                },
+            ));
+        module.member_accesses.push(MemberAccess {
+            object: ANGULAR_TPL_SENTINEL.to_string(),
+            member: "legacy".to_string(),
+        });
+
+        let names: Vec<&str> = angular_template_member_names(&module).collect();
+
+        assert_eq!(names, vec!["typed", "legacy"]);
+        assert!(has_angular_template_members(&module));
+    }
+
+    #[test]
+    fn angular_this_spread_accepts_typed_and_legacy_facts() {
+        let mut typed = minimal_module_info();
+        typed
+            .semantic_facts
+            .push(SemanticFact::AngularThisSpread(AngularThisSpreadFact));
+        let mut legacy = minimal_module_info();
+        legacy.member_accesses.push(MemberAccess {
+            object: ANGULAR_THIS_SPREAD_SENTINEL.to_string(),
+            member: "*".to_string(),
+        });
+
+        assert!(has_angular_this_spread(&typed));
+        assert!(has_angular_this_spread(&legacy));
+        assert!(!has_angular_this_spread(&minimal_module_info()));
     }
 
     #[test]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1536,15 +1536,18 @@ pub fn is_legacy_template_or_semantic_whole_object_use(object: &str) -> bool {
 
 /// Iterate Angular template member names from typed facts plus decoded legacy
 /// template member-access sentinels.
-pub fn angular_template_member_names(module: &ModuleInfo) -> impl Iterator<Item = &str> {
-    let typed = module.semantic_facts.iter().filter_map(|fact| {
+pub fn angular_template_member_names_from_parts<'a>(
+    semantic_facts: &'a [SemanticFact],
+    member_accesses: &'a [MemberAccess],
+) -> impl Iterator<Item = &'a str> + 'a {
+    let typed = semantic_facts.iter().filter_map(|fact| {
         if let SemanticFact::AngularTemplateMemberAccess(access) = fact {
             Some(access.member.as_str())
         } else {
             None
         }
     });
-    let legacy = module.member_accesses.iter().filter_map(|access| {
+    let legacy = member_accesses.iter().filter_map(|access| {
         if is_legacy_angular_template_member_access_object(&access.object) {
             Some(access.member.as_str())
         } else {
@@ -1554,10 +1557,28 @@ pub fn angular_template_member_names(module: &ModuleInfo) -> impl Iterator<Item 
     typed.chain(legacy)
 }
 
+/// Iterate Angular template member names from a module's typed facts plus
+/// decoded legacy template member-access sentinels.
+pub fn angular_template_member_names(module: &ModuleInfo) -> impl Iterator<Item = &str> {
+    angular_template_member_names_from_parts(&module.semantic_facts, &module.member_accesses)
+}
+
+/// Return true when the fact/member-access slices contain any Angular template
+/// member reference.
+#[must_use]
+pub fn has_angular_template_members_from_parts(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> bool {
+    angular_template_member_names_from_parts(semantic_facts, member_accesses)
+        .next()
+        .is_some()
+}
+
 /// Return true when the module contains any Angular template member reference.
 #[must_use]
 pub fn has_angular_template_members(module: &ModuleInfo) -> bool {
-    angular_template_member_names(module).next().is_some()
+    has_angular_template_members_from_parts(&module.semantic_facts, &module.member_accesses)
 }
 
 /// Return true when a module spreads `this` in Angular template context.


### PR DESCRIPTION
## Summary
- Move Angular template fact helper reads into fallow-types.
- Keep typed facts and legacy sentinels accepted during migration.
- Let input and output analysis share the same typed-plus-legacy contract.

## Verification
- cargo test -p fallow-types angular_template --lib
- cargo test -p fallow-types angular_this_spread --lib
- cargo test -p fallow-core unused_component_input --lib
- cargo test -p fallow-core unused_component_output --lib
- cargo check -p fallow-types -p fallow-core
- cargo clippy -p fallow-types -p fallow-core --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check