### PR TITLE
feat(review): runtime-weighted focus map + safe explicit-skip

### DIFF
--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -254,12 +254,119 @@ fn build_focus_map(result: &AuditResult, deltas: &ReviewDeltas) -> crate::audit_
     // threaded onto the brief.
     let taint_touched_files = taint_touched_files(result.check.as_ref());
 
+    // Runtime evidence (paid): `Some` only on the `--runtime-coverage` path.
+    // It weights hot files and enables safe-skip; `None` in free mode, where the
+    // focus map degrades to the deterministic no-runtime baseline byte-for-byte.
+    let runtime_focus = build_runtime_focus(result, root);
+
     build_focus_map(&FocusInputs {
         graph_facts,
         boundary_files: &boundary_files,
         public_api_added: &deltas.public_api_added,
         coordination_changed_files: &coordination_changed_files,
         taint_touched_files: &taint_touched_files,
+        runtime: runtime_focus.as_ref(),
+    })
+}
+
+/// Build the per-file [`crate::audit_focus::RuntimeFocus`] from the
+/// runtime-coverage health report, or `None` when the run carried no
+/// `--runtime-coverage` data (free mode, where the focus map stays byte-identical
+/// to the no-runtime baseline).
+///
+/// Hot files come from the report's `hot_paths` (peak invocation per file). Cold
+/// files are the runtime-proven-unused ones: a file with at least one
+/// `safe_to_delete` finding, NO finding of any other verdict, and no hot path.
+///
+/// Honest boundary: the report's `findings` omit `active` functions, so a file
+/// can carry a live, executed function this signal never sees. `hot_paths` only
+/// surfaces functions at/above the configured hot threshold (`min_invocations_hot`,
+/// default 100, raisable via `--min-invocations-hot`), so an `active` function in
+/// the `[low_traffic .. hot)` band shows up in NEITHER list:
+/// such a file, if its only retained finding is `safe_to_delete`, is classified
+/// cold here despite having run. This is why the cold signal is never trusted on
+/// its own: the safe-skip label additionally requires zero static risk and no
+/// confidence flag, applies only to a file already in the diff, and is always
+/// advisory (the skip stays in the escape-hatch list, never hidden). Paths are
+/// normalized to the brief's root-relative forward-slashed space so the
+/// focus-map joins are byte-exact.
+fn build_runtime_focus(
+    result: &AuditResult,
+    root: &std::path::Path,
+) -> Option<crate::audit_focus::RuntimeFocus> {
+    let report = result.health.as_ref()?.report.runtime_coverage.as_ref()?;
+
+    let hot_pairs: Vec<(String, u64)> = report
+        .hot_paths
+        .iter()
+        .map(|hot| {
+            (
+                crate::audit::keys::relative_key_path(&hot.path, root),
+                hot.invocations,
+            )
+        })
+        .collect();
+
+    // Partition findings into safe_to_delete (cold candidate) vs any other verdict
+    // (the disqualifier that keeps a mixed-verdict file out of the cold set).
+    let mut safe_to_delete: FxHashSet<String> = FxHashSet::default();
+    let mut other_verdict: FxHashSet<String> = FxHashSet::default();
+    for finding in &report.findings {
+        let file = crate::audit::keys::relative_key_path(&finding.path, root);
+        if matches!(
+            finding.verdict,
+            fallow_output::RuntimeCoverageVerdict::SafeToDelete
+        ) {
+            safe_to_delete.insert(file);
+        } else {
+            other_verdict.insert(file);
+        }
+    }
+
+    reconcile_runtime_focus(hot_pairs, &safe_to_delete, &other_verdict)
+}
+
+/// Reconcile the projected runtime signals into a [`crate::audit_focus::RuntimeFocus`]:
+/// peak-aggregate hot invocations per file, and keep a file cold only when it has
+/// a `safe_to_delete` finding, no other-verdict finding, and no hot path (so the
+/// hot and cold lists are disjoint by construction). Returns `None` when both
+/// lists are empty. Pure (no I/O), so the mixed-verdict exclusion, the
+/// hot-excludes-cold filter, and the peak aggregation are unit-tested without
+/// constructing a full health report.
+fn reconcile_runtime_focus(
+    hot_pairs: Vec<(String, u64)>,
+    safe_to_delete: &FxHashSet<String>,
+    other_verdict: &FxHashSet<String>,
+) -> Option<crate::audit_focus::RuntimeFocus> {
+    use crate::audit_focus::{RuntimeFocus, RuntimeHotFile};
+
+    // Peak invocation per hot file (max across the file's hot functions).
+    let mut hot_by_file: rustc_hash::FxHashMap<String, u64> = rustc_hash::FxHashMap::default();
+    for (file, invocations) in hot_pairs {
+        let entry = hot_by_file.entry(file).or_insert(0);
+        *entry = (*entry).max(invocations);
+    }
+
+    let mut hot_files: Vec<RuntimeHotFile> = hot_by_file
+        .into_iter()
+        .map(|(file, invocations)| RuntimeHotFile { file, invocations })
+        .collect();
+    hot_files.sort_by(|a, b| a.file.cmp(&b.file));
+    let hot_set: FxHashSet<&str> = hot_files.iter().map(|hot| hot.file.as_str()).collect();
+
+    let mut cold_files: Vec<String> = safe_to_delete
+        .iter()
+        .filter(|file| !other_verdict.contains(*file) && !hot_set.contains(file.as_str()))
+        .cloned()
+        .collect();
+    cold_files.sort();
+
+    if hot_files.is_empty() && cold_files.is_empty() {
+        return None;
+    }
+    Some(RuntimeFocus {
+        hot_files,
+        cold_files,
     })
 }
 
