### PR TITLE
refactor: return engine health results to api

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,7 +22,7 @@ pub mod dupes_output;
 pub mod runtime;
 pub use dupes_output::{CloneFamilyFinding, CloneGroupFinding, DupesReportPayload};
 pub use runtime::{
-    HealthJsonReportInput, ProgrammaticHealthReport, ProgrammaticHealthRunner,
+    HealthJsonReportInput, ProgrammaticHealthRun, ProgrammaticHealthRunner,
     compute_complexity_with_runner, compute_health_with_runner, detect_boundary_violations,
     detect_circular_dependencies, detect_dead_code, detect_duplication,
     serialize_health_report_json,

--- a/crates/api/src/runtime.rs
+++ b/crates/api/src/runtime.rs
@@ -7,7 +7,9 @@ use fallow_config::{
     DetectionMode, DuplicatesConfig, OutputFormat, ProductionAnalysis, WorkspaceInfo,
 };
 use fallow_engine::duplicates::{CloneInstance, DuplicationReport, DuplicationStats};
-use fallow_engine::{AnalysisResults, AnalysisSession, ProjectConfig, ProjectConfigOptions};
+use fallow_engine::{
+    AnalysisResults, AnalysisSession, HealthAnalysisResult, ProjectConfig, ProjectConfigOptions,
+};
 use fallow_output::{
     CHECK_SCHEMA_VERSION, CheckOutputInput, DiffIndex, DupesOutput, DupesOutputInput, GroupByMode,
     HealthGroup, HealthJsonOutputInput, HealthOutputInput, HealthReport, MAX_DIFF_BYTES,
@@ -42,10 +44,12 @@ pub struct HealthJsonReportInput<'a> {
 }
 
 /// Health runner output consumed by the API-owned programmatic serializer.
-pub struct ProgrammaticHealthReport {
-    pub report: HealthReport,
-    pub root: PathBuf,
-    pub elapsed: std::time::Duration,
+///
+/// The analysis payload is the typed engine result. Runtime-only presentation
+/// probes stay explicit so the API boundary, not the concrete runner, owns the
+/// final programmatic report assembly.
+pub struct ProgrammaticHealthRun {
+    pub analysis: HealthAnalysisResult,
     pub workspace_diagnostics: Vec<WorkspaceDiagnosticOutput>,
     pub next_steps: Vec<NextStep>,
     pub envelope_mode: RootEnvelopeMode,
@@ -64,7 +68,7 @@ pub trait ProgrammaticHealthRunner {
     fn run_programmatic_health(
         &self,
         options: &ComplexityOptions,
-    ) -> Result<ProgrammaticHealthReport, ProgrammaticError>;
+    ) -> Result<ProgrammaticHealthRun, ProgrammaticError>;
 }
 
 struct ResolvedAnalysisOptions {
@@ -187,10 +191,11 @@ pub fn compute_complexity_with_runner(
 ) -> ProgrammaticResult<serde_json::Value> {
     crate::validate_complexity_options(options)?;
     let result = runner.run_programmatic_health(options)?;
+    let root = result.analysis.config.root.clone();
     let mut output = serialize_health_report_json(HealthJsonReportInput {
-        report: result.report,
-        root: &result.root,
-        elapsed: result.elapsed,
+        report: result.analysis.report,
+        root: &root,
+        elapsed: result.analysis.elapsed,
         explain: options.analysis.explain,
         grouped_by: None,
         groups: None,
@@ -1360,11 +1365,32 @@ mod tests {
         fn run_programmatic_health(
             &self,
             _options: &ComplexityOptions,
-        ) -> Result<ProgrammaticHealthReport, ProgrammaticError> {
-            Ok(ProgrammaticHealthReport {
-                report: HealthReport::default(),
-                root: self.root.clone(),
-                elapsed: std::time::Duration::ZERO,
+        ) -> Result<ProgrammaticHealthRun, ProgrammaticError> {
+            let project_config = fallow_engine::config_for_project_analysis(
+                &self.root,
+                None,
+                ProjectConfigOptions {
+                    output: OutputFormat::Json,
+                    no_cache: true,
+                    threads: 1,
+                    production_override: None,
+                    quiet: true,
+                    analysis: ProductionAnalysis::Health,
+                },
+            )
+            .expect("test config loads");
+
+            Ok(ProgrammaticHealthRun {
+                analysis: HealthAnalysisResult {
+                    report: HealthReport::default(),
+                    grouping: None,
+                    group_resolver: None,
+                    config: project_config.config,
+                    elapsed: std::time::Duration::ZERO,
+                    timings: None,
+                    coverage_gaps_has_findings: false,
+                    should_fail_on_coverage_gaps: false,
+                },
                 workspace_diagnostics: vec![WorkspaceDiagnosticOutput(serde_json::json!({
                     "path": self.root.join("package.json")
                 }))],
@@ -1435,7 +1461,8 @@ mod tests {
 
     #[test]
     fn programmatic_health_runner_serializes_api_owned_output() {
-        let root = PathBuf::from("/repo");
+        let project = tempfile::tempdir().expect("temp dir");
+        let root = project.path().to_path_buf();
         let json = compute_health_with_runner(
             &ComplexityOptions {
                 analysis: AnalysisOptions {

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -671,13 +671,14 @@ impl fallow_api::ProgrammaticHealthRunner for CliProgrammaticHealthRunner {
     fn run_programmatic_health(
         &self,
         options: &ComplexityOptions,
-    ) -> ProgrammaticResult<fallow_api::ProgrammaticHealthReport> {
+    ) -> ProgrammaticResult<fallow_api::ProgrammaticHealthRun> {
         let resolved = resolve_analysis_options(&options.analysis)?;
         resolved.install(|| {
             let health_options = build_complexity_options(&resolved, options);
             let result = crate::health::execute_health(&health_options)
                 .map_err(|_| generic_analysis_error("health"))?;
             let root = &result.config.root;
+            let workspace_diagnostics = workspace_diagnostics_for_programmatic_output(root);
             let next_steps = fallow_output::build_health_next_steps(
                 fallow_output::build_health_next_steps_input(
                     &result.report,
@@ -688,11 +689,18 @@ impl fallow_api::ProgrammaticHealthRunner for CliProgrammaticHealthRunner {
                     crate::report::suggestions::audit_changed_applicable(root),
                 ),
             );
-            Ok(fallow_api::ProgrammaticHealthReport {
-                workspace_diagnostics: workspace_diagnostics_for_programmatic_output(root),
-                root: result.config.root.clone(),
-                report: result.report,
-                elapsed: result.elapsed,
+            Ok(fallow_api::ProgrammaticHealthRun {
+                analysis: fallow_engine::HealthAnalysisResult {
+                    report: result.report,
+                    grouping: result.grouping,
+                    group_resolver: None,
+                    config: result.config,
+                    elapsed: result.elapsed,
+                    timings: result.timings,
+                    coverage_gaps_has_findings: result.coverage_gaps_has_findings,
+                    should_fail_on_coverage_gaps: result.should_fail_on_coverage_gaps,
+                },
+                workspace_diagnostics,
                 next_steps,
                 envelope_mode: programmatic_root_envelope_mode(&resolved),
                 telemetry_analysis_run_id: crate::output_envelope::telemetry_analysis_run_id(),

--- a/crates/programmatic-cli/src/lib.rs
+++ b/crates/programmatic-cli/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(not(test), deny(clippy::disallowed_methods))]
 
-use fallow_api::{ComplexityOptions, ProgrammaticError, ProgrammaticHealthReport};
+use fallow_api::{ComplexityOptions, ProgrammaticError, ProgrammaticHealthRun};
 
 /// CLI-backed health runner used by embedders during the health migration.
 pub struct CliHealthRunner;
@@ -16,7 +16,7 @@ impl fallow_api::ProgrammaticHealthRunner for CliHealthRunner {
     fn run_programmatic_health(
         &self,
         options: &ComplexityOptions,
-    ) -> Result<ProgrammaticHealthReport, ProgrammaticError> {
+    ) -> Result<ProgrammaticHealthRun, ProgrammaticError> {
         fallow_cli::programmatic::CliProgrammaticHealthRunner.run_programmatic_health(options)
     }
 }


### PR DESCRIPTION
## Summary
- replace the programmatic health report runner output with a typed engine health run result
- let fallow-api assemble the programmatic health JSON from the engine result
- keep CLI runtime probes explicit while dropping the CLI ownership resolver at the API boundary

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-api -p fallow-cli -p fallow-programmatic-cli -p fallow-node
- cargo test -p fallow-api runtime --lib
- cargo test -p fallow-cli programmatic --lib
- cargo test -p fallow-programmatic-cli --lib
- cargo clippy -p fallow-api -p fallow-cli -p fallow-programmatic-cli -p fallow-node --all-targets -- -D warnings