### PR TITLE
refactor: centralize legacy semantic sentinel parsing

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -6,15 +6,15 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::discover::FileId;
-use crate::extract::{
-    ANGULAR_TPL_SENTINEL, ExportName, FACTORY_CALL_SENTINEL, FLUENT_CHAIN_NEW_SENTINEL,
-    FLUENT_CHAIN_SENTINEL, INSTANCE_EXPORT_SENTINEL, MemberInfo, MemberKind, ModuleInfo,
-};
+use crate::extract::{ANGULAR_TPL_SENTINEL, ExportName, MemberInfo, MemberKind, ModuleInfo};
 use crate::graph::{ModuleGraph, ReferenceKind};
 use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
-use fallow_types::extract::SemanticFact;
+use fallow_types::extract::{
+    LegacySemanticMemberAccess, SemanticFact, is_legacy_semantic_member_access_object,
+    is_legacy_semantic_whole_object_use, parse_legacy_semantic_member_access,
+};
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
 use super::{LineOffsetsMap, byte_offset_to_line_col};
@@ -1377,10 +1377,10 @@ fn instance_export_binding_accesses(
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacyMemberAccess::InstanceExportBinding {
+        if let Some(LegacySemanticMemberAccess::InstanceExportBinding {
             export_name,
             target_local,
-        }) = legacy_member_access(access.object.as_str(), access.member.as_str())
+        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
         {
             accesses.push(InstanceExportBindingAccess {
                 export_name,
@@ -1621,87 +1621,12 @@ fn propagate_typed_whole_object_uses(
     }
 }
 
-enum LegacyMemberAccess<'a> {
-    InstanceExportBinding {
-        export_name: &'a str,
-        target_local: &'a str,
-    },
-    FactoryCall {
-        callee_object: &'a str,
-        callee_method: &'a str,
-        member: &'a str,
-    },
-    FluentChain {
-        root_local: &'a str,
-        root_method: &'a str,
-        chain: Vec<&'a str>,
-        member: &'a str,
-    },
-    FluentChainNew {
-        class_local: &'a str,
-        chain: Vec<&'a str>,
-        member: &'a str,
-    },
-}
-
 fn is_legacy_member_access_object(object: &str) -> bool {
-    object == ANGULAR_TPL_SENTINEL
-        || object.starts_with(INSTANCE_EXPORT_SENTINEL)
-        || object.starts_with(FACTORY_CALL_SENTINEL)
-        || object.starts_with(FLUENT_CHAIN_SENTINEL)
-        || object.starts_with(FLUENT_CHAIN_NEW_SENTINEL)
+    object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_member_access_object(object)
 }
 
 fn is_legacy_whole_object_use(object: &str) -> bool {
-    object == ANGULAR_TPL_SENTINEL
-        || object.starts_with(INSTANCE_EXPORT_SENTINEL)
-        || object.starts_with(FACTORY_CALL_SENTINEL)
-}
-
-fn legacy_member_access<'a>(object: &'a str, member: &'a str) -> Option<LegacyMemberAccess<'a>> {
-    if let Some(export_name) = object.strip_prefix(INSTANCE_EXPORT_SENTINEL) {
-        return Some(LegacyMemberAccess::InstanceExportBinding {
-            export_name,
-            target_local: member,
-        });
-    }
-    if let Some((callee_object, callee_method)) = object
-        .strip_prefix(FACTORY_CALL_SENTINEL)
-        .and_then(|payload| payload.split_once(':'))
-    {
-        return Some(LegacyMemberAccess::FactoryCall {
-            callee_object,
-            callee_method,
-            member,
-        });
-    }
-    if let Some(payload) = object.strip_prefix(FLUENT_CHAIN_SENTINEL) {
-        let (root_local, rest) = payload.split_once(':')?;
-        let (root_method, chain_str) = rest.split_once(':')?;
-        let chain = if chain_str.is_empty() {
-            Vec::new()
-        } else {
-            chain_str.split(',').collect()
-        };
-        return Some(LegacyMemberAccess::FluentChain {
-            root_local,
-            root_method,
-            chain,
-            member,
-        });
-    }
-    if let Some(payload) = object.strip_prefix(FLUENT_CHAIN_NEW_SENTINEL) {
-        let (class_local, chain_str) = payload.split_once(':')?;
-        if chain_str.is_empty() {
-            return None;
-        }
-        return Some(LegacyMemberAccess::FluentChainNew {
-            class_local,
-            chain: chain_str.split(',').collect(),
-            member,
-        });
-    }
-    None
+    object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_whole_object_use(object)
 }
 
 struct FactoryCallAccess<'a> {
@@ -1722,11 +1647,11 @@ fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess<'_>> 
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacyMemberAccess::FactoryCall {
+        if let Some(LegacySemanticMemberAccess::FactoryCall {
             callee_object,
             callee_method,
             member,
-        }) = legacy_member_access(access.object.as_str(), access.member.as_str())
+        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
         {
             accesses.push(FactoryCallAccess {
                 callee_object,
@@ -1804,12 +1729,12 @@ fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess<'_>> 
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacyMemberAccess::FluentChain {
+        if let Some(LegacySemanticMemberAccess::FluentChain {
             root_local,
             root_method,
             chain,
             member,
-        }) = legacy_member_access(access.object.as_str(), access.member.as_str())
+        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
         {
             accesses.push(FluentChainAccess {
                 root_local,
@@ -1912,11 +1837,11 @@ fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAcces
         }
     }
     for access in &module.member_accesses {
-        if let Some(LegacyMemberAccess::FluentChainNew {
+        if let Some(LegacySemanticMemberAccess::FluentChainNew {
             class_local,
             chain,
             member,
-        }) = legacy_member_access(access.object.as_str(), access.member.as_str())
+        }) = parse_legacy_semantic_member_access(access.object.as_str(), access.member.as_str())
         {
             accesses.push(FluentChainNewAccess {
                 class_local,
@@ -2774,10 +2699,10 @@ mod tests {
     use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
     use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
     use fallow_types::extract::{
-        ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-        FluentChainNewMemberAccessFact, InstanceExportBindingFact, PlaywrightFixtureAliasFact,
-        PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
-        SemanticFact,
+        ClassHeritageInfo, FLUENT_CHAIN_NEW_SENTINEL, FactoryCallMemberAccessFact,
+        FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, InstanceExportBindingFact,
+        PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+        PlaywrightFixtureUseFact, SemanticFact,
     };
     use oxc_span::Span;
     use std::path::PathBuf;
@@ -5282,78 +5207,10 @@ mod tests {
     }
 
     #[test]
-    fn legacy_member_access_decodes_instance_binding() {
-        let object = format!("{INSTANCE_EXPORT_SENTINEL}exported");
-        let access = legacy_member_access(&object, "target").expect("legacy access");
-
-        match access {
-            LegacyMemberAccess::InstanceExportBinding {
-                export_name,
-                target_local,
-            } => {
-                assert_eq!(export_name, "exported");
-                assert_eq!(target_local, "target");
-            }
-            _ => panic!("expected instance binding"),
-        }
-    }
-
-    #[test]
-    fn legacy_member_access_decodes_factory_and_fluent_chains() {
-        let factory = format!("{FACTORY_CALL_SENTINEL}Service:create");
-        let factory_access = legacy_member_access(&factory, "run").expect("factory access");
-        match factory_access {
-            LegacyMemberAccess::FactoryCall {
-                callee_object,
-                callee_method,
-                member,
-            } => {
-                assert_eq!(callee_object, "Service");
-                assert_eq!(callee_method, "create");
-                assert_eq!(member, "run");
-            }
-            _ => panic!("expected factory access"),
-        }
-
-        let fluent = format!("{FLUENT_CHAIN_SENTINEL}Builder:start:next,finish");
-        let fluent_access = legacy_member_access(&fluent, "value").expect("fluent access");
-        match fluent_access {
-            LegacyMemberAccess::FluentChain {
-                root_local,
-                root_method,
-                chain,
-                member,
-            } => {
-                assert_eq!(root_local, "Builder");
-                assert_eq!(root_method, "start");
-                assert_eq!(chain, vec!["next", "finish"]);
-                assert_eq!(member, "value");
-            }
-            _ => panic!("expected fluent access"),
-        }
-
-        let fluent_new = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:next,finish");
-        let fluent_new_access =
-            legacy_member_access(&fluent_new, "value").expect("new fluent access");
-        match fluent_new_access {
-            LegacyMemberAccess::FluentChainNew {
-                class_local,
-                chain,
-                member,
-            } => {
-                assert_eq!(class_local, "Builder");
-                assert_eq!(chain, vec!["next", "finish"]);
-                assert_eq!(member, "value");
-            }
-            _ => panic!("expected new fluent access"),
-        }
-    }
-
-    #[test]
     fn malformed_legacy_member_access_is_skip_only() {
         let malformed = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:");
 
         assert!(is_legacy_member_access_object(&malformed));
-        assert!(legacy_member_access(&malformed, "value").is_none());
+        assert!(parse_legacy_semantic_member_access(&malformed, "value").is_none());
     }
 }

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -54,9 +54,12 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 pub use fallow_types::extract::{
     AngularTemplateMemberAccessFact, AngularThisSpreadFact, ClassHeritageInfo,
     DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
-    ExportName, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
-    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
-    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
+    ExportName, FACTORY_CALL_SENTINEL, FLUENT_CHAIN_NEW_SENTINEL, FLUENT_CHAIN_SENTINEL,
+    FactoryCallMemberAccessFact, FluentChainMemberAccessFact, FluentChainNewMemberAccessFact,
+    INSTANCE_EXPORT_SENTINEL, ImportInfo, ImportedName, InstanceExportBindingFact,
+    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
+    PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL, PLAYWRIGHT_FIXTURE_DEF_SENTINEL,
+    PLAYWRIGHT_FIXTURE_TYPE_SENTINEL, PLAYWRIGHT_FIXTURE_USE_SENTINEL, ParseResult,
     PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
     PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
     SemanticFact, VisibilityTag, compute_line_offsets,
@@ -89,63 +92,6 @@ pub use tailwind::{TailwindArbitraryUse, scan_tailwind_arbitrary_values};
 pub(crate) fn static_regex(pattern: &str) -> regex::Regex {
     regex::Regex::new(pattern).expect("static regex pattern should compile")
 }
-
-/// Legacy member-access object prefix for exported-instance bindings.
-///
-/// New extraction writes [`SemanticFact::InstanceExportBinding`]. The prefix
-/// remains available so analysis can decode older cache entries that used
-/// `MemberAccess.object` as a string protocol.
-pub const INSTANCE_EXPORT_SENTINEL: &str = "__fallow_instance_export__:";
-
-/// Legacy member-access object prefix for typed Playwright fixture definitions.
-///
-/// New extraction writes [`SemanticFact::PlaywrightFixtureDefinition`]. The
-/// prefix remains available so analysis can decode older cache entries that
-/// used `MemberAccess.object` as a string protocol.
-pub const PLAYWRIGHT_FIXTURE_DEF_SENTINEL: &str = "__fallow_playwright_fixture_def__:";
-
-/// Legacy member-access object prefix for Playwright fixture wrapper aliases.
-///
-/// New extraction writes [`SemanticFact::PlaywrightFixtureAlias`]. The prefix
-/// remains available so analysis can decode older cache entries that used
-/// `MemberAccess.object` as a string protocol.
-pub const PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL: &str = "__fallow_playwright_fixture_alias__:";
-
-/// Legacy member-access object prefix for Playwright fixture member uses.
-///
-/// New extraction writes [`SemanticFact::PlaywrightFixtureUse`]. The prefix
-/// remains available so analysis can decode older cache entries that used
-/// `MemberAccess.object` as a string protocol.
-pub const PLAYWRIGHT_FIXTURE_USE_SENTINEL: &str = "__fallow_playwright_fixture_use__:";
-
-/// Legacy member-access object prefix for exported Playwright fixture type aliases.
-///
-/// New extraction writes [`SemanticFact::PlaywrightFixtureType`]. The prefix
-/// remains available so analysis can decode older cache entries that used
-/// `MemberAccess.object` as a string protocol.
-pub const PLAYWRIGHT_FIXTURE_TYPE_SENTINEL: &str = "__fallow_playwright_fixture_type__:";
-
-/// Legacy member-access object prefix for static-factory call returns.
-///
-/// New extraction writes [`SemanticFact::FactoryCallMemberAccess`]. The prefix
-/// remains available so analysis can decode older cache entries that used
-/// `MemberAccess.object` as a string protocol. See issue #346.
-pub const FACTORY_CALL_SENTINEL: &str = "__fallow_factory_call__:";
-
-/// Legacy member-access object prefix for fluent-builder chain credit.
-///
-/// New extraction writes [`SemanticFact::FluentChainMemberAccess`]. The prefix
-/// remains available so analysis can decode older cache entries that used
-/// `MemberAccess.object` as a string protocol. See issue #387.
-pub const FLUENT_CHAIN_SENTINEL: &str = "__fallow_fluent_chain__:";
-
-/// Legacy member-access object prefix for fluent chains rooted at a `new`
-/// expression.
-///
-/// New extraction writes [`SemanticFact::FluentChainNewMemberAccess`]. The
-/// prefix remains available so analysis can decode older cache entries that
-/// used `MemberAccess.object` as a string protocol. See issue #605.
-pub const FLUENT_CHAIN_NEW_SENTINEL: &str = "__fallow_fluent_chain_new__:";
 
 pub use parse::parse_source_to_module;
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1375,6 +1375,175 @@ pub enum SemanticFact {
     DynamicCustomElementRender(DynamicCustomElementRenderFact),
 }
 
+/// Legacy member-access object prefix for exported-instance bindings.
+///
+/// New extraction writes [`SemanticFact::InstanceExportBinding`]. The prefix
+/// remains available so analysis can decode older cache entries that used
+/// `MemberAccess.object` as a string protocol.
+pub const INSTANCE_EXPORT_SENTINEL: &str = "__fallow_instance_export__:";
+
+/// Legacy member-access object prefix for typed Playwright fixture definitions.
+///
+/// New extraction writes [`SemanticFact::PlaywrightFixtureDefinition`]. The
+/// prefix remains available so analysis can decode older cache entries that
+/// used `MemberAccess.object` as a string protocol.
+pub const PLAYWRIGHT_FIXTURE_DEF_SENTINEL: &str = "__fallow_playwright_fixture_def__:";
+
+/// Legacy member-access object prefix for Playwright fixture wrapper aliases.
+///
+/// New extraction writes [`SemanticFact::PlaywrightFixtureAlias`]. The prefix
+/// remains available so analysis can decode older cache entries that used
+/// `MemberAccess.object` as a string protocol.
+pub const PLAYWRIGHT_FIXTURE_ALIAS_SENTINEL: &str = "__fallow_playwright_fixture_alias__:";
+
+/// Legacy member-access object prefix for Playwright fixture member uses.
+///
+/// New extraction writes [`SemanticFact::PlaywrightFixtureUse`]. The prefix
+/// remains available so analysis can decode older cache entries that used
+/// `MemberAccess.object` as a string protocol.
+pub const PLAYWRIGHT_FIXTURE_USE_SENTINEL: &str = "__fallow_playwright_fixture_use__:";
+
+/// Legacy member-access object prefix for exported Playwright fixture type aliases.
+///
+/// New extraction writes [`SemanticFact::PlaywrightFixtureType`]. The prefix
+/// remains available so analysis can decode older cache entries that used
+/// `MemberAccess.object` as a string protocol.
+pub const PLAYWRIGHT_FIXTURE_TYPE_SENTINEL: &str = "__fallow_playwright_fixture_type__:";
+
+/// Legacy member-access object prefix for static-factory call returns.
+///
+/// New extraction writes [`SemanticFact::FactoryCallMemberAccess`]. The prefix
+/// remains available so analysis can decode older cache entries that used
+/// `MemberAccess.object` as a string protocol. See issue #346.
+pub const FACTORY_CALL_SENTINEL: &str = "__fallow_factory_call__:";
+
+/// Legacy member-access object prefix for fluent-builder chain credit.
+///
+/// New extraction writes [`SemanticFact::FluentChainMemberAccess`]. The prefix
+/// remains available so analysis can decode older cache entries that used
+/// `MemberAccess.object` as a string protocol. See issue #387.
+pub const FLUENT_CHAIN_SENTINEL: &str = "__fallow_fluent_chain__:";
+
+/// Legacy member-access object prefix for fluent chains rooted at a `new`
+/// expression.
+///
+/// New extraction writes [`SemanticFact::FluentChainNewMemberAccess`]. The
+/// prefix remains available so analysis can decode older cache entries that
+/// used `MemberAccess.object` as a string protocol. See issue #605.
+pub const FLUENT_CHAIN_NEW_SENTINEL: &str = "__fallow_fluent_chain_new__:";
+
+/// A semantic member-access fact decoded from older sentinel-backed parse-cache
+/// entries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LegacySemanticMemberAccess<'a> {
+    /// An exported value whose runtime instance targets a local class or
+    /// interface.
+    InstanceExportBinding {
+        /// Exported binding name.
+        export_name: &'a str,
+        /// Local class or interface symbol used as the instance target.
+        target_local: &'a str,
+    },
+    /// A member access on a value returned by an imported static factory call.
+    FactoryCall {
+        /// Local imported class or namespace object used as the factory callee.
+        callee_object: &'a str,
+        /// Static factory method invoked on the callee object.
+        callee_method: &'a str,
+        /// Member accessed on the returned instance-like object.
+        member: &'a str,
+    },
+    /// A member access on a fluent chain rooted at an imported static factory.
+    FluentChain {
+        /// Local imported class or namespace object used as the chain root.
+        root_local: &'a str,
+        /// Static factory method that starts the fluent chain.
+        root_method: &'a str,
+        /// Intermediate fluent methods between the root method and final member.
+        chain: Vec<&'a str>,
+        /// Member accessed at this chain step.
+        member: &'a str,
+    },
+    /// A member access on a fluent chain rooted at a `new` expression.
+    FluentChainNew {
+        /// Local imported class constructed by the `new` expression.
+        class_local: &'a str,
+        /// Intermediate fluent methods between construction and final member.
+        chain: Vec<&'a str>,
+        /// Member accessed at this chain step.
+        member: &'a str,
+    },
+}
+
+/// Return true for legacy member-access object strings that encode semantic
+/// facts now represented by [`SemanticFact`].
+#[must_use]
+pub fn is_legacy_semantic_member_access_object(object: &str) -> bool {
+    object.starts_with(INSTANCE_EXPORT_SENTINEL)
+        || object.starts_with(FACTORY_CALL_SENTINEL)
+        || object.starts_with(FLUENT_CHAIN_SENTINEL)
+        || object.starts_with(FLUENT_CHAIN_NEW_SENTINEL)
+}
+
+/// Return true for legacy whole-object-use strings that should not be treated
+/// as ordinary value reads.
+#[must_use]
+pub fn is_legacy_semantic_whole_object_use(object: &str) -> bool {
+    object.starts_with(INSTANCE_EXPORT_SENTINEL) || object.starts_with(FACTORY_CALL_SENTINEL)
+}
+
+/// Decode an older sentinel-backed member access into the semantic fact shape
+/// used by current extraction.
+#[must_use]
+pub fn parse_legacy_semantic_member_access<'a>(
+    object: &'a str,
+    member: &'a str,
+) -> Option<LegacySemanticMemberAccess<'a>> {
+    if let Some(export_name) = object.strip_prefix(INSTANCE_EXPORT_SENTINEL) {
+        return Some(LegacySemanticMemberAccess::InstanceExportBinding {
+            export_name,
+            target_local: member,
+        });
+    }
+    if let Some((callee_object, callee_method)) = object
+        .strip_prefix(FACTORY_CALL_SENTINEL)
+        .and_then(|payload| payload.split_once(':'))
+    {
+        return Some(LegacySemanticMemberAccess::FactoryCall {
+            callee_object,
+            callee_method,
+            member,
+        });
+    }
+    if let Some(payload) = object.strip_prefix(FLUENT_CHAIN_SENTINEL) {
+        let (root_local, rest) = payload.split_once(':')?;
+        let (root_method, chain_str) = rest.split_once(':')?;
+        let chain = if chain_str.is_empty() {
+            Vec::new()
+        } else {
+            chain_str.split(',').collect()
+        };
+        return Some(LegacySemanticMemberAccess::FluentChain {
+            root_local,
+            root_method,
+            chain,
+            member,
+        });
+    }
+    if let Some(payload) = object.strip_prefix(FLUENT_CHAIN_NEW_SENTINEL) {
+        let (class_local, chain_str) = payload.split_once(':')?;
+        if chain_str.is_empty() {
+            return None;
+        }
+        return Some(LegacySemanticMemberAccess::FluentChainNew {
+            class_local,
+            chain: chain_str.split(',').collect(),
+            member,
+        });
+    }
+    None
+}
+
 /// A member name referenced from an Angular template surface.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -2057,6 +2226,84 @@ mod tests {
                 "{name} should remain secret-shaped"
             );
         }
+    }
+
+    #[test]
+    fn legacy_semantic_member_access_decodes_instance_binding() {
+        let object = format!("{INSTANCE_EXPORT_SENTINEL}exported");
+        let access = parse_legacy_semantic_member_access(&object, "target").expect("legacy access");
+
+        match access {
+            LegacySemanticMemberAccess::InstanceExportBinding {
+                export_name,
+                target_local,
+            } => {
+                assert_eq!(export_name, "exported");
+                assert_eq!(target_local, "target");
+            }
+            _ => panic!("expected instance binding"),
+        }
+    }
+
+    #[test]
+    fn legacy_semantic_member_access_decodes_factory_and_fluent_chains() {
+        let factory = format!("{FACTORY_CALL_SENTINEL}Service:create");
+        let factory_access =
+            parse_legacy_semantic_member_access(&factory, "run").expect("factory access");
+        match factory_access {
+            LegacySemanticMemberAccess::FactoryCall {
+                callee_object,
+                callee_method,
+                member,
+            } => {
+                assert_eq!(callee_object, "Service");
+                assert_eq!(callee_method, "create");
+                assert_eq!(member, "run");
+            }
+            _ => panic!("expected factory access"),
+        }
+
+        let fluent = format!("{FLUENT_CHAIN_SENTINEL}Builder:start:next,finish");
+        let fluent_access =
+            parse_legacy_semantic_member_access(&fluent, "value").expect("fluent access");
+        match fluent_access {
+            LegacySemanticMemberAccess::FluentChain {
+                root_local,
+                root_method,
+                chain,
+                member,
+            } => {
+                assert_eq!(root_local, "Builder");
+                assert_eq!(root_method, "start");
+                assert_eq!(chain, vec!["next", "finish"]);
+                assert_eq!(member, "value");
+            }
+            _ => panic!("expected fluent access"),
+        }
+
+        let fluent_new = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:next,finish");
+        let fluent_new_access =
+            parse_legacy_semantic_member_access(&fluent_new, "value").expect("new fluent access");
+        match fluent_new_access {
+            LegacySemanticMemberAccess::FluentChainNew {
+                class_local,
+                chain,
+                member,
+            } => {
+                assert_eq!(class_local, "Builder");
+                assert_eq!(chain, vec!["next", "finish"]);
+                assert_eq!(member, "value");
+            }
+            _ => panic!("expected new fluent access"),
+        }
+    }
+
+    #[test]
+    fn legacy_semantic_member_access_rejects_malformed_new_chain() {
+        let malformed = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:");
+
+        assert!(is_legacy_semantic_member_access_object(&malformed));
+        assert!(parse_legacy_semantic_member_access(&malformed, "value").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Replaces #1512 after branch cleanup.