@@ -790,8 +897,47 @@ mod tests {
 
     use fallow_config::{AuditGate, OutputFormat};
     use fallow_output::REVIEW_BRIEF_SCHEMA_VERSION;
+    use rustc_hash::FxHashSet;
 
     use crate::audit::{AuditAttribution, AuditResult, AuditSummary, AuditVerdict};
+
+    fn str_set(files: &[&str]) -> FxHashSet<String> {
+        files.iter().map(|file| (*file).to_string()).collect()
+    }
+
+    // Producer: the runtime hot/cold reconciliation. A file with a peak hot
+    // path is hot (peak = max over its functions); a file with only a
+    // safe_to_delete finding is cold; a mixed-verdict file is excluded; a file
+    // that is both safe_to_delete AND hot stays hot (disjoint lists).
+    #[test]
+    fn reconcile_runtime_focus_classifies_hot_cold_and_excludes_mixed() {
+        let hot_pairs = vec![
+            ("src/hot.ts".to_string(), 120),
+            ("src/hot.ts".to_string(), 900),  // peak wins
+            ("src/both.ts".to_string(), 300), // also safe_to_delete below -> stays hot
+        ];
+        let safe = str_set(&["src/cold.ts", "src/mixed.ts", "src/both.ts"]);
+        let other = str_set(&["src/mixed.ts"]); // mixed.ts also has a review_required -> not cold
+        let focus =
+            super::reconcile_runtime_focus(hot_pairs, &safe, &other).expect("non-empty focus");
+
+        // Hot files: peak-aggregated, sorted.
+        let hot: Vec<(&str, u64)> = focus
+            .hot_files
+            .iter()
+            .map(|hot| (hot.file.as_str(), hot.invocations))
+            .collect();
+        assert_eq!(hot, vec![("src/both.ts", 300), ("src/hot.ts", 900)]);
+
+        // Cold = safe_to_delete minus other-verdict minus hot. Only `cold.ts`.
+        assert_eq!(focus.cold_files, vec!["src/cold.ts".to_string()]);
+    }
+
+    // Producer: no signal at all -> None (free-mode fall-through).
+    #[test]
+    fn reconcile_runtime_focus_is_none_when_empty() {
+        assert!(super::reconcile_runtime_focus(Vec::new(), &str_set(&[]), &str_set(&[])).is_none());
+    }
 
     use super::*;
 

--- a/crates/cli/src/audit_focus.rs
+++ b/crates/cli/src/audit_focus.rs
@@ -25,13 +25,16 @@
 //! 4. **change shape**: new export / widened visibility / signature change (the
 //!    coordination-gap proxy, ADR-001 syntactic).
 //!
-//! ## The runtime seam (documented, NOT built)
+//! ## The runtime layer (paid, built)
 //!
-//! `FocusScore` keeps the four component sub-scores on the wire so the paid
-//! runtime layer can multiply a runtime hot/cold weight into `total` WITHOUT recomputing the
-//! deterministic signals. The single `// runtime seam` marker sits at the point the
-//! components are summed. No runtime field, no runtime read, no runtime gate here:
-//! free mode is the complete surface.
+//! When `FocusInputs::runtime` is `Some` (the paid `--runtime-coverage` path),
+//! a hot file adds an invocation-bucketed `runtime` component to its score so it
+//! amplifies the blast and outranks an otherwise-equal cold unit, and a unit the
+//! runtime proves cold AND that carries no deterministic signal earns the SAFE
+//! explicit-skip label (`FocusLabel::Skip`). When `runtime` is `None` (free
+//! mode) the layer contributes nothing: the `runtime` component is `0`, no unit
+//! can reach the `Skip` arm, and the output is byte-identical to the no-runtime baseline. The free
+//! tier ranks but never skips; safe-skip is runtime-backed only.
 
 use fallow_engine::graph::FocusFileFactsPaths;
 pub use fallow_output::{ConfidenceFlag, FocusLabel, FocusMap, FocusScore, FocusUnit};
@@ -58,12 +61,63 @@ const CHANGE_SHAPE_WEIGHT: u32 = 2;
 /// Points added when a unit sits on a security source -> sink taint trace.
 const SECURITY_TAINT_WEIGHT: u32 = 3;
 
+/// Runtime-weight floor: any hot path adds at least this, so a hot unit
+/// always outranks an otherwise-equal cold one. At/above [`REVIEW_HERE_THRESHOLD`]
+/// so a hot path alone pulls a unit into `review-here`.
+const RUNTIME_HOT_FLOOR: u32 = 3;
+/// Runtime weight for a warm path (>= [`RUNTIME_WARM_INVOCATIONS`]).
+const RUNTIME_HOT_WARM: u32 = 4;
+/// Runtime weight for a blazing path (>= [`RUNTIME_BLAZING_INVOCATIONS`]). Capped
+/// (bucketed, not the raw count) so one extreme-traffic file cannot swamp the
+/// bounded deterministic signals and the score stays deterministic.
+const RUNTIME_HOT_BLAZING: u32 = 6;
+/// Invocation count at/above which a hot path is "warm".
+const RUNTIME_WARM_INVOCATIONS: u64 = 100;
+/// Invocation count at/above which a hot path is "blazing".
+const RUNTIME_BLAZING_INVOCATIONS: u64 = 1_000;
+
+/// The bucketed runtime weight for a hot file's peak invocation count. Bucketed
+/// (three bands) rather than raw so the weight stays bounded and deterministic.
+fn runtime_weight(invocations: u64) -> u32 {
+    if invocations >= RUNTIME_BLAZING_INVOCATIONS {
+        RUNTIME_HOT_BLAZING
+    } else if invocations >= RUNTIME_WARM_INVOCATIONS {
+        RUNTIME_HOT_WARM
+    } else {
+        RUNTIME_HOT_FLOOR
+    }
+}
+
 /// A boundary-zone signal for a unit: the unit's file introduced a new cross-zone
 /// edge (it is the `from_file` of an introduced boundary edge).
 #[derive(Debug, Clone)]
 pub struct BoundaryZoneFile {
     /// Root-relative path of the importing file that introduced the edge.
     pub from_file: String,
+}
+
+/// A runtime-hot file: a changed file with a runtime hot path, paired with the
+/// file's peak invocation count (the max over the file's hot functions).
+#[derive(Debug, Clone)]
+pub struct RuntimeHotFile {
+    /// Root-relative path of the hot file (the brief's canonical path space).
+    pub file: String,
+    /// Peak invocation count across the file's hot functions; drives the band.
+    pub invocations: u64,
+}
+
+/// Per-file runtime evidence for the paid weighting layer, built from the
+/// runtime-coverage health report at the brief path. `None` in free mode; when
+/// present it adds the runtime score component and enables the safe explicit-skip
+/// label. The two lists are disjoint by construction (a hot file is never cold).
+#[derive(Debug, Clone, Default)]
+pub struct RuntimeFocus {
+    /// Files with a runtime hot path; each adds a bucketed runtime weight.
+    pub hot_files: Vec<RuntimeHotFile>,
+    /// Files the runtime proves cold (every retained finding is `safe_to_delete`
+    /// and the file has no hot path). Eligible for safe-skip when also carrying no
+    /// deterministic signal.
+    pub cold_files: Vec<String>,
 }
 
 /// Everything the focus extractor needs, gathered from the assembled brief data.
@@ -89,6 +143,10 @@ pub struct FocusInputs<'a> {
     /// engine is the opt-in `fallow security` command); the seam lights up the
     /// moment a security pass is threaded, with no focus-map code change.
     pub taint_touched_files: &'a [String],
+    /// Per-file runtime evidence (paid). `None` in free mode, where the focus
+    /// map degrades to the deterministic no-runtime baseline byte-for-byte; `Some` on the
+    /// `--runtime-coverage` path, where it weights hot files and enables safe-skip.
+    pub runtime: Option<&'a RuntimeFocus>,
 }
 
 /// Whether a unit `file` is the `<rel_path>` prefix of any public-API delta key
