### PR TITLE
refactor: route fix result contracts through engine

### DIFF
--- a/crates/cli/src/fix/catalog.rs
+++ b/crates/cli/src/fix/catalog.rs
@@ -23,7 +23,7 @@
 use std::path::Path;
 
 use fallow_config::{CatalogPrecedingCommentPolicy, OutputFormat};
-use fallow_core::results::{
+use fallow_engine::results::{
     EmptyCatalogGroup, EmptyCatalogGroupFinding, UnusedCatalogEntry, UnusedCatalogEntryFinding,
 };
 

--- a/crates/cli/src/fix/config.rs
+++ b/crates/cli/src/fix/config.rs
@@ -38,7 +38,7 @@ use fallow_config::{
     ConfigFixPlan as ResolvedConfigPlan, IgnoreExportRule, OutputFormat,
     add_ignore_exports_rule_to_string, classify_config_fix_plan as classify_plan,
 };
-use fallow_core::results::{AnalysisResults, DuplicateExportFinding};
+use fallow_engine::results::{AnalysisResults, DuplicateExportFinding};
 use rustc_hash::FxHashSet;
 
 use super::io::atomic_write;
@@ -458,7 +458,7 @@ fn display_path(root: &Path, path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fallow_core::results::{DuplicateExport, DuplicateLocation};
+    use fallow_engine::results::{DuplicateExport, DuplicateLocation};
 
     fn duplicate(paths: &[PathBuf]) -> DuplicateExportFinding {
         DuplicateExportFinding::with_actions(DuplicateExport {
@@ -536,7 +536,7 @@ mod tests {
     #[cfg(not(miri))]
     mod fs {
         use super::*;
-        use fallow_core::results::AnalysisResults;
+        use fallow_engine::results::AnalysisResults;
 
         fn results_with_duplicate(root: &Path, name: &str) -> AnalysisResults {
             AnalysisResults {

--- a/crates/cli/src/fix/deps.rs
+++ b/crates/cli/src/fix/deps.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use fallow_config::OutputFormat;
-use fallow_core::results::UnusedDependency;
+use fallow_engine::results::UnusedDependency;
 
 use super::plan::{CapturedHashes, FixPlan};
 
@@ -12,7 +12,7 @@ use super::plan::{CapturedHashes, FixPlan};
 /// re-read and reparsed here, so the hash check is a no-op.
 pub(super) struct DependencyFixInput<'a> {
     pub(super) root: &'a Path,
-    pub(super) results: &'a fallow_core::results::AnalysisResults,
+    pub(super) results: &'a fallow_engine::results::AnalysisResults,
     pub(super) hashes: &'a CapturedHashes,
     pub(super) plan: &'a mut FixPlan,
     pub(super) output: OutputFormat,
@@ -149,7 +149,7 @@ mod tests {
 
     fn run_fix_deps(
         root: &Path,
-        results: &fallow_core::results::AnalysisResults,
+        results: &fallow_engine::results::AnalysisResults,
         output: OutputFormat,
         dry_run: bool,
         fixes: &mut Vec<serde_json::Value>,
@@ -180,11 +180,11 @@ mod tests {
             r#"{"dependencies": {"lodash": "^4.0.0"}, "devDependencies": {"jest": "^29.0.0"}}"#;
         std::fs::write(&pkg_path, original).unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 5,
                 used_in_workspaces: Vec::new(),
@@ -211,11 +211,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 5,
                 used_in_workspaces: Vec::new(),
@@ -245,11 +245,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash-es".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 5,
                 used_in_workspaces: vec![root.join("packages/consumer")],
@@ -272,7 +272,7 @@ mod tests {
     fn dependency_fix_empty_results_returns_early() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        let results = fallow_core::results::AnalysisResults::default();
+        let results = fallow_engine::results::AnalysisResults::default();
         let mut fixes = Vec::new();
         let had_error = run_fix_deps(root, &results, OutputFormat::Human, false, &mut fixes);
         assert!(!had_error);
@@ -290,11 +290,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dev_dependencies.push(
-            fallow_core::results::UnusedDevDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDevDependencyFinding::with_actions(UnusedDependency {
                 package_name: "jest".into(),
-                location: fallow_core::results::DependencyLocation::DevDependencies,
+                location: fallow_engine::results::DependencyLocation::DevDependencies,
                 path: pkg_path.clone(),
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -326,15 +326,17 @@ mod tests {
         )
         .unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_optional_dependencies.push(
-            fallow_core::results::UnusedOptionalDependencyFinding::with_actions(UnusedDependency {
-                package_name: "sharp".into(),
-                location: fallow_core::results::DependencyLocation::OptionalDependencies,
-                path: pkg_path.clone(),
-                line: 3,
-                used_in_workspaces: Vec::new(),
-            }),
+            fallow_engine::results::UnusedOptionalDependencyFinding::with_actions(
+                UnusedDependency {
+                    package_name: "sharp".into(),
+                    location: fallow_engine::results::DependencyLocation::OptionalDependencies,
+                    path: pkg_path.clone(),
+                    line: 3,
+                    used_in_workspaces: Vec::new(),
+                },
+            ),
         );
 
         let mut fixes = Vec::new();
@@ -359,20 +361,20 @@ mod tests {
         )
         .unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 3,
                 used_in_workspaces: Vec::new(),
             }),
         );
         results.unused_dev_dependencies.push(
-            fallow_core::results::UnusedDevDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDevDependencyFinding::with_actions(UnusedDependency {
                 package_name: "jest".into(),
-                location: fallow_core::results::DependencyLocation::DevDependencies,
+                location: fallow_engine::results::DependencyLocation::DevDependencies,
                 path: pkg_path.clone(),
                 line: 5,
                 used_in_workspaces: Vec::new(),
@@ -399,11 +401,11 @@ mod tests {
         let pkg_path = root.join("package.json");
         std::fs::write(&pkg_path, r#"{"dependencies": {"lodash": "^4.0.0"}}"#).unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -428,11 +430,11 @@ mod tests {
         let original = r#"{"dependencies": {"react": "^18.0.0"}}"#;
         std::fs::write(&pkg_path, original).unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "nonexistent".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path,
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -454,11 +456,11 @@ mod tests {
         let original = r#"{"dependencies": {"lodash": "^4.0.0"}}"#;
         std::fs::write(&pkg_path, original).unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -480,11 +482,11 @@ mod tests {
         let pkg_path = root.join("package.json");
         std::fs::write(&pkg_path, "not valid json").unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path,
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -504,11 +506,11 @@ mod tests {
         let root = dir.path();
         let pkg_path = root.join("package.json"); // Does not exist
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path,
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -530,11 +532,11 @@ mod tests {
         let original = r#"{"name": "test"}"#;
         std::fs::write(&pkg_path, original).unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path,
                 line: 3,
                 used_in_workspaces: Vec::new(),
@@ -559,11 +561,11 @@ mod tests {
         )
         .unwrap();
 
-        let mut results = fallow_core::results::AnalysisResults::default();
+        let mut results = fallow_engine::results::AnalysisResults::default();
         results.unused_dependencies.push(
-            fallow_core::results::UnusedDependencyFinding::with_actions(UnusedDependency {
+            fallow_engine::results::UnusedDependencyFinding::with_actions(UnusedDependency {
                 package_name: "lodash".into(),
-                location: fallow_core::results::DependencyLocation::Dependencies,
+                location: fallow_engine::results::DependencyLocation::Dependencies,
                 path: pkg_path.clone(),
                 line: 3,
                 used_in_workspaces: Vec::new(),

--- a/crates/cli/src/fix/enum_members.rs
+++ b/crates/cli/src/fix/enum_members.rs
@@ -113,7 +113,7 @@ fn detect_folded_enums(lines: &[&str], member_fixes: &[EnumMemberFix]) -> Vec<Fo
 pub(super) struct EnumMemberFixInput<'a, 'member> {
     pub(super) root: &'a Path,
     pub(super) members_by_file:
-        &'a FxHashMap<PathBuf, Vec<&'member fallow_core::results::UnusedMember>>,
+        &'a FxHashMap<PathBuf, Vec<&'member fallow_engine::results::UnusedMember>>,
     pub(super) hashes: &'a CapturedHashes,
     pub(super) plan: &'a mut FixPlan,
     pub(super) output: OutputFormat,
@@ -190,7 +190,7 @@ pub(super) fn apply_enum_member_fixes(input: EnumMemberFixInput<'_, '_>) {
 /// not shift earlier indices.
 fn collect_enum_member_fixes(
     lines: &[&str],
-    file_members: &[&fallow_core::results::UnusedMember],
+    file_members: &[&fallow_engine::results::UnusedMember],
 ) -> Vec<EnumMemberFix> {
     let mut member_fixes: Vec<EnumMemberFix> = Vec::new();
     for member in file_members {
@@ -417,7 +417,7 @@ fn remove_member_from_single_line(line: &str, member_name: &str) -> String {
 mod tests {
     use super::*;
     use fallow_core::extract::MemberKind;
-    use fallow_core::results::UnusedMember;
+    use fallow_engine::results::UnusedMember;
 
     fn make_enum_member(path: &Path, parent: &str, name: &str, line: u32) -> UnusedMember {
         UnusedMember {

--- a/crates/cli/src/fix/exports.rs
+++ b/crates/cli/src/fix/exports.rs
@@ -79,7 +79,7 @@ pub(super) struct ExportFix {
 pub(super) struct ExportFixInput<'a, 'export> {
     pub(super) root: &'a Path,
     pub(super) exports_by_file:
-        &'a FxHashMap<PathBuf, Vec<&'export fallow_core::results::UnusedExport>>,
+        &'a FxHashMap<PathBuf, Vec<&'export fallow_engine::results::UnusedExport>>,
     pub(super) hashes: &'a CapturedHashes,
     pub(super) unresolved_import_files: &'a FxHashSet<PathBuf>,
     pub(super) plan: &'a mut FixPlan,
@@ -251,7 +251,7 @@ pub(super) fn apply_export_fixes(input: &mut ExportFixInput<'_, '_>) {
 
 fn collect_export_line_fixes(
     lines: &[&str],
-    file_exports: &[&fallow_core::results::UnusedExport],
+    file_exports: &[&fallow_engine::results::UnusedExport],
 ) -> Vec<ExportFix> {
     file_exports
         .iter()
@@ -261,7 +261,7 @@ fn collect_export_line_fixes(
 
 fn export_line_fix(
     lines: &[&str],
-    export: &fallow_core::results::UnusedExport,
+    export: &fallow_engine::results::UnusedExport,
 ) -> Option<ExportFix> {
     let line_idx = export.line.saturating_sub(1) as usize;
     let line = *lines.get(line_idx)?;
@@ -451,7 +451,7 @@ fn delete_export_lines(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fallow_core::results::UnusedExport;
+    use fallow_engine::results::UnusedExport;
 
     #[expect(
         clippy::too_many_arguments,

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -21,7 +21,7 @@ use plan::{CapturedHashes, CommitOutcome, FixPlan, SkippedFile};
 fn run_analyze(
     config: &fallow_config::ResolvedConfig,
     output: OutputFormat,
-) -> Result<(fallow_core::results::AnalysisResults, CapturedHashes), ExitCode> {
+) -> Result<(fallow_engine::results::AnalysisResults, CapturedHashes), ExitCode> {
     #[expect(
         deprecated,
         reason = "ADR-008 deprecates fallow_core::analyze_with_file_hashes externally; the CLI still uses the workspace path dependency"
@@ -142,7 +142,7 @@ fn finalize_fix_run(
 fn apply_all_fixes(
     opts: &FixOptions<'_>,
     config: &fallow_config::ResolvedConfig,
-    results: &fallow_core::results::AnalysisResults,
+    results: &fallow_engine::results::AnalysisResults,
     file_hashes: &CapturedHashes,
     plan: &mut FixPlan,
     fixes: &mut Vec<serde_json::Value>,
@@ -227,7 +227,7 @@ fn emit_empty_fix_output(opts: &FixOptions<'_>) -> ExitCode {
 
 struct FixApplicationInput<'a> {
     root: &'a Path,
-    results: &'a fallow_core::results::AnalysisResults,
+    results: &'a fallow_engine::results::AnalysisResults,
     file_hashes: &'a CapturedHashes,
     plan: &'a mut FixPlan,
     output: OutputFormat,
@@ -236,7 +236,7 @@ struct FixApplicationInput<'a> {
 }
 
 fn apply_unused_export_fixes(input: &mut FixApplicationInput<'_>) {
-    let mut exports_by_file: FxHashMap<PathBuf, Vec<&fallow_core::results::UnusedExport>> =
+    let mut exports_by_file: FxHashMap<PathBuf, Vec<&fallow_engine::results::UnusedExport>> =
         FxHashMap::default();
     for finding in &input.results.unused_exports {
         exports_by_file
@@ -266,7 +266,7 @@ fn apply_unused_enum_member_fixes(input: &mut FixApplicationInput<'_>) {
     if input.results.unused_enum_members.is_empty() {
         return;
     }
-    let mut enum_members_by_file: FxHashMap<PathBuf, Vec<&fallow_core::results::UnusedMember>> =
+    let mut enum_members_by_file: FxHashMap<PathBuf, Vec<&fallow_engine::results::UnusedMember>> =
         FxHashMap::default();
     for finding in &input.results.unused_enum_members {
         enum_members_by_file
@@ -322,7 +322,7 @@ struct CatalogFixTotals {
 
 struct CatalogFixRequest<'a> {
     root: &'a Path,
-    results: &'a fallow_core::results::AnalysisResults,
+    results: &'a fallow_engine::results::AnalysisResults,
     file_hashes: &'a CapturedHashes,
     plan: &'a mut FixPlan,
     delete_preceding_comments: CatalogPrecedingCommentPolicy,


### PR DESCRIPTION
## Summary
- Route fix command result contracts through fallow-engine.
- Remove direct fallow_core::results references from crates/cli/src/fix modules.

## Verification
- cargo check -p fallow-engine -p fallow-cli
- cargo test -p fallow-cli fix
- cargo fmt --all -- --check
- cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings
- ./.githooks/pre-commit
- ./.githooks/pre-push