### PR TITLE
refactor: erase health resolvers in engine

### DIFF
--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -688,16 +688,7 @@ impl fallow_api::ProgrammaticHealthRunner for CliProgrammaticHealthRunner {
                 ),
             );
             Ok(fallow_api::ProgrammaticHealthRun {
-                analysis: fallow_engine::HealthAnalysisResult {
-                    report: result.report,
-                    grouping: result.grouping,
-                    group_resolver: None,
-                    config: result.config,
-                    elapsed: result.elapsed,
-                    timings: result.timings,
-                    coverage_gaps_has_findings: result.coverage_gaps_has_findings,
-                    should_fail_on_coverage_gaps: result.should_fail_on_coverage_gaps,
-                },
+                analysis: result.without_group_resolver(),
                 workspace_diagnostics,
                 next_steps,
                 envelope_mode: programmatic_root_envelope_mode(&resolved),

--- a/crates/engine/src/health.rs
+++ b/crates/engine/src/health.rs
@@ -405,6 +405,24 @@ pub struct HealthAnalysisResult<GroupResolver = ()> {
     pub should_fail_on_coverage_gaps: bool,
 }
 
+impl<GroupResolver> HealthAnalysisResult<GroupResolver> {
+    /// Drop presentation-only grouping resolver state while preserving the
+    /// command-neutral health analysis payload.
+    #[must_use]
+    pub fn without_group_resolver(self) -> HealthAnalysisResult<()> {
+        HealthAnalysisResult {
+            report: self.report,
+            grouping: self.grouping,
+            group_resolver: None,
+            config: self.config,
+            elapsed: self.elapsed,
+            timings: self.timings,
+            coverage_gaps_has_findings: self.coverage_gaps_has_findings,
+            should_fail_on_coverage_gaps: self.should_fail_on_coverage_gaps,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -433,6 +451,41 @@ mod tests {
             coverage_inputs: HealthCoverageInputs::default(),
             runtime_coverage: None,
         }
+    }
+
+    #[test]
+    fn health_analysis_result_drops_presentation_resolver() {
+        let project = tempfile::tempdir().expect("temp dir");
+        let project_config = crate::config_for_project_analysis(
+            project.path(),
+            None,
+            crate::ProjectConfigOptions {
+                output: OutputFormat::Json,
+                no_cache: true,
+                threads: 1,
+                production_override: None,
+                quiet: true,
+                analysis: fallow_config::ProductionAnalysis::Health,
+            },
+        )
+        .expect("project config loads");
+        let result = HealthAnalysisResult {
+            report: HealthReport::default(),
+            grouping: None,
+            group_resolver: Some("resolver"),
+            config: project_config.config,
+            elapsed: Duration::from_millis(7),
+            timings: None,
+            coverage_gaps_has_findings: true,
+            should_fail_on_coverage_gaps: true,
+        };
+
+        let neutral = result.without_group_resolver();
+
+        assert!(neutral.group_resolver.is_none());
+        assert_eq!(neutral.elapsed, Duration::from_millis(7));
+        assert!(neutral.coverage_gaps_has_findings);
+        assert!(neutral.should_fail_on_coverage_gaps);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an engine-owned helper to drop presentation-only health grouping resolver state
- let the CLI programmatic health runner pass a resolver-neutral engine result to fallow-api
- remove manual field-by-field health result reconstruction from the CLI boundary

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-engine -p fallow-api -p fallow-cli -p fallow-programmatic-cli -p fallow-node
- cargo test -p fallow-engine health_analysis_result_drops_presentation_resolver --lib
- cargo test -p fallow-api runtime --lib
- cargo test -p fallow-cli programmatic --lib
- cargo clippy -p fallow-engine -p fallow-api -p fallow-cli -p fallow-programmatic-cli -p fallow-node --all-targets -- -D warnings