@@ -131,20 +189,45 @@ fn score_unit(facts: &FocusFileFactsPaths, inputs: &FocusInputs<'_>) -> FocusSco
     let shapes = u32::from(new_export) + u32::from(sig_change);
     let change_shape = shapes * CHANGE_SHAPE_WEIGHT;
 
-    // runtime seam: the paid runtime layer multiplies a runtime hot/cold weight into `total` here,
-    // reading the per-unit runtime coverage and scaling the deterministic sum so a
-    // hot path amplifies the blast. The four component sub-scores stay on the wire
-    // so it re-weights WITHOUT recomputing the signals. Free mode is the
-    // complete surface; the paid layer degrades cleanly to it when no runtime data.
-    let total = fan_io + security_taint + risk_zone + change_shape;
+    // Runtime layer (paid): a hot file adds an invocation-bucketed weight so a
+    // hot path amplifies the blast and outranks an otherwise-equal cold unit. The
+    // deterministic components stay on the wire, so this ADDS without recomputing
+    // them. `0` when no runtime input (free mode), keeping `total` the four
+    // deterministic components and the output byte-identical to the no-runtime baseline.
+    let runtime = inputs.runtime.map_or(0, |rt| {
+        rt.hot_files
+            .iter()
+            .find(|hot| hot.file == facts.file)
+            .map_or(0, |hot| runtime_weight(hot.invocations))
+    });
+
+    let total = fan_io + security_taint + risk_zone + change_shape + runtime;
 
     FocusScore {
         fan_io,
         security_taint,
         risk_zone,
         change_shape,
+        runtime,
         total,
     }
+}
+
+/// Whether a unit is the SAFE explicit-skip case: runtime-backed ONLY. All
+/// of: the runtime proves the file cold (in [`RuntimeFocus::cold_files`]); it
+/// carries no deterministic signal (`total` is the runtime component alone, i.e.
+/// `0`, so no fan-in/out, risk-zone, change-shape, or taint); and it carries NO
+/// confidence flag (a dynamically-wired / re-export-heavy unit has uncertain
+/// reachability, so a single runtime capture is not enough to call it safe to
+/// skip). Any of those keeps the unit visible. Returns `false` whenever `runtime`
+/// is `None`, so free mode can never label a unit `skip`.
+fn is_safe_skip(facts: &FocusFileFactsPaths, score: &FocusScore, inputs: &FocusInputs<'_>) -> bool {
+    inputs.runtime.is_some_and(|rt| {
+        score.total == 0
+            && !facts.dynamic_dispatch
+            && !facts.re_export_indirection
+            && rt.cold_files.iter().any(|file| file == &facts.file)
+    })
 }
 
 /// Build the human reason for a unit from the present signals.
