### PR TITLE
refactor: move runtime coverage options to engine

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -2557,7 +2557,7 @@ fn run_audit_health<'a>(
 fn build_audit_health_options<'a>(
     opts: &'a AuditOptions<'a>,
     changed_since: Option<&'a str>,
-    runtime_coverage: Option<crate::health::RuntimeCoverageOptions>,
+    runtime_coverage: Option<fallow_engine::RuntimeCoverageOptions>,
 ) -> HealthOptions<'a> {
     HealthOptions {
         root: opts.root,

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -151,7 +151,7 @@ fn run_local(path: &Path, args: &AnalyzeArgs, ctx: &RunContext<'_>) -> ExitCode 
 fn local_health_options<'a>(
     args: &AnalyzeArgs,
     ctx: &RunContext<'a>,
-    runtime_coverage: crate::health::RuntimeCoverageOptions,
+    runtime_coverage: fallow_engine::RuntimeCoverageOptions,
 ) -> HealthOptions<'a> {
     HealthOptions {
         root: ctx.root,

--- a/crates/cli/src/health/coverage.rs
+++ b/crates/cli/src/health/coverage.rs
@@ -27,7 +27,6 @@ use tempfile::TempDir;
 use url::Url;
 
 use crate::error::emit_error;
-use crate::health::RuntimeCoverageOptions;
 use crate::health::scoring::IstanbulCoverage;
 use crate::health_types::{
     RuntimeCoverageAction, RuntimeCoverageConfidence, RuntimeCoverageDataSource,
@@ -37,6 +36,7 @@ use crate::health_types::{
     RuntimeCoverageVerdict, RuntimeCoverageWatermark,
 };
 use crate::license::verifying_key;
+use fallow_engine::RuntimeCoverageOptions;
 
 /// Ed25519 public key used to verify the fallow-cov sidecar binary at every
 /// spawn. Intentionally SEPARATE from the license-signing pubkey at
@@ -2143,13 +2143,13 @@ mod tests {
         resolve_sidecar_via_command, sidecar_binary_name, static_function,
         verify_sidecar_signature, write_istanbul_coverage_file,
     };
-    use crate::health::RuntimeCoverageOptions;
     use fallow_config::{FallowConfig, OutputFormat};
     use fallow_cov_protocol::{
         Confidence, CoverageSource, DiagnosticMessage, Evidence, Finding, FunctionIdentity,
         HotPath, IdentityResolution, PROTOCOL_VERSION, ReportVerdict, Response, Summary, Verdict,
         function_identity_id,
     };
+    use fallow_engine::RuntimeCoverageOptions;
     use globset::{Glob, GlobSetBuilder};
     use oxc_coverage_instrument::{Location, Position};
     use rustc_hash::{FxHashMap, FxHashSet};

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 use fallow_config::{OutputFormat, PackageJson, ResolvedConfig, Severity};
-use fallow_engine::HealthSort;
+use fallow_engine::{HealthSort, RuntimeCoverageOptions};
 
 use crate::baseline::{HealthBaselineData, filter_new_health_findings, filter_new_health_targets};
 use crate::check::{get_changed_files, resolve_workspace_scope};
@@ -40,22 +40,6 @@ pub struct SharedParseData {
     pub analysis_output: Option<fallow_core::AnalysisOutput>,
 }
 use targets::{TargetAuxData, compute_refactoring_targets};
-
-pub struct RuntimeCoverageOptions {
-    pub path: std::path::PathBuf,
-    pub min_invocations_hot: u64,
-    /// Minimum total trace volume before high-confidence `safe_to_delete` /
-    /// `review_required` verdicts may be emitted. Below this the sidecar caps
-    /// confidence at `medium`. `None` lets the sidecar use its spec-default
-    /// (5000).
-    pub min_observation_volume: Option<u32>,
-    /// Fraction of total trace count below which an invoked function is
-    /// classified as `low_traffic` rather than `active`. `None` lets the
-    /// sidecar use its spec-default (0.001 = 0.1%).
-    pub low_traffic_threshold: Option<f64>,
-    pub license_jwt: String,
-    pub watermark: Option<crate::health_types::RuntimeCoverageWatermark>,
-}
 
 /// Sort criteria for complexity output.
 #[derive(Clone, clap::ValueEnum)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5567,7 +5567,7 @@ fn resolve_runtime_coverage_options(
     min_observation_volume: Option<u32>,
     low_traffic_threshold: Option<f64>,
     output: fallow_config::OutputFormat,
-) -> Result<Option<health::RuntimeCoverageOptions>, ExitCode> {
+) -> Result<Option<fallow_engine::RuntimeCoverageOptions>, ExitCode> {
     let Some(path) = runtime_coverage else {
         return Ok(None);
     };
@@ -5646,7 +5646,7 @@ fn dispatch_health(dispatch: &DispatchContext<'_>, args: HealthDispatchArgs<'_>)
 /// runtime-coverage options.
 struct ResolvedHealthDispatch<'a> {
     sections: &'a fallow_api::DerivedHealthSections,
-    runtime_coverage: Option<health::RuntimeCoverageOptions>,
+    runtime_coverage: Option<fallow_engine::RuntimeCoverageOptions>,
     production: bool,
     coverage_inputs: &'a ResolvedHealthCoverageInputs,
     ownership: bool,

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -1130,7 +1130,7 @@ fn analyze_security_runtime(
 /// context for security findings (complexity/hotspot/ownership all disabled).
 fn security_runtime_health_options<'a>(
     opts: &SecurityOptions<'a>,
-    runtime_coverage: crate::health::RuntimeCoverageOptions,
+    runtime_coverage: fallow_engine::RuntimeCoverageOptions,
 ) -> HealthOptions<'a> {
     HealthOptions {
         root: opts.root,

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -1,9 +1,10 @@
 //! Typed health result contracts exposed through the engine boundary.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use fallow_config::ResolvedConfig;
-use fallow_output::{HealthGrouping, HealthReport, HealthTimings};
+use fallow_output::{HealthGrouping, HealthReport, HealthTimings, RuntimeCoverageWatermark};
 
 /// Command-neutral sort criteria for health complexity findings.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,6 +13,24 @@ pub enum HealthSort {
     Cyclomatic,
     Cognitive,
     Lines,
+}
+
+/// Command-neutral runtime coverage input for health analysis.
+#[derive(Debug, Clone)]
+pub struct RuntimeCoverageOptions {
+    pub path: PathBuf,
+    pub min_invocations_hot: u64,
+    /// Minimum total trace volume before high-confidence `safe_to_delete` /
+    /// `review_required` verdicts may be emitted. Below this the sidecar caps
+    /// confidence at `medium`. `None` lets the sidecar use its spec-default
+    /// (5000).
+    pub min_observation_volume: Option<u32>,
+    /// Fraction of total trace count below which an invoked function is
+    /// classified as `low_traffic` rather than `active`. `None` lets the
+    /// sidecar use its spec-default (0.001 = 0.1%).
+    pub low_traffic_threshold: Option<f64>,
+    pub license_jwt: String,
+    pub watermark: Option<RuntimeCoverageWatermark>,
 }
 
 /// Typed health analysis result shared by CLI, API, NAPI, and future embedders.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -66,7 +66,7 @@ pub use fallow_core::duplicates::{
 pub use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::ModuleInfo;
 pub use fallow_types::results::AnalysisResults;
-pub use health::{HealthAnalysisResult, HealthSort};
+pub use health::{HealthAnalysisResult, HealthSort, RuntimeCoverageOptions};
 
 /// Result alias for typed engine operations.
 pub type EngineResult<T> = Result<T, EngineError>;


### PR DESCRIPTION
Replaces #1504 after branch cleanup.