### PR TITLE
refactor: route dupes next steps through output contract

### DIFF
--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -22,8 +22,9 @@ use std::process::Command;
 
 use fallow_core::results::AnalysisResults;
 use fallow_output::{
-    DeadCodeNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
-    build_dead_code_next_steps as build_dead_code_next_steps_contract, impact_digest_summary,
+    DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
+    build_dead_code_next_steps as build_dead_code_next_steps_contract,
+    build_dupes_next_steps as build_dupes_next_steps_contract, impact_digest_summary,
 };
 use fallow_types::output::NextStep;
 
@@ -368,23 +369,18 @@ pub fn build_dupes_next_steps(
     offer_setup: bool,
     digest: Option<crate::impact::ImpactDigest>,
 ) -> Vec<NextStep> {
-    if !suggestions_enabled() {
-        return Vec::new();
-    }
-    if payload.clone_groups.is_empty() {
-        return impact_digest_step(digest).into_iter().collect();
-    }
-    let mut steps: Vec<NextStep> = [
-        setup_pointer(offer_setup),
-        impact_digest_step(digest),
-        trace_clone(payload),
-        audit_changed(root),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-    steps.truncate(MAX_NEXT_STEPS);
-    steps
+    let clone_fingerprints = payload
+        .clone_groups
+        .iter()
+        .map(|group| group.fingerprint.as_str())
+        .collect::<Vec<_>>();
+    build_dupes_next_steps_contract(DupesNextStepsInput {
+        suggestions_enabled: suggestions_enabled(),
+        clone_fingerprints: &clone_fingerprints,
+        offer_setup,
+        impact_digest: digest.map(impact_counts),
+        audit_changed: audit_changed(root).is_some(),
+    })
 }
 
 /// Aggregated next-steps for bare `fallow` (combined). Candidates are pushed in
@@ -476,6 +472,9 @@ mod tests {
     use crate::health_types::{
         ComplexityViolation, ExceededThreshold, FindingSeverity, HealthFinding, HealthReport,
     };
+    use fallow_engine::duplicates::{
+        CloneGroup, CloneInstance, DuplicationReport, DuplicationStats,
+    };
     use fallow_output::build_health_next_steps as build_health_next_steps_contract;
     use fallow_types::output_dead_code::UnusedExportFinding;
     use fallow_types::results::{AnalysisResults, UnusedExport};
@@ -499,6 +498,34 @@ mod tests {
             unused_exports: exports,
             ..AnalysisResults::default()
         }
+    }
+
+    fn clone_instance(path: &str, fragment: &str) -> CloneInstance {
+        CloneInstance {
+            file: PathBuf::from(path),
+            start_line: 1,
+            end_line: 8,
+            start_col: 0,
+            end_col: 0,
+            fragment: fragment.to_string(),
+        }
+    }
+
+    fn dupes_payload() -> DupesReportPayload {
+        let group = CloneGroup {
+            instances: vec![
+                clone_instance("/project/src/a.ts", "export const shared = 1;"),
+                clone_instance("/project/src/b.ts", "export const shared = 1;"),
+            ],
+            token_count: 20,
+            line_count: 8,
+        };
+        DupesReportPayload::from_report(&DuplicationReport {
+            clone_groups: vec![group],
+            clone_families: Vec::new(),
+            mirrored_directories: Vec::new(),
+            stats: DuplicationStats::default(),
+        })
     }
 
     fn health_report_with_finding() -> HealthReport {
@@ -692,6 +719,18 @@ mod tests {
         let steps = build_health_next_steps_contract(input);
         let ids: Vec<&str> = steps.iter().map(|s| s.id.as_str()).collect();
         assert_eq!(ids, ["setup", "impact-report", "complexity-breakdown"]);
+    }
+
+    #[test]
+    fn dupes_next_steps_route_payload_fingerprints_to_output_contract() {
+        let payload = dupes_payload();
+
+        let steps = build_dupes_next_steps(&payload, Path::new("/project"), false, None);
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "trace-clone");
+        assert!(steps[0].command.starts_with("fallow dupes --trace dup:"));
+        assert_valid(&steps[0]);
     }
 
     #[test]

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -177,8 +177,9 @@ pub use list_envelopes::{
     ListBoundariesOutput, WorkspaceInfo, WorkspacesOutput,
 };
 pub use next_steps::{
-    DeadCodeNextStepsInput, HealthNextStepsInput, ImpactDigestCounts, build_dead_code_next_steps,
-    build_health_next_steps, impact_digest_summary,
+    DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
+    build_dead_code_next_steps, build_dupes_next_steps, build_health_next_steps,
+    impact_digest_summary,
 };
 pub use report_contract::{
     COVERAGE_ANALYZE_DOCS, COVERAGE_SETUP_DOCS, DUPES_DOCS, HEALTH_DOCS, SECURITY_DOCS,

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -30,6 +30,16 @@ pub struct DeadCodeNextStepsInput<'a> {
     pub audit_changed: bool,
 }
 
+/// Runtime-independent inputs for standalone duplication next steps.
+#[derive(Debug, Clone, Copy)]
+pub struct DupesNextStepsInput<'a> {
+    pub suggestions_enabled: bool,
+    pub clone_fingerprints: &'a [&'a str],
+    pub offer_setup: bool,
+    pub impact_digest: Option<ImpactDigestCounts>,
+    pub audit_changed: bool,
+}
+
 /// Runtime-independent inputs for standalone health next steps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HealthNextStepsInput {
