### PR TITLE
fix(review): correct `--walkthrough` rendered output

### DIFF
--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -2092,21 +2092,38 @@ pub fn build_walkthrough_markdown(
     out
 }
 
-/// Push the `**Focus:**` line built from the guide's triage.
+/// Push the `**Focus:**` line built from the guide's triage, with the reconciled
+/// file accounting (staged + cleared + excluded) so the count matches the real
+/// changed set and non-source files are surfaced, not silently dropped.
 fn push_walkthrough_focus(out: &mut String, guide: &fallow_output::StandardWalkthroughGuide) {
     let triage = &guide.digest.triage;
+    // The markdown surface is a paste artifact with no local viewed-state, so the
+    // only collapse is de-prioritized; pass an empty viewed list.
+    let acc = fallow_output::WalkthroughAccounting::compute(guide, &[]);
+    let total = acc.header_total();
     let _ = write!(
         out,
-        "**Focus:** {} risk \u{00b7} {} \u{00b7} {} file{}\n\n",
+        "**Focus:** {} risk \u{00b7} {} \u{00b7} {} file{}",
         walkthrough_risk_label(triage.risk_class),
         walkthrough_effort_label(triage.review_effort),
-        triage.files,
-        plural(triage.files),
+        total,
+        plural(total),
     );
+    let mut parts = vec![format!("{} in stages", acc.staged)];
+    if acc.cleared > 0 {
+        parts.push(format!("{} cleared", acc.cleared));
+    }
+    if acc.excluded > 0 {
+        parts.push(format!("{} non-source not reviewed", acc.excluded));
+    }
+    if acc.cleared > 0 || acc.excluded > 0 {
+        let _ = write!(out, " ({})", parts.join(" \u{00b7} "));
+    }
+    out.push_str("\n\n");
 }
 
