### PR TITLE
refactor: route cli analysis runners through engine

### DIFF
--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -404,9 +404,9 @@ fn run_check_analysis(
             .map_err(|e| emit_error(&format!("Analysis error: {e}"), 2, opts.output));
     }
 
-    fallow_core::analyze(config)
-        .map(|results| CheckAnalysisData {
-            results,
+    fallow_engine::analyze(config)
+        .map(|analysis| CheckAnalysisData {
+            results: analysis.results,
             trace_graph: None,
             trace_timings: None,
             retained_modules: None,

--- a/crates/cli/src/coverage/upload_static_findings.rs
+++ b/crates/cli/src/coverage/upload_static_findings.rs
@@ -164,11 +164,8 @@ fn run_inner(args: &UploadStaticFindingsArgs, root: &Path) -> Result<(), UploadE
     enforce_clean_worktree(args, root)?;
 
     let config = load_resolved_config(root)?;
-    #[expect(
-        deprecated,
-        reason = "ADR-008 deprecates fallow_core::analyze* externally; the CLI still uses the workspace path dependency"
-    )]
-    let results = fallow_core::analyze(&config)
+    let results = fallow_engine::analyze(&config)
+        .map(|analysis| analysis.results)
         .map_err(|err| UploadError::Validation(format!("analysis failed: {err}")))?;
     let findings = collect_findings(&config, &results);
 

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -22,11 +22,7 @@ fn run_analyze(
     config: &fallow_config::ResolvedConfig,
     output: OutputFormat,
 ) -> Result<(fallow_engine::results::AnalysisResults, CapturedHashes), ExitCode> {
-    #[expect(
-        deprecated,
-        reason = "ADR-008 deprecates fallow_core::analyze_with_file_hashes externally; the CLI still uses the workspace path dependency"
-    )]
-    let output_struct = fallow_core::analyze_with_file_hashes(config)
+    let output_struct = fallow_engine::analyze_with_file_hashes(config)
         .map_err(|e| crate::error::emit_error(&format!("Analysis error: {e}"), 2, output))?;
     Ok((output_struct.results, output_struct.file_hashes))
 }

--- a/crates/cli/src/watch.rs
+++ b/crates/cli/src/watch.rs
@@ -295,12 +295,8 @@ fn print_waiting(opts: &WatchOptions<'_>) {
 
 fn analyze_and_report(config: &fallow_config::ResolvedConfig, opts: &WatchOptions<'_>) -> ExitCode {
     let start = Instant::now();
-    #[expect(
-        deprecated,
-        reason = "ADR-008 deprecates fallow_core::analyze externally; the CLI still uses the workspace path dependency"
-    )]
-    let results = match fallow_core::analyze(config) {
-        Ok(r) => r,
+    let results = match fallow_engine::analyze(config) {
+        Ok(analysis) => analysis.results,
         Err(e) => {
             eprintln!("Analysis error: {e}");
             return ExitCode::from(2);

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 use fallow_config::{
     DuplicatesConfig, FallowConfig, OutputFormat, ProductionAnalysis, ResolvedConfig,
 };
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Duplication result types exposed through the engine boundary.
 pub mod duplicates {
@@ -183,6 +183,13 @@ pub struct ProjectConfigOptions {
 #[derive(Debug)]
 pub struct DeadCodeAnalysis {
     pub results: AnalysisResults,
+}
+
+/// Typed dead-code analysis result with per-file source hashes.
+#[derive(Debug)]
+pub struct DeadCodeAnalysisWithHashes {
+    pub results: AnalysisResults,
+    pub file_hashes: FxHashMap<PathBuf, u64>,
 }
 
 /// Typed dead-code analysis result with retained parser artifacts.
@@ -487,6 +494,21 @@ fn joined_config_errors(label: &str, errors: &[impl ToString]) -> EngineError {
     EngineError::new(format!("{label}:\n  - {joined}"))
 }
 
+/// Run dead-code analysis for a resolved config.
+///
+/// # Errors
+///
+/// Returns an error if file discovery, parsing, or analysis fails.
+pub fn analyze(config: &ResolvedConfig) -> EngineResult<DeadCodeAnalysis> {
+    #[expect(
+        deprecated,
+        reason = "fallow-engine is the typed migration boundary over the internal core backend"
+    )]
+    fallow_core::analyze(config)
+        .map(|results| DeadCodeAnalysis { results })
+        .map_err(engine_error)
+}
+
 /// Run dead-code analysis with export usage collection for a resolved config.
 ///
 /// # Errors
@@ -499,6 +521,26 @@ pub fn analyze_with_usages(config: &ResolvedConfig) -> EngineResult<DeadCodeAnal
     )]
     fallow_core::analyze_with_usages(config)
         .map(|results| DeadCodeAnalysis { results })
+        .map_err(engine_error)
+}
+
+/// Run dead-code analysis with source hashes for drift-sensitive fixers.
+///
+/// # Errors
+///
+/// Returns an error if file discovery, parsing, or analysis fails.
+pub fn analyze_with_file_hashes(
+    config: &ResolvedConfig,
+) -> EngineResult<DeadCodeAnalysisWithHashes> {
+    #[expect(
+        deprecated,
+        reason = "fallow-engine is the typed migration boundary over the internal core backend"
+    )]
+    fallow_core::analyze_with_file_hashes(config)
+        .map(|output| DeadCodeAnalysisWithHashes {
+            results: output.results,
+            file_hashes: output.file_hashes,
+        })
         .map_err(engine_error)
 }
 


### PR DESCRIPTION
## Summary
- Add typed fallow-engine facades for plain dead-code analysis and hash-capturing analysis.
- Route CLI callers for fix, check fallback, watch, and static findings upload through those engine facades.
- Keep retained-module and trace analysis paths for a follow-up typed retained-output slice.

## Verification
- cargo check -p fallow-engine -p fallow-cli
- cargo test -p fallow-cli fix
- cargo test -p fallow-cli check
- cargo test -p fallow-cli upload_static
- cargo fmt --all -- --check
- cargo clippy -p fallow-engine -p fallow-cli --all-targets -- -D warnings
- ./.githooks/pre-commit
- ./.githooks/pre-push