### PR TITLE
feat(mcp): teach the F4 augment-not-gate rule in blast-radius + importance descriptions

### DIFF
--- a/crates/mcp/src/server/mod.rs
+++ b/crates/mcp/src/server/mod.rs
@@ -356,7 +356,7 @@ impl FallowMcp {
     }
 
     #[tool(
-        description = "Return first-class blast-radius context alongside local runtime coverage. Pass `coverage` as a V8 coverage directory, single V8 JSON file, or Istanbul `coverage-final.json`. A single local capture is free and runs without a license; continuous or multi-capture runtime monitoring requires an active license. Returns the standard health JSON; agents should read `runtime_coverage.blast_radius`, which contains stable `fallow:blast:<hash>` IDs, caller counts, traffic-weighted caller reach, and low/medium/high risk bands.",
+        description = "Return first-class blast-radius context alongside local runtime coverage. Pass `coverage` as a V8 coverage directory, single V8 JSON file, or Istanbul `coverage-final.json`. A single local capture is free and runs without a license; continuous or multi-capture runtime monitoring requires an active license. Returns the standard health JSON; agents should read `runtime_coverage.blast_radius`, which contains stable `fallow:blast:<hash>` IDs, caller counts, traffic-weighted caller reach, and low/medium/high risk bands. This blast-radius signal augments context only: it scores the RISK of changing a function. It MUST NOT gate `safe_to_delete` or a confidence score (a function having callers does not make it 'keep'); only the three-state runtime tracking signal (called / never_called / untracked) can issue a deletion verdict.",
         annotations(read_only_hint = true, open_world_hint = true)
     )]
     async fn get_blast_radius(
@@ -368,7 +368,7 @@ impl FallowMcp {
     }
 
     #[tool(
-        description = "Return first-class production-importance context from local runtime coverage plus static health signals. Pass `coverage` as a V8 coverage directory, single V8 JSON file, or Istanbul `coverage-final.json`. A single local capture is free and runs without a license; continuous or multi-capture runtime monitoring requires an active license. Returns the standard health JSON; agents should read `runtime_coverage.importance`, which contains stable `fallow:importance:<hash>` IDs, invocations, cyclomatic complexity, owner count, a 0-100 score, and a templated reason.",
+        description = "Return first-class production-importance context from local runtime coverage plus static health signals. Pass `coverage` as a V8 coverage directory, single V8 JSON file, or Istanbul `coverage-final.json`. A single local capture is free and runs without a license; continuous or multi-capture runtime monitoring requires an active license. Returns the standard health JSON; agents should read `runtime_coverage.importance`, which contains stable `fallow:importance:<hash>` IDs, invocations, cyclomatic complexity, owner count, a 0-100 score, and a templated reason. This importance signal augments context only. It MUST NOT gate `safe_to_delete` or a confidence score (a high or low score never decides deletion); only the three-state runtime tracking signal (called / never_called / untracked) can issue a deletion verdict.",
         annotations(read_only_hint = true, open_world_hint = true)
     )]
     async fn get_importance(

--- a/crates/types/src/mcp_manifest.rs
+++ b/crates/types/src/mcp_manifest.rs
@@ -170,7 +170,7 @@ pub const MCP_TOOLS: &[McpToolInfo] = &[
     McpToolInfo {
         name: "get_blast_radius",
         kind: "runtime-coverage",
-        description: "Blast-radius context (caller counts, risk bands) from runtime coverage",
+        description: "Blast-radius context (caller counts, risk bands) from runtime coverage; augments review only, never gates safe_to_delete (three-state tracking issues that verdict)",
         key_params: &["coverage", "group_by"],
         license: McpToolLicense::Freemium,
         license_note: Some(RUNTIME_COVERAGE_LICENSE_NOTE),
@@ -179,7 +179,7 @@ pub const MCP_TOOLS: &[McpToolInfo] = &[
     McpToolInfo {
         name: "get_importance",
         kind: "runtime-coverage",
-        description: "Production-importance scores (0-100) combining invocations, complexity, and ownership",
+        description: "Production-importance scores (0-100) combining invocations, complexity, and ownership; augments review only, never gates safe_to_delete (three-state tracking issues that verdict)",
         key_params: &["coverage", "group_by"],
         license: McpToolLicense::Freemium,
         license_note: Some(RUNTIME_COVERAGE_LICENSE_NOTE),


### PR DESCRIPTION
`get_blast_radius` and `get_importance` return CONTEXT (caller counts, risk bands, importance scores). Nothing in their tool contract told an agent these signals must not gate a deletion decision, so a naive agent could wire blast-radius or importance into a `safe_to_delete` gate.

Bakes the rule into both the rmcp wire descriptions (`crates/mcp/src/server/mod.rs`) and the capability-manifest one-liners (`crates/types/src/mcp_manifest.rs`): the signal augments review only and MUST NOT gate `safe_to_delete` or a confidence score; only the three-state runtime tracking signal (called / never_called / untracked) can issue a deletion verdict.

Aligns the agent-facing contract with the server-side F4 enforcement (ADR 019). `coverage_intelligence` (the third surface named in the issue) is a CLI health builder, not an MCP tool with an agent-facing description, so the contract gap was specifically these two context tools.

Refs fallow-rs/fallow-cloud#323.