### PR TITLE
fix(vue): credit v-bind shorthand and <style> v-bind() as prop usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not.
   (Closes [#1641](https://github.com/fallow-rs/fallow/issues/1641))
 
+- **`unused-component-props` no longer false-flags a Vue prop used only through
+  a value-less `v-bind` same-name shorthand.** Vue 3.4+ lets `:open` stand for
+  `:open="open"` and `:some-prop` for `:some-prop="someProp"`, so the argument
+  itself references the prop. Template-usage extraction now credits the
+  camelCase argument of a value-less `v-bind`. A `v-bind` written with an
+  explicit value (`:label="text"`) is unchanged: the value names the reference,
+  not the bare argument.
+  (Refs [#1641](https://github.com/fallow-rs/fallow/issues/1641))
+
 - **`unused-store-members` no longer false-flags a Pinia store member reached
   through indirection.** A member used inline on a store-factory call
   (`useFooStore().member`), or through a store passed as a param typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not the bare argument.
   (Refs [#1641](https://github.com/fallow-rs/fallow/issues/1641))
 
+- **`unused-component-props` no longer false-flags a Vue prop used only through
+  a `<style> v-bind()` reference.** Vue SFC CSS `v-bind(accent)`,
+  `v-bind(props.accent)`, and the string form `v-bind('a.b')` bind a script or
+  prop value into CSS. Template-usage extraction now scans `<style>` blocks for
+  these references, so a prop consumed only by CSS `v-bind()` is credited
+  instead of reported as unused.
+
 - **`unused-store-members` no longer false-flags a Pinia store member reached
   through indirection.** A member used inline on a store-factory call
   (`useFooStore().member`), or through a store passed as a param typed

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -618,7 +618,13 @@ use crate::MemberKind;
 /// `bind:open={open}`) as references, so a prop used only via a shorthand
 /// directive sets `used_in_template`. A warm cache from 192 carries the stale
 /// (uncredited) prop-usage flags.
-pub(super) const CACHE_VERSION: u32 = 193;
+///
+/// Bumped to 194 (issue #1641, Vue side): Vue template usage now credits the
+/// 3.4+ same-name `v-bind` shorthand (`:open` = `:open="open"`, `:some-prop` =
+/// `:some-prop="someProp"`) as a reference, so a prop used only via a value-less
+/// `v-bind` sets `used_in_template`. A warm cache from 193 carries the stale
+/// (uncredited) prop-usage flags.
+pub(super) const CACHE_VERSION: u32 = 194;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -624,7 +624,12 @@ use crate::MemberKind;
 /// `:some-prop="someProp"`) as a reference, so a prop used only via a value-less
 /// `v-bind` sets `used_in_template`. A warm cache from 193 carries the stale
 /// (uncredited) prop-usage flags.
-pub(super) const CACHE_VERSION: u32 = 194;
+///
+/// Bumped to 195: Vue SFC `<style> v-bind(expr)` references are now scanned, so
+/// a prop / import used only via CSS `v-bind(accent)` / `v-bind(props.x)` /
+/// `v-bind('a.b')` sets `used_in_template`. A warm cache from 194 carries the
+/// stale (uncredited) prop-usage flags.
+pub(super) const CACHE_VERSION: u32 = 195;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/sfc_template/scanners.rs
+++ b/crates/extract/src/sfc_template/scanners.rs
@@ -14,6 +14,14 @@ pub(super) fn scan_bracket_section(source: &str, start: usize) -> Option<(&str, 
     scan_delimited_section(source, start, 1, 1, b'[', b']')
 }
 
+/// Scan a parenthesized section `(...)` starting at the `(` at `start`, returning
+/// the inner text and the index just past the closing `)`. Quote- and
+/// nesting-aware, so a `)` inside a string or a nested `(...)` does not close
+/// early. Used for Vue SFC `<style>` `v-bind(expr)` extraction.
+pub(super) fn scan_paren_section(source: &str, start: usize) -> Option<(&str, usize)> {
+    scan_delimited_section(source, start, 1, 1, b'(', b')')
+}
+
 fn scan_delimited_section(
     source: &str,
     start: usize,

--- a/crates/extract/src/sfc_template/shared.rs
+++ b/crates/extract/src/sfc_template/shared.rs
@@ -245,7 +245,7 @@ fn mark_binding_used(
     }
 }
 
-fn kebab_to_camel_case(source: &str) -> String {
+pub(super) fn kebab_to_camel_case(source: &str) -> String {
     let mut camel = String::new();
     let mut uppercase_next = false;
 

--- a/crates/extract/src/sfc_template/vue.rs
+++ b/crates/extract/src/sfc_template/vue.rs
@@ -4,7 +4,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::template_usage::TemplateUsage;
 
-use super::scanners::{scan_bracket_section, scan_curly_section, scan_html_tag};
+use super::scanners::{
+    scan_bracket_section, scan_curly_section, scan_html_tag, scan_paren_section,
+};
 use super::shared::{
     HTML_COMMENT_RE, ParsedAttr, ParsedTag, kebab_to_camel_case, merge_component_tag_usage,
     merge_expression_usage_with_bound_targets, merge_pattern_binding_usage,
@@ -23,6 +25,13 @@ static TEMPLATE_OPEN_RE: LazyLock<regex::Regex> =
 
 static VUE_FOR_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| crate::static_regex(r"(?is)^(?P<binding>.+?)\s+(?:in|of)\s+(?P<source>.+)$"));
+
+/// Matches a `<style ...>...</style>` block, capturing the body. Used to scan
+/// for Vue SFC CSS `v-bind(expr)` references, which bind a script/prop binding
+/// into CSS and otherwise look like usage nowhere in the `<template>`.
+static VUE_STYLE_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    crate::static_regex(r#"(?is)<style\b(?:[^>"']|"[^"]*"|'[^']*')*>(?P<body>.*?)</style>"#)
+});
 
 #[cfg(test)]
 pub(super) fn collect_template_usage(
@@ -74,7 +83,83 @@ pub(super) fn collect_template_usage_with_bound_targets(
         scan_from = body_end;
     }
 
+    scan_style_vbind_usage(source, imported_bindings, bound_targets, &mut usage);
+
     usage
+}
+
+/// Scan each `<style>` block for Vue SFC CSS `v-bind(expr)` references and credit
+/// the referenced bindings, so a prop / import used only via `v-bind(accent)` is
+/// not reported as unused. Handles the identifier form `v-bind(accent)`, the
+/// member form `v-bind(props.accent)`, and the string form `v-bind('a.b')` (the
+/// quoted content is itself a JS expression). Restricted to `<style>` bodies so a
+/// template attribute `v-bind="..."` is never matched here.
+fn scan_style_vbind_usage(
+    source: &str,
+    imported_bindings: &FxHashSet<String>,
+    bound_targets: &FxHashMap<String, String>,
+    usage: &mut TemplateUsage,
+) {
+    for caps in VUE_STYLE_RE.captures_iter(source) {
+        let Some(body) = caps.name("body") else {
+            continue;
+        };
+        let body = body.as_str();
+        let bytes = body.as_bytes();
+        let mut index = 0;
+        while let Some(rel) = body[index..].find("v-bind") {
+            let start = index + rel;
+            // Require a token boundary before `v-bind` so a longer identifier
+            // (e.g. a CSS custom property containing the substring) is not matched.
+            let preceded_by_word = start
+                .checked_sub(1)
+                .is_some_and(|prev| bytes[prev].is_ascii_alphanumeric() || bytes[prev] == b'_');
+            let mut paren = start + "v-bind".len();
+            while bytes.get(paren).is_some_and(u8::is_ascii_whitespace) {
+                paren += 1;
+            }
+            if !preceded_by_word
+                && bytes.get(paren) == Some(&b'(')
+                && let Some((expr, next)) = scan_paren_section(body, paren)
+            {
+                credit_style_vbind_expr(expr.trim(), imported_bindings, bound_targets, usage);
+                index = next;
+                continue;
+            }
+            index = start + "v-bind".len();
+        }
+    }
+}
+
+/// Credit the bindings referenced by a single `v-bind(...)` style expression.
+/// A wholly-quoted argument (`v-bind('foo.bar')`) is unwrapped because Vue treats
+/// the string content as the JS expression.
+fn credit_style_vbind_expr(
+    expr: &str,
+    imported_bindings: &FxHashSet<String>,
+    bound_targets: &FxHashMap<String, String>,
+    usage: &mut TemplateUsage,
+) {
+    let inner = strip_wrapping_quotes(expr).unwrap_or(expr);
+    if inner.is_empty() {
+        return;
+    }
+    merge_expression_usage_with_bound_targets(usage, inner, imported_bindings, bound_targets, &[]);
+}
+
+/// Strip a single matching wrapping quote pair (`'x'` / `"x"`), but only when the
+/// quote does not reappear inside, so a real expression such as `'a' + b` is left
+/// intact for the analyzer.
+fn strip_wrapping_quotes(expr: &str) -> Option<&str> {
+    let bytes = expr.as_bytes();
+    let first = *bytes.first()?;
+    if (first == b'\'' || first == b'"') && bytes.len() >= 2 && *bytes.last()? == first {
+        let inner = &expr[1..expr.len() - 1];
+        if !inner.as_bytes().contains(&first) {
+            return Some(inner);
+        }
+    }
+    None
 }
 
 /// Locate the `</template>` that closes the root template whose body starts at

--- a/crates/extract/src/sfc_template/vue.rs
+++ b/crates/extract/src/sfc_template/vue.rs
@@ -6,7 +6,7 @@ use crate::template_usage::TemplateUsage;
 
 use super::scanners::{scan_bracket_section, scan_curly_section, scan_html_tag};
 use super::shared::{
-    HTML_COMMENT_RE, ParsedAttr, ParsedTag, merge_component_tag_usage,
+    HTML_COMMENT_RE, ParsedAttr, ParsedTag, kebab_to_camel_case, merge_component_tag_usage,
     merge_expression_usage_with_bound_targets, merge_pattern_binding_usage,
     merge_statement_usage_with_bound_targets, parse_tag_attrs,
 };
@@ -351,6 +351,17 @@ fn scan_vue_attrs(
                 arg_locals,
             );
         }
+        if attr.value.is_none()
+            && let Some(binding) = vbind_shorthand_binding(&attr.name)
+        {
+            merge_expression_usage_with_bound_targets(
+                usage,
+                &binding,
+                imported_bindings,
+                bound_targets,
+                attr_locals,
+            );
+        }
         scan_vue_attr_value(attr, imported_bindings, bound_targets, attr_locals, usage);
     }
 }
@@ -454,6 +465,31 @@ fn directive_name(attr_name: &str) -> Option<&str> {
         .next()
         .map(str::trim)
         .filter(|name| !name.is_empty())
+}
+
+/// Vue 3.4+ same-name `v-bind` shorthand: a value-less `:arg` (or `v-bind:arg`)
+/// is shorthand for `:arg="arg"`, so the argument name references a local
+/// binding (`:open` = `:open="open"`, `:some-prop` = `:some-prop="someProp"`).
+/// Only fires for a value-less attribute; with an explicit value the value
+/// expression names the reference and the bare argument is the binding target.
+/// A dynamic argument (`:[expr]`) has no static same-name form and is credited
+/// separately via `dynamic_argument_expression`. Modifiers (`:foo.prop`) do not
+/// change the referenced variable, so the argument before the first `.` wins.
+/// The argument is camelized via `kebab_to_camel_case` to match Vue's own
+/// `camelize` (hyphen-only, so `:some_prop` stays `some_prop`).
+fn vbind_shorthand_binding(attr_name: &str) -> Option<String> {
+    let arg = attr_name
+        .strip_prefix(':')
+        .or_else(|| attr_name.strip_prefix("v-bind:"))?;
+    if arg.starts_with('[') {
+        return None;
+    }
+    let name = arg
+        .split('.')
+        .next()
+        .map(str::trim)
+        .filter(|n| !n.is_empty())?;
+    Some(kebab_to_camel_case(name))
 }
 
 fn is_custom_directive_attr(name: &str) -> bool {

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -327,6 +327,132 @@ const text = 'hi';
 }
 
 #[test]
+fn vue_style_vbind_credits_prop_usage() {
+    // A prop used ONLY via Vue SFC `<style> v-bind(prop)` (CSS v-bind) must count
+    // as template usage; an unused prop stays flagged. Regression for the
+    // unused-component-props style-v-bind gap.
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const { accent, gap } = defineProps<{ accent: string; gap: string }>();
+</script>
+<template><div class="box" /></template>
+<style scoped>
+.box { color: v-bind(accent); }
+</style>
+"#,
+        "Styled.vue",
+    );
+
+    let accent = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "accent")
+        .expect("accent prop should be harvested");
+    assert!(
+        accent.used_in_template,
+        "accent is referenced via <style> v-bind(accent), so used_in_template should be true",
+    );
+    let gap = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "gap")
+        .expect("gap prop should be harvested");
+    assert!(
+        !gap.used_in_template,
+        "gap is referenced nowhere, so it stays unused",
+    );
+}
+
+#[test]
+fn vue_style_vbind_member_and_string_forms_credit_prop_usage() {
+    // `v-bind(props.color)` (member) and `v-bind('props.size')` (string form,
+    // whose content is itself a JS expression) both credit the prop.
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const props = defineProps<{ color: string; size: string }>();
+</script>
+<template><div /></template>
+<style>
+.a { color: v-bind(props.color); }
+.b { width: v-bind('props.size'); }
+</style>
+"#,
+        "Styled.vue",
+    );
+
+    for name in ["color", "size"] {
+        let prop = info
+            .component_props
+            .iter()
+            .find(|prop| prop.name == name)
+            .unwrap_or_else(|| panic!("prop {name} should be harvested"));
+        assert!(
+            prop.used_in_template,
+            "{name} is referenced via a <style> v-bind member/string form, so used_in_template should be true",
+        );
+    }
+}
+
+#[test]
+fn vue_style_vbind_word_boundary_guard_does_not_credit() {
+    // `zv-bind(accent)` is not the `v-bind` function; the boundary guard must
+    // not credit `accent`, so the prop stays correctly flagged as unused.
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const { accent } = defineProps<{ accent: string }>();
+</script>
+<template><div /></template>
+<style>
+.box { color: zv-bind(accent); }
+</style>
+"#,
+        "Styled.vue",
+    );
+
+    let accent = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "accent")
+        .expect("accent prop should be harvested");
+    assert!(
+        !accent.used_in_template,
+        "zv-bind(accent) is not a v-bind() reference, so accent stays unused",
+    );
+}
+
+#[test]
+fn vue_style_vbind_multibyte_body_does_not_panic() {
+    // A multi-byte UTF-8 character in the style body must not break byte-offset
+    // scanning of `v-bind()`.
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const { accent } = defineProps<{ accent: string }>();
+</script>
+<template><div /></template>
+<style>
+/* 日本語コメント */
+.box { color: v-bind(accent); }
+</style>
+"#,
+        "Styled.vue",
+    );
+
+    let accent = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "accent")
+        .expect("accent prop should be harvested");
+    assert!(
+        accent.used_in_template,
+        "accent is referenced via v-bind(accent) after a multibyte comment",
+    );
+}
+
+#[test]
 fn vue_v_on_object_syntax_clears_unused_import_binding() {
     let info = parse_sfc(
         r#"

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -246,6 +246,87 @@ import { tooltipText } from './utils';
 }
 
 #[test]
+fn vue_vbind_shorthand_credits_prop_usage() {
+    // Props referenced ONLY via a value-less Vue 3.4+ same-name `v-bind`
+    // shorthand (`:open` = `:open="open"`, `:some-prop` = `:some-prop="someProp"`)
+    // must count as template usage, otherwise `unused-component-props`
+    // false-flags them. Regression for #1641 (Vue side).
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const { open, someProp } = defineProps<{ open: boolean; someProp: string }>();
+</script>
+<template><Child :open :some-prop /></template>
+"#,
+        "Parent.vue",
+    );
+
+    for name in ["open", "someProp"] {
+        let prop = info
+            .component_props
+            .iter()
+            .find(|prop| prop.name == name)
+            .unwrap_or_else(|| panic!("prop {name} should be harvested"));
+        assert!(
+            prop.used_in_template,
+            "{name} is referenced via a value-less v-bind shorthand, so used_in_template should be true",
+        );
+    }
+}
+
+#[test]
+fn vue_vbind_longform_shorthand_credits_prop_usage() {
+    // The long-form `v-bind:open` value-less shorthand is equivalent to `:open`
+    // and must credit the prop the same way. Regression for #1641 (Vue side).
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const { open } = defineProps<{ open: boolean }>();
+</script>
+<template><Child v-bind:open /></template>
+"#,
+        "Parent.vue",
+    );
+
+    let prop = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "open")
+        .expect("open prop should be harvested");
+    assert!(
+        prop.used_in_template,
+        "open is referenced via a value-less v-bind:open, so used_in_template should be true",
+    );
+}
+
+#[test]
+fn vue_vbind_valued_does_not_credit_target_name() {
+    // With an explicit value the `v-bind` argument is the binding target, not a
+    // local reference: `:label="text"` references `text`, so a same-named prop
+    // `label` stays unused.
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+const { label } = defineProps<{ label: string }>();
+const text = 'hi';
+</script>
+<template><Child :label="text" /></template>
+"#,
+        "Parent.vue",
+    );
+
+    let prop = info
+        .component_props
+        .iter()
+        .find(|prop| prop.name == "label")
+        .expect("label prop should be harvested");
+    assert!(
+        !prop.used_in_template,
+        ":label=\"text\" references text, not the prop label, so it stays unused",
+    );
+}
+
+#[test]
 fn vue_v_on_object_syntax_clears_unused_import_binding() {
     let info = parse_sfc(
         r#"


### PR DESCRIPTION
Two Vue `unused-component-props` false positives, both from the SFC scanner only seeing an attribute's value expression (or only the `<template>`), missing references that bind a prop through other syntax.

1. **Value-less `v-bind` same-name shorthand** (Vue 3.4+): `:open` = `:open="open"`, `:some-prop` = `:some-prop="someProp"`. The camelCase argument of a value-less `:arg` / `v-bind:arg` is now credited.

2. **`<style> v-bind()`**: Vue SFC CSS `v-bind(accent)` / `v-bind(props.accent)` / `v-bind('a.b')` binds a script or prop value into CSS. `<style>` bodies are now scanned for these references (quote- and paren-aware) and the referenced binding is credited.

A `v-bind` written with an explicit value is unchanged: the value names the reference, not the bare argument. CACHE_VERSION 193 -> 195.

Refs #1641 (the Svelte/Vue directive-shorthand false positives; Ericlm flagged the Vue v-bind shorthand parallel).