### PR TITLE
refactor: isolate napi health cli bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ name = "fallow-node"
 version = "2.102.0"
 dependencies = [
  "fallow-api",
- "fallow-cli",
+ "fallow-programmatic-cli",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1258,6 +1258,14 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "fallow-programmatic-cli"
+version = "2.102.0"
+dependencies = [
+ "fallow-api",
+ "fallow-cli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ fallow-extract = { version = "2.102.0", path = "crates/extract" }
 fallow-engine = { version = "2.102.0", path = "crates/engine" }
 fallow-graph = { version = "2.102.0", path = "crates/graph" }
 fallow-output = { version = "2.102.0", path = "crates/output" }
+fallow-programmatic-cli = { version = "2.102.0", path = "crates/programmatic-cli" }
 fallow-types = { version = "2.102.0", path = "crates/types" }
 fallow-cli = { version = "2.102.0", path = "crates/cli" }
 

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [dependencies]
 fallow-api = { workspace = true }
-fallow-cli = { workspace = true }
+fallow-programmatic-cli = { workspace = true }
 napi = { version = "3", features = ["serde-json", "tokio_rt"] }
 napi-derive = "3"
 serde_json = { workspace = true }

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 
 use fallow_api as api;
-use fallow_cli::programmatic::CliProgrammaticHealthRunner;
+use fallow_programmatic_cli::CliHealthRunner;
 use napi::bindgen_prelude::{AsyncTask, JsObjectValue, ToNapiValue, Unknown};
 use napi::{Env, ScopedTask, Status};
 use napi_derive::napi;
@@ -543,7 +543,7 @@ pub fn compute_complexity(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        api::compute_complexity_with_runner(&options, &CliProgrammaticHealthRunner)
+        api::compute_complexity_with_runner(&options, &CliHealthRunner)
     })))
 }
 
@@ -553,7 +553,7 @@ pub fn compute_health(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        api::compute_health_with_runner(&options, &CliProgrammaticHealthRunner)
+        api::compute_health_with_runner(&options, &CliHealthRunner)
     })))
 }
 

--- a/crates/programmatic-cli/Cargo.toml
+++ b/crates/programmatic-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fallow-programmatic-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Temporary CLI-backed programmatic bridge for fallow embedders"
+readme = "../../README.md"
+
+[dependencies]
+fallow-api = { workspace = true }
+fallow-cli = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/programmatic-cli/src/lib.rs
+++ b/crates/programmatic-cli/src/lib.rs
@@ -1,0 +1,22 @@
+//! Temporary programmatic bridge for CLI-backed runtime paths.
+//!
+//! `fallow-api` owns the public programmatic contracts. Most NAPI calls now use
+//! the API runtime directly. Health still needs the CLI implementation until
+//! the health execution pipeline finishes moving behind typed engine results, so
+//! this crate keeps that dependency explicit and removable.
+
+#![cfg_attr(not(test), deny(clippy::disallowed_methods))]
+
+use fallow_api::{ComplexityOptions, ProgrammaticError, ProgrammaticHealthReport};
+
+/// CLI-backed health runner used by embedders during the health migration.
+pub struct CliHealthRunner;
+
+impl fallow_api::ProgrammaticHealthRunner for CliHealthRunner {
+    fn run_programmatic_health(
+        &self,
+        options: &ComplexityOptions,
+    ) -> Result<ProgrammaticHealthReport, ProgrammaticError> {
+        fallow_cli::programmatic::CliProgrammaticHealthRunner.run_programmatic_health(options)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a narrow `fallow-programmatic-cli` bridge for the remaining CLI-backed programmatic health runner.
- Removes the direct `fallow-node` dependency on `fallow-cli`; NAPI now depends on `fallow-api` plus the explicit bridge.
- Keeps health behavior unchanged while making the final API-owned health runner migration localized.

## Verification
- `cargo check -p fallow-programmatic-cli -p fallow-node`
- `cargo test -p fallow-programmatic-cli -p fallow-node --lib`
- `cargo check -p fallow-api -p fallow-programmatic-cli -p fallow-node`
- `cargo clippy -p fallow-programmatic-cli -p fallow-node --all-targets -- -D warnings`
