### PR TITLE
refactor: route named json roots through output contract

### DIFF
--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -8,10 +8,9 @@
 //! audit verdict is `fail`. The verdict is still computed and carried in the
 //! brief JSON informationally, but it never drives the exit code on this path.
 //!
-//! The JSON envelope is an independently-versioned
-//! [`crate::output_envelope::FallowOutput::AuditBrief`] variant
-//! (`kind: "audit-brief"`) so the brief shape evolves on its own cadence
-//! without bumping the main `--format json` contract.
+//! The JSON envelope is independently versioned and tagged as
+//! `kind: "audit-brief"` so the brief shape evolves on its own cadence without
+//! bumping the main `--format json` contract.
 
 use std::process::ExitCode;
 
@@ -489,9 +488,12 @@ fn build_brief_json(result: &AuditResult) -> Result<serde_json::Value, ExitCode>
 /// surfaces the error but the brief contract still exits 0.
 fn print_brief_json(result: &AuditResult) -> ExitCode {
     match build_brief_json(result) {
-        Ok(mut output) => {
-            crate::output_envelope::apply_root_kind(&mut output, "audit-brief");
-            crate::output_envelope::attach_telemetry_meta(&mut output);
+        Ok(output) => {
+            let Ok(output) =
+                crate::output_envelope::serialize_named_root_output(output, "audit-brief")
+            else {
+                return ExitCode::SUCCESS;
+            };
             let _ = crate::report::emit_json(&output, "audit-brief");
             ExitCode::SUCCESS
         }
@@ -801,7 +803,7 @@ pub fn print_brief_result(
 /// tool's output + `fallow decision-surface`). Emits ONLY the ranked, capped
 /// decisions with structured `actions[]`, never the full brief. Always exit 0.
 ///
-/// JSON renders the `FallowOutput::DecisionSurface` envelope (`kind:
+/// JSON renders the typed decision-surface envelope (`kind:
 /// "decision-surface"`); human / compact / markdown render the apex header.
 #[must_use]
 pub fn print_decision_surface_result(result: &AuditResult, quiet: bool) -> ExitCode {
@@ -810,13 +812,9 @@ pub fn print_decision_surface_result(result: &AuditResult, quiet: bool) -> ExitC
     let surface = result.decision_surface.clone().unwrap_or_default();
     match result.output {
         OutputFormat::Json => {
-            let envelope = crate::output_envelope::FallowOutput::DecisionSurface(
-                crate::audit_decision_surface::build_decision_surface_output(&surface),
-            );
-            match serde_json::to_value(&envelope) {
-                Ok(mut value) => {
-                    crate::output_envelope::apply_root_kind(&mut value, "decision-surface");
-                    crate::output_envelope::attach_telemetry_meta(&mut value);
+            let output = crate::audit_decision_surface::build_decision_surface_output(&surface);
+            match crate::output_envelope::serialize_named_root_output(output, "decision-surface") {
+                Ok(value) => {
                     let _ = crate::report::emit_json(&value, "decision-surface");
                     ExitCode::SUCCESS
                 }
@@ -834,17 +832,16 @@ pub fn print_decision_surface_result(result: &AuditResult, quiet: bool) -> ExitC
 
 /// Render the agent-contract WALKTHROUGH GUIDE: the digest (brief +
 /// decision surface), the review direction, the JSON schema the agent returns,
-/// and the deterministic graph-snapshot pin. JSON renders the
-/// `FallowOutput::WalkthroughGuide` envelope (`kind: "review-walkthrough-guide"`).
-/// Every format emits the guide as JSON: the guide is an agent-facing contract,
-/// not a human walkthrough. Always exit 0.
+/// and the deterministic graph-snapshot pin. JSON renders the typed guide
+/// envelope (`kind: "review-walkthrough-guide"`). Every format emits the guide
+/// as JSON: the guide is an agent-facing contract, not a human walkthrough.
+/// Always exit 0.
 #[must_use]
 pub fn print_walkthrough_guide_result(result: &AuditResult) -> ExitCode {
     let guide = crate::audit_walkthrough::build_guide_from_result(result);
-    let envelope = crate::output_envelope::FallowOutput::WalkthroughGuide(guide);
-    if let Ok(mut value) = serde_json::to_value(&envelope) {
-        crate::output_envelope::apply_root_kind(&mut value, "review-walkthrough-guide");
-        crate::output_envelope::attach_telemetry_meta(&mut value);
+    if let Ok(value) =
+        crate::output_envelope::serialize_named_root_output(guide, "review-walkthrough-guide")
+    {
         let _ = crate::report::emit_json(&value, "review-walkthrough-guide");
     }
     ExitCode::SUCCESS
@@ -853,7 +850,7 @@ pub fn print_walkthrough_guide_result(result: &AuditResult) -> ExitCode {
 /// Ingest the agent's judgment JSON from `path` and POST-VALIDATE it against
 /// the live graph: reject unanchored signal_ids (anti-hallucination), refuse the
 /// whole payload when the echoed graph-snapshot hash is stale (the tree moved).
-/// JSON renders the `FallowOutput::WalkthroughValidation` envelope (`kind:
+/// JSON renders the typed walkthrough-validation envelope (`kind:
 /// "review-walkthrough-validation"`). Always exit 0 (advisory).
 ///
 /// A path that cannot be read yields an empty agent payload (default `""` hash),
@@ -873,10 +870,10 @@ pub fn print_walkthrough_file_result(result: &AuditResult, path: &std::path::Pat
         &change_anchor_ids,
         &current_hash,
     );
-    let envelope = crate::output_envelope::FallowOutput::WalkthroughValidation(validation);
-    if let Ok(mut value) = serde_json::to_value(&envelope) {
-        crate::output_envelope::apply_root_kind(&mut value, "review-walkthrough-validation");
-        crate::output_envelope::attach_telemetry_meta(&mut value);
+    if let Ok(value) = crate::output_envelope::serialize_named_root_output(
+        validation,
+        "review-walkthrough-validation",
+    ) {
         let _ = crate::report::emit_json(&value, "review-walkthrough-validation");
     }
     ExitCode::SUCCESS
@@ -949,8 +946,11 @@ mod tests {
     #[test]
     fn brief_json_validates_against_audit_brief_schema_variant() {
         let result = audit_result(AuditVerdict::Fail, OutputFormat::Json);
-        let mut value = build_brief_json(&result).expect("brief json must build");
-        crate::output_envelope::apply_root_kind(&mut value, "audit-brief");
+        let value = crate::output_envelope::serialize_named_root_output(
+            build_brief_json(&result).expect("brief json must build"),
+            "audit-brief",
+        )
+        .expect("brief json must serialize");
 
         assert_eq!(value["kind"], "audit-brief");
         assert_eq!(value["command"], "audit-brief");

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -161,9 +161,7 @@ fn emit_reconcile_result(
         failed_fingerprints: applied.failed_fingerprints.iter().cloned().collect(),
         unapplied_fingerprints: applied.unapplied_fingerprints.iter().cloned().collect(),
     };
-    match crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::ReviewReconcile(envelope_struct),
-    ) {
+    match crate::output_envelope::serialize_named_root_output(envelope_struct, "review-reconcile") {
         Ok(value) => crate::report::emit_json(&value, "review reconcile"),
         Err(e) => emit_error(
             &format!("JSON serialization error: {e}"),

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -1172,7 +1172,8 @@ fn print_runtime_json(
     explain: bool,
 ) -> ExitCode {
     use crate::output_envelope::{
-        CoverageAnalyzeOutput, CoverageAnalyzeSchemaVersion, FallowOutput, serialize_root_output,
+        CoverageAnalyzeOutput, CoverageAnalyzeSchemaVersion,
+        serialize_named_root_output_without_telemetry,
     };
     use fallow_types::envelope::{ElapsedMs, ToolVersion};
 
@@ -1188,13 +1189,14 @@ fn print_runtime_json(
         runtime_coverage: report.clone(),
         meta: None,
     };
-    let mut output = match serialize_root_output(FallowOutput::CoverageAnalyze(envelope)) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("Error: failed to serialize runtime coverage report: {err}");
-            return ExitCode::from(2);
-        }
-    };
+    let mut output =
+        match serialize_named_root_output_without_telemetry(envelope, "coverage-analyze") {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("Error: failed to serialize runtime coverage report: {err}");
+                return ExitCode::from(2);
+            }
+        };
     if explain && let Some(map) = output.as_object_mut() {
         map.insert("_meta".to_owned(), crate::explain::coverage_analyze_meta());
     }

--- a/crates/cli/src/coverage/mod.rs
+++ b/crates/cli/src/coverage/mod.rs
@@ -726,10 +726,8 @@ fn run_setup_json(root: &Path, explain: bool) -> ExitCode {
 )]
 fn build_setup_json(root: &Path, explain: bool) -> serde_json::Value {
     let envelope = build_setup_envelope(root, explain);
-    crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::CoverageSetup(envelope),
-    )
-    .expect("CoverageSetupOutput serializes infallibly")
+    crate::output_envelope::serialize_named_root_output(envelope, "coverage-setup")
+        .expect("CoverageSetupOutput serializes infallibly")
 }
 
 fn build_setup_envelope(root: &Path, explain: bool) -> crate::output_envelope::CoverageSetupOutput {

--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -870,9 +870,7 @@ pub fn run_explain(issue_type: &str, output: OutputFormat) -> ExitCode {
                 how_to_fix: guide.how_to_fix.to_string(),
                 docs: rule_docs_url(rule),
             };
-            match crate::output_envelope::serialize_root_output(
-                crate::output_envelope::FallowOutput::Explain(envelope),
-            ) {
+            match crate::output_envelope::serialize_named_root_output(envelope, "explain") {
                 Ok(value) => crate::report::emit_json(&value, "explain"),
                 Err(e) => {
                     crate::error::emit_error(&format!("JSON serialization error: {e}"), 2, output)

--- a/crates/cli/src/impact.rs
+++ b/crates/cli/src/impact.rs
@@ -2064,10 +2064,8 @@ fn render_human_footer(out: &mut String, report: &ImpactReport) {
 
 /// Render the report as JSON.
 pub fn render_json(report: &ImpactReport) -> String {
-    let value = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::Impact(report.clone()),
-    )
-    .unwrap_or_else(|_| serde_json::json!({"error":"failed to serialize impact report"}));
+    let value = crate::output_envelope::serialize_named_root_output(report.clone(), "impact")
+        .unwrap_or_else(|_| serde_json::json!({"error":"failed to serialize impact report"}));
     serde_json::to_string_pretty(&value)
         .unwrap_or_else(|_| "{\"error\":\"failed to serialize impact report\"}".to_owned())
 }
@@ -2200,12 +2198,11 @@ fn render_markdown_footer(out: &mut String, report: &ImpactReport) {
 /// Render the cross-repo report as JSON via the typed `ImpactCrossRepo` envelope.
 #[must_use]
 pub fn render_cross_repo_json(report: &CrossRepoImpactReport) -> String {
-    let value = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::ImpactCrossRepo(report.clone()),
-    )
-    .unwrap_or_else(
-        |_| serde_json::json!({"error":"failed to serialize cross-repo impact report"}),
-    );
+    let value =
+        crate::output_envelope::serialize_named_root_output(report.clone(), "impact-cross-repo")
+            .unwrap_or_else(
+                |_| serde_json::json!({"error":"failed to serialize cross-repo impact report"}),
+            );
     serde_json::to_string_pretty(&value).unwrap_or_else(|_| {
         "{\"error\":\"failed to serialize cross-repo impact report\"}".to_owned()
     })

--- a/crates/cli/src/inspect.rs
+++ b/crates/cli/src/inspect.rs
@@ -6,9 +6,9 @@ use serde_json::{Value, json};
 
 use crate::error::emit_error;
 use crate::output_envelope::{
-    FallowOutput, InspectEvidence, InspectEvidenceScope, InspectEvidenceSection,
-    InspectFileIdentity, InspectIdentity, InspectOutput, InspectSectionStatus,
-    InspectSymbolIdentity, InspectTargetDescriptor, serialize_root_output,
+    InspectEvidence, InspectEvidenceScope, InspectEvidenceSection, InspectFileIdentity,
+    InspectIdentity, InspectOutput, InspectSectionStatus, InspectSymbolIdentity,
+    InspectTargetDescriptor, serialize_named_root_output,
 };
 use crate::report;
 use crate::report::sink::outln;
@@ -290,7 +290,7 @@ fn build_inspect_identity(
 fn emit_inspect_bundle(bundle: InspectOutput, opts: &InspectOptions<'_>) -> ExitCode {
     match opts.output {
         OutputFormat::Json => {
-            let value = match serialize_root_output(FallowOutput::Inspect(bundle)) {
+            let value = match serialize_named_root_output(bundle, "inspect_target") {
                 Ok(value) => value,
                 Err(err) => {
                     return emit_error(

--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -312,12 +312,32 @@ fn print_list_json(input: &ListJsonInput<'_>) -> ExitCode {
         && !input.opts.entry_points
         && !input.opts.boundaries;
 
-    let mut output = serde_json::Value::Object(result);
-    if has_boundaries {
-        crate::output_envelope::apply_root_kind(&mut output, "list-boundaries");
+    let output = serde_json::Value::Object(result);
+    let output = if has_boundaries {
+        match crate::output_envelope::serialize_named_root_output_without_telemetry(
+            output,
+            "list-boundaries",
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("Error: failed to serialize list output: {err}");
+                return ExitCode::from(2);
+            }
+        }
     } else if workspace_only {
-        crate::output_envelope::apply_root_kind(&mut output, "list-workspaces");
-    }
+        match crate::output_envelope::serialize_named_root_output_without_telemetry(
+            output,
+            "list-workspaces",
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("Error: failed to serialize list output: {err}");
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        output
+    };
 
     match serde_json::to_string_pretty(&output) {
         Ok(json) => {

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -33,6 +33,7 @@ pub use fallow_output::{
     build_dupes_output, build_health_output, default_marker_regex, default_marker_regex_flags,
     is_false,
 };
+use serde::Serialize;
 
 static LEGACY_ENVELOPE: AtomicBool = AtomicBool::new(false);
 static TELEMETRY_ANALYSIS_RUN_ID: Mutex<Option<String>> = Mutex::new(None);
@@ -75,10 +76,21 @@ pub fn serialize_root_output(output: FallowOutput) -> Result<serde_json::Value, 
     serialize_root_output_with_mode(output, EnvelopeMode::current())
 }
 
-pub fn serialize_root_output_without_telemetry(
-    output: FallowOutput,
+pub fn serialize_named_root_output<T: Serialize>(
+    output: T,
+    kind: &'static str,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    fallow_output::serialize_json_root_output(output, EnvelopeMode::current().into())
+    let mut value =
+        fallow_output::serialize_named_json_output(output, kind, EnvelopeMode::current().into())?;
+    attach_telemetry_meta(&mut value);
+    Ok(value)
+}
+
+pub fn serialize_named_root_output_without_telemetry<T: Serialize>(
+    output: T,
+    kind: &'static str,
+) -> Result<serde_json::Value, serde_json::Error> {
+    fallow_output::serialize_named_json_output(output, kind, EnvelopeMode::current().into())
 }
 
 pub fn serialize_root_output_with_mode(
@@ -92,10 +104,6 @@ pub fn serialize_root_output_with_mode(
 
 pub fn attach_telemetry_meta(value: &mut serde_json::Value) {
     fallow_output::attach_telemetry_meta(value, telemetry_analysis_run_id().as_deref());
-}
-
-pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str) {
-    fallow_output::apply_root_kind(value, kind, EnvelopeMode::current().into());
 }
 
 impl From<EnvelopeMode> for fallow_output::RootEnvelopeMode {

--- a/crates/cli/src/report/ci/review.rs
+++ b/crates/cli/src/report/ci/review.rs
@@ -208,10 +208,8 @@ fn print_review_envelope_from_ci_issues(
     issues: &[CiIssue],
 ) -> ExitCode {
     let envelope = render_review_envelope(command, provider, issues);
-    let value = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::ReviewEnvelope(envelope),
-    )
-    .expect("ReviewEnvelopeOutput serializes infallibly");
+    let value = crate::output_envelope::serialize_named_root_output(envelope, "review-envelope")
+        .expect("ReviewEnvelopeOutput serializes infallibly");
     emit_json(&value, "review envelope")
 }
 

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -1618,9 +1618,8 @@ fn relativize(path: &Path, root: &Path) -> PathBuf {
 /// JSON: the `SecurityOutput` envelope, pretty-printed.
 #[must_use]
 pub fn render_json(output: &SecurityOutput) -> String {
-    let Ok(value) = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::Security(output.clone()),
-    ) else {
+    let Ok(value) = crate::output_envelope::serialize_named_root_output(output.clone(), "security")
+    else {
         return "{\"error\":\"failed to serialize security output\"}".to_owned();
     };
     serde_json::to_string_pretty(&value)
@@ -1639,9 +1638,9 @@ pub fn render_json_summary(output: &SecurityOutput) -> String {
         gate: output.gate,
         summary: security_summary(output),
     };
-    let Ok(value) = crate::output_envelope::serialize_root_output_without_telemetry(
-        crate::output_envelope::FallowOutput::SecuritySummary(summary),
-    ) else {
+    let Ok(value) =
+        crate::output_envelope::serialize_named_root_output_without_telemetry(summary, "security")
+    else {
         return "{\"error\":\"failed to serialize security summary output\"}".to_owned();
     };
     serde_json::to_string_pretty(&value).unwrap_or_else(|_| {
@@ -1661,8 +1660,9 @@ fn render_survivors_output(
 
 #[must_use]
 pub fn render_survivors_json(output: &SecuritySurvivorsOutput) -> String {
-    let Ok(value) = crate::output_envelope::serialize_root_output_without_telemetry(
-        crate::output_envelope::FallowOutput::SecuritySurvivors(output.clone()),
+    let Ok(value) = crate::output_envelope::serialize_named_root_output_without_telemetry(
+        output.clone(),
+        "security-survivors",
     ) else {
         return "{\"error\":\"failed to serialize security survivors output\"}".to_owned();
     };
@@ -1861,8 +1861,9 @@ fn render_blind_spots_output(
 
 #[must_use]
 pub fn render_blind_spots_json(output: &SecurityBlindSpotsOutput) -> String {
-    let Ok(value) = crate::output_envelope::serialize_root_output_without_telemetry(
-        crate::output_envelope::FallowOutput::SecurityBlindSpots(output.clone()),
+    let Ok(value) = crate::output_envelope::serialize_named_root_output_without_telemetry(
+        output.clone(),
+        "security-blind-spots",
     ) else {
         return "{\"error\":\"failed to serialize security blind-spots output\"}".to_owned();
     };

--- a/crates/cli/src/trace_chain.rs
+++ b/crates/cli/src/trace_chain.rs
@@ -14,7 +14,7 @@ use fallow_config::{OutputFormat, ProductionAnalysis};
 use fallow_engine::trace_chain::{SymbolChainQuery, SymbolChainTrace, TraceDirections};
 
 use crate::error::emit_error;
-use crate::output_envelope::{FallowOutput, serialize_root_output};
+use crate::output_envelope::serialize_named_root_output;
 use crate::report;
 use crate::report::sink::outln;
 use crate::{ConfigLoadOptions, load_config_for_analysis};
@@ -113,7 +113,7 @@ fn parse_target(target: &str) -> Option<(String, String)> {
 fn emit_trace(trace: SymbolChainTrace, opts: &TraceChainOptions<'_>) -> ExitCode {
     match opts.output {
         OutputFormat::Json => {
-            let value = match serialize_root_output(FallowOutput::Trace(trace)) {
+            let value = match serialize_named_root_output(trace, "trace") {
                 Ok(value) => value,
                 Err(err) => {
                     return emit_error(

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -202,7 +202,7 @@ pub use review_envelopes::{
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
     apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_audit_json_output,
-    serialize_combined_json_output, serialize_json_root_output,
+    serialize_combined_json_output, serialize_json_root_output, serialize_named_json_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -41,6 +41,26 @@ pub fn serialize_json_root_output<T: Serialize>(
     Ok(value)
 }
 
+/// Serialize an output envelope and apply an explicit root discriminator.
+///
+/// Use this for command surfaces whose runtime shape is already a typed
+/// envelope struct and does not need to pass through the schema-only
+/// [`FallowOutput`] enum just to get a top-level `kind`.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_named_json_output<T: Serialize>(
+    output: T,
+    kind: &'static str,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let mut value = serde_json::to_value(output)?;
+    apply_root_kind(&mut value, kind, mode);
+    Ok(value)
+}
+
 /// Serialize a typed `fallow audit --format json` envelope with the standard
 /// root discriminator policy.
 ///
@@ -432,6 +452,22 @@ mod tests {
 
         assert!(value.get("kind").is_none());
         assert_eq!(value["schema_version"], 1);
+    }
+
+    #[test]
+    fn serialize_named_json_output_applies_explicit_kind() {
+        let value = serialize_named_json_output(
+            json!({
+                "schema_version": 1,
+                "summary": { "total": 0 }
+            }),
+            "example",
+            RootEnvelopeMode::Tagged,
+        )
+        .expect("named output should serialize");
+
+        assert_eq!(value["kind"], "example");
+        assert_eq!(value["summary"]["total"], 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an output-owned named root serializer for typed JSON envelopes
- route explain, inspect, trace, review, coverage, list, impact, security, and audit-review JSON roots through that contract
- remove now-unused CLI root-kind helpers while preserving telemetry and legacy-envelope behavior

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-output -p fallow-cli
- cargo clippy -p fallow-output -p fallow-cli --all-targets -- -D warnings
- cargo test -p fallow-output root_envelopes::tests::
- cargo test -p fallow-cli audit_brief::tests
- cargo test -p fallow-cli inspect::tests
- cargo test -p fallow-cli trace_chain::tests
- cargo test -p fallow-cli coverage::
- cargo test -p fallow-cli list::tests
- cargo test -p fallow-cli report::ci::review::tests
- cargo test -p fallow-cli impact::tests
- cargo test -p fallow-cli security::tests
- cargo test -p fallow-cli coverage::analyze::tests
- .githooks/pre-commit
- .githooks/pre-push