### PR TITLE
refactor: route napi health and json outputs through contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,6 @@ version = "2.102.0"
 dependencies = [
  "fallow-api",
  "fallow-cli",
- "serde_json",
 ]
 
 [[package]]

--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -8,10 +8,9 @@
 //! audit verdict is `fail`. The verdict is still computed and carried in the
 //! brief JSON informationally, but it never drives the exit code on this path.
 //!
-//! The JSON envelope is an independently-versioned
-//! [`crate::output_envelope::FallowOutput::AuditBrief`] variant
-//! (`kind: "audit-brief"`) so the brief shape evolves on its own cadence
-//! without bumping the main `--format json` contract.
+//! The JSON envelope is independently versioned and tagged as
+//! `kind: "audit-brief"` so the brief shape evolves on its own cadence without
+//! bumping the main `--format json` contract.
 
 use std::process::ExitCode;
 
@@ -489,9 +488,12 @@ fn build_brief_json(result: &AuditResult) -> Result<serde_json::Value, ExitCode>
 /// surfaces the error but the brief contract still exits 0.
 fn print_brief_json(result: &AuditResult) -> ExitCode {
     match build_brief_json(result) {
-        Ok(mut output) => {
-            crate::output_envelope::apply_root_kind(&mut output, "audit-brief");
-            crate::output_envelope::attach_telemetry_meta(&mut output);
+        Ok(output) => {
+            let Ok(output) =
+                crate::output_envelope::serialize_named_root_output(output, "audit-brief")
+            else {
+                return ExitCode::SUCCESS;
+            };
             let _ = crate::report::emit_json(&output, "audit-brief");
             ExitCode::SUCCESS
         }
@@ -801,7 +803,7 @@ pub fn print_brief_result(
 /// tool's output + `fallow decision-surface`). Emits ONLY the ranked, capped
 /// decisions with structured `actions[]`, never the full brief. Always exit 0.
 ///
-/// JSON renders the `FallowOutput::DecisionSurface` envelope (`kind:
+/// JSON renders the typed decision-surface envelope (`kind:
 /// "decision-surface"`); human / compact / markdown render the apex header.
 #[must_use]
 pub fn print_decision_surface_result(result: &AuditResult, quiet: bool) -> ExitCode {
@@ -810,13 +812,9 @@ pub fn print_decision_surface_result(result: &AuditResult, quiet: bool) -> ExitC
     let surface = result.decision_surface.clone().unwrap_or_default();
     match result.output {
         OutputFormat::Json => {
-            let envelope = crate::output_envelope::FallowOutput::DecisionSurface(
-                crate::audit_decision_surface::build_decision_surface_output(&surface),
-            );
-            match serde_json::to_value(&envelope) {
-                Ok(mut value) => {
-                    crate::output_envelope::apply_root_kind(&mut value, "decision-surface");
-                    crate::output_envelope::attach_telemetry_meta(&mut value);
+            let output = crate::audit_decision_surface::build_decision_surface_output(&surface);
+            match crate::output_envelope::serialize_named_root_output(output, "decision-surface") {
+                Ok(value) => {
                     let _ = crate::report::emit_json(&value, "decision-surface");
                     ExitCode::SUCCESS
                 }
@@ -834,17 +832,16 @@ pub fn print_decision_surface_result(result: &AuditResult, quiet: bool) -> ExitC
 
 /// Render the agent-contract WALKTHROUGH GUIDE: the digest (brief +
 /// decision surface), the review direction, the JSON schema the agent returns,
-/// and the deterministic graph-snapshot pin. JSON renders the
-/// `FallowOutput::WalkthroughGuide` envelope (`kind: "review-walkthrough-guide"`).
-/// Every format emits the guide as JSON: the guide is an agent-facing contract,
-/// not a human walkthrough. Always exit 0.
+/// and the deterministic graph-snapshot pin. JSON renders the typed guide
+/// envelope (`kind: "review-walkthrough-guide"`). Every format emits the guide
+/// as JSON: the guide is an agent-facing contract, not a human walkthrough.
+/// Always exit 0.
 #[must_use]
 pub fn print_walkthrough_guide_result(result: &AuditResult) -> ExitCode {
     let guide = crate::audit_walkthrough::build_guide_from_result(result);
-    let envelope = crate::output_envelope::FallowOutput::WalkthroughGuide(guide);
-    if let Ok(mut value) = serde_json::to_value(&envelope) {
-        crate::output_envelope::apply_root_kind(&mut value, "review-walkthrough-guide");
-        crate::output_envelope::attach_telemetry_meta(&mut value);
+    if let Ok(value) =
+        crate::output_envelope::serialize_named_root_output(guide, "review-walkthrough-guide")
+    {
         let _ = crate::report::emit_json(&value, "review-walkthrough-guide");
     }
     ExitCode::SUCCESS
@@ -853,7 +850,7 @@ pub fn print_walkthrough_guide_result(result: &AuditResult) -> ExitCode {
 /// Ingest the agent's judgment JSON from `path` and POST-VALIDATE it against
 /// the live graph: reject unanchored signal_ids (anti-hallucination), refuse the
 /// whole payload when the echoed graph-snapshot hash is stale (the tree moved).
-/// JSON renders the `FallowOutput::WalkthroughValidation` envelope (`kind:
+/// JSON renders the typed walkthrough-validation envelope (`kind:
 /// "review-walkthrough-validation"`). Always exit 0 (advisory).
 ///
 /// A path that cannot be read yields an empty agent payload (default `""` hash),
@@ -873,10 +870,10 @@ pub fn print_walkthrough_file_result(result: &AuditResult, path: &std::path::Pat
         &change_anchor_ids,
         &current_hash,
     );
-    let envelope = crate::output_envelope::FallowOutput::WalkthroughValidation(validation);
-    if let Ok(mut value) = serde_json::to_value(&envelope) {
-        crate::output_envelope::apply_root_kind(&mut value, "review-walkthrough-validation");
-        crate::output_envelope::attach_telemetry_meta(&mut value);
+    if let Ok(value) = crate::output_envelope::serialize_named_root_output(
+        validation,
+        "review-walkthrough-validation",
+    ) {
         let _ = crate::report::emit_json(&value, "review-walkthrough-validation");
     }
     ExitCode::SUCCESS
@@ -949,8 +946,11 @@ mod tests {
     #[test]
     fn brief_json_validates_against_audit_brief_schema_variant() {
         let result = audit_result(AuditVerdict::Fail, OutputFormat::Json);
-        let mut value = build_brief_json(&result).expect("brief json must build");
-        crate::output_envelope::apply_root_kind(&mut value, "audit-brief");
+        let value = crate::output_envelope::serialize_named_root_output(
+            build_brief_json(&result).expect("brief json must build"),
+            "audit-brief",
+        )
+        .expect("brief json must serialize");
 
         assert_eq!(value["kind"], "audit-brief");
         assert_eq!(value["command"], "audit-brief");

--- a/crates/cli/src/audit_decision_surface.rs
+++ b/crates/cli/src/audit_decision_surface.rs
@@ -39,8 +39,7 @@
 //! never emitted is REJECTED. The agent proposes; the graph disposes.
 
 pub use fallow_output::{
-    Decision, DecisionCategory, DecisionSurface, DecisionSurfaceOutput, TruncationNote,
-    build_decision_surface_output,
+    Decision, DecisionCategory, DecisionSurface, TruncationNote, build_decision_surface_output,
 };
 use xxhash_rust::xxh3::xxh3_64;
 

--- a/crates/cli/src/audit_output.rs
+++ b/crates/cli/src/audit_output.rs
@@ -3,7 +3,8 @@ use std::process::ExitCode;
 
 use colored::Colorize;
 use fallow_config::{AuditGate, OutputFormat};
-use fallow_output::CodeClimateIssue;
+use fallow_output::{AuditCommand, AuditOutput, CodeClimateIssue, RootEnvelopeMode};
+use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
 use crate::error::emit_error;
 use crate::report;
@@ -329,40 +330,69 @@ fn print_audit_status_line(result: &AuditResult) {
 }
 
 fn print_audit_json(result: &AuditResult) -> ExitCode {
-    let mut obj = serde_json::Map::new();
-    insert_audit_json_header(&mut obj, result);
-
-    if let Some(ref check) = result.check
-        && let Err(code) = insert_audit_dead_code_json(&mut obj, result, check)
-    {
-        return code;
-    }
-
-    if let Some(ref dupes) = result.dupes
-        && let Err(code) = insert_audit_duplication_json(&mut obj, result, dupes)
-    {
-        return code;
-    }
-
-    if let Some(ref health) = result.health
-        && let Err(code) = insert_audit_health_json(&mut obj, result, health)
-    {
-        return code;
-    }
-
-    insert_audit_next_steps_json(&mut obj, result);
-
-    let mut output = serde_json::Value::Object(obj);
-    crate::output_envelope::apply_root_kind(&mut output, "audit");
+    let mut output = match build_audit_json_output(result) {
+        Ok(output) => output,
+        Err(code) => return code,
+    };
     report::harmonize_multi_kind_suppress_line_actions(&mut output);
     crate::output_envelope::attach_telemetry_meta(&mut output);
     report::emit_json(&output, "audit")
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "elapsed milliseconds won't exceed u64::MAX"
-)]
+fn build_audit_json_output(result: &AuditResult) -> Result<serde_json::Value, ExitCode> {
+    let dead_code = result
+        .check
+        .as_ref()
+        .map(|check| build_audit_dead_code_json(result, check))
+        .transpose()?;
+    let duplication = result
+        .dupes
+        .as_ref()
+        .map(|dupes| build_audit_duplication_json(result, dupes))
+        .transpose()?;
+    let complexity = result
+        .health
+        .as_ref()
+        .map(|health| build_audit_health_json(result, health))
+        .transpose()?;
+
+    let output = AuditOutput {
+        schema_version: SchemaVersion(crate::report::SCHEMA_VERSION),
+        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
+        command: AuditCommand::Audit,
+        verdict: result.verdict,
+        changed_files_count: changed_files_count_for_output(result.changed_files_count),
+        base_ref: result.base_ref.clone(),
+        base_description: result.base_description.clone(),
+        head_sha: result.head_sha.clone(),
+        elapsed_ms: ElapsedMs(elapsed_ms_for_output(result.elapsed)),
+        base_snapshot_skipped: result.performance.then_some(result.base_snapshot_skipped),
+        summary: result.summary.clone(),
+        attribution: result.attribution.clone(),
+        meta: None,
+        dead_code,
+        duplication,
+        complexity,
+        next_steps: audit_next_steps(result),
+    };
+
+    fallow_output::serialize_audit_json_output(output, RootEnvelopeMode::Tagged).map_err(|err| {
+        emit_error(
+            &format!("JSON serialization error: {err}"),
+            2,
+            OutputFormat::Json,
+        )
+    })
+}
+
+fn elapsed_ms_for_output(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn changed_files_count_for_output(changed_files_count: usize) -> u32 {
+    u32::try_from(changed_files_count).unwrap_or(u32::MAX)
+}
+
 pub fn insert_audit_json_header(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     result: &AuditResult,
@@ -402,7 +432,9 @@ pub fn insert_audit_json_header(
     }
     obj.insert(
         "elapsed_ms".into(),
-        serde_json::Value::Number(serde_json::Number::from(result.elapsed.as_millis() as u64)),
+        serde_json::Value::Number(serde_json::Number::from(elapsed_ms_for_output(
+            result.elapsed,
+        ))),
     );
     if result.performance {
         obj.insert(
@@ -424,6 +456,15 @@ pub fn insert_audit_dead_code_json(
     result: &AuditResult,
     check: &crate::check::CheckResult,
 ) -> Result<(), ExitCode> {
+    let json = build_audit_dead_code_json(result, check)?;
+    obj.insert("dead_code".into(), json);
+    Ok(())
+}
+
+fn build_audit_dead_code_json(
+    result: &AuditResult,
+    check: &crate::check::CheckResult,
+) -> Result<serde_json::Value, ExitCode> {
     match report::build_check_json_payload_with_config_fixable(
         &check.results,
         &check.config.root,
@@ -439,8 +480,7 @@ pub fn insert_audit_dead_code_json(
                     &base.dead_code,
                 );
             }
-            obj.insert("dead_code".into(), json);
-            Ok(())
+            Ok(json)
         }
         Err(e) => Err(emit_error(
             &format!("JSON serialization error: {e}"),
@@ -455,6 +495,15 @@ pub fn insert_audit_duplication_json(
     result: &AuditResult,
     dupes: &crate::dupes::DupesResult,
 ) -> Result<(), ExitCode> {
+    let json = build_audit_duplication_json(result, dupes)?;
+    obj.insert("duplication".into(), json);
+    Ok(())
+}
+
+fn build_audit_duplication_json(
+    result: &AuditResult,
+    dupes: &crate::dupes::DupesResult,
+) -> Result<serde_json::Value, ExitCode> {
     let payload = crate::output_dupes::DupesReportPayload::from_report(&dupes.report);
     match serde_json::to_value(&payload) {
         Ok(mut json) => {
@@ -463,8 +512,7 @@ pub fn insert_audit_duplication_json(
             if let Some(ref base) = result.base_snapshot {
                 annotate_dupes_json(&mut json, &dupes.report, &dupes.config.root, &base.dupes);
             }
-            obj.insert("duplication".into(), json);
-            Ok(())
+            Ok(json)
         }
         Err(e) => Err(emit_error(
             &format!("JSON serialization error: {e}"),
@@ -479,6 +527,15 @@ pub fn insert_audit_health_json(
     result: &AuditResult,
     health: &crate::health::HealthResult,
 ) -> Result<(), ExitCode> {
+    let json = build_audit_health_json(result, health)?;
+    obj.insert("complexity".into(), json);
+    Ok(())
+}
+
+fn build_audit_health_json(
+    result: &AuditResult,
+    health: &crate::health::HealthResult,
+) -> Result<serde_json::Value, ExitCode> {
     match serde_json::to_value(&health.report) {
         Ok(mut json) => {
             let root_prefix = format!("{}/", health.config.root.display());
@@ -486,8 +543,7 @@ pub fn insert_audit_health_json(
             if let Some(ref base) = result.base_snapshot {
                 annotate_health_json(&mut json, &health.report, &health.config.root, &base.health);
             }
-            obj.insert("complexity".into(), json);
-            Ok(())
+            Ok(json)
         }
         Err(e) => Err(emit_error(
             &format!("JSON serialization error: {e}"),
@@ -497,10 +553,7 @@ pub fn insert_audit_health_json(
     }
 }
 
-fn insert_audit_next_steps_json(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    result: &AuditResult,
-) {
+fn audit_next_steps(result: &AuditResult) -> Vec<fallow_types::output::NextStep> {
     let input = fallow_output::build_audit_next_steps_input(
         result
             .check
@@ -509,12 +562,7 @@ fn insert_audit_next_steps_json(
         result.health.as_ref().map(|health| &health.report),
         crate::report::suggestions::suggestions_enabled(),
     );
-    let next_steps = fallow_output::build_audit_next_steps(&input);
-    if !next_steps.is_empty()
-        && let Ok(value) = serde_json::to_value(&next_steps)
-    {
-        obj.insert("next_steps".into(), value);
-    }
+    fallow_output::build_audit_next_steps(&input)
 }
 
 fn print_audit_sarif(result: &AuditResult) -> ExitCode {
@@ -613,8 +661,8 @@ mod tests {
     use crate::audit::{AuditAttribution, AuditResult, AuditSummary, AuditVerdict};
 
     use super::{
-        build_audit_codeclimate, build_status_parts, build_vital_sign_parts,
-        format_scope_line_parts, print_audit_result, short_base_ref,
+        build_audit_codeclimate, build_audit_json_output, build_status_parts,
+        build_vital_sign_parts, format_scope_line_parts, print_audit_result, short_base_ref,
     };
 
     fn audit_result(verdict: AuditVerdict, output: OutputFormat) -> AuditResult {
@@ -808,6 +856,25 @@ mod tests {
         // exercises insert_audit_json_header's optional base_description / head_sha
         // / performance branches and the empty next-steps path.
         assert_eq!(print_audit_result(&result, true, false), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn build_audit_json_output_uses_typed_audit_contract() {
+        let mut result = audit_result(AuditVerdict::Pass, OutputFormat::Json);
+        result.base_description = Some("merge-base with origin/main".to_string());
+        result.head_sha = Some("abc123".to_string());
+        result.performance = true;
+        result.base_snapshot_skipped = true;
+        result.changed_files_count = 5;
+
+        let json = build_audit_json_output(&result).expect("audit JSON should build");
+
+        assert_eq!(json["kind"], "audit");
+        assert_eq!(json["command"], "audit");
+        assert_eq!(json["base_description"], "merge-base with origin/main");
+        assert_eq!(json["head_sha"], "abc123");
+        assert_eq!(json["base_snapshot_skipped"], true);
+        assert_eq!(json["changed_files_count"], 5);
     }
 
     #[test]

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -161,9 +161,7 @@ fn emit_reconcile_result(
         failed_fingerprints: applied.failed_fingerprints.iter().cloned().collect(),
         unapplied_fingerprints: applied.unapplied_fingerprints.iter().cloned().collect(),
     };
-    match crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::ReviewReconcile(envelope_struct),
-    ) {
+    match crate::output_envelope::serialize_named_root_output(envelope_struct, "review-reconcile") {
         Ok(value) => crate::report::emit_json(&value, "review reconcile"),
         Err(e) => emit_error(
             &format!("JSON serialization error: {e}"),

--- a/crates/cli/src/combined/output.rs
+++ b/crates/cli/src/combined/output.rs
@@ -5,7 +5,8 @@ use std::process::ExitCode;
 
 use colored::Colorize;
 use fallow_config::OutputFormat;
-use fallow_output::CodeClimateIssue;
+use fallow_output::{CodeClimateIssue, CombinedMeta, CombinedOutput, RootEnvelopeMode};
+use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
 
 use crate::check::CheckResult;
 use crate::dupes::DupesResult;
@@ -445,172 +446,141 @@ struct CombinedJsonPrintInput<'a> {
 }
 
 fn print_combined_json(input: CombinedJsonPrintInput<'_>) -> ExitCode {
-    let mut combined = match combined_json_root(input.elapsed) {
-        Ok(combined) => combined,
+    let output = match build_combined_json_output(input) {
+        Ok(output) => output,
         Err(code) => return code,
     };
+    emit_combined_json_output(output)
+}
+
+fn build_combined_json_output(
+    input: CombinedJsonPrintInput<'_>,
+) -> Result<serde_json::Value, ExitCode> {
     let root_prefix = format!("{}/", input.root.display());
 
-    if let Some(result) = input.check_result
-        && let Err(code) = insert_combined_check_json(&mut combined, result, input.config_fixable)
-    {
-        return code;
-    }
+    let check = input
+        .check_result
+        .map(|result| build_combined_check_json(result, input.config_fixable))
+        .transpose()?;
 
     let dupes_payload = input
         .dupes_result
         .map(|result| crate::output_dupes::DupesReportPayload::from_report(&result.report));
-    if let Err(code) = insert_combined_dupes_json(&mut combined, dupes_payload.as_ref(), input.root)
-    {
-        return code;
-    }
-    if let Err(code) = insert_combined_health_json(&mut combined, input.health_result, &root_prefix)
-    {
-        return code;
-    }
-    if let Err(code) = insert_combined_next_steps(
-        &mut combined,
+    let dupes = build_combined_dupes_json(dupes_payload.as_ref(), input.root)?;
+    let health = build_combined_health_json(input.health_result, &root_prefix)?;
+    let next_steps = combined_next_steps(
         input.check_result,
         dupes_payload.as_ref(),
         input.health_result,
         input.root,
-    ) {
-        return code;
-    }
+    );
 
-    emit_combined_json_output(
-        combined,
-        input.check_result,
-        input.dupes_result,
-        input.health_result,
-        input.explain,
-    )
+    let output = CombinedOutput {
+        schema_version: SchemaVersion(crate::report::SCHEMA_VERSION),
+        version: ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
+        elapsed_ms: ElapsedMs(elapsed_ms_for_output(input.elapsed)),
+        meta: input.explain.then(|| {
+            combined_meta_for_output(
+                input.check_result.is_some(),
+                input.dupes_result.is_some(),
+                input.health_result.is_some(),
+            )
+        }),
+        check,
+        dupes,
+        health,
+        next_steps,
+    };
+
+    fallow_output::serialize_combined_json_output(output, RootEnvelopeMode::Tagged)
+        .map_err(|err| json_output_error(&err))
 }
 
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "elapsed milliseconds won't exceed u64::MAX"
-)]
-fn combined_json_root(
-    elapsed: std::time::Duration,
-) -> Result<serde_json::Map<String, serde_json::Value>, ExitCode> {
-    let envelope = crate::output_envelope::CombinedOutput {
+fn elapsed_ms_for_output(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+fn combined_json_root(elapsed: std::time::Duration) -> Result<serde_json::Value, ExitCode> {
+    let envelope = CombinedOutput::<serde_json::Value, serde_json::Value, serde_json::Value> {
         schema_version: fallow_types::envelope::SchemaVersion(crate::report::SCHEMA_VERSION),
         version: fallow_types::envelope::ToolVersion(env!("CARGO_PKG_VERSION").to_string()),
-        elapsed_ms: fallow_types::envelope::ElapsedMs(elapsed.as_millis() as u64),
+        elapsed_ms: fallow_types::envelope::ElapsedMs(elapsed_ms_for_output(elapsed)),
         meta: None,
         check: None,
         dupes: None,
         health: None,
-        // Aggregated and injected into the map below, after the sub-blocks.
         next_steps: Vec::new(),
     };
-    match crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::Combined(envelope),
-    ) {
-        Ok(serde_json::Value::Object(map)) => Ok(map),
-        Ok(_) => unreachable!("CombinedOutput serializes as a JSON object"),
-        Err(e) => Err(emit_error(
-            &format!("JSON serialization error: {e}"),
-            2,
-            OutputFormat::Json,
-        )),
-    }
+    fallow_output::serialize_combined_json_output(envelope, RootEnvelopeMode::Tagged)
+        .map_err(|err| json_output_error(&err))
 }
 
-fn insert_combined_dupes_json(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn build_combined_dupes_json(
     dupes_payload: Option<&crate::output_dupes::DupesReportPayload>,
     root: &std::path::Path,
-) -> Result<(), ExitCode> {
+) -> Result<Option<serde_json::Value>, ExitCode> {
     let root_prefix = format!("{}/", root.display());
     if let Some(payload) = dupes_payload {
         match serde_json::to_value(payload) {
             Ok(mut json) => {
                 report::strip_root_prefix(&mut json, &root_prefix);
-                combined.insert("dupes".into(), json);
+                Ok(Some(json))
             }
-            Err(e) => {
-                return Err(emit_error(
-                    &format!("JSON serialization error: {e}"),
-                    2,
-                    OutputFormat::Json,
-                ));
-            }
+            Err(e) => Err(json_output_error(&e)),
         }
+    } else {
+        Ok(None)
     }
-    Ok(())
 }
 
-fn insert_combined_health_json(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn build_combined_health_json(
     health: Option<&HealthResult>,
     root_prefix: &str,
-) -> Result<(), ExitCode> {
+) -> Result<Option<serde_json::Value>, ExitCode> {
     if let Some(result) = health {
         match serde_json::to_value(&result.report) {
             Ok(mut json) => {
                 report::strip_root_prefix(&mut json, root_prefix);
-                combined.insert("health".into(), json);
+                Ok(Some(json))
             }
-            Err(e) => {
-                return Err(emit_error(
-                    &format!("JSON serialization error: {e}"),
-                    2,
-                    OutputFormat::Json,
-                ));
-            }
+            Err(e) => Err(json_output_error(&e)),
         }
+    } else {
+        Ok(None)
     }
-    Ok(())
 }
 
-fn insert_combined_next_steps(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn combined_next_steps(
     check: Option<&CheckResult>,
     dupes_payload: Option<&crate::output_dupes::DupesReportPayload>,
     health: Option<&HealthResult>,
     root: &std::path::Path,
-) -> Result<(), ExitCode> {
-    let next_steps = crate::report::suggestions::build_combined_next_steps(
+) -> Vec<fallow_types::output::NextStep> {
+    crate::report::suggestions::build_combined_next_steps(
         check.map(|result| &result.results),
         dupes_payload,
         health.map(|result| &result.report),
         root,
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
-    );
-    if !next_steps.is_empty() {
-        match serde_json::to_value(&next_steps) {
-            Ok(value) => {
-                combined.insert("next_steps".into(), value);
-            }
-            Err(e) => {
-                return Err(emit_error(
-                    &format!("JSON serialization error: {e}"),
-                    2,
-                    OutputFormat::Json,
-                ));
-            }
-        }
-    }
-    Ok(())
+    )
 }
 
-fn emit_combined_json_output(
-    combined: serde_json::Map<String, serde_json::Value>,
-    check: Option<&CheckResult>,
-    dupes: Option<&DupesResult>,
-    health: Option<&HealthResult>,
-    explain: bool,
-) -> ExitCode {
-    let mut output = serde_json::Value::Object(combined);
-    if explain && let serde_json::Value::Object(ref mut map) = output {
-        map.insert(
-            "_meta".to_string(),
-            crate::explain::combined_meta(check.is_some(), dupes.is_some(), health.is_some()),
-        );
+fn combined_meta_for_output(
+    include_check: bool,
+    include_dupes: bool,
+    include_health: bool,
+) -> CombinedMeta {
+    CombinedMeta {
+        check: include_check.then(fallow_output::check_meta),
+        dupes: include_dupes.then(fallow_output::dupes_meta),
+        health: include_health.then(fallow_output::health_meta),
+        telemetry: None,
     }
+}
+
+fn emit_combined_json_output(mut output: serde_json::Value) -> ExitCode {
     report::harmonize_multi_kind_suppress_line_actions(&mut output);
     crate::output_envelope::attach_telemetry_meta(&mut output);
 
@@ -627,11 +597,10 @@ fn emit_combined_json_output(
     }
 }
 
-fn insert_combined_check_json(
-    combined: &mut serde_json::Map<String, serde_json::Value>,
+fn build_combined_check_json(
     result: &CheckResult,
     config_fixable: bool,
-) -> Result<(), ExitCode> {
+) -> Result<serde_json::Value, ExitCode> {
     let mut json = report::build_check_json_payload_with_config_fixable(
         &result.results,
         &result.config.root,
@@ -640,8 +609,7 @@ fn insert_combined_check_json(
     )
     .map_err(|error| json_output_error(&error))?;
     attach_combined_check_extras(&mut json, result);
-    combined.insert("check".into(), json);
-    Ok(())
+    Ok(json)
 }
 
 fn attach_combined_check_extras(json: &mut serde_json::Value, result: &CheckResult) {
@@ -820,9 +788,9 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        build_combined_codeclimate, combined_json_root, combined_machine_success,
-        emit_combined_json_output, exit_code_to_u8, insert_combined_dupes_json,
-        insert_combined_health_json, print_combined_codeclimate, print_combined_sarif,
+        build_combined_codeclimate, build_combined_dupes_json, build_combined_health_json,
+        combined_json_root, combined_machine_success, emit_combined_json_output, exit_code_to_u8,
+        print_combined_codeclimate, print_combined_sarif,
     };
 
     #[test]
@@ -879,22 +847,19 @@ mod tests {
 
     #[test]
     fn insert_empty_optional_sections_leaves_combined_map_unchanged() {
-        let mut combined = serde_json::Map::new();
-        insert_combined_dupes_json(&mut combined, None, std::path::Path::new("."))
+        let dupes = build_combined_dupes_json(None, std::path::Path::new("."))
             .expect("empty dupes section should serialize");
-        insert_combined_health_json(&mut combined, None, ".")
-            .expect("empty health section should serialize");
+        let health =
+            build_combined_health_json(None, ".").expect("empty health section should serialize");
 
-        assert!(combined.is_empty());
+        assert!(dupes.is_none());
+        assert!(health.is_none());
     }
 
     #[test]
     fn emit_combined_json_output_can_attach_empty_meta() {
         let combined = combined_json_root(Duration::ZERO).expect("combined JSON root");
 
-        assert_eq!(
-            emit_combined_json_output(combined, None, None, None, true),
-            ExitCode::SUCCESS
-        );
+        assert_eq!(emit_combined_json_output(combined), ExitCode::SUCCESS);
     }
 }

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -1172,7 +1172,8 @@ fn print_runtime_json(
     explain: bool,
 ) -> ExitCode {
     use crate::output_envelope::{
-        CoverageAnalyzeOutput, CoverageAnalyzeSchemaVersion, FallowOutput, serialize_root_output,
+        CoverageAnalyzeOutput, CoverageAnalyzeSchemaVersion,
+        serialize_named_root_output_without_telemetry,
     };
     use fallow_types::envelope::{ElapsedMs, ToolVersion};
 
@@ -1188,13 +1189,14 @@ fn print_runtime_json(
         runtime_coverage: report.clone(),
         meta: None,
     };
-    let mut output = match serialize_root_output(FallowOutput::CoverageAnalyze(envelope)) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("Error: failed to serialize runtime coverage report: {err}");
-            return ExitCode::from(2);
-        }
-    };
+    let mut output =
+        match serialize_named_root_output_without_telemetry(envelope, "coverage-analyze") {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("Error: failed to serialize runtime coverage report: {err}");
+                return ExitCode::from(2);
+            }
+        };
     if explain && let Some(map) = output.as_object_mut() {
         map.insert("_meta".to_owned(), crate::explain::coverage_analyze_meta());
     }

--- a/crates/cli/src/coverage/mod.rs
+++ b/crates/cli/src/coverage/mod.rs
@@ -726,10 +726,8 @@ fn run_setup_json(root: &Path, explain: bool) -> ExitCode {
 )]
 fn build_setup_json(root: &Path, explain: bool) -> serde_json::Value {
     let envelope = build_setup_envelope(root, explain);
-    crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::CoverageSetup(envelope),
-    )
-    .expect("CoverageSetupOutput serializes infallibly")
+    crate::output_envelope::serialize_named_root_output(envelope, "coverage-setup")
+        .expect("CoverageSetupOutput serializes infallibly")
 }
 
 fn build_setup_envelope(root: &Path, explain: bool) -> crate::output_envelope::CoverageSetupOutput {

--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -870,9 +870,7 @@ pub fn run_explain(issue_type: &str, output: OutputFormat) -> ExitCode {
                 how_to_fix: guide.how_to_fix.to_string(),
                 docs: rule_docs_url(rule),
             };
-            match crate::output_envelope::serialize_root_output(
-                crate::output_envelope::FallowOutput::Explain(envelope),
-            ) {
+            match crate::output_envelope::serialize_named_root_output(envelope, "explain") {
                 Ok(value) => crate::report::emit_json(&value, "explain"),
                 Err(e) => {
                     crate::error::emit_error(&format!("JSON serialization error: {e}"), 2, output)

--- a/crates/cli/src/explain.rs
+++ b/crates/cli/src/explain.rs
@@ -8,22 +8,9 @@ use std::process::ExitCode;
 
 use colored::Colorize;
 use fallow_config::OutputFormat;
-use serde_json::{Value, json};
+use serde_json::Value;
 
 const DOCS_BASE: &str = "https://docs.fallow.tools";
-
-/// Docs URL for the dead-code (check) command.
-pub const CHECK_DOCS: &str = "https://docs.fallow.tools/cli/dead-code";
-
-/// `_meta` description for the per-finding `actions[]` array shared across
-/// `check`, `health`, and `dupes` JSON output.
-const ACTIONS_FIELD_DEFINITION: &str = "Per-finding fix and suppression suggestions. Each entry carries a `type` discriminant (kebab-case) plus a per-action `auto_fixable` bool. Consumers dispatch on `type` to choose the remediation and filter on `auto_fixable` of each individual entry.";
-
-/// `_meta` description for the per-action `auto_fixable` bool. Calls out the
-/// per-finding (not per-action-type) evaluation rule and the currently active
-/// per-instance flips so agents know to branch on the field value of EACH
-/// finding's action, not on the action `type` alone.
-const ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION: &str = "Evaluated PER FINDING, not per action type. The same `type` may carry `auto_fixable: true` on one finding and `auto_fixable: false` on another when per-instance guards in the `fallow fix` applier discriminate. Filter on this bool of each individual action, not on `type` alone. Current per-instance flips: (1) `remove-catalog-entry` is `true` only when the finding's `hardcoded_consumers` array is empty (else fallow fix skips the entry to avoid breaking `pnpm install`); (2) the primary dependency action flips between `remove-dependency` (`auto_fixable: true`) and `move-dependency` (`auto_fixable: false`) based on `used_in_workspaces`; (3) `add-to-config` for `ignoreExports` is `true` when fallow fix can safely apply the action, which means EITHER a fallow config file already exists OR no config exists and the working directory is NOT inside a monorepo subpackage (the applier then creates `.fallowrc.json` using `fallow init`'s framework-aware scaffolding and layers the new rules on top); `false` inside a monorepo subpackage with no workspace-root config because the applier refuses to fragment per-package configs; (4) `update-catalog-reference` is always `false` today (catalog-switching applier not yet wired). All `suppress-line` and `suppress-file` actions are uniformly `false`.";
 
 /// Rule definition for SARIF `fullDescription` and JSON `_meta`.
 pub struct RuleDef {
@@ -1267,68 +1254,6 @@ pub const SECURITY_RULES: &[RuleDef] = &[
     ),
 ];
 
-/// Build the `_meta` object for `fallow dead-code --format json --explain`.
-#[must_use]
-pub fn check_meta() -> Value {
-    let rules: Value = CHECK_RULES
-        .iter()
-        .map(|r| {
-            (
-                r.id.replace("fallow/", ""),
-                json!({
-                    "name": r.name,
-                    "description": r.full,
-                    "docs": rule_docs_url(r)
-                }),
-            )
-        })
-        .collect::<serde_json::Map<String, Value>>()
-        .into();
-
-    json!({
-        "docs": CHECK_DOCS,
-        "rules": rules,
-        "field_definitions": {
-            "actions[]": ACTIONS_FIELD_DEFINITION,
-            "actions[].auto_fixable": ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION
-        }
-    })
-}
-
-/// Build the sectioned `_meta` object for bare `fallow --format json --explain`.
-#[must_use]
-pub fn combined_meta(include_check: bool, include_dupes: bool, include_health: bool) -> Value {
-    let mut sections = serde_json::Map::new();
-    if include_check {
-        sections.insert("check".to_string(), check_meta());
-    }
-    if include_dupes {
-        sections.insert("dupes".to_string(), dupes_meta());
-    }
-    if include_health {
-        sections.insert("health".to_string(), health_meta());
-    }
-    Value::Object(sections)
-}
-
-/// Build the `_meta` object for `fallow health --format json --explain`.
-#[must_use]
-pub fn health_meta() -> Value {
-    match serde_json::to_value(fallow_output::health_meta()) {
-        Ok(value) => value,
-        Err(_) => json!({}),
-    }
-}
-
-/// Build the `_meta` object for `fallow dupes --format json --explain`.
-#[must_use]
-pub fn dupes_meta() -> Value {
-    match serde_json::to_value(fallow_output::dupes_meta()) {
-        Ok(value) => value,
-        Err(_) => json!({}),
-    }
-}
-
 /// Build the `_meta` object for `fallow security --format json --explain`.
 #[must_use]
 pub fn security_meta() -> fallow_types::envelope::Meta {
@@ -1357,6 +1282,23 @@ pub fn coverage_analyze_meta() -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    fn meta_value(meta: fallow_types::envelope::Meta) -> Value {
+        serde_json::to_value(meta).expect("metadata should serialize")
+    }
+
+    fn check_meta() -> Value {
+        meta_value(fallow_output::check_meta())
+    }
+
+    fn health_meta() -> Value {
+        meta_value(fallow_output::health_meta())
+    }
+
+    fn dupes_meta() -> Value {
+        meta_value(fallow_output::dupes_meta())
+    }
 
     #[test]
     fn rule_by_id_finds_check_rule() {
@@ -1497,11 +1439,11 @@ mod tests {
             let defs = meta["field_definitions"].as_object().unwrap();
             assert_eq!(
                 defs["actions[]"].as_str().unwrap(),
-                ACTIONS_FIELD_DEFINITION,
+                fallow_output::ACTIONS_FIELD_DEFINITION,
             );
             assert_eq!(
                 defs["actions[].auto_fixable"].as_str().unwrap(),
-                ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION,
+                fallow_output::ACTIONS_AUTO_FIXABLE_FIELD_DEFINITION,
             );
         }
     }
@@ -1864,8 +1806,8 @@ mod tests {
 
     #[test]
     fn check_docs_url_valid() {
-        assert!(CHECK_DOCS.starts_with("https://"));
-        assert!(CHECK_DOCS.contains("dead-code"));
+        assert!(fallow_output::CHECK_DOCS.starts_with("https://"));
+        assert!(fallow_output::CHECK_DOCS.contains("dead-code"));
     }
 
     #[test]
@@ -1883,7 +1825,7 @@ mod tests {
     #[test]
     fn check_meta_docs_url_matches_constant() {
         let meta = check_meta();
-        assert_eq!(meta["docs"].as_str().unwrap(), CHECK_DOCS);
+        assert_eq!(meta["docs"].as_str().unwrap(), fallow_output::CHECK_DOCS);
     }
 
     #[test]

--- a/crates/cli/src/impact.rs
+++ b/crates/cli/src/impact.rs
@@ -2064,10 +2064,8 @@ fn render_human_footer(out: &mut String, report: &ImpactReport) {
 
 /// Render the report as JSON.
 pub fn render_json(report: &ImpactReport) -> String {
-    let value = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::Impact(report.clone()),
-    )
-    .unwrap_or_else(|_| serde_json::json!({"error":"failed to serialize impact report"}));
+    let value = crate::output_envelope::serialize_named_root_output(report.clone(), "impact")
+        .unwrap_or_else(|_| serde_json::json!({"error":"failed to serialize impact report"}));
     serde_json::to_string_pretty(&value)
         .unwrap_or_else(|_| "{\"error\":\"failed to serialize impact report\"}".to_owned())
 }
@@ -2200,12 +2198,11 @@ fn render_markdown_footer(out: &mut String, report: &ImpactReport) {
 /// Render the cross-repo report as JSON via the typed `ImpactCrossRepo` envelope.
 #[must_use]
 pub fn render_cross_repo_json(report: &CrossRepoImpactReport) -> String {
-    let value = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::ImpactCrossRepo(report.clone()),
-    )
-    .unwrap_or_else(
-        |_| serde_json::json!({"error":"failed to serialize cross-repo impact report"}),
-    );
+    let value =
+        crate::output_envelope::serialize_named_root_output(report.clone(), "impact-cross-repo")
+            .unwrap_or_else(
+                |_| serde_json::json!({"error":"failed to serialize cross-repo impact report"}),
+            );
     serde_json::to_string_pretty(&value).unwrap_or_else(|_| {
         "{\"error\":\"failed to serialize cross-repo impact report\"}".to_owned()
     })

--- a/crates/cli/src/inspect.rs
+++ b/crates/cli/src/inspect.rs
@@ -6,9 +6,9 @@ use serde_json::{Value, json};
 
 use crate::error::emit_error;
 use crate::output_envelope::{
-    FallowOutput, InspectEvidence, InspectEvidenceScope, InspectEvidenceSection,
-    InspectFileIdentity, InspectIdentity, InspectOutput, InspectSectionStatus,
-    InspectSymbolIdentity, InspectTargetDescriptor, serialize_root_output,
+    InspectEvidence, InspectEvidenceScope, InspectEvidenceSection, InspectFileIdentity,
+    InspectIdentity, InspectOutput, InspectSectionStatus, InspectSymbolIdentity,
+    InspectTargetDescriptor, serialize_named_root_output,
 };
 use crate::report;
 use crate::report::sink::outln;
@@ -290,7 +290,7 @@ fn build_inspect_identity(
 fn emit_inspect_bundle(bundle: InspectOutput, opts: &InspectOptions<'_>) -> ExitCode {
     match opts.output {
         OutputFormat::Json => {
-            let value = match serialize_root_output(FallowOutput::Inspect(bundle)) {
+            let value = match serialize_named_root_output(bundle, "inspect_target") {
                 Ok(value) => value,
                 Err(err) => {
                     return emit_error(

--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -312,12 +312,32 @@ fn print_list_json(input: &ListJsonInput<'_>) -> ExitCode {
         && !input.opts.entry_points
         && !input.opts.boundaries;
 
-    let mut output = serde_json::Value::Object(result);
-    if has_boundaries {
-        crate::output_envelope::apply_root_kind(&mut output, "list-boundaries");
+    let output = serde_json::Value::Object(result);
+    let output = if has_boundaries {
+        match crate::output_envelope::serialize_named_root_output_without_telemetry(
+            output,
+            "list-boundaries",
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("Error: failed to serialize list output: {err}");
+                return ExitCode::from(2);
+            }
+        }
     } else if workspace_only {
-        crate::output_envelope::apply_root_kind(&mut output, "list-workspaces");
-    }
+        match crate::output_envelope::serialize_named_root_output_without_telemetry(
+            output,
+            "list-workspaces",
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("Error: failed to serialize list output: {err}");
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        output
+    };
 
     match serde_json::to_string_pretty(&output) {
         Ok(json) => {

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -6,9 +6,13 @@
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(any(test, feature = "schema-emit"))]
 use crate::audit::{AuditAttribution, AuditSummary, AuditVerdict};
+#[cfg(any(test, feature = "schema-emit"))]
 use crate::health_types::{HealthGroup, HealthReport};
+#[cfg(any(test, feature = "schema-emit"))]
 use crate::output_dupes::DupesReportPayload;
+#[cfg(any(test, feature = "schema-emit"))]
 use crate::report::dupes_grouping::DuplicationGroup;
 #[allow(
     unused_imports,
@@ -72,10 +76,6 @@ pub fn telemetry_analysis_run_id() -> Option<String> {
         .and_then(|id| id.clone())
 }
 
-pub fn serialize_root_output(output: FallowOutput) -> Result<serde_json::Value, serde_json::Error> {
-    serialize_root_output_with_mode(output, EnvelopeMode::current())
-}
-
 pub fn serialize_named_root_output<T: Serialize>(
     output: T,
     kind: &'static str,
@@ -93,7 +93,8 @@ pub fn serialize_named_root_output_without_telemetry<T: Serialize>(
     fallow_output::serialize_named_json_output(output, kind, EnvelopeMode::current().into())
 }
 
-pub fn serialize_root_output_with_mode(
+#[cfg(test)]
+fn serialize_root_output_with_mode(
     output: FallowOutput,
     mode: EnvelopeMode,
 ) -> Result<serde_json::Value, serde_json::Error> {
@@ -114,6 +115,7 @@ impl From<EnvelopeMode> for fallow_output::RootEnvelopeMode {
         }
     }
 }
+#[cfg(any(test, feature = "schema-emit"))]
 pub type AuditOutput = fallow_output::AuditOutput<
     AuditVerdict,
     AuditSummary,
@@ -123,9 +125,11 @@ pub type AuditOutput = fallow_output::AuditOutput<
     HealthReport,
 >;
 
+#[cfg(any(test, feature = "schema-emit"))]
 pub type CombinedOutput =
     fallow_output::CombinedOutput<CheckOutput, DupesReportPayload, HealthReport>;
 
+#[cfg(any(test, feature = "schema-emit"))]
 pub type ListBoundariesOutput = fallow_output::ListBoundariesOutput<
     fallow_config::LogicalGroupStatus,
     fallow_config::AuthoredRule,
@@ -151,6 +155,7 @@ pub type BoundariesListLogicalGroup = fallow_output::BoundariesListLogicalGroup<
     fallow_config::AuthoredRule,
 >;
 
+#[cfg(any(test, feature = "schema-emit"))]
 #[allow(
     clippy::type_complexity,
     reason = "concrete CLI alias fills every generic payload slot in the shared root output contract"
@@ -178,7 +183,7 @@ pub type FallowOutput = fallow_output::FallowOutput<
     CheckOutput,
     CombinedOutput,
     crate::audit_brief::ReviewBriefOutput,
-    crate::audit_decision_surface::DecisionSurfaceOutput,
+    fallow_output::DecisionSurfaceOutput,
     crate::audit_walkthrough::WalkthroughGuide,
     crate::audit_walkthrough::WalkthroughValidation,
 >;

--- a/crates/cli/src/output_envelope.rs
+++ b/crates/cli/src/output_envelope.rs
@@ -33,6 +33,7 @@ pub use fallow_output::{
     build_dupes_output, build_health_output, default_marker_regex, default_marker_regex_flags,
     is_false,
 };
+use serde::Serialize;
 
 static LEGACY_ENVELOPE: AtomicBool = AtomicBool::new(false);
 static TELEMETRY_ANALYSIS_RUN_ID: Mutex<Option<String>> = Mutex::new(None);
@@ -75,10 +76,21 @@ pub fn serialize_root_output(output: FallowOutput) -> Result<serde_json::Value, 
     serialize_root_output_with_mode(output, EnvelopeMode::current())
 }
 
-pub fn serialize_root_output_without_telemetry(
-    output: FallowOutput,
+pub fn serialize_named_root_output<T: Serialize>(
+    output: T,
+    kind: &'static str,
 ) -> Result<serde_json::Value, serde_json::Error> {
-    fallow_output::serialize_json_root_output(output, EnvelopeMode::current().into())
+    let mut value =
+        fallow_output::serialize_named_json_output(output, kind, EnvelopeMode::current().into())?;
+    attach_telemetry_meta(&mut value);
+    Ok(value)
+}
+
+pub fn serialize_named_root_output_without_telemetry<T: Serialize>(
+    output: T,
+    kind: &'static str,
+) -> Result<serde_json::Value, serde_json::Error> {
+    fallow_output::serialize_named_json_output(output, kind, EnvelopeMode::current().into())
 }
 
 pub fn serialize_root_output_with_mode(
@@ -92,10 +104,6 @@ pub fn serialize_root_output_with_mode(
 
 pub fn attach_telemetry_meta(value: &mut serde_json::Value) {
     fallow_output::attach_telemetry_meta(value, telemetry_analysis_run_id().as_deref());
-}
-
-pub fn apply_root_kind(value: &mut serde_json::Value, kind: &'static str) {
-    fallow_output::apply_root_kind(value, kind, EnvelopeMode::current().into());
 }
 
 impl From<EnvelopeMode> for fallow_output::RootEnvelopeMode {

--- a/crates/cli/src/programmatic.rs
+++ b/crates/cli/src/programmatic.rs
@@ -280,7 +280,12 @@ fn build_dead_code_json(
                     .with_context("dead-code")
             })?;
     if explain {
-        insert_meta(&mut output, crate::explain::check_meta());
+        let meta = serde_json::to_value(fallow_output::check_meta()).map_err(|err| {
+            ProgrammaticError::new(format!("failed to serialize dead-code metadata: {err}"), 2)
+                .with_code("FALLOW_SERIALIZE_DEAD_CODE_META")
+                .with_context("dead-code")
+        })?;
+        insert_meta(&mut output, meta);
     }
     // `build_dead_code_json` is only called after options have been resolved;
     // callers apply the root-envelope compatibility setting at the boundary.

--- a/crates/cli/src/report/ci/review.rs
+++ b/crates/cli/src/report/ci/review.rs
@@ -208,10 +208,8 @@ fn print_review_envelope_from_ci_issues(
     issues: &[CiIssue],
 ) -> ExitCode {
     let envelope = render_review_envelope(command, provider, issues);
-    let value = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::ReviewEnvelope(envelope),
-    )
-    .expect("ReviewEnvelopeOutput serializes infallibly");
+    let value = crate::output_envelope::serialize_named_root_output(envelope, "review-envelope")
+        .expect("ReviewEnvelopeOutput serializes infallibly");
     emit_json(&value, "review envelope")
 }
 

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -13,10 +13,10 @@ use fallow_output::strip_root_prefix;
 use super::emit_json;
 use crate::output_dupes::DupesReportPayload;
 use crate::output_envelope::{
-    CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutputInput,
-    EnvelopeMode, FallowOutput, GroupByMode, WorkspaceDiagnosticOutput,
+    CheckGroupedEntry, CheckGroupedOutput, CheckOutput, CheckOutputInput, DupesOutput,
+    DupesOutputInput, EnvelopeMode, GroupByMode, WorkspaceDiagnosticOutput,
     apply_config_fixable_to_duplicate_exports, build_check_output, build_dupes_output,
-    serialize_root_output,
+    serialize_named_root_output,
 };
 use crate::report::grouping::{OwnershipResolver, ResultGroup};
 
@@ -120,7 +120,7 @@ pub(super) fn print_grouped_json(input: &PrintGroupedJsonInput<'_>) -> ExitCode 
         ),
     };
 
-    let mut output = match serialize_root_output(FallowOutput::CheckGrouped(envelope)) {
+    let mut output = match serialize_named_root_output(envelope, "dead-code-grouped") {
         Ok(value) => value,
         Err(e) => {
             eprintln!("Error: failed to serialize grouped results: {e}");
@@ -185,7 +185,7 @@ fn build_json_with_config_fixable_and_meta(
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
     );
-    let mut output = serialize_root_output(FallowOutput::Check(envelope))?;
+    let mut output = serialize_named_root_output(envelope, "dead-code")?;
     postprocess_check_json(&mut output, root);
     Ok(output)
 }
@@ -520,19 +520,20 @@ pub fn build_duplication_json(
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
     );
-    let envelope = build_dupes_output(DupesOutputInput {
-        schema_version: SCHEMA_VERSION,
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        elapsed,
-        report: payload,
-        grouped_by: None,
-        total_issues: None,
-        groups: None,
-        meta: explain.then(fallow_output::dupes_meta),
-        workspace_diagnostics: workspace_diagnostics_for_output(root),
-        next_steps,
-    });
-    let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;
+    let envelope: DupesOutput<DupesReportPayload, super::dupes_grouping::DuplicationGroup> =
+        build_dupes_output(DupesOutputInput {
+            schema_version: SCHEMA_VERSION,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            elapsed,
+            report: payload,
+            grouped_by: None,
+            total_issues: None,
+            groups: None,
+            meta: explain.then(fallow_output::dupes_meta),
+            workspace_diagnostics: workspace_diagnostics_for_output(root),
+            next_steps,
+        });
+    let mut output = serialize_named_root_output(envelope, "dupes")?;
     let root_prefix = format!("{}/", root.display());
     strip_root_prefix(&mut output, &root_prefix);
 
@@ -569,19 +570,20 @@ pub fn build_grouped_duplication_json(
         crate::report::suggestions::setup_pointer_applicable(root),
         crate::report::suggestions::due_impact_digest(root),
     );
-    let envelope = build_dupes_output(DupesOutputInput {
-        schema_version: SCHEMA_VERSION,
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        elapsed,
-        report: payload,
-        grouped_by: Some(group_by_mode_from_label(grouping.mode)),
-        total_issues: Some(report.clone_groups.len()),
-        groups: None,
-        meta: explain.then(fallow_output::dupes_meta),
-        workspace_diagnostics: workspace_diagnostics_for_output(root),
-        next_steps,
-    });
-    let mut output = serialize_root_output(FallowOutput::Dupes(envelope))?;
+    let envelope: DupesOutput<DupesReportPayload, super::dupes_grouping::DuplicationGroup> =
+        build_dupes_output(DupesOutputInput {
+            schema_version: SCHEMA_VERSION,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            elapsed,
+            report: payload,
+            grouped_by: Some(group_by_mode_from_label(grouping.mode)),
+            total_issues: Some(report.clone_groups.len()),
+            groups: None,
+            meta: explain.then(fallow_output::dupes_meta),
+            workspace_diagnostics: workspace_diagnostics_for_output(root),
+            next_steps,
+        });
+    let mut output = serialize_named_root_output(envelope, "dupes")?;
     strip_root_prefix(&mut output, &root_prefix);
 
     let group_values: Vec<serde_json::Value> = grouping

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -1618,9 +1618,8 @@ fn relativize(path: &Path, root: &Path) -> PathBuf {
 /// JSON: the `SecurityOutput` envelope, pretty-printed.
 #[must_use]
 pub fn render_json(output: &SecurityOutput) -> String {
-    let Ok(value) = crate::output_envelope::serialize_root_output(
-        crate::output_envelope::FallowOutput::Security(output.clone()),
-    ) else {
+    let Ok(value) = crate::output_envelope::serialize_named_root_output(output.clone(), "security")
+    else {
         return "{\"error\":\"failed to serialize security output\"}".to_owned();
     };
     serde_json::to_string_pretty(&value)
@@ -1639,9 +1638,9 @@ pub fn render_json_summary(output: &SecurityOutput) -> String {
         gate: output.gate,
         summary: security_summary(output),
     };
-    let Ok(value) = crate::output_envelope::serialize_root_output_without_telemetry(
-        crate::output_envelope::FallowOutput::SecuritySummary(summary),
-    ) else {
+    let Ok(value) =
+        crate::output_envelope::serialize_named_root_output_without_telemetry(summary, "security")
+    else {
         return "{\"error\":\"failed to serialize security summary output\"}".to_owned();
     };
     serde_json::to_string_pretty(&value).unwrap_or_else(|_| {
@@ -1661,8 +1660,9 @@ fn render_survivors_output(
 
 #[must_use]
 pub fn render_survivors_json(output: &SecuritySurvivorsOutput) -> String {
-    let Ok(value) = crate::output_envelope::serialize_root_output_without_telemetry(
-        crate::output_envelope::FallowOutput::SecuritySurvivors(output.clone()),
+    let Ok(value) = crate::output_envelope::serialize_named_root_output_without_telemetry(
+        output.clone(),
+        "security-survivors",
     ) else {
         return "{\"error\":\"failed to serialize security survivors output\"}".to_owned();
     };
@@ -1861,8 +1861,9 @@ fn render_blind_spots_output(
 
 #[must_use]
 pub fn render_blind_spots_json(output: &SecurityBlindSpotsOutput) -> String {
-    let Ok(value) = crate::output_envelope::serialize_root_output_without_telemetry(
-        crate::output_envelope::FallowOutput::SecurityBlindSpots(output.clone()),
+    let Ok(value) = crate::output_envelope::serialize_named_root_output_without_telemetry(
+        output.clone(),
+        "security-blind-spots",
     ) else {
         return "{\"error\":\"failed to serialize security blind-spots output\"}".to_owned();
     };

--- a/crates/cli/src/trace_chain.rs
+++ b/crates/cli/src/trace_chain.rs
@@ -14,7 +14,7 @@ use fallow_config::{OutputFormat, ProductionAnalysis};
 use fallow_engine::trace_chain::{SymbolChainQuery, SymbolChainTrace, TraceDirections};
 
 use crate::error::emit_error;
-use crate::output_envelope::{FallowOutput, serialize_root_output};
+use crate::output_envelope::serialize_named_root_output;
 use crate::report;
 use crate::report::sink::outln;
 use crate::{ConfigLoadOptions, load_config_for_analysis};
@@ -113,7 +113,7 @@ fn parse_target(target: &str) -> Option<(String, String)> {
 fn emit_trace(trace: SymbolChainTrace, opts: &TraceChainOptions<'_>) -> ExitCode {
     match opts.output {
         OutputFormat::Json => {
-            let value = match serialize_root_output(FallowOutput::Trace(trace)) {
+            let value = match serialize_named_root_output(trace, "trace") {
                 Ok(value) => value,
                 Err(err) => {
                     return emit_error(

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 
 use fallow_api as api;
-use fallow_programmatic_cli as cli_health;
+use fallow_programmatic_cli::CliHealthRunner;
 use napi::bindgen_prelude::{AsyncTask, JsObjectValue, ToNapiValue, Unknown};
 use napi::{Env, ScopedTask, Status};
 use napi_derive::napi;
@@ -543,7 +543,7 @@ pub fn compute_complexity(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        cli_health::compute_complexity(&options)
+        api::compute_complexity_with_runner(&options, &CliHealthRunner)
     })))
 }
 
@@ -553,7 +553,7 @@ pub fn compute_health(
 ) -> napi::Result<AsyncTask<ProgrammaticTask>> {
     let options = api::ComplexityOptions::try_from(options.unwrap_or_default())?;
     Ok(AsyncTask::new(ProgrammaticTask::new(move || {
-        cli_health::compute_health(&options)
+        api::compute_health_with_runner(&options, &CliHealthRunner)
     })))
 }
 
@@ -1042,6 +1042,26 @@ mod tests {
             .as_ref()
             .expect("programmatic error should be retained for reject");
         assert_eq!(stored.code.as_deref(), Some("FALLOW_TEST_FAILURE"));
+    }
+
+    #[test]
+    fn compute_health_uses_api_runner_boundary() {
+        let project = tiny_dead_code_project();
+        let options = api::ComplexityOptions::try_from(ComplexityOptions {
+            root: Some(project.path().display().to_string()),
+            no_cache: Some(true),
+            threads: Some(1),
+            score: Some(true),
+            ..ComplexityOptions::default()
+        })
+        .expect("health options should map");
+
+        let json = api::compute_health_with_runner(&options, &CliHealthRunner)
+            .expect("health should run through API runner boundary");
+
+        assert_eq!(json["kind"], "health");
+        assert_eq!(json["schema_version"], 7);
+        assert!(json.get("health_score").is_some());
     }
 
     fn tiny_dead_code_project() -> tempfile::TempDir {

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -201,7 +201,8 @@ pub use review_envelopes::{
 };
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
-    apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_json_root_output,
+    apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_audit_json_output,
+    serialize_json_root_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -202,7 +202,7 @@ pub use review_envelopes::{
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
     apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_audit_json_output,
-    serialize_combined_json_output, serialize_json_root_output,
+    serialize_combined_json_output, serialize_json_root_output, serialize_named_json_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -202,7 +202,7 @@ pub use review_envelopes::{
 pub use root_envelopes::{
     AuditCommand, AuditOutput, CombinedMeta, CombinedOutput, FallowOutput, RootEnvelopeMode,
     apply_root_kind, attach_telemetry_meta, remove_root_kind, serialize_audit_json_output,
-    serialize_json_root_output,
+    serialize_combined_json_output, serialize_json_root_output,
 };
 pub use security::{
     SecurityBlindSpotFile, SecurityBlindSpotGroup, SecurityBlindSpotsOutput,

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -41,6 +41,26 @@ pub fn serialize_json_root_output<T: Serialize>(
     Ok(value)
 }
 
+/// Serialize an output envelope and apply an explicit root discriminator.
+///
+/// Use this for command surfaces whose runtime shape is already a typed
+/// envelope struct and does not need to pass through the schema-only
+/// [`FallowOutput`] enum just to get a top-level `kind`.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_named_json_output<T: Serialize>(
+    output: T,
+    kind: &'static str,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let mut value = serde_json::to_value(output)?;
+    apply_root_kind(&mut value, kind, mode);
+    Ok(value)
+}
+
 /// Serialize a typed `fallow audit --format json` envelope with the standard
 /// root discriminator policy.
 ///
@@ -432,6 +452,22 @@ mod tests {
 
         assert!(value.get("kind").is_none());
         assert_eq!(value["schema_version"], 1);
+    }
+
+    #[test]
+    fn serialize_named_json_output_applies_explicit_kind() {
+        let value = serialize_named_json_output(
+            json!({
+                "schema_version": 1,
+                "summary": { "total": 0 }
+            }),
+            "example",
+            RootEnvelopeMode::Tagged,
+        )
+        .expect("named output should serialize");
+
+        assert_eq!(value["kind"], "example");
+        assert_eq!(value["summary"]["total"], 0);
     }
 
     #[test]

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -41,6 +41,37 @@ pub fn serialize_json_root_output<T: Serialize>(
     Ok(value)
 }
 
+/// Serialize a typed `fallow audit --format json` envelope with the standard
+/// root discriminator policy.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_audit_json_output<
+    Verdict,
+    Summary,
+    Attribution,
+    DeadCode,
+    Duplication,
+    Complexity,
+>(
+    output: AuditOutput<Verdict, Summary, Attribution, DeadCode, Duplication, Complexity>,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error>
+where
+    Verdict: Serialize,
+    Summary: Serialize,
+    Attribution: Serialize,
+    DeadCode: Serialize,
+    Duplication: Serialize,
+    Complexity: Serialize,
+{
+    let mut value = serde_json::to_value(output)?;
+    apply_root_kind(&mut value, "audit", mode);
+    Ok(value)
+}
+
 /// Remove only the document-root discriminator. Nested objects may carry their
 /// own meaningful `kind` fields, so this intentionally does not recurse.
 pub fn remove_root_kind(value: &mut serde_json::Value) {
@@ -296,6 +327,7 @@ pub enum FallowOutput<
 
 #[cfg(test)]
 mod tests {
+    use fallow_types::envelope::{ElapsedMs, SchemaVersion, ToolVersion};
     use serde_json::json;
 
     use super::*;
@@ -379,5 +411,36 @@ mod tests {
 
         assert!(value.get("kind").is_none());
         assert_eq!(value["schema_version"], 1);
+    }
+
+    #[test]
+    fn serialize_audit_json_output_applies_audit_kind() {
+        let value = serialize_audit_json_output(
+            AuditOutput {
+                schema_version: SchemaVersion(7),
+                version: ToolVersion("1.2.3".to_string()),
+                command: AuditCommand::Audit,
+                verdict: "pass",
+                changed_files_count: 2,
+                base_ref: "origin/main".to_string(),
+                base_description: Some("merge-base with origin/main".to_string()),
+                head_sha: Some("abc123".to_string()),
+                elapsed_ms: ElapsedMs(42),
+                base_snapshot_skipped: Some(false),
+                summary: json!({ "dead_code_issues": 0 }),
+                attribution: json!({ "gate": "new_only" }),
+                meta: None,
+                dead_code: Some(json!({ "summary": { "total_issues": 0 } })),
+                duplication: None::<serde_json::Value>,
+                complexity: None::<serde_json::Value>,
+                next_steps: Vec::new(),
+            },
+            RootEnvelopeMode::Tagged,
+        )
+        .expect("audit output should serialize");
+
+        assert_eq!(value["kind"], "audit");
+        assert_eq!(value["command"], "audit");
+        assert_eq!(value["dead_code"]["summary"]["total_issues"], 0);
     }
 }

--- a/crates/output/src/root_envelopes.rs
+++ b/crates/output/src/root_envelopes.rs
@@ -72,6 +72,27 @@ where
     Ok(value)
 }
 
+/// Serialize a typed bare `fallow --format json` combined envelope with the
+/// standard root discriminator policy.
+///
+/// # Errors
+///
+/// Returns a serde error when the provided envelope cannot be converted to a
+/// JSON value.
+pub fn serialize_combined_json_output<Check, Dupes, Health>(
+    output: CombinedOutput<Check, Dupes, Health>,
+    mode: RootEnvelopeMode,
+) -> Result<serde_json::Value, serde_json::Error>
+where
+    Check: Serialize,
+    Dupes: Serialize,
+    Health: Serialize,
+{
+    let mut value = serde_json::to_value(output)?;
+    apply_root_kind(&mut value, "combined", mode);
+    Ok(value)
+}
+
 /// Remove only the document-root discriminator. Nested objects may carry their
 /// own meaningful `kind` fields, so this intentionally does not recurse.
 pub fn remove_root_kind(value: &mut serde_json::Value) {
@@ -442,5 +463,26 @@ mod tests {
         assert_eq!(value["kind"], "audit");
         assert_eq!(value["command"], "audit");
         assert_eq!(value["dead_code"]["summary"]["total_issues"], 0);
+    }
+
+    #[test]
+    fn serialize_combined_json_output_applies_combined_kind() {
+        let value = serialize_combined_json_output(
+            CombinedOutput {
+                schema_version: SchemaVersion(7),
+                version: ToolVersion("1.2.3".to_string()),
+                elapsed_ms: ElapsedMs(42),
+                meta: None,
+                check: Some(json!({ "summary": { "total_issues": 0 } })),
+                dupes: None::<serde_json::Value>,
+                health: None::<serde_json::Value>,
+                next_steps: Vec::new(),
+            },
+            RootEnvelopeMode::Tagged,
+        )
+        .expect("combined output should serialize");
+
+        assert_eq!(value["kind"], "combined");
+        assert_eq!(value["check"]["summary"]["total_issues"], 0);
     }
 }

--- a/crates/programmatic-cli/Cargo.toml
+++ b/crates/programmatic-cli/Cargo.toml
@@ -8,13 +8,12 @@ homepage.workspace = true
 documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Temporary CLI-backed programmatic bridge for fallow embedders"
+description = "Temporary CLI-backed health runner adapter for fallow embedders"
 readme = "../../README.md"
 
 [dependencies]
 fallow-api = { workspace = true }
 fallow-cli = { workspace = true }
-serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/programmatic-cli/src/lib.rs
+++ b/crates/programmatic-cli/src/lib.rs
@@ -1,9 +1,9 @@
-//! Temporary programmatic bridge for CLI-backed runtime paths.
+//! Temporary programmatic runner bridge for CLI-backed health execution.
 //!
-//! `fallow-api` owns the public programmatic contracts. Most NAPI calls now use
-//! the API runtime directly. Health still needs the CLI implementation until
-//! the health execution pipeline finishes moving behind typed engine results, so
-//! this crate keeps that dependency explicit and removable.
+//! `fallow-api` owns the public programmatic contracts and serialization.
+//! Health execution still needs the CLI implementation until the health
+//! pipeline finishes moving behind typed engine results, so this crate exposes
+//! only the removable runner adapter.
 
 #![cfg_attr(not(test), deny(clippy::disallowed_methods))]
 
@@ -19,26 +19,4 @@ impl fallow_api::ProgrammaticHealthRunner for CliHealthRunner {
     ) -> Result<ProgrammaticHealthRun, ProgrammaticError> {
         fallow_cli::programmatic::CliProgrammaticHealthRunner.run_programmatic_health(options)
     }
-}
-
-/// Run complexity analysis through the temporary CLI-backed health bridge.
-///
-/// # Errors
-///
-/// Returns structured programmatic errors from option validation, analysis, or
-/// JSON serialization.
-pub fn compute_complexity(
-    options: &ComplexityOptions,
-) -> Result<serde_json::Value, ProgrammaticError> {
-    fallow_api::compute_complexity_with_runner(options, &CliHealthRunner)
-}
-
-/// Run health analysis through the temporary CLI-backed health bridge.
-///
-/// # Errors
-///
-/// Returns structured programmatic errors from option validation, analysis, or
-/// JSON serialization.
-pub fn compute_health(options: &ComplexityOptions) -> Result<serde_json::Value, ProgrammaticError> {
-    fallow_api::compute_health_with_runner(options, &CliHealthRunner)
 }


### PR DESCRIPTION
## Summary
- route NAPI health through the API runner boundary
- route audit, combined, named, and report JSON roots through fallow-output contract helpers
- keep CLI schema and test consumers on the cfg-gated legacy root enum path only

## Verification
- cargo fmt --all -- --check
- cargo check -p fallow-cli -p fallow-output
- cargo clippy -p fallow-cli -p fallow-output --all-targets -- -D warnings
- cargo test -p fallow-cli report::json::tests
- cargo test -p fallow-cli output_envelope::tests
- cargo check -p fallow-cli --features schema-emit --bin fallow-schema-emit
- .githooks/pre-commit
- .githooks/pre-push