@@ -154,6 +237,24 @@ fn build_reason(
     inputs: &FocusInputs<'_>,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
+    // Runtime evidence first (it amplifies / disarms the static signals). On the
+    // free path `inputs.runtime` is `None`, so no runtime clause is ever added and
+    // the reason string stays byte-identical to the no-runtime baseline.
+    if let Some(rt) = inputs.runtime {
+        if let Some(hot) = rt.hot_files.iter().find(|hot| hot.file == facts.file) {
+            parts.push(format!(
+                "hot path ({} invocation{})",
+                hot.invocations,
+                if hot.invocations == 1 { "" } else { "s" }
+            ));
+        } else if rt.cold_files.iter().any(|file| file == &facts.file) {
+            // "no hot path" is the honest, file-level-true claim: the cold signal
+            // means no hot path here and the file's tracked findings are all
+            // safe-to-delete. It deliberately does NOT say "0 invocations" -- a
+            // sub-hot-threshold active function is invisible to this signal.
+            parts.push("runtime-cold (no hot path)".to_string());
+        }
+    }
     if facts.fan_in > 0 {
         parts.push(format!(
             "high fan-in ({} importer{})",
@@ -220,7 +321,12 @@ pub fn build_focus_map(inputs: &FocusInputs<'_>) -> FocusMap {
         .iter()
         .map(|facts| {
             let score = score_unit(facts, inputs);
-            let label = if score.total >= REVIEW_HERE_THRESHOLD {
+            // Safe explicit-skip wins first, but is runtime-backed only:
+            // `is_safe_skip` is always false without runtime input, so free mode
+            // falls through to the no-runtime review-here / not-prioritized split.
+            let label = if is_safe_skip(facts, &score, inputs) {
+                FocusLabel::Skip
+            } else if score.total >= REVIEW_HERE_THRESHOLD {
                 FocusLabel::ReviewHere
             } else {
                 FocusLabel::NotPrioritized
@@ -249,7 +355,9 @@ pub fn build_focus_map(inputs: &FocusInputs<'_>) -> FocusMap {
     for unit in units {
         match unit.label {
             FocusLabel::ReviewHere => review_here.push(unit),
-            FocusLabel::NotPrioritized => deprioritized.push(unit),
+            // Both not-prioritized and the runtime-backed safe-skip land in the
+            // escape hatch: nothing is hidden, a skip is just labelled safe.
+            FocusLabel::NotPrioritized | FocusLabel::Skip => deprioritized.push(unit),
         }
     }
     // The deprioritized escape hatch is path-sorted (stable enumeration order).
@@ -294,6 +402,38 @@ mod tests {
             public_api_added,
             coordination_changed_files,
             taint_touched_files,
+            runtime: None,
+        }
+    }
+
+    /// Build a `RuntimeFocus` from `(file, invocations)` hot pairs and cold files.
+    fn runtime(hot: &[(&str, u64)], cold: &[&str]) -> RuntimeFocus {
+        RuntimeFocus {
+            hot_files: hot
+                .iter()
+                .map(|(file, invocations)| RuntimeHotFile {
+                    file: (*file).to_string(),
+                    invocations: *invocations,
+                })
+                .collect(),
+            cold_files: cold.iter().map(|file| (*file).to_string()).collect(),
+        }
+    }
+
+    /// `inputs` with a runtime layer attached (the paid `--runtime-coverage` path).
+    fn inputs_rt<'a>(
+        graph_facts: &'a [FocusFileFactsPaths],
+        public_api_added: &'a [String],
+        taint_touched_files: &'a [String],
+        runtime: &'a RuntimeFocus,
+    ) -> FocusInputs<'a> {
+        FocusInputs {
+            graph_facts,
+            boundary_files: &[],
+            public_api_added,
+            coordination_changed_files: &[],
+            taint_touched_files,
+            runtime: Some(runtime),
         }
     }
 
@@ -546,8 +686,11 @@ mod tests {
             public_api_added: _,
             coordination_changed_files: _,
             taint_touched_files: _,
-            // NOTE: no `symbol_chain` / `trace` field exists. If the trace ever wired
-            // one in, this destructure would fail to compile.
+            // `runtime` is the legitimate paid weighting seam, not a ranking
+            // input the free tier reads. NOTE: no `symbol_chain` / `trace` field
+            // exists. If the trace ever wired one in, this destructure would fail
+            // to compile -- the guard that the trace stays OUT of the focus inputs.
+            runtime: _,
         } = inputs(
             empty_facts,
             empty_boundary,
@@ -569,8 +712,158 @@ mod tests {
         let score = &unit.score;
         assert_eq!(
             score.total,
-            score.fan_io + score.security_taint + score.risk_zone + score.change_shape,
-            "the focus total must be the four documented components only -- no symbol-chain term"
+            score.fan_io
+                + score.security_taint
+                + score.risk_zone
+                + score.change_shape
+                + score.runtime,
+            "the focus total must be the documented components only -- no symbol-chain term"
+        );
+        // Free-mode (no runtime input): the runtime component is 0, so the total
+        // is the four deterministic components, byte-identical to the no-runtime baseline.
+        assert_eq!(score.runtime, 0, "free mode adds no runtime weight");
+    }
+
+    // With runtime data, a HOT unit outranks a COLD unit
+    // that is otherwise identical. The hot path's bucketed runtime weight lifts it.
+    #[test]
+    fn hot_unit_outranks_cold_with_runtime_data() {
+        let gf = vec![
+            facts("src/hot.ts", 2, 0, false, false),
+            facts("src/cold.ts", 2, 0, false, false),
+        ];
+        let rt = runtime(&[("src/hot.ts", 500)], &["src/cold.ts"]);
+        let map = build_focus_map(&inputs_rt(&gf, &[], &[], &rt));
+        let find = |file: &str| {
+            map.review_here
+                .iter()
+                .chain(map.deprioritized.iter())
+                .find(|unit| unit.file == file)
+                .unwrap_or_else(|| panic!("{file} present"))
+        };
+        let hot = find("src/hot.ts");
+        let cold = find("src/cold.ts");
+        assert!(hot.score.runtime > 0, "hot unit carries a runtime weight");
+        assert_eq!(cold.score.runtime, 0, "cold unit carries no runtime weight");
+        assert!(
+            hot.score.total > cold.score.total,
+            "hot ({}) must outrank cold ({})",
+            hot.score.total,
+            cold.score.total
+        );
+        assert!(hot.reason.contains("hot path (500 invocations)"));
+    }
+
+    // A blazing path outweighs a merely-warm one (bands).
+    #[test]
+    fn runtime_weight_is_invocation_bucketed() {
+        assert_eq!(runtime_weight(0), RUNTIME_HOT_FLOOR);
+        assert_eq!(runtime_weight(50), RUNTIME_HOT_FLOOR);
+        assert_eq!(runtime_weight(100), RUNTIME_HOT_WARM);
+        assert_eq!(runtime_weight(1_000), RUNTIME_HOT_BLAZING);
+    }
+
+    // The `skip` label is emitted ONLY with runtime
+    // evidence, and ONLY for a runtime-cold unit that carries no deterministic
+    // signal. A cold unit WITH a risk signal stays visible (never skipped).
+    #[test]
+    fn safe_skip_only_with_runtime_evidence_and_zero_risk() {
+        // Fully isolated + runtime-cold -> skip.
+        let isolated = vec![facts("src/dead.ts", 0, 0, false, false)];
+        let rt = runtime(&[], &["src/dead.ts"]);
+        let map = build_focus_map(&inputs_rt(&isolated, &[], &[], &rt));
+        let unit = map
+            .review_here
+            .iter()
+            .chain(map.deprioritized.iter())
+            .next()
+            .expect("unit present");
+        assert_eq!(unit.label, FocusLabel::Skip);
+        assert_eq!(unit.label.token(), "skip");
+        assert!(unit.reason.contains("runtime-cold"));
+        // The skip unit is in the escape hatch (nothing hidden).
+        assert!(map.deprioritized.iter().any(|u| u.file == "src/dead.ts"));
+
+        // Same file but with a risk signal (public-API delta) -> NOT skipped, even
+        // though runtime says cold. A deterministic signal keeps it visible.
+        let public_api = vec!["src/dead.ts::Widget".to_string()];
+        let with_risk = build_focus_map(&inputs_rt(&isolated, &public_api, &[], &rt));
+        let risky = with_risk
+            .review_here
+            .iter()
+            .chain(with_risk.deprioritized.iter())
+            .next()
+            .expect("unit present");
+        assert_ne!(
+            risky.label,
+            FocusLabel::Skip,
+            "a risk signal blocks safe-skip"
+        );
+    }
+
+    // Safety: a confidence-flagged unit (dynamic dispatch / re-export
+    // indirection) is NOT auto-skipped even when the runtime proves it cold and it
+    // carries no other signal -- its reachability is uncertain, so one runtime
+    // capture is not proof it is safe to skip.
+    #[test]
+    fn confidence_flag_blocks_safe_skip_even_when_runtime_cold() {
+        let dyn_cold = vec![facts("src/dyn.ts", 0, 0, true, false)];
+        let rt = runtime(&[], &["src/dyn.ts"]);
+        let map = build_focus_map(&inputs_rt(&dyn_cold, &[], &[], &rt));
+        let unit = map
+            .review_here
+            .iter()
+            .chain(map.deprioritized.iter())
+            .next()
+            .expect("unit present");
+        assert_ne!(
+            unit.label,
+            FocusLabel::Skip,
+            "dynamic-dispatch reachability uncertainty blocks safe-skip"
+        );
+        assert!(unit.confidence.contains(&ConfidenceFlag::DynamicDispatch));
+    }
+
+    // With NO runtime input, the map is byte-identical to
+    // the no-runtime baseline -- no skip label, no runtime component, same JSON.
+    #[test]
+    fn no_runtime_data_is_byte_identical_to_e7() {
+        let gf = vec![
+            facts("src/a.ts", 12, 3, false, false),
+            facts("src/b.ts", 0, 0, false, false),
+            facts("src/c.ts", 2, 0, false, true),
+        ];
+        let public_api = vec!["src/c.ts::Thing".to_string()];
+        let e7 = build_focus_map(&inputs(&gf, &[], &public_api, &[], &[]));
+        let json = serde_json::to_string_pretty(&e7).expect("serialize");
+        assert!(!json.contains("\"skip\""), "free mode emits no skip label");
+        assert!(
+            !json.contains("\"runtime\""),
+            "free mode omits the runtime component from the wire"
+        );
+        for unit in e7.review_here.iter().chain(e7.deprioritized.iter()) {
+            assert_eq!(unit.score.runtime, 0);
+            assert_ne!(unit.label, FocusLabel::Skip);
+        }
+    }
+
+    // Runtime weighting + safe-skip is deterministic (byte-identical re-runs).
+    #[test]
+    fn runtime_focus_map_is_byte_identical_across_runs() {
+        let gf = vec![
+            facts("src/hot.ts", 4, 2, false, false),
+            facts("src/cold.ts", 0, 0, false, false),
+            facts("src/warm.ts", 1, 0, false, false),
+        ];
+        let rt = runtime(
+            &[("src/hot.ts", 2_000), ("src/warm.ts", 120)],
+            &["src/cold.ts"],
+        );
+        let first = build_focus_map(&inputs_rt(&gf, &[], &[], &rt));
+        let second = build_focus_map(&inputs_rt(&gf, &[], &[], &rt));
+        assert_eq!(
+            serde_json::to_string_pretty(&first).unwrap(),
+            serde_json::to_string_pretty(&second).unwrap()
         );
     }
 }

--- a/crates/output/src/audit_focus.rs
+++ b/crates/output/src/audit_focus.rs
@@ -2,10 +2,12 @@
 
 use serde::Serialize;
 
-/// The focus label for a review unit. EXACTLY two variants: `Skip` is NOT
-/// representable, so the type system is the guarantee that free mode never emits
-/// a `skip` label (safe explicit-skip is paid, runtime-backed only). Mirrors
-/// the decision surface's "cut category not representable" structural posture.
+/// The focus label for a review unit. `Skip` is the SAFE explicit-skip label and
+/// is runtime-backed ONLY: it is producible solely on the paid runtime path
+/// and solely for a unit runtime-proves cold with zero risk signals. Free mode
+/// (no runtime evidence) emits only `ReviewHere` / `NotPrioritized`, never `Skip`
+/// (the build-focus-map labeller cannot reach the `Skip` arm without runtime
+/// input), so the free-tier "rank but never skip" stance holds by construction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -14,6 +16,9 @@ pub enum FocusLabel {
     ReviewHere,
     /// Not prioritized, but still visible in the escape-hatch list.
     NotPrioritized,
+    /// Safe to skip: runtime evidence proves the unit cold (only `safe_to_delete`
+    /// findings, no hot path) AND it carries no risk signal. Runtime-backed only.
+    Skip,
 }
 
 impl FocusLabel {
@@ -23,6 +28,7 @@ impl FocusLabel {
         match self {
             Self::ReviewHere => "review-here",
             Self::NotPrioritized => "not-prioritized",
+            Self::Skip => "skip",
         }
     }
 }
@@ -52,9 +58,9 @@ impl ConfidenceFlag {
     }
 }
 
-/// The composite attention score, with the four deterministic component
-/// sub-scores kept on the wire so the runtime seam can re-weight `total`
-/// without recomputing the signals.
+/// The composite attention score, with the deterministic component sub-scores
+/// kept on the wire so the runtime layer adds its weight without recomputing the
+/// signals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct FocusScore {
@@ -67,8 +73,27 @@ pub struct FocusScore {
     pub risk_zone: u32,
     /// Change-shape component (new/widened export, signature change proxy).
     pub change_shape: u32,
-    /// The summed total. The paid runtime layer multiplies a runtime hot/cold weight in here.
+    /// Runtime-weight component (paid): a hot path (runtime evidence of high
+    /// invocation) adds an invocation-bucketed weight so it amplifies the blast
+    /// and outranks an otherwise-equal cold unit. `0` in free mode (no runtime
+    /// input), so the free-tier total stays the four deterministic components and
+    /// is byte-identical to the no-runtime baseline.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[cfg_attr(feature = "schema", schemars(default))]
+    pub runtime: u32,
+    /// The summed total of every present component (the four deterministic ones
+    /// plus the runtime weight).
     pub total: u32,
+}
+
+/// Whether a `u32` is zero (serde skip predicate so the `runtime` component is
+/// omitted from the wire in free mode, keeping the no-runtime JSON byte-identical).
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip predicate signature"
+)]
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 /// One review unit on the focus map: its file, composite score, label, human
@@ -80,7 +105,8 @@ pub struct FocusUnit {
     pub file: String,
     /// The composite attention score and its component breakdown.
     pub score: FocusScore,
-    /// The focus label (`review-here` / `not-prioritized`; NEVER `skip`).
+    /// The focus label (`review-here` / `not-prioritized`, or the runtime-backed
+    /// `skip` on the paid path).
     pub label: FocusLabel,
     /// A human-readable reason for the label, built from the present signals.
     pub reason: String,
@@ -101,10 +127,11 @@ pub struct FocusMap {
     /// Units labeled `review-here`, ranked by composite score (descending), ties
     /// broken by path for determinism.
     pub review_here: Vec<FocusUnit>,
-    /// EVERY `not-prioritized` unit (the escape hatch). Always present and fully
+    /// EVERY de-prioritized unit (`not-prioritized`, plus runtime-backed `skip`
+    /// units on the paid path) -- the escape hatch. Always present and fully
     /// enumerated so a reviewer can always "show me what you de-prioritized"; the
     /// human brief collapses it by default and re-expands under
-    /// `--show-deprioritized`.
+    /// `--show-deprioritized`. Nothing is ever hidden, including a `skip`.
     pub deprioritized: Vec<FocusUnit>,
 }
 

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -16881,9 +16881,14 @@
           "type": "string",
           "const": "not-prioritized",
           "description": "Not prioritized, but still visible in the escape-hatch list."
+        },
+        {
+          "type": "string",
+          "const": "skip",
+          "description": "Safe to skip: runtime evidence proves the unit cold (only `safe_to_delete`\nfindings, no hot path) AND it carries no risk signal. Runtime-backed only."
         }
       ],
-      "description": "The focus label for a review unit. EXACTLY two variants: `Skip` is NOT\nrepresentable, so the type system is the guarantee that free mode never emits\na `skip` label (safe explicit-skip is paid, runtime-backed only). Mirrors\nthe decision surface's \"cut category not representable\" structural posture."
+      "description": "The focus label for a review unit. `Skip` is the SAFE explicit-skip label and\nis runtime-backed ONLY: it is producible solely on the paid runtime path\nand solely for a unit runtime-proves cold with zero risk signals. Free mode\n(no runtime evidence) emits only `ReviewHere` / `NotPrioritized`, never `Skip`\n(the build-focus-map labeller cannot reach the `Skip` arm without runtime\ninput), so the free-tier \"rank but never skip\" stance holds by construction."
     },
     "ConfidenceFlag": {
       "oneOf": [
@@ -16919,9 +16924,13 @@
           "type": "integer",
           "description": "Change-shape component (new/widened export, signature change proxy)."
         },
+        "runtime": {
+          "type": "integer",
+          "description": "Runtime-weight component (paid): a hot path (runtime evidence of high\ninvocation) adds an invocation-bucketed weight so it amplifies the blast\nand outranks an otherwise-equal cold unit. `0` in free mode (no runtime\ninput), so the free-tier total stays the four deterministic components and\nis byte-identical to the no-runtime baseline."
+        },
         "total": {
           "type": "integer",
-          "description": "The summed total. The paid runtime layer multiplies a runtime hot/cold weight in here."
+          "description": "The summed total of every present component (the four deterministic ones\nplus the runtime weight)."
         }
       },
       "required": [
@@ -16931,7 +16940,7 @@
         "change_shape",
         "total"
       ],
-      "description": "The composite attention score, with the four deterministic component\nsub-scores kept on the wire so the runtime seam can re-weight `total`\nwithout recomputing the signals."
+      "description": "The composite attention score, with the deterministic component sub-scores\nkept on the wire so the runtime layer adds its weight without recomputing the\nsignals."
     },
     "FocusUnit": {
       "type": "object",
@@ -16945,7 +16954,7 @@
           "$ref": "#/definitions/FocusScore"
         },
         "label": {
-          "description": "The focus label (`review-here` / `not-prioritized`; NEVER `skip`).",
+          "description": "The focus label (`review-here` / `not-prioritized`, or the runtime-backed\n`skip` on the paid path).",
           "$ref": "#/definitions/FocusLabel"
         },
         "reason": {
@@ -16983,7 +16992,7 @@
           "items": {
             "$ref": "#/definitions/FocusUnit"
           },
-          "description": "EVERY `not-prioritized` unit (the escape hatch). Always present and fully\nenumerated so a reviewer can always \"show me what you de-prioritized\"; the\nhuman brief collapses it by default and re-expands under\n`--show-deprioritized`."
+          "description": "EVERY de-prioritized unit (`not-prioritized`, plus runtime-backed `skip`\nunits on the paid path) -- the escape hatch. Always present and fully\nenumerated so a reviewer can always \"show me what you de-prioritized\"; the\nhuman brief collapses it by default and re-expands under\n`--show-deprioritized`. Nothing is ever hidden, including a `skip`."
         }
       },
       "required": [

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -788,12 +788,14 @@ export type RiskClass = ("low" | "medium" | "high")
  */
 export type ReviewEffort = ("glance" | "review" | "deep_dive")
 /**
- * The focus label for a review unit. EXACTLY two variants: `Skip` is NOT
- * representable, so the type system is the guarantee that free mode never emits
- * a `skip` label (safe explicit-skip is paid, runtime-backed only). Mirrors
- * the decision surface's "cut category not representable" structural posture.
+ * The focus label for a review unit. `Skip` is the SAFE explicit-skip label and
+ * is runtime-backed ONLY: it is producible solely on the paid runtime path
+ * and solely for a unit runtime-proves cold with zero risk signals. Free mode
+ * (no runtime evidence) emits only `ReviewHere` / `NotPrioritized`, never `Skip`
+ * (the build-focus-map labeller cannot reach the `Skip` arm without runtime
+ * input), so the free-tier "rank but never skip" stance holds by construction.
  */
-export type FocusLabel = ("review-here" | "not-prioritized")
+export type FocusLabel = ("review-here" | "not-prioritized" | "skip")
 /**
  * A per-unit confidence flag. The EXACT panel-decided strings: a dynamically-
  * wired or re-export-heavy unit carries one so its static-reachability signal is
@@ -8778,10 +8780,11 @@ export interface FocusMap {
  */
 review_here: FocusUnit[]
 /**
- * EVERY `not-prioritized` unit (the escape hatch). Always present and fully
+ * EVERY de-prioritized unit (`not-prioritized`, plus runtime-backed `skip`
+ * units on the paid path) -- the escape hatch. Always present and fully
  * enumerated so a reviewer can always "show me what you de-prioritized"; the
  * human brief collapses it by default and re-expands under
- * `--show-deprioritized`.
+ * `--show-deprioritized`. Nothing is ever hidden, including a `skip`.
  */
 deprioritized: FocusUnit[]
 }
