### PR TITLE
refactor: route git ref validation through engine

### DIFF
--- a/crates/cli/src/validate.rs
+++ b/crates/cli/src/validate.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 pub fn validate_git_ref(s: &str) -> Result<&str, String> {
-    fallow_core::changed_files::validate_git_ref(s)
+    fallow_engine::changed_files::validate_git_ref(s)
 }
 
 pub fn validate_root(root: &std::path::Path) -> Result<PathBuf, String> {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -60,7 +60,7 @@ pub mod suppress {
 pub mod changed_files {
     pub use fallow_core::changed_files::{
         ChangedFilesError, filter_duplication_by_changed_files, filter_results_by_changed_files,
-        resolve_git_toplevel, try_get_changed_files_with_toplevel,
+        resolve_git_toplevel, try_get_changed_files_with_toplevel, validate_git_ref,
     };
 }
 


### PR DESCRIPTION
## Summary
- expose git ref validation through `fallow-engine::changed_files`
- route the CLI validation wrapper through the engine facade instead of core

## Verification
- `cargo check -p fallow-engine -p fallow-cli`
- `cargo test -p fallow-cli validate`
- `cargo fmt --all -- --check`
- `cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push guard
