### PR TITLE
fix(telemetry): note find-state for flags/watch and guard the workflow class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Telemetry: `fallow flags` and `fallow watch` now record `findings_present`,
+  and a guard prevents the whole class of regression.** Both commands emit a
+  `code_quality_review` telemetry event (the same workflow as combined `fallow`,
+  which does populate the field) but never noted their find-state, so
+  `findings_present` serialized as null, the same gap fixed for the `security`
+  subcommands. `flags` now notes its feature-flag count and `watch` notes each
+  cycle's issue count. Focused `dead-code` / `dupes` trace and impact-closure
+  views also record their underlying analysis count, so `findings_present`
+  reflects what the analysis surfaced independent of the output view. A
+  debug-build invariant at the single telemetry event-emission point now fails
+  fast if any finding-surfacing workflow records a non-failing event without
+  noting find-state, so a future analysis command cannot silently reintroduce
+  the gap. No change to the telemetry payload shape.
+  (Refs [#1650](https://github.com/fallow-rs/fallow/issues/1650))
+
 - **Telemetry: the `security` workflow once again records `findings_present` for
   the `survivors` and `blind-spots` subcommands.** Both subcommands emit a
   `security` telemetry event but never noted their find-state, so the

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -692,13 +692,24 @@ pub fn execute_check(opts: &CheckOptions<'_>) -> Result<CheckResult, ExitCode> {
     let mut data = run_check_analysis(opts, &config)?;
     let elapsed = start.elapsed();
 
-    handle_trace_side_effects(
+    if let Err(code) = handle_trace_side_effects(
         opts,
         &config,
         data.trace_graph.as_ref(),
         data.trace_timings.as_ref(),
         &data.script_used_packages,
-    )?;
+    ) {
+        // A focused trace / closure view exits here without building the full
+        // CheckResult (where the normal path records find-state below). The full
+        // analysis still ran, so record its find-state for telemetry on the
+        // focused-success exit, keeping the DeadCode workflow's findings_present
+        // populated regardless of the output view (issue #1650). A trace error
+        // (exit 2) is a failed run and is left unset.
+        if code == ExitCode::SUCCESS {
+            crate::telemetry::note_result_count(data.results.total_issues());
+        }
+        return Err(code);
+    }
 
     apply_scope_filters(
         opts,

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -358,12 +358,15 @@ fn execute_dupes_inner(
     );
 
     if let Some(trace_spec) = opts.trace {
-        return Err(run_clone_trace(
-            &report,
-            &config.root,
-            trace_spec,
-            opts.output,
-        ));
+        // The trace view ran the full duplication analysis; record its find-state
+        // for telemetry before the focused early-return so the Dupes workflow's
+        // findings_present stays populated regardless of the output view (issue
+        // #1650). A trace error (exit 2) is a failed run and is left unset.
+        let code = run_clone_trace(&report, &config.root, trace_spec, opts.output);
+        if code == ExitCode::SUCCESS {
+            crate::telemetry::note_result_count(report.clone_groups.len());
+        }
+        return Err(code);
     }
 
     save_duplication_baseline(&report, &config, opts)?;

--- a/crates/cli/src/flags.rs
+++ b/crates/cli/src/flags.rs
@@ -42,6 +42,12 @@ pub fn run_flags(opts: &FlagsOptions<'_>) -> ExitCode {
     if let Err(code) = apply_flag_scopes(&mut flags, opts) {
         return code;
     }
+    // Note find-state for telemetry before any exit (issue #1650 follow-up): the
+    // flags command emits a `code_quality_review` workflow event (the same label
+    // as combined `fallow`), so without this its findings_present serialized as
+    // null. Count the scope-filtered flags BEFORE `--top` truncation so the
+    // bucket reflects the full set, not the displayed head.
+    crate::telemetry::note_result_count(flags.len());
     sort_and_limit_flags(&mut flags, opts.top);
 
     let elapsed = start.elapsed();

--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -646,6 +646,81 @@ pub enum Workflow {
     Unknown,
 }
 
+impl Workflow {
+    /// Whether a non-failing run of this workflow surfaces findings and therefore
+    /// MUST populate `findings_present` on its telemetry event.
+    ///
+    /// `findings_present` decouples "found something" from the exit-code outcome,
+    /// so every exit path of a finding-surfacing workflow has to call
+    /// [`note_result_count`] or [`note_findings_present`] before the at-exit event
+    /// is recorded; otherwise the field serializes null (issue #1650). Admin,
+    /// setup, mutation, report, and reserved / non-CLI workflows return `false`.
+    ///
+    /// The match is exhaustive on purpose: a new `Workflow` variant fails to
+    /// compile until it is classified here, which keeps the
+    /// [`find_state_invariant_violated`] guard honest.
+    fn surfaces_findings(self) -> bool {
+        match self {
+            Workflow::Audit
+            | Workflow::DeadCode
+            | Workflow::Health
+            | Workflow::Dupes
+            | Workflow::CodeQualityReview
+            | Workflow::Security => true,
+            Workflow::DependencyCleanup
+            | Workflow::GithubAction
+            | Workflow::GitlabCi
+            | Workflow::EditorDiagnostic
+            | Workflow::ProgrammaticAnalysis
+            | Workflow::RuntimeCoverageSetup
+            | Workflow::Impact
+            | Workflow::Fix
+            | Workflow::Explain
+            | Workflow::ProjectInventory
+            | Workflow::Setup
+            | Workflow::License
+            | Workflow::Unknown => false,
+        }
+    }
+}
+
+/// Debug-only guard predicate: `true` when a finding-surfacing workflow recorded
+/// a non-failing event without noting its find-state (findings_present stayed
+/// `None`).
+///
+/// Pure so it can be unit-tested without the process-global accumulator. A
+/// `failed` outcome may legitimately leave findings_present unset because
+/// analysis never completed.
+fn find_state_invariant_violated(
+    workflow: Workflow,
+    outcome: &str,
+    findings_present: Option<bool>,
+) -> bool {
+    workflow.surfaces_findings() && outcome != "failed" && findings_present.is_none()
+}
+
+/// Debug-time guard at the single event-emission choke point in
+/// [`record_workflow`]: a finding-surfacing workflow that emits a non-failing
+/// event must have noted its find-state, or a dispatch arm forgot to call
+/// `note_result_count` / `note_findings_present` (the originating bug was issue
+/// #1650). Runs on every recorded workflow regardless of telemetry mode so the
+/// check is deterministic across machines. `findings_present` reflects what the
+/// analysis surfaced independent of the output view, so focused trace / closure
+/// views record their underlying analysis count rather than skipping the note.
+fn debug_assert_find_state_noted(
+    workflow: Workflow,
+    outcome: &str,
+    findings_present: Option<bool>,
+) {
+    debug_assert!(
+        !find_state_invariant_violated(workflow, outcome, findings_present),
+        "telemetry find-state invariant violated: workflow {workflow:?} surfaced findings but \
+         findings_present is unset on a non-failing run. Every exit path of a finding-surfacing \
+         workflow must call telemetry::note_result_count or note_findings_present before the \
+         event is recorded (issue #1650)."
+    );
+}
+
 #[expect(
     dead_code,
     reason = "telemetry schema reserves v1 values for LSP/editor/programmatic surfaces before every surface is wired"
@@ -949,6 +1024,7 @@ pub fn run(command: TelemetryCommand, output: OutputFormat) -> ExitCode {
 pub fn record_workflow(record: &WorkflowRecord<'_>) {
     let parent_run = parent_run_context(record.parent_run, record.workflow);
     let event = build_workflow_event(record, &parent_run);
+    debug_assert_find_state_noted(record.workflow, event.outcome, event.findings_present);
     match effective_config().mode {
         EffectiveMode::Off | EffectiveMode::DisabledByAdmin => {}
         EffectiveMode::Inspect => print_event_to_stderr(&event),
@@ -2785,6 +2861,94 @@ mod tests {
         assert_eq!(findings_present_from_state(FINDINGS_FOUND), Some(true));
         // Any unexpected value is treated as unset, never a misleading false.
         assert_eq!(findings_present_from_state(99), None);
+    }
+
+    #[test]
+    fn surfaces_findings_classification_pins_the_analysis_workflows() {
+        // Workflows whose successful runs surface findings and therefore MUST
+        // populate findings_present (each has a note_result_count/note_findings_present
+        // call on every exit path). The exhaustive match in `surfaces_findings`
+        // forces a new variant to be classified; this test pins the intent.
+        for workflow in [
+            Workflow::Audit,
+            Workflow::DeadCode,
+            Workflow::Health,
+            Workflow::Dupes,
+            Workflow::CodeQualityReview,
+            Workflow::Security,
+        ] {
+            assert!(
+                workflow.surfaces_findings(),
+                "{workflow:?} must require findings_present"
+            );
+        }
+        // The constructed non-surfacing workflows. The reserved, never-constructed
+        // variants (DependencyCleanup, EditorDiagnostic, ProgrammaticAnalysis) are
+        // intentionally omitted so they stay dead for the enum's expect(dead_code);
+        // the exhaustive match in `surfaces_findings` still forces them to be
+        // classified.
+        for workflow in [
+            Workflow::GithubAction,
+            Workflow::GitlabCi,
+            Workflow::RuntimeCoverageSetup,
+            Workflow::Impact,
+            Workflow::Fix,
+            Workflow::Explain,
+            Workflow::ProjectInventory,
+            Workflow::Setup,
+            Workflow::License,
+            Workflow::Unknown,
+        ] {
+            assert!(
+                !workflow.surfaces_findings(),
+                "{workflow:?} must not require findings_present"
+            );
+        }
+    }
+
+    #[test]
+    fn find_state_invariant_catches_unnoted_surfacing_runs() {
+        // Violation: a finding-surfacing workflow recorded a non-failing event
+        // without noting find-state (the issue #1650 / flags / watch bug shape).
+        assert!(find_state_invariant_violated(
+            Workflow::Security,
+            "success",
+            None
+        ));
+        assert!(find_state_invariant_violated(
+            Workflow::CodeQualityReview,
+            "issues_found",
+            None
+        ));
+        // Noted (clean or found): fine.
+        assert!(!find_state_invariant_violated(
+            Workflow::Security,
+            "success",
+            Some(false)
+        ));
+        assert!(!find_state_invariant_violated(
+            Workflow::Dupes,
+            "issues_found",
+            Some(true)
+        ));
+        // A failed run may legitimately leave findings_present unset (analysis
+        // never completed).
+        assert!(!find_state_invariant_violated(
+            Workflow::Security,
+            "failed",
+            None
+        ));
+        // Non-surfacing workflows never require findings_present.
+        assert!(!find_state_invariant_violated(
+            Workflow::License,
+            "success",
+            None
+        ));
+        assert!(!find_state_invariant_violated(
+            Workflow::Fix,
+            "success",
+            None
+        ));
     }
 
     #[test]

--- a/crates/cli/src/watch.rs
+++ b/crates/cli/src/watch.rs
@@ -302,6 +302,10 @@ fn analyze_and_report(config: &fallow_config::ResolvedConfig, opts: &WatchOption
             return ExitCode::from(2);
         }
     };
+    // Note find-state for telemetry (issue #1650 follow-up): watch emits a
+    // `code_quality_review` workflow event at process exit, so each analysis
+    // cycle records its find-state (the accumulator is sticky across cycles).
+    crate::telemetry::note_result_count(results.total_issues());
     let elapsed = start.elapsed();
     let ctx = report::ReportContext {
         root: &config.root,

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -445,6 +445,23 @@ fn write_survivor_inputs(dir: &Path, verdict: &str) -> (String, String) {
     )
 }
 
+/// Write a project containing two environment-variable feature flags so
+/// `fallow flags` surfaces findings (issue #1650 follow-up find-state coverage).
+fn write_flags_project(dir: &Path) {
+    let src = dir.join("src");
+    fs::create_dir_all(&src).expect("create src");
+    fs::write(
+        dir.join("package.json"),
+        "{\n  \"name\": \"flags-fixture\"\n}\n",
+    )
+    .expect("write package.json");
+    fs::write(
+        src.join("index.ts"),
+        "export function f(): number {\n  if (process.env.FEATURE_NEW_CHECKOUT === \"true\") {\n    return 1;\n  }\n  if (process.env.FEATURE_BETA_BANNER) {\n    return 2;\n  }\n  return 0;\n}\n",
+    )
+    .expect("write flags source");
+}
+
 #[test]
 fn dupes_with_duplication_sets_findings_present_despite_success_outcome() {
     let dir = tempfile::tempdir().expect("temp project");
@@ -1019,6 +1036,48 @@ fn security_survivors_needs_human_review_sets_findings_present_true() {
         Some(true),
         "a needs-human-review candidate must report findings_present=true"
     );
+}
+
+#[test]
+fn flags_with_findings_sets_findings_present_true() {
+    // Regression for the issue #1650 follow-up: `fallow flags` emits a
+    // `code_quality_review` workflow event (the same label as combined `fallow`,
+    // which populates findings_present) but historically never noted find-state,
+    // so its findings_present serialized as null. The fixture surfaces two
+    // feature flags, so a correct run reports findings_present=true.
+    let dir = tempfile::tempdir().expect("temp project");
+    write_flags_project(dir.path());
+
+    let (event, output) =
+        inspect_event_output(dir.path(), &["flags", "--format", "json", "--quiet"], &[]);
+
+    assert_eq!(output.code, 0, "flags should exit 0: {}", output.stderr);
+    assert_eq!(event["workflow"].as_str(), Some("code_quality_review"));
+    assert_eq!(event["outcome"].as_str(), Some("success"));
+    assert_eq!(
+        event["findings_present"].as_bool(),
+        Some(true),
+        "flags surfacing feature flags must report findings_present=true"
+    );
+}
+
+#[test]
+fn flags_on_clean_project_sets_findings_present_false() {
+    // The false branch: a project with no feature flags must still populate
+    // findings_present (false), never leave it null.
+    let dir = tempfile::tempdir().expect("temp project");
+    write_clean_project(dir.path());
+
+    let (event, output) =
+        inspect_event_output(dir.path(), &["flags", "--format", "json", "--quiet"], &[]);
+
+    assert_eq!(output.code, 0, "flags should exit 0: {}", output.stderr);
+    assert_eq!(event["workflow"].as_str(), Some("code_quality_review"));
+    assert!(
+        !event["findings_present"].is_null(),
+        "flags must populate findings_present, not leave it null"
+    );
+    assert_eq!(event["findings_present"].as_bool(), Some(false));
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #1650. An audit of every telemetry workflow found the same
find-state gap in two more commands and added a structural guard.

- `fallow flags` and `fallow watch` emit a `code_quality_review` telemetry event
  (the same workflow as combined `fallow`, which populates `findings_present`)
  but never noted their find-state, so `findings_present` serialized as null.
  `flags` now notes its feature-flag count and `watch` notes each cycle's issue
  count.
- Focused `dead-code` / `dupes` trace and `--impact-closure` views early-return
  before the normal find-state note; they still run the full analysis, so they
  now record its result count. `findings_present` reflects what the analysis
  surfaced independent of the output view.
- Structural guard so the class cannot silently recur: an exhaustive
  `Workflow::surfaces_findings()` classification (a new workflow variant fails to
  compile until classified) plus a debug-build invariant at the single telemetry
  event-emission point that fails fast if a finding-surfacing workflow records a
  non-failing event without noting find-state. The guard caught the dead-code and
  dupes trace-mode gaps during this change.

No change to the telemetry payload shape.

Refs #1650.