### PR TITLE
refactor: move health next-step input to output

### DIFF
--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -677,18 +677,19 @@ impl fallow_api::ProgrammaticHealthRunner for CliProgrammaticHealthRunner {
             let health_options = build_complexity_options(&resolved, options);
             let result = crate::health::execute_health(&health_options)
                 .map_err(|_| generic_analysis_error("health"))?;
+            let root = &result.config.root;
             let next_steps = fallow_output::build_health_next_steps(
-                crate::report::suggestions::health_next_steps_input(
+                fallow_output::build_health_next_steps_input(
                     &result.report,
-                    &result.config.root,
-                    crate::report::suggestions::setup_pointer_applicable(&result.config.root),
-                    crate::report::suggestions::due_impact_digest(&result.config.root),
+                    crate::report::suggestions::suggestions_enabled(),
+                    crate::report::suggestions::setup_pointer_applicable(root),
+                    crate::report::suggestions::due_impact_digest(root)
+                        .map(crate::report::suggestions::impact_counts),
+                    crate::report::suggestions::audit_changed_applicable(root),
                 ),
             );
             Ok(fallow_api::ProgrammaticHealthReport {
-                workspace_diagnostics: workspace_diagnostics_for_programmatic_output(
-                    &result.config.root,
-                ),
+                workspace_diagnostics: workspace_diagnostics_for_programmatic_output(root),
                 root: result.config.root.clone(),
                 report: result.report,
                 elapsed: result.elapsed,

--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -96,7 +96,7 @@ pub const SETUP_HINT: &str = "Setup: `fallow init --agents` writes an agent guid
 
 /// Real-counter summary fragment shared by the next-step reason and the human
 /// one-liner. The output crate owns the `impact-report` command contract.
-fn impact_counts(digest: crate::impact::ImpactDigest) -> ImpactDigestCounts {
+pub fn impact_counts(digest: crate::impact::ImpactDigest) -> ImpactDigestCounts {
     ImpactDigestCounts {
         containment_count: digest.containment_count,
         resolved_total: digest.resolved_total,
@@ -138,7 +138,7 @@ fn default_workspace_ref_for_next_step(root: &Path) -> Option<String> {
 
 /// `audit-changed`: gate only the files the current branch changed. `fallow
 /// audit` auto-detects its base, so no ref needs embedding.
-fn audit_changed_applicable(root: &Path) -> bool {
+pub fn audit_changed_applicable(root: &Path) -> bool {
     fallow_core::churn::is_git_repo(root)
 }
 
@@ -230,13 +230,13 @@ pub fn health_next_steps_input(
     offer_setup: bool,
     digest: Option<crate::impact::ImpactDigest>,
 ) -> HealthNextStepsInput {
-    HealthNextStepsInput {
-        suggestions_enabled: suggestions_enabled(),
-        has_findings: !report.findings.is_empty(),
+    fallow_output::build_health_next_steps_input(
+        report,
+        suggestions_enabled(),
         offer_setup,
-        impact_digest: digest.map(impact_counts),
-        audit_changed: audit_changed_applicable(root),
-    }
+        digest.map(impact_counts),
+        audit_changed_applicable(root),
+    )
 }
 
 /// Next-steps for standalone `fallow dupes`. See [`build_dead_code_next_steps`]

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -184,7 +184,7 @@ pub use next_steps::{
     AuditNextStepsInput, CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput,
     HealthNextStepsInput, ImpactDigestCounts, TraceUnusedExportInput, build_audit_next_steps,
     build_combined_next_steps, build_dead_code_next_steps, build_dupes_next_steps,
-    build_health_next_steps, impact_digest_summary,
+    build_health_next_steps, build_health_next_steps_input, impact_digest_summary,
 };
 pub use report_contract::{
     COVERAGE_ANALYZE_DOCS, COVERAGE_SETUP_DOCS, DUPES_DOCS, HEALTH_DOCS, SECURITY_DOCS,

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -8,6 +8,8 @@ use fallow_types::output::NextStep;
 use fallow_types::results::AnalysisResults;
 use std::path::Path;
 
+use crate::HealthReport;
+
 const MAX_NEXT_STEPS: usize = 3;
 const MUTATING_VERBS: [&str; 5] = ["fix", "init", "hooks", "migrate", "setup-hooks"];
 
@@ -77,6 +79,25 @@ pub struct HealthNextStepsInput {
     pub offer_setup: bool,
     pub impact_digest: Option<ImpactDigestCounts>,
     pub audit_changed: bool,
+}
+
+/// Build standalone health next-step inputs from a typed health report plus
+/// caller-supplied runtime probes.
+#[must_use]
+pub fn build_health_next_steps_input(
+    report: &HealthReport,
+    suggestions_enabled: bool,
+    offer_setup: bool,
+    impact_digest: Option<ImpactDigestCounts>,
+    audit_changed: bool,
+) -> HealthNextStepsInput {
+    HealthNextStepsInput {
+        suggestions_enabled,
+        has_findings: !report.findings.is_empty(),
+        offer_setup,
+        impact_digest,
+        audit_changed,
+    }
 }
 
 /// Render the human-readable impact counter summary shared by JSON and human
@@ -351,6 +372,7 @@ fn scope_workspaces(workspace_ref: Option<&str>) -> Option<NextStep> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{ComplexityViolation, ExceededThreshold, FindingSeverity, HealthFinding};
     use fallow_types::output_dead_code::UnusedExportFinding;
     use fallow_types::results::UnusedExport;
 
@@ -368,6 +390,37 @@ mod tests {
             offer_setup: false,
             impact_digest: None,
             audit_changed: false,
+        }
+    }
+
+    fn dirty_report() -> HealthReport {
+        HealthReport {
+            findings: vec![HealthFinding::from(ComplexityViolation {
+                path: "/project/src/hot.ts".into(),
+                name: "hot".to_string(),
+                line: 1,
+                col: 0,
+                cyclomatic: 21,
+                cognitive: 16,
+                line_count: 42,
+                param_count: 0,
+                react_hook_count: 0,
+                react_jsx_max_depth: 0,
+                react_prop_count: 0,
+                react_hook_profile: None,
+                exceeded: ExceededThreshold::Both,
+                severity: FindingSeverity::High,
+                crap: None,
+                coverage_pct: None,
+                coverage_tier: None,
+                coverage_source: None,
+                inherited_from: None,
+                component_rollup: None,
+                contributions: Vec::new(),
+                effective_thresholds: None,
+                threshold_source: None,
+            })],
+            ..HealthReport::default()
         }
     }
 
@@ -501,6 +554,30 @@ mod tests {
         });
 
         assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn health_input_builder_derives_findings_from_report() {
+        let clean = build_health_next_steps_input(
+            &HealthReport::default(),
+            true,
+            true,
+            Some(digest(2, 1)),
+            true,
+        );
+        assert_eq!(
+            clean,
+            HealthNextStepsInput {
+                suggestions_enabled: true,
+                has_findings: false,
+                offer_setup: true,
+                impact_digest: Some(digest(2, 1)),
+                audit_changed: true,
+            }
+        );
+
+        let dirty = build_health_next_steps_input(&dirty_report(), true, false, None, false);
+        assert!(dirty.has_findings);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move health next-step input derivation into fallow-output
- keep CLI-owned runtime probes at the CLI boundary
- route programmatic health next steps through the output contract directly

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli -p fallow-api -p fallow-programmatic-cli -p fallow-node
- cargo test -p fallow-output next_steps --lib
- cargo test -p fallow-cli suggestions --lib
- cargo clippy -p fallow-output -p fallow-cli -p fallow-api -p fallow-programmatic-cli -p fallow-node --all-targets -- -D warnings