### PR TITLE
refactor: route audit brief graph types through engine

### DIFF
--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -122,7 +122,7 @@ pub fn build_triage(result: &AuditResult) -> DiffTriage {
 #[must_use]
 pub fn derive_graph_facts(
     results: &AnalysisResults,
-    closure: Option<&fallow_core::graph::ImpactClosurePaths>,
+    closure: Option<&fallow_engine::graph::ImpactClosurePaths>,
 ) -> GraphFacts {
     let mut zones: FxHashSet<String> = FxHashSet::default();
     for finding in &results.boundary_violations {
@@ -997,7 +997,7 @@ mod tests {
 
     #[test]
     fn derive_graph_facts_populates_reachable_from_from_closure() {
-        use fallow_core::graph::{CoordinationGapPaths, ImpactClosurePaths};
+        use fallow_engine::graph::{CoordinationGapPaths, ImpactClosurePaths};
         let results = AnalysisResults::default();
         let closure = ImpactClosurePaths {
             in_diff: vec!["src/core.ts".to_string()],


### PR DESCRIPTION
## Summary
- route audit brief graph fact inputs through `fallow-engine::graph`
- remove direct core graph type references from the audit brief surface

## Verification
- `cargo check -p fallow-engine -p fallow-cli`
- `cargo test -p fallow-cli audit_brief`
- `cargo fmt --all -- --check`
- `cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push guard
