### PR TITLE
refactor: hide health runner wiring from napi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ version = "2.102.0"
 dependencies = [
  "fallow-api",
  "fallow-cli",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 
 use fallow_api as api;
-use fallow_programmatic_cli::CliHealthRunner;
+use fallow_programmatic_cli as cli_health;
 use napi::bindgen_prelude::{AsyncTask, JsObjectValue, ToNapiValue, Unknown};
 use napi::{Env, ScopedTask, Status};
 use napi_derive::napi;
@@ -543,7 +543,7 @@ pub fn compute_complexity(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        api::compute_complexity_with_runner(&options, &CliHealthRunner)
+        cli_health::compute_complexity(&options)
     })))
 }
 
@@ -553,7 +553,7 @@ pub fn compute_health(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        api::compute_health_with_runner(&options, &CliHealthRunner)
+        cli_health::compute_health(&options)
     })))
 }
 

--- a/crates/programmatic-cli/Cargo.toml
+++ b/crates/programmatic-cli/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../../README.md"
 [dependencies]
 fallow-api = { workspace = true }
 fallow-cli = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/programmatic-cli/src/lib.rs
+++ b/crates/programmatic-cli/src/lib.rs
@@ -20,3 +20,25 @@ impl fallow_api::ProgrammaticHealthRunner for CliHealthRunner {
         fallow_cli::programmatic::CliProgrammaticHealthRunner.run_programmatic_health(options)
     }
 }
+
+/// Run complexity analysis through the temporary CLI-backed health bridge.
+///
+/// # Errors
+///
+/// Returns structured programmatic errors from option validation, analysis, or
+/// JSON serialization.
+pub fn compute_complexity(
+    options: &ComplexityOptions,
+) -> Result<serde_json::Value, ProgrammaticError> {
+    fallow_api::compute_complexity_with_runner(options, &CliHealthRunner)
+}
+
+/// Run health analysis through the temporary CLI-backed health bridge.
+///
+/// # Errors
+///
+/// Returns structured programmatic errors from option validation, analysis, or
+/// JSON serialization.
+pub fn compute_health(options: &ComplexityOptions) -> Result<serde_json::Value, ProgrammaticError> {
+    fallow_api::compute_health_with_runner(options, &CliHealthRunner)
+}


### PR DESCRIPTION
## Summary
- add health and complexity wrapper functions to the temporary programmatic CLI bridge
- route NAPI health calls through those bridge functions instead of wiring the API runner trait directly
- keep the CLI-backed health dependency isolated while NAPI dead-code and dupes remain API-owned

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-programmatic-cli -p fallow-node
- cargo test -p fallow-programmatic-cli --lib
- cargo test -p fallow-node compute_complexity --lib
- cargo test -p fallow-node compute_health --lib
- cargo clippy -p fallow-programmatic-cli -p fallow-node --all-targets -- -D warnings