### PR TITLE
refactor: route trace chain through engine

### DIFF
--- a/crates/cli/src/bin/schema_emit.rs
+++ b/crates/cli/src/bin/schema_emit.rs
@@ -809,10 +809,10 @@ fn register_per_command_envelope_definitions(generator: &mut schemars::SchemaGen
     let _ = generator.subschema_for::<InspectSectionStatus>();
     let _ = generator.subschema_for::<InspectEvidenceScope>();
     // Symbol-level call chain (`fallow trace`, `FallowOutput::Trace`).
-    let _ = generator.subschema_for::<fallow_core::trace_chain::SymbolChainTrace>();
-    let _ = generator.subschema_for::<fallow_core::trace_chain::ChainHop>();
-    let _ = generator.subschema_for::<fallow_core::trace_chain::UnresolvedCallee>();
-    let _ = generator.subschema_for::<fallow_core::trace_chain::UnresolvedReason>();
+    let _ = generator.subschema_for::<fallow_engine::trace_chain::SymbolChainTrace>();
+    let _ = generator.subschema_for::<fallow_engine::trace_chain::ChainHop>();
+    let _ = generator.subschema_for::<fallow_engine::trace_chain::UnresolvedCallee>();
+    let _ = generator.subschema_for::<fallow_engine::trace_chain::UnresolvedReason>();
     let _ = generator.subschema_for::<CodeClimateOutput>();
     let _ = generator.subschema_for::<CodeClimateIssue>();
     let _ = generator.subschema_for::<CodeClimateIssueKind>();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3879,7 +3879,7 @@ fn dispatch_trace_command(
         target: symbol,
         callers,
         callees,
-        depth: depth.unwrap_or(fallow_core::trace_chain::DEFAULT_TRACE_DEPTH),
+        depth: depth.unwrap_or(fallow_engine::trace_chain::DEFAULT_TRACE_DEPTH),
     })
 }
 

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -151,7 +151,7 @@ pub type FallowOutput = fallow_output::FallowOutput<
     AuditOutput,
     ExplainOutput,
     InspectOutput,
-    fallow_core::trace_chain::SymbolChainTrace,
+    fallow_engine::trace_chain::SymbolChainTrace,
     ReviewEnvelopeOutput,
     ReviewReconcileOutput,
     CoverageSetupOutput,

--- a/crates/cli/src/trace_chain.rs
+++ b/crates/cli/src/trace_chain.rs
@@ -11,9 +11,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use fallow_config::{OutputFormat, ProductionAnalysis};
-use fallow_core::trace_chain::{
-    SymbolChainQuery, SymbolChainTrace, TraceDirections, trace_symbol_chain,
-};
+use fallow_engine::trace_chain::{SymbolChainQuery, SymbolChainTrace, TraceDirections};
 
 use crate::error::emit_error;
 use crate::output_envelope::{FallowOutput, serialize_root_output};
@@ -40,10 +38,6 @@ pub struct TraceChainOptions<'a> {
 }
 
 /// Run the symbol-level call-chain trace and emit its own output surface.
