### PR TITLE
refactor: centralize legacy semantic sentinel predicates

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -6,14 +6,15 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::discover::FileId;
-use crate::extract::{ANGULAR_TPL_SENTINEL, ExportName, MemberInfo, MemberKind, ModuleInfo};
+use crate::extract::{ExportName, MemberInfo, MemberKind, ModuleInfo};
 use crate::graph::{ModuleGraph, ReferenceKind};
 use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
-    SemanticFact, is_legacy_semantic_member_access_object, is_legacy_semantic_whole_object_use,
-    semantic_facts_with_legacy_member_accesses,
+    SemanticFact, is_legacy_angular_template_member_access_object,
+    is_legacy_template_or_semantic_member_access_object,
+    is_legacy_template_or_semantic_whole_object_use, semantic_facts_with_legacy_member_accesses,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -596,7 +597,8 @@ fn build_angular_template_chain_accesses(
                 .member_accesses
                 .iter()
                 .filter(|access| {
-                    access.object != "this" && !is_legacy_member_access_object(&access.object)
+                    access.object != "this"
+                        && !is_legacy_template_or_semantic_member_access_object(&access.object)
                 })
                 .map(|access| (access.object.as_str(), access.member.as_str()))
                 .collect();
@@ -624,7 +626,7 @@ fn angular_template_member_refs(module: &ResolvedModule) -> Vec<&str> {
             module
                 .member_accesses
                 .iter()
-                .filter(|access| access.object == ANGULAR_TPL_SENTINEL)
+                .filter(|access| is_legacy_angular_template_member_access_object(&access.object))
                 .map(|access| access.member.as_str()),
         )
         .collect()
@@ -638,7 +640,7 @@ fn has_angular_template_member_refs(module: &ResolvedModule) -> bool {
         || module
             .member_accesses
             .iter()
-            .any(|access| access.object == ANGULAR_TPL_SENTINEL)
+            .any(|access| is_legacy_angular_template_member_access_object(&access.object))
 }
 
 struct AngularTemplateRefContext<'a, 'b> {
@@ -1549,13 +1551,13 @@ fn propagate_accesses_through_typed_instance_bindings(
 /// fluent-chain / Angular-template), which the typed-instance chain resolver
 /// must skip because it is handled by a dedicated propagation pass.
 fn is_typed_instance_member_sentinel(object: &str) -> bool {
-    is_legacy_member_access_object(object)
+    is_legacy_template_or_semantic_member_access_object(object)
 }
 
 /// Whether a whole-object-use name is a synthetic sentinel the typed-instance
 /// chain resolver must skip (the fluent-chain sentinels never appear here).
 fn is_typed_instance_whole_object_sentinel(object: &str) -> bool {
-    is_legacy_whole_object_use(object)
+    is_legacy_template_or_semantic_whole_object_use(object)
 }
 
 /// Credit each non-sentinel member access in one module onto the typed-instance
@@ -1607,14 +1609,6 @@ fn propagate_typed_whole_object_uses(
             whole_object_used_exports.insert(target_key);
         }
     }
-}
-
-fn is_legacy_member_access_object(object: &str) -> bool {
-    object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_member_access_object(object)
-}
-
-fn is_legacy_whole_object_use(object: &str) -> bool {
-    object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_whole_object_use(object)
 }
 
 struct FactoryCallAccess {
@@ -2602,7 +2596,7 @@ fn collect_direct_member_accesses(resolved_modules: &[ResolvedModule]) -> Member
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
         for access in &resolved.member_accesses {
-            if is_legacy_member_access_object(&access.object) {
+            if is_legacy_template_or_semantic_member_access_object(&access.object) {
                 continue;
             }
             if access.object == "this" {
@@ -5167,7 +5161,9 @@ mod tests {
             member: "value".to_string(),
         }];
 
-        assert!(is_legacy_member_access_object(&malformed));
+        assert!(is_legacy_template_or_semantic_member_access_object(
+            &malformed
+        ));
         assert!(
             semantic_facts_with_legacy_member_accesses(&[], &member_accesses)
                 .next()

--- a/crates/extract/src/sfc_template/angular.rs
+++ b/crates/extract/src/sfc_template/angular.rs
@@ -17,25 +17,12 @@ use std::sync::LazyLock;
 use rustc_hash::FxHashSet;
 
 use fallow_types::extract::SinkSite;
+pub use fallow_types::extract::{ANGULAR_THIS_SPREAD_SENTINEL, ANGULAR_TPL_SENTINEL};
 
 use crate::MemberAccess;
 use crate::template_usage::{TemplateSnippetKind, collect_unresolved_refs_and_accesses};
 
 use super::scanners::{scan_curly_section, scan_html_tag};
-
-/// Sentinel value used as the `object` field in `MemberAccess` entries
-/// produced by the Angular template scanner. The analysis phase checks imports
-/// for entries with this sentinel and merges them into the component's
-/// `self_accessed_members` set.
-pub const ANGULAR_TPL_SENTINEL: &str = "__angular_tpl__";
-
-/// Sentinel `object` for a `MemberAccess` recorded when a class body spreads
-/// `this` into an object literal (`{ ...this }`, the Angular "headless pattern"
-/// convention that forwards every signal input/output into a behavior pattern).
-/// The `unused-component-input` / `unused-component-output` detectors treat its
-/// presence as a whole-component abstain, since every member is consumed
-/// opaquely through the spread.
-pub const ANGULAR_THIS_SPREAD_SENTINEL: &str = "__angular_this_spread__";
 
 /// Result of scanning an Angular template for member references.
 #[derive(Debug, Default)]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1375,6 +1375,20 @@ pub enum SemanticFact {
     DynamicCustomElementRender(DynamicCustomElementRenderFact),
 }
 
+/// Legacy member-access object used by Angular template scanners.
+///
+/// New extraction writes [`SemanticFact::AngularTemplateMemberAccess`]. The
+/// object value remains available so analysis can decode older cache entries
+/// that used `MemberAccess.object` as a string protocol.
+pub const ANGULAR_TPL_SENTINEL: &str = "__angular_tpl__";
+
+/// Legacy member-access object recorded for Angular `{ ...this }` forwarding.
+///
+/// New extraction writes [`SemanticFact::AngularThisSpread`]. The object value
+/// remains available so component member detectors can honor older cache
+/// entries that used `MemberAccess.object` as a string protocol.
+pub const ANGULAR_THIS_SPREAD_SENTINEL: &str = "__angular_this_spread__";
+
 /// Legacy member-access object prefix for exported-instance bindings.
 ///
 /// New extraction writes [`SemanticFact::InstanceExportBinding`]. The prefix
@@ -1490,6 +1504,28 @@ pub fn is_legacy_semantic_member_access_object(object: &str) -> bool {
 #[must_use]
 pub fn is_legacy_semantic_whole_object_use(object: &str) -> bool {
     object.starts_with(INSTANCE_EXPORT_SENTINEL) || object.starts_with(FACTORY_CALL_SENTINEL)
+}
+
+/// Return true for legacy Angular template member-access objects.
+#[must_use]
+pub fn is_legacy_angular_template_member_access_object(object: &str) -> bool {
+    object == ANGULAR_TPL_SENTINEL
+}
+
+/// Return true for legacy member-access object strings that encode either an
+/// Angular template reference or a typed semantic fact.
+#[must_use]
+pub fn is_legacy_template_or_semantic_member_access_object(object: &str) -> bool {
+    is_legacy_angular_template_member_access_object(object)
+        || is_legacy_semantic_member_access_object(object)
+}
+
+/// Return true for legacy whole-object-use strings that should not be treated
+/// as ordinary value reads in typed-instance propagation.
+#[must_use]
+pub fn is_legacy_template_or_semantic_whole_object_use(object: &str) -> bool {
+    is_legacy_angular_template_member_access_object(object)
+        || is_legacy_semantic_whole_object_use(object)
 }
 
 /// Decode an older sentinel-backed member access into the semantic fact shape
@@ -2386,6 +2422,27 @@ mod tests {
 
         assert!(is_legacy_semantic_member_access_object(&malformed));
         assert!(parse_legacy_semantic_member_access(&malformed, "value").is_none());
+    }
+
+    #[test]
+    fn legacy_template_or_semantic_predicates_include_angular_template_sentinel() {
+        assert!(is_legacy_angular_template_member_access_object(
+            ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_template_or_semantic_member_access_object(
+            ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_template_or_semantic_whole_object_use(
+            ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_template_or_semantic_member_access_object(
+            &format!("{INSTANCE_EXPORT_SENTINEL}exported")
+        ));
+        assert!(is_legacy_template_or_semantic_whole_object_use(&format!(
+            "{FACTORY_CALL_SENTINEL}Svc:create"
+        )));
+        assert!(!is_legacy_template_or_semantic_member_access_object("this"));
+        assert!(!is_legacy_template_or_semantic_whole_object_use("this"));
     }
 
     #[test]


### PR DESCRIPTION
Replaces #1527 after branch cleanup.