@@ -8806,9 +8809,9 @@ reason: string
 confidence?: ConfidenceFlag[]
 }
 /**
- * The composite attention score, with the four deterministic component
- * sub-scores kept on the wire so the runtime seam can re-weight `total`
- * without recomputing the signals.
+ * The composite attention score, with the deterministic component sub-scores
+ * kept on the wire so the runtime layer adds its weight without recomputing the
+ * signals.
  */
 export interface FocusScore {
 /**
@@ -8829,7 +8832,16 @@ risk_zone: number
  */
 change_shape: number
 /**
- * The summed total. The paid runtime layer multiplies a runtime hot/cold weight in here.
+ * Runtime-weight component (paid): a hot path (runtime evidence of high
+ * invocation) adds an invocation-bucketed weight so it amplifies the blast
+ * and outranks an otherwise-equal cold unit. `0` in free mode (no runtime
+ * input), so the free-tier total stays the four deterministic components and
+ * is byte-identical to the no-runtime baseline.
+ */
+runtime?: number
+/**
+ * The summed total of every present component (the four deterministic ones
+ * plus the runtime weight).
  */
 total: number
 }

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -788,12 +788,14 @@ export type RiskClass = ("low" | "medium" | "high")
  */
 export type ReviewEffort = ("glance" | "review" | "deep_dive")
 /**
- * The focus label for a review unit. EXACTLY two variants: `Skip` is NOT
- * representable, so the type system is the guarantee that free mode never emits
- * a `skip` label (safe explicit-skip is paid, runtime-backed only). Mirrors
- * the decision surface's "cut category not representable" structural posture.
+ * The focus label for a review unit. `Skip` is the SAFE explicit-skip label and
+ * is runtime-backed ONLY: it is producible solely on the paid runtime path
+ * and solely for a unit runtime-proves cold with zero risk signals. Free mode
+ * (no runtime evidence) emits only `ReviewHere` / `NotPrioritized`, never `Skip`
+ * (the build-focus-map labeller cannot reach the `Skip` arm without runtime
+ * input), so the free-tier "rank but never skip" stance holds by construction.
  */
