### PR TITLE
refactor: centralize playwright fixture fact accessors

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -12,11 +12,13 @@ use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
-    SemanticFact, angular_template_member_names_from_parts,
-    has_angular_template_members_from_parts, is_legacy_template_or_semantic_member_access_object,
+    angular_template_member_names_from_parts, factory_call_member_access_facts_with_legacy,
+    fluent_chain_member_access_facts_with_legacy, fluent_chain_new_member_access_facts_with_legacy,
+    has_angular_template_members_from_parts, instance_export_binding_facts_with_legacy,
+    is_legacy_template_or_semantic_member_access_object,
     is_legacy_template_or_semantic_whole_object_use, playwright_fixture_alias_facts,
     playwright_fixture_definition_facts, playwright_fixture_type_facts,
-    playwright_fixture_use_facts, semantic_facts_with_legacy_member_accesses,
+    playwright_fixture_use_facts,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -1238,8 +1240,11 @@ fn build_instance_export_targets(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in instance_export_binding_accesses(resolved) {
-            let Some(target_keys) = local_to_export_keys.get(access.target_local.as_str()) else {
+        for access in instance_export_binding_facts_with_legacy(
+            &resolved.semantic_facts,
+            &resolved.member_accesses,
+        ) {
+            let Some(target_keys) = local_to_export_keys.get(access.target_name.as_str()) else {
                 continue;
             };
 
@@ -1254,26 +1259,6 @@ fn build_instance_export_targets(
     }
 
     targets_by_instance
-}
-
-struct InstanceExportBindingAccess {
-    export_name: String,
-    target_local: String,
-}
-
-fn instance_export_binding_accesses(module: &ResolvedModule) -> Vec<InstanceExportBindingAccess> {
-    let mut accesses = Vec::new();
-    for fact in
-        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
-    {
-        if let SemanticFact::InstanceExportBinding(access) = fact.as_fact() {
-            accesses.push(InstanceExportBindingAccess {
-                export_name: access.export_name.clone(),
-                target_local: access.target_name.clone(),
-            });
-        }
-    }
-    accesses
 }
 
 fn propagate_accesses_through_instance_exports(
@@ -1506,28 +1491,6 @@ fn propagate_typed_whole_object_uses(
     }
 }
 
-struct FactoryCallAccess {
-    callee_object: String,
-    callee_method: String,
-    member: String,
-}
-
-fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess> {
-    let mut accesses = Vec::new();
-    for fact in
-        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
-    {
-        if let SemanticFact::FactoryCallMemberAccess(access) = fact.as_fact() {
-            accesses.push(FactoryCallAccess {
-                callee_object: access.callee_object.clone(),
-                callee_method: access.callee_method.clone(),
-                member: access.member.clone(),
-            });
-        }
-    }
-    accesses
-}
-
 /// Credit member accesses produced by static-factory call bindings on the
 /// originating class export.
 fn propagate_factory_call_accesses(
@@ -1542,7 +1505,10 @@ fn propagate_factory_call_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in factory_call_accesses(resolved) {
+        for access in factory_call_member_access_facts_with_legacy(
+            &resolved.semantic_facts,
+            &resolved.member_accesses,
+        ) {
             let Some(seed_keys) = local_to_export_keys.get(access.callee_object.as_str()) else {
                 continue;
             };
@@ -1572,30 +1538,6 @@ fn propagate_factory_call_accesses(
             }
         }
     }
-}
-
-struct FluentChainAccess {
-    root_local: String,
-    root_method: String,
-    chain: Vec<String>,
-    member: String,
-}
-
-fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess> {
-    let mut accesses = Vec::new();
-    for fact in
-        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
-    {
-        if let SemanticFact::FluentChainMemberAccess(access) = fact.as_fact() {
-            accesses.push(FluentChainAccess {
-                root_local: access.root_object.clone(),
-                root_method: access.root_method.clone(),
-                chain: access.chain.clone(),
-                member: access.member.clone(),
-            });
-        }
-    }
-    accesses
 }
 
 /// Validate a fluent chain against a single class export.
@@ -1638,8 +1580,11 @@ fn propagate_fluent_chain_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in fluent_chain_accesses(resolved) {
-            let Some(seed_keys) = local_to_export_keys.get(access.root_local.as_str()) else {
+        for access in fluent_chain_member_access_facts_with_legacy(
+            &resolved.semantic_facts,
+            &resolved.member_accesses,
+        ) {
+            let Some(seed_keys) = local_to_export_keys.get(access.root_object.as_str()) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -1669,28 +1614,6 @@ fn propagate_fluent_chain_accesses(
             }
         }
     }
-}
-
-struct FluentChainNewAccess {
-    class_local: String,
-    chain: Vec<String>,
-    member: String,
-}
-
-fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAccess> {
-    let mut accesses = Vec::new();
-    for fact in
-        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
-    {
-        if let SemanticFact::FluentChainNewMemberAccess(access) = fact.as_fact() {
-            accesses.push(FluentChainNewAccess {
-                class_local: access.class_name.clone(),
-                chain: access.chain.clone(),
-                member: access.member.clone(),
-            });
-        }
-    }
-    accesses
 }
 
 /// Validate a constructor-rooted fluent chain against a single class export.
@@ -1724,8 +1647,11 @@ fn propagate_fluent_chain_new_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in fluent_chain_new_accesses(resolved) {
-            let Some(seed_keys) = local_to_export_keys.get(access.class_local.as_str()) else {
+        for access in fluent_chain_new_member_access_facts_with_legacy(
+            &resolved.semantic_facts,
+            &resolved.member_accesses,
+        ) {
+            let Some(seed_keys) = local_to_export_keys.get(access.class_name.as_str()) else {
                 continue;
             };
             for seed_key in seed_keys {
@@ -2544,7 +2470,7 @@ mod tests {
         ClassHeritageInfo, FLUENT_CHAIN_NEW_SENTINEL, FactoryCallMemberAccessFact,
         FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, InstanceExportBindingFact,
         PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
-        PlaywrightFixtureUseFact, SemanticFact,
+        PlaywrightFixtureUseFact, SemanticFact, semantic_facts_with_legacy_member_accesses,
     };
     use oxc_span::Span;
     use std::path::PathBuf;

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -14,7 +14,9 @@ use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
     SemanticFact, angular_template_member_names_from_parts,
     has_angular_template_members_from_parts, is_legacy_template_or_semantic_member_access_object,
-    is_legacy_template_or_semantic_whole_object_use, semantic_facts_with_legacy_member_accesses,
+    is_legacy_template_or_semantic_whole_object_use, playwright_fixture_alias_facts,
+    playwright_fixture_definition_facts, playwright_fixture_type_facts,
+    playwright_fixture_use_facts, semantic_facts_with_legacy_member_accesses,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -921,90 +923,6 @@ fn is_entry_point_public_class_export(
             || export_has_entry_point_re_export_reference(graph, export, public_api_entry_points))
 }
 
-struct PlaywrightFixtureUseAccess<'a> {
-    test_local_name: &'a str,
-    fixture_name: &'a str,
-    member: &'a str,
-}
-
-struct PlaywrightFixtureDefinitionAccess<'a> {
-    test_local: &'a str,
-    fixture: &'a str,
-    type_local: &'a str,
-}
-
-struct PlaywrightFixtureAliasAccess<'a> {
-    test_local: &'a str,
-    base_local: &'a str,
-}
-
-struct PlaywrightFixtureTypeAccess<'a> {
-    alias_local: &'a str,
-    fixture: &'a str,
-    type_local: &'a str,
-}
-
-fn playwright_fixture_type_accesses(
-    module: &ResolvedModule,
-) -> Vec<PlaywrightFixtureTypeAccess<'_>> {
-    let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::PlaywrightFixtureType(access) = fact {
-            accesses.push(PlaywrightFixtureTypeAccess {
-                alias_local: access.alias_name.as_str(),
-                fixture: access.fixture_name.as_str(),
-                type_local: access.type_name.as_str(),
-            });
-        }
-    }
-    accesses
-}
-
-fn playwright_fixture_alias_accesses(
-    module: &ResolvedModule,
-) -> Vec<PlaywrightFixtureAliasAccess<'_>> {
-    let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::PlaywrightFixtureAlias(access) = fact {
-            accesses.push(PlaywrightFixtureAliasAccess {
-                test_local: access.test_name.as_str(),
-                base_local: access.base_name.as_str(),
-            });
-        }
-    }
-    accesses
-}
-
-fn playwright_fixture_definition_accesses(
-    module: &ResolvedModule,
-) -> Vec<PlaywrightFixtureDefinitionAccess<'_>> {
-    let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::PlaywrightFixtureDefinition(access) = fact {
-            accesses.push(PlaywrightFixtureDefinitionAccess {
-                test_local: access.test_name.as_str(),
-                fixture: access.fixture_name.as_str(),
-                type_local: access.type_name.as_str(),
-            });
-        }
-    }
-    accesses
-}
-
-fn playwright_fixture_use_accesses(module: &ResolvedModule) -> Vec<PlaywrightFixtureUseAccess<'_>> {
-    let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::PlaywrightFixtureUse(access) = fact {
-            accesses.push(PlaywrightFixtureUseAccess {
-                test_local_name: access.test_name.as_str(),
-                fixture_name: access.fixture_name.as_str(),
-                member: access.member.as_str(),
-            });
-        }
-    }
-    accesses
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum PlaywrightTestKey {
     Export(ExportKey),
@@ -1019,11 +937,11 @@ fn push_playwright_test_key(keys: &mut Vec<PlaywrightTestKey>, key: PlaywrightTe
 
 fn collect_playwright_local_test_names(resolved: &ResolvedModule) -> FxHashSet<&str> {
     let mut names = FxHashSet::default();
-    for access in playwright_fixture_definition_accesses(resolved) {
-        names.insert(access.test_local);
+    for access in playwright_fixture_definition_facts(&resolved.semantic_facts) {
+        names.insert(access.test_name.as_str());
     }
-    for access in playwright_fixture_alias_accesses(resolved) {
-        names.insert(access.test_local);
+    for access in playwright_fixture_alias_facts(&resolved.semantic_facts) {
+        names.insert(access.test_name.as_str());
     }
     names
 }
@@ -1100,14 +1018,14 @@ fn collect_playwright_fixture_def_targets(
     type_targets: &FxHashMap<ExportKey, FxHashMap<String, Vec<ExportKey>>>,
     targets_by_test: &mut FxHashMap<PlaywrightTestKey, FxHashMap<String, Vec<ExportKey>>>,
 ) {
-    for access in playwright_fixture_definition_accesses(resolved) {
+    for access in playwright_fixture_definition_facts(&resolved.semantic_facts) {
         let test_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
             resolved.file_id,
-            access.test_local,
+            access.test_name.as_str(),
         );
-        let Some(target_keys) = local_to_export_keys.get(access.type_local) else {
+        let Some(target_keys) = local_to_export_keys.get(access.type_name.as_str()) else {
             continue;
         };
 
@@ -1118,7 +1036,7 @@ fn collect_playwright_fixture_def_targets(
                     graph,
                     type_targets,
                     fixture_targets,
-                    access.fixture,
+                    access.fixture_name.as_str(),
                     target_key,
                 );
             }
@@ -1135,18 +1053,18 @@ fn collect_playwright_fixture_aliases(
     local_playwright_test_names: &FxHashSet<&str>,
     aliases_by_test: &mut FxHashMap<PlaywrightTestKey, Vec<PlaywrightTestKey>>,
 ) {
-    for access in playwright_fixture_alias_accesses(resolved) {
+    for access in playwright_fixture_alias_facts(&resolved.semantic_facts) {
         let test_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
             resolved.file_id,
-            access.test_local,
+            access.test_name.as_str(),
         );
         let base_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
             resolved.file_id,
-            access.base_local,
+            access.base_name.as_str(),
         );
 
         for test_key in test_keys {
@@ -1252,17 +1170,19 @@ fn build_playwright_fixture_type_targets(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in playwright_fixture_type_accesses(resolved) {
-            let Some(alias_keys) = local_to_export_keys.get(access.alias_local) else {
+        for access in playwright_fixture_type_facts(&resolved.semantic_facts) {
+            let Some(alias_keys) = local_to_export_keys.get(access.alias_name.as_str()) else {
                 continue;
             };
-            let Some(target_keys) = local_to_export_keys.get(access.type_local) else {
+            let Some(target_keys) = local_to_export_keys.get(access.type_name.as_str()) else {
                 continue;
             };
 
             for alias_key in alias_keys {
                 let alias_targets = targets_by_alias.entry(alias_key.clone()).or_default();
-                let fixture_targets = alias_targets.entry(access.fixture.to_string()).or_default();
+                let fixture_targets = alias_targets
+                    .entry(access.fixture_name.clone())
+                    .or_default();
                 for target_key in target_keys {
                     for key in export_key_with_origins(graph, target_key) {
                         push_export_key(fixture_targets, key);
@@ -1287,8 +1207,8 @@ fn propagate_playwright_fixture_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in playwright_fixture_use_accesses(resolved) {
-            let Some(test_keys) = local_to_export_keys.get(access.test_local_name) else {
+        for access in playwright_fixture_use_facts(&resolved.semantic_facts) {
+            let Some(test_keys) = local_to_export_keys.get(access.test_name.as_str()) else {
                 continue;
             };
 
@@ -1296,14 +1216,14 @@ fn propagate_playwright_fixture_accesses(
                 let Some(fixture_targets) = targets_by_test.get(test_key) else {
                     continue;
                 };
-                let Some(target_keys) = fixture_targets.get(access.fixture_name) else {
+                let Some(target_keys) = fixture_targets.get(access.fixture_name.as_str()) else {
                     continue;
                 };
                 for target_key in target_keys {
                     accessed_members
                         .entry(target_key.clone())
                         .or_default()
-                        .insert(access.member.to_string());
+                        .insert(access.member.clone());
                 }
             }
         }

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1745,6 +1745,58 @@ pub fn semantic_facts_with_legacy_member_accesses<'a>(
         }))
 }
 
+/// Iterate typed Playwright fixture-use facts.
+pub fn playwright_fixture_use_facts(
+    semantic_facts: &[SemanticFact],
+) -> impl Iterator<Item = &PlaywrightFixtureUseFact> {
+    semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::PlaywrightFixtureUse(access) = fact {
+            Some(access)
+        } else {
+            None
+        }
+    })
+}
+
+/// Iterate typed Playwright fixture-definition facts.
+pub fn playwright_fixture_definition_facts(
+    semantic_facts: &[SemanticFact],
+) -> impl Iterator<Item = &PlaywrightFixtureDefinitionFact> {
+    semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::PlaywrightFixtureDefinition(access) = fact {
+            Some(access)
+        } else {
+            None
+        }
+    })
+}
+
+/// Iterate typed Playwright fixture-alias facts.
+pub fn playwright_fixture_alias_facts(
+    semantic_facts: &[SemanticFact],
+) -> impl Iterator<Item = &PlaywrightFixtureAliasFact> {
+    semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::PlaywrightFixtureAlias(access) = fact {
+            Some(access)
+        } else {
+            None
+        }
+    })
+}
+
+/// Iterate typed Playwright fixture-type facts.
+pub fn playwright_fixture_type_facts(
+    semantic_facts: &[SemanticFact],
+) -> impl Iterator<Item = &PlaywrightFixtureTypeFact> {
+    semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::PlaywrightFixtureType(access) = fact {
+            Some(access)
+        } else {
+            None
+        }
+    })
+}
+
 /// A member name referenced from an Angular template surface.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -2668,6 +2720,71 @@ mod tests {
                     target_name: "target".to_string(),
                 }
             ))
+        );
+    }
+
+    #[test]
+    fn playwright_fixture_fact_helpers_select_each_fact_family() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::PlaywrightFixtureUse(
+                PlaywrightFixtureUseFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "page".to_string(),
+                    member: "goto".to_string(),
+                },
+            ));
+        module
+            .semantic_facts
+            .push(SemanticFact::PlaywrightFixtureDefinition(
+                PlaywrightFixtureDefinitionFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "adminPage".to_string(),
+                    type_name: "AdminPage".to_string(),
+                },
+            ));
+        module
+            .semantic_facts
+            .push(SemanticFact::PlaywrightFixtureAlias(
+                PlaywrightFixtureAliasFact {
+                    test_name: "mergedTest".to_string(),
+                    base_name: "test".to_string(),
+                },
+            ));
+        module
+            .semantic_facts
+            .push(SemanticFact::PlaywrightFixtureType(
+                PlaywrightFixtureTypeFact {
+                    alias_name: "Pages".to_string(),
+                    fixture_name: "adminPage".to_string(),
+                    type_name: "AdminPage".to_string(),
+                },
+            ));
+
+        assert_eq!(
+            playwright_fixture_use_facts(&module.semantic_facts)
+                .map(|fact| fact.member.as_str())
+                .collect::<Vec<_>>(),
+            vec!["goto"]
+        );
+        assert_eq!(
+            playwright_fixture_definition_facts(&module.semantic_facts)
+                .map(|fact| fact.type_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["AdminPage"]
+        );
+        assert_eq!(
+            playwright_fixture_alias_facts(&module.semantic_facts)
+                .map(|fact| fact.base_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["test"]
+        );
+        assert_eq!(
+            playwright_fixture_type_facts(&module.semantic_facts)
+                .map(|fact| fact.fixture_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["adminPage"]
         );
     }
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1745,6 +1745,71 @@ pub fn semantic_facts_with_legacy_member_accesses<'a>(
         }))
 }
 
