### PR TITLE
refactor: route NAPI health through fallow-api runner contract

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,8 +22,10 @@ pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
 pub use runtime::{
-    HealthJsonReportInput, detect_boundary_violations, detect_circular_dependencies,
-    detect_dead_code, detect_duplication, serialize_health_report_json,
+    HealthJsonReportInput, ProgrammaticHealthReport, ProgrammaticHealthRunner,
+    compute_complexity_with_runner, compute_health_with_runner, detect_boundary_violations,
+    detect_circular_dependencies, detect_dead_code, detect_duplication,
+    serialize_health_report_json,
 };
 
 pub const COMMON_ANALYSIS_OPTION_FLAGS: &[&str] = &[

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -19,8 +19,8 @@ use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    AnalysisOptions, DeadCodeFilters, DeadCodeOptions, DupesReportPayload, DuplicationMode,
-    DuplicationOptions, ProgrammaticError,
+    AnalysisOptions, ComplexityOptions, DeadCodeFilters, DeadCodeOptions, DupesReportPayload,
+    DuplicationMode, DuplicationOptions, ProgrammaticError,
 };
 
 const SCHEMA_VERSION: u32 = 1;
@@ -39,6 +39,32 @@ pub struct HealthJsonReportInput<'a> {
     pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
     pub next_steps: Vec<NextStep>,
     pub envelope_mode: RootEnvelopeMode,
+}
+
+/// Health runner output consumed by the API-owned programmatic serializer.
+pub struct ProgrammaticHealthReport {
+    pub report: HealthReport,
+    pub root: PathBuf,
+    pub elapsed: std::time::Duration,
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    pub next_steps: Vec<NextStep>,
+    pub envelope_mode: RootEnvelopeMode,
+    pub telemetry_analysis_run_id: Option<String>,
+}
+
+/// Temporary runner boundary for programmatic health while execution moves
+/// from the CLI crate into the engine/API stack.
+pub trait ProgrammaticHealthRunner {
+    /// Run health analysis for public programmatic options.
+    ///
+    /// # Errors
+    ///
+    /// Returns a structured programmatic error when the concrete runner cannot
+    /// resolve options or complete health analysis.
+    fn run_programmatic_health(
+        &self,
+        options: &ComplexityOptions,
+    ) -> Result<ProgrammaticHealthReport, ProgrammaticError>;
 }
 
 struct ResolvedAnalysisOptions {
@@ -144,6 +170,53 @@ pub fn serialize_health_report_json(
         root_prefix: Some(&root_prefix),
         envelope_mode: input.envelope_mode,
     })
