### PR TITLE
refactor: type cache source fingerprints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "criterion2",
  "fallow-cli",
  "fallow-core",
+ "fallow-types",
  "tempfile",
 ]
 

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 criterion2 = { workspace = true }
 fallow-cli = { workspace = true }
 fallow-core = { workspace = true }
+fallow-types = { workspace = true }
 tempfile = { workspace = true }
 
 [features]

--- a/crates/benchmarks/benches/programmatic_commands.rs
+++ b/crates/benchmarks/benches/programmatic_commands.rs
@@ -753,7 +753,10 @@ fn create_warm_hash_workspace_project() -> ExtractCacheInput {
 
     for file in &files {
         let module = parse_single_file(file).expect("benchmark fixture parses");
-        let cached = module_to_cached(&module, 1, 1);
+        let cached = module_to_cached(
+            &module,
+            fallow_types::source_fingerprint::SourceFingerprint::new(1, 1),
+        );
         cache.insert(&file.path, cached);
     }
 

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -745,12 +745,13 @@ fn create_cache_round_trip_input() -> fallow_core::extract::ModuleInfo {
 fn cache_round_trip(c: &mut Criterion) {
     use fallow_core::cache::{cached_to_module, module_to_cached};
     use fallow_core::discover::FileId;
+    use fallow_types::source_fingerprint::SourceFingerprint;
 
     c.bench_function("cache_round_trip", |bencher| {
         bencher.iter_batched_ref(
             create_cache_round_trip_input,
             |module| {
-                let cached = module_to_cached(module, 0, 0);
+                let cached = module_to_cached(module, SourceFingerprint::new(0, 0));
                 let _ = cached_to_module(&cached, FileId(0));
             },
             BatchSize::LargeInput,

--- a/crates/core/src/duplicates/cache.rs
+++ b/crates/core/src/duplicates/cache.rs
@@ -45,6 +45,12 @@ struct CachedTokenFile {
     suppressions: Vec<CachedSuppression>,
 }
 
+impl CachedTokenFile {
+    fn source_fingerprint(&self) -> SourceFingerprint {
+        SourceFingerprint::new(self.mtime_ns, self.file_size)
+    }
+}
+
 #[derive(Debug, Clone, Encode, Decode)]
 struct CachedHashedToken {
     hash: u64,
@@ -146,9 +152,7 @@ impl TokenCache {
             return None;
         }
         let entry = self.store.entries.get(&cache_key(path))?;
-        if SourceFingerprint::new(entry.mtime_ns, entry.file_size) != fingerprint
-            || entry.normalization_hash != mode.hash
-        {
+        if entry.source_fingerprint() != fingerprint || entry.normalization_hash != mode.hash {
             return None;
         }
         Some(entry.to_entry())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -180,26 +180,15 @@ fn update_cache(
             if let Some(cached) = store.get_by_path_only(&file.path)
                 && cached.content_hash == module.content_hash
             {
-                let cached_fingerprint = fallow_types::source_fingerprint::SourceFingerprint::new(
-                    cached.mtime_secs,
-                    cached.file_size,
-                );
-                if cached_fingerprint != fingerprint {
+                if cached.source_fingerprint() != fingerprint {
                     let preserved_last_access = cached.last_access_secs;
-                    let mut refreshed = cache::module_to_cached(
-                        module,
-                        fingerprint.mtime_ns,
-                        fingerprint.file_size,
-                    );
+                    let mut refreshed = cache::module_to_cached(module, fingerprint);
                     refreshed.last_access_secs = preserved_last_access;
                     store.insert(&file.path, refreshed);
                 }
                 continue;
             }
-            store.insert(
-                &file.path,
-                cache::module_to_cached(module, fingerprint.mtime_ns, fingerprint.file_size),
-            );
+            store.insert(&file.path, cache::module_to_cached(module, fingerprint));
         }
     }
     store.retain_paths(files);

--- a/crates/core/tests/integration_test/caching.rs
+++ b/crates/core/tests/integration_test/caching.rs
@@ -200,7 +200,10 @@ fn incremental_with_cache_all_hits() {
         if let Some(file) = files.get(module.file_id.0 as usize) {
             cache_store.insert(
                 &file.path,
-                fallow_core::cache::module_to_cached(module, 0, 0),
+                fallow_core::cache::module_to_cached(
+                    module,
+                    fallow_types::source_fingerprint::SourceFingerprint::new(0, 0),
+                ),
             );
         }
     }
@@ -223,7 +226,10 @@ fn incremental_results_identical() {
         if let Some(file) = files.get(module.file_id.0 as usize) {
             cache_store.insert(
                 &file.path,
-                fallow_core::cache::module_to_cached(module, 0, 0),
+                fallow_core::cache::module_to_cached(
+                    module,
+                    fallow_types::source_fingerprint::SourceFingerprint::new(0, 0),
+                ),
             );
         }
     }

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -549,20 +549,18 @@ pub fn cached_to_module_opts(
 
 /// Convert a [`ModuleInfo`](crate::ModuleInfo) to a [`CachedModule`] for storage.
 ///
-/// `mtime_secs` and `file_size` come from `std::fs::metadata()` at parse time
-/// and enable fast cache validation on subsequent runs (skip file read when
-/// mtime+size match). Despite the legacy field name, callers now pass the
-/// shared source-fingerprint mtime value.
+/// The [`SourceFingerprint`](fallow_types::source_fingerprint::SourceFingerprint)
+/// comes from `std::fs::metadata()` at parse time and enables fast cache
+/// validation on subsequent runs.
 #[must_use]
 pub fn module_to_cached(
     module: &crate::ModuleInfo,
-    mtime_secs: u64,
-    file_size: u64,
+    fingerprint: fallow_types::source_fingerprint::SourceFingerprint,
 ) -> CachedModule {
     CachedModule {
         content_hash: module.content_hash,
-        mtime_secs,
-        file_size,
+        mtime_secs: fingerprint.mtime_ns,
+        file_size: fingerprint.file_size,
         last_access_secs: current_unix_seconds(),
         exports: module_exports_to_cached(&module.exports),
         imports: module_imports_to_cached(&module.imports),
@@ -639,4 +637,21 @@ pub fn module_to_cached(
         svelte_listened_events: module.svelte_listened_events.clone(),
         has_dynamic_dispatch: module.has_dynamic_dispatch,
     }
+}
+
+/// Convert a module to a cache entry from explicit source-fingerprint parts.
+///
+/// Kept for tests that need literal invalidation inputs without filesystem
+/// metadata.
+#[cfg(test)]
+#[must_use]
+pub fn module_to_cached_from_parts(
+    module: &crate::ModuleInfo,
+    mtime_ns: u64,
+    file_size: u64,
+) -> CachedModule {
+    module_to_cached(
+        module,
+        fallow_types::source_fingerprint::SourceFingerprint::new(mtime_ns, file_size),
+    )
 }

--- a/crates/extract/src/cache/mod.rs
+++ b/crates/extract/src/cache/mod.rs
@@ -11,6 +11,8 @@ mod types;
 #[cfg(all(test, not(miri)))]
 mod tests;
 
+#[cfg(test)]
+pub use conversion::module_to_cached_from_parts;
 pub use conversion::{
     cached_to_module, cached_to_module_opts, current_unix_seconds, module_to_cached,
 };

--- a/crates/extract/src/cache/store.rs
+++ b/crates/extract/src/cache/store.rs
@@ -185,8 +185,7 @@ impl CacheStore {
     ) -> Option<&CachedModule> {
         let key = path.to_string_lossy();
         let entry = self.entries.get(key.as_ref())?;
-        let cached = SourceFingerprint::new(entry.mtime_secs, entry.file_size);
-        if cached == fingerprint && fingerprint.has_known_mtime() {
+        if entry.source_fingerprint() == fingerprint && fingerprint.has_known_mtime() {
             Some(entry)
         } else {
             None

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -34,7 +34,7 @@ fn cache_roundtrip_preserves_unresolved_callee_diagnostics() {
     assert_eq!(module.security_sinks_skipped, 1);
     assert_eq!(module.security_unresolved_callee_sites.len(), 1);
 
-    let cached = module_to_cached(&module, 10, 20);
+    let cached = module_to_cached_from_parts(&module, 10, 20);
     let restored = cached_to_module(&cached, FileId(7));
     let diagnostic = restored
         .security_unresolved_callee_sites
@@ -64,7 +64,7 @@ fn cache_roundtrip_preserves_react_structural_ir() {
     assert_eq!(module.hook_uses.len(), 1);
     assert_eq!(module.render_edges.len(), 1);
 
-    let cached = module_to_cached(&module, 10, 20);
+    let cached = module_to_cached_from_parts(&module, 10, 20);
     let restored = cached_to_module(&cached, FileId(7));
 
     assert_eq!(restored.component_functions.len(), 1);
@@ -501,7 +501,7 @@ fn module_to_cached_roundtrip_named_export() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(
@@ -614,7 +614,7 @@ fn module_to_cached_roundtrip_side_effect_used_export() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports.len(), 1);
@@ -712,7 +712,7 @@ fn module_to_cached_roundtrip_default_export() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports[0].name, ExportName::Default);
@@ -836,7 +836,7 @@ fn module_to_cached_roundtrip_imports() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.imports.len(), 4);
@@ -940,7 +940,7 @@ fn module_to_cached_roundtrip_re_exports() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.re_exports.len(), 1);
@@ -1089,7 +1089,7 @@ fn module_to_cached_roundtrip_dynamic_imports() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.dynamic_imports.len(), 1);
@@ -1272,7 +1272,7 @@ fn module_to_cached_roundtrip_members() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports[0].members.len(), 3);
@@ -1575,7 +1575,7 @@ fn module_to_cached_roundtrip_type_only_import() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert!(restored.imports[0].is_type_only);
@@ -2299,7 +2299,7 @@ fn module_to_cached_stores_mtime_and_size() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 12345, 6789);
+    let cached = module_to_cached_from_parts(&module, 12345, 6789);
     assert_eq!(cached.mtime_secs, 12345);
     assert_eq!(cached.file_size, 6789);
     assert_eq!(cached.content_hash, 42);
@@ -2381,7 +2381,7 @@ fn module_to_cached_roundtrip_line_offsets() {
         has_dynamic_component_render: false,
         has_dynamic_dispatch: false,
     };
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.line_offsets, vec![0, 15, 30, 45]);
 }
@@ -2474,7 +2474,7 @@ fn module_to_cached_roundtrip_suppressions_with_kinds() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.suppressions.len(), 4);
@@ -2590,7 +2590,7 @@ fn module_to_cached_roundtrip_unknown_suppression_kinds() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.unknown_suppression_kinds.len(), 2);
@@ -2692,7 +2692,7 @@ fn module_to_cached_roundtrip_visibility() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Public);
@@ -2785,7 +2785,7 @@ fn module_to_cached_roundtrip_visibility_internal() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     assert_eq!(cached.exports[0].visibility, 2);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Internal);
@@ -2878,7 +2878,7 @@ fn module_to_cached_roundtrip_visibility_beta() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     assert_eq!(cached.exports[0].visibility, 3);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Beta);
@@ -2971,7 +2971,7 @@ fn module_to_cached_roundtrip_visibility_alpha() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     assert_eq!(cached.exports[0].visibility, 4);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Alpha);
@@ -3065,7 +3065,7 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.dynamic_import_patterns.len(), 2);
@@ -3157,7 +3157,7 @@ fn module_to_cached_roundtrip_unused_import_bindings() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.unused_import_bindings.len(), 2);
@@ -3286,7 +3286,7 @@ fn module_to_cached_roundtrip_complexity() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.complexity.len(), 2);
@@ -3382,7 +3382,7 @@ fn module_to_cached_roundtrip_require_with_destructured() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.require_calls.len(), 1);
@@ -3477,7 +3477,7 @@ fn module_to_cached_roundtrip_dynamic_import_with_local() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(
@@ -3571,7 +3571,7 @@ fn module_to_cached_roundtrip_source_span() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.imports[0].source_span.start, 25);
@@ -3673,7 +3673,7 @@ fn module_to_cached_roundtrip_member_decorators() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert!(restored.exports[0].members[0].has_decorator);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -936,6 +936,18 @@ pub struct CachedModule {
     pub has_dynamic_dispatch: bool,
 }
 
+impl CachedModule {
+    /// Source metadata fingerprint stored with this cache entry.
+    ///
+    /// The on-disk field name `mtime_secs` is legacy. It stores the shared
+    /// nanosecond mtime value used by
+    /// [`SourceFingerprint`](fallow_types::source_fingerprint::SourceFingerprint).
+    #[must_use]
+    pub fn source_fingerprint(&self) -> fallow_types::source_fingerprint::SourceFingerprint {
+        fallow_types::source_fingerprint::SourceFingerprint::new(self.mtime_secs, self.file_size)
+    }
+}
+
 /// Cached namespace-object alias.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct CachedNamespaceObjectAlias {


### PR DESCRIPTION
Replaces #1532 after branch cleanup.