### PR TITLE
fix(review): make `--walkthrough` output release-clean

### DIFF
--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -2059,21 +2059,28 @@ fn write_metric_legend(out: &mut String, report: &fallow_output::HealthReport) {
 /// Stage 2 (mechanical) sections partitioned by `concern_lens`, with synthesized
 /// badges as inline code spans, then a collapsible Cleared panel. The JSON guide
 /// path is untouched; this is the only NEW walkthrough markdown surface. No ANSI.
+///
+/// `viewed` is the root-relative file list the local ledger marked viewed (the
+/// `--mark-viewed` state). Viewed files collapse out of their stage and into the
+/// Cleared panel, and the Cleared summary reports the viewed count, so the
+/// markdown surface honors `--mark-viewed` the same way the human surface does
+/// instead of silently ignoring it.
 #[must_use]
 pub fn build_walkthrough_markdown(
     guide: &fallow_output::StandardWalkthroughGuide,
     root: &Path,
+    viewed: &[String],
 ) -> String {
     let mut out = String::new();
-    out.push_str("## Fallow Review \u{2014} Walkthrough\n\n");
-    push_walkthrough_focus(&mut out, guide);
+    out.push_str("## Fallow Review: Walkthrough\n\n");
+    push_walkthrough_focus(&mut out, guide, viewed);
 
     if guide.direction.order.is_empty() {
         out.push_str("_No reviewable units in this change (orientation only)._\n");
         return out;
     }
 
-    let (stage1, stage2) = partition_walkthrough_stages(guide);
+    let (stage1, stage2) = partition_walkthrough_stages(guide, viewed);
     push_walkthrough_stage(
         &mut out,
         "Stage 1 \u{00b7} Load-bearing",
@@ -2088,18 +2095,20 @@ pub fn build_walkthrough_markdown(
         guide,
         root,
     );
-    push_walkthrough_cleared(&mut out, guide, root);
+    push_walkthrough_cleared(&mut out, guide, root, viewed);
     out
 }
 
 /// Push the `**Focus:**` line built from the guide's triage, with the reconciled
 /// file accounting (staged + cleared + excluded) so the count matches the real
 /// changed set and non-source files are surfaced, not silently dropped.
-fn push_walkthrough_focus(out: &mut String, guide: &fallow_output::StandardWalkthroughGuide) {
+fn push_walkthrough_focus(
+    out: &mut String,
+    guide: &fallow_output::StandardWalkthroughGuide,
+    viewed: &[String],
+) {
     let triage = &guide.digest.triage;
-    // The markdown surface is a paste artifact with no local viewed-state, so the
-    // only collapse is de-prioritized; pass an empty viewed list.
-    let acc = fallow_output::WalkthroughAccounting::compute(guide, &[]);
+    let acc = fallow_output::WalkthroughAccounting::compute(guide, viewed);
     let total = acc.header_total();
     let _ = write!(
         out,
@@ -2122,17 +2131,19 @@ fn push_walkthrough_focus(out: &mut String, guide: &fallow_output::StandardWalkt
     out.push_str("\n\n");
 }
 
-/// Partition the guide's VISIBLE stage units (de-prioritized files collapsed out
-/// into Cleared) into (contract-break, orientation), each in `direction.order`.
-fn partition_walkthrough_stages(
-    guide: &fallow_output::StandardWalkthroughGuide,
+/// Partition the guide's VISIBLE stage units (de-prioritized AND viewed files
+/// collapsed out into Cleared) into (contract-break, orientation), each in
+/// `direction.order`.
+fn partition_walkthrough_stages<'a>(
+    guide: &'a fallow_output::StandardWalkthroughGuide,
+    viewed: &[String],
 ) -> (
-    Vec<&fallow_output::DirectionUnit>,
-    Vec<&fallow_output::DirectionUnit>,
+    Vec<&'a fallow_output::DirectionUnit>,
+    Vec<&'a fallow_output::DirectionUnit>,
 ) {
     let mut load_bearing = Vec::new();
     let mut mechanical = Vec::new();
-    for unit in fallow_output::visible_stage_units(guide, &[]) {
+    for unit in fallow_output::visible_stage_units(guide, viewed) {
         if unit.concern_lens == "contract-break" {
             load_bearing.push(unit);
         } else {
@@ -2162,14 +2173,12 @@ fn push_walkthrough_stage(
         } else {
             format!("  {}", badges.join(" "))
         };
-        // The raw "(score N)" is intentionally omitted: it is an internal composite
-        // that does not explain the visible within-stage order, so showing it
-        // contradicted the order. The fact carries the real ordering signal.
-        let _ = writeln!(
-            out,
-            "- `{rel}` \u{2014} {}{suffix}",
-            walkthrough_fact(unit, guide),
-        );
+        // The raw composite "(score N)" is omitted: it is an opaque attention total
+        // that did not explain the within-stage order. `walkthrough_fact` is the
+        // concrete "why" each row carries (out-of-diff count, importer count), which
+        // is also the number the within-stage order follows, so a row's position is
+        // explained by the count it shows.
+        let _ = writeln!(out, "- `{rel}`: {}{suffix}", walkthrough_fact(unit, guide));
     }
     out.push('\n');
 }
@@ -2212,8 +2221,10 @@ fn walkthrough_markdown_badges(
     badges
 }
 
-/// The one-line "why" for a markdown file row: decision question > out-of-diff
-/// count > focus reason > orientation only.
+/// The one-line "why" for a markdown file row. The cascade is decision question >
+/// out-of-diff count > focus reason > orientation only. The concrete count it
+/// carries (consumers, importers) is the same number the within-stage order
+/// follows, so the order mirrors the human surface (the count it shows).
 fn walkthrough_fact(
     unit: &fallow_output::DirectionUnit,
     guide: &fallow_output::StandardWalkthroughGuide,
@@ -2278,27 +2289,45 @@ fn walkthrough_weakened(file: &str, guide: &fallow_output::StandardWalkthroughGu
     guide.digest.weakening.iter().any(|w| w.file == file)
 }
 
-/// Push the collapsible Cleared `<details>` panel.
+/// Push the collapsible Cleared `<details>` panel: de-prioritized files plus any
+/// `--mark-viewed` files (collapsed out of their stage), with both counts in the
+/// summary so the panel reports the same `N de-prioritized, M viewed` split the
+/// human surface does.
 fn push_walkthrough_cleared(
     out: &mut String,
     guide: &fallow_output::StandardWalkthroughGuide,
     root: &Path,
+    viewed: &[String],
 ) {
     let deprioritized = &guide.digest.focus.deprioritized;
-    if deprioritized.is_empty() {
+    // Viewed files NOT already de-prioritized, so a viewed-and-de-prioritized file
+    // lands in exactly one bucket (no double count), mirroring the human surface.
+    let viewed_only: Vec<&String> = viewed
+        .iter()
+        .filter(|file| !deprioritized.iter().any(|u| &u.file == *file))
+        .collect();
+    if deprioritized.is_empty() && viewed_only.is_empty() {
         return;
     }
     let _ = write!(
         out,
-        "<details><summary>Cleared ({} de-prioritized)</summary>\n\n",
+        "<details><summary>Cleared ({} de-prioritized, {} viewed)</summary>\n\n",
         deprioritized.len(),
+        viewed_only.len(),
     );
     for unit in deprioritized {
         let _ = writeln!(
             out,
-            "- `{}` \u{2014} {}",
+            "- `{}`: {}",
             markdown_relative_path_str(&unit.file, root),
             escape_backticks(&unit.reason),
+        );
+    }
+    for file in viewed_only {
+        let _ = writeln!(
+            out,
+            "- `{}`: \u{2713} viewed",
+            markdown_relative_path_str(file, root),
         );
     }
     out.push_str("\n</details>\n");
@@ -2430,12 +2459,46 @@ mod walkthrough_markdown_tests {
     #[test]
     fn renders_header_stage_and_code_span_badges() {
         let guide = guide_with_question("src/page.ts", "Couple ui to db?");
-        let md = build_walkthrough_markdown(&guide, Path::new("/project"));
+        let md = build_walkthrough_markdown(&guide, Path::new("/project"), &[]);
         assert!(md.starts_with("## Fallow Review"), "got: {md}");
         assert!(md.contains("### Stage 1"), "got: {md}");
         assert!(md.contains("`COUPLING`"), "badges are code spans: {md}");
         assert!(md.contains("`OUT-OF-DIFF`"), "got: {md}");
         assert!(!md.contains('\u{1b}'), "no ANSI in markdown");
+        // The file->description separator is a colon, not the house-style-banned
+        // em-dash that the list items used to lead with.
+        assert!(
+            md.contains("- `src/page.ts`: "),
+            "list items use a colon separator: {md}"
+        );
+        assert!(
+            !md.contains("- `src/page.ts` \u{2014} "),
+            "no em-dash file separator: {md}"
+        );
+    }
+
+    // The markdown surface honors `--mark-viewed`: a viewed file collapses out of
+    // its stage into the Cleared panel, and the summary reports the viewed count
+    // (the same on-disk state the human surface reads), no longer ignored.
+    #[test]
+    fn viewed_file_collapses_into_cleared_in_markdown() {
+        let guide = guide_with_question("src/page.ts", "Couple ui to db?");
+        let viewed = vec!["src/page.ts".to_string()];
+        let md = build_walkthrough_markdown(&guide, Path::new("/project"), &viewed);
+        // The viewed file is no longer rendered in a stage section.
+        assert!(
+            !md.contains("### Stage 1"),
+            "viewed file left its stage: {md}"
+        );
+        // The Cleared panel reports the viewed count and lists the viewed file.
+        assert!(
+            md.contains("Cleared (0 de-prioritized, 1 viewed)"),
+            "cleared reports viewed count: {md}"
+        );
+        assert!(
+            md.contains("- `src/page.ts`: \u{2713} viewed"),
+            "viewed file listed under cleared: {md}"
+        );
     }
 
     // F5/F7: a coordination question must NOT re-print the anchor path inside the
@@ -2445,7 +2508,7 @@ mod walkthrough_markdown_tests {
     fn fact_does_not_reprint_path_or_emit_escaped_backticks() {
         let q = "`src/page.ts` changes a contract (a, b, c, d, e, f, g, h, i) consumed by 9 modules NOT in this diff. Coordinate the change, or is the contract stable?";
         let guide = guide_with_question("src/page.ts", q);
-        let md = build_walkthrough_markdown(&guide, Path::new("/project"));
+        let md = build_walkthrough_markdown(&guide, Path::new("/project"), &[]);
         // No backslash-backtick anywhere (the F5 corruption).
         assert!(
             !md.contains("\\`"),
@@ -2472,7 +2535,7 @@ mod walkthrough_markdown_tests {
         let mut guide = guide_with_question("src/page.ts", "q");
         guide.direction.order.clear();
         guide.direction.units.clear();
-        let md = build_walkthrough_markdown(&guide, Path::new("/project"));
+        let md = build_walkthrough_markdown(&guide, Path::new("/project"), &[]);
         assert!(md.contains("orientation only"), "got: {md}");
     }
 }

--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -930,13 +930,19 @@ pub fn print_walkthrough_human_result(
     let guide = crate::audit_walkthrough::build_guide_from_result(result);
     record_walkthrough_marks(&guide, root, cache_dir, mark_viewed);
 
+    // Load the viewed-state ledger ONCE and share it across both surfaces, so the
+    // markdown render honors `--mark-viewed` the same way the human render does
+    // (the two formats agree on the same on-disk state instead of markdown
+    // silently ignoring it).
+    let viewed = crate::walkthrough_state::load_viewed_state(cache_dir);
+
     if matches!(result.output, OutputFormat::Markdown) {
-        let markdown = fallow_api::build_walkthrough_markdown(&guide, root);
+        let viewed_files = crate::report::walkthrough_viewed_files(&guide, &viewed);
+        let markdown = fallow_api::build_walkthrough_markdown(&guide, root, &viewed_files);
         outln!("{markdown}");
         return ExitCode::SUCCESS;
     }
 
-    let viewed = crate::walkthrough_state::load_viewed_state(cache_dir);
     let render = crate::report::build_walkthrough_human(&guide, &viewed, show_cleared);
     if !quiet {
         for line in &render.header {

--- a/crates/cli/src/audit_walkthrough.rs
+++ b/crates/cli/src/audit_walkthrough.rs
@@ -239,6 +239,31 @@ fn is_reviewable_source_unit(file: &str) -> bool {
     )
 }
 
+/// Read the displayed fan-in (importer) and fan-out counts back out of a focus
+/// unit's reason string. The reason is the canonical rendered "why" both surfaces
+/// print verbatim for a Stage-2 row ("high fan-in (N importers), fan-out M, ..."),
+/// built in `audit_focus::build_reason` straight from the raw
+/// `facts.fan_in` / `facts.fan_out`. Sorting on these parsed counts makes the
+/// within-stage order EQUAL the number on the row, instead of the hidden, capped
+/// `fan_io` blend the composite feeds on (which undersells a high-fan-in file
+/// past the cap). Returns `(0, 0)` when neither phrase is present (the reason has
+/// no fan signal), so such a unit sorts last and falls to the path tiebreak.
+fn parse_fan_counts(reason: &str) -> (u32, u32) {
+    let fan_in = extract_count(reason, "high fan-in (");
+    let fan_out = extract_count(reason, "fan-out ");
+    (fan_in, fan_out)
+}
+
+/// Parse the leading run of decimal digits immediately following `marker` in
+/// `text`. Returns `0` when the marker is absent or is not followed by a digit.
+fn extract_count(text: &str, marker: &str) -> u32 {
+    let Some(rest) = text.find(marker).map(|i| &text[i + marker.len()..]) else {
+        return 0;
+    };
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().unwrap_or(0)
+}
+
 /// Build the review direction. The SPINE is the change itself: every reviewable
 /// focus unit (`review_here` + the `deprioritized` escape hatch), so the
 /// direction is never empty when there is code to review. Ownership routing is a
@@ -299,12 +324,31 @@ pub fn build_direction(
         .collect();
 
     // Review the load-bearing units first: contract-breakers (out-of-diff
-    // consumers) ahead of the rest, then by budget (riskiest first), then path.
+    // consumers) ahead of the rest, ordered by their consumer count (the number
+    // each Stage-1 row shows as "consumed by N modules"). Within the
+    // non-contract-break tier (Stage 2, out-of-diff empty) the order follows the
+    // exact importer count each row displays as "high fan-in (N importers)" --
+    // descending fan-in, then descending fan-out, then path. We read those counts
+    // back out of the focus reason string (the canonical rendered text both
+    // surfaces print), so the top-to-bottom order is always the visible number,
+    // not the hidden, capped `fan_io` blend (a 60-importer file outranks a
+    // 5-importer file even though both cap to the same `fan_io`).
+    let fan_counts_by_file: FxHashMap<&str, (u32, u32)> = focus
+        .review_here
+        .iter()
+        .chain(focus.deprioritized.iter())
+        .map(|fu| (fu.file.as_str(), parse_fan_counts(&fu.reason)))
+        .collect();
+    let fan_counts =
+        |file: &str| -> (u32, u32) { fan_counts_by_file.get(file).copied().unwrap_or((0, 0)) };
     units.sort_by(|a, b| {
+        let (a_in, a_out) = fan_counts(&a.file);
+        let (b_in, b_out) = fan_counts(&b.file);
         b.out_of_diff
             .len()
             .cmp(&a.out_of_diff.len())
-            .then_with(|| b.scoring_budget.cmp(&a.scoring_budget))
+            .then_with(|| b_in.cmp(&a_in))
+            .then_with(|| b_out.cmp(&a_out))
             .then_with(|| a.file.cmp(&b.file))
     });
 
@@ -640,6 +684,113 @@ mod tests {
             reason: String::new(),
             confidence: Vec::new(),
         }
+    }
+
+    /// A focus unit whose `reason` carries a displayed importer count (the exact
+    /// "high fan-in (N importers)" phrasing `build_reason` emits) AND a deliberately
+    /// disagreeing, capped `fan_io` + composite `total`, so a test can prove the
+    /// within-stage order follows the DISPLAYED importer count, not the hidden blend.
+    fn focus_unit_fan(
+        file: &str,
+        importers: u32,
+        fan_io: u32,
+        total: u32,
+    ) -> crate::audit_focus::FocusUnit {
+        let s = if importers == 1 { "" } else { "s" };
+        crate::audit_focus::FocusUnit {
+            file: file.to_string(),
+            score: crate::audit_focus::FocusScore {
+                fan_io,
+                total,
+                ..Default::default()
+            },
+            label: crate::audit_focus::FocusLabel::ReviewHere,
+            reason: format!("high fan-in ({importers} importer{s})"),
+            confidence: Vec::new(),
+        }
+    }
+
+    // ORDERING PRINCIPLE: within Stage 2 the order is the DISPLAYED importer count
+    // ("high fan-in (N importers)"), NOT the hidden, capped `fan_io` blend. Here
+    // a.ts shows 5 importers, b.ts shows 60 -- but both cap to the SAME `fan_io`
+    // and a.ts even has the larger composite `total`. Neither has out-of-diff
+    // consumers (both Stage 2), so the order must follow the shown importer count:
+    // the 60-importer file first.
+    #[test]
+    fn within_stage_order_follows_visible_fan_io_not_hidden_total() {
+        let focus = FocusMap {
+            review_here: vec![
+                // a.ts: 5 importers shown, fan_io capped to 8, total 99 (hidden high).
+                focus_unit_fan("src/a.ts", 5, 8, 99),
+                // b.ts: 60 importers shown, fan_io ALSO capped to 8, total 1.
+                focus_unit_fan("src/b.ts", 60, 8, 1),
+            ],
+            deprioritized: vec![],
+        };
+        let direction = build_direction(&focus, &FxHashMap::default(), &RoutingFacts::default());
+        // The displayed importer count decides: b.ts (60 importers) before a.ts (5),
+        // even though they share a `fan_io` and a.ts has the larger composite total.
+        assert_eq!(direction.order, vec!["src/b.ts", "src/a.ts"]);
+    }
+
+    // Reading top-to-bottom, the shown importer count is non-increasing, and
+    // fan-out breaks ties among equal-importer files (here zero-importer files).
+    #[test]
+    fn stage_two_orders_by_importer_then_fanout_then_path() {
+        let focus = FocusMap {
+            review_here: vec![
+                // Two zero-importer files separated only by fan-out, plus one
+                // high-importer file that must lead regardless.
+                crate::audit_focus::FocusUnit {
+                    file: "src/zlo.ts".to_string(),
+                    score: crate::audit_focus::FocusScore::default(),
+                    label: crate::audit_focus::FocusLabel::ReviewHere,
+                    reason: "fan-out 1".to_string(),
+                    confidence: Vec::new(),
+                },
+                crate::audit_focus::FocusUnit {
+                    file: "src/zhi.ts".to_string(),
+                    score: crate::audit_focus::FocusScore::default(),
+                    label: crate::audit_focus::FocusLabel::ReviewHere,
+                    reason: "fan-out 9".to_string(),
+                    confidence: Vec::new(),
+                },
+                focus_unit_fan("src/top.ts", 12, 8, 1),
+            ],
+            deprioritized: vec![],
+        };
+        let direction = build_direction(&focus, &FxHashMap::default(), &RoutingFacts::default());
+        // top.ts (12 importers) leads; then the zero-importer files by fan-out
+        // (9 before 1), so the displayed counts are non-increasing top to bottom.
+        assert_eq!(
+            direction.order,
+            vec!["src/top.ts", "src/zhi.ts", "src/zlo.ts"]
+        );
+    }
+
+    // Contract-breakers (out-of-diff consumers) remain the strict first priority
+    // class regardless of importer count: an out-of-diff unit sorts ahead of a
+    // higher-fan-in orientation unit.
+    #[test]
+    fn out_of_diff_units_sort_ahead_of_higher_fan_io_orientation_units() {
+        let focus = FocusMap {
+            review_here: vec![
+                // contract.ts shows just 1 importer; orient.ts shows 9.
+                focus_unit_fan("src/contract.ts", 1, 1, 1),
+                focus_unit_fan("src/orient.ts", 9, 9, 9),
+            ],
+            deprioritized: vec![],
+        };
+        let mut out_of_diff = FxHashMap::default();
+        out_of_diff.insert(
+            "src/contract.ts".to_string(),
+            vec!["src/consumer.ts".to_string()],
+        );
+        let direction = build_direction(&focus, &out_of_diff, &RoutingFacts::default());
+        // contract.ts breaks a contract -> sorts first even with the lower importer
+        // count.
+        assert_eq!(direction.order, vec!["src/contract.ts", "src/orient.ts"]);
+        assert_eq!(direction.units[0].concern_lens, "contract-break");
     }
 
     #[test]

--- a/crates/cli/src/report/human/walkthrough.rs
+++ b/crates/cli/src/report/human/walkthrough.rs
@@ -96,7 +96,10 @@ fn viewed_files(input: &WalkthroughHumanInput<'_>) -> Vec<String> {
 
 /// Same, but from a raw guide + viewed-state pair (used by the header/status
 /// accounting, which do not build a full `WalkthroughHumanInput`).
-fn viewed_files_for(guide: &StandardWalkthroughGuide, viewed: &ViewedState) -> Vec<String> {
+pub(in crate::report) fn viewed_files_for(
+    guide: &StandardWalkthroughGuide,
+    viewed: &ViewedState,
+) -> Vec<String> {
     guide
         .direction
         .order
@@ -151,11 +154,12 @@ fn push_stage(
 }
 
 /// Render one file's row: the header line (path + badges) and the one-line fact
-/// beneath it. The raw "(score N)" is intentionally NOT shown: it is an internal
-/// composite that does not explain the visible within-stage order (Stage 1 is
-/// ordered by out-of-diff consumer count, Stage 2 by that same composite), so
-/// surfacing the number contradicted the order. The fact line carries the real
-/// ordering signal (consumer count / fan-in) instead.
+/// beneath it. The raw composite "(score N)" is intentionally NOT shown: it is an
+/// opaque attention total that did not explain the within-stage order. The fact
+/// line is the concrete "why" each row already carries (out-of-diff consumer
+/// count, importer count, decision question), which is also the number the
+/// within-stage order follows, so a row's position is explained by the count it
+/// shows.
 fn push_file_row(lines: &mut Vec<String>, unit: &DirectionUnit, input: &WalkthroughHumanInput<'_>) {
     let badges = synthesize_badges(unit, input);
     let badge_suffix = if badges.is_empty() {
@@ -164,13 +168,14 @@ fn push_file_row(lines: &mut Vec<String>, unit: &DirectionUnit, input: &Walkthro
         format!(" {}", badges.join(" "))
     };
     lines.push(format!("  {}{badge_suffix}", format_path(&unit.file)));
-    lines.push(format!("    {}", fact_line(unit, input.guide).dimmed()));
+    lines.push(format!("    {}", fact_why(unit, input.guide).dimmed()));
 }
 
-/// The one-line "why" for a file: the strongest available signal. Decision
-/// question (anchored at this file) > out-of-diff consumers > focus reason >
-/// orientation-only.
-fn fact_line(unit: &DirectionUnit, guide: &StandardWalkthroughGuide) -> String {
+/// The one-line "why" for a file: the strongest available signal. The cascade is
+/// decision question (anchored at this file) > out-of-diff consumers > focus
+/// reason > orientation-only. The concrete count it carries (consumers, importers)
+/// is the same number the within-stage order follows.
+fn fact_why(unit: &DirectionUnit, guide: &StandardWalkthroughGuide) -> String {
     if let Some(decision) = guide
         .digest
         .decisions
@@ -313,7 +318,7 @@ fn push_cleared_panel(lines: &mut Vec<String>, input: &WalkthroughHumanInput<'_>
     if !input.show_cleared {
         lines.push(
             format!(
-                "\u{25b8} Cleared ({} de-prioritized, {} viewed) \u{2014} pass --show-cleared to expand",
+                "\u{25b8} Cleared ({} de-prioritized, {} viewed) \u{00b7} pass --show-cleared to expand",
                 deprioritized.len(),
                 viewed_count,
             )
@@ -402,7 +407,7 @@ pub(in crate::report) fn build_focus_header(
         "{} {}",
         "\u{25cf}".cyan(),
         format!(
-            "Review Focus \u{2014} {} risk \u{00b7} {} \u{00b7} {} file{}",
+            "Review Focus: {} risk \u{00b7} {} \u{00b7} {} file{}",
             risk_label(triage.risk_class),
             effort_label(triage.review_effort),
             total,
@@ -467,16 +472,26 @@ fn focus_subline(guide: &StandardWalkthroughGuide) -> Option<String> {
 /// The final green status line (rendered to stderr by the entry point). Never a
 /// failure glyph; the walkthrough always exits 0. The count is the files visible
 /// in stages (de-prioritized + viewed already collapsed into Cleared), so it
-/// reconciles with the header's `staged` bucket.
+/// reconciles with the header's `staged` bucket. The stage count reflects the
+/// stages ACTUALLY rendered (a Stage-1-only or empty change no longer claims a
+/// hardcoded "2 stages"), and the clause is dropped entirely when nothing staged.
 #[must_use]
 pub(in crate::report) fn build_status_line(
     guide: &StandardWalkthroughGuide,
     viewed: &ViewedState,
 ) -> String {
-    let acc = WalkthroughAccounting::compute(guide, &viewed_files_for(guide, viewed));
+    let viewed_in_order = viewed_files_for(guide, viewed);
+    let acc = WalkthroughAccounting::compute(guide, &viewed_in_order);
     let files = acc.staged;
+    let (stage1, stage2) = partition_stages(guide, &viewed_in_order);
+    let stages = usize::from(!stage1.is_empty()) + usize::from(!stage2.is_empty());
+    let across = if stages == 0 {
+        String::new()
+    } else {
+        format!(" across {stages} stage{}", plural(stages))
+    };
     format!(
-        "{} Walkthrough ready \u{2014} {} file{} across 2 stages",
+        "{} Walkthrough ready: {} file{}{across}",
         "\u{2713}".green(),
         files,
         plural(files),
@@ -852,10 +867,12 @@ mod tests {
             header.contains("3 non-source not reviewed"),
             "excluded: {header}"
         );
-        // The status line agrees with the staged bucket (not the total).
+        // The status line agrees with the staged bucket (not the total). Both
+        // staged units are orientation-only, so a single Stage 2 renders and the
+        // status reports "1 stage", not a hardcoded "2 stages".
         let status = crate::report::human::strip_ansi(&build_status_line(&guide, &viewed));
         assert!(
-            status.contains("2 files across 2 stages"),
+            status.contains("2 files across 1 stage"),
             "status: {status}"
         );
     }
@@ -947,12 +964,10 @@ mod tests {
             body.contains("fresh.ts"),
             "the un-viewed file stays staged: {body}"
         );
-        // Header staged count drops the viewed file; status agrees.
+        // Header staged count drops the viewed file; status agrees. The remaining
+        // staged unit is orientation-only, so one Stage 2 renders ("1 stage").
         let status = crate::report::human::strip_ansi(&build_status_line(&guide, &viewed));
-        assert!(
-            status.contains("1 file across 2 stages"),
-            "status: {status}"
-        );
+        assert!(status.contains("1 file across 1 stage"), "status: {status}");
     }
 
     // F4/F5/F7: the contract member list is capped and the trailing guidance

--- a/crates/cli/src/report/mod.rs
+++ b/crates/cli/src/report/mod.rs
@@ -48,6 +48,18 @@ pub struct WalkthroughHumanRender {
     pub status: String,
 }
 
+/// The root-relative files (in `direction.order`) the local ledger marked viewed
+/// against the guide's current hash. Exposed so the markdown surface can collapse
+/// the same viewed files into Cleared that the human surface does, keeping the two
+/// formats consistent on the same on-disk `--mark-viewed` state.
+#[must_use]
+pub fn walkthrough_viewed_files(
+    guide: &fallow_output::StandardWalkthroughGuide,
+    viewed: &crate::walkthrough_state::ViewedState,
+) -> Vec<String> {
+    human::walkthrough::viewed_files_for(guide, viewed)
+}
+
 /// Build the human walkthrough tour from the in-memory guide. Pure: no IO, no
 /// mutation. `viewed` decorates each file row; `show_cleared` expands the
 /// Cleared panel.


### PR DESCRIPTION
## What

Follow-up to #1660. A tidiness pass making `fallow review --walkthrough` output release-clean.

- **Legible ordering**: each stage now orders by the concrete count it displays, so a file's position is explained by a visible number. Stage 1 by out-of-diff consumer count ("consumed by N modules"); Stage 2 by fan-in importer count, then fan-out. The most-imported file now leads Stage 2 instead of sitting mid-list, and no abstract score/connectedness number is shown.
- **Markdown honors `--mark-viewed`**: viewed files now collapse out of their stage into Cleared in markdown too (previously silently ignored), matching the human surface.
- **Honest stage count**: the status line reports the number of stages actually rendered (was a hardcoded "2 stages" that could lie when a stage was empty).
- **No em-dashes**: removed em-dashes from the rendered output (headers and list separators) for one consistent separator vocabulary.

## Invariants

Render-surface and sort-order only. `--walkthrough --format json` stays byte-identical to `--walkthrough-guide` (asserted by test); the `--walkthrough-guide` / `--walkthrough-file` JSON contracts and the review exit-0 invariant are untouched.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean; output + cli walkthrough suites green; re-rendered on two real multi-file diffs to confirm each stage's order matches its shown count, with no abstract number and no em-dashes.