+}
+
+/// Run programmatic health / complexity through the API-owned output boundary.
+///
+/// The concrete runner is injected while the health implementation is still
+/// being migrated out of the CLI crate.
+///
+/// # Errors
+///
+/// Returns a structured programmatic error for invalid options, runner
+/// failures, or output serialization failures.
+pub fn compute_complexity_with_runner(
+    options: &ComplexityOptions,
+    runner: &impl ProgrammaticHealthRunner,
+) -> ProgrammaticResult<serde_json::Value> {
+    crate::validate_complexity_options(options)?;
+    let result = runner.run_programmatic_health(options)?;
+    let mut output = serialize_health_report_json(HealthJsonReportInput {
+        report: result.report,
+        root: &result.root,
+        elapsed: result.elapsed,
+        explain: options.analysis.explain,
+        grouped_by: None,
+        groups: None,
+        workspace_diagnostics: result.workspace_diagnostics,
+        next_steps: result.next_steps,
+        envelope_mode: result.envelope_mode,
+    })
+    .map_err(|err| {
+        ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
+            .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
+            .with_context("health")
+    })?;
+    fallow_output::attach_telemetry_meta(&mut output, result.telemetry_analysis_run_id.as_deref());
+    Ok(output)
+}
+
+/// Alias for [`compute_complexity_with_runner`] with a product-oriented name.
+///
+/// # Errors
+///
+/// Returns the same structured errors as [`compute_complexity_with_runner`].
+pub fn compute_health_with_runner(
+    options: &ComplexityOptions,
+    runner: &impl ProgrammaticHealthRunner,
+) -> ProgrammaticResult<serde_json::Value> {
+    compute_complexity_with_runner(options, runner)
 }
 
 fn detect_dead_code_inner(
@@ -1277,6 +1350,35 @@ mod tests {
 
     use super::*;
 
+    struct FakeHealthRunner {
+        root: PathBuf,
+        envelope_mode: RootEnvelopeMode,
+        telemetry_analysis_run_id: Option<String>,
+    }
+
+    impl ProgrammaticHealthRunner for FakeHealthRunner {
+        fn run_programmatic_health(
+            &self,
+            _options: &ComplexityOptions,
+        ) -> Result<ProgrammaticHealthReport, ProgrammaticError> {
+            Ok(ProgrammaticHealthReport {
+                report: HealthReport::default(),
+                root: self.root.clone(),
+                elapsed: std::time::Duration::ZERO,
+                workspace_diagnostics: vec![WorkspaceDiagnosticOutput(serde_json::json!({
+                    "path": self.root.join("package.json")
+                }))],
+                next_steps: vec![NextStep {
+                    id: "inspect-health".to_string(),
+                    command: "fallow health --format json".to_string(),
+                    reason: "inspect health details".to_string(),
+                }],
+                envelope_mode: self.envelope_mode,
+                telemetry_analysis_run_id: self.telemetry_analysis_run_id.clone(),
+            })
+        }
+    }
+
     fn analysis_at(root: &Path) -> AnalysisOptions {
         AnalysisOptions {
             root: Some(root.to_path_buf()),
@@ -1329,6 +1431,34 @@ mod tests {
         .expect("health JSON serializes");
 
         assert!(json.get("kind").is_none());
+    }
+
+    #[test]
+    fn programmatic_health_runner_serializes_api_owned_output() {
+        let root = PathBuf::from("/repo");
+        let json = compute_health_with_runner(
+            &ComplexityOptions {
+                analysis: AnalysisOptions {
+                    explain: true,
+                    ..AnalysisOptions::default()
+                },
+                ..ComplexityOptions::default()
+            },
+            &FakeHealthRunner {
+                root,
+                envelope_mode: RootEnvelopeMode::Tagged,
+                telemetry_analysis_run_id: Some("run-123".to_string()),
+            },
+        )
+        .expect("programmatic health should serialize");
+
+        assert_eq!(json["kind"], "health");
+        assert_eq!(json["workspace_diagnostics"][0]["path"], "package.json");
+        assert_eq!(json["next_steps"][0]["id"], "inspect-health");
+        assert_eq!(
+            json["_meta"]["telemetry"]["analysis_run_id"],
+            serde_json::Value::from("run-123")
+        );
     }
 
     #[test]

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -64,7 +64,7 @@ pub fn set_telemetry_analysis_run_id(run_id: Option<String>) {
     }
 }
 
-fn telemetry_analysis_run_id() -> Option<String> {
+pub fn telemetry_analysis_run_id() -> Option<String> {
     TELEMETRY_ANALYSIS_RUN_ID
         .lock()
         .ok()

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -665,50 +665,49 @@ fn build_complexity_options<'a>(
     }
 }
 
-/// Run the health / complexity analysis and return the CLI JSON contract as a value.
-pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<serde_json::Value> {
-    let resolved = resolve_analysis_options(&options.analysis)?;
-    fallow_api::validate_complexity_options(options)?;
+pub struct CliProgrammaticHealthRunner;
 
-    resolved.install(|| {
-        let health_options = build_complexity_options(&resolved, options);
-        let result = crate::health::execute_health(&health_options)
-            .map_err(|_| generic_analysis_error("health"))?;
-        let next_steps = fallow_output::build_health_next_steps(
-            crate::report::suggestions::health_next_steps_input(
-                &result.report,
-                &result.config.root,
-                crate::report::suggestions::setup_pointer_applicable(&result.config.root),
-                crate::report::suggestions::due_impact_digest(&result.config.root),
-            ),
-        );
-        let mut output =
-            fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
-                report: result.report,
-                root: &result.config.root,
-                elapsed: result.elapsed,
-                explain: resolved.explain,
-                grouped_by: None,
-                groups: None,
+impl fallow_api::ProgrammaticHealthRunner for CliProgrammaticHealthRunner {
+    fn run_programmatic_health(
+        &self,
+        options: &ComplexityOptions,
+    ) -> ProgrammaticResult<fallow_api::ProgrammaticHealthReport> {
+        let resolved = resolve_analysis_options(&options.analysis)?;
+        resolved.install(|| {
+            let health_options = build_complexity_options(&resolved, options);
+            let result = crate::health::execute_health(&health_options)
+                .map_err(|_| generic_analysis_error("health"))?;
+            let next_steps = fallow_output::build_health_next_steps(
+                crate::report::suggestions::health_next_steps_input(
+                    &result.report,
+                    &result.config.root,
+                    crate::report::suggestions::setup_pointer_applicable(&result.config.root),
+                    crate::report::suggestions::due_impact_digest(&result.config.root),
+                ),
+            );
+            Ok(fallow_api::ProgrammaticHealthReport {
                 workspace_diagnostics: workspace_diagnostics_for_programmatic_output(
                     &result.config.root,
                 ),
+                root: result.config.root.clone(),
+                report: result.report,
+                elapsed: result.elapsed,
                 next_steps,
                 envelope_mode: programmatic_root_envelope_mode(&resolved),
+                telemetry_analysis_run_id: crate::output_envelope::telemetry_analysis_run_id(),
             })
-            .map_err(|err| {
-                ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
-                    .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
-                    .with_context("health")
-            })?;
-        crate::output_envelope::attach_telemetry_meta(&mut output);
-        Ok(output)
-    })
+        })
+    }
+}
+
+/// Run the health / complexity analysis and return the CLI JSON contract as a value.
+pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<serde_json::Value> {
+    fallow_api::compute_complexity_with_runner(options, &CliProgrammaticHealthRunner)
 }
 
 /// Alias for `compute_complexity` with a more product-oriented name.
 pub fn compute_health(options: &ComplexityOptions) -> ProgrammaticResult<serde_json::Value> {
-    compute_complexity(options)
+    fallow_api::compute_health_with_runner(options, &CliProgrammaticHealthRunner)
 }
 
 #[cfg(test)]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 
 use fallow_api as api;
-use fallow_cli::programmatic;
+use fallow_cli::programmatic::CliProgrammaticHealthRunner;
 use napi::bindgen_prelude::{AsyncTask, JsObjectValue, ToNapiValue, Unknown};
 use napi::{Env, ScopedTask, Status};
 use napi_derive::napi;
@@ -543,7 +543,7 @@ pub fn compute_complexity(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        programmatic::compute_complexity(&options)
+        api::compute_complexity_with_runner(&options, &CliProgrammaticHealthRunner)
     })))
 }
 
@@ -553,7 +553,7 @@ pub fn compute_health(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        programmatic::compute_health(&options)
+        api::compute_health_with_runner(&options, &CliProgrammaticHealthRunner)
     })))
 }
 


### PR DESCRIPTION
## Summary
- Add fallow-api ProgrammaticHealthRunner plus computeHealth / computeComplexity entrypoints that own health JSON serialization.
- Keep the CLI health runner as a temporary adapter through CliProgrammaticHealthRunner.
- Route NAPI computeHealth / computeComplexity through fallow-api instead of calling fallow-cli::programmatic functions directly.

## Stack
- Stacked on #1546.

## Verification
- cargo fmt --all -- --check
- cargo test -p fallow-api programmatic_health --lib
- cargo test -p fallow-cli compute_health --lib
- cargo test -p fallow-cli compute_complexity --lib
- cargo test -p fallow-node compute_complexity --lib
- cargo check -p fallow-api -p fallow-cli -p fallow-node
- cargo clippy -p fallow-api -p fallow-cli -p fallow-node --all-targets -- -D warnings
- git diff --check
- em dash scan over touched files