### PR TITLE
refactor: route changed-file helpers through engine

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1881,7 +1881,7 @@ fn compute_change_anchors(
     if let Some(raw) = crate::report::ci::diff_filter::shared_diff_raw() {
         return crate::audit_walkthrough::parse_change_anchors(raw);
     }
-    fallow_core::changed_files::try_get_changed_diff(root, base_ref)
+    fallow_engine::changed_files::try_get_changed_diff(root, base_ref)
         .map(|diff| crate::audit_walkthrough::parse_change_anchors(&diff))
         .unwrap_or_default()
 }
@@ -2006,7 +2006,7 @@ fn compute_decision_surface(
 /// the blast and the union of consumed symbols as the contract. Sorted by changed
 /// file for deterministic output.
 fn aggregate_coordination_gaps(
-    gaps: &[fallow_core::graph::CoordinationGapPaths],
+    gaps: &[fallow_engine::graph::CoordinationGapPaths],
 ) -> Vec<crate::audit_decision_surface::CoordinationAnchor> {
     use crate::audit_decision_surface::CoordinationAnchor;
     let mut by_file: FxHashMap<String, (u64, FxHashSet<String>)> = FxHashMap::default();

--- a/crates/cli/src/impact.rs
+++ b/crates/cli/src/impact.rs
@@ -280,11 +280,11 @@ fn project_identity(root: &Path) -> ProjectIdentity {
         return found.clone();
     }
     let common = resolve_or_root(
-        fallow_core::changed_files::resolve_git_common_dir(root).ok(),
+        fallow_engine::changed_files::resolve_git_common_dir(root).ok(),
         root,
     );
     let toplevel = resolve_or_root(
-        fallow_core::changed_files::resolve_git_toplevel(root).ok(),
+        fallow_engine::changed_files::resolve_git_toplevel(root).ok(),
         root,
     );
     let identity = (

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -648,9 +648,9 @@ fn security_output_config(
 
 fn apply_changed_scope(opts: &SecurityOptions<'_>, results: &mut AnalysisResults) {
     if let Some(git_ref) = opts.changed_since
-        && let Some(changed) = fallow_core::changed_files::get_changed_files(opts.root, git_ref)
+        && let Some(changed) = fallow_engine::changed_files::get_changed_files(opts.root, git_ref)
     {
-        fallow_core::changed_files::filter_results_by_changed_files(results, &changed);
+        fallow_engine::changed_files::filter_results_by_changed_files(results, &changed);
     }
     if opts.use_shared_diff_index
         && let Some(diff_index) = crate::report::ci::diff_filter::shared_diff_index()
@@ -704,7 +704,7 @@ fn apply_security_gate(
         if let Some(shared) = crate::report::ci::diff_filter::shared_diff_index() {
             shared
         } else if let Some(git_ref) = opts.changed_since {
-            match fallow_core::changed_files::try_get_changed_diff(opts.root, git_ref) {
+            match fallow_engine::changed_files::try_get_changed_diff(opts.root, git_ref) {
                 Ok(text) => owned_gate_diff
                     .insert(crate::report::ci::diff_filter::DiffIndex::from_unified_diff(&text)),
                 Err(err) => {
@@ -1553,7 +1553,7 @@ fn filter_to_files(
     }
 
     let file_set: rustc_hash::FxHashSet<PathBuf> = resolved_files.into_iter().collect();
-    fallow_core::changed_files::filter_results_by_changed_files(results, &file_set);
+    fallow_engine::changed_files::filter_results_by_changed_files(results, &file_set);
 }
 
 fn prepare_findings(

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -60,7 +60,8 @@ pub mod suppress {
 pub mod changed_files {
     pub use fallow_core::changed_files::{
         ChangedFilesError, filter_duplication_by_changed_files, filter_results_by_changed_files,
-        resolve_git_toplevel, try_get_changed_files_with_toplevel, validate_git_ref,
+        get_changed_files, resolve_git_common_dir, resolve_git_toplevel, try_get_changed_diff,
+        try_get_changed_files_with_toplevel, validate_git_ref,
     };
 }
 


### PR DESCRIPTION
## Summary
- expose the remaining changed-file helpers through `fallow-engine::changed_files`
- route audit, security, and impact changed-file callsites through the engine facade
- keep graph coordination gap typing on the engine graph facade

## Verification
- `cargo check -p fallow-engine -p fallow-cli`
- `cargo test -p fallow-cli security`
- `cargo test -p fallow-cli impact`
- `cargo test -p fallow-cli audit`
- `cargo fmt --all -- --check`
- `cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push guard