-#[expect(
-    deprecated,
-    reason = "ADR-008 deprecates fallow_core::analyze APIs externally; the CLI uses the workspace path dependency"
-)]
 pub fn run_trace(opts: &TraceChainOptions<'_>) -> ExitCode {
     let Some((file, symbol)) = parse_target(&opts.target) else {
         return emit_error(
@@ -83,33 +77,24 @@ pub fn run_trace(opts: &TraceChainOptions<'_>) -> ExitCode {
         Err(code) => return code,
     };
 
-    // Retain BOTH the graph (for the import-symbol edge walk) and the parsed
-    // modules (for honest unresolved-callee reporting).
-    let output = match fallow_core::analyze_retaining_modules(&config, true, true) {
-        Ok(output) => output,
-        Err(err) => return emit_error(&format!("Analysis error: {err}"), 2, opts.output),
-    };
-    let Some(graph) = output.graph.as_ref() else {
-        return emit_error("trace requires a retained module graph", 2, opts.output);
-    };
-    let modules = output.modules.as_deref().unwrap_or(&[]);
-
-    let Some(trace) = trace_symbol_chain(
-        graph,
-        modules,
-        &config.root,
+    let trace = match fallow_engine::trace_symbol_chain(
+        &config,
         SymbolChainQuery {
             file: &file,
             symbol: &symbol,
             depth: opts.depth,
             directions,
         },
-    ) else {
-        return emit_error(
-            &format!("file '{file}' not found in module graph"),
-            2,
-            opts.output,
-        );
+    ) {
+        Ok(Some(trace)) => trace,
+        Ok(None) => {
+            return emit_error(
+                &format!("file '{file}' not found in module graph"),
+                2,
+                opts.output,
+            );
+        }
+        Err(err) => return emit_error(&format!("Analysis error: {err}"), 2, opts.output),
     };
 
     emit_trace(trace, opts)

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -62,8 +62,8 @@ pub mod security {
 /// Symbol trace types exposed through the engine boundary.
 pub mod trace_chain {
     pub use fallow_core::trace_chain::{
-        ChainHop, SymbolChainQuery, SymbolChainTrace, TraceDirections, UnresolvedCallee,
-        UnresolvedReason,
+        ChainHop, DEFAULT_TRACE_DEPTH, SymbolChainQuery, SymbolChainTrace, TraceDirections,
+        UnresolvedCallee, UnresolvedReason,
     };
 }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -59,6 +59,14 @@ pub mod security {
     pub use fallow_core::analyze::security_catalogue_title;
 }
 
+/// Symbol trace types exposed through the engine boundary.
+pub mod trace_chain {
+    pub use fallow_core::trace_chain::{
+        ChainHop, SymbolChainQuery, SymbolChainTrace, TraceDirections, UnresolvedCallee,
+        UnresolvedReason,
+    };
+}
+
 pub use fallow_core::duplicates::{
     CloneFamily, CloneGroup, CloneInstance, DefaultIgnoreSkips, DuplicationReport,
     DuplicationStats, MirroredDirectory, RefactoringSuggestion,
@@ -502,6 +510,35 @@ pub fn changed_files(
     fallow_core::changed_files::try_get_changed_files(root, git_ref)
 }
 
+/// Run symbol-level call-chain tracing through the engine boundary.
+///
+/// # Errors
+///
+/// Returns an error if parsing, graph construction, or retained module
+/// analysis fails.
+pub fn trace_symbol_chain(
+    config: &ResolvedConfig,
+    query: trace_chain::SymbolChainQuery<'_>,
+) -> EngineResult<Option<trace_chain::SymbolChainTrace>> {
+    #[expect(
+        deprecated,
+        reason = "fallow-engine is the typed migration boundary over the internal core backend"
+    )]
+    let output =
+        fallow_core::analyze_retaining_modules(config, true, true).map_err(engine_error)?;
+    let graph = output
+        .graph
+        .as_ref()
+        .ok_or_else(|| EngineError::new("trace requires a retained module graph"))?;
+    let modules = output.modules.as_deref().unwrap_or(&[]);
+    Ok(fallow_core::trace_chain::trace_symbol_chain(
+        graph,
+        modules,
+        &config.root,
+        query,
+    ))
+}
+
 /// Run duplication detection and include metadata about built-in ignored files.
 #[must_use]
 pub fn find_duplicates_with_defaults(
@@ -654,5 +691,58 @@ mod tests {
 
         assert!(!analysis.report.clone_groups.is_empty());
         assert!(analysis.default_ignore_skips.total > 0);
+    }
+
+    #[test]
+    fn trace_symbol_chain_uses_retained_engine_analysis() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let src = temp.path().join("src");
+        std::fs::create_dir(&src).expect("src dir");
+        std::fs::write(
+            src.join("util.ts"),
+            "export function helper() { return 1; }\n",
+        )
+        .expect("util source");
+        std::fs::write(
+            src.join("index.ts"),
+            "import { helper } from './util';\nexport const value = helper();\n",
+        )
+        .expect("index source");
+
+        let project_config = config_for_project_analysis(
+            temp.path(),
+            None,
+            ProjectConfigOptions {
+                output: OutputFormat::Json,
+                no_cache: true,
+                threads: 1,
+                production_override: None,
+                quiet: true,
+                analysis: ProductionAnalysis::DeadCode,
+            },
+        )
+        .expect("project config loads");
+        let trace = trace_symbol_chain(
+            &project_config.config,
+            trace_chain::SymbolChainQuery {
+                file: "src/util.ts",
+                symbol: "helper",
+                depth: 1,
+                directions: trace_chain::TraceDirections {
+                    callers: true,
+                    callees: false,
+                },
+            },
+        )
+        .expect("trace succeeds")
+        .expect("trace target exists");
+
+        assert!(trace.symbol_found);
+        assert_eq!(trace.file, Path::new("src/util.ts"));
+        assert!(trace.callers.is_some_and(|callers| {
+            callers
+                .iter()
+                .any(|caller| caller.file == Path::new("src/index.ts"))
+        }));
     }
 }


### PR DESCRIPTION
## Summary
- Add a typed engine facade for symbol trace-chain analysis.
- Route the CLI trace command through fallow-engine instead of calling fallow-core directly.
- Keep trace output rendering in the CLI surface.

## Verification
- cargo check -p fallow-engine -p fallow-cli
- cargo test -p fallow-engine trace_symbol_chain_uses_retained_engine_analysis --lib
- cargo test -p fallow-cli trace_chain
- cargo fmt --all -- --check
- cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings
- CLI smoke: fallow trace src/util.ts:helper --callers --format json