### PR TITLE
refactor: route duplicate report types through engine

### DIFF
--- a/crates/cli/src/bin/schema_emit.rs
+++ b/crates/cli/src/bin/schema_emit.rs
@@ -74,7 +74,7 @@ use fallow_cli::security::{
     SecurityUnresolvedCalleeTopFile, SecurityVerifierVerdict, SecurityVerifierVerdictStatus,
 };
 use fallow_config::{AuthoredRule, LogicalGroup, LogicalGroupStatus};
-use fallow_core::duplicates::{
+use fallow_engine::duplicates::{
     CloneFamily, CloneGroup, CloneInstance, DuplicationReport, DuplicationStats, MirroredDirectory,
     RefactoringKind, RefactoringSuggestion,
 };

--- a/crates/cli/src/report/dupes_grouping.rs
+++ b/crates/cli/src/report/dupes_grouping.rs
@@ -14,7 +14,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use fallow_core::duplicates::{
+use fallow_engine::duplicates::{
     CloneFingerprintSet, CloneGroup, CloneInstance, DuplicationReport, DuplicationStats,
 };
 use rustc_hash::FxHashSet;
@@ -290,7 +290,7 @@ fn sort_duplication_groups(groups: &mut [DuplicationGroup]) {
 mod tests {
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{CloneInstance, DuplicationStats};
+    use fallow_engine::duplicates::{CloneInstance, DuplicationStats};
 
     use super::*;
     use crate::codeowners::CodeOwners;

--- a/crates/cli/src/report/human/traces.rs
+++ b/crates/cli/src/report/human/traces.rs
@@ -325,7 +325,7 @@ fn push_clone_group_lines(
 mod tests {
     use std::path::PathBuf;
 
-    use fallow_core::duplicates::{CloneInstance, RefactoringKind, RefactoringSuggestion};
+    use fallow_engine::duplicates::{CloneInstance, RefactoringKind, RefactoringSuggestion};
     use fallow_engine::trace::{
         CloneTrace, DependencyTrace, ExportReference, ExportTrace, FileTrace, ReExportChain,
         TracedCloneGroup, TracedExport, TracedReExport,


### PR DESCRIPTION
## Summary
- route duplicate report and schema-emission types through `fallow-engine::duplicates`
- remove direct core duplicate type imports from grouping and human trace report surfaces

## Verification
- `cargo check -p fallow-engine -p fallow-cli`
- `cargo test -p fallow-cli dupes_grouping`
- `cargo test -p fallow-cli report::human::traces`
- `cargo fmt --all -- --check`
- `cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push guard
