### PR TITLE
refactor: route root json through output contracts

### DIFF
--- a/crates/cli/src/audit_output.rs
+++ b/crates/cli/src/audit_output.rs
@@ -3,7 +3,8 @@ use std::process::ExitCode;
 
 use colored::Colorize;
 use fallow_config::{AuditGate, OutputFormat};
-use fallow_output::CodeClimateIssue;
+use fallow_output::{AuditCommand, AuditOutput, CodeClimateIssue, RootEnvelopeMode};
+use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
 use crate::error::emit_error;
 use crate::report;
@@ -329,40 +330,69 @@ fn print_audit_status_line(result: &AuditResult) {
 }
 
 fn print_audit_json(result: &AuditResult) -> ExitCode {
-    let mut obj = serde_json::Map::new();
-    insert_audit_json_header(&mut obj, result);
-
-    if let Some(ref check) = result.check
-        && let Err(code) = insert_audit_dead_code_json(&mut obj, result, check)
-    {
-        return code;
-    }
-
-    if let Some(ref dupes) = result.dupes
-        && let Err(code) = insert_audit_duplication_json(&mut obj, result, dupes)
-    {
-        return code;
-    }
-
-    if let Some(ref health) = result.health
-        && let Err(code) = insert_audit_health_json(&mut obj, result, health)
-    {
-        return code;
-    }
-
-    insert_audit_next_steps_json(&mut obj, result);
-
-    let mut output = serde_json::Value::Object(obj);
-    crate::output_envelope::apply_root_kind(&mut output, "audit");
+    let mut output = match build_audit_json_output(result) {
+        Ok(output) => output,
+        Err(code) => return code,
+    };
     report::harmonize_multi_kind_suppress_line_actions(&mut output);
     crate::output_envelope::attach_telemetry_meta(&mut output);
     report::emit_json(&output, "audit")
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "elapsed milliseconds won't exceed u64::MAX"
-)]
+fn build_audit_json_output(result: &AuditResult) -> Result<serde_json::Value, ExitCode> {
+    let dead_code = result
+        .check
+        .as_ref()
+        .map(|check| build_audit_dead_code_json(result, check))
+        .transpose()?;
+    let duplication = result
+        .dupes
+        .as_ref()
+        .map(|dupes| build_audit_duplication_json(result, dupes))
+        .transpose()?;
+    let complexity = result
+        .health
+        .as_ref()
+        .map(|health| build_audit_health_json(result, health))
+        .transpose()?;
+
+    let output = AuditOutput {
+        schema_version: SchemaVersion(crate::report::SCHEMA_VERSION),
+        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
+        command: AuditCommand::Audit,
+        verdict: result.verdict,
+        changed_files_count: changed_files_count_for_output(result.changed_files_count),
+        base_ref: result.base_ref.clone(),
+        base_description: result.base_description.clone(),
+        head_sha: result.head_sha.clone(),
+        elapsed_ms: ElapsedMs(elapsed_ms_for_output(result.elapsed)),
+        base_snapshot_skipped: result.performance.then_some(result.base_snapshot_skipped),
+        summary: result.summary.clone(),
+        attribution: result.attribution.clone(),
+        meta: None,
+        dead_code,
+        duplication,
+        complexity,
+        next_steps: audit_next_steps(result),
+    };
+
+    fallow_output::serialize_audit_json_output(output, RootEnvelopeMode::Tagged).map_err(|err| {
+        emit_error(
+            &format!("JSON serialization error: {err}"),
+            2,
+            OutputFormat::Json,
+        )
+    })
+}
+
+fn elapsed_ms_for_output(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn changed_files_count_for_output(changed_files_count: usize) -> u32 {
+    u32::try_from(changed_files_count).unwrap_or(u32::MAX)
+}
+
 pub fn insert_audit_json_header(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     result: &AuditResult,
@@ -402,7 +432,9 @@ pub fn insert_audit_json_header(
     }
     obj.insert(
         "elapsed_ms".into(),
-        serde_json::Value::Number(serde_json::Number::from(result.elapsed.as_millis() as u64)),
+        serde_json::Value::Number(serde_json::Number::from(elapsed_ms_for_output(
+            result.elapsed,
+        ))),
     );
     if result.performance {
         obj.insert(
@@ -424,6 +456,15 @@ pub fn insert_audit_dead_code_json(
     result: &AuditResult,
     check: &crate::check::CheckResult,
 ) -> Result<(), ExitCode> {
+    let json = build_audit_dead_code_json(result, check)?;
+    obj.insert("dead_code".into(), json);
+    Ok(())
+}
+
+fn build_audit_dead_code_json(
+    result: &AuditResult,
+    check: &crate::check::CheckResult,
+) -> Result<serde_json::Value, ExitCode> {
     match report::build_check_json_payload_with_config_fixable(
         &check.results,
         &check.config.root,
@@ -439,8 +480,7 @@ pub fn insert_audit_dead_code_json(
                     &base.dead_code,
                 );
             }
-            obj.insert("dead_code".into(), json);
-            Ok(())
+            Ok(json)
         }
         Err(e) => Err(emit_error(
             &format!("JSON serialization error: {e}"),
@@ -455,6 +495,15 @@ pub fn insert_audit_duplication_json(
     result: &AuditResult,
     dupes: &crate::dupes::DupesResult,
 ) -> Result<(), ExitCode> {
+    let json = build_audit_duplication_json(result, dupes)?;
+    obj.insert("duplication".into(), json);
+    Ok(())
+}
+
+fn build_audit_duplication_json(
+    result: &AuditResult,
+    dupes: &crate::dupes::DupesResult,
+) -> Result<serde_json::Value, ExitCode> {
     let payload = crate::output_dupes::DupesReportPayload::from_report(&dupes.report);
     match serde_json::to_value(&payload) {
         Ok(mut json) => {
@@ -463,8 +512,7 @@ pub fn insert_audit_duplication_json(
             if let Some(ref base) = result.base_snapshot {
                 annotate_dupes_json(&mut json, &dupes.report, &dupes.config.root, &base.dupes);
             }
-            obj.insert("duplication".into(), json);
-            Ok(())
+            Ok(json)
         }
         Err(e) => Err(emit_error(
             &format!("JSON serialization error: {e}"),
@@ -479,6 +527,15 @@ pub fn insert_audit_health_json(
     result: &AuditResult,
     health: &crate::health::HealthResult,
 ) -> Result<(), ExitCode> {
+    let json = build_audit_health_json(result, health)?;
+    obj.insert("complexity".into(), json);
+    Ok(())
+}
+
+fn build_audit_health_json(
+    result: &AuditResult,
+    health: &crate::health::HealthResult,
+) -> Result<serde_json::Value, ExitCode> {
     match serde_json::to_value(&health.report) {
         Ok(mut json) => {
             let root_prefix = format!("{}/", health.config.root.display());
@@ -486,8 +543,7 @@ pub fn insert_audit_health_json(
             if let Some(ref base) = result.base_snapshot {
                 annotate_health_json(&mut json, &health.report, &health.config.root, &base.health);
             }
-            obj.insert("complexity".into(), json);
-            Ok(())
+            Ok(json)
         }
         Err(e) => Err(emit_error(
             &format!("JSON serialization error: {e}"),
@@ -497,10 +553,7 @@ pub fn insert_audit_health_json(
     }
 }
 
-fn insert_audit_next_steps_json(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    result: &AuditResult,
-) {
+fn audit_next_steps(result: &AuditResult) -> Vec<fallow_types::output::NextStep> {
     let input = fallow_output::build_audit_next_steps_input(
         result
             .check
@@ -509,12 +562,7 @@ fn insert_audit_next_steps_json(
         result.health.as_ref().map(|health| &health.report),
         crate::report::suggestions::suggestions_enabled(),
     );
-    let next_steps = fallow_output::build_audit_next_steps(&input);
-    if !next_steps.is_empty()
-        && let Ok(value) = serde_json::to_value(&next_steps)
-    {
-        obj.insert("next_steps".into(), value);
-    }
+    fallow_output::build_audit_next_steps(&input)
 }
 
 fn print_audit_sarif(result: &AuditResult) -> ExitCode {
@@ -613,8 +661,8 @@ mod tests {
     use crate::audit::{AuditAttribution, AuditResult, AuditSummary, AuditVerdict};
 
     use super::{
-        build_audit_codeclimate, build_status_parts, build_vital_sign_parts,
-        format_scope_line_parts, print_audit_result, short_base_ref,
+        build_audit_codeclimate, build_audit_json_output, build_status_parts,
+        build_vital_sign_parts, format_scope_line_parts, print_audit_result, short_base_ref,
     };
 
     fn audit_result(verdict: AuditVerdict, output: OutputFormat) -> AuditResult {
@@ -808,6 +856,25 @@ mod tests {
         // exercises insert_audit_json_header's optional base_description / head_sha
         // / performance branches and the empty next-steps path.
         assert_eq!(print_audit_result(&result, true, false), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn build_audit_json_output_uses_typed_audit_contract() {
+        let mut result = audit_result(AuditVerdict::Pass, OutputFormat::Json);
+        result.base_description = Some("merge-base with origin/main".to_string());
+        result.head_sha = Some("abc123".to_string());
+        result.performance = true;
+        result.base_snapshot_skipped = true;
+        result.changed_files_count = 5;
+
+        let json = build_audit_json_output(&result).expect("audit JSON should build");
+
+        assert_eq!(json["kind"], "audit");
+        assert_eq!(json["command"], "audit");
+        assert_eq!(json["base_description"], "merge-base with origin/main");
+        assert_eq!(json["head_sha"], "abc123");
+        assert_eq!(json["base_snapshot_skipped"], true);
+        assert_eq!(json["changed_files_count"], 5);
     }
 
     #[test]

--- a/crates/cli/src/combined/output.rs
+++ b/crates/cli/src/combined/output.rs
@@ -5,7 +5,8 @@ use std::process::ExitCode;
 
 use colored::Colorize;
 use fallow_config::OutputFormat;
-use fallow_output::CodeClimateIssue;
+use fallow_output::{CodeClimateIssue, CombinedMeta, CombinedOutput, RootEnvelopeMode};
+use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
 use crate::check::CheckResult;
 use crate::dupes::DupesResult;
@@ -445,172 +446,141 @@ struct CombinedJsonPrintInput<'a> {
 }
 
 fn print_combined_json(input: CombinedJsonPrintInput<'_>) -> ExitCode {
-    let mut combined = match combined_json_root(input.elapsed) {
-        Ok(combined) => combined,
+    let output = match build_combined_json_output(input) {
+        Ok(output) => output,
         Err(code) => return code,
     };
+    emit_combined_json_output(output)
+}
+
+fn build_combined_json_output(
+    input: CombinedJsonPrintInput<'_>,
+) -> Result<serde_json::Value, ExitCode> {
     let root_prefix = format!("{}/", input.root.display());
 
-    if let Some(result) = input.check_result
-        && let Err(code) = insert_combined_check_json(&mut combined, result, input.config_fixable)
-    {
-        return code;
-    }
+    let check = input
+        .check_result
+        .map(|result| build_combined_check_json(result, input.config_fixable))
+        .transpose()?;
 
     let dupes_payload = input
         .dupes_result
         .map(|result| crate::output_dupes::DupesReportPayload::from_report(&result.report));
-    if let Err(code) = insert_combined_dupes_json(&mut combined, dupes_payload.as_ref(), input.root)
-    {
-        return code;
-    }
-    if let Err(code) = insert_combined_health_json(&mut combined, input.health_result, &root_prefix)
-    {
-        return code;
-    }
-    if let Err(code) = insert_combined_next_steps(
-        &mut combined,
+    let dupes = build_combined_dupes_json(dupes_payload.as_ref(), input.root)?;
+    let health = build_combined_health_json(input.health_result, &root_prefix)?;
+    let next_steps = combined_next_steps(
         input.check_result,
         dupes_payload.as_ref(),
         input.health_result,
         input.root,
-    ) {
-        return code;
-    }
+    );
 
-    emit_combined_json_output(
-        combined,
-        input.check_result,
-        input.dupes_result,
-        input.health_result,
-        input.explain,
-    )
+    let output = CombinedOutput {
+        schema_version: SchemaVersion(crate::report::SCHEMA_VERSION),
+        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
+        elapsed_ms: ElapsedMs(elapsed_ms_for_output(input.elapsed)),
+        meta: input.explain.then(|| {
+            combined_meta_for_output(
+                input.check_result.is_some(),
+                input.dupes_result.is_some(),
+                input.health_result.is_some(),
+            )
+        }),
+        check,
+        dupes,
+        health,
+        next_steps,
+    };
+
+    fallow_output::serialize_combined_json_output(output, RootEnvelopeMode::Tagged)
+        .map_err(|err| json_output_error(&err))
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "elapsed milliseconds won't exceed u64::MAX"
-)]
-fn combined_json_root(
-    elapsed: std::time::Duration,
-) -> Result<serde_json::Map<String, serde_json::Value>, ExitCode> {
-    let envelope = crate::output_envelope::CombinedOutput {
+fn elapsed_ms_for_output(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+fn combined_json_root(elapsed: std::time::Duration) -> Result<serde_json::Value, ExitCode> {
+    let envelope = CombinedOutput::<serde_json::Value, serde_json::Value, serde_json::Value> {
         schema_version: fallow_types::envelope::SchemaVersion(crate::report::SCHEMA_VERSION),
         version: fallow_types::envelope::ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: fallow_types::envelope::ElapsedMs(elapsed.as_millis() as u64),
+        elapsed_ms: fallow_types::envelope::ElapsedMs(elapsed_ms_for_output(elapsed)),
         meta: None,
         check: None,
         dupes: None,
         health: None,
-        // Aggregated and injected into the map below, after the sub-blocks.
         next_steps: Vec::new(),
     };
-    match crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::Combined(envelope),
-    ) {
-        Ok(serde_json::Value::Object(map)) => Ok(map),
-        Ok(_) => unreachable!("CombinedOutput serializes as a JSON object"),
-        Err(e) => Err(emit_error(
-            &format!("JSON serialization error: {e}"),
-            2,
-            OutputFormat::Json,
-        )),
-    }
+    fallow_output::serialize_combined_json_output(envelope, RootEnvelopeMode::Tagged)
+        .map_err(|err| json_output_error(&err))
 }
 
-fn insert_combined_dupes_json(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn build_combined_dupes_json(
     dupes_payload: Option<&crate::output_dupes::DupesReportPayload>,
     root: &std::path::Path,
-) -> Result<(), ExitCode> {
+) -> Result<Option<serde_json::Value>, ExitCode> {
     let root_prefix = format!("{}/", root.display());
     if let Some(payload) = dupes_payload {
         match serde_json::to_value(payload) {
             Ok(mut json) => {
                 report::strip_root_prefix(&mut json, &root_prefix);
-                combined.insert("dupes".into(), json);
+                Ok(Some(json))
             }
-            Err(e) => {
-                return Err(emit_error(
-                    &format!("JSON serialization error: {e}"),
-                    2,
-                    OutputFormat::Json,
-                ));
-            }
+            Err(e) => Err(json_output_error(&e)),
         }
+    } else {
+        Ok(None)
     }
-    Ok(())
 }
 
-fn insert_combined_health_json(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn build_combined_health_json(
     health: Option<&HealthResult>,
     root_prefix: &str,
-) -> Result<(), ExitCode> {
+) -> Result<Option<serde_json::Value>, ExitCode> {
     if let Some(result) = health {
         match serde_json::to_value(&result.report) {
             Ok(mut json) => {
                 report::strip_root_prefix(&mut json, root_prefix);
-                combined.insert("health".into(), json);
+                Ok(Some(json))
             }
-            Err(e) => {
-                return Err(emit_error(
-                    &format!("JSON serialization error: {e}"),
-                    2,
-                    OutputFormat::Json,
-                ));
-            }
+            Err(e) => Err(json_output_error(&e)),
         }
+    } else {
+        Ok(None)
     }
-    Ok(())
 }
 
-fn insert_combined_next_steps(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn combined_next_steps(
     check: Option<&CheckResult>,
     dupes_payload: Option<&crate::output_dupes::DupesReportPayload>,
     health: Option<&HealthResult>,
     root: &std::path::Path,
-) -> Result<(), ExitCode> {
-    let next_steps = crate::report::suggestions::build_combined_next_steps(
+) -> Vec<fallow_types::output::NextStep> {
+    crate::report::suggestions::build_combined_next_steps(
         check.map(|result| &result.results),
         dupes_payload,
         health.map(|result| &result.report),
         root,
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
-    );
-    if !next_steps.is_empty() {
-        match serde_json::to_value(&next_steps) {
-            Ok(value) => {
-                combined.insert("next_steps".into(), value);
-            }
-            Err(e) => {
-                return Err(emit_error(
-                    &format!("JSON serialization error: {e}"),
-                    2,
-                    OutputFormat::Json,
-                ));
-            }
-        }
-    }
-    Ok(())
+    )
 }
 
-fn emit_combined_json_output(
-    combined: serde_json::Map<String, serde_json::Value>,
-    check: Option<&CheckResult>,
-    dupes: Option<&DupesResult>,
-    health: Option<&HealthResult>,
-    explain: bool,
-) -> ExitCode {
-    let mut output = serde_json::Value::Object(combined);
-    if explain && let serde_json::Value::Object(ref mut map) = output {
-        map.insert(
-            "_meta".to_string(),
-            crate::explain::combined_meta(check.is_some(), dupes.is_some(), health.is_some()),
-        );
+fn combined_meta_for_output(
+    include_check: bool,
+    include_dupes: bool,
+    include_health: bool,
+) -> CombinedMeta {
+    CombinedMeta {
+        check: include_check.then(fallow_output::check_meta),
+        dupes: include_dupes.then(fallow_output::dupes_meta),
+        health: include_health.then(fallow_output::health_meta),
+        telemetry: None,
     }
+}
+
+fn emit_combined_json_output(mut output: serde_json::Value) -> ExitCode {
     report::harmonize_multi_kind_suppress_line_actions(&mut output);
     crate::output_envelope::attach_telemetry_meta(&mut output);
 
@@ -627,11 +597,10 @@ fn emit_combined_json_output(
     }
 }
 
-fn insert_combined_check_json(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn build_combined_check_json(
     result: &CheckResult,
     config_fixable: bool,
-) -> Result<(), ExitCode> {
+) -> Result<serde_json::Value, ExitCode> {
     let mut json = report::build_check_json_payload_with_config_fixable(
         &result.results,
         &result.config.root,
@@ -640,8 +609,7 @@ fn insert_combined_check_json(
     )
     .map_err(|error| json_output_error(&error))?;
     attach_combined_check_extras(&mut json, result);
-    combined.insert("check".into(), json);
-    Ok(())
+    Ok(json)
 }
 
 fn attach_combined_check_extras(json: &mut serde_json::Value, result: &CheckResult) {
@@ -820,9 +788,9 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        build_combined_codeclimate, combined_json_root, combined_machine_success,
-        emit_combined_json_output, exit_code_to_u8, insert_combined_dupes_json,
-        insert_combined_health_json, print_combined_codeclimate, print_combined_sarif,
+        build_combined_codeclimate, build_combined_dupes_json, build_combined_health_json,
+        combined_json_root, combined_machine_success, emit_combined_json_output, exit_code_to_u8,
+        print_combined_codeclimate, print_combined_sarif,
     };
 
     #[test]
@@ -879,22 +847,19 @@ mod tests {
 
     #[test]
     fn insert_empty_optional_sections_leaves_combined_map_unchanged() {
-        let mut combined = serde_json::Map::new();
-        insert_combined_dupes_json(&mut combined, None, std::path::Path::new("."))
+        let dupes = build_combined_dupes_json(None, std::path::Path::new("."))
             .expect("empty dupes section should serialize");
-        insert_combined_health_json(&mut combined, None, ".")
-            .expect("empty health section should serialize");
+        let health =
+            build_combined_health_json(None, ".").expect("empty health section should serialize");
 
-        assert!(combined.is_empty());
+        assert!(dupes.is_none());
+        assert!(health.is_none());
     }
 
     #[test]
     fn emit_combined_json_output_can_attach_empty_meta() {
         let combined = combined_json_root(Duration::ZERO).expect("combined JSON root");
 
-        assert_eq!(
-            emit_combined_json_output(combined, None, None, None, true),
-            ExitCode::SUCCESS
-        );
+        assert_eq!(emit_combined_json_output(combined), ExitCode::SUCCESS);
     }
 }

--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -8,22 +8,9 @@ use std::process::ExitCode;
 
 use colored::Colorize;
 use fallow_config::OutputFormat;
-use serde_json::{Value, json};
+use serde_json::Value;
 
 const DOCS_BASE: &str = "https://docs.fallow.tools";
-
-/// Docs URL for the dead-code (check) command.
-pub const CHECK_DOCS: &str = "https://docs.fallow.tools/cli/dead-code";
-
-/// `_meta` description for the per-finding `actions[]` array shared across
-/// `check`, `health`, and `dupes` JSON output.
-const ACTIONS_FIELD_DEFINITION: &str = "Per-finding fix and suppression suggestions. Each entry carries a `type` discriminant (kebab-case) plus a per-action `auto_fixable` bool. Consumers dispatch on `type` to choose the remediation and filter on `auto_fixable` of each individual entry.";
-
-/// `_meta` description for the per-action `auto_fixable` bool. Calls out the
-/// per-finding (not per-action-type) evaluation rule and the currently active
-/// per-instance flips so agents know to branch on the field value of EACH
-/// finding's action, not on the action `type` alone.
-const ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION: &str = "Evaluated PER FINDING, not per action type. The same `type` may carry `auto_fixable: true` on one finding and `auto_fixable: false` on another when per-instance guards in the `fallow fix` applier discriminate. Filter on this bool of each individual action, not on `type` alone. Current per-instance flips: (1) `remove-catalog-entry` is `true` only when the finding's `hardcoded_consumers` array is empty (else fallow fix skips the entry to avoid breaking `pnpm install`); (2) the primary dependency action flips between `remove-dependency` (`auto_fixable: true`) and `move-dependency` (`auto_fixable: false`) based on `used_in_workspaces`; (3) `add-to-config` for `ignoreExports` is `true` when fallow fix can safely apply the action, which means EITHER a fallow config file already exists OR no config exists and the working directory is NOT inside a monorepo subpackage (the applier then creates `.fallowrc.json` using `fallow init`'s framework-aware scaffolding and layers the new rules on top); `false` inside a monorepo subpackage with no workspace-root config because the applier refuses to fragment per-package configs; (4) `update-catalog-reference` is always `false` today (catalog-switching applier not yet wired). All `suppress-line` and `suppress-file` actions are uniformly `false`.";
 
 /// Rule definition for SARIF `fullDescription` and JSON `_meta`.
 pub struct RuleDef {
@@ -1267,68 +1254,6 @@ pub const SECURITY_RULES: &[RuleDef] = &[
     ),
 ];
 
-/// Build the `_meta` object for `fallow dead-code --format json --explain`.
-#[must_use]
-pub fn check_meta() -> Value {
-    let rules: Value = CHECK_RULES
-        .iter()
-        .map(|r| {
-            (
-                r.id.replace("fallow/", ""),
-                json!({
-                    "name": r.name,
-                    "description": r.full,
-                    "docs": rule_docs_url(r)
-                }),
-            )
-        })
-        .collect::<serde_json::Map<String, Value>>()
-        .into();
-
-    json!({
-        "docs": CHECK_DOCS,
-        "rules": rules,
-        "field_definitions": {
-            "actions[]": ACTIONS_FIELD_DEFINITION,
-            "actions[].auto_fixable": ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION
-        }
-    })
-}
-
-/// Build the sectioned `_meta` object for bare `fallow --format json --explain`.
-#[must_use]
-pub fn combined_meta(include_check: bool, include_dupes: bool, include_health: bool) -> Value {
-    let mut sections = serde_json::Map::new();
-    if include_check {
-        sections.insert("check".to_string(), check_meta());
-    }
-    if include_dupes {
-        sections.insert("dupes".to_string(), dupes_meta());
-    }
-    if include_health {
-        sections.insert("health".to_string(), health_meta());
-    }
-    Value::Object(sections)
-}
-
-/// Build the `_meta` object for `fallow health --format json --explain`.
-#[must_use]
-pub fn health_meta() -> Value {
-    match serde_json::to_value(fallow_output::health_meta()) {
-        Ok(value) => value,
-        Err(_) => json!({}),
-    }
-}
-
-/// Build the `_meta` object for `fallow dupes --format json --explain`.
-#[must_use]
-pub fn dupes_meta() -> Value {
-    match serde_json::to_value(fallow_output::dupes_meta()) {
-        Ok(value) => value,
-        Err(_) => json!({}),
-    }
-}
-
 /// Build the `_meta` object for `fallow security --format json --explain`.
 #[must_use]
 pub fn security_meta() -> fallow_types::envelope::Meta {
@@ -1357,6 +1282,23 @@ pub fn coverage_analyze_meta() -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    fn meta_value(meta: fallow_types::envelope::Meta) -> Value {
+        serde_json::to_value(meta).expect("metadata should serialize")
+    }
+
+    fn check_meta() -> Value {
+        meta_value(fallow_output::check_meta())
+    }
+
+    fn health_meta() -> Value {
+        meta_value(fallow_output::health_meta())
+    }
+
+    fn dupes_meta() -> Value {
+        meta_value(fallow_output::dupes_meta())
+    }
 
     #[test]
     fn rule_by_id_finds_check_rule() {
@@ -1497,11 +1439,11 @@ mod tests {
             let defs = meta["field_definitions"].as_object().unwrap();
             assert_eq!(
                 defs["actions[]"].as_str().unwrap(),
-                ACTIONS_FIELD_DEFINITION,
+                fallow_output::ACTIONS_FIELD_DEFINITION,
             );
             assert_eq!(
                 defs["actions[].auto_fixable"].as_str().unwrap(),
-                ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION,
+                fallow_output::ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION,
             );
         }
     }
@@ -1864,8 +1806,8 @@ mod tests {
 
     #[test]
     fn check_docs_url_valid() {
-        assert!(CHECK_DOCS.starts_with("https://"));
-        assert!(CHECK_DOCS.contains("dead-code"));
+        assert!(fallow_output::CHECK_DOCS.starts_with("https://"));
+        assert!(fallow_output::CHECK_DOCS.contains("dead-code"));
     }
 
     #[test]
@@ -1883,7 +1825,7 @@ mod tests {
     #[test]
     fn check_meta_docs_url_matches_constant() {
         let meta = check_meta();
-        assert_eq!(meta["docs"].as_str().unwrap(), CHECK_DOCS);
+        assert_eq!(meta["docs"].as_str().unwrap(), fallow_output::CHECK_DOCS);
     }
 
     #[test]

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -280,7 +280,12 @@ fn build_dead_code_json(
                     .with_context("dead-code")
             })?;
     if explain {
-        insert_meta(&mut output, crate::explain::check_meta());
+        let meta = serde_json::to_value(fallow_output::check_meta()).map_err(|err| {
+            ProgrammaticError::new(format!("failed to serialize dead-code metadata: {err}"), 2)
+                .with_code("FALLOW_SERIALIZE_DEAD_CODE_META")
+                .with_context("dead-code")
+        })?;
+        insert_meta(&mut output, meta);
     }
     // `build_dead_code_json` is only called after options have been resolved;
     // callers apply the root-envelope compatibility setting at the boundary.

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -201,7 +201,8 @@ pub use review_envelopes::{
 };
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
-    apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_json_root_output,
+    apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_audit_json_output,
+    serialize_json_root_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -202,7 +202,7 @@ pub use review_envelopes::{
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
     apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_audit_json_output,
-    serialize_json_root_output,
+    serialize_combined_json_output, serialize_json_root_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -41,6 +41,37 @@ pub fn serialize_json_root_output<T: Serialize>(
     Ok(value)
 }
 
+/// Serialize a typed `fallow audit --format json` envelope with the standard
+/// root discriminator policy.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_audit_json_output<
+    Verdict,
+    Summary,
+    Attribution,
+    DeadCode,
+    Duplication,
+    Complexity,
+>(
+    output: AuditOutput<Verdict, Summary, Attribution, DeadCode, Duplication, Complexity>,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error>
+where
+    Verdict: Serialize,
+    Summary: Serialize,
+    Attribution: Serialize,
+    DeadCode: Serialize,
+    Duplication: Serialize,
+    Complexity: Serialize,
+{
+    let mut value = serde_json::to_value(output)?;
+    apply_root_kind(&mut value, "audit", mode);
+    Ok(value)
+}
+
 /// Remove only the document-root discriminator. Nested objects may carry their
 /// own meaningful `kind` fields, so this intentionally does not recurse.
 pub fn remove_root_kind(value: &mut serde_json::Value) {
@@ -296,6 +327,7 @@ pub enum FallowOutput<
 
 #[cfg(test)]
 mod tests {
+    use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
     use serde_json::json;
 
     use super::*;
@@ -379,5 +411,36 @@ mod tests {
 
         assert!(value.get("kind").is_none());
         assert_eq!(value["schema_version"], 1);
+    }
+
+    #[test]
+    fn serialize_audit_json_output_applies_audit_kind() {
+        let value = serialize_audit_json_output(
+            AuditOutput {
+                schema_version: SchemaVersion(7),
+                version: ToolVersion("1.2.3".to_string()),
+                command: AuditCommand::Audit,
+                verdict: "pass",
+                changed_files_count: 2,
+                base_ref: "origin/main".to_string(),
+                base_description: Some("merge-base with origin/main".to_string()),
+                head_sha: Some("abc123".to_string()),
+                elapsed_ms: ElapsedMs(42),
+                base_snapshot_skipped: Some(false),
+                summary: json!({ "dead_code_issues": 0 }),
+                attribution: json!({ "gate": "new_only" }),
+                meta: None,
+                dead_code: Some(json!({ "summary": { "total_issues": 0 } })),
+                duplication: None::<serde_json::Value>,
+                complexity: None::<serde_json::Value>,
+                next_steps: Vec::new(),
+            },
+            RootEnvelopeMode::Tagged,
+        )
+        .expect("audit output should serialize");
+
+        assert_eq!(value["kind"], "audit");
+        assert_eq!(value["command"], "audit");
+        assert_eq!(value["dead_code"]["summary"]["total_issues"], 0);
     }
 }

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -72,6 +72,27 @@ where
     Ok(value)
 }
 
+/// Serialize a typed bare `fallow --format json` combined envelope with the
+/// standard root discriminator policy.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_combined_json_output<Check, Dupes, Health>(
+    output: CombinedOutput<Check, Dupes, Health>,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error>
+where
+    Check: Serialize,
+    Dupes: Serialize,
+    Health: Serialize,
+{
+    let mut value = serde_json::to_value(output)?;
+    apply_root_kind(&mut value, "combined", mode);
+    Ok(value)
+}
+
 /// Remove only the document-root discriminator. Nested objects may carry their
 /// own meaningful `kind` fields, so this intentionally does not recurse.
 pub fn remove_root_kind(value: &mut serde_json::Value) {
@@ -442,5 +463,26 @@ mod tests {
         assert_eq!(value["kind"], "audit");
         assert_eq!(value["command"], "audit");
         assert_eq!(value["dead_code"]["summary"]["total_issues"], 0);
+    }
+
+    #[test]
+    fn serialize_combined_json_output_applies_combined_kind() {
+        let value = serialize_combined_json_output(
+            CombinedOutput {
+                schema_version: SchemaVersion(7),
+                version: ToolVersion("1.2.3".to_string()),
+                elapsed_ms: ElapsedMs(42),
+                meta: None,
+                check: Some(json!({ "summary": { "total_issues": 0 } })),
+                dupes: None::<serde_json::Value>,
+                health: None::<serde_json::Value>,
+                next_steps: Vec::new(),
+            },
+            RootEnvelopeMode::Tagged,
+        )
+        .expect("combined output should serialize");
+
+        assert_eq!(value["kind"], "combined");
+        assert_eq!(value["check"]["summary"]["total_issues"], 0);
     }
 }


### PR DESCRIPTION
## Summary
- route audit JSON through fallow-output typed root envelopes
- route bare combined JSON through fallow-output typed root envelopes
- move shared dead-code metadata use to fallow-output and remove duplicate CLI meta wrappers

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- cargo test -p fallow-output root_envelopes::tests::serialize_
- cargo test -p fallow-cli combined::output::tests
- cargo test -p fallow-cli audit_output::tests
- cargo test -p fallow-cli explain::tests
- .githooks/pre-commit
- .githooks/pre-push