### PR TITLE
refactor: route programmatic results through engine

### DIFF
--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use fallow_config::OutputFormat;
-use fallow_core::results::AnalysisResults;
+use fallow_engine::results::AnalysisResults;
 
 use crate::check::{CheckOptions, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions};


### PR DESCRIPTION
## Summary
- Route cli::programmatic result typing through the engine facade.
- Reduce direct core result coupling at the programmatic boundary.

## Verification
- cargo check -p fallow-cli
- cargo test -p fallow-cli programmatic --lib
- cargo clippy -p fallow-cli --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check