-/// Partition the guide's units into (contract-break, orientation), each in
-/// `direction.order`.
+/// Partition the guide's VISIBLE stage units (de-prioritized files collapsed out
+/// into Cleared) into (contract-break, orientation), each in `direction.order`.
 fn partition_walkthrough_stages(
     guide: &fallow_output::StandardWalkthroughGuide,
 ) -> (
@@ -2115,10 +2132,7 @@ fn partition_walkthrough_stages(
 ) {
     let mut load_bearing = Vec::new();
     let mut mechanical = Vec::new();
-    for file in &guide.direction.order {
-        let Some(unit) = guide.direction.units.iter().find(|u| &u.file == file) else {
-            continue;
-        };
+    for unit in fallow_output::visible_stage_units(guide, &[]) {
         if unit.concern_lens == "contract-break" {
             load_bearing.push(unit);
         } else {
@@ -2148,10 +2162,12 @@ fn push_walkthrough_stage(
         } else {
             format!("  {}", badges.join(" "))
         };
+        // The raw "(score N)" is intentionally omitted: it is an internal composite
+        // that does not explain the visible within-stage order, so showing it
+        // contradicted the order. The fact carries the real ordering signal.
         let _ = writeln!(
             out,
-            "- `{rel}` (score {}) \u{2014} {}{suffix}",
-            unit.scoring_budget,
+            "- `{rel}` \u{2014} {}{suffix}",
             walkthrough_fact(unit, guide),
         );
     }
@@ -2209,7 +2225,15 @@ fn walkthrough_fact(
         .iter()
         .find(|d| d.anchor_file == unit.file)
     {
-        return escape_backticks(&decision.question);
+        // Strip the redundant leading path (the bullet already shows it) and cap
+        // the contract-member list, PRESERVING the trailing guidance question. The
+        // result is plain prose with no backticks, so it never emits a
+        // backslash-backtick sequence and never re-prints the path.
+        return fallow_output::clean_decision_fact(
+            &decision.question,
+            &unit.file,
+            fallow_output::MAX_CONTRACT_MEMBERS,
+        );
     }
     if !unit.out_of_diff.is_empty() {
         return format!(
@@ -2311,9 +2335,10 @@ mod walkthrough_markdown_tests {
     use super::build_walkthrough_markdown;
     use fallow_output::{
         AgentSchema, Decision, DecisionCategory, DecisionSurface, DiffTriage, DirectionUnit,
-        FocusMap, GraphFacts, INJECTION_NOTE, ImpactClosureFacts, PartitionFacts,
-        ReviewBriefSchemaVersion, ReviewDeltas, ReviewDirection, ReviewEffort, RiskClass,
-        RoutingFacts, StandardReviewBriefOutput, StandardWalkthroughGuide,
+        FocusLabel, FocusMap, FocusScore, FocusUnit, GraphFacts, INJECTION_NOTE,
+        ImpactClosureFacts, PartitionFacts, ReviewBriefSchemaVersion, ReviewDeltas,
+        ReviewDirection, ReviewEffort, RiskClass, RoutingFacts, StandardReviewBriefOutput,
+        StandardWalkthroughGuide,
     };
     use std::path::Path;
 
@@ -2324,6 +2349,16 @@ mod walkthrough_markdown_tests {
             scoring_budget: 3,
             out_of_diff: vec!["src/consumer.ts".to_string()],
             expert: Vec::new(),
+        };
+        // The direction unit comes FROM the focus map's review_here in reality, so
+        // mirror that here: review_here has the one source unit and triage.files
+        // matches it, keeping the excluded bucket at 0 for this synthetic guide.
+        let review_unit = FocusUnit {
+            file: file.to_string(),
+            score: FocusScore::default(),
+            label: FocusLabel::ReviewHere,
+            reason: "reason".to_string(),
+            confidence: Vec::new(),
         };
         let decision = Decision {
             signal_id: "sig:1".to_string(),
@@ -2359,7 +2394,10 @@ mod walkthrough_markdown_tests {
             },
             partition: PartitionFacts::default(),
             impact_closure: ImpactClosureFacts::default(),
-            focus: FocusMap::default(),
+            focus: FocusMap {
+                review_here: vec![review_unit],
+                deprioritized: Vec::new(),
+            },
             deltas: ReviewDeltas::default(),
             weakening: Vec::new(),
             routing: RoutingFacts::default(),
@@ -2400,19 +2438,33 @@ mod walkthrough_markdown_tests {
         assert!(!md.contains('\u{1b}'), "no ANSI in markdown");
     }
 
+    // F5/F7: a coordination question must NOT re-print the anchor path inside the
+    // fact text, must NOT emit a backslash-backtick sequence, and must cap the
+    // contract member list while keeping the trailing guidance question.
     #[test]
-    fn escapes_backticks_in_decision_question() {
-        // A backtick-laden question must not break code fences when escaped.
-        let guide = guide_with_question("src/page.ts", "Replace `old` with `new`?");
+    fn fact_does_not_reprint_path_or_emit_escaped_backticks() {
+        let q = "`src/page.ts` changes a contract (a, b, c, d, e, f, g, h, i) consumed by 9 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+        let guide = guide_with_question("src/page.ts", q);
         let md = build_walkthrough_markdown(&guide, Path::new("/project"));
+        // No backslash-backtick anywhere (the F5 corruption).
         assert!(
-            md.contains("Replace \\`old\\` with \\`new\\`?"),
-            "backticks in the question are escaped: {md}"
+            !md.contains("\\`"),
+            "fact must never emit a backslash-backtick sequence: {md}"
         );
-        // The number of UNESCAPED backticks stays balanced (even count), so no
-        // dangling code fence.
-        let unescaped = md.matches('`').count() - md.matches("\\`").count();
-        assert_eq!(unescaped % 2, 0, "code spans stay balanced: {md}");
+        // The path is printed once (the bullet lead), not a second time in the fact.
+        assert!(
+            !md.contains("`src/page.ts` changes a contract"),
+            "fact must not re-print the path: {md}"
+        );
+        // The member list is capped with a "+N more".
+        assert!(md.contains("+3 more"), "member list capped: {md}");
+        // The trailing actionable question survives in full.
+        assert!(
+            md.contains("Coordinate the change, or is the contract stable?"),
+            "trailing guidance must survive: {md}"
+        );
+        // The raw "(score N)" is gone.
+        assert!(!md.contains("(score "), "raw score removed: {md}");
     }
 
     #[test]

--- a/crates/cli/src/report/human/walkthrough.rs
+++ b/crates/cli/src/report/human/walkthrough.rs
@@ -26,7 +26,9 @@
 
 use colored::Colorize;
 use fallow_output::{
-    DecisionCategory, DirectionUnit, ReviewEffort, RiskClass, StandardWalkthroughGuide,
+    DecisionCategory, DirectionUnit, MAX_CONTRACT_MEMBERS, ReviewEffort, RiskClass,
+    StandardWalkthroughGuide, WalkthroughAccounting, cap_names, clean_decision_fact,
+    visible_stage_units,
 };
 
 use crate::walkthrough_state::ViewedState;
@@ -36,9 +38,6 @@ use crate::report::plural;
 
 /// Max out-of-diff consumers named on a per-file fact line before truncating.
 const MAX_NAMED_CONSUMERS: usize = 3;
-
-/// Max characters of a per-file "why" fact line before truncating with an ellipsis.
-const FACT_LINE_MAX: usize = 120;
 
 /// Inputs to the human tour builder, bundled so the per-file row helpers do not
 /// each take a long parameter list.
@@ -68,7 +67,8 @@ pub(in crate::report) fn build_walkthrough_human_lines(
         return lines;
     }
 
-    let (stage1, stage2) = partition_stages(guide);
+    let viewed = viewed_files(input);
+    let (stage1, stage2) = partition_stages(guide, &viewed);
     push_stage(
         &mut lines,
         "Stage 1: Load-bearing (contract-break)",
@@ -88,17 +88,34 @@ pub(in crate::report) fn build_walkthrough_human_lines(
     lines
 }
 
-/// Partition the guide's units into (contract-break, orientation), each in
-/// `direction.order`. Files in `order` with no matching unit are skipped.
-fn partition_stages(
-    guide: &StandardWalkthroughGuide,
-) -> (Vec<&DirectionUnit>, Vec<&DirectionUnit>) {
+/// The staged source files the local state has marked viewed (current hash only),
+/// so the shared membership helpers can collapse them into Cleared.
+fn viewed_files(input: &WalkthroughHumanInput<'_>) -> Vec<String> {
+    viewed_files_for(input.guide, input.viewed)
+}
+
+/// Same, but from a raw guide + viewed-state pair (used by the header/status
+/// accounting, which do not build a full `WalkthroughHumanInput`).
+fn viewed_files_for(guide: &StandardWalkthroughGuide, viewed: &ViewedState) -> Vec<String> {
+    guide
+        .direction
+        .order
+        .iter()
+        .filter(|file| viewed.is_viewed(file, &guide.graph_snapshot_hash))
+        .cloned()
+        .collect()
+}
+
+/// Partition the guide's VISIBLE stage units (de-prioritized + viewed files
+/// already collapsed out into Cleared) into (contract-break, orientation), each
+/// in `direction.order`. Each file is in exactly one place: a stage XOR Cleared.
+fn partition_stages<'a>(
+    guide: &'a StandardWalkthroughGuide,
+    viewed: &[String],
+) -> (Vec<&'a DirectionUnit>, Vec<&'a DirectionUnit>) {
     let mut load_bearing = Vec::new();
     let mut mechanical = Vec::new();
-    for file in &guide.direction.order {
-        let Some(unit) = guide.direction.units.iter().find(|u| &u.file == file) else {
-            continue;
-        };
+    for unit in visible_stage_units(guide, viewed) {
         if unit.concern_lens == "contract-break" {
             load_bearing.push(unit);
         } else {
@@ -133,20 +150,20 @@ fn push_stage(
     }
 }
 
-/// Render one file's row: the header line (path + score + badges) and the
-/// one-line fact beneath it.
+/// Render one file's row: the header line (path + badges) and the one-line fact
+/// beneath it. The raw "(score N)" is intentionally NOT shown: it is an internal
+/// composite that does not explain the visible within-stage order (Stage 1 is
+/// ordered by out-of-diff consumer count, Stage 2 by that same composite), so
+/// surfacing the number contradicted the order. The fact line carries the real
+/// ordering signal (consumer count / fan-in) instead.
 fn push_file_row(lines: &mut Vec<String>, unit: &DirectionUnit, input: &WalkthroughHumanInput<'_>) {
     let badges = synthesize_badges(unit, input);
-    let score = format!("(score {})", unit.scoring_budget).dimmed();
     let badge_suffix = if badges.is_empty() {
         String::new()
     } else {
         format!(" {}", badges.join(" "))
     };
-    lines.push(format!(
-        "  {} {score}{badge_suffix}",
-        format_path(&unit.file)
-    ));
+    lines.push(format!("  {}{badge_suffix}", format_path(&unit.file)));
     lines.push(format!("    {}", fact_line(unit, input.guide).dimmed()));
 }
 
@@ -161,13 +178,16 @@ fn fact_line(unit: &DirectionUnit, guide: &StandardWalkthroughGuide) -> String {
         .iter()
         .find(|d| d.anchor_file == unit.file)
     {
-        return truncate(&decision.question, FACT_LINE_MAX);
+        // Strip the redundant leading path (the row already shows it) and cap the
+        // contract-member list, PRESERVING the trailing guidance question instead
+        // of truncating it away.
+        return clean_decision_fact(&decision.question, &unit.file, MAX_CONTRACT_MEMBERS);
     }
     if !unit.out_of_diff.is_empty() {
         return out_of_diff_fact(unit);
     }
     if let Some(reason) = focus_reason(unit, guide) {
-        return truncate(reason, FACT_LINE_MAX);
+        return reason.to_string();
     }
     "orientation only".to_string()
 }
@@ -175,14 +195,9 @@ fn fact_line(unit: &DirectionUnit, guide: &StandardWalkthroughGuide) -> String {
 /// The out-of-diff consumer fact: a count plus the first few consumer paths.
 fn out_of_diff_fact(unit: &DirectionUnit) -> String {
     let total = unit.out_of_diff.len();
-    let named: Vec<&str> = unit
-        .out_of_diff
-        .iter()
-        .take(MAX_NAMED_CONSUMERS)
-        .map(String::as_str)
-        .collect();
-    let more = if total > named.len() {
-        format!(" (+{} more)", total - named.len())
+    let (named, more_count) = cap_names(&unit.out_of_diff, MAX_NAMED_CONSUMERS);
+    let more = if more_count > 0 {
+        format!(" (+{more_count} more)")
     } else {
         String::new()
     };
@@ -286,10 +301,9 @@ fn weakened_here(file: &str, guide: &StandardWalkthroughGuide) -> bool {
 fn push_cleared_panel(lines: &mut Vec<String>, input: &WalkthroughHumanInput<'_>) {
     let guide = input.guide;
     let deprioritized = &guide.digest.focus.deprioritized;
-    let viewed_count = input.viewed.viewed_count(
-        guide.direction.order.iter().map(String::as_str),
-        &guide.graph_snapshot_hash,
-    );
+    // Count viewed files that are NOT already in the de-prioritized bucket, so a
+    // de-prioritized-and-viewed file lands in exactly one bucket (no double count).
+    let viewed_count = viewed_only_files(input).len();
 
     if deprioritized.is_empty() && viewed_count == 0 {
         return;
@@ -344,22 +358,45 @@ fn push_cleared_detail(lines: &mut Vec<String>, input: &WalkthroughHumanInput<'_
             .dimmed()
         ));
     }
-    for file in &guide.direction.order {
-        if input.viewed.is_viewed(file, &guide.graph_snapshot_hash) {
-            lines.push(format!(
-                "    {} {}",
-                format_path(file),
-                "\u{2713} viewed".dimmed()
-            ));
-        }
+    for file in viewed_only_files(input) {
+        lines.push(format!(
+            "    {} {}",
+            format_path(&file),
+            "\u{2713} viewed".dimmed()
+        ));
     }
 }
 
+/// Files marked viewed (current hash) that are NOT already in the de-prioritized
+/// bucket, so the viewed sub-list of Cleared never re-lists a de-prioritized file.
+fn viewed_only_files(input: &WalkthroughHumanInput<'_>) -> Vec<String> {
+    let guide = input.guide;
+    viewed_files(input)
+        .into_iter()
+        .filter(|file| {
+            !guide
+                .digest
+                .focus
+                .deprioritized
+                .iter()
+                .any(|u| &u.file == file)
+        })
+        .collect()
+}
+
 /// The Review Focus orientation header lines (rendered to stderr by the entry
-/// point). Built from the guide's triage + graph facts. Never a verdict.
+/// point). Built from the guide's triage + graph facts. Never a verdict. The
+/// file count is the reconciled changed set (`staged + cleared + excluded`), so
+/// the header, the status line, and reality agree.
 #[must_use]
-pub(in crate::report) fn build_focus_header(guide: &StandardWalkthroughGuide) -> Vec<String> {
+pub(in crate::report) fn build_focus_header(
+    guide: &StandardWalkthroughGuide,
+    viewed: &ViewedState,
+) -> Vec<String> {
     let triage = &guide.digest.triage;
+    let viewed_in_order = viewed_files_for(guide, viewed);
+    let acc = WalkthroughAccounting::compute(guide, &viewed_in_order);
+    let total = acc.header_total();
     let mut lines = Vec::new();
     lines.push(format!(
         "{} {}",
@@ -368,16 +405,37 @@ pub(in crate::report) fn build_focus_header(guide: &StandardWalkthroughGuide) ->
             "Review Focus \u{2014} {} risk \u{00b7} {} \u{00b7} {} file{}",
             risk_label(triage.risk_class),
             effort_label(triage.review_effort),
-            triage.files,
-            plural(triage.files),
+            total,
+            plural(total),
         )
         .cyan()
         .bold()
     ));
+    if let Some(breakdown) = accounting_breakdown(&acc) {
+        lines.push(format!("  {}", breakdown.dimmed()));
+    }
     if let Some(sub) = focus_subline(guide) {
         lines.push(format!("  {}", sub.dimmed()));
     }
     lines
+}
+
+/// The honest accounting sub-line: how the changed set splits into staged /
+/// cleared / excluded buckets, so non-source files are surfaced, not dropped.
+/// Returns `None` when there is nothing beyond the staged files to explain.
+fn accounting_breakdown(acc: &WalkthroughAccounting) -> Option<String> {
+    let mut parts = Vec::new();
+    parts.push(format!("{} in stages", acc.staged));
+    if acc.cleared > 0 {
+        parts.push(format!("{} cleared", acc.cleared));
+    }
+    if acc.excluded > 0 {
+        parts.push(format!("{} non-source not reviewed", acc.excluded));
+    }
+    if acc.cleared == 0 && acc.excluded == 0 {
+        return None;
+    }
+    Some(parts.join(" \u{00b7} "))
 }
 
 /// The optional dim sub-line: boundaries touched + affected-not-shown counts.
@@ -407,10 +465,16 @@ fn focus_subline(guide: &StandardWalkthroughGuide) -> Option<String> {
 }
 
 /// The final green status line (rendered to stderr by the entry point). Never a
-/// failure glyph; the walkthrough always exits 0.
+/// failure glyph; the walkthrough always exits 0. The count is the files visible
+/// in stages (de-prioritized + viewed already collapsed into Cleared), so it
+/// reconciles with the header's `staged` bucket.
 #[must_use]
-pub(in crate::report) fn build_status_line(guide: &StandardWalkthroughGuide) -> String {
-    let files = guide.direction.order.len();
+pub(in crate::report) fn build_status_line(
+    guide: &StandardWalkthroughGuide,
+    viewed: &ViewedState,
+) -> String {
+    let acc = WalkthroughAccounting::compute(guide, &viewed_files_for(guide, viewed));
+    let files = acc.staged;
     format!(
         "{} Walkthrough ready \u{2014} {} file{} across 2 stages",
         "\u{2713}".green(),
@@ -435,15 +499,6 @@ fn effort_label(effort: ReviewEffort) -> &'static str {
         ReviewEffort::Review => "review",
         ReviewEffort::DeepDive => "deep-dive",
     }
-}
-
-/// Truncate `s` to at most `max` chars, appending an ellipsis when cut.
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    let cut: String = s.chars().take(max.saturating_sub(1)).collect();
-    format!("{cut}\u{2026}")
 }
 
 #[cfg(test)]
@@ -485,13 +540,23 @@ mod tests {
         routing: RoutingFacts,
         weakening: Vec<WeakeningSignal>,
     ) -> StandardWalkthroughGuide {
-        let order = units.iter().map(|u| u.file.clone()).collect();
+        let order: Vec<String> = units.iter().map(|u| u.file.clone()).collect();
+        // Mirror reality: the focus map's review_here is the direction units that
+        // are NOT de-prioritized, so review_here + deprioritized == the source set
+        // and triage.files (no extra non-source churn) keeps `excluded` at 0 for
+        // the synthetic guides that don't deliberately add non-source files.
+        let review_here: Vec<FocusUnit> = order
+            .iter()
+            .filter(|f| !deprioritized.iter().any(|d| &d.file == *f))
+            .map(|f| focus_unit(f, FocusLabel::ReviewHere))
+            .collect();
+        let total_files = review_here.len() + deprioritized.len();
         let digest = StandardReviewBriefOutput {
             schema_version: ReviewBriefSchemaVersion::default(),
             version: "test".to_string(),
             command: "audit-brief".to_string(),
             triage: DiffTriage {
-                files: order_len(&units),
+                files: total_files,
                 hunks: None,
                 net_lines: None,
                 risk_class: RiskClass::Medium,
@@ -506,7 +571,7 @@ mod tests {
             partition: PartitionFacts::default(),
             impact_closure: ImpactClosureFacts::default(),
             focus: FocusMap {
-                review_here: Vec::new(),
+                review_here,
                 deprioritized,
             },
             deltas: ReviewDeltas::default(),
@@ -533,10 +598,6 @@ mod tests {
             },
             injection_note: INJECTION_NOTE,
         }
-    }
-
-    fn order_len(units: &[DirectionUnit]) -> usize {
-        units.len()
     }
 
     fn coupling_decision(file: &str) -> Decision {
@@ -752,18 +813,190 @@ mod tests {
             RoutingFacts::default(),
             Vec::new(),
         );
-        let header = plain(&build_focus_header(&guide));
+        let viewed = ViewedState::default();
+        let header = plain(&build_focus_header(&guide, &viewed));
         assert!(header.contains("Review Focus"), "got: {header}");
-        let status = crate::report::human::strip_ansi(&build_status_line(&guide));
+        let status = crate::report::human::strip_ansi(&build_status_line(&guide, &viewed));
         assert!(status.contains("Walkthrough ready"), "got: {status}");
         assert!(!status.contains('\u{2717}'), "no failure glyph");
     }
 
+    // F1/F2: the header count matches the staged set and surfaces the cleared +
+    // excluded buckets; the status count agrees with the header's staged bucket.
     #[test]
-    fn truncate_caps_long_strings() {
-        let long = "x".repeat(200);
-        let cut = truncate(&long, 50);
-        assert!(cut.chars().count() <= 50);
-        assert!(cut.ends_with('\u{2026}'));
+    fn header_and_status_counts_reconcile() {
+        // Two review-here source units in stages, one de-prioritized, and the diff
+        // also touched 3 non-source files (migrations/config) not in the focus map.
+        let units = vec![
+            unit("src/a.ts", "orientation", Vec::new()),
+            unit("src/b.ts", "orientation", Vec::new()),
+        ];
+        let deprioritized = vec![focus_unit("src/c.ts", FocusLabel::NotPrioritized)];
+        let mut guide = guide_with(
+            units,
+            Vec::new(),
+            deprioritized,
+            RoutingFacts::default(),
+            Vec::new(),
+        );
+        // a.ts + b.ts (review-here) + c.ts (deprioritized) = 3 source; +3 non-source.
+        guide.digest.triage.files = 6;
+        let viewed = ViewedState::default();
+        let header = plain(&build_focus_header(&guide, &viewed));
+        // The header total is the whole changed set, not the staged subset.
+        assert!(header.contains("6 files"), "header total: {header}");
+        // The breakdown surfaces the cleared + excluded buckets honestly.
+        assert!(header.contains("2 in stages"), "staged: {header}");
+        assert!(header.contains("1 cleared"), "cleared: {header}");
+        assert!(
+            header.contains("3 non-source not reviewed"),
+            "excluded: {header}"
+        );
+        // The status line agrees with the staged bucket (not the total).
+        let status = crate::report::human::strip_ansi(&build_status_line(&guide, &viewed));
+        assert!(
+            status.contains("2 files across 2 stages"),
+            "status: {status}"
+        );
+    }
+
+    // F3: a de-prioritized file appears ONLY under Cleared, never in a stage.
+    #[test]
+    fn deprioritized_file_is_not_double_listed() {
+        // One review-here source unit plus one DE-PRIORITIZED source unit; the
+        // engine puts both in direction.order, but the render must collapse the
+        // de-prioritized one into Cleared only.
+        let units = vec![
+            unit("src/keep.ts", "orientation", Vec::new()),
+            unit("src/drop.ts", "orientation", Vec::new()),
+        ];
+        let deprioritized = vec![focus_unit("src/drop.ts", FocusLabel::NotPrioritized)];
+        let guide = guide_with(
+            units,
+            Vec::new(),
+            deprioritized,
+            RoutingFacts::default(),
+            Vec::new(),
+        );
+        let viewed = ViewedState::default();
+        let body = plain(&build_walkthrough_human_lines(&WalkthroughHumanInput {
+            guide: &guide,
+            viewed: &viewed,
+            show_cleared: true,
+        }));
+        assert!(
+            body.contains("keep.ts"),
+            "review-here file stays staged: {body}"
+        );
+        // The de-prioritized file appears only in the Cleared section, never in the
+        // stage section above it (each file is in exactly one place).
+        let cleared_at = body.find("Cleared").expect("cleared panel present");
+        let (stage_section, cleared_section) = body.split_at(cleared_at);
+        assert!(
+            !stage_section.contains("drop.ts"),
+            "de-prioritized file must not be in a stage: {body}"
+        );
+        assert!(
+            cleared_section.contains("drop.ts"),
+            "de-prioritized file must be under Cleared: {body}"
+        );
+    }
+
+    // F3: a --mark-viewed file is removed from its stage and counted ONLY in
+    // Cleared (no double listing).
+    #[test]
+    fn viewed_file_collapses_into_cleared_only() {
+        let units = vec![
+            unit("src/seen.ts", "orientation", Vec::new()),
+            unit("src/fresh.ts", "orientation", Vec::new()),
+        ];
+        let guide = guide_with(
+            units,
+            Vec::new(),
+            Vec::new(),
+            RoutingFacts::default(),
+            Vec::new(),
+        );
+        let mut viewed = ViewedState {
+            graph_snapshot_hash: "hash1".to_string(),
+            ..Default::default()
+        };
+        viewed.entries.insert(
+            "src/seen.ts".to_string(),
+            crate::walkthrough_state::ViewedEntry {
+                viewed_at: "t".to_string(),
+            },
+        );
+        let body = plain(&build_walkthrough_human_lines(&WalkthroughHumanInput {
+            guide: &guide,
+            viewed: &viewed,
+            show_cleared: true,
+        }));
+        // seen.ts appears only under Cleared (as viewed), never in a stage row.
+        let cleared_at = body.find("Cleared").expect("cleared panel present");
+        let (stage_section, cleared_section) = body.split_at(cleared_at);
+        assert!(
+            !stage_section.contains("seen.ts"),
+            "viewed file must not be in a stage: {body}"
+        );
+        assert!(
+            cleared_section.contains("seen.ts"),
+            "viewed file must be under Cleared: {body}"
+        );
+        assert!(
+            body.contains("fresh.ts"),
+            "the un-viewed file stays staged: {body}"
+        );
+        // Header staged count drops the viewed file; status agrees.
+        let status = crate::report::human::strip_ansi(&build_status_line(&guide, &viewed));
+        assert!(
+            status.contains("1 file across 2 stages"),
+            "status: {status}"
+        );
+    }
+
+    // F4/F5/F7: the contract member list is capped and the trailing guidance
+    // question survives (not truncated away); no raw score is shown.
+    #[test]
+    fn contract_question_keeps_trailing_guidance_and_caps_members() {
+        let members =
+            "alertRules, apiKeys, auditLog, budgetAlerts, coverageAlerts, deployments, users, orgs";
+        let question = format!(
+            "`src/db/schema.ts` changes a contract ({members}) consumed by 32 modules NOT in this diff. Coordinate the change, or is the contract stable?"
+        );
+        let mut decision = coupling_decision("src/db/schema.ts");
+        decision.question = question;
+        let units = vec![unit(
+            "src/db/schema.ts",
+            "contract-break",
+            vec!["src/x.ts".to_string()],
+        )];
+        let guide = guide_with(
+            units,
+            vec![decision],
+            Vec::new(),
+            RoutingFacts::default(),
+            Vec::new(),
+        );
+        let viewed = ViewedState::default();
+        let body = plain(&build_walkthrough_human_lines(&WalkthroughHumanInput {
+            guide: &guide,
+            viewed: &viewed,
+            show_cleared: false,
+        }));
+        // The trailing actionable question is NOT truncated away.
+        assert!(
+            body.contains("Coordinate the change, or is the contract stable?"),
+            "trailing guidance must survive: {body}"
+        );
+        // The member list is capped with a "+N more".
+        assert!(body.contains("+2 more"), "member list capped: {body}");
+        // The leading path is not re-printed inside the fact text.
+        assert!(
+            !body.contains("`src/db/schema.ts` changes a contract"),
+            "fact must not re-print the path: {body}"
+        );
+        // The contradictory raw "(score N)" is gone.
+        assert!(!body.contains("(score "), "raw score removed: {body}");
     }
 }

--- a/crates/cli/src/report/mod.rs
+++ b/crates/cli/src/report/mod.rs
@@ -63,9 +63,9 @@ pub fn build_walkthrough_human(
         show_cleared,
     };
     WalkthroughHumanRender {
-        header: human::walkthrough::build_focus_header(guide),
+        header: human::walkthrough::build_focus_header(guide, viewed),
         body: human::walkthrough::build_walkthrough_human_lines(&input),
-        status: human::walkthrough::build_status_line(guide),
+        status: human::walkthrough::build_status_line(guide, viewed),
     }
 }
 

--- a/crates/cli/src/walkthrough_state.rs
+++ b/crates/cli/src/walkthrough_state.rs
@@ -73,19 +73,6 @@ impl ViewedState {
         }
         self.entries.contains_key(file)
     }
-
-    /// Count of files in `order` that are currently viewed (hash-matched).
-    #[must_use]
-    pub fn viewed_count<'a>(
-        &self,
-        order: impl IntoIterator<Item = &'a str>,
-        current_hash: &str,
-    ) -> usize {
-        order
-            .into_iter()
-            .filter(|file| self.is_viewed(file, current_hash))
-            .count()
-    }
 }
 
 /// Load the viewed-state ledger from `cache_dir`, returning an empty default
@@ -221,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn viewed_count_only_counts_hash_matched() {
+    fn is_viewed_only_matches_current_hash() {
         let dir = temp_cache();
         mark_viewed(
             dir.path(),
@@ -230,9 +217,13 @@ mod tests {
         )
         .expect("mark");
         let state = load_viewed_state(dir.path());
-        let order = ["src/a.ts", "src/b.ts", "src/c.ts"];
-        assert_eq!(state.viewed_count(order.iter().copied(), "hash1"), 2);
-        assert_eq!(state.viewed_count(order.iter().copied(), "stale"), 0);
+        // Hash-matched files read as viewed; an un-marked file does not.
+        assert!(state.is_viewed("src/a.ts", "hash1"));
+        assert!(state.is_viewed("src/b.ts", "hash1"));
+        assert!(!state.is_viewed("src/c.ts", "hash1"));
+        // A stale snapshot hash matches nothing.
+        assert!(!state.is_viewed("src/a.ts", "stale"));
+        assert!(!state.is_viewed("src/b.ts", "stale"));
     }
 
     #[test]

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -2792,3 +2792,128 @@ fn w2_walkthrough_conflicts_with_guide_and_file() {
         "--walkthrough + --walkthrough-file is rejected by clap"
     );
 }
+
+/// A fixture whose HEAD diff mixes a load-bearing exported source file (consumed
+/// by an UNCHANGED consumer outside the diff), plain source churn, and a
+/// NON-source migration file. Exercises the file-accounting + membership fixes:
+/// the migration must be surfaced as excluded (not dropped), and no file may
+/// appear in both a stage and the Cleared panel.
+fn create_mixed_walkthrough_fixture() -> TempDir {
+    let tmp = TempDir::new().expect("temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::create_dir_all(dir.join("migrations")).unwrap();
+
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name": "wt-mixed", "main": "src/app.ts"}"#,
+    )
+    .unwrap();
+    fs::write(dir.join(".fallowrc.json"), r#"{"entry": ["src/app.ts"]}"#).unwrap();
+
+    // The consumer imports the contract; it is NOT touched by the HEAD diff, so
+    // `lib.ts` is consumed out-of-diff -> load-bearing.
+    fs::write(
+        dir.join("src/app.ts"),
+        "import { value } from './lib';\nexport const run = () => value();\n",
+    )
+    .unwrap();
+    fs::write(dir.join("src/lib.ts"), "export const value = () => 1;\n").unwrap();
+    git(dir, &["init", "-b", "main"]);
+    commit_all(dir, "initial");
+
+    // HEAD: change the load-bearing contract, add plain source churn, and add a
+    // non-source migration file (which must be surfaced as excluded).
+    fs::write(
+        dir.join("src/lib.ts"),
+        "export const value = () => 2;\nexport const extra = () => 3;\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/helper.ts"),
+        "export const help = () => 'x';\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("migrations/0001_init.sql"),
+        "CREATE TABLE t (id INTEGER);\n",
+    )
+    .unwrap();
+    commit_all(dir, "change lib, add helper + migration");
+    tmp
+}
+
+// F1/F2: the rendered Review Focus count reconciles staged + cleared + excluded,
+// and the non-source migration file is surfaced as excluded, never dropped.
+#[test]
+fn w2_walkthrough_surfaces_non_source_and_reconciles_counts() {
+    let tmp = create_mixed_walkthrough_fixture();
+    let output = run_walkthrough_human(tmp.path());
+    assert_eq!(output.code, 0, "exits 0. stderr: {}", output.stderr);
+    // The non-source migration is surfaced honestly, not silently dropped.
+    assert!(
+        output.stderr.contains("non-source not reviewed"),
+        "the .sql migration must be surfaced as excluded. stderr: {}",
+        output.stderr
+    );
+    // The accounting sub-line names the staged bucket.
+    assert!(
+        output.stderr.contains("in stages"),
+        "the header breakdown names the staged bucket. stderr: {}",
+        output.stderr
+    );
+    // The migration file never appears as a reviewable stage row in the tour body.
+    assert!(
+        !output.stdout.contains("0001_init.sql"),
+        "the non-source migration is not a stage row. stdout: {}",
+        output.stdout
+    );
+}
+
+// F3: a --mark-viewed file is removed from its stage and shown only under
+// Cleared (each file in exactly one place: stage XOR cleared).
+#[test]
+fn w2_walkthrough_viewed_file_collapses_into_cleared_only() {
+    let tmp = create_mixed_walkthrough_fixture();
+    // Mark the load-bearing file viewed, then render with the Cleared panel open.
+    let marked = run_fallow_raw(&[
+        "review",
+        "--root",
+        tmp.path().to_str().unwrap(),
+        "--base",
+        "main~1",
+        "--walkthrough",
+        "--mark-viewed",
+        "src/lib.ts",
+    ]);
+    assert_eq!(
+        marked.code, 0,
+        "mark-viewed exits 0. stderr: {}",
+        marked.stderr
+    );
+
+    let output = run_fallow_raw(&[
+        "review",
+        "--root",
+        tmp.path().to_str().unwrap(),
+        "--base",
+        "main~1",
+        "--walkthrough",
+        "--show-cleared",
+    ]);
+    assert_eq!(output.code, 0, "exits 0. stderr: {}", output.stderr);
+    let body = &output.stdout;
+    let cleared_at = body
+        .find("Cleared")
+        .unwrap_or_else(|| panic!("cleared panel present. stdout: {body}"));
+    let (stage_section, cleared_section) = body.split_at(cleared_at);
+    // The viewed file is gone from the stage section and present only in Cleared.
+    assert!(
+        !stage_section.contains("lib.ts"),
+        "the viewed file left its stage. stage section: {stage_section}"
+    );
+    assert!(
+        cleared_section.contains("lib.ts"),
+        "the viewed file shows only under Cleared. cleared section: {cleared_section}"
+    );
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -54,6 +54,7 @@ mod root_envelopes;
 mod sarif;
 mod security;
 mod trace_envelopes;
+mod walkthrough_render;
 
 pub use audit_brief::{
     CoordinationGapFact, DiffTriage, GraphFacts, ImpactClosureFacts, PartitionFacts,
@@ -260,3 +261,7 @@ pub use security::{
     serialize_security_summary_json_output, serialize_security_survivors_json_output,
 };
 pub use trace_envelopes::serialize_trace_json_output;
+pub use walkthrough_render::{
+    MAX_CONTRACT_MEMBERS, WalkthroughAccounting, cap_names, clean_decision_fact,
+    visible_stage_units,
+};

--- a/crates/output/src/walkthrough_render.rs
+++ b/crates/output/src/walkthrough_render.rs
@@ -1,0 +1,398 @@
+//! Shared, render-surface-agnostic helpers for the review walkthrough (W2).
+//!
+//! Both the human terminal renderer (`fallow-cli`) and the markdown renderer
+//! (`fallow-api`) project the SAME [`StandardWalkthroughGuide`] into a staged
+//! tour. The per-file "why" fact line, the staged/cleared membership split, and
+//! the file-accounting math were independently re-derived in each surface and
+//! drifted (double-counted files, a path printed twice, mid-word truncation,
+//! escaped backticks). This module centralizes that shared logic as pure
+//! functions so the two surfaces stay consistent by construction and the wire
+//! contracts (`--walkthrough-guide` JSON, audit/brief) are never touched.
+
+use crate::audit_walkthrough::{DirectionUnit, StandardWalkthroughGuide};
+
+/// Max contract members named inline in a coordination fact before collapsing
+/// the rest into a "+N more" suffix. Keeps the most load-bearing line readable
+/// in a terminal without discarding the trailing guidance.
+pub const MAX_CONTRACT_MEMBERS: usize = 6;
+
+/// Honest file accounting for the walkthrough header + status, reconciled so the
+/// numbers add up: `staged + cleared + excluded == changed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WalkthroughAccounting {
+    /// Total changed files in the diff (the engine's `triage.files`, the real set).
+    pub changed: usize,
+    /// Source units shown in a stage (in `direction.order`, not collapsed).
+    pub staged: usize,
+    /// Source units collapsed into the Cleared panel (de-prioritized + viewed).
+    pub cleared: usize,
+    /// Non-source files in the diff that carry no contract to review (migrations,
+    /// lockfiles, config, docs): counted, never silently dropped.
+    pub excluded: usize,
+}
+
+impl WalkthroughAccounting {
+    /// Reconcile the change into `staged + cleared + excluded`.
+    ///
+    /// `staged` is the count of direction units that REMAIN in a stage after the
+    /// de-prioritized and viewed files collapse out. `cleared` is the
+    /// de-prioritized escape hatch plus any staged-then-viewed files. `excluded`
+    /// is the remainder of the real changed set that is not a reviewable source
+    /// unit. The header renders `staged + cleared + excluded` (which equals
+    /// `changed` whenever the engine's changed count is the real set), so the
+    /// header, the status line, and reality agree, and no file is counted twice.
+    #[must_use]
+    pub fn compute(guide: &StandardWalkthroughGuide, viewed: &[String]) -> Self {
+        // Each direction unit lands in exactly one rendered bucket: collapsed into
+        // Cleared (de-prioritized OR viewed) or visible in a stage.
+        let mut staged_visible = 0usize;
+        let mut collapsed = 0usize;
+        for file in &guide.direction.order {
+            if is_deprioritized(guide, file) || is_collapsed_into_cleared(file, viewed) {
+                collapsed += 1;
+            } else {
+                staged_visible += 1;
+            }
+        }
+        // De-prioritized NON-source files (if any ever appear) plus de-prioritized
+        // source files all live under Cleared; the loop above already counted the
+        // source ones (they are in `direction.order`). Add de-prioritized files NOT
+        // in the order so the escape hatch stays fully accounted.
+        let deprioritized_off_spine = guide
+            .digest
+            .focus
+            .deprioritized
+            .iter()
+            .filter(|u| !guide.direction.order.iter().any(|f| f == &u.file))
+            .count();
+        let cleared = collapsed + deprioritized_off_spine;
+        // Source units the engine analyzed (review_here + deprioritized). The diff
+        // may also touch non-source files (counted in `changed` but never in the
+        // focus map); surface them as the excluded bucket instead of dropping them.
+        let source_units = guide.digest.focus.total_units();
+        let changed = guide.digest.triage.files;
+        let excluded = changed.saturating_sub(source_units);
+        WalkthroughAccounting {
+            changed,
+            staged: staged_visible,
+            cleared,
+            excluded,
+        }
+    }
+
+    /// The honest "files in this change" total the header should display:
+    /// `staged + cleared + excluded`. Equal to `changed` on a normal change; the
+    /// `max` guards the rare case where the engine's count lags the parts.
+    #[must_use]
+    pub fn header_total(&self) -> usize {
+        (self.staged + self.cleared + self.excluded).max(self.changed)
+    }
+}
+
+/// The clean, surface-agnostic fact text for a coordination decision question.
+///
+/// The raw wire `question` leads with `` `<anchor_file>` `` (which every render
+/// surface ALREADY shows as the row's leading path) and inlines the full,
+/// unbounded contract-member list. This strips the redundant leading path and
+/// caps the member list to `max_members` names + "+N more", PRESERVING the
+/// trailing guidance sentence. The result is plain prose (no backticks), so a
+/// markdown surface needs no escaping and a human surface needs no truncation.
+#[must_use]
+pub fn clean_decision_fact(question: &str, anchor_file: &str, max_members: usize) -> String {
+    let stripped = strip_leading_path(question, anchor_file);
+    cap_member_list(&stripped, max_members)
+}
+
+/// Drop a leading `` `<anchor_file>` `` token (with one trailing space) from the
+/// question, so the path is not printed a second time after the row's path.
+fn strip_leading_path(question: &str, anchor_file: &str) -> String {
+    let prefix = format!("`{anchor_file}` ");
+    question
+        .strip_prefix(&prefix)
+        .map_or_else(|| question.to_string(), str::to_string)
+}
+
+/// Cap the FIRST parenthesized comma-list (the contract members) to
+/// `max_members` names, replacing the overflow with "+N more". Text outside that
+/// first parenthetical (including the trailing question) is preserved verbatim.
+fn cap_member_list(text: &str, max_members: usize) -> String {
+    let Some(open) = text.find('(') else {
+        return text.to_string();
+    };
+    let Some(rel_close) = text[open..].find(')') else {
+        return text.to_string();
+    };
+    let close = open + rel_close;
+    let inner = &text[open + 1..close];
+    // Only collapse a genuine member list (comma-separated identifiers), never a
+    // prose parenthetical like "(env)" or "(the cache)".
+    let members: Vec<&str> = inner.split(", ").collect();
+    if members.len() <= max_members {
+        return text.to_string();
+    }
+    let shown = members[..max_members].join(", ");
+    let more = members.len() - max_members;
+    format!(
+        "{}({shown}, +{more} more){}",
+        &text[..open],
+        &text[close + 1..]
+    )
+}
+
+/// Cap an arbitrary list of names for inline display: first `max` names, then a
+/// "+N more" sentinel. Shared by the out-of-diff consumer fact in both surfaces.
+#[must_use]
+pub fn cap_names(names: &[String], max: usize) -> (Vec<&str>, usize) {
+    let shown: Vec<&str> = names.iter().take(max).map(String::as_str).collect();
+    let more = names.len().saturating_sub(shown.len());
+    (shown, more)
+}
+
+/// Whether a staged file collapses into Cleared instead of showing in its stage.
+/// A file is cleared when the local viewed-state marked it seen (the
+/// `--mark-viewed` collapse): it must appear ONLY under Cleared, never in both.
+#[must_use]
+fn is_collapsed_into_cleared(file: &str, viewed: &[String]) -> bool {
+    viewed.iter().any(|v| v == file)
+}
+
+/// Whether `file` is a de-prioritized focus unit. The `--help` contract is that
+/// de-prioritized files collapse INTO the Cleared panel, so they must be removed
+/// from their stage row and shown only under Cleared.
+#[must_use]
+fn is_deprioritized(guide: &StandardWalkthroughGuide, file: &str) -> bool {
+    guide
+        .digest
+        .focus
+        .deprioritized
+        .iter()
+        .any(|u| u.file == file)
+}
+
+/// True when a direction unit collapses out of its stage and into Cleared,
+/// because it is de-prioritized OR locally viewed. Each file is then in exactly
+/// one rendered place (stage XOR cleared).
+#[must_use]
+fn collapses_into_cleared(guide: &StandardWalkthroughGuide, file: &str, viewed: &[String]) -> bool {
+    is_deprioritized(guide, file) || is_collapsed_into_cleared(file, viewed)
+}
+
+/// The visible stage members for a guide: direction units in order, MINUS any
+/// file collapsed into Cleared (de-prioritized or viewed). Returned as references
+/// into the guide so the caller can render rows without cloning.
+#[must_use]
+pub fn visible_stage_units<'a>(
+    guide: &'a StandardWalkthroughGuide,
+    viewed: &[String],
+) -> Vec<&'a DirectionUnit> {
+    guide
+        .direction
+        .order
+        .iter()
+        .filter(|file| !collapses_into_cleared(guide, file, viewed))
+        .filter_map(|file| guide.direction.units.iter().find(|u| &u.file == file))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit_brief::{
+        DiffTriage, GraphFacts, ImpactClosureFacts, PartitionFacts, ReviewBriefSchemaVersion,
+        ReviewDeltas, ReviewEffort, RiskClass, StandardReviewBriefOutput,
+    };
+    use crate::audit_decision_surface::DecisionSurface;
+    use crate::audit_focus::{FocusLabel, FocusMap, FocusScore, FocusUnit};
+    use crate::audit_routing::RoutingFacts;
+    use crate::audit_walkthrough::{
+        AgentSchema, DirectionUnit, INJECTION_NOTE, ReviewDirection, StandardWalkthroughGuide,
+    };
+
+    fn focus_unit(file: &str, label: FocusLabel) -> FocusUnit {
+        FocusUnit {
+            file: file.to_string(),
+            score: FocusScore::default(),
+            label,
+            reason: format!("reason for {file}"),
+            confidence: Vec::new(),
+        }
+    }
+
+    fn dir_unit(file: &str) -> DirectionUnit {
+        DirectionUnit {
+            file: file.to_string(),
+            concern_lens: "orientation".to_string(),
+            scoring_budget: 1,
+            out_of_diff: Vec::new(),
+            expert: Vec::new(),
+        }
+    }
+
+    /// A guide whose direction is the review_here + deprioritized source units (as
+    /// the engine builds it), with `changed` total files that may exceed the source
+    /// unit count (the non-source excluded bucket).
+    fn guide_for(
+        review_here: &[&str],
+        deprioritized: &[&str],
+        changed_total: usize,
+    ) -> StandardWalkthroughGuide {
+        let order: Vec<String> = review_here
+            .iter()
+            .chain(deprioritized.iter())
+            .map(|s| (*s).to_string())
+            .collect();
+        let units: Vec<DirectionUnit> = order.iter().map(|f| dir_unit(f)).collect();
+        let digest = StandardReviewBriefOutput {
+            schema_version: ReviewBriefSchemaVersion::default(),
+            version: "test".to_string(),
+            command: "audit-brief".to_string(),
+            triage: DiffTriage {
+                files: changed_total,
+                hunks: None,
+                net_lines: None,
+                risk_class: RiskClass::Medium,
+                review_effort: ReviewEffort::Review,
+            },
+            graph_facts: GraphFacts {
+                exports_added: 0,
+                api_width_delta: 0,
+                reachable_from: Vec::new(),
+                boundaries_touched: Vec::new(),
+            },
+            partition: PartitionFacts::default(),
+            impact_closure: ImpactClosureFacts::default(),
+            focus: FocusMap {
+                review_here: review_here
+                    .iter()
+                    .map(|f| focus_unit(f, FocusLabel::ReviewHere))
+                    .collect(),
+                deprioritized: deprioritized
+                    .iter()
+                    .map(|f| focus_unit(f, FocusLabel::NotPrioritized))
+                    .collect(),
+            },
+            deltas: ReviewDeltas::default(),
+            weakening: Vec::new(),
+            routing: RoutingFacts::default(),
+            decisions: DecisionSurface::default(),
+        };
+        StandardWalkthroughGuide {
+            schema_version: ReviewBriefSchemaVersion::default(),
+            version: "test".to_string(),
+            command: "review-walkthrough-guide".to_string(),
+            graph_snapshot_hash: "hash1".to_string(),
+            digest,
+            direction: ReviewDirection { order, units },
+            change_anchors: Vec::new(),
+            agent_schema: AgentSchema {
+                judgment_shape: "",
+                echo_field: "graph_snapshot_hash",
+                anchoring_rule: "",
+            },
+            injection_note: INJECTION_NOTE,
+        }
+    }
+
+    #[test]
+    fn accounting_reconciles_staged_cleared_excluded() {
+        // 16 changed files: 2 review-here source, 1 de-prioritized source, 13
+        // non-source (migrations/config/docs). No viewed.
+        let guide = guide_for(&["src/a.ts", "src/b.ts"], &["src/c.ts"], 16);
+        let acc = WalkthroughAccounting::compute(&guide, &[]);
+        assert_eq!(acc.changed, 16);
+        assert_eq!(acc.staged, 2, "review-here source units stay in stages");
+        assert_eq!(acc.cleared, 1, "de-prioritized collapses into cleared");
+        assert_eq!(
+            acc.excluded, 13,
+            "non-source files are excluded, not dropped"
+        );
+        // The header total accounts for the whole changed set.
+        assert_eq!(acc.header_total(), 16);
+        assert_eq!(acc.staged + acc.cleared + acc.excluded, acc.changed);
+    }
+
+    #[test]
+    fn viewed_file_moves_from_staged_to_cleared() {
+        let guide = guide_for(&["src/a.ts", "src/b.ts"], &[], 2);
+        let viewed = vec!["src/a.ts".to_string()];
+        let acc = WalkthroughAccounting::compute(&guide, &viewed);
+        assert_eq!(acc.staged, 1, "the viewed file left the stage");
+        assert_eq!(acc.cleared, 1, "the viewed file is counted in cleared");
+        assert_eq!(acc.excluded, 0);
+        assert_eq!(acc.staged + acc.cleared + acc.excluded, acc.changed);
+    }
+
+    #[test]
+    fn deprioritized_and_viewed_appear_in_exactly_one_place() {
+        let guide = guide_for(&["src/a.ts", "src/b.ts"], &["src/c.ts"], 3);
+        let viewed = vec!["src/a.ts".to_string()];
+        // a.ts is viewed -> cleared; c.ts is de-prioritized -> cleared; only b.ts
+        // remains visible in a stage.
+        let visible = visible_stage_units(&guide, &viewed);
+        let files: Vec<&str> = visible.iter().map(|u| u.file.as_str()).collect();
+        assert_eq!(files, vec!["src/b.ts"]);
+        assert!(collapses_into_cleared(&guide, "src/a.ts", &viewed));
+        assert!(collapses_into_cleared(&guide, "src/c.ts", &viewed));
+        assert!(!collapses_into_cleared(&guide, "src/b.ts", &viewed));
+    }
+
+    #[test]
+    fn strips_leading_path_and_caps_members() {
+        let q = "`src/db/schema.ts` changes a contract (a, b, c, d, e, f, g, h) consumed by 32 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+        let out = clean_decision_fact(q, "src/db/schema.ts", 3);
+        // The leading path is gone (printed once by the row).
+        assert!(
+            !out.starts_with("`src/db/schema.ts`"),
+            "leading path must be stripped: {out}"
+        );
+        // The member list is capped with a "+N more".
+        assert!(out.contains("(a, b, c, +5 more)"), "got: {out}");
+        // The trailing guidance survives in full.
+        assert!(
+            out.ends_with("Coordinate the change, or is the contract stable?"),
+            "trailing question must survive: {out}"
+        );
+        // No backticks remain to be escaped.
+        assert!(!out.contains('`'), "no backticks remain: {out}");
+    }
+
+    #[test]
+    fn short_member_list_is_untouched() {
+        let q = "`src/lib/r2.ts` changes a contract (getR2, getR2Text) consumed by 6 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+        let out = clean_decision_fact(q, "src/lib/r2.ts", 6);
+        assert_eq!(
+            out,
+            "changes a contract (getR2, getR2Text) consumed by 6 modules NOT in this diff. Coordinate the change, or is the contract stable?"
+        );
+    }
+
+    #[test]
+    fn single_member_prose_parenthetical_is_untouched() {
+        let q = "`src/lib/env.ts` changes a contract (env) consumed by 22 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+        let out = clean_decision_fact(q, "src/lib/env.ts", 6);
+        assert!(out.contains("(env)"), "single member kept: {out}");
+        assert!(out.ends_with("stable?"), "trailing kept: {out}");
+    }
+
+    #[test]
+    fn non_anchor_question_keeps_its_own_path() {
+        // A boundary question names a DIFFERENT path than the anchor; it must not
+        // be stripped (the leading token is not the anchor file).
+        let q = "`ui` now imports `db` for the first time. Intended coupling, or should this edge not exist?";
+        let out = clean_decision_fact(q, "src/ui/page.ts", 6);
+        assert_eq!(out, q, "non-matching leading token is preserved");
+    }
+
+    #[test]
+    fn cap_names_first_k_then_more() {
+        let names = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ];
+        let (shown, more) = cap_names(&names, 2);
+        assert_eq!(shown, vec!["a", "b"]);
+        assert_eq!(more, 2);
+    }
+}


### PR DESCRIPTION
## What

Follow-up to #1657. Smoke-testing `fallow review --walkthrough` on a real multi-file diff surfaced rendered-output bugs. The data and JSON contracts were fine; these are presentation fixes.

- **Counts reconcile**: the Review Focus header, the status line, and the real changed set now agree (`staged + cleared + excluded == changed`), with the breakdown shown instead of three disagreeing totals.
- **Non-source files surfaced**: migrations, lockfiles, and config show as an honest "N non-source not reviewed" bucket instead of being silently dropped.
- **No double-listing**: a de-prioritized or `--mark-viewed` file collapses out of its stage and appears only under Cleared (each file in exactly one place).
- **No truncated guidance**: Stage-1 coordination guidance is no longer cut mid-word; the trailing question survives and only the contract-member list caps to N + "+M more".
- **Clean markdown**: no re-printed path, no escaped backticks.
- **Dropped the contradictory raw "(score N)"**: the visible fact carries the ordering signal.

## How

The fact, accounting, and membership logic is centralized in a new `fallow-output::walkthrough_render` module so the human and markdown surfaces stay consistent by construction.

## Invariants preserved

`--walkthrough --format json` stays byte-identical to `--walkthrough-guide` (asserted by test); the `--walkthrough-guide` / `--walkthrough-file` JSON contracts and the review exit-0 invariant are untouched.

## Verification

New tests assert the fixed behavior (counts reconcile, no file in both a stage and Cleared, viewed-file collapse, markdown has no escaped backticks or duplicated path, Stage-1 guidance survives, member lists cap). `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean; walkthrough suites green.
