### PR TITLE
refactor: route audit graph types through engine

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1401,7 +1401,7 @@ fn compute_brief_impact_closure(
     root: &std::path::Path,
     check: &CheckResult,
     changed_files: &FxHashSet<PathBuf>,
-) -> Option<fallow_core::graph::ImpactClosurePaths> {
+) -> Option<fallow_engine::graph::ImpactClosurePaths> {
     let graph = check
         .shared_parse
         .as_ref()
@@ -1444,7 +1444,7 @@ fn compute_brief_partition_order(
     root: &std::path::Path,
     check: &CheckResult,
     changed_files: &FxHashSet<PathBuf>,
-) -> Option<fallow_core::graph::PartitionOrderPaths> {
+) -> Option<fallow_engine::graph::PartitionOrderPaths> {
     let graph = check
         .shared_parse
         .as_ref()
@@ -1579,7 +1579,7 @@ fn compute_brief_focus_facts(
     root: &std::path::Path,
     check: &CheckResult,
     changed_files: &FxHashSet<PathBuf>,
-) -> Option<Vec<fallow_core::graph::FocusFileFactsPaths>> {
+) -> Option<Vec<fallow_engine::graph::FocusFileFactsPaths>> {
     let graph = check
         .shared_parse
         .as_ref()

--- a/crates/cli/src/audit_focus.rs
+++ b/crates/cli/src/audit_focus.rs
@@ -33,7 +33,7 @@
 //! components are summed. No runtime field, no runtime read, no runtime gate here:
 //! free mode is the complete surface.
 
-use fallow_core::graph::FocusFileFactsPaths;
+use fallow_engine::graph::FocusFileFactsPaths;
 pub use fallow_output::{ConfidenceFlag, FocusLabel, FocusMap, FocusScore, FocusUnit};
 
 /// A unit's score at or above this threshold is labeled [`FocusLabel::ReviewHere`];


### PR DESCRIPTION
## Summary
- route audit review graph return types through `fallow-engine::graph`
- route audit focus map input typing through the engine graph facade

## Verification
- `cargo check -p fallow-engine -p fallow-cli`
- `cargo test -p fallow-cli audit_focus`
- `cargo test -p fallow-cli audit`
- `cargo fmt --all -- --check`
- `cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push guard
