### PR TITLE
refactor: move workspace diagnostics output conversion

### DIFF
--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -260,11 +260,9 @@ fn programmatic_root_envelope_mode(
 fn workspace_diagnostics_for_programmatic_output(
     root: &Path,
 ) -> Vec<fallow_output::WorkspaceDiagnosticOutput> {
-    crate::runtime_support::workspace_diagnostics_for(root)
-        .into_iter()
-        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
-        .map(fallow_output::WorkspaceDiagnosticOutput)
-        .collect()
+    fallow_output::workspace_diagnostics_output(crate::runtime_support::workspace_diagnostics_for(
+        root,
+    ))
 }
 
 fn build_dead_code_json(

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -225,11 +225,9 @@ fn build_cli_check_output(
 }
 
 fn workspace_diagnostics_for_output(root: &Path) -> Vec<WorkspaceDiagnosticOutput> {
-    crate::runtime_support::workspace_diagnostics_for(root)
-        .into_iter()
-        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
-        .map(WorkspaceDiagnosticOutput)
-        .collect()
+    fallow_output::workspace_diagnostics_output(crate::runtime_support::workspace_diagnostics_for(
+        root,
+    ))
 }
 
 fn postprocess_check_json(output: &mut serde_json::Value, root: &Path) {

--- a/crates/output/src/check.rs
+++ b/crates/output/src/check.rs
@@ -21,6 +21,22 @@ pub const CHECK_SCHEMA_VERSION: u32 = 7;
 #[serde(transparent)]
 pub struct WorkspaceDiagnosticOutput(pub serde_json::Value);
 
+/// Convert runtime workspace diagnostics into the output-layer DTO.
+///
+/// Serialization failures are skipped to match the existing JSON output
+/// behavior: diagnostics are advisory and must never make analysis fail.
+pub fn workspace_diagnostics_output<I, T>(diagnostics: I) -> Vec<WorkspaceDiagnosticOutput>
+where
+    I: IntoIterator<Item = T>,
+    T: Serialize,
+{
+    diagnostics
+        .into_iter()
+        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
+        .map(WorkspaceDiagnosticOutput)
+        .collect()
+}
+
 /// Envelope emitted by `fallow dead-code --format json` (plus the `check`
 /// block inside the combined and audit envelopes).
 ///
@@ -231,6 +247,13 @@ mod tests {
     use super::*;
     use fallow_types::output_dead_code::UnusedFileFinding;
     use fallow_types::results::UnusedFile;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Diagnostic {
+        path: &'static str,
+        message: &'static str,
+    }
 
     #[test]
     fn build_check_output_counts_issues_and_entry_points() {
@@ -256,5 +279,17 @@ mod tests {
         assert_eq!(output.total_issues, 1);
         assert_eq!(output.summary.unused_files, 1);
         assert_eq!(output.elapsed_ms.0, 42);
+    }
+
+    #[test]
+    fn workspace_diagnostics_output_serializes_runtime_diagnostics() {
+        let output = workspace_diagnostics_output([Diagnostic {
+            path: "package.json",
+            message: "workspace is not declared",
+        }]);
+
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].0["path"], "package.json");
+        assert_eq!(output[0].0["message"], "workspace is not declared");
     }
 }

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -72,7 +72,7 @@ pub use audit_weakening::{WeakeningKind, WeakeningSignal};
 pub use check::{
     CHECK_SCHEMA_VERSION, CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput,
     GroupByMode, WorkspaceDiagnosticOutput, apply_config_fixable_to_duplicate_exports,
-    build_check_output, build_check_summary,
+    build_check_output, build_check_summary, workspace_diagnostics_output,
 };
 pub use codeclimate::{
     CodeClimateIssue, CodeClimateIssueKind, CodeClimateLines, CodeClimateLocation,


### PR DESCRIPTION
## Summary
- add an output-layer helper for serializing workspace diagnostics into the DTO used by JSON reports
- remove duplicate workspace diagnostic JSON conversion from CLI report and programmatic paths
- keep runtime diagnostic collection in CLI while moving the wire conversion into fallow-output

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli -p fallow-api -p fallow-programmatic-cli -p fallow-node
- cargo test -p fallow-output workspace_diagnostics_output --lib
- cargo test -p fallow-cli programmatic --lib
- cargo test -p fallow-cli report::json --lib
- cargo clippy -p fallow-output -p fallow-cli -p fallow-api -p fallow-programmatic-cli -p fallow-node --all-targets -- -D warnings