### PR TITLE
docs(test): target the binary in the runtime-focus e2e run command

### DIFF
--- a/crates/cli/tests/audit_brief_runtime_focus_tests.rs
+++ b/crates/cli/tests/audit_brief_runtime_focus_tests.rs
@@ -22,8 +22,9 @@
 //! Gated behind the `test-sidecar-key` cargo feature, which swaps in the
 //! deterministic test sidecar-signing and license keypairs and builds the
 //! `stub_sidecar` bin (a `compile_error!` blocks the feature from release
-//! builds). Run:
-//!   cargo test -p fallow-cli --features test-sidecar-key runtime_focus
+//! builds). Run (the test fn names do not contain "runtime_focus", so target the
+//! binary rather than a bare name filter, which would match zero of them):
+//!   cargo test -p fallow-cli --features test-sidecar-key --test audit_brief_runtime_focus_tests
 
 #[path = "common/mod.rs"]
 mod common;


### PR DESCRIPTION
Follow-up: the runtime-focus e2e test's module doc documented its run command as a bare `runtime_focus` name filter, which matches none of the test fn names (`review_runtime_coverage_*`) and so runs zero of the two tests. Switches it to `--test audit_brief_runtime_focus_tests`, which actually runs them. Comment-only.