### PR TITLE
fix(telemetry): note find-state for security survivors and blind-spots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Telemetry: the `security` workflow once again records `findings_present` for
+  the `survivors` and `blind-spots` subcommands.** Both subcommands emit a
+  `security` telemetry event but never noted their find-state, so the
+  process-global accumulator stayed unset and `findings_present` serialized as
+  null. Because `fallow security` exits non-zero only when findings exist and the
+  rule is raised to `error`, `findings_present` is the field that distinguishes
+  "found candidates" from "errored," and a null value lost that signal for these
+  modes. `survivors` now notes its retained (non-dismissed) candidate count and
+  `blind-spots` notes its unresolved-callee-site count before exit, matching the
+  default / `--file` / `--gate` paths. No change to the telemetry payload shape.
+  (Closes [#1650](https://github.com/fallow-rs/fallow/issues/1650))
 - **`unused-files` no longer false-flags a custom version-bump `updater` script
   referenced under the package.json `commit-and-tag-version` key.** A custom
   updater module (`app/scripts/gradle-updater.cjs`) is loaded by

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -153,6 +153,14 @@ pub fn run_survivors(opts: &SecuritySurvivorsOptions<'_>) -> ExitCode {
         Ok(output) => output,
         Err(message) => return emit_error(&message, 2, opts.output),
     };
+    // Note find-state for telemetry before any exit (issue #1650): the survivors
+    // subcommand emits a `security` workflow event, and without this the
+    // process-global findings-present accumulator stays unset (-> null). The
+    // retained, non-dismissed candidates (survivors + needs-human-review) are
+    // what this run surfaced as actionable; an all-dismissed run is clean.
+    crate::telemetry::note_result_count(
+        output.summary.survivors + output.summary.needs_human_review,
+    );
     if opts.require_verdict_for_each_candidate && output.summary.unverdicted > 0 {
         return emit_error(
             &format!(
@@ -179,6 +187,11 @@ pub fn run_blind_spots(opts: &SecurityOptions<'_>) -> ExitCode {
         Err(code) => return code,
     };
     let output = build_blind_spots_output(&security_output);
+    // Note find-state for telemetry before exit (issue #1650): the blind-spots
+    // subcommand emits a `security` workflow event; without this the
+    // findings-present accumulator stays unset (-> null). Its findings are the
+    // unresolved callee sites it surfaces; zero blind spots is a clean run.
+    crate::telemetry::note_result_count(output.summary.unresolved_callee_sites);
     outln!("{}", render_blind_spots_output(opts.output, &output));
     ExitCode::SUCCESS
 }

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -984,6 +984,44 @@ fn security_survivors_all_dismissed_sets_findings_present_false() {
 }
 
 #[test]
+fn security_survivors_needs_human_review_sets_findings_present_true() {
+    // Pins the additive `needs_human_review` term in the survivors find-state: a
+    // candidate the verifier routes to human review is retained (non-dismissed)
+    // and must report findings_present=true even with zero outright survivors.
+    let dir = tempfile::tempdir().expect("temp project");
+    write_security_project(dir.path());
+    let (candidates, verdicts) = write_survivor_inputs(dir.path(), "needs-human-review");
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &[
+            "security",
+            "survivors",
+            "--candidates",
+            &candidates,
+            "--verdicts",
+            &verdicts,
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "security survivors should exit 0: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("security"));
+    assert_eq!(
+        event["findings_present"].as_bool(),
+        Some(true),
+        "a needs-human-review candidate must report findings_present=true"
+    );
+}
+
+#[test]
 fn review_output_reports_comment_limit_truncation() {
     let dir = tempfile::tempdir().expect("temp project");
     write_many_unused_project(dir.path());

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -407,6 +407,44 @@ fn write_security_project(dir: &Path) {
     .expect("write security source");
 }
 
+/// Write a one-candidate file plus a verdict file (with `verdict` applied to the
+/// single candidate) into `dir`, returning their absolute paths. Used by the
+/// `fallow security survivors` find-state regression tests (issue #1650).
+fn write_survivor_inputs(dir: &Path, verdict: &str) -> (String, String) {
+    let candidates = dir.join("candidates.json");
+    let verdicts = dir.join("verdicts.json");
+    let candidate_doc = serde_json::json!({
+        "kind": "security",
+        "security_findings": [{
+            "finding_id": "sec-a",
+            "kind": "tainted-sink",
+            "category": "ssrf",
+            "path": "src/a.ts",
+            "line": 1,
+            "col": 0,
+            "evidence": "test evidence",
+            "severity": "high",
+            "trace": [],
+            "actions": [],
+            "candidate": {
+                "sink": { "path": "src/a.ts", "line": 1, "col": 0, "category": "ssrf" },
+                "boundary": { "client_server": false, "cross_module": false }
+            }
+        }]
+    });
+    fs::write(&candidates, candidate_doc.to_string()).expect("write candidates");
+    let verdict_doc = serde_json::json!([{
+        "schema_version": "fallow-security-verdict/v1",
+        "finding_id": "sec-a",
+        "verdict": verdict
+    }]);
+    fs::write(&verdicts, verdict_doc.to_string()).expect("write verdicts");
+    (
+        candidates.to_string_lossy().to_string(),
+        verdicts.to_string_lossy().to_string(),
+    )
+}
+
 #[test]
 fn dupes_with_duplication_sets_findings_present_despite_success_outcome() {
     let dir = tempfile::tempdir().expect("temp project");
@@ -837,6 +875,112 @@ fn security_on_clean_project_sets_findings_present_false() {
     assert_eq!(event["outcome"].as_str(), Some("success"));
     assert_eq!(event["findings_present"].as_bool(), Some(false));
     assert_eq!(event["result_count_bucket"].as_str(), Some("0"));
+}
+
+#[test]
+fn security_blind_spots_sets_findings_present() {
+    // Regression for issue #1650: `security blind-spots` emits a `security`
+    // workflow event but historically never noted find-state, so findings_present
+    // serialized as null. This fixture has no unresolved callees, so a correct
+    // run reports findings_present=false (the key is present, not null).
+    let dir = tempfile::tempdir().expect("temp project");
+    write_security_project(dir.path());
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &["security", "blind-spots", "--format", "json", "--quiet"],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "security blind-spots should exit 0: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("security"));
+    assert_eq!(event["outcome"].as_str(), Some("success"));
+    assert!(
+        !event["findings_present"].is_null(),
+        "security blind-spots must populate findings_present, not leave it null"
+    );
+    assert_eq!(event["findings_present"].as_bool(), Some(false));
+}
+
+#[test]
+fn security_survivors_with_survivor_sets_findings_present_true() {
+    // Regression for issue #1650: `security survivors` emitted a `security` event
+    // with findings_present=null. A retained (survivor) candidate is actionable
+    // output, so the run must report findings_present=true.
+    let dir = tempfile::tempdir().expect("temp project");
+    write_security_project(dir.path());
+    let (candidates, verdicts) = write_survivor_inputs(dir.path(), "survivor");
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &[
+            "security",
+            "survivors",
+            "--candidates",
+            &candidates,
+            "--verdicts",
+            &verdicts,
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "security survivors should exit 0: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("security"));
+    assert_eq!(event["outcome"].as_str(), Some("success"));
+    assert_eq!(
+        event["findings_present"].as_bool(),
+        Some(true),
+        "a retained survivor candidate must report findings_present=true"
+    );
+}
+
+#[test]
+fn security_survivors_all_dismissed_sets_findings_present_false() {
+    // Pins the false branch and the decouple-from-candidates semantics: a run
+    // whose verifier dismissed every candidate surfaced nothing actionable, so
+    // findings_present is false (present, not null).
+    let dir = tempfile::tempdir().expect("temp project");
+    write_security_project(dir.path());
+    let (candidates, verdicts) = write_survivor_inputs(dir.path(), "dismissed");
+
+    let (event, output) = inspect_event_output(
+        dir.path(),
+        &[
+            "security",
+            "survivors",
+            "--candidates",
+            &candidates,
+            "--verdicts",
+            &verdicts,
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &[],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "security survivors should exit 0: {}",
+        output.stderr
+    );
+    assert_eq!(event["workflow"].as_str(), Some("security"));
+    assert!(
+        !event["findings_present"].is_null(),
+        "security survivors must populate findings_present even when all dismissed"
+    );
+    assert_eq!(event["findings_present"].as_bool(), Some(false));
 }
 
 #[test]


### PR DESCRIPTION
The `security survivors` and `security blind-spots` subcommands emit a security
workflow telemetry event but never noted their find-state, so the process-global
findings-present accumulator stayed unset and `findings_present` serialized as
null. Because `fallow security` exits non-zero only when findings exist and the
rule is raised to error, `findings_present` is the field that distinguishes
found-candidates from errored, so a null value lost that signal for these modes.

`run_survivors` now notes its retained (non-dismissed) candidate count and
`run_blind_spots` notes its unresolved-callee-site count before exit, matching the
default, `--file`, and `--gate` paths that already route through `run()`. No change
to the telemetry payload shape. Adds four regression tests asserting
`findings_present` is non-null for each subcommand, each neuter-verified.

Fixes #1650.