### PR TITLE
refactor: decode legacy Playwright fixture facts

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -16,9 +16,9 @@ use fallow_types::extract::{
     fluent_chain_member_access_facts_with_legacy, fluent_chain_new_member_access_facts_with_legacy,
     has_angular_template_members_from_parts, instance_export_binding_facts_with_legacy,
     is_legacy_template_or_semantic_member_access_object,
-    is_legacy_template_or_semantic_whole_object_use, playwright_fixture_alias_facts,
-    playwright_fixture_definition_facts, playwright_fixture_type_facts,
-    playwright_fixture_use_facts,
+    is_legacy_template_or_semantic_whole_object_use, playwright_fixture_alias_facts_with_legacy,
+    playwright_fixture_definition_facts_with_legacy, playwright_fixture_type_facts_with_legacy,
+    playwright_fixture_use_facts_with_legacy,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -937,20 +937,28 @@ fn push_playwright_test_key(keys: &mut Vec<PlaywrightTestKey>, key: PlaywrightTe
     }
 }
 
-fn collect_playwright_local_test_names(resolved: &ResolvedModule) -> FxHashSet<&str> {
+fn collect_playwright_local_test_names(resolved: &ResolvedModule) -> FxHashSet<String> {
     let mut names = FxHashSet::default();
-    for access in playwright_fixture_definition_facts(&resolved.semantic_facts) {
-        names.insert(access.test_name.as_str());
+    let definition_facts = playwright_fixture_definition_facts_with_legacy(
+        &resolved.semantic_facts,
+        &resolved.member_accesses,
+    );
+    for access in &definition_facts {
+        names.insert(access.test_name.clone());
     }
-    for access in playwright_fixture_alias_facts(&resolved.semantic_facts) {
-        names.insert(access.test_name.as_str());
+    let alias_facts = playwright_fixture_alias_facts_with_legacy(
+        &resolved.semantic_facts,
+        &resolved.member_accesses,
+    );
+    for access in &alias_facts {
+        names.insert(access.test_name.clone());
     }
     names
 }
 
 fn playwright_test_keys_for_local(
     local_to_export_keys: &FxHashMap<&str, Vec<ExportKey>>,
-    local_playwright_test_names: &FxHashSet<&str>,
+    local_playwright_test_names: &FxHashSet<String>,
     file_id: FileId,
     local_name: &str,
 ) -> Vec<PlaywrightTestKey> {
@@ -1016,11 +1024,15 @@ fn collect_playwright_fixture_def_targets(
     graph: &ModuleGraph,
     resolved: &ResolvedModule,
     local_to_export_keys: &FxHashMap<&str, Vec<ExportKey>>,
-    local_playwright_test_names: &FxHashSet<&str>,
+    local_playwright_test_names: &FxHashSet<String>,
     type_targets: &FxHashMap<ExportKey, FxHashMap<String, Vec<ExportKey>>>,
     targets_by_test: &mut FxHashMap<PlaywrightTestKey, FxHashMap<String, Vec<ExportKey>>>,
 ) {
-    for access in playwright_fixture_definition_facts(&resolved.semantic_facts) {
+    let definition_facts = playwright_fixture_definition_facts_with_legacy(
+        &resolved.semantic_facts,
+        &resolved.member_accesses,
+    );
+    for access in definition_facts {
         let test_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
@@ -1052,10 +1064,14 @@ fn collect_playwright_fixture_aliases(
     graph: &ModuleGraph,
     resolved: &ResolvedModule,
     local_to_export_keys: &FxHashMap<&str, Vec<ExportKey>>,
-    local_playwright_test_names: &FxHashSet<&str>,
+    local_playwright_test_names: &FxHashSet<String>,
     aliases_by_test: &mut FxHashMap<PlaywrightTestKey, Vec<PlaywrightTestKey>>,
 ) {
-    for access in playwright_fixture_alias_facts(&resolved.semantic_facts) {
+    let alias_facts = playwright_fixture_alias_facts_with_legacy(
+        &resolved.semantic_facts,
+        &resolved.member_accesses,
+    );
+    for access in alias_facts {
         let test_keys = playwright_test_keys_for_local(
             local_to_export_keys,
             local_playwright_test_names,
@@ -1172,7 +1188,11 @@ fn build_playwright_fixture_type_targets(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in playwright_fixture_type_facts(&resolved.semantic_facts) {
+        let type_facts = playwright_fixture_type_facts_with_legacy(
+            &resolved.semantic_facts,
+            &resolved.member_accesses,
+        );
+        for access in type_facts {
             let Some(alias_keys) = local_to_export_keys.get(access.alias_name.as_str()) else {
                 continue;
             };
@@ -1209,7 +1229,11 @@ fn propagate_playwright_fixture_accesses(
 
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
-        for access in playwright_fixture_use_facts(&resolved.semantic_facts) {
+        let use_facts = playwright_fixture_use_facts_with_legacy(
+            &resolved.semantic_facts,
+            &resolved.member_accesses,
+        );
+        for access in use_facts {
             let Some(test_keys) = local_to_export_keys.get(access.test_name.as_str()) else {
                 continue;
             };
@@ -2469,6 +2493,7 @@ mod tests {
     use fallow_types::extract::{
         ClassHeritageInfo, FLUENT_CHAIN_NEW_SENTINEL, FactoryCallMemberAccessFact,
         FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, InstanceExportBindingFact,
+        PLAYWRIGHT_FIXTURE_DEF_SENTINEL, PLAYWRIGHT_FIXTURE_USE_SENTINEL,
         PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
         PlaywrightFixtureUseFact, SemanticFact, semantic_facts_with_legacy_member_accesses,
     };
@@ -2649,6 +2674,51 @@ mod tests {
         let credited = accessed_members
             .get(&ExportKey::new(FileId(2), "AdminPage"))
             .expect("fixture target class should be credited");
+        assert!(credited.contains("assertGreeting"));
+    }
+
+    #[test]
+    fn legacy_playwright_fixture_sentinels_credit_fixture_member() {
+        let mut graph = build_graph(&[
+            ("/src/spec.ts", true),
+            ("/src/fixtures.ts", false),
+            ("/src/admin-page.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members("test", vec![], Some(0))];
+        graph.modules[2].set_reachable(true);
+        graph.modules[2].exports = vec![make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(0),
+        )];
+
+        let resolved_modules = vec![ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/src/spec.ts"),
+            resolved_imports: vec![
+                make_resolved_import("./fixtures", "test", "test", 1),
+                make_resolved_import("./admin-page", "AdminPage", "AdminPage", 2),
+            ],
+            member_accesses: vec![
+                MemberAccess {
+                    object: format!("{PLAYWRIGHT_FIXTURE_DEF_SENTINEL}test:adminPage"),
+                    member: "AdminPage".to_string(),
+                },
+                MemberAccess {
+                    object: format!("{PLAYWRIGHT_FIXTURE_USE_SENTINEL}test:adminPage"),
+                    member: "assertGreeting".to_string(),
+                },
+            ],
+            ..Default::default()
+        }];
+
+        let mut accessed_members = FxHashMap::default();
+        propagate_playwright_fixture_accesses(&graph, &resolved_modules, &mut accessed_members);
+
+        let credited = accessed_members
+            .get(&ExportKey::new(FileId(2), "AdminPage"))
+            .expect("legacy fixture target class should be credited");
         assert!(credited.contains("assertGreeting"));
     }
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1810,6 +1810,13 @@ pub fn fluent_chain_new_member_access_facts_with_legacy(
         .collect()
 }
 
+fn parse_legacy_playwright_fixture_member_access<'a>(
+    object: &'a str,
+    prefix: &str,
+) -> Option<(&'a str, &'a str)> {
+    object.strip_prefix(prefix)?.split_once(':')
+}
+
 /// Iterate typed Playwright fixture-use facts.
 pub fn playwright_fixture_use_facts(
     semantic_facts: &[SemanticFact],
@@ -1821,6 +1828,27 @@ pub fn playwright_fixture_use_facts(
             None
         }
     })
+}
+
+/// Collect Playwright fixture-use facts from typed facts plus legacy sentinels.
+pub fn playwright_fixture_use_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<PlaywrightFixtureUseFact> {
+    playwright_fixture_use_facts(semantic_facts)
+        .cloned()
+        .chain(member_accesses.iter().filter_map(|access| {
+            let (test_name, fixture_name) = parse_legacy_playwright_fixture_member_access(
+                access.object.as_str(),
+                PLAYWRIGHT_FIXTURE_USE_SENTINEL,
+            )?;
+            Some(PlaywrightFixtureUseFact {
+                test_name: test_name.to_string(),
+                fixture_name: fixture_name.to_string(),
+                member: access.member.clone(),
+            })
+        }))
+        .collect()
 }
 
 /// Iterate typed Playwright fixture-definition facts.
@@ -1836,6 +1864,27 @@ pub fn playwright_fixture_definition_facts(
     })
 }
 
+/// Collect Playwright fixture-definition facts from typed facts plus legacy sentinels.
+pub fn playwright_fixture_definition_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<PlaywrightFixtureDefinitionFact> {
+    playwright_fixture_definition_facts(semantic_facts)
+        .cloned()
+        .chain(member_accesses.iter().filter_map(|access| {
+            let (test_name, fixture_name) = parse_legacy_playwright_fixture_member_access(
+                access.object.as_str(),
+                PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
+            )?;
+            Some(PlaywrightFixtureDefinitionFact {
+                test_name: test_name.to_string(),
+                fixture_name: fixture_name.to_string(),
+                type_name: access.member.clone(),
+            })
+        }))
+        .collect()
+}
+
 /// Iterate typed Playwright fixture-alias facts.
 pub fn playwright_fixture_alias_facts(
     semantic_facts: &[SemanticFact],
@@ -1849,6 +1898,26 @@ pub fn playwright_fixture_alias_facts(
     })
 }
 
+/// Collect Playwright fixture-alias facts from typed facts plus legacy sentinels.
+pub fn playwright_fixture_alias_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<PlaywrightFixtureAliasFact> {
+    playwright_fixture_alias_facts(semantic_facts)
+        .cloned()
+        .chain(member_accesses.iter().filter_map(|access| {
+            let (test_name, _) = parse_legacy_playwright_fixture_member_access(
+                access.object.as_str(),
+                PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL,
+            )?;
+            Some(PlaywrightFixtureAliasFact {
+                test_name: test_name.to_string(),
+                base_name: access.member.clone(),
+            })
+        }))
+        .collect()
+}
+
 /// Iterate typed Playwright fixture-type facts.
 pub fn playwright_fixture_type_facts(
     semantic_facts: &[SemanticFact],
@@ -1860,6 +1929,27 @@ pub fn playwright_fixture_type_facts(
             None
         }
     })
+}
+
+/// Collect Playwright fixture-type facts from typed facts plus legacy sentinels.
+pub fn playwright_fixture_type_facts_with_legacy(
+    semantic_facts: &[SemanticFact],
+    member_accesses: &[MemberAccess],
+) -> Vec<PlaywrightFixtureTypeFact> {
+    playwright_fixture_type_facts(semantic_facts)
+        .cloned()
+        .chain(member_accesses.iter().filter_map(|access| {
+            let (alias_name, fixture_name) = parse_legacy_playwright_fixture_member_access(
+                access.object.as_str(),
+                PLAYWRIGHT_FIXTURE_TYPE_SENTINEL,
+            )?;
+            Some(PlaywrightFixtureTypeFact {
+                alias_name: alias_name.to_string(),
+                fixture_name: fixture_name.to_string(),
+                type_name: access.member.clone(),
+            })
+        }))
+        .collect()
 }
 
 /// A member name referenced from an Angular template surface.
@@ -2922,6 +3012,87 @@ mod tests {
                 .map(|fact| fact.fixture_name.as_str())
                 .collect::<Vec<_>>(),
             vec!["adminPage"]
+        );
+    }
+
+    #[test]
+    fn playwright_fixture_legacy_backed_helpers_collect_owned_family_facts() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::PlaywrightFixtureUse(
+                PlaywrightFixtureUseFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "typedPage".to_string(),
+                    member: "goto".to_string(),
+                },
+            ));
+        module.member_accesses.push(MemberAccess {
+            object: format!("{PLAYWRIGHT_FIXTURE_USE_SENTINEL}test:legacyPage"),
+            member: "click".to_string(),
+        });
+        module.member_accesses.push(MemberAccess {
+            object: format!("{PLAYWRIGHT_FIXTURE_DEF_SENTINEL}test:adminPage"),
+            member: "AdminPage".to_string(),
+        });
+        module.member_accesses.push(MemberAccess {
+            object: format!("{PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL}mergedTest:"),
+            member: "test".to_string(),
+        });
+        module.member_accesses.push(MemberAccess {
+            object: format!("{PLAYWRIGHT_FIXTURE_TYPE_SENTINEL}Pages:adminPage"),
+            member: "AdminPage".to_string(),
+        });
+
+        assert_eq!(
+            playwright_fixture_use_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![
+                PlaywrightFixtureUseFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "typedPage".to_string(),
+                    member: "goto".to_string(),
+                },
+                PlaywrightFixtureUseFact {
+                    test_name: "test".to_string(),
+                    fixture_name: "legacyPage".to_string(),
+                    member: "click".to_string(),
+                }
+            ]
+        );
+        assert_eq!(
+            playwright_fixture_definition_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![PlaywrightFixtureDefinitionFact {
+                test_name: "test".to_string(),
+                fixture_name: "adminPage".to_string(),
+                type_name: "AdminPage".to_string(),
+            }]
+        );
+        assert_eq!(
+            playwright_fixture_alias_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![PlaywrightFixtureAliasFact {
+                test_name: "mergedTest".to_string(),
+                base_name: "test".to_string(),
+            }]
+        );
+        assert_eq!(
+            playwright_fixture_type_facts_with_legacy(
+                &module.semantic_facts,
+                &module.member_accesses
+            ),
+            vec![PlaywrightFixtureTypeFact {
+                alias_name: "Pages".to_string(),
+                fixture_name: "adminPage".to_string(),
+                type_name: "AdminPage".to_string(),
+            }]
         );
     }
 


### PR DESCRIPTION
## Summary
- Decode legacy Playwright fixture member-access facts behind typed fallow-types helpers.
- Move core Playwright fixture propagation to the shared compatibility helpers.

## Stack
- Stacked on #1543.

## Verification
- cargo fmt --all -- --check
- cargo test -p fallow-types playwright_fixture --lib
- cargo test -p fallow-core playwright_fixture --lib
- cargo check -p fallow-types -p fallow-core
- cargo clippy -p fallow-types -p fallow-core --all-targets -- -D warnings
- git diff --check