### PR TITLE
refactor: expose check trace helpers through engine

### DIFF
--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -318,7 +318,7 @@ pub struct CheckResult {
     pub baseline_deltas: Option<crate::baseline::BaselineDeltas>,
     /// When a baseline was loaded: (total entries in baseline, entries that matched current issues).
     pub baseline_matched: Option<(usize, usize)>,
-    pub timings: Option<fallow_core::trace::PipelineTimings>,
+    pub timings: Option<fallow_engine::trace::PipelineTimings>,
     /// Retained parse data for sharing with health (only populated when retain_modules_for_health=true).
     pub shared_parse: Option<fallow_engine::HealthSharedParseData>,
     /// Impact closure for the review brief: the transitive
@@ -363,8 +363,8 @@ pub struct CheckResult {
 
 struct CheckAnalysisData {
     results: AnalysisResults,
-    trace_graph: Option<fallow_core::graph::ModuleGraph>,
-    trace_timings: Option<fallow_core::trace::PipelineTimings>,
+    trace_graph: Option<fallow_engine::graph::ModuleGraph>,
+    trace_timings: Option<fallow_engine::trace::PipelineTimings>,
     retained_modules: Option<Vec<fallow_core::extract::ModuleInfo>>,
     retained_files: Option<Vec<fallow_core::discover::DiscoveredFile>>,
     script_used_packages: rustc_hash::FxHashSet<String>,
@@ -441,8 +441,8 @@ fn prepare_check_config(opts: &CheckOptions<'_>) -> Result<ResolvedConfig, ExitC
 fn handle_trace_side_effects(
     opts: &CheckOptions<'_>,
     config: &ResolvedConfig,
-    trace_graph: Option<&fallow_core::graph::ModuleGraph>,
-    trace_timings: Option<&fallow_core::trace::PipelineTimings>,
+    trace_graph: Option<&fallow_engine::graph::ModuleGraph>,
+    trace_timings: Option<&fallow_engine::trace::PipelineTimings>,
     script_used_packages: &rustc_hash::FxHashSet<String>,
 ) -> Result<(), ExitCode> {
     if let Some(timings) = trace_timings
@@ -586,7 +586,7 @@ fn regression_config_path(opts: &CheckOptions<'_>) -> std::path::PathBuf {
 
 fn build_shared_parse_data(
     results: &AnalysisResults,
-    trace_graph: Option<fallow_core::graph::ModuleGraph>,
+    trace_graph: Option<fallow_engine::graph::ModuleGraph>,
     retained_modules: Option<Vec<fallow_core::extract::ModuleInfo>>,
     retained_files: Option<Vec<fallow_core::discover::DiscoveredFile>>,
     script_used_packages: &rustc_hash::FxHashSet<String>,

--- a/crates/cli/src/check/output.rs
+++ b/crates/cli/src/check/output.rs
@@ -2,7 +2,7 @@ use std::io::{BufWriter, Write};
 use std::process::ExitCode;
 
 use fallow_config::{OutputFormat, ResolvedConfig};
-use fallow_core::graph::ModuleGraph;
+use fallow_engine::graph::ModuleGraph;
 use rustc_hash::FxHashSet;
 
 use super::TraceOptions;
@@ -24,7 +24,7 @@ pub(super) fn handle_trace_output(
                 output,
             ));
         };
-        match fallow_core::trace::trace_export(graph, root, file_path, export_name) {
+        match fallow_engine::trace::trace_export(graph, root, file_path, export_name) {
             Some(trace) => {
                 report::print_export_trace(&trace, output);
                 return Some(ExitCode::SUCCESS);
@@ -40,7 +40,7 @@ pub(super) fn handle_trace_output(
     }
 
     if let Some(ref file_path) = trace_opts.trace_file {
-        match fallow_core::trace::trace_file(graph, root, file_path) {
+        match fallow_engine::trace::trace_file(graph, root, file_path) {
             Some(trace) => {
                 report::print_file_trace(&trace, output);
                 return Some(ExitCode::SUCCESS);
@@ -57,13 +57,13 @@ pub(super) fn handle_trace_output(
 
     if let Some(ref pkg_name) = trace_opts.trace_dependency {
         let trace =
-            fallow_core::trace::trace_dependency(graph, root, pkg_name, script_used_packages);
+            fallow_engine::trace::trace_dependency(graph, root, pkg_name, script_used_packages);
         report::print_dependency_trace(&trace, output);
         return Some(ExitCode::SUCCESS);
     }
 
     if let Some(ref file_path) = trace_opts.impact_closure {
-        match fallow_core::trace::trace_impact_closure(graph, root, file_path) {
+        match fallow_engine::trace::trace_impact_closure(graph, root, file_path) {
             Some(trace) => {
                 report::print_impact_closure_trace(&trace, output);
                 return Some(ExitCode::SUCCESS);

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -107,22 +107,23 @@ fn run_clone_trace(
     trace_spec: &str,
     output: OutputFormat,
 ) -> ExitCode {
-    let (trace_result, not_found) =
-        if let Some(fp) = trace_spec.strip_prefix(fallow_core::duplicates::FINGERPRINT_PREFIX) {
-            let fingerprint = format!("{}{fp}", fallow_core::duplicates::FINGERPRINT_PREFIX);
-            let result = fallow_core::trace::trace_clone_by_fingerprint(report, root, &fingerprint);
-            (
-                result,
-                format!("no clone group with fingerprint {fingerprint}"),
-            )
-        } else {
-            let (file_path, line) = match parse_trace_spec(trace_spec) {
-                Ok(parsed) => parsed,
-                Err(msg) => return emit_error(msg, 2, output),
-            };
-            let result = fallow_core::trace::trace_clone(report, root, file_path, line);
-            (result, format!("no clone found at {file_path}:{line}"))
+    let (trace_result, not_found) = if let Some(fp) =
+        trace_spec.strip_prefix(fallow_core::duplicates::FINGERPRINT_PREFIX)
+    {
+        let fingerprint = format!("{}{fp}", fallow_core::duplicates::FINGERPRINT_PREFIX);
+        let result = fallow_engine::trace::trace_clone_by_fingerprint(report, root, &fingerprint);
+        (
+            result,
+            format!("no clone group with fingerprint {fingerprint}"),
+        )
+    } else {
+        let (file_path, line) = match parse_trace_spec(trace_spec) {
+            Ok(parsed) => parsed,
+            Err(msg) => return emit_error(msg, 2, output),
         };
+        let result = fallow_engine::trace::trace_clone(report, root, file_path, line);
+        (result, format!("no clone found at {file_path}:{line}"))
+    };
     if trace_result.matched_instance.is_none() {
         return emit_error(&not_found, 2, output);
     }

--- a/crates/cli/src/report/human/perf.rs
+++ b/crates/cli/src/report/human/perf.rs
@@ -1,5 +1,5 @@
 use colored::Colorize;
-use fallow_core::trace::PipelineTimings;
+use fallow_engine::trace::PipelineTimings;
 
 /// Stages below this wall-clock time are too cheap to annotate as parallel;
 /// the multiplier would be noise.

--- a/crates/cli/src/report/human/traces.rs
+++ b/crates/cli/src/report/human/traces.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use colored::Colorize;
-use fallow_core::trace::{CloneTrace, DependencyTrace, ExportTrace, FileTrace};
+use fallow_engine::trace::{CloneTrace, DependencyTrace, ExportTrace, FileTrace};
 
 use super::{plural, relative_path};
 
@@ -272,7 +272,7 @@ fn build_clone_trace_human_lines(trace: &CloneTrace, root: &Path) -> Vec<String>
 fn push_clone_group_lines(
     lines: &mut Vec<String>,
     index: usize,
-    group: &fallow_core::trace::TracedCloneGroup,
+    group: &fallow_engine::trace::TracedCloneGroup,
     trace: &CloneTrace,
     root: &Path,
 ) {
@@ -326,7 +326,7 @@ mod tests {
     use std::path::PathBuf;
 
     use fallow_core::duplicates::{CloneInstance, RefactoringKind, RefactoringSuggestion};
-    use fallow_core::trace::{
+    use fallow_engine::trace::{
         CloneTrace, DependencyTrace, ExportReference, ExportTrace, FileTrace, ReExportChain,
         TracedCloneGroup, TracedExport, TracedReExport,
     };

--- a/crates/cli/src/report/mod.rs
+++ b/crates/cli/src/report/mod.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use fallow_config::{OutputFormat, RulesConfig, Severity};
 use fallow_core::duplicates::DuplicationReport;
 use fallow_core::results::AnalysisResults;
-use fallow_core::trace::{CloneTrace, DependencyTrace, ExportTrace, FileTrace, PipelineTimings};
+use fallow_engine::trace::{CloneTrace, DependencyTrace, ExportTrace, FileTrace, PipelineTimings};
 
 use crate::report::sink::outln;
 
@@ -622,7 +622,7 @@ pub fn print_clone_trace(trace: &CloneTrace, root: &Path, format: OutputFormat) 
 /// Print impact-closure trace results. JSON only emits the structured
 /// closure; human renders a short summary.
 pub fn print_impact_closure_trace(
-    trace: &fallow_core::trace::ImpactClosureTrace,
+    trace: &fallow_engine::trace::ImpactClosureTrace,
     format: OutputFormat,
 ) {
     match format {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -35,6 +35,11 @@ pub mod extract {
     pub use fallow_types::extract::*;
 }
 
+/// Module graph types exposed through the engine boundary.
+pub mod graph {
+    pub use fallow_core::graph::*;
+}
+
 /// Analysis result types exposed through the engine boundary.
 pub mod results {
     pub use fallow_core::results::*;
@@ -64,6 +69,16 @@ pub mod trace_chain {
     pub use fallow_core::trace_chain::{
         ChainHop, DEFAULT_TRACE_DEPTH, SymbolChainQuery, SymbolChainTrace, TraceDirections,
         UnresolvedCallee, UnresolvedReason,
+    };
+}
+
+/// Read-only trace helpers exposed through the engine boundary.
+pub mod trace {
+    pub use fallow_core::trace::{
+        CloneTrace, DependencyTrace, ExportReference, ExportTrace, FileTrace, ImpactClosureGap,
+        ImpactClosureTrace, PipelineTimings, ReExportChain, TracedCloneGroup, TracedExport,
+        TracedReExport, trace_clone, trace_clone_by_fingerprint, trace_dependency, trace_export,
+        trace_file, trace_impact_closure,
     };
 }
 


### PR DESCRIPTION
## Summary
- Add engine facade modules for graph and read-only trace helper contracts.
- Route dead-code trace, clone trace, and trace report rendering types through fallow-engine.
- Keep CLI output rendering behavior unchanged while reducing direct core coupling.

## Verification
- cargo check -p fallow-engine -p fallow-cli
- cargo test -p fallow-cli check::output
- cargo test -p fallow-cli report::human::traces
- cargo test -p fallow-engine --lib trace_symbol_chain_uses_retained_engine_analysis
- cargo fmt --all -- --check
- cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings
- CLI smoke: dead-code --trace src/util.ts:used --format json
- CLI smoke: dupes --trace src/a.ts:1 --format json