### PR TITLE
refactor: route napi health through api runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,6 @@ version = "2.102.0"
 dependencies = [
  "fallow-api",
  "fallow-cli",
- "serde_json",
 ]
 
 [[package]]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 
 use fallow_api as api;
-use fallow_programmatic_cli as cli_health;
+use fallow_programmatic_cli::CliHealthRunner;
 use napi::bindgen_prelude::{AsyncTask, JsObjectValue, ToNapiValue, Unknown};
 use napi::{Env, ScopedTask, Status};
 use napi_derive::napi;
@@ -543,7 +543,7 @@ pub fn compute_complexity(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        cli_health::compute_complexity(&options)
+        api::compute_complexity_with_runner(&options, &CliHealthRunner)
     })))
 }
 
@@ -553,7 +553,7 @@ pub fn compute_health(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        cli_health::compute_health(&options)
+        api::compute_health_with_runner(&options, &CliHealthRunner)
     })))
 }
 
@@ -1042,6 +1042,26 @@ mod tests {
             .as_ref()
             .expect("programmatic error should be retained for reject");
         assert_eq!(stored.code.as_deref(), Some("FALLOW_TEST_FAILURE"));
+    }
+
+    #[test]
+    fn compute_health_uses_api_runner_boundary() {
+        let project = tiny_dead_code_project();
+        let options = api::ComplexityOptions::try_from(ComplexityOptions {
+            root: Some(project.path().display().to_string()),
+            no_cache: Some(true),
+            threads: Some(1),
+            score: Some(true),
+            ..ComplexityOptions::default()
+        })
+        .expect("health options should map");
+
+        let json = api::compute_health_with_runner(&options, &CliHealthRunner)
+            .expect("health should run through API runner boundary");
+
+        assert_eq!(json["kind"], "health");
+        assert_eq!(json["schema_version"], 7);
+        assert!(json.get("health_score").is_some());
     }
 
     fn tiny_dead_code_project() -> tempfile::TempDir {

--- a/crates/programmatic-cli/Cargo.toml
+++ b/crates/programmatic-cli/Cargo.toml
@@ -8,13 +8,12 @@ homepage.workspace = true
 documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Temporary CLI-backed programmatic bridge for fallow embedders"
+description = "Temporary CLI-backed health runner adapter for fallow embedders"
 readme = "../../README.md"
 
 [dependencies]
 fallow-api = { workspace = true }
 fallow-cli = { workspace = true }
-serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/programmatic-cli/src/lib.rs
+++ b/crates/programmatic-cli/src/lib.rs
@@ -1,9 +1,9 @@
-//! Temporary programmatic bridge for CLI-backed runtime paths.
+//! Temporary programmatic runner bridge for CLI-backed health execution.
 //!
-//! `fallow-api` owns the public programmatic contracts. Most NAPI calls now use
-//! the API runtime directly. Health still needs the CLI implementation until
-//! the health execution pipeline finishes moving behind typed engine results, so
-//! this crate keeps that dependency explicit and removable.
+//! `fallow-api` owns the public programmatic contracts and serialization.
+//! Health execution still needs the CLI implementation until the health
+//! pipeline finishes moving behind typed engine results, so this crate exposes
+//! only the removable runner adapter.
 
 #![cfg_attr(not(test), deny(clippy::disallowed_methods))]
 
@@ -19,26 +19,4 @@ impl fallow_api::ProgrammaticHealthRunner for CliHealthRunner {
     ) -> Result<ProgrammaticHealthRun, ProgrammaticError> {
         fallow_cli::programmatic::CliProgrammaticHealthRunner.run_programmatic_health(options)
     }
-}
-
-/// Run complexity analysis through the temporary CLI-backed health bridge.
-///
-/// # Errors
-///
-/// Returns structured programmatic errors from option validation, analysis, or
-/// JSON serialization.
-pub fn compute_complexity(
-    options: &ComplexityOptions,
-) -> Result<serde_json::Value, ProgrammaticError> {
-    fallow_api::compute_complexity_with_runner(options, &CliHealthRunner)
-}
-
-/// Run health analysis through the temporary CLI-backed health bridge.
-///
-/// # Errors
-///
-/// Returns structured programmatic errors from option validation, analysis, or
-/// JSON serialization.
-pub fn compute_health(options: &ComplexityOptions) -> Result<serde_json::Value, ProgrammaticError> {
-    fallow_api::compute_health_with_runner(options, &CliHealthRunner)
 }


### PR DESCRIPTION
## Summary
- route NAPI health and complexity through fallow-api runner serialization
- narrow fallow-programmatic-cli to a temporary CLI-backed health runner adapter
- remove the bridge crate's serde_json dependency and add a NAPI-side health runner smoke

## Verification
- cargo check -p fallow-node -p fallow-programmatic-cli -p fallow-api
- cargo test -p fallow-node
- cargo test -p fallow-programmatic-cli -p fallow-api
- cargo fmt --all -- --check
- cargo clippy -p fallow-node -p fallow-programmatic-cli -p fallow-api --all-targets -- -D warnings
- .githooks/pre-commit
- .githooks/pre-push