### PR TITLE
test(core): pin #1441 inferred-return factory member crediting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is now credited, so it is not reported as unused. Resolution is gated on the
   `use<Name>Store` naming convention, so a non-store `ReturnType<typeof ...>`
   param never masks a genuinely unused member.
-  (Refs [#1489](https://github.com/fallow-rs/fallow/issues/1489))
+  (Closes [#1489](https://github.com/fallow-rs/fallow/issues/1489))
+
+- **`unused-class-members` no longer false-flags a member reached through a
+  factory or composable return value.** When a class instance reaches a call
+  site only through a function that returns it (a `useApi()` composable, a
+  singleton getter), `const api = useApi(); api.Member()` now credits
+  `Class.Member`, including when the factory's return type is inferred rather
+  than annotated. Previously the member was reported as unused unless the
+  instance was reached through a directly-typed reference.
+  (Closes [#1441](https://github.com/fallow-rs/fallow/issues/1441))
 
 - **`ignorePatterns` now accepts a leading `./`.** Entries such as
   `./src/generated/**` now match the same project-root-relative files as

--- a/crates/core/tests/integration_test/issue_1441_factory_return_member.rs
+++ b/crates/core/tests/integration_test/issue_1441_factory_return_member.rs
@@ -68,3 +68,37 @@ fn cross_module_factory_return_credits_class_member() {
         "RESTApi.unusedMethod has no call site and must stay flagged, found: {unused:?}"
     );
 }
+
+#[test]
+fn inferred_return_factory_credits_class_member() {
+    // The exact issue #1441 repro: `useApi()` has an INFERRED return type (no
+    // `: Api` annotation), so the class type reaches the consumer only through the
+    // typed module-local `let api: Api` the factory returns. The headline of the
+    // issue is precisely the inferred-return form; the other #1441 fixtures all
+    // annotate the return, so this pins the inferred case against regression.
+    //   const api = useApi(); api.ViaFactory.call() -> must credit Api.ViaFactory
+    //   useDirect(api: Api) { api.Direct.call() }    -> must credit Api.Direct
+    //   Api.DeadMember (never accessed)              -> must stay flagged (control)
+    let root = fixture_path("issue-1441-inferred-return-member");
+    let mut config = create_config(root);
+    config.rules.unused_class_members = fallow_config::Severity::Error;
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.member.parent_name, m.member.member_name))
+        .collect();
+
+    for credited in ["Api.Direct", "Api.ViaFactory"] {
+        assert!(
+            !unused.contains(&credited.to_string()),
+            "{credited} is a genuine usage reached through the inferred-return factory and must be \
+             credited (issue #1441), found: {unused:?}"
+        );
+    }
+    assert!(
+        unused.contains(&"Api.DeadMember".to_string()),
+        "Api.DeadMember has no call site and must stay flagged (non-vacuous control), found: {unused:?}"
+    );
+}

--- a/tests/fixtures/issue-1441-inferred-return-member/package.json
+++ b/tests/fixtures/issue-1441-inferred-return-member/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "issue-1441-inferred-return-member",
+  "private": true,
+  "main": "src/main.ts"
+}

--- a/tests/fixtures/issue-1441-inferred-return-member/src/api.ts
+++ b/tests/fixtures/issue-1441-inferred-return-member/src/api.ts
@@ -1,0 +1,10 @@
+function makeRes() {
+  return { call() { return 1 } }
+}
+
+export class Api {
+  public readonly Direct = makeRes()
+  public readonly ViaFactory = makeRes()
+  // Never accessed by any consumer: must stay flagged (non-vacuous control).
+  public readonly DeadMember = makeRes()
+}

--- a/tests/fixtures/issue-1441-inferred-return-member/src/composable.ts
+++ b/tests/fixtures/issue-1441-inferred-return-member/src/composable.ts
@@ -1,0 +1,12 @@
+import { Api } from './api'
+
+// Inferred return type (NO `: Api` annotation): the class type reaches the
+// consumer only through the typed module-local `let api: Api` this returns.
+// This is the exact #1441 repro; the #1634 fixtures all annotate the return.
+let api: Api
+export function useApi() {
+  if (!api) {
+    api = new Api()
+  }
+  return api
+}

--- a/tests/fixtures/issue-1441-inferred-return-member/src/consumerDirect.ts
+++ b/tests/fixtures/issue-1441-inferred-return-member/src/consumerDirect.ts
@@ -1,0 +1,5 @@
+import { Api } from './api'
+
+export function useDirect(api: Api) {
+  return api.Direct.call() // genuine usage of Api.Direct via a directly-typed param
+}

--- a/tests/fixtures/issue-1441-inferred-return-member/src/consumerFactory.ts
+++ b/tests/fixtures/issue-1441-inferred-return-member/src/consumerFactory.ts
@@ -1,0 +1,6 @@
+import { useApi } from './composable'
+
+export function useFactory() {
+  const api = useApi()
+  return api.ViaFactory.call() // genuine usage of Api.ViaFactory via the factory
+}

--- a/tests/fixtures/issue-1441-inferred-return-member/src/main.ts
+++ b/tests/fixtures/issue-1441-inferred-return-member/src/main.ts
@@ -1,0 +1,7 @@
+import { useFactory } from './consumerFactory'
+import { useDirect } from './consumerDirect'
+import { Api } from './api'
+
+export function boot() {
+  return useFactory() + useDirect(new Api())
+}


### PR DESCRIPTION
## Summary

The factory/composable indirection false positive for `unused-class-members` was
fixed in #1634 (factory-return crediting), but its fixtures all annotate the
factory return type. Issue #1441's headline is specifically the INFERRED return
type: `const api = useApi(); api.Member()` where `useApi` has no return
annotation, so the class type reaches the consumer only through the typed
module-local the factory returns.

Verified on current `main` that the exact #1441 repro is fixed (`Api.ViaFactory`
no longer flagged), with a non-vacuous control (a genuinely dead member still
flags). This PR pins that exact inferred-return shape against regression and
records the user-facing CHANGELOG entry the original fix omitted.

Test-only plus a fixture and CHANGELOG entry; no production code change.

Closes #1441.