@@ -117,6 +127,31 @@ pub fn build_dead_code_next_steps(input: DeadCodeNextStepsInput<'_>) -> Vec<Next
     steps
 }
 
+/// Next-steps for standalone `fallow dupes`.
+#[must_use]
+pub fn build_dupes_next_steps(input: DupesNextStepsInput<'_>) -> Vec<NextStep> {
+    if !input.suggestions_enabled {
+        return Vec::new();
+    }
+    if input.clone_fingerprints.is_empty() {
+        return impact_digest_step(input.impact_digest)
+            .into_iter()
+            .collect();
+    }
+
+    let mut steps: Vec<NextStep> = [
+        setup_pointer(input.offer_setup),
+        impact_digest_step(input.impact_digest),
+        trace_clone(input.clone_fingerprints),
+        audit_changed(input.audit_changed),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    steps.truncate(MAX_NEXT_STEPS);
+    steps
+}
+
 fn relative_command_path(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -139,6 +174,15 @@ fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextSte
         "trace-unused-export",
         format!("fallow dead-code --trace {}:{}", target.0, target.1),
         "verify an export is truly unused before deleting",
+    ))
+}
+
+fn trace_clone(fingerprints: &[&str]) -> Option<NextStep> {
+    let fingerprint = fingerprints.iter().copied().min()?;
+    Some(next_step(
+        "trace-clone",
+        format!("fallow dupes --trace {fingerprint}"),
+        "see sibling locations and an extract-function suggestion",
     ))
 }
 
@@ -261,6 +305,16 @@ mod tests {
         }
     }
 
+    fn dupes_input<'a>(clone_fingerprints: &'a [&'a str]) -> DupesNextStepsInput<'a> {
+        DupesNextStepsInput {
+            suggestions_enabled: true,
+            clone_fingerprints,
+            offer_setup: false,
+            impact_digest: None,
+            audit_changed: false,
+        }
+    }
+
     fn assert_valid(step: &NextStep) {
         assert!(
             !step.command.contains('<') && !step.command.contains('>'),
@@ -338,6 +392,49 @@ mod tests {
             impact_digest: Some(digest(2, 1)),
             audit_changed: true,
             ..dead_code_input(&results)
+        });
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "impact-report");
+    }
+
+    #[test]
+    fn dupes_steps_trace_smallest_clone_fingerprint() {
+        let fingerprints = ["dup:bbbbbbbb", "dup:aaaaaaaa"];
+
+        let steps = build_dupes_next_steps(dupes_input(&fingerprints));
+
+        assert_eq!(steps[0].id, "trace-clone");
+        assert_eq!(steps[0].command, "fallow dupes --trace dup:aaaaaaaa");
+        assert_valid(&steps[0]);
+    }
+
+    #[test]
+    fn dupes_steps_order_setup_impact_trace_then_audit() {
+        let fingerprints = ["dup:aaaaaaaa"];
+        let steps = build_dupes_next_steps(DupesNextStepsInput {
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..dupes_input(&fingerprints)
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["setup", "impact-report", "trace-clone"]);
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
+    fn clean_dupes_run_emits_only_due_impact_digest() {
+        let steps = build_dupes_next_steps(DupesNextStepsInput {
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..dupes_input(&[])
         });
 
         assert_eq!(steps.len(), 1);


### PR DESCRIPTION
Replaces #1517 after branch cleanup.