+/// Collect instance-export binding facts from typed facts plus legacy sentinels.
+pub fn instance_export_binding_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<InstanceExportBindingFact> {
+    semantic_facts_with_legacy_member_accesses(semantic_facts, member_accesses)
+        .filter_map(|fact| {
+            if let SemanticFact::InstanceExportBinding(access) = fact.as_fact() {
+                Some(access.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Collect factory-call member facts from typed facts plus legacy sentinels.
+pub fn factory_call_member_access_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<FactoryCallMemberAccessFact> {
+    semantic_facts_with_legacy_member_accesses(semantic_facts, member_accesses)
+        .filter_map(|fact| {
+            if let SemanticFact::FactoryCallMemberAccess(access) = fact.as_fact() {
+                Some(access.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Collect fluent-chain member facts from typed facts plus legacy sentinels.
+pub fn fluent_chain_member_access_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<FluentChainMemberAccessFact> {
+    semantic_facts_with_legacy_member_accesses(semantic_facts, member_accesses)
+        .filter_map(|fact| {
+            if let SemanticFact::FluentChainMemberAccess(access) = fact.as_fact() {
+                Some(access.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Collect constructor-rooted fluent-chain member facts from typed facts plus
+/// legacy sentinels.
+pub fn fluent_chain_new_member_access_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<FluentChainNewMemberAccessFact> {
+    semantic_facts_with_legacy_member_accesses(semantic_facts, member_accesses)
+        .filter_map(|fact| {
+            if let SemanticFact::FluentChainNewMemberAccess(access) = fact.as_fact() {
+                Some(access.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Iterate typed Playwright fixture-use facts.
 pub fn playwright_fixture_use_facts(
     semantic_facts: &[SemanticFact],
@@ -2720,6 +2785,78 @@ mod tests {
                     target_name: "target".to_string(),
                 }
             ))
+        );
+    }
+
+    #[test]
+    fn legacy_backed_fact_helpers_collect_owned_family_facts() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::FluentChainMemberAccess(
+                FluentChainMemberAccessFact {
+                    root_object: "Builder".to_string(),
+                    root_method: "start".to_string(),
+                    chain: vec!["next".to_string()],
+                    member: "value".to_string(),
+                },
+            ));
+        module.member_accesses.push(MemberAccess {
+            object: format!("{INSTANCE_EXPORT_SENTINEL}exported"),
+            member: "target".to_string(),
+        });
+        module.member_accesses.push(MemberAccess {
+            object: format!("{FACTORY_CALL_SENTINEL}Svc:create"),
+            member: "run".to_string(),
+        });
+        module.member_accesses.push(MemberAccess {
+            object: format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:next,finish"),
+            member: "done".to_string(),
+        });
+
+        assert_eq!(
+            instance_export_binding_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![InstanceExportBindingFact {
+                export_name: "exported".to_string(),
+                target_name: "target".to_string(),
+            }]
+        );
+        assert_eq!(
+            factory_call_member_access_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![FactoryCallMemberAccessFact {
+                callee_object: "Svc".to_string(),
+                callee_method: "create".to_string(),
+                member: "run".to_string(),
+            }]
+        );
+        assert_eq!(
+            fluent_chain_member_access_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![FluentChainMemberAccessFact {
+                root_object: "Builder".to_string(),
+                root_method: "start".to_string(),
+                chain: vec!["next".to_string()],
+                member: "value".to_string(),
+            }]
+        );
+        assert_eq!(
+            fluent_chain_new_member_access_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![FluentChainNewMemberAccessFact {
+                class_name: "Builder".to_string(),
+                chain: vec!["next".to_string(), "finish".to_string()],
+                member: "done".to_string(),
+            }]
         );
     }
 


### PR DESCRIPTION
## Summary
- Add shared Playwright fixture fact accessors to fallow-types.
- Add shared typed-plus-legacy accessors for instance export, factory call, and fluent chain semantic facts.
- Remove local semantic fact enum filtering from unused-members analysis.
- Keep behavior unchanged while moving fact consumption toward the shared extraction contract layer.

## Verification
- cargo test -p fallow-types fact_helpers --lib
- cargo test -p fallow-core unused_members --lib
- cargo check -p fallow-types -p fallow-core
- cargo clippy -p fallow-types -p fallow-core --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check