### PR TITLE
refactor: route git env helpers through engine

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -4,7 +4,7 @@ use std::process::{Command, ExitCode};
 use std::time::{Duration, Instant};
 
 use fallow_config::{AuditGate, OutputFormat};
-use fallow_core::git_env::clear_ambient_git_env;
+use fallow_engine::git_env::clear_ambient_git_env;
 use rustc_hash::{FxHashMap, FxHashSet};
 use xxhash_rust::xxh3::xxh3_64;
 
@@ -659,7 +659,7 @@ fn save_cached_base_snapshot(
 /// surface the most likely culprit so a user hitting an unexpected worktree
 /// failure can short-circuit the diagnosis. Returns `None` otherwise.
 fn ambient_git_env_hint() -> Option<String> {
-    use fallow_core::git_env::AMBIENT_GIT_ENV_VARS;
+    use fallow_engine::git_env::AMBIENT_GIT_ENV_VARS;
     for var in AMBIENT_GIT_ENV_VARS {
         if let Ok(value) = std::env::var(var)
             && !value.is_empty()

--- a/crates/cli/src/base_worktree.rs
+++ b/crates/cli/src/base_worktree.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
-use fallow_core::git_env::clear_ambient_git_env;
+use fallow_engine::git_env::clear_ambient_git_env;
 use xxhash_rust::xxh3::xxh3_64;
 
 use crate::report::plural;

--- a/crates/cli/src/combined/impact.rs
+++ b/crates/cli/src/combined/impact.rs
@@ -2,6 +2,8 @@ use crate::check::CheckResult;
 use crate::dupes::DupesResult;
 use crate::health::HealthResult;
 
+use fallow_engine::git_env::clear_ambient_git_env;
+
 use super::CombinedOptions;
 
 pub(super) fn record_combined_cache_state(
@@ -52,7 +54,7 @@ fn combined_git_sha(root: &std::path::Path) -> Option<String> {
     command
         .args(["rev-parse", "--short", "HEAD"])
         .current_dir(root);
-    fallow_core::git_env::clear_ambient_git_env(&mut command);
+    clear_ambient_git_env(&mut command);
     command
         .output()
         .ok()

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -6,8 +6,8 @@ use std::process::{Command, ExitCode};
 use std::time::Instant;
 
 use fallow_config::OutputFormat;
-use fallow_core::git_env::clear_ambient_git_env;
 use fallow_cov_protocol::function_identity_id;
+use fallow_engine::git_env::clear_ambient_git_env;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::coverage::RunContext;

--- a/crates/cli/src/coverage/mod.rs
+++ b/crates/cli/src/coverage/mod.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 use fallow_config::{OutputFormat, PackageJson, WorkspaceInfo, atomic_write, discover_workspaces};
-use fallow_core::git_env::clear_ambient_git_env;
+use fallow_engine::git_env::clear_ambient_git_env;
 use fallow_license::{DEFAULT_HARD_FAIL_DAYS, LicenseStatus};
 use fallow_types::serde_path;
 use serde::{Deserialize, Serialize};

--- a/crates/cli/src/coverage/upload_common.rs
+++ b/crates/cli/src/coverage/upload_common.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 use fallow_config::{FallowConfig, OutputFormat, ResolvedConfig};
-use fallow_core::git_env::clear_ambient_git_env;
+use fallow_engine::git_env::clear_ambient_git_env;
 
 pub(super) const GIT_SHA_MAX_LEN: usize = 64;
 

--- a/crates/cli/src/coverage/upload_source_maps.rs
+++ b/crates/cli/src/coverage/upload_source_maps.rs
@@ -10,7 +10,7 @@ use std::process::{Command, ExitCode};
 use std::time::SystemTime;
 
 use colored::Colorize as _;
-use fallow_core::git_env::clear_ambient_git_env;
+use fallow_engine::git_env::clear_ambient_git_env;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use fallow_config::{ExternalPluginDef, FallowConfig, PackageJson};
-use fallow_core::git_env::clear_ambient_git_env;
+use fallow_engine::git_env::clear_ambient_git_env;
 
 use crate::validate;
 

--- a/crates/cli/src/regression/baseline.rs
+++ b/crates/cli/src/regression/baseline.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use fallow_config::OutputFormat;
-use fallow_core::git_env::clear_ambient_git_env;
 use fallow_core::results::AnalysisResults;
+use fallow_engine::git_env::clear_ambient_git_env;
 
 use super::counts::{CheckCounts, DupesCounts, REGRESSION_SCHEMA_VERSION, RegressionBaseline};
 use super::outcome::RegressionOutcome;

--- a/crates/cli/src/vital_signs.rs
+++ b/crates/cli/src/vital_signs.rs
@@ -6,6 +6,8 @@
 
 use std::path::{Path, PathBuf};
 
+use fallow_engine::git_env::clear_ambient_git_env;
+
 /// Number of seconds in one day.
 const SECS_PER_DAY: u64 = 86_400;
 
@@ -602,7 +604,7 @@ fn git_sha(root: &Path) -> Option<String> {
     command
         .args(["rev-parse", "--short", "HEAD"])
         .current_dir(root);
-    fallow_core::git_env::clear_ambient_git_env(&mut command);
+    clear_ambient_git_env(&mut command);
     command
         .output()
         .ok()
@@ -616,7 +618,7 @@ fn git_branch(root: &Path) -> Option<String> {
     command
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(root);
-    fallow_core::git_env::clear_ambient_git_env(&mut command);
+    clear_ambient_git_env(&mut command);
     command
         .output()
         .ok()

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -40,6 +40,11 @@ pub mod graph {
     pub use fallow_core::graph::*;
 }
 
+/// Git process environment helpers exposed through the engine boundary.
+pub mod git_env {
+    pub use fallow_core::git_env::{AMBIENT_GIT_ENV_VARS, clear_ambient_git_env};
+}
+
 /// Analysis result types exposed through the engine boundary.
 pub mod results {
     pub use fallow_core::results::*;


### PR DESCRIPTION
## Summary
- expose git environment cleanup helpers through `fallow-engine`
- route CLI git subprocess cleanup callsites through the engine facade
- remove the remaining direct `fallow_core::git_env` use from API/LSP/NAPI/MCP/programmatic/CLI surfaces

## Verification
- `cargo check -p fallow-engine -p fallow-cli`
- `cargo fmt --all -- --check`
- `cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings`
- `cargo test -p fallow-cli audit`
- `cargo test -p fallow-cli --test coverage_analyze_tests`
- `cargo test -p fallow-cli regression`
- pre-commit hook
- pre-push guard
