### PR TITLE
refactor: route regression results through engine

### DIFF
--- a/crates/cli/src/regression/baseline.rs
+++ b/crates/cli/src/regression/baseline.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use fallow_config::OutputFormat;
-use fallow_core::results::AnalysisResults;
 use fallow_engine::git_env::clear_ambient_git_env;
+use fallow_engine::results::AnalysisResults;
 
 use super::counts::{CheckCounts, DupesCounts, REGRESSION_SCHEMA_VERSION, RegressionBaseline};
 use super::outcome::RegressionOutcome;
@@ -597,7 +597,7 @@ fn chrono_now() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fallow_core::results::*;
+    use fallow_engine::results::*;
     use std::path::PathBuf;
 
     fn sample_baseline() -> fallow_config::RegressionBaseline {

--- a/crates/cli/src/regression/counts.rs
+++ b/crates/cli/src/regression/counts.rs
@@ -1,4 +1,4 @@
-use fallow_core::results::AnalysisResults;
+use fallow_engine::results::AnalysisResults;
 
 /// Regression baseline: stores issue counts per type for comparison.
 ///
@@ -287,7 +287,7 @@ pub struct DupesCounts {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fallow_core::results::*;
+    use fallow_engine::results::*;
     use std::path::PathBuf;
 
     #[test]


### PR DESCRIPTION
## Summary
- Route regression baseline result contracts through fallow-engine.
- Remove direct fallow_core::results imports from the regression count/baseline modules.

## Verification
- cargo check -p fallow-engine -p fallow-cli
- cargo test -p fallow-cli regression
- cargo fmt --all -- --check
- cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings
- ./.githooks/pre-commit
- ./.githooks/pre-push