-export type FocusLabel = ("review-here" | "not-prioritized")
+export type FocusLabel = ("review-here" | "not-prioritized" | "skip")
 /**
  * A per-unit confidence flag. The EXACT panel-decided strings: a dynamically-
  * wired or re-export-heavy unit carries one so its static-reachability signal is
@@ -8778,10 +8780,11 @@ export interface FocusMap {
  */
 review_here: FocusUnit[]
 /**
- * EVERY `not-prioritized` unit (the escape hatch). Always present and fully
+ * EVERY de-prioritized unit (`not-prioritized`, plus runtime-backed `skip`
+ * units on the paid path) -- the escape hatch. Always present and fully
  * enumerated so a reviewer can always "show me what you de-prioritized"; the
  * human brief collapses it by default and re-expands under
- * `--show-deprioritized`.
+ * `--show-deprioritized`. Nothing is ever hidden, including a `skip`.
  */
 deprioritized: FocusUnit[]
 }
@@ -8806,9 +8809,9 @@ reason: string
 confidence?: ConfidenceFlag[]
 }
 /**
- * The composite attention score, with the four deterministic component
- * sub-scores kept on the wire so the runtime seam can re-weight `total`
- * without recomputing the signals.
+ * The composite attention score, with the deterministic component sub-scores
+ * kept on the wire so the runtime layer adds its weight without recomputing the
+ * signals.
  */
 export interface FocusScore {
 /**
@@ -8829,7 +8832,16 @@ risk_zone: number
  */
 change_shape: number
 /**
- * The summed total. The paid runtime layer multiplies a runtime hot/cold weight in here.
+ * Runtime-weight component (paid): a hot path (runtime evidence of high
+ * invocation) adds an invocation-bucketed weight so it amplifies the blast
+ * and outranks an otherwise-equal cold unit. `0` in free mode (no runtime
+ * input), so the free-tier total stays the four deterministic components and
+ * is byte-identical to the no-runtime baseline.
+ */
+runtime?: number
+/**
+ * The summed total of every present component (the four deterministic ones
+ * plus the runtime weight).
  */
 total: number
 }


### PR DESCRIPTION
Adds a runtime-weighted layer to the `fallow review` / `audit --brief` focus map.

When `--runtime-coverage` is present:

- **Hot weighting:** a hot file gets an invocation-bucketed weight, so a hot path amplifies its blast and outranks an otherwise-equal cold unit.
- **Safe explicit-skip:** a unit the runtime proves cold (only `safe_to_delete` findings, no hot path) that also carries zero deterministic signal and no confidence flag is labelled `skip`. It always stays in the escape-hatch (`deprioritized`) list, never hidden, and is purely advisory.

Without `--runtime-coverage` the output is byte-identical to before: the runtime score component is `0` and omitted from the wire, and no unit can reach the `skip` arm.

**Honest boundary:** the runtime report's findings omit `active` functions, so a mid-traffic active function below the hot threshold is invisible to the cold signal. Safe-skip is therefore conservatively gated (zero static risk, no confidence flag, diff files only, advisory), and the cold reason reads "no hot path" rather than "0 invocations".

**Contract:** `FocusLabel` gains `skip`; `FocusScore` gains an optional `runtime` component. `docs/output-schema.json` and the generated VS Code / npm type contracts are regenerated. Additive and backward-compatible (no schema-version bump).

Verified locally: full `fallow-cli` test suite, schema-drift gate, codegen check, clippy, and fmt all green.