### PR TITLE
refactor: move audit next-step input to output

### DIFF
--- a/crates/cli/src/audit_output.rs
+++ b/crates/cli/src/audit_output.rs
@@ -501,13 +501,15 @@ fn insert_audit_next_steps_json(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     result: &AuditResult,
 ) {
-    let next_steps = crate::report::suggestions::build_audit_next_steps(
+    let input = fallow_output::build_audit_next_steps_input(
         result
             .check
             .as_ref()
             .map(|check| (&check.results, check.config.root.as_path())),
         result.health.as_ref().map(|health| &health.report),
+        crate::report::suggestions::suggestions_enabled(),
     );
+    let next_steps = fallow_output::build_audit_next_steps(&input);
     if !next_steps.is_empty()
         && let Ok(value) = serde_json::to_value(&next_steps)
     {

--- a/crates/cli/src/report/suggestions.rs
+++ b/crates/cli/src/report/suggestions.rs
@@ -2,20 +2,18 @@
 //!
 //! The stable command strings, ordering, caps, and read-only contract live in
 //! `fallow-output`. This module keeps the CLI-specific probes: environment
-//! toggles, project setup state, git refs, changed-branch applicability, and
-//! deterministic finding targets.
+//! toggles, project setup state, git refs, and changed-branch applicability.
 
 use std::path::Path;
 use std::process::Command;
 
 use fallow_core::results::AnalysisResults;
 use fallow_output::{
-    AuditNextStepsInput, CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput,
-    HealthNextStepsInput, ImpactDigestCounts, TraceUnusedExportInput,
-    build_audit_next_steps as build_audit_next_steps_contract,
-    build_combined_next_steps as build_combined_next_steps_contract,
+    CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput, HealthNextStepsInput,
+    ImpactDigestCounts, build_combined_next_steps as build_combined_next_steps_contract,
     build_dead_code_next_steps as build_dead_code_next_steps_contract,
     build_dupes_next_steps as build_dupes_next_steps_contract, impact_digest_summary,
+    trace_unused_export_input,
 };
 use fallow_types::output::NextStep;
 
@@ -42,39 +40,6 @@ fn suggestions_enabled_from(value: Option<&str>) -> bool {
         ),
         None => true,
     }
-}
-
-/// Project-root-relative, forward-slash path for embedding in a command string,
-/// matching the wire form of finding paths.
-fn relative_command_path(path: &Path, root: &Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-// ---------------------------------------------------------------------------
-// Individual triggers. Each returns `Some(step)` only when its evidence exists.
-// ---------------------------------------------------------------------------
-
-fn trace_unused_export_input(
-    results: &AnalysisResults,
-    root: &Path,
-) -> Option<TraceUnusedExportInput> {
-    let target = results
-        .unused_exports
-        .iter()
-        .map(|finding| {
-            (
-                relative_command_path(&finding.export.path, root),
-                finding.export.export_name.clone(),
-            )
-        })
-        .min()?;
-    Some(TraceUnusedExportInput {
-        path: target.0,
-        export_name: target.1,
-    })
 }
 
 /// Shared first-contact gate for the `setup` next-step and the human setup hint
@@ -306,16 +271,16 @@ pub fn build_combined_next_steps(
 /// so the trace anchor is made root-relative the same way every other surface
 /// does it (in-memory finding paths are absolute; the wire form is relative).
 #[must_use]
+#[cfg(test)]
 pub fn build_audit_next_steps(
     check: Option<(&AnalysisResults, &Path)>,
     complexity: Option<&HealthReport>,
 ) -> Vec<NextStep> {
-    build_audit_next_steps_contract(&AuditNextStepsInput {
-        suggestions_enabled: suggestions_enabled(),
-        trace_unused_export: check
-            .and_then(|(results, root)| trace_unused_export_input(results, root)),
-        has_complexity_findings: complexity.is_some_and(|report| !report.findings.is_empty()),
-    })
+    fallow_output::build_audit_next_steps(&fallow_output::build_audit_next_steps_input(
+        check,
+        complexity,
+        suggestions_enabled(),
+    ))
 }
 
 /// The single highest-priority next-step for the human `Next:` line, computed

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -183,8 +183,9 @@ pub use list_envelopes::{
 pub use next_steps::{
     AuditNextStepsInput, CombinedNextStepsInput, DeadCodeNextStepsInput, DupesNextStepsInput,
     HealthNextStepsInput, ImpactDigestCounts, TraceUnusedExportInput, build_audit_next_steps,
-    build_combined_next_steps, build_dead_code_next_steps, build_dupes_next_steps,
-    build_health_next_steps, build_health_next_steps_input, impact_digest_summary,
+    build_audit_next_steps_input, build_combined_next_steps, build_dead_code_next_steps,
+    build_dupes_next_steps, build_health_next_steps, build_health_next_steps_input,
+    impact_digest_summary, trace_unused_export_input,
 };
 pub use report_contract::{
     COVERAGE_ANALYZE_DOCS, COVERAGE_SETUP_DOCS, DUPES_DOCS, HEALTH_DOCS, SECURITY_DOCS,

--- a/crates/output/src/next_steps.rs
+++ b/crates/output/src/next_steps.rs
@@ -251,6 +251,22 @@ pub fn build_audit_next_steps(input: &AuditNextStepsInput) -> Vec<NextStep> {
     steps
 }
 
+/// Build audit next-step inputs from typed analysis payloads plus the
+/// caller-supplied runtime suggestions gate.
+#[must_use]
+pub fn build_audit_next_steps_input(
+    check: Option<(&AnalysisResults, &Path)>,
+    complexity: Option<&HealthReport>,
+    suggestions_enabled: bool,
+) -> AuditNextStepsInput {
+    AuditNextStepsInput {
+        suggestions_enabled,
+        trace_unused_export: check
+            .and_then(|(results, root)| trace_unused_export_input(results, root)),
+        has_complexity_findings: complexity.is_some_and(|report| !report.findings.is_empty()),
+    }
+}
+
 fn relative_command_path(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -258,7 +274,13 @@ fn relative_command_path(path: &Path, root: &Path) -> String {
         .replace('\\', "/")
 }
 
-fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextStep> {
+/// Select the deterministic unused-export target used by read-only trace
+/// next-step commands.
+#[must_use]
+pub fn trace_unused_export_input(
+    results: &AnalysisResults,
+    root: &Path,
+) -> Option<TraceUnusedExportInput> {
     let target = results
         .unused_exports
         .iter()
@@ -269,11 +291,14 @@ fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextSte
             )
         })
         .min()?;
-    Some(next_step(
-        "trace-unused-export",
-        format!("fallow dead-code --trace {}:{}", target.0, target.1),
-        "verify an export is truly unused before deleting",
-    ))
+    Some(TraceUnusedExportInput {
+        path: target.0,
+        export_name: target.1,
+    })
+}
+
+fn trace_unused_export(results: &AnalysisResults, root: &Path) -> Option<NextStep> {
+    trace_unused_export_from_input(trace_unused_export_input(results, root).as_ref())
 }
 
 fn trace_unused_export_from_input(target: Option<&TraceUnusedExportInput>) -> Option<NextStep> {
@@ -508,6 +533,34 @@ mod tests {
         });
 
         assert!(steps.is_empty());
+    }
+
+    #[test]
+    fn audit_input_builder_derives_trace_and_complexity_facts() {
+        let results = AnalysisResults {
+            unused_exports: vec![
+                unused_export("/project/src/b.ts", "beta"),
+                unused_export("/project/src/a.ts", "alpha"),
+            ],
+            ..AnalysisResults::default()
+        };
+        let report = dirty_report();
+
+        let input = build_audit_next_steps_input(
+            Some((&results, Path::new("/project"))),
+            Some(&report),
+            true,
+        );
+
+        assert_eq!(
+            input.trace_unused_export,
+            Some(TraceUnusedExportInput {
+                path: "src/a.ts".to_string(),
+                export_name: "alpha".to_string(),
+            })
+        );
+        assert!(input.has_complexity_findings);
+        assert!(input.suggestions_enabled);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move audit next-step input derivation into fallow-output.
- Keep CLI responsible only for the runtime suggestions gate.
- Route audit JSON next_steps through the output contract directly.

## Verification
- cargo check -p fallow-output -p fallow-cli
- cargo test -p fallow-output next_steps
- cargo test -p fallow-cli report::suggestions
- cargo test -p fallow-cli audit_json
- cargo fmt --all -- --check
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings