### PR TITLE
fix(svelte): credit bind:/style:/class: directive shorthands as prop usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`unused-component-props` no longer false-flags a Svelte prop used only
+  through a `bind:`/`style:`/`class:` directive shorthand.** A value-less
+  directive such as `bind:open`, `style:height`, or `class:active` is shorthand
+  for `directive:NAME={NAME}`, so the directive name itself references the prop.
+  Template-usage extraction now credits these, alongside the existing
+  `use:`/`transition:`/`in:`/`out:`/`animate:` handling. Directives written with
+  an explicit value (`style:height={h}`) are unchanged: the value names the
+  reference, and the bare target (CSS property, class name, child prop) does
+  not.
+  (Closes [#1641](https://github.com/fallow-rs/fallow/issues/1641))
+
 - **`unused-store-members` no longer false-flags a Pinia store member reached
   through indirection.** A member used inline on a store-factory call
   (`useFooStore().member`), or through a store passed as a param typed

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -612,7 +612,13 @@ use crate::MemberKind;
 /// (`ReturnType<typeof useFooStore>`, inline or aliased) now binds to the store
 /// factory, so `props.store.member` / `const { m } = props.store` emit factory
 /// `member_accesses` a 191 warm cache lacks.
-pub(super) const CACHE_VERSION: u32 = 192;
+///
+/// Bumped to 193 (issue #1641): Svelte template usage now credits
+/// `bind:`/`style:`/`class:` directive shorthands (`bind:open` =
+/// `bind:open={open}`) as references, so a prop used only via a shorthand
+/// directive sets `used_in_template`. A warm cache from 192 carries the stale
+/// (uncredited) prop-usage flags.
+pub(super) const CACHE_VERSION: u32 = 193;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/sfc_template/svelte.rs
+++ b/crates/extract/src/sfc_template/svelte.rs
@@ -669,6 +669,17 @@ fn merge_markup_attr_usage(
                 current,
             );
         }
+        if attr.value.is_none()
+            && let Some(binding) = directive_shorthand_binding_name(&attr.name)
+        {
+            merge_expression_usage_allow_dollar_refs_with_bound_targets(
+                usage,
+                binding,
+                imported_bindings,
+                bound_targets,
+                current,
+            );
+        }
         if let Some(local) = attr.name.strip_prefix("let:")
             && !local.is_empty()
         {
@@ -733,6 +744,31 @@ fn directive_binding_name(attr_name: &str) -> Option<&str> {
                 .next()
                 .map(str::trim)
                 .filter(|name| !name.is_empty());
+            if binding.is_some() {
+                return binding;
+            }
+        }
+    }
+    None
+}
+
+/// Directive shorthands whose *name* is itself a reference to a local binding
+/// when written without an explicit value: `bind:open` (= `bind:open={open}`),
+/// `style:height` (= `style:height={height}`), `class:active`
+/// (= `class:active={active}`). With an explicit `={…}` value the name is a
+/// target (child prop, CSS property, or class name), not a local reference, so
+/// the caller only consults this for value-less attributes and the value path
+/// credits the binding instead. The leading-character guard rejects CSS custom
+/// properties (`style:--accent`) that would otherwise parse as a `--foo`
+/// pre-decrement expression.
+fn directive_shorthand_binding_name(attr_name: &str) -> Option<&str> {
+    for prefix in ["bind:", "style:", "class:"] {
+        if let Some(rest) = attr_name.strip_prefix(prefix) {
+            let binding = rest.split('|').next().map(str::trim).filter(|name| {
+                name.chars()
+                    .next()
+                    .is_some_and(|c| c.is_alphabetic() || c == '_' || c == '$')
+            });
             if binding.is_some() {
                 return binding;
             }

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -501,6 +501,64 @@ import { isActive } from './utils';
 }
 
 #[test]
+fn svelte_shorthand_directive_credits_prop_usage() {
+    // Props referenced ONLY via `bind:`/`style:`/`class:` shorthand directives
+    // (where the directive name IS the prop reference) must count as template
+    // usage, otherwise `unused-component-props` false-flags them. Regression
+    // for #1641.
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+let { open = $bindable(), height = '200px', active = false } = $props();
+</script>
+<details bind:open>
+  <div style:height class:active>x</div>
+</details>
+"#,
+        "Modal.svelte",
+    );
+
+    for name in ["open", "height", "active"] {
+        let prop = info
+            .component_props
+            .iter()
+            .find(|prop| prop.name == name)
+            .unwrap_or_else(|| panic!("prop {name} should be harvested"));
+        assert!(
+            prop.used_in_template,
+            "{name} is referenced via a shorthand directive, so used_in_template should be true",
+        );
+    }
+}
+
+#[test]
+fn svelte_directive_value_does_not_credit_target_name() {
+    // With an explicit `={…}` value the directive name is a target (CSS
+    // property / class name), not a local reference. The value expression is
+    // credited; the bare target name is not, so a same-named prop stays unused.
+    let info = parse_sfc(
+        r#"
+<script lang="ts">
+let { height = '200px' } = $props();
+let h = '300px';
+</script>
+<div style:height={h}>x</div>
+"#,
+        "Box.svelte",
+    );
+
+    let prop = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "height")
+        .expect("height prop should be harvested");
+    assert!(
+        !prop.used_in_template,
+        "style:height={{h}} references h, not the prop height, so it stays unused",
+    );
+}
+
+#[test]
 fn svelte_store_subscription_clears_unused_import_binding() {
     let info = parse_sfc(
         r#"


### PR DESCRIPTION
A Svelte directive written without an explicit value is shorthand for `directive:NAME={NAME}`, so the directive name itself references a local binding: `bind:open` = `bind:open={open}`, `style:height` = `style:height={height}`, `class:active` = `class:active={active}`. The template scanner only credited `use:`/`animate:`/`in:`/`out:`/`transition:` directive names, so a prop referenced only through a `bind:`/`style:`/`class:` shorthand was reported as `unused-component-props`.

Credit the directive name as a reference only for value-less attributes; with an explicit `={...}` value the name is a target (child prop, CSS property, or class name) and the value path already credits the real binding. A leading-character guard skips CSS custom properties (`style:--accent`).

The `_`-prefix accepted-but-unused destructure convention (Repro 3 in the issue) is a separate opt-in config request and is out of scope here.

Fixes #1641