### PR TITLE
refactor: centralize output next steps and api health boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "criterion2",
  "fallow-cli",
  "fallow-core",
+ "fallow-types",
  "tempfile",
 ]
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,8 +22,8 @@ pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
 pub use runtime::{
-    ProgrammaticHealthJsonInput, detect_boundary_violations, detect_circular_dependencies,
-    detect_dead_code, detect_duplication, serialize_programmatic_health_json,
+    HealthJsonReportInput, detect_boundary_violations, detect_circular_dependencies,
+    detect_dead_code, detect_duplication, serialize_health_report_json,
 };
 
 pub const COMMON_ANALYSIS_OPTION_FLAGS: &[&str] = &[

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,7 +22,8 @@ pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
 pub use runtime::{
-    detect_boundary_violations, detect_circular_dependencies, detect_dead_code, detect_duplication,
+    ProgrammaticHealthJsonInput, detect_boundary_violations, detect_circular_dependencies,
+    detect_dead_code, detect_duplication, serialize_programmatic_health_json,
 };
 
 pub const COMMON_ANALYSIS_OPTION_FLAGS: &[&str] = &[

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -1349,11 +1349,7 @@ fn is_absolute_path_any_platform(path: &Path) -> bool {
 }
 
 const fn root_envelope_mode(legacy_envelope: bool) -> RootEnvelopeMode {
-    if legacy_envelope {
-        RootEnvelopeMode::Legacy
-    } else {
-        RootEnvelopeMode::Tagged
-    }
+    RootEnvelopeMode::from_legacy(legacy_envelope)
 }
 
 #[cfg(test)]

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -9,9 +9,10 @@ use fallow_config::{
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
-    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, HealthJsonOutputInput,
-    HealthOutputInput, HealthReport, RootEnvelopeMode, WorkspaceDiagnosticOutput, apply_root_kind,
-    build_check_output, build_dupes_output, check_meta, health_meta, strip_root_prefix,
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, GroupByMode,
+    HealthGroup, HealthJsonOutputInput, HealthOutputInput, HealthReport, RootEnvelopeMode,
+    WorkspaceDiagnosticOutput, apply_root_kind, build_check_output, build_dupes_output, check_meta,
+    health_meta, strip_root_prefix,
 };
 use fallow_types::output::NextStep;
 use globset::Glob;
@@ -28,12 +29,14 @@ const MAX_DIFF_BYTES: u64 = 10 * 1024 * 1024;
 
 type ProgrammaticResult<T> = Result<T, ProgrammaticError>;
 
-/// Inputs for serializing programmatic health / complexity output.
-pub struct ProgrammaticHealthJsonInput<'a> {
+/// Inputs for serializing health JSON output through the API boundary.
+pub struct HealthJsonReportInput<'a> {
     pub report: HealthReport,
     pub root: &'a Path,
     pub elapsed: std::time::Duration,
     pub explain: bool,
+    pub grouped_by: Option<GroupByMode>,
+    pub groups: Option<Vec<HealthGroup>>,
     pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
     pub next_steps: Vec<NextStep>,
     pub envelope_mode: RootEnvelopeMode,
@@ -114,8 +117,7 @@ pub fn detect_boundary_violations(
     resolved.install(|| detect_dead_code_inner(options, &resolved, keep_boundary_violations))
 }
 
-/// Serialize a programmatic health / complexity report into the stable JSON
-/// output contract.
+/// Serialize a health / complexity report into the stable JSON output contract.
 ///
 /// The health runner is still migrating out of the CLI crate, so callers pass
 /// the already assembled report plus CLI-owned suggestion and workspace
@@ -124,8 +126,8 @@ pub fn detect_boundary_violations(
 /// # Errors
 ///
 /// Returns a serde error when the report cannot be converted to JSON.
-pub fn serialize_programmatic_health_json(
-    input: ProgrammaticHealthJsonInput<'_>,
+pub fn serialize_health_report_json(
+    input: HealthJsonReportInput<'_>,
 ) -> Result<serde_json::Value, serde_json::Error> {
     let root_prefix = format!("{}/", input.root.display());
     fallow_output::serialize_health_json_output(HealthJsonOutputInput {
@@ -134,8 +136,8 @@ pub fn serialize_programmatic_health_json(
             version: env!("CARGO_PKG_VERSION").to_string(),
             elapsed: input.elapsed,
             report: input.report,
-            grouped_by: None,
-            groups: None::<Vec<fallow_output::HealthGroup>>,
+            grouped_by: input.grouped_by,
+            groups: input.groups,
             meta: input.explain.then(health_meta),
             workspace_diagnostics: input.workspace_diagnostics,
             next_steps: input.next_steps,
@@ -1368,13 +1370,15 @@ mod tests {
     }
 
     #[test]
-    fn serialize_programmatic_health_json_tags_meta_and_strips_paths() {
+    fn serialize_health_report_json_tags_meta_and_strips_paths() {
         let root = Path::new("/repo");
-        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+        let json = serialize_health_report_json(HealthJsonReportInput {
             report: HealthReport::default(),
             root,
             elapsed: std::time::Duration::ZERO,
             explain: true,
+            grouped_by: None,
+            groups: None,
             workspace_diagnostics: vec![WorkspaceDiagnosticOutput(serde_json::json!({
                 "path": "/repo/package.json"
             }))],
@@ -1395,12 +1399,14 @@ mod tests {
     }
 
     #[test]
-    fn serialize_programmatic_health_json_respects_legacy_envelope() {
-        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+    fn serialize_health_report_json_respects_legacy_envelope() {
+        let json = serialize_health_report_json(HealthJsonReportInput {
             report: HealthReport::default(),
             root: Path::new("/repo"),
             elapsed: std::time::Duration::ZERO,
             explain: false,
+            grouped_by: None,
+            groups: None,
             workspace_diagnostics: Vec::new(),
             next_steps: Vec::new(),
             envelope_mode: RootEnvelopeMode::Legacy,

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -9,9 +9,11 @@ use fallow_config::{
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
 use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
 use fallow_output::{
-    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, RootEnvelopeMode,
-    apply_root_kind, build_check_output, build_dupes_output, check_meta, strip_root_prefix,
+    CHECK_SCHEMA_VERSION, CheckOutputInput, DupesOutput, DupesOutputInput, HealthJsonOutputInput,
+    HealthOutputInput, HealthReport, RootEnvelopeMode, WorkspaceDiagnosticOutput, apply_root_kind,
+    build_check_output, build_dupes_output, check_meta, health_meta, strip_root_prefix,
 };
+use fallow_types::output::NextStep;
 use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -21,9 +23,21 @@ use crate::{
 };
 
 const SCHEMA_VERSION: u32 = 1;
+const HEALTH_SCHEMA_VERSION: u32 = 7;
 const MAX_DIFF_BYTES: u64 = 10 * 1024 * 1024;
 
 type ProgrammaticResult<T> = Result<T, ProgrammaticError>;
+
+/// Inputs for serializing programmatic health / complexity output.
+pub struct ProgrammaticHealthJsonInput<'a> {
+    pub report: HealthReport,
+    pub root: &'a Path,
+    pub elapsed: std::time::Duration,
+    pub explain: bool,
+    pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
+    pub next_steps: Vec<NextStep>,
+    pub envelope_mode: RootEnvelopeMode,
+}
 
 struct ResolvedAnalysisOptions {
     root: PathBuf,
@@ -98,6 +112,37 @@ pub fn detect_boundary_violations(
 ) -> ProgrammaticResult<serde_json::Value> {
     let resolved = resolve_analysis_options(&options.analysis)?;
     resolved.install(|| detect_dead_code_inner(options, &resolved, keep_boundary_violations))
+}
+
+/// Serialize a programmatic health / complexity report into the stable JSON
+/// output contract.
+///
+/// The health runner is still migrating out of the CLI crate, so callers pass
+/// the already assembled report plus CLI-owned suggestion and workspace
+/// diagnostics policy as explicit typed inputs.
+///
+/// # Errors
+///
+/// Returns a serde error when the report cannot be converted to JSON.
+pub fn serialize_programmatic_health_json(
+    input: ProgrammaticHealthJsonInput<'_>,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let root_prefix = format!("{}/", input.root.display());
+    fallow_output::serialize_health_json_output(HealthJsonOutputInput {
+        output: HealthOutputInput {
+            schema_version: HEALTH_SCHEMA_VERSION,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            elapsed: input.elapsed,
+            report: input.report,
+            grouped_by: None,
+            groups: None::<Vec<fallow_output::HealthGroup>>,
+            meta: input.explain.then(health_meta),
+            workspace_diagnostics: input.workspace_diagnostics,
+            next_steps: input.next_steps,
+        },
+        root_prefix: Some(&root_prefix),
+        envelope_mode: input.envelope_mode,
+    })
 }
 
 fn detect_dead_code_inner(
@@ -1320,6 +1365,49 @@ mod tests {
             root: Some(root.to_path_buf()),
             ..AnalysisOptions::default()
         }
+    }
+
+    #[test]
+    fn serialize_programmatic_health_json_tags_meta_and_strips_paths() {
+        let root = Path::new("/repo");
+        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+            report: HealthReport::default(),
+            root,
+            elapsed: std::time::Duration::ZERO,
+            explain: true,
+            workspace_diagnostics: vec![WorkspaceDiagnosticOutput(serde_json::json!({
+                "path": "/repo/package.json"
+            }))],
+            next_steps: vec![NextStep {
+                id: "inspect-health".to_string(),
+                command: "fallow health --format json".to_string(),
+                reason: "inspect health details".to_string(),
+            }],
+            envelope_mode: RootEnvelopeMode::Tagged,
+        })
+        .expect("health JSON serializes");
+
+        assert_eq!(json["kind"], "health");
+        assert_eq!(json["schema_version"], HEALTH_SCHEMA_VERSION);
+        assert!(json["_meta"].is_object());
+        assert_eq!(json["workspace_diagnostics"][0]["path"], "package.json");
+        assert_eq!(json["next_steps"][0]["id"], "inspect-health");
+    }
+
+    #[test]
+    fn serialize_programmatic_health_json_respects_legacy_envelope() {
+        let json = serialize_programmatic_health_json(ProgrammaticHealthJsonInput {
+            report: HealthReport::default(),
+            root: Path::new("/repo"),
+            elapsed: std::time::Duration::ZERO,
+            explain: false,
+            workspace_diagnostics: Vec::new(),
+            next_steps: Vec::new(),
+            envelope_mode: RootEnvelopeMode::Legacy,
+        })
+        .expect("health JSON serializes");
+
+        assert!(json.get("kind").is_none());
     }
 
     #[test]

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 criterion2 = { workspace = true }
 fallow-cli = { workspace = true }
 fallow-core = { workspace = true }
+fallow-types = { workspace = true }
 tempfile = { workspace = true }
 
 [features]

--- a/crates/benchmarks/benches/programmatic_commands.rs
+++ b/crates/benchmarks/benches/programmatic_commands.rs
@@ -753,7 +753,10 @@ fn create_warm_hash_workspace_project() -> ExtractCacheInput {
 
     for file in &files {
         let module = parse_single_file(file).expect("benchmark fixture parses");
-        let cached = module_to_cached(&module, 1, 1);
+        let cached = module_to_cached(
+            &module,
+            fallow_types::source_fingerprint::SourceFingerprint::new(1, 1),
+        );
         cache.insert(&file.path, cached);
     }
 

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -91,24 +91,7 @@ pub fn serialize_root_output_with_mode(
 }
 
 pub fn attach_telemetry_meta(value: &mut serde_json::Value) {
-    let Some(run_id) = telemetry_analysis_run_id() else {
-        return;
-    };
-    let serde_json::Value::Object(map) = value else {
-        return;
-    };
-    let meta = map
-        .entry("_meta".to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-    if !meta.is_object() {
-        *meta = serde_json::Value::Object(serde_json::Map::new());
-    }
-    if let serde_json::Value::Object(meta_map) = meta {
-        meta_map.insert(
-            "telemetry".to_string(),
-            serde_json::json!({ "analysis_run_id": run_id }),
-        );
-    }
+    fallow_output::attach_telemetry_meta(value, telemetry_analysis_run_id().as_deref());
 }
 
 pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str) {

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -686,24 +686,25 @@ pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<ser
                 crate::report::suggestions::due_impact_digest(&result.config.root),
             ),
         );
-        let mut output = fallow_api::serialize_programmatic_health_json(
-            fallow_api::ProgrammaticHealthJsonInput {
+        let mut output =
+            fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
                 report: result.report,
                 root: &result.config.root,
                 elapsed: result.elapsed,
                 explain: resolved.explain,
+                grouped_by: None,
+                groups: None,
                 workspace_diagnostics: workspace_diagnostics_for_programmatic_output(
                     &result.config.root,
                 ),
                 next_steps,
                 envelope_mode: programmatic_root_envelope_mode(&resolved),
-            },
-        )
-        .map_err(|err| {
-            ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
-                .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
-                .with_context("health")
-        })?;
+            })
+            .map_err(|err| {
+                ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
+                    .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
+                    .with_context("health")
+            })?;
         crate::output_envelope::attach_telemetry_meta(&mut output);
         Ok(output)
     })

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -6,8 +6,8 @@ use fallow_core::results::AnalysisResults;
 use crate::check::{CheckOptions, IssueFilters, TraceOptions};
 use crate::dupes::{DupesMode, DupesOptions};
 use crate::health::HealthOptions;
+use crate::report::build_duplication_json;
 use crate::report::ci::diff_filter::{DiffIndex, LoadedDiff, MAX_DIFF_BYTES};
-use crate::report::{build_duplication_json, build_health_json};
 
 pub use fallow_api::{
     AnalysisOptions, COMMON_ANALYSIS_OPTION_FLAGS, ComplexityOptions, ComplexitySort,
@@ -249,6 +249,26 @@ fn apply_programmatic_envelope_options(
     if resolved.legacy_envelope {
         fallow_output::remove_root_kind(output);
     }
+}
+
+fn programmatic_root_envelope_mode(
+    resolved: &ResolvedAnalysisOptions,
+) -> fallow_output::RootEnvelopeMode {
+    if resolved.legacy_envelope {
+        fallow_output::RootEnvelopeMode::Legacy
+    } else {
+        fallow_output::RootEnvelopeMode::Tagged
+    }
+}
+
+fn workspace_diagnostics_for_programmatic_output(
+    root: &Path,
+) -> Vec<fallow_output::WorkspaceDiagnosticOutput> {
+    crate::runtime_support::workspace_diagnostics_for(root)
+        .into_iter()
+        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
+        .map(fallow_output::WorkspaceDiagnosticOutput)
+        .collect()
 }
 
 fn build_dead_code_json(
@@ -658,18 +678,33 @@ pub fn compute_complexity(options: &ComplexityOptions) -> ProgrammaticResult<ser
         let health_options = build_complexity_options(&resolved, options);
         let result = crate::health::execute_health(&health_options)
             .map_err(|_| generic_analysis_error("health"))?;
-        let mut output = build_health_json(
-            &result.report,
-            &result.config.root,
-            result.elapsed,
-            resolved.explain,
+        let next_steps = fallow_output::build_health_next_steps(
+            crate::report::suggestions::health_next_steps_input(
+                &result.report,
+                &result.config.root,
+                crate::report::suggestions::setup_pointer_applicable(&result.config.root),
+                crate::report::suggestions::due_impact_digest(&result.config.root),
+            ),
+        );
+        let mut output = fallow_api::serialize_programmatic_health_json(
+            fallow_api::ProgrammaticHealthJsonInput {
+                report: result.report,
+                root: &result.config.root,
+                elapsed: result.elapsed,
+                explain: resolved.explain,
+                workspace_diagnostics: workspace_diagnostics_for_programmatic_output(
+                    &result.config.root,
+                ),
+                next_steps,
+                envelope_mode: programmatic_root_envelope_mode(&resolved),
+            },
         )
         .map_err(|err| {
             ProgrammaticError::new(format!("failed to serialize health report: {err}"), 2)
                 .with_code("FALLOW_SERIALIZE_HEALTH_REPORT")
                 .with_context("health")
         })?;
-        apply_programmatic_envelope_options(&mut output, &resolved);
+        crate::output_envelope::attach_telemetry_meta(&mut output);
         Ok(output)
     })
 }

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -254,11 +254,7 @@ fn apply_programmatic_envelope_options(
 fn programmatic_root_envelope_mode(
     resolved: &ResolvedAnalysisOptions,
 ) -> fallow_output::RootEnvelopeMode {
-    if resolved.legacy_envelope {
-        fallow_output::RootEnvelopeMode::Legacy
-    } else {
-        fallow_output::RootEnvelopeMode::Tagged
-    }
+    fallow_output::RootEnvelopeMode::from_legacy(resolved.legacy_envelope)
 }
 
 fn workspace_diagnostics_for_programmatic_output(

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -8,13 +8,13 @@ use fallow_core::duplicates::DuplicationReport;
 use fallow_core::results::AnalysisResults;
 use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
-use fallow_output::{HealthJsonOutputInput, strip_root_prefix};
+use fallow_output::strip_root_prefix;
 
 use super::emit_json;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
     CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutputInput,
-    EnvelopeMode, FallowOutput, GroupByMode, HealthOutputInput, WorkspaceDiagnosticOutput,
+    EnvelopeMode, FallowOutput, GroupByMode, WorkspaceDiagnosticOutput,
     apply_config_fixable_to_duplicate_exports, build_check_output, build_dupes_output,
     serialize_root_output,
 };
@@ -429,27 +429,22 @@ pub fn build_health_json(
     elapsed: Duration,
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let root_prefix = format!("{}/", root.display());
-    let mut output = fallow_output::serialize_health_json_output(HealthJsonOutputInput {
-        output: HealthOutputInput {
-            schema_version: SCHEMA_VERSION,
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            elapsed,
-            report: report.clone(),
-            grouped_by: None,
-            groups: None::<Vec<crate::health_types::HealthGroup>>,
-            meta: explain.then(fallow_output::health_meta),
-            workspace_diagnostics: workspace_diagnostics_for_output(root),
-            next_steps: fallow_output::build_health_next_steps(
-                crate::report::suggestions::health_next_steps_input(
-                    report,
-                    root,
-                    crate::report::suggestions::setup_pointer_applicable(root),
-                    crate::report::suggestions::due_impact_digest(root),
-                ),
+    let mut output = fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
+        report: report.clone(),
+        root,
+        elapsed,
+        explain,
+        grouped_by: None,
+        groups: None,
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
+        next_steps: fallow_output::build_health_next_steps(
+            crate::report::suggestions::health_next_steps_input(
+                report,
+                root,
+                crate::report::suggestions::setup_pointer_applicable(root),
+                crate::report::suggestions::due_impact_digest(root),
             ),
-        },
-        root_prefix: Some(&root_prefix),
+        ),
         envelope_mode: EnvelopeMode::current().into(),
     })?;
     crate::output_envelope::attach_telemetry_meta(&mut output);
@@ -463,27 +458,22 @@ pub fn build_grouped_health_json(
     elapsed: Duration,
     explain: bool,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    let root_prefix = format!("{}/", root.display());
-    fallow_output::serialize_health_json_output(HealthJsonOutputInput {
-        output: HealthOutputInput {
-            schema_version: SCHEMA_VERSION,
-            version: env!("CARGO_PKG_VERSION").to_string(),
-            elapsed,
-            report: report.clone(),
-            grouped_by: Some(group_by_mode_from_label(grouping.mode)),
-            groups: Some(grouping.groups.clone()),
-            meta: explain.then(fallow_output::health_meta),
-            workspace_diagnostics: workspace_diagnostics_for_output(root),
-            next_steps: fallow_output::build_health_next_steps(
-                crate::report::suggestions::health_next_steps_input(
-                    report,
-                    root,
-                    crate::report::suggestions::setup_pointer_applicable(root),
-                    crate::report::suggestions::due_impact_digest(root),
-                ),
+    fallow_api::serialize_health_report_json(fallow_api::HealthJsonReportInput {
+        report: report.clone(),
+        root,
+        elapsed,
+        explain,
+        grouped_by: Some(group_by_mode_from_label(grouping.mode)),
+        groups: Some(grouping.groups.clone()),
+        workspace_diagnostics: workspace_diagnostics_for_output(root),
+        next_steps: fallow_output::build_health_next_steps(
+            crate::report::suggestions::health_next_steps_input(
+                report,
+                root,
+                crate::report::suggestions::setup_pointer_applicable(root),
+                crate::report::suggestions::due_impact_digest(root),
             ),
-        },
-        root_prefix: Some(&root_prefix),
+        ),
         envelope_mode: EnvelopeMode::current().into(),
     })
 }
@@ -839,7 +829,7 @@ mod tests {
     }
 
     #[test]
-    fn grouped_health_json_uses_output_serializer_for_group_paths() {
+    fn grouped_health_json_uses_api_contract_for_group_paths() {
         let root = PathBuf::from("/project");
         let grouping = crate::health_types::HealthGrouping {
             mode: "package",

--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -22,7 +22,9 @@ use std::process::Command;
 
 use fallow_core::results::AnalysisResults;
 use fallow_output::{
-    DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
+    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
+    ImpactDigestCounts, TraceUnusedExportInput,
+    build_combined_next_steps as build_combined_next_steps_contract,
     build_dead_code_next_steps as build_dead_code_next_steps_contract,
     build_dupes_next_steps as build_dupes_next_steps_contract, impact_digest_summary,
 };
@@ -97,6 +99,21 @@ fn relative_command_path(path: &Path, root: &Path) -> String {
 /// Uses the lexicographically smallest `(path, name)` finding so the embedded
 /// command is deterministic across runs (independent of internal vec order).
 fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextStep> {
+    let target = trace_unused_export_input(results, root)?;
+    Some(next_step(
+        "trace-unused-export",
+        format!(
+            "fallow dead-code --trace {}:{}",
+            target.path, target.export_name
+        ),
+        "verify an export is truly unused before deleting",
+    ))
+}
+
+fn trace_unused_export_input(
+    results: &AnalysisResults,
+    root: &Path,
+) -> Option<TraceUnusedExportInput> {
     let target = results
         .unused_exports
         .iter()
@@ -107,29 +124,10 @@ fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextSte
             )
         })
         .min()?;
-    Some(next_step(
-        "trace-unused-export",
-        format!("fallow dead-code --trace {}:{}", target.0, target.1),
-        "verify an export is truly unused before deleting",
-    ))
-}
-
-/// `setup`: first-contact pointer for unconfigured projects. The command is the
-/// read-only capability manifest (`fallow schema`), whose `task_matrix` and
-/// commands list name the guided-setup surface (`init --agents`, the hooks
-/// installer); the mutating commands themselves are never embedded here (the
-/// read-only contract), the agent offers them to the user instead. Callers gate
-/// this via [`setup_pointer_applicable`] so CI runs, configured projects, and
-/// projects that declined onboarding never see it.
-fn setup_pointer(offer_setup: bool) -> Option<NextStep> {
-    if !offer_setup {
-        return None;
-    }
-    Some(next_step(
-        "setup",
-        "fallow schema".to_string(),
-        "fallow has no config here; the manifest lists guided-setup commands (agent guide, commit gate) to offer the user",
-    ))
+    Some(TraceUnusedExportInput {
+        path: target.0,
+        export_name: target.1,
+    })
 }
 
 /// Shared first-contact gate for the `setup` next-step and the human setup hint
@@ -149,27 +147,8 @@ pub fn setup_pointer_applicable(root: &Path) -> bool {
 /// Worded as an offer, not a deficiency: zero-config is a supported happy path.
 pub const SETUP_HINT: &str = "Setup: `fallow init --agents` writes an agent guide; `fallow hooks install --target agent` adds a commit gate (hide this hint: `fallow init --decline`).";
 
-/// `impact-report`: the periodic local value digest. Emitted at most once per
-/// week per project (the cadence stamp lives in the impact store, not the
-/// agent, so it is consistent across agents and sessions), only when impact
-/// tracking is enabled and has non-zero value to report, never in CI. Unlike
-/// every other trigger this one may surface on a CLEAN run: a clean project
-/// after a period of gate containment is exactly the moment the value report
-/// is informative.
-fn impact_digest_step(digest: Option<crate::impact::ImpactDigest>) -> Option<NextStep> {
-    let digest = digest?;
-    Some(next_step(
-        "impact-report",
-        "fallow impact".to_string(),
-        &format!(
-            "local value report: {}; share the non-zero numbers with the user",
-            digest_summary(digest)
-        ),
-    ))
-}
-
 /// Real-counter summary fragment shared by the next-step reason and the human
-/// one-liner (the placeholder-free contract: numbers come from the store).
+/// one-liner. The output crate owns the `impact-report` command contract.
 fn impact_counts(digest: crate::impact::ImpactDigest) -> ImpactDigestCounts {
     ImpactDigestCounts {
         containment_count: digest.containment_count,
@@ -203,21 +182,6 @@ pub fn due_impact_digest(root: &Path) -> Option<crate::impact::ImpactDigest> {
     crate::impact::take_due_digest(root)
 }
 
-/// `trace-clone`: see sibling locations and an extract-function suggestion for a
-/// duplicated block. Uses the smallest fingerprint for run-to-run determinism.
-fn trace_clone(payload: &DupesReportPayload) -> Option<NextStep> {
-    let fingerprint = payload
-        .clone_groups
-        .iter()
-        .map(|group| group.fingerprint.as_str())
-        .min()?;
-    Some(next_step(
-        "trace-clone",
-        format!("fallow dupes --trace {fingerprint}"),
-        "see sibling locations and an extract-function suggestion",
-    ))
-}
-
 /// `complexity-breakdown`: see the per-decision-point contributions behind a
 /// high-complexity finding.
 fn complexity_breakdown(report: &HealthReport) -> Option<NextStep> {
@@ -228,18 +192,6 @@ fn complexity_breakdown(report: &HealthReport) -> Option<NextStep> {
         "complexity-breakdown",
         "fallow health --complexity-breakdown".to_string(),
         "see per-decision-point contributions for a hotspot",
-    ))
-}
-
-/// `scope-workspaces`: scope a monorepo run to the packages touched since the
-/// default branch. Emitted only when the project is a monorepo AND a concrete
-/// default ref resolves, so the embedded ref is real (never a placeholder).
-fn scope_workspaces(root: &Path) -> Option<NextStep> {
-    let reference = default_workspace_ref_for_next_step(root)?;
-    Some(next_step(
-        "scope-workspaces",
-        format!("fallow dead-code --changed-workspaces {reference}"),
-        "scope a monorepo run to the packages your branch touched",
     ))
 }
 
@@ -398,29 +350,27 @@ pub fn build_combined_next_steps(
     offer_setup: bool,
     digest: Option<crate::impact::ImpactDigest>,
 ) -> Vec<NextStep> {
-    if !suggestions_enabled() {
-        return Vec::new();
-    }
-    let has_findings = results.is_some_and(|r| r.total_issues() > 0)
-        || dupes.is_some_and(|d| !d.clone_groups.is_empty())
-        || health.is_some_and(|h| !h.findings.is_empty());
-    if !has_findings {
-        return impact_digest_step(digest).into_iter().collect();
-    }
-    let mut steps: Vec<NextStep> = [
-        setup_pointer(offer_setup),
-        impact_digest_step(digest),
-        results.and_then(|r| trace_unused_export(r, root)),
-        scope_workspaces(root),
-        dupes.and_then(trace_clone),
-        health.and_then(complexity_breakdown),
-        audit_changed(root),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-    steps.truncate(MAX_NEXT_STEPS);
-    steps
+    let workspace_ref = default_workspace_ref_for_next_step(root);
+    let clone_fingerprints = dupes
+        .map(|payload| {
+            payload
+                .clone_groups
+                .iter()
+                .map(|group| group.fingerprint.as_str())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    build_combined_next_steps_contract(&CombinedNextStepsInput {
+        suggestions_enabled: suggestions_enabled(),
+        has_dead_code_findings: results.is_some_and(|r| r.total_issues() > 0),
+        trace_unused_export: results.and_then(|r| trace_unused_export_input(r, root)),
+        workspace_ref: workspace_ref.as_deref(),
+        clone_fingerprints: &clone_fingerprints,
+        has_complexity_findings: health.is_some_and(|h| !h.findings.is_empty()),
+        offer_setup,
+        impact_digest: digest.map(impact_counts),
+        audit_changed: audit_changed(root).is_some(),
+    })
 }
 
 /// Next-steps for `fallow audit`. No `audit-changed` (audit IS the changed
@@ -610,15 +560,6 @@ mod tests {
     }
 
     #[test]
-    fn setup_pointer_emits_only_when_applicable() {
-        assert!(setup_pointer(false).is_none());
-        let step = setup_pointer(true).expect("step");
-        assert_eq!(step.id, "setup");
-        assert_eq!(step.command, "fallow schema");
-        assert_valid(&step);
-    }
-
-    #[test]
     fn setup_pointer_gate_ignores_nonexistent_roots() {
         assert!(!setup_pointer_applicable(Path::new(
             "/fallow-test-project-does-not-exist"
@@ -649,20 +590,6 @@ mod tests {
             containment_count: containment,
             resolved_total: resolved,
         }
-    }
-
-    #[test]
-    fn impact_digest_step_carries_real_counters() {
-        assert!(impact_digest_step(None).is_none());
-        let step = impact_digest_step(Some(digest(4, 12))).expect("step");
-        assert_eq!(step.id, "impact-report");
-        assert_eq!(step.command, "fallow impact");
-        assert!(step.reason.contains("4 commits contained at the gate"));
-        assert!(step.reason.contains("12 findings resolved"));
-        assert_valid(&step);
-        let singular = impact_digest_step(Some(digest(1, 0))).expect("step");
-        assert!(singular.reason.contains("1 commit contained at the gate"));
-        assert!(!singular.reason.contains("resolved"));
     }
 
     #[test]
@@ -734,6 +661,33 @@ mod tests {
     }
 
     #[test]
+    fn combined_next_steps_route_payload_facts_to_output_contract() {
+        let root = PathBuf::from("/project");
+        let results = results_with_exports(vec![
+            unused_export("/project/src/b.ts", "beta"),
+            unused_export("/project/src/a.ts", "alpha"),
+        ]);
+        let payload = dupes_payload();
+        let report = health_report_with_finding();
+
+        let steps = build_combined_next_steps(
+            Some(&results),
+            Some(&payload),
+            Some(&report),
+            &root,
+            true,
+            Some(digest(2, 1)),
+        );
+        let ids: Vec<&str> = steps.iter().map(|s| s.id.as_str()).collect();
+
+        assert_eq!(ids, ["setup", "impact-report", "trace-unused-export"]);
+        assert_eq!(steps[2].command, "fallow dead-code --trace src/a.ts:alpha");
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
     fn impact_digest_line_renders_counters() {
         let line = impact_digest_line(digest(2, 1));
         assert_eq!(
@@ -777,7 +731,7 @@ mod tests {
             "fallow dupes --trace dup:abcd1234".to_string(),
             "x",
         ));
-        all.extend(setup_pointer(true));
+        all.push(next_step("setup", "fallow schema".to_string(), "x"));
         assert!(!all.is_empty());
         for step in &all {
             assert_valid(step);

--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -1,21 +1,9 @@
-//! Command-level `next_steps[]` builder.
+//! Runtime fact adapters for `next_steps[]` builders.
 //!
-//! Computes a small list of read-only, runnable follow-up commands from a run's
-//! findings, surfaced at the JSON root (and as a one-line human `Next:` hint).
-//! The purpose is to point agents and humans sideways to fallow's adjacent
-//! verification capabilities (trace, complexity breakdown, audit, workspace
-//! scoping) that telemetry shows agents rarely discover, because they act on the
-//! output in front of them rather than on reference docs.
-//!
-//! Two hard contracts, both enforced by the tests in this module and by the
-//! `next_step` constructor's debug assertions:
-//!
-//! 1. **Read-only.** A step NEVER suggests `fallow fix` or any mutating command.
-//! 2. **Runnable, placeholder-free.** Every `command` runs as-is; it never
-//!    contains an angle-bracket placeholder. Finding-derived values come from a
-//!    real, deterministically-selected finding; values that cannot be made
-//!    concrete (a coverage path) are dropped from v1 rather than shipped as a
-//!    placeholder, and an unresolvable git ref omits its step entirely.
+//! The stable command strings, ordering, caps, and read-only contract live in
+//! `fallow-output`. This module keeps the CLI-specific probes: environment
+//! toggles, project setup state, git refs, changed-branch applicability, and
+//! deterministic finding targets.
 
 use std::path::Path;
 use std::process::Command;
@@ -33,9 +21,6 @@ use fallow_types::output::NextStep;
 
 use crate::health_types::HealthReport;
 use crate::output_dupes::DupesReportPayload;
-
-/// Mutating verbs a next-step must never suggest (the read-only contract).
-const MUTATING_VERBS: [&str; 5] = ["fix", "init", "hooks", "migrate", "setup-hooks"];
 
 /// `FALLOW_SUGGESTIONS=off` (or `0`/`false`/`no`/`disabled`) disables next-steps
 /// entirely. Default on. This is the documented escape hatch for CI consumers
@@ -56,26 +41,6 @@ fn suggestions_enabled_from(value: Option<&str>) -> bool {
             "off" | "0" | "false" | "no" | "disabled"
         ),
         None => true,
-    }
-}
-
-/// Construct a next-step, asserting the two contracts in debug builds so a new
-/// trigger that violates them trips the test suite rather than shipping.
-fn next_step(id: &str, command: String, reason: &str) -> NextStep {
-    debug_assert!(
-        !command.contains('<') && !command.contains('>'),
-        "next-step command must be runnable (no placeholder): {command}"
-    );
-    debug_assert!(
-        !command
-            .split_whitespace()
-            .any(|token| MUTATING_VERBS.contains(&token)),
-        "next-step command must be read-only (no mutating verb): {command}"
-    );
-    NextStep {
-        id: id.to_string(),
-        command,
-        reason: reason.to_string(),
     }
 }
 
@@ -173,15 +138,8 @@ fn default_workspace_ref_for_next_step(root: &Path) -> Option<String> {
 
 /// `audit-changed`: gate only the files the current branch changed. `fallow
 /// audit` auto-detects its base, so no ref needs embedding.
-fn audit_changed(root: &Path) -> Option<NextStep> {
-    if !fallow_core::churn::is_git_repo(root) {
-        return None;
-    }
-    Some(next_step(
-        "audit-changed",
-        "fallow audit".to_string(),
-        "gate only the files your branch changed (auto-detects the base)",
-    ))
+fn audit_changed_applicable(root: &Path) -> bool {
+    fallow_core::churn::is_git_repo(root)
 }
 
 // ---------------------------------------------------------------------------
@@ -259,7 +217,7 @@ pub fn build_dead_code_next_steps(
         offer_setup,
         impact_digest: digest.map(impact_counts),
         workspace_ref: workspace_ref.as_deref(),
-        audit_changed: audit_changed(root).is_some(),
+        audit_changed: audit_changed_applicable(root),
     })
 }
 
@@ -277,7 +235,7 @@ pub fn health_next_steps_input(
         has_findings: !report.findings.is_empty(),
         offer_setup,
         impact_digest: digest.map(impact_counts),
-        audit_changed: audit_changed(root).is_some(),
+        audit_changed: audit_changed_applicable(root),
     }
 }
 
@@ -300,7 +258,7 @@ pub fn build_dupes_next_steps(
         clone_fingerprints: &clone_fingerprints,
         offer_setup,
         impact_digest: digest.map(impact_counts),
-        audit_changed: audit_changed(root).is_some(),
+        audit_changed: audit_changed_applicable(root),
     })
 }
 
@@ -338,7 +296,7 @@ pub fn build_combined_next_steps(
         has_complexity_findings: health.is_some_and(|h| !h.findings.is_empty()),
         offer_setup,
         impact_digest: digest.map(impact_counts),
-        audit_changed: audit_changed(root).is_some(),
+        audit_changed: audit_changed_applicable(root),
     })
 }
 
@@ -473,6 +431,8 @@ mod tests {
     }
 
     fn assert_valid(step: &NextStep) {
+        const MUTATING_VERBS: [&str; 5] = ["fix", "init", "hooks", "migrate", "setup-hooks"];
+
         assert!(
             !step.command.contains('<') && !step.command.contains('>'),
             "command must be placeholder-free: {}",
@@ -693,29 +653,31 @@ mod tests {
 
     #[test]
     fn every_emitted_command_is_runnable_and_read_only() {
-        // Exercise every data-driven trigger and assert both contracts.
+        // Exercise CLI adapters and assert the output-owned command contracts.
         let root = PathBuf::from("/project");
         let results = results_with_exports(vec![unused_export("/project/src/a.ts", "alpha")]);
+        let payload = dupes_payload();
+        let report = health_report_with_finding();
         let mut all = Vec::new();
         all.extend(build_audit_next_steps(Some((&results, &root)), None));
-        // Static-command triggers (no findings needed to inspect the string).
-        all.push(next_step("audit-changed", "fallow audit".to_string(), "x"));
-        all.push(next_step(
-            "scope-workspaces",
-            "fallow dead-code --changed-workspaces origin/main".to_string(),
-            "x",
+        all.extend(build_dead_code_next_steps(
+            &results,
+            &root,
+            true,
+            Some(digest(2, 1)),
         ));
-        all.push(next_step(
-            "complexity-breakdown",
-            "fallow health --complexity-breakdown".to_string(),
-            "x",
+        all.extend(build_dupes_next_steps(&payload, &root, false, None));
+        all.extend(build_health_next_steps_contract(health_next_steps_input(
+            &report, &root, false, None,
+        )));
+        all.extend(build_combined_next_steps(
+            Some(&results),
+            Some(&payload),
+            Some(&report),
+            &root,
+            true,
+            Some(digest(2, 1)),
         ));
-        all.push(next_step(
-            "trace-clone",
-            "fallow dupes --trace dup:abcd1234".to_string(),
-            "x",
-        ));
-        all.push(next_step("setup", "fallow schema".to_string(), "x"));
         assert!(!all.is_empty());
         for step in &all {
             assert_valid(step);

--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -22,8 +22,9 @@ use std::process::Command;
 
 use fallow_core::results::AnalysisResults;
 use fallow_output::{
-    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
-    ImpactDigestCounts, TraceUnusedExportInput,
+    AuditNextStepsInput, CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput,
+    HealthNextStepsInput, ImpactDigestCounts, TraceUnusedExportInput,
+    build_audit_next_steps as build_audit_next_steps_contract,
     build_combined_next_steps as build_combined_next_steps_contract,
     build_dead_code_next_steps as build_dead_code_next_steps_contract,
     build_dupes_next_steps as build_dupes_next_steps_contract, impact_digest_summary,
@@ -32,10 +33,6 @@ use fallow_types::output::NextStep;
 
 use crate::health_types::HealthReport;
 use crate::output_dupes::DupesReportPayload;
-
-/// Maximum number of next-steps emitted per envelope. Keeps the array a glance,
-/// not a wall; the priority order decides which survive the cap.
-const MAX_NEXT_STEPS: usize = 3;
 
 /// Mutating verbs a next-step must never suggest (the read-only contract).
 const MUTATING_VERBS: [&str; 5] = ["fix", "init", "hooks", "migrate", "setup-hooks"];
@@ -94,21 +91,6 @@ fn relative_command_path(path: &Path, root: &Path) -> String {
 // ---------------------------------------------------------------------------
 // Individual triggers. Each returns `Some(step)` only when its evidence exists.
 // ---------------------------------------------------------------------------
-
-/// `trace-unused-export`: verify an export is truly unused before deleting.
-/// Uses the lexicographically smallest `(path, name)` finding so the embedded
-/// command is deterministic across runs (independent of internal vec order).
-fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextStep> {
-    let target = trace_unused_export_input(results, root)?;
-    Some(next_step(
-        "trace-unused-export",
-        format!(
-            "fallow dead-code --trace {}:{}",
-            target.path, target.export_name
-        ),
-        "verify an export is truly unused before deleting",
-    ))
-}
 
 fn trace_unused_export_input(
     results: &AnalysisResults,
@@ -180,19 +162,6 @@ pub fn due_impact_digest(root: &Path) -> Option<crate::impact::ImpactDigest> {
         return None;
     }
     crate::impact::take_due_digest(root)
-}
-
-/// `complexity-breakdown`: see the per-decision-point contributions behind a
-/// high-complexity finding.
-fn complexity_breakdown(report: &HealthReport) -> Option<NextStep> {
-    if report.findings.is_empty() {
-        return None;
-    }
-    Some(next_step(
-        "complexity-breakdown",
-        "fallow health --complexity-breakdown".to_string(),
-        "see per-decision-point contributions for a hotspot",
-    ))
 }
 
 fn default_workspace_ref_for_next_step(root: &Path) -> Option<String> {
@@ -383,18 +352,12 @@ pub fn build_audit_next_steps(
     check: Option<(&AnalysisResults, &Path)>,
     complexity: Option<&HealthReport>,
 ) -> Vec<NextStep> {
-    if !suggestions_enabled() {
-        return Vec::new();
-    }
-    let mut steps: Vec<NextStep> = [
-        check.and_then(|(results, root)| trace_unused_export(results, root)),
-        complexity.and_then(complexity_breakdown),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-    steps.truncate(MAX_NEXT_STEPS);
-    steps
+    build_audit_next_steps_contract(&AuditNextStepsInput {
+        suggestions_enabled: suggestions_enabled(),
+        trace_unused_export: check
+            .and_then(|(results, root)| trace_unused_export_input(results, root)),
+        has_complexity_findings: complexity.is_some_and(|report| !report.findings.is_empty()),
+    })
 }
 
 /// The single highest-priority next-step for the human `Next:` line, computed
@@ -526,17 +489,19 @@ mod tests {
     }
 
     #[test]
-    fn trace_unused_export_emits_runnable_relative_command() {
+    fn audit_next_steps_emit_runnable_relative_trace_command() {
         let root = PathBuf::from("/project");
         let results = results_with_exports(vec![unused_export("/project/src/util.ts", "foo")]);
-        let step = trace_unused_export(&results, &root).expect("step");
-        assert_eq!(step.id, "trace-unused-export");
-        assert_eq!(step.command, "fallow dead-code --trace src/util.ts:foo");
-        assert_valid(&step);
+        let steps = build_audit_next_steps(Some((&results, &root)), None);
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "trace-unused-export");
+        assert_eq!(steps[0].command, "fallow dead-code --trace src/util.ts:foo");
+        assert_valid(&steps[0]);
     }
 
     #[test]
-    fn trace_unused_export_is_deterministic_regardless_of_vec_order() {
+    fn audit_next_steps_select_deterministic_trace_target() {
         let root = PathBuf::from("/project");
         let forward = results_with_exports(vec![
             unused_export("/project/src/b.ts", "beta"),
@@ -546,10 +511,10 @@ mod tests {
             unused_export("/project/src/a.ts", "alpha"),
             unused_export("/project/src/b.ts", "beta"),
         ]);
-        let a = trace_unused_export(&forward, &root).expect("step");
-        let b = trace_unused_export(&reverse, &root).expect("step");
-        assert_eq!(a.command, b.command);
-        assert_eq!(a.command, "fallow dead-code --trace src/a.ts:alpha");
+        let a = build_audit_next_steps(Some((&forward, &root)), None);
+        let b = build_audit_next_steps(Some((&reverse, &root)), None);
+        assert_eq!(a[0].command, b[0].command);
+        assert_eq!(a[0].command, "fallow dead-code --trace src/a.ts:alpha");
     }
 
     #[test]
@@ -688,6 +653,25 @@ mod tests {
     }
 
     #[test]
+    fn audit_next_steps_route_payload_facts_to_output_contract() {
+        let root = PathBuf::from("/project");
+        let results = results_with_exports(vec![
+            unused_export("/project/src/b.ts", "beta"),
+            unused_export("/project/src/a.ts", "alpha"),
+        ]);
+        let report = health_report_with_finding();
+
+        let steps = build_audit_next_steps(Some((&results, &root)), Some(&report));
+        let ids: Vec<&str> = steps.iter().map(|s| s.id.as_str()).collect();
+
+        assert_eq!(ids, ["trace-unused-export", "complexity-breakdown"]);
+        assert_eq!(steps[0].command, "fallow dead-code --trace src/a.ts:alpha");
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
     fn impact_digest_line_renders_counters() {
         let line = impact_digest_line(digest(2, 1));
         assert_eq!(
@@ -713,7 +697,7 @@ mod tests {
         let root = PathBuf::from("/project");
         let results = results_with_exports(vec![unused_export("/project/src/a.ts", "alpha")]);
         let mut all = Vec::new();
-        all.extend(trace_unused_export(&results, &root));
+        all.extend(build_audit_next_steps(Some((&results, &root)), None));
         // Static-command triggers (no findings needed to inspect the string).
         all.push(next_step("audit-changed", "fallow audit".to_string(), "x"));
         all.push(next_step(
@@ -744,6 +728,6 @@ mod tests {
         let results = results_with_exports(vec![unused_export("/project/src/a.ts", "alpha")]);
         // Even if git/workspaces/setup add candidates, the cap holds.
         let steps = build_dead_code_next_steps(&results, &root, true, None);
-        assert!(steps.len() <= MAX_NEXT_STEPS);
+        assert!(steps.len() <= 3);
     }
 }

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -745,12 +745,13 @@ fn create_cache_round_trip_input() -> fallow_core::extract::ModuleInfo {
 fn cache_round_trip(c: &mut Criterion) {
     use fallow_core::cache::{cached_to_module, module_to_cached};
     use fallow_core::discover::FileId;
+    use fallow_types::source_fingerprint::SourceFingerprint;
 
     c.bench_function("cache_round_trip", |bencher| {
         bencher.iter_batched_ref(
             create_cache_round_trip_input,
             |module| {
-                let cached = module_to_cached(module, 0, 0);
+                let cached = module_to_cached(module, SourceFingerprint::new(0, 0));
                 let _ = cached_to_module(&cached, FileId(0));
             },
             BatchSize::LargeInput,

--- a/crates/core/src/analyze/unrendered_component.rs
+++ b/crates/core/src/analyze/unrendered_component.rs
@@ -37,7 +37,8 @@ use std::path::Path;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::extract::{
-    AngularComponentSelector, ExportName, ImportedName, ModuleInfo, SemanticFact,
+    AngularComponentSelector, ExportName, ImportedName, ModuleInfo,
+    has_dynamic_custom_element_render,
 };
 
 use crate::discover::FileId;
@@ -571,17 +572,10 @@ pub fn find_unrendered_lit_elements(input: &LitUnrenderedInput<'_>) -> Vec<Unren
     // parse caches conservative.
     let mut rendered_tags: FxHashSet<&str> = FxHashSet::default();
     for module in modules {
-        if module
-            .semantic_facts
-            .iter()
-            .any(|fact| matches!(fact, SemanticFact::DynamicCustomElementRender(_)))
-        {
+        if has_dynamic_custom_element_render(module) {
             return Vec::new();
         }
         for tag in &module.used_custom_element_tags {
-            if tag == fallow_types::extract::DYNAMIC_CUSTOM_ELEMENT_TAG {
-                return Vec::new();
-            }
             rendered_tags.insert(tag.as_str());
         }
     }

--- a/crates/core/src/analyze/unused_component_input.rs
+++ b/crates/core/src/analyze/unused_component_input.rs
@@ -38,8 +38,10 @@ use std::path::Path;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use fallow_extract::{ANGULAR_THIS_SPREAD_SENTINEL, ANGULAR_TPL_SENTINEL};
-use fallow_types::extract::{ModuleInfo, SemanticFact};
+use fallow_types::extract::{
+    ModuleInfo, SemanticFact, is_legacy_angular_template_member_access_object,
+    is_legacy_angular_this_spread_object,
+};
 
 use crate::discover::FileId;
 use crate::graph::{ModuleGraph, ModuleNode};
@@ -168,7 +170,7 @@ pub(super) fn insert_angular_template_members<'a>(
         }
     }
     for access in &module.member_accesses {
-        if access.object == ANGULAR_TPL_SENTINEL {
+        if is_legacy_angular_template_member_access_object(&access.object) {
             out.insert(access.member.as_str());
         }
     }
@@ -182,7 +184,7 @@ pub(super) fn has_angular_template_members(module: &ModuleInfo) -> bool {
         || module
             .member_accesses
             .iter()
-            .any(|a| a.object == ANGULAR_TPL_SENTINEL)
+            .any(|a| is_legacy_angular_template_member_access_object(&a.object))
 }
 
 /// Whether the component declares an `extends` heritage clause anywhere in its
@@ -206,7 +208,7 @@ pub(super) fn component_spreads_this(module: &ModuleInfo) -> bool {
         || module
             .member_accesses
             .iter()
-            .any(|a| a.object == ANGULAR_THIS_SPREAD_SENTINEL)
+            .any(|a| is_legacy_angular_this_spread_object(&a.object))
 }
 
 /// The `.ts` modules reached from `from` by a `SideEffect`-shaped edge that hold
@@ -297,8 +299,8 @@ pub(super) fn is_js_reserved_word(name: &str) -> bool {
 mod tests {
     use fallow_types::discover::FileId;
     use fallow_types::extract::{
-        AngularInputMember, AngularTemplateMemberAccessFact, AngularThisSpreadFact,
-        ClassHeritageInfo, MemberAccess, SemanticFact,
+        ANGULAR_TPL_SENTINEL, AngularInputMember, AngularTemplateMemberAccessFact,
+        AngularThisSpreadFact, ClassHeritageInfo, MemberAccess, SemanticFact,
     };
     use rustc_hash::FxHashSet;
 

--- a/crates/core/src/analyze/unused_component_output.rs
+++ b/crates/core/src/analyze/unused_component_output.rs
@@ -212,12 +212,10 @@ fn component_name_for(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use fallow_types::extract::{
-        AngularOutputMember, AngularTemplateMemberAccessFact, ClassHeritageInfo, MemberAccess,
-        SemanticFact,
+        ANGULAR_TPL_SENTINEL, AngularOutputMember, AngularTemplateMemberAccessFact,
+        ClassHeritageInfo, MemberAccess, SemanticFact,
     };
     use rustc_hash::FxHashSet;
-
-    use fallow_extract::ANGULAR_TPL_SENTINEL;
 
     use super::*;
     use crate::analyze::test_support::empty_module;

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -6,14 +6,15 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::discover::FileId;
-use crate::extract::{ANGULAR_TPL_SENTINEL, ExportName, MemberInfo, MemberKind, ModuleInfo};
+use crate::extract::{ExportName, MemberInfo, MemberKind, ModuleInfo};
 use crate::graph::{ModuleGraph, ReferenceKind};
 use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
-    SemanticFact, is_legacy_semantic_member_access_object, is_legacy_semantic_whole_object_use,
-    semantic_facts_with_legacy_member_accesses,
+    SemanticFact, is_legacy_angular_template_member_access_object,
+    is_legacy_template_or_semantic_member_access_object,
+    is_legacy_template_or_semantic_whole_object_use, semantic_facts_with_legacy_member_accesses,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -596,7 +597,8 @@ fn build_angular_template_chain_accesses(
                 .member_accesses
                 .iter()
                 .filter(|access| {
-                    access.object != "this" && !is_legacy_member_access_object(&access.object)
+                    access.object != "this"
+                        && !is_legacy_template_or_semantic_member_access_object(&access.object)
                 })
                 .map(|access| (access.object.as_str(), access.member.as_str()))
                 .collect();
@@ -624,7 +626,7 @@ fn angular_template_member_refs(module: &ResolvedModule) -> Vec<&str> {
             module
                 .member_accesses
                 .iter()
-                .filter(|access| access.object == ANGULAR_TPL_SENTINEL)
+                .filter(|access| is_legacy_angular_template_member_access_object(&access.object))
                 .map(|access| access.member.as_str()),
         )
         .collect()
@@ -638,7 +640,7 @@ fn has_angular_template_member_refs(module: &ResolvedModule) -> bool {
         || module
             .member_accesses
             .iter()
-            .any(|access| access.object == ANGULAR_TPL_SENTINEL)
+            .any(|access| is_legacy_angular_template_member_access_object(&access.object))
 }
 
 struct AngularTemplateRefContext<'a, 'b> {
@@ -1549,13 +1551,13 @@ fn propagate_accesses_through_typed_instance_bindings(
 /// fluent-chain / Angular-template), which the typed-instance chain resolver
 /// must skip because it is handled by a dedicated propagation pass.
 fn is_typed_instance_member_sentinel(object: &str) -> bool {
-    is_legacy_member_access_object(object)
+    is_legacy_template_or_semantic_member_access_object(object)
 }
 
 /// Whether a whole-object-use name is a synthetic sentinel the typed-instance
 /// chain resolver must skip (the fluent-chain sentinels never appear here).
 fn is_typed_instance_whole_object_sentinel(object: &str) -> bool {
-    is_legacy_whole_object_use(object)
+    is_legacy_template_or_semantic_whole_object_use(object)
 }
 
 /// Credit each non-sentinel member access in one module onto the typed-instance
@@ -1607,14 +1609,6 @@ fn propagate_typed_whole_object_uses(
             whole_object_used_exports.insert(target_key);
         }
     }
-}
-
-fn is_legacy_member_access_object(object: &str) -> bool {
-    object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_member_access_object(object)
-}
-
-fn is_legacy_whole_object_use(object: &str) -> bool {
-    object == ANGULAR_TPL_SENTINEL || is_legacy_semantic_whole_object_use(object)
 }
 
 struct FactoryCallAccess {
@@ -2602,7 +2596,7 @@ fn collect_direct_member_accesses(resolved_modules: &[ResolvedModule]) -> Member
     for resolved in resolved_modules {
         let local_to_export_keys = build_local_to_export_keys(resolved);
         for access in &resolved.member_accesses {
-            if is_legacy_member_access_object(&access.object) {
+            if is_legacy_template_or_semantic_member_access_object(&access.object) {
                 continue;
             }
             if access.object == "this" {
@@ -5167,7 +5161,9 @@ mod tests {
             member: "value".to_string(),
         }];
 
-        assert!(is_legacy_member_access_object(&malformed));
+        assert!(is_legacy_template_or_semantic_member_access_object(
+            &malformed
+        ));
         assert!(
             semantic_facts_with_legacy_member_accesses(&[], &member_accesses)
                 .next()

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -13,7 +13,7 @@ use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
     SemanticFact, is_legacy_semantic_member_access_object, is_legacy_semantic_whole_object_use,
-    legacy_member_access_to_semantic_fact,
+    semantic_facts_with_legacy_member_accesses,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -1366,21 +1366,13 @@ struct InstanceExportBindingAccess {
 
 fn instance_export_binding_accesses(module: &ResolvedModule) -> Vec<InstanceExportBindingAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::InstanceExportBinding(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::InstanceExportBinding(access) = fact.as_fact() {
             accesses.push(InstanceExportBindingAccess {
                 export_name: access.export_name.clone(),
                 target_local: access.target_name.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::InstanceExportBinding(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(InstanceExportBindingAccess {
-                export_name: fact.export_name,
-                target_local: fact.target_name,
             });
         }
     }
@@ -1633,23 +1625,14 @@ struct FactoryCallAccess {
 
 fn factory_call_accesses(module: &ResolvedModule) -> Vec<FactoryCallAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::FactoryCallMemberAccess(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::FactoryCallMemberAccess(access) = fact.as_fact() {
             accesses.push(FactoryCallAccess {
                 callee_object: access.callee_object.clone(),
                 callee_method: access.callee_method.clone(),
                 member: access.member.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::FactoryCallMemberAccess(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(FactoryCallAccess {
-                callee_object: fact.callee_object,
-                callee_method: fact.callee_method,
-                member: fact.member,
             });
         }
     }
@@ -1711,25 +1694,15 @@ struct FluentChainAccess {
 
 fn fluent_chain_accesses(module: &ResolvedModule) -> Vec<FluentChainAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::FluentChainMemberAccess(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::FluentChainMemberAccess(access) = fact.as_fact() {
             accesses.push(FluentChainAccess {
                 root_local: access.root_object.clone(),
                 root_method: access.root_method.clone(),
                 chain: access.chain.clone(),
                 member: access.member.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::FluentChainMemberAccess(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(FluentChainAccess {
-                root_local: fact.root_object,
-                root_method: fact.root_method,
-                chain: fact.chain,
-                member: fact.member,
             });
         }
     }
@@ -1817,23 +1790,14 @@ struct FluentChainNewAccess {
 
 fn fluent_chain_new_accesses(module: &ResolvedModule) -> Vec<FluentChainNewAccess> {
     let mut accesses = Vec::new();
-    for fact in &module.semantic_facts {
-        if let SemanticFact::FluentChainNewMemberAccess(access) = fact {
+    for fact in
+        semantic_facts_with_legacy_member_accesses(&module.semantic_facts, &module.member_accesses)
+    {
+        if let SemanticFact::FluentChainNewMemberAccess(access) = fact.as_fact() {
             accesses.push(FluentChainNewAccess {
                 class_local: access.class_name.clone(),
                 chain: access.chain.clone(),
                 member: access.member.clone(),
-            });
-        }
-    }
-    for access in &module.member_accesses {
-        if let Some(SemanticFact::FluentChainNewMemberAccess(fact)) =
-            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
-        {
-            accesses.push(FluentChainNewAccess {
-                class_local: fact.class_name,
-                chain: fact.chain,
-                member: fact.member,
             });
         }
     }
@@ -5198,8 +5162,16 @@ mod tests {
     #[test]
     fn malformed_legacy_member_access_is_skip_only() {
         let malformed = format!("{FLUENT_CHAIN_NEW_SENTINEL}Builder:");
+        let member_accesses = vec![crate::extract::MemberAccess {
+            object: malformed.clone(),
+            member: "value".to_string(),
+        }];
 
         assert!(is_legacy_member_access_object(&malformed));
-        assert!(legacy_member_access_to_semantic_fact(&malformed, "value").is_none());
+        assert!(
+            semantic_facts_with_legacy_member_accesses(&[], &member_accesses)
+                .next()
+                .is_none()
+        );
     }
 }

--- a/crates/core/src/duplicates/cache.rs
+++ b/crates/core/src/duplicates/cache.rs
@@ -45,6 +45,12 @@ struct CachedTokenFile {
     suppressions: Vec<CachedSuppression>,
 }
 
+impl CachedTokenFile {
+    fn source_fingerprint(&self) -> SourceFingerprint {
+        SourceFingerprint::new(self.mtime_ns, self.file_size)
+    }
+}
+
 #[derive(Debug, Clone, Encode, Decode)]
 struct CachedHashedToken {
     hash: u64,
@@ -146,9 +152,7 @@ impl TokenCache {
             return None;
         }
         let entry = self.store.entries.get(&cache_key(path))?;
-        if SourceFingerprint::new(entry.mtime_ns, entry.file_size) != fingerprint
-            || entry.normalization_hash != mode.hash
-        {
+        if entry.source_fingerprint() != fingerprint || entry.normalization_hash != mode.hash {
             return None;
         }
         Some(entry.to_entry())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -180,26 +180,15 @@ fn update_cache(
             if let Some(cached) = store.get_by_path_only(&file.path)
                 && cached.content_hash == module.content_hash
             {
-                let cached_fingerprint = fallow_types::source_fingerprint::SourceFingerprint::new(
-                    cached.mtime_secs,
-                    cached.file_size,
-                );
-                if cached_fingerprint != fingerprint {
+                if cached.source_fingerprint() != fingerprint {
                     let preserved_last_access = cached.last_access_secs;
-                    let mut refreshed = cache::module_to_cached(
-                        module,
-                        fingerprint.mtime_ns,
-                        fingerprint.file_size,
-                    );
+                    let mut refreshed = cache::module_to_cached(module, fingerprint);
                     refreshed.last_access_secs = preserved_last_access;
                     store.insert(&file.path, refreshed);
                 }
                 continue;
             }
-            store.insert(
-                &file.path,
-                cache::module_to_cached(module, fingerprint.mtime_ns, fingerprint.file_size),
-            );
+            store.insert(&file.path, cache::module_to_cached(module, fingerprint));
         }
     }
     store.retain_paths(files);

--- a/crates/core/tests/integration_test/caching.rs
+++ b/crates/core/tests/integration_test/caching.rs
@@ -200,7 +200,10 @@ fn incremental_with_cache_all_hits() {
         if let Some(file) = files.get(module.file_id.0 as usize) {
             cache_store.insert(
                 &file.path,
-                fallow_core::cache::module_to_cached(module, 0, 0),
+                fallow_core::cache::module_to_cached(
+                    module,
+                    fallow_types::source_fingerprint::SourceFingerprint::new(0, 0),
+                ),
             );
         }
     }
@@ -223,7 +226,10 @@ fn incremental_results_identical() {
         if let Some(file) = files.get(module.file_id.0 as usize) {
             cache_store.insert(
                 &file.path,
-                fallow_core::cache::module_to_cached(module, 0, 0),
+                fallow_core::cache::module_to_cached(
+                    module,
+                    fallow_types::source_fingerprint::SourceFingerprint::new(0, 0),
+                ),
             );
         }
     }

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -549,20 +549,18 @@ pub fn cached_to_module_opts(
 
 /// Convert a [`ModuleInfo`](crate::ModuleInfo) to a [`CachedModule`] for storage.
 ///
-/// `mtime_secs` and `file_size` come from `std::fs::metadata()` at parse time
-/// and enable fast cache validation on subsequent runs (skip file read when
-/// mtime+size match). Despite the legacy field name, callers now pass the
-/// shared source-fingerprint mtime value.
+/// The [`SourceFingerprint`](fallow_types::source_fingerprint::SourceFingerprint)
+/// comes from `std::fs::metadata()` at parse time and enables fast cache
+/// validation on subsequent runs.
 #[must_use]
 pub fn module_to_cached(
     module: &crate::ModuleInfo,
-    mtime_secs: u64,
-    file_size: u64,
+    fingerprint: fallow_types::source_fingerprint::SourceFingerprint,
 ) -> CachedModule {
     CachedModule {
         content_hash: module.content_hash,
-        mtime_secs,
-        file_size,
+        mtime_secs: fingerprint.mtime_ns,
+        file_size: fingerprint.file_size,
         last_access_secs: current_unix_seconds(),
         exports: module_exports_to_cached(&module.exports),
         imports: module_imports_to_cached(&module.imports),
@@ -639,4 +637,21 @@ pub fn module_to_cached(
         svelte_listened_events: module.svelte_listened_events.clone(),
         has_dynamic_dispatch: module.has_dynamic_dispatch,
     }
+}
+
+/// Convert a module to a cache entry from explicit source-fingerprint parts.
+///
+/// Kept for tests that need literal invalidation inputs without filesystem
+/// metadata.
+#[cfg(test)]
+#[must_use]
+pub fn module_to_cached_from_parts(
+    module: &crate::ModuleInfo,
+    mtime_ns: u64,
+    file_size: u64,
+) -> CachedModule {
+    module_to_cached(
+        module,
+        fallow_types::source_fingerprint::SourceFingerprint::new(mtime_ns, file_size),
+    )
 }

--- a/crates/extract/src/cache/mod.rs
+++ b/crates/extract/src/cache/mod.rs
@@ -11,6 +11,8 @@ mod types;
 #[cfg(all(test, not(miri)))]
 mod tests;
 
+#[cfg(test)]
+pub use conversion::module_to_cached_from_parts;
 pub use conversion::{
     cached_to_module, cached_to_module_opts, current_unix_seconds, module_to_cached,
 };

--- a/crates/extract/src/cache/store.rs
+++ b/crates/extract/src/cache/store.rs
@@ -185,8 +185,7 @@ impl CacheStore {
     ) -> Option<&CachedModule> {
         let key = path.to_string_lossy();
         let entry = self.entries.get(key.as_ref())?;
-        let cached = SourceFingerprint::new(entry.mtime_secs, entry.file_size);
-        if cached == fingerprint && fingerprint.has_known_mtime() {
+        if entry.source_fingerprint() == fingerprint && fingerprint.has_known_mtime() {
             Some(entry)
         } else {
             None

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -34,7 +34,7 @@ fn cache_roundtrip_preserves_unresolved_callee_diagnostics() {
     assert_eq!(module.security_sinks_skipped, 1);
     assert_eq!(module.security_unresolved_callee_sites.len(), 1);
 
-    let cached = module_to_cached(&module, 10, 20);
+    let cached = module_to_cached_from_parts(&module, 10, 20);
     let restored = cached_to_module(&cached, FileId(7));
     let diagnostic = restored
         .security_unresolved_callee_sites
@@ -64,7 +64,7 @@ fn cache_roundtrip_preserves_react_structural_ir() {
     assert_eq!(module.hook_uses.len(), 1);
     assert_eq!(module.render_edges.len(), 1);
 
-    let cached = module_to_cached(&module, 10, 20);
+    let cached = module_to_cached_from_parts(&module, 10, 20);
     let restored = cached_to_module(&cached, FileId(7));
 
     assert_eq!(restored.component_functions.len(), 1);
@@ -501,7 +501,7 @@ fn module_to_cached_roundtrip_named_export() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(
@@ -614,7 +614,7 @@ fn module_to_cached_roundtrip_side_effect_used_export() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports.len(), 1);
@@ -712,7 +712,7 @@ fn module_to_cached_roundtrip_default_export() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports[0].name, ExportName::Default);
@@ -836,7 +836,7 @@ fn module_to_cached_roundtrip_imports() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.imports.len(), 4);
@@ -940,7 +940,7 @@ fn module_to_cached_roundtrip_re_exports() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.re_exports.len(), 1);
@@ -1089,7 +1089,7 @@ fn module_to_cached_roundtrip_dynamic_imports() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.dynamic_imports.len(), 1);
@@ -1272,7 +1272,7 @@ fn module_to_cached_roundtrip_members() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports[0].members.len(), 3);
@@ -1575,7 +1575,7 @@ fn module_to_cached_roundtrip_type_only_import() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert!(restored.imports[0].is_type_only);
@@ -2299,7 +2299,7 @@ fn module_to_cached_stores_mtime_and_size() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 12345, 6789);
+    let cached = module_to_cached_from_parts(&module, 12345, 6789);
     assert_eq!(cached.mtime_secs, 12345);
     assert_eq!(cached.file_size, 6789);
     assert_eq!(cached.content_hash, 42);
@@ -2381,7 +2381,7 @@ fn module_to_cached_roundtrip_line_offsets() {
         has_dynamic_component_render: false,
         has_dynamic_dispatch: false,
     };
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.line_offsets, vec![0, 15, 30, 45]);
 }
@@ -2474,7 +2474,7 @@ fn module_to_cached_roundtrip_suppressions_with_kinds() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.suppressions.len(), 4);
@@ -2590,7 +2590,7 @@ fn module_to_cached_roundtrip_unknown_suppression_kinds() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.unknown_suppression_kinds.len(), 2);
@@ -2692,7 +2692,7 @@ fn module_to_cached_roundtrip_visibility() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Public);
@@ -2785,7 +2785,7 @@ fn module_to_cached_roundtrip_visibility_internal() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     assert_eq!(cached.exports[0].visibility, 2);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Internal);
@@ -2878,7 +2878,7 @@ fn module_to_cached_roundtrip_visibility_beta() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     assert_eq!(cached.exports[0].visibility, 3);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Beta);
@@ -2971,7 +2971,7 @@ fn module_to_cached_roundtrip_visibility_alpha() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     assert_eq!(cached.exports[0].visibility, 4);
     let restored = cached_to_module(&cached, FileId(0));
     assert_eq!(restored.exports[0].visibility, VisibilityTag::Alpha);
@@ -3065,7 +3065,7 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.dynamic_import_patterns.len(), 2);
@@ -3157,7 +3157,7 @@ fn module_to_cached_roundtrip_unused_import_bindings() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.unused_import_bindings.len(), 2);
@@ -3286,7 +3286,7 @@ fn module_to_cached_roundtrip_complexity() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.complexity.len(), 2);
@@ -3382,7 +3382,7 @@ fn module_to_cached_roundtrip_require_with_destructured() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.require_calls.len(), 1);
@@ -3477,7 +3477,7 @@ fn module_to_cached_roundtrip_dynamic_import_with_local() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(
@@ -3571,7 +3571,7 @@ fn module_to_cached_roundtrip_source_span() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert_eq!(restored.imports[0].source_span.start, 25);
@@ -3673,7 +3673,7 @@ fn module_to_cached_roundtrip_member_decorators() {
         has_dynamic_dispatch: false,
     };
 
-    let cached = module_to_cached(&module, 0, 0);
+    let cached = module_to_cached_from_parts(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
 
     assert!(restored.exports[0].members[0].has_decorator);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -936,6 +936,18 @@ pub struct CachedModule {
     pub has_dynamic_dispatch: bool,
 }
 
+impl CachedModule {
+    /// Source metadata fingerprint stored with this cache entry.
+    ///
+    /// The on-disk field name `mtime_secs` is legacy. It stores the shared
+    /// nanosecond mtime value used by
+    /// [`SourceFingerprint`](fallow_types::source_fingerprint::SourceFingerprint).
+    #[must_use]
+    pub fn source_fingerprint(&self) -> fallow_types::source_fingerprint::SourceFingerprint {
+        fallow_types::source_fingerprint::SourceFingerprint::new(self.mtime_secs, self.file_size)
+    }
+}
+
 /// Cached namespace-object alias.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct CachedNamespaceObjectAlias {

--- a/crates/extract/src/sfc_template/angular.rs
+++ b/crates/extract/src/sfc_template/angular.rs
@@ -9,8 +9,9 @@
 //! - `@let name = expr;` template-local variables (Angular 18+)
 //! - `| pipeName` pipe references
 //!
-//! Referenced identifiers are stored as `MemberAccess` entries with a sentinel object name
-//! so the analysis phase can bridge them to the importing component's class members.
+//! Referenced bare identifiers are persisted as typed semantic facts, while
+//! member-access chains keep their real object/member shape for typed-instance
+//! propagation.
 
 use std::sync::LazyLock;
 

--- a/crates/extract/src/sfc_template/angular.rs
+++ b/crates/extract/src/sfc_template/angular.rs
@@ -17,25 +17,12 @@ use std::sync::LazyLock;
 use rustc_hash::FxHashSet;
 
 use fallow_types::extract::SinkSite;
+pub use fallow_types::extract::{ANGULAR_THIS_SPREAD_SENTINEL, ANGULAR_TPL_SENTINEL};
 
 use crate::MemberAccess;
 use crate::template_usage::{TemplateSnippetKind, collect_unresolved_refs_and_accesses};
 
 use super::scanners::{scan_curly_section, scan_html_tag};
-
-/// Sentinel value used as the `object` field in `MemberAccess` entries
-/// produced by the Angular template scanner. The analysis phase checks imports
-/// for entries with this sentinel and merges them into the component's
-/// `self_accessed_members` set.
-pub const ANGULAR_TPL_SENTINEL: &str = "__angular_tpl__";
-
-/// Sentinel `object` for a `MemberAccess` recorded when a class body spreads
-/// `this` into an object literal (`{ ...this }`, the Angular "headless pattern"
-/// convention that forwards every signal input/output into a behavior pattern).
-/// The `unused-component-input` / `unused-component-output` detectors treat its
-/// presence as a whole-component abstain, since every member is consumed
-/// opaquely through the spread.
-pub const ANGULAR_THIS_SPREAD_SENTINEL: &str = "__angular_this_spread__";
 
 /// Result of scanning an Angular template for member references.
 #[derive(Debug, Default)]

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -177,10 +177,10 @@ pub use list_envelopes::{
     ListBoundariesOutput, WorkspaceInfo, WorkspacesOutput,
 };
 pub use next_steps::{
-    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
-    ImpactDigestCounts, TraceUnusedExportInput, build_combined_next_steps,
-    build_dead_code_next_steps, build_dupes_next_steps, build_health_next_steps,
-    impact_digest_summary,
+    AuditNextStepsInput, CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput,
+    HealthNextStepsInput, ImpactDigestCounts, TraceUnusedExportInput, build_audit_next_steps,
+    build_combined_next_steps, build_dead_code_next_steps, build_dupes_next_steps,
+    build_health_next_steps, impact_digest_summary,
 };
 pub use report_contract::{
     COVERAGE_ANALYZE_DOCS, COVERAGE_SETUP_DOCS, DUPES_DOCS, HEALTH_DOCS, SECURITY_DOCS,

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -196,7 +196,7 @@ pub use review_envelopes::{
 };
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
-    apply_root_kind, remove_root_kind, serialize_json_root_output,
+    apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_json_root_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -177,7 +177,8 @@ pub use list_envelopes::{
     ListBoundariesOutput, WorkspaceInfo, WorkspacesOutput,
 };
 pub use next_steps::{
-    DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput, ImpactDigestCounts,
+    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
+    ImpactDigestCounts, TraceUnusedExportInput, build_combined_next_steps,
     build_dead_code_next_steps, build_dupes_next_steps, build_health_next_steps,
     impact_digest_summary,
 };

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -61,6 +61,14 @@ pub struct CombinedNextStepsInput<'a> {
     pub audit_changed: bool,
 }
 
+/// Runtime-independent inputs for audit next steps.
+#[derive(Debug, Clone)]
+pub struct AuditNextStepsInput {
+    pub suggestions_enabled: bool,
+    pub trace_unused_export: Option<TraceUnusedExportInput>,
+    pub has_complexity_findings: bool,
+}
+
 /// Runtime-independent inputs for standalone health next steps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HealthNextStepsInput {
@@ -196,6 +204,24 @@ pub fn build_combined_next_steps(input: &CombinedNextStepsInput<'_>) -> Vec<Next
         trace_clone(input.clone_fingerprints),
         complexity_breakdown(input.has_complexity_findings),
         audit_changed(input.audit_changed),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    steps.truncate(MAX_NEXT_STEPS);
+    steps
+}
+
+/// Next-steps for `fallow audit`.
+#[must_use]
+pub fn build_audit_next_steps(input: &AuditNextStepsInput) -> Vec<NextStep> {
+    if !input.suggestions_enabled {
+        return Vec::new();
+    }
+
+    let mut steps: Vec<NextStep> = [
+        trace_unused_export_from_input(input.trace_unused_export.as_ref()),
+        complexity_breakdown(input.has_complexity_findings),
     ]
     .into_iter()
     .flatten()
@@ -393,6 +419,14 @@ mod tests {
         }
     }
 
+    fn audit_input() -> AuditNextStepsInput {
+        AuditNextStepsInput {
+            suggestions_enabled: true,
+            trace_unused_export: None,
+            has_complexity_findings: false,
+        }
+    }
+
     fn assert_valid(step: &NextStep) {
         assert!(
             !step.command.contains('<') && !step.command.contains('>'),
@@ -407,6 +441,53 @@ mod tests {
             "command must be read-only: {}",
             step.command
         );
+    }
+
+    #[test]
+    fn audit_steps_are_empty_when_suggestions_are_disabled() {
+        let steps = build_audit_next_steps(&AuditNextStepsInput {
+            suggestions_enabled: false,
+            trace_unused_export: Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            }),
+            has_complexity_findings: true,
+        });
+
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn audit_steps_order_trace_before_complexity() {
+        let steps = build_audit_next_steps(&AuditNextStepsInput {
+            trace_unused_export: Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            }),
+            has_complexity_findings: true,
+            ..audit_input()
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["trace-unused-export", "complexity-breakdown"]);
+        assert_eq!(steps[0].command, "fallow dead-code --trace src/a.ts:alpha");
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
+    fn audit_steps_emit_complexity_without_trace_target() {
+        let steps = build_audit_next_steps(&AuditNextStepsInput {
+            has_complexity_findings: true,
+            ..audit_input()
+        });
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "complexity-breakdown");
     }
 
     #[test]

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -40,6 +40,27 @@ pub struct DupesNextStepsInput<'a> {
     pub audit_changed: bool,
 }
 
+/// Deterministic unused-export trace target selected by the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceUnusedExportInput {
+    pub path: String,
+    pub export_name: String,
+}
+
+/// Runtime-independent inputs for bare `fallow` combined next steps.
+#[derive(Debug, Clone)]
+pub struct CombinedNextStepsInput<'a> {
+    pub suggestions_enabled: bool,
+    pub has_dead_code_findings: bool,
+    pub trace_unused_export: Option<TraceUnusedExportInput>,
+    pub workspace_ref: Option<&'a str>,
+    pub clone_fingerprints: &'a [&'a str],
+    pub has_complexity_findings: bool,
+    pub offer_setup: bool,
+    pub impact_digest: Option<ImpactDigestCounts>,
+    pub audit_changed: bool,
+}
+
 /// Runtime-independent inputs for standalone health next steps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HealthNextStepsInput {
@@ -152,6 +173,37 @@ pub fn build_dupes_next_steps(input: DupesNextStepsInput<'_>) -> Vec<NextStep> {
     steps
 }
 
+/// Aggregated next-steps for bare `fallow` combined output.
+#[must_use]
+pub fn build_combined_next_steps(input: &CombinedNextStepsInput<'_>) -> Vec<NextStep> {
+    if !input.suggestions_enabled {
+        return Vec::new();
+    }
+    let has_findings = input.has_dead_code_findings
+        || !input.clone_fingerprints.is_empty()
+        || input.has_complexity_findings;
+    if !has_findings {
+        return impact_digest_step(input.impact_digest)
+            .into_iter()
+            .collect();
+    }
+
+    let mut steps: Vec<NextStep> = [
+        setup_pointer(input.offer_setup),
+        impact_digest_step(input.impact_digest),
+        trace_unused_export_from_input(input.trace_unused_export.as_ref()),
+        scope_workspaces(input.workspace_ref),
+        trace_clone(input.clone_fingerprints),
+        complexity_breakdown(input.has_complexity_findings),
+        audit_changed(input.audit_changed),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    steps.truncate(MAX_NEXT_STEPS);
+    steps
+}
+
 fn relative_command_path(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -173,6 +225,18 @@ fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextSte
     Some(next_step(
         "trace-unused-export",
         format!("fallow dead-code --trace {}:{}", target.0, target.1),
+        "verify an export is truly unused before deleting",
+    ))
+}
+
+fn trace_unused_export_from_input(target: Option<&TraceUnusedExportInput>) -> Option<NextStep> {
+    let target = target?;
+    Some(next_step(
+        "trace-unused-export",
+        format!(
+            "fallow dead-code --trace {}:{}",
+            target.path, target.export_name
+        ),
         "verify an export is truly unused before deleting",
     ))
 }
@@ -315,6 +379,20 @@ mod tests {
         }
     }
 
+    fn combined_input<'a>(clone_fingerprints: &'a [&'a str]) -> CombinedNextStepsInput<'a> {
+        CombinedNextStepsInput {
+            suggestions_enabled: true,
+            has_dead_code_findings: false,
+            trace_unused_export: None,
+            workspace_ref: None,
+            clone_fingerprints,
+            has_complexity_findings: false,
+            offer_setup: false,
+            impact_digest: None,
+            audit_changed: false,
+        }
+    }
+
     fn assert_valid(step: &NextStep) {
         assert!(
             !step.command.contains('<') && !step.command.contains('>'),
@@ -439,6 +517,87 @@ mod tests {
 
         assert_eq!(steps.len(), 1);
         assert_eq!(steps[0].id, "impact-report");
+    }
+
+    #[test]
+    fn combined_steps_are_empty_when_suggestions_are_disabled() {
+        let fingerprints = ["dup:aaaaaaaa"];
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            suggestions_enabled: false,
+            has_dead_code_findings: true,
+            trace_unused_export: Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            }),
+            workspace_ref: Some("origin/main"),
+            clone_fingerprints: &fingerprints,
+            has_complexity_findings: true,
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+        });
+
+        assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn clean_combined_run_emits_only_due_impact_digest() {
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..combined_input(&[])
+        });
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].id, "impact-report");
+    }
+
+    #[test]
+    fn combined_steps_order_and_cap_all_signals() {
+        let fingerprints = ["dup:bbbbbbbb", "dup:aaaaaaaa"];
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            has_dead_code_findings: true,
+            trace_unused_export: Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            }),
+            workspace_ref: Some("origin/main"),
+            has_complexity_findings: true,
+            offer_setup: true,
+            impact_digest: Some(digest(2, 1)),
+            audit_changed: true,
+            ..combined_input(&fingerprints)
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids, ["setup", "impact-report", "trace-unused-export"]);
+        for step in &steps {
+            assert_valid(step);
+        }
+    }
+
+    #[test]
+    fn combined_steps_keep_workspace_before_clone_and_complexity() {
+        let fingerprints = ["dup:aaaaaaaa"];
+        let steps = build_combined_next_steps(&CombinedNextStepsInput {
+            has_dead_code_findings: true,
+            workspace_ref: Some("origin/main"),
+            has_complexity_findings: true,
+            audit_changed: true,
+            ..combined_input(&fingerprints)
+        });
+        let ids = steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ids,
+            ["scope-workspaces", "trace-clone", "complexity-breakdown"]
+        );
     }
 
     #[test]

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -11,6 +11,18 @@ pub enum RootEnvelopeMode {
     Legacy,
 }
 
+impl RootEnvelopeMode {
+    /// Convert a legacy-envelope flag into the root envelope mode.
+    #[must_use]
+    pub const fn from_legacy(legacy_envelope: bool) -> Self {
+        if legacy_envelope {
+            Self::Legacy
+        } else {
+            Self::Tagged
+        }
+    }
+}
+
 /// Serialize a typed fallow root envelope with the requested discriminator
 /// mode.
 ///
@@ -285,6 +297,18 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn root_envelope_mode_maps_legacy_flag() {
+        assert_eq!(
+            RootEnvelopeMode::from_legacy(false),
+            RootEnvelopeMode::Tagged
+        );
+        assert_eq!(
+            RootEnvelopeMode::from_legacy(true),
+            RootEnvelopeMode::Legacy
+        );
+    }
 
     #[test]
     fn legacy_mode_removes_only_root_kind() {

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -50,6 +50,28 @@ pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str, mode: 
     }
 }
 
+/// Attach telemetry metadata to a JSON root object when a run id is available.
+pub fn attach_telemetry_meta(value: &mut serde_json::Value, analysis_run_id: Option<&str>) {
+    let Some(analysis_run_id) = analysis_run_id else {
+        return;
+    };
+    let serde_json::Value::Object(map) = value else {
+        return;
+    };
+    let meta = map
+        .entry("_meta".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    if !meta.is_object() {
+        *meta = serde_json::Value::Object(serde_json::Map::new());
+    }
+    if let serde_json::Value::Object(meta_map) = meta {
+        meta_map.insert(
+            "telemetry".to_string(),
+            serde_json::json!({ "analysis_run_id": analysis_run_id }),
+        );
+    }
+}
+
 /// `fallow audit --format json` envelope.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -295,6 +317,27 @@ mod tests {
         apply_root_kind(&mut value, "dead_code", RootEnvelopeMode::Tagged);
 
         assert_eq!(value["kind"], "dead_code");
+    }
+
+    #[test]
+    fn attach_telemetry_meta_sets_analysis_run_id() {
+        let mut value = json!({});
+
+        attach_telemetry_meta(&mut value, Some("run-123"));
+
+        assert_eq!(
+            value["_meta"]["telemetry"]["analysis_run_id"],
+            json!("run-123")
+        );
+    }
+
+    #[test]
+    fn attach_telemetry_meta_preserves_non_object_roots() {
+        let mut value = json!(["not", "an", "object"]);
+
+        attach_telemetry_meta(&mut value, Some("run-123"));
+
+        assert_eq!(value, json!(["not", "an", "object"]));
     }
 
     #[test]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1375,6 +1375,20 @@ pub enum SemanticFact {
     DynamicCustomElementRender(DynamicCustomElementRenderFact),
 }
 
+/// Legacy member-access object used by Angular template scanners.
+///
+/// New extraction writes [`SemanticFact::AngularTemplateMemberAccess`]. The
+/// object value remains available so analysis can decode older cache entries
+/// that used `MemberAccess.object` as a string protocol.
+pub const ANGULAR_TPL_SENTINEL: &str = "__angular_tpl__";
+
+/// Legacy member-access object recorded for Angular `{ ...this }` forwarding.
+///
+/// New extraction writes [`SemanticFact::AngularThisSpread`]. The object value
+/// remains available so component member detectors can honor older cache
+/// entries that used `MemberAccess.object` as a string protocol.
+pub const ANGULAR_THIS_SPREAD_SENTINEL: &str = "__angular_this_spread__";
+
 /// Legacy member-access object prefix for exported-instance bindings.
 ///
 /// New extraction writes [`SemanticFact::InstanceExportBinding`]. The prefix
@@ -1490,6 +1504,28 @@ pub fn is_legacy_semantic_member_access_object(object: &str) -> bool {
 #[must_use]
 pub fn is_legacy_semantic_whole_object_use(object: &str) -> bool {
     object.starts_with(INSTANCE_EXPORT_SENTINEL) || object.starts_with(FACTORY_CALL_SENTINEL)
+}
+
+/// Return true for legacy Angular template member-access objects.
+#[must_use]
+pub fn is_legacy_angular_template_member_access_object(object: &str) -> bool {
+    object == ANGULAR_TPL_SENTINEL
+}
+
+/// Return true for legacy member-access object strings that encode either an
+/// Angular template reference or a typed semantic fact.
+#[must_use]
+pub fn is_legacy_template_or_semantic_member_access_object(object: &str) -> bool {
+    is_legacy_angular_template_member_access_object(object)
+        || is_legacy_semantic_member_access_object(object)
+}
+
+/// Return true for legacy whole-object-use strings that should not be treated
+/// as ordinary value reads in typed-instance propagation.
+#[must_use]
+pub fn is_legacy_template_or_semantic_whole_object_use(object: &str) -> bool {
+    is_legacy_angular_template_member_access_object(object)
+        || is_legacy_semantic_whole_object_use(object)
 }
 
 /// Decode an older sentinel-backed member access into the semantic fact shape
@@ -2386,6 +2422,27 @@ mod tests {
 
         assert!(is_legacy_semantic_member_access_object(&malformed));
         assert!(parse_legacy_semantic_member_access(&malformed, "value").is_none());
+    }
+
+    #[test]
+    fn legacy_template_or_semantic_predicates_include_angular_template_sentinel() {
+        assert!(is_legacy_angular_template_member_access_object(
+            ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_template_or_semantic_member_access_object(
+            ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_template_or_semantic_whole_object_use(
+            ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_template_or_semantic_member_access_object(
+            &format!("{INSTANCE_EXPORT_SENTINEL}exported")
+        ));
+        assert!(is_legacy_template_or_semantic_whole_object_use(&format!(
+            "{FACTORY_CALL_SENTINEL}Svc:create"
+        )));
+        assert!(!is_legacy_template_or_semantic_member_access_object("this"));
+        assert!(!is_legacy_template_or_semantic_whole_object_use("this"));
     }
 
     #[test]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1588,6 +1588,44 @@ pub fn legacy_member_access_to_semantic_fact(object: &str, member: &str) -> Opti
     })
 }
 
+/// A semantic fact yielded from current typed extraction or decoded from an
+/// older sentinel-backed cache entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemanticFactCompat<'a> {
+    /// Fact borrowed from a module's typed semantic facts.
+    Borrowed(&'a SemanticFact),
+    /// Fact decoded from a legacy `MemberAccess` sentinel.
+    Owned(SemanticFact),
+}
+
+impl SemanticFactCompat<'_> {
+    /// View the semantic fact regardless of whether it was borrowed or decoded.
+    #[must_use]
+    pub const fn as_fact(&self) -> &SemanticFact {
+        match self {
+            Self::Borrowed(fact) => fact,
+            Self::Owned(fact) => fact,
+        }
+    }
+}
+
+/// Iterate over typed semantic facts plus decoded legacy member-access facts.
+///
+/// New extraction persists typed facts directly. The legacy path exists only so
+/// older parse-cache entries still feed the same typed analysis code.
+pub fn semantic_facts_with_legacy_member_accesses<'a>(
+    semantic_facts: &'a [SemanticFact],
+    member_accesses: &'a [MemberAccess],
+) -> impl Iterator<Item = SemanticFactCompat<'a>> + 'a {
+    semantic_facts
+        .iter()
+        .map(SemanticFactCompat::Borrowed)
+        .chain(member_accesses.iter().filter_map(|access| {
+            legacy_member_access_to_semantic_fact(access.object.as_str(), access.member.as_str())
+                .map(SemanticFactCompat::Owned)
+        }))
+}
+
 /// A member name referenced from an Angular template surface.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -2406,6 +2444,49 @@ mod tests {
                 chain: vec!["next".to_string(), "finish".to_string()],
                 member: "value".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn semantic_fact_compat_iterator_yields_typed_and_legacy_facts() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::FactoryCallMemberAccess(
+                FactoryCallMemberAccessFact {
+                    callee_object: "Svc".to_string(),
+                    callee_method: "make".to_string(),
+                    member: "run".to_string(),
+                },
+            ));
+        module.member_accesses.push(MemberAccess {
+            object: format!("{INSTANCE_EXPORT_SENTINEL}exported"),
+            member: "target".to_string(),
+        });
+
+        let facts = semantic_facts_with_legacy_member_accesses(
+            &module.semantic_facts,
+            &module.member_accesses,
+        )
+        .collect::<Vec<_>>();
+
+        assert!(matches!(facts[0], SemanticFactCompat::Borrowed(_)));
+        assert_eq!(
+            facts[0].as_fact(),
+            &SemanticFact::FactoryCallMemberAccess(FactoryCallMemberAccessFact {
+                callee_object: "Svc".to_string(),
+                callee_method: "make".to_string(),
+                member: "run".to_string(),
+            })
+        );
+        assert_eq!(
+            facts[1],
+            SemanticFactCompat::Owned(SemanticFact::InstanceExportBinding(
+                InstanceExportBindingFact {
+                    export_name: "exported".to_string(),
+                    target_name: "target".to_string(),
+                }
+            ))
         );
     }
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1534,6 +1534,23 @@ pub fn is_legacy_template_or_semantic_whole_object_use(object: &str) -> bool {
         || is_legacy_semantic_whole_object_use(object)
 }
 
+/// Return true when a module contains a dynamic custom-element render.
+///
+/// Current extraction writes [`SemanticFact::DynamicCustomElementRender`].
+/// The tag fallback is decode-only compatibility for older parse caches that
+/// persisted [`DYNAMIC_CUSTOM_ELEMENT_TAG`] in `used_custom_element_tags`.
+#[must_use]
+pub fn has_dynamic_custom_element_render(module: &ModuleInfo) -> bool {
+    module
+        .semantic_facts
+        .iter()
+        .any(|fact| matches!(fact, SemanticFact::DynamicCustomElementRender(_)))
+        || module
+            .used_custom_element_tags
+            .iter()
+            .any(|tag| tag == DYNAMIC_CUSTOM_ELEMENT_TAG)
+}
+
 /// Decode an older sentinel-backed member access into the semantic fact shape
 /// used by current extraction.
 #[must_use]
@@ -3939,6 +3956,28 @@ mod tests {
             svelte_listened_events: Vec::new(),
             has_dynamic_dispatch: false,
         }
+    }
+
+    #[test]
+    fn dynamic_custom_element_render_helper_prefers_typed_fact() {
+        let mut module = minimal_module_info();
+        module
+            .semantic_facts
+            .push(SemanticFact::DynamicCustomElementRender(
+                DynamicCustomElementRenderFact,
+            ));
+
+        assert!(has_dynamic_custom_element_render(&module));
+    }
+
+    #[test]
+    fn dynamic_custom_element_render_helper_decodes_legacy_tag() {
+        let mut module = minimal_module_info();
+        module
+            .used_custom_element_tags
+            .push(DYNAMIC_CUSTOM_ELEMENT_TAG.to_string());
+
+        assert!(has_dynamic_custom_element_render(&module));
     }
 
     #[test]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1512,6 +1512,12 @@ pub fn is_legacy_angular_template_member_access_object(object: &str) -> bool {
     object == ANGULAR_TPL_SENTINEL
 }
 
+/// Return true for legacy Angular `{ ...this }` spread objects.
+#[must_use]
+pub fn is_legacy_angular_this_spread_object(object: &str) -> bool {
+    object == ANGULAR_THIS_SPREAD_SENTINEL
+}
+
 /// Return true for legacy member-access object strings that encode either an
 /// Angular template reference or a typed semantic fact.
 #[must_use]
@@ -2428,6 +2434,9 @@ mod tests {
     fn legacy_template_or_semantic_predicates_include_angular_template_sentinel() {
         assert!(is_legacy_angular_template_member_access_object(
             ANGULAR_TPL_SENTINEL
+        ));
+        assert!(is_legacy_angular_this_spread_object(
+            ANGULAR_THIS_SPREAD_SENTINEL
         ));
         assert!(is_legacy_template_or_semantic_member_access_object(
             ANGULAR_TPL_SENTINEL

--- a/crates/types/src/issue_meta.rs
+++ b/crates/types/src/issue_meta.rs
@@ -1378,8 +1378,7 @@ mod tests {
 
     #[test]
     fn issue_kind_variants_have_metadata() {
-        for discriminant in 1..=47 {
-            let kind = IssueKind::from_discriminant(discriminant).unwrap();
+        for &kind in IssueKind::ALL {
             assert!(
                 issue_meta_by_kind(kind).is_some(),
                 "IssueKind {kind:?} has no metadata row"

--- a/crates/types/src/suppress.rs
+++ b/crates/types/src/suppress.rs
@@ -172,6 +172,57 @@ pub enum IssueKind {
 }
 
 impl IssueKind {
+    /// Stable inventory of all issue kinds.
+    pub const ALL: &'static [Self] = &[
+        Self::UnusedFile,
+        Self::UnusedExport,
+        Self::UnusedType,
+        Self::PrivateTypeLeak,
+        Self::UnusedDependency,
+        Self::UnusedDevDependency,
+        Self::UnusedEnumMember,
+        Self::UnusedClassMember,
+        Self::UnresolvedImport,
+        Self::UnlistedDependency,
+        Self::DuplicateExport,
+        Self::CodeDuplication,
+        Self::CircularDependency,
+        Self::ReExportCycle,
+        Self::TypeOnlyDependency,
+        Self::TestOnlyDependency,
+        Self::BoundaryViolation,
+        Self::CoverageGaps,
+        Self::FeatureFlag,
+        Self::Complexity,
+        Self::StaleSuppression,
+        Self::PnpmCatalogEntry,
+        Self::EmptyCatalogGroup,
+        Self::UnresolvedCatalogReference,
+        Self::UnusedDependencyOverride,
+        Self::MisconfiguredDependencyOverride,
+        Self::SecurityClientServerLeak,
+        Self::SecuritySink,
+        Self::PolicyViolation,
+        Self::InvalidClientExport,
+        Self::MixedClientServerBarrel,
+        Self::MisplacedDirective,
+        Self::UnusedStoreMember,
+        Self::UnprovidedInject,
+        Self::RouteCollision,
+        Self::DynamicSegmentNameConflict,
+        Self::UnrenderedComponent,
+        Self::UnusedComponentProp,
+        Self::UnusedComponentEmit,
+        Self::UnusedComponentInput,
+        Self::UnusedComponentOutput,
+        Self::UnusedServerAction,
+        Self::UnusedLoadDataKey,
+        Self::PropDrilling,
+        Self::ThinWrapper,
+        Self::DuplicatePropShape,
+        Self::UnusedSvelteEvent,
+    ];
+
     /// Parse an issue kind from the string tokens used in CLI output and suppression comments.
     #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
@@ -348,56 +399,11 @@ impl SuppressionTarget {
 
 /// Convert an [`IssueKind`] to its canonical suppression token.
 #[must_use]
-pub const fn issue_kind_to_kebab(kind: IssueKind) -> &'static str {
-    match kind {
-        IssueKind::UnusedFile => "unused-file",
-        IssueKind::UnusedExport => "unused-export",
-        IssueKind::UnusedType => "unused-type",
-        IssueKind::PrivateTypeLeak => "private-type-leak",
-        IssueKind::UnusedDependency => "unused-dependency",
-        IssueKind::UnusedDevDependency => "unused-dev-dependency",
-        IssueKind::UnusedEnumMember => "unused-enum-member",
-        IssueKind::UnusedClassMember => "unused-class-member",
-        IssueKind::UnresolvedImport => "unresolved-import",
-        IssueKind::UnlistedDependency => "unlisted-dependency",
-        IssueKind::DuplicateExport => "duplicate-export",
-        IssueKind::CodeDuplication => "code-duplication",
-        IssueKind::CircularDependency => "circular-dependency",
-        IssueKind::ReExportCycle => "re-export-cycle",
-        IssueKind::TypeOnlyDependency => "type-only-dependency",
-        IssueKind::TestOnlyDependency => "test-only-dependency",
-        IssueKind::BoundaryViolation => "boundary-violation",
-        IssueKind::CoverageGaps => "coverage-gaps",
-        IssueKind::FeatureFlag => "feature-flag",
-        IssueKind::Complexity => "complexity",
-        IssueKind::StaleSuppression => "stale-suppression",
-        IssueKind::PnpmCatalogEntry => "unused-catalog-entry",
-        IssueKind::EmptyCatalogGroup => "empty-catalog-group",
-        IssueKind::UnresolvedCatalogReference => "unresolved-catalog-reference",
-        IssueKind::UnusedDependencyOverride => "unused-dependency-override",
-        IssueKind::MisconfiguredDependencyOverride => "misconfigured-dependency-override",
-        IssueKind::SecurityClientServerLeak => "security-client-server-leak",
-        IssueKind::SecuritySink => "security-sink",
-        IssueKind::PolicyViolation => "policy-violation",
-        IssueKind::InvalidClientExport => "invalid-client-export",
-        IssueKind::MixedClientServerBarrel => "mixed-client-server-barrel",
-        IssueKind::MisplacedDirective => "misplaced-directive",
-        IssueKind::UnusedStoreMember => "unused-store-member",
-        IssueKind::UnprovidedInject => "unprovided-inject",
-        IssueKind::RouteCollision => "route-collision",
-        IssueKind::DynamicSegmentNameConflict => "dynamic-segment-name-conflict",
-        IssueKind::UnrenderedComponent => "unrendered-component",
-        IssueKind::UnusedComponentProp => "unused-component-prop",
-        IssueKind::UnusedComponentEmit => "unused-component-emit",
-        IssueKind::UnusedComponentInput => "unused-component-input",
-        IssueKind::UnusedComponentOutput => "unused-component-output",
-        IssueKind::UnusedServerAction => "unused-server-action",
-        IssueKind::UnusedLoadDataKey => "unused-load-data-key",
-        IssueKind::PropDrilling => "prop-drilling",
-        IssueKind::ThinWrapper => "thin-wrapper",
-        IssueKind::DuplicatePropShape => "duplicate-prop-shape",
-        IssueKind::UnusedSvelteEvent => "unused-svelte-event",
-    }
+pub fn issue_kind_to_kebab(kind: IssueKind) -> &'static str {
+    let Some(meta) = crate::issue_meta::issue_meta_by_kind(kind) else {
+        unreachable!("IssueKind {kind:?} has no metadata row");
+    };
+    meta.suppress_token.unwrap_or(meta.code)
 }
 
 /// Parse a suppression token into a structured target.
@@ -999,122 +1005,38 @@ mod tests {
             IssueKind::from_discriminant(47),
             Some(IssueKind::UnusedSvelteEvent)
         );
-        assert_eq!(IssueKind::from_discriminant(48), None);
+        let max_discriminant = IssueKind::ALL
+            .iter()
+            .map(|kind| kind.to_discriminant())
+            .max()
+            .expect("IssueKind::ALL should not be empty");
+        assert_eq!(IssueKind::from_discriminant(max_discriminant + 1), None);
         assert_eq!(IssueKind::from_discriminant(u8::MAX), None);
     }
 
     #[test]
     fn discriminant_roundtrip() {
-        for kind in [
-            IssueKind::UnusedFile,
-            IssueKind::UnusedExport,
-            IssueKind::UnusedType,
-            IssueKind::PrivateTypeLeak,
-            IssueKind::UnusedDependency,
-            IssueKind::UnusedDevDependency,
-            IssueKind::UnusedEnumMember,
-            IssueKind::UnusedClassMember,
-            IssueKind::UnresolvedImport,
-            IssueKind::UnlistedDependency,
-            IssueKind::DuplicateExport,
-            IssueKind::CodeDuplication,
-            IssueKind::CircularDependency,
-            IssueKind::ReExportCycle,
-            IssueKind::TypeOnlyDependency,
-            IssueKind::TestOnlyDependency,
-            IssueKind::BoundaryViolation,
-            IssueKind::CoverageGaps,
-            IssueKind::FeatureFlag,
-            IssueKind::Complexity,
-            IssueKind::StaleSuppression,
-            IssueKind::PnpmCatalogEntry,
-            IssueKind::EmptyCatalogGroup,
-            IssueKind::UnresolvedCatalogReference,
-            IssueKind::UnusedDependencyOverride,
-            IssueKind::MisconfiguredDependencyOverride,
-            IssueKind::SecurityClientServerLeak,
-            IssueKind::SecuritySink,
-            IssueKind::PolicyViolation,
-            IssueKind::InvalidClientExport,
-            IssueKind::MixedClientServerBarrel,
-            IssueKind::MisplacedDirective,
-            IssueKind::UnusedStoreMember,
-            IssueKind::UnprovidedInject,
-            IssueKind::RouteCollision,
-            IssueKind::DynamicSegmentNameConflict,
-            IssueKind::UnrenderedComponent,
-            IssueKind::UnusedComponentProp,
-            IssueKind::UnusedComponentEmit,
-            IssueKind::UnusedServerAction,
-            IssueKind::UnusedLoadDataKey,
-            IssueKind::PropDrilling,
-            IssueKind::ThinWrapper,
-            IssueKind::DuplicatePropShape,
-            IssueKind::UnusedComponentInput,
-            IssueKind::UnusedComponentOutput,
-            IssueKind::UnusedSvelteEvent,
-        ] {
+        for &kind in IssueKind::ALL {
             assert_eq!(
                 IssueKind::from_discriminant(kind.to_discriminant()),
                 Some(kind)
             );
         }
         assert_eq!(IssueKind::from_discriminant(0), None);
-        assert_eq!(IssueKind::from_discriminant(48), None);
+        let max_discriminant = IssueKind::ALL
+            .iter()
+            .map(|kind| kind.to_discriminant())
+            .max()
+            .expect("IssueKind::ALL should not be empty");
+        assert_eq!(IssueKind::from_discriminant(max_discriminant + 1), None);
     }
 
     #[test]
     fn discriminant_values_are_unique() {
-        let all_kinds = [
-            IssueKind::UnusedFile,
-            IssueKind::UnusedExport,
-            IssueKind::UnusedType,
-            IssueKind::PrivateTypeLeak,
-            IssueKind::UnusedDependency,
-            IssueKind::UnusedDevDependency,
-            IssueKind::UnusedEnumMember,
-            IssueKind::UnusedClassMember,
-            IssueKind::UnresolvedImport,
-            IssueKind::UnlistedDependency,
-            IssueKind::DuplicateExport,
-            IssueKind::CodeDuplication,
-            IssueKind::CircularDependency,
-            IssueKind::ReExportCycle,
-            IssueKind::TypeOnlyDependency,
-            IssueKind::TestOnlyDependency,
-            IssueKind::BoundaryViolation,
-            IssueKind::CoverageGaps,
-            IssueKind::FeatureFlag,
-            IssueKind::Complexity,
-            IssueKind::StaleSuppression,
-            IssueKind::PnpmCatalogEntry,
-            IssueKind::EmptyCatalogGroup,
-            IssueKind::UnresolvedCatalogReference,
-            IssueKind::UnusedDependencyOverride,
-            IssueKind::MisconfiguredDependencyOverride,
-            IssueKind::SecurityClientServerLeak,
-            IssueKind::SecuritySink,
-            IssueKind::PolicyViolation,
-            IssueKind::InvalidClientExport,
-            IssueKind::MixedClientServerBarrel,
-            IssueKind::MisplacedDirective,
-            IssueKind::UnusedStoreMember,
-            IssueKind::UnprovidedInject,
-            IssueKind::RouteCollision,
-            IssueKind::DynamicSegmentNameConflict,
-            IssueKind::UnrenderedComponent,
-            IssueKind::UnusedComponentProp,
-            IssueKind::UnusedComponentEmit,
-            IssueKind::UnusedServerAction,
-            IssueKind::UnusedLoadDataKey,
-            IssueKind::PropDrilling,
-            IssueKind::ThinWrapper,
-            IssueKind::DuplicatePropShape,
-            IssueKind::UnusedComponentInput,
-            IssueKind::UnusedComponentOutput,
-            IssueKind::UnusedSvelteEvent,
-        ];
-        let discriminants: Vec<u8> = all_kinds.iter().map(|k| k.to_discriminant()).collect();
+        let discriminants: Vec<u8> = IssueKind::ALL
+            .iter()
+            .map(|kind| kind.to_discriminant())
+            .collect();
         let mut sorted = discriminants.clone();
         sorted.sort_unstable();
         sorted.dedup();
@@ -1128,6 +1050,17 @@ mod tests {
     #[test]
     fn discriminant_starts_at_one() {
         assert_eq!(IssueKind::UnusedFile.to_discriminant(), 1);
+    }
+
+    #[test]
+    fn issue_kind_to_kebab_uses_registry_suppression_token() {
+        for &kind in IssueKind::ALL {
+            let meta = crate::issue_meta::issue_meta_by_kind(kind)
+                .unwrap_or_else(|| panic!("IssueKind {kind:?} has no metadata row"));
+            let token = issue_kind_to_kebab(kind);
+            assert_eq!(token, meta.suppress_token.unwrap_or(meta.code));
+            assert_eq!(IssueKind::parse(token), Some(kind));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- centralize output next-step contracts for combined and audit reports
- move CLI next-step command construction out of CLI-owned code paths
- extend API/NAPI health boundaries and root envelope mapping

## Verification
- covered by the stacked branch checks already run for these commits