### PR TITLE
feat(ci): let the GitLab CI template reuse a pre-installed fallow binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The GitLab CI template can reuse a pre-installed fallow binary.** Set
+  `FALLOW_SKIP_INSTALL: "true"` to skip `npm install -g fallow` and run the
+  `fallow` already resolvable on `PATH`, for example a version pinned through
+  a pnpm catalog and exposed on `PATH`, so CI runs the same binary as your
+  local lint gate. The job fails fast with a clear error when no `fallow` is
+  found. Default behavior is unchanged.
+
 - **Fuzzy CSS clones via CSS-aware value canonicalization (CSS program Phase 4).**
   `fallow dupes` already tokenized CSS, but the lexer was character-naive, so
   near-miss / value-drifted CSS clones (the same shadow / gradient / transition

--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ The GitLab CI template can post rich comments directly on merge requests -- summ
 | `FALLOW_GITLAB_BASE_SHA` / `FALLOW_GITLAB_START_SHA` / `FALLOW_GITLAB_HEAD_SHA` | `""` | Optional overrides for the GitLab MR `diff_refs` used to build inline discussion positions |
 | `FALLOW_SCRIPTS_REF` | `""` | Pinned tag or commit for remote MR-integration scripts; leave empty to prefer vendored local `ci/` + `action/` scripts |
 | `FALLOW_VERSION` | `""` | Fallow version to install. Empty reads the project's `package.json` `fallow` dependency, then falls back to `latest`; set explicitly to override the local pin |
+| `FALLOW_SKIP_INSTALL` | `""` | Set to `"true"` to skip `npm install -g fallow` and use the `fallow` already resolvable on `PATH` (for example a pnpm-catalog pin you expose by adding its `node_modules/.bin` to `PATH`, or a global install). The job fails fast if no `fallow` is found. Lets you run the template's MR feedback against your own pinned binary and base `image:` |
 
 In MR pipelines, `--changed-since` is set automatically to scope analysis to changed files, and the comment / review scripts derive a unified diff so inline discussions stay on touched lines by default. Fallow edits sticky comments in place and fingerprints inline review comments so repeated runs can skip duplicates. `FALLOW_SUMMARY_SCOPE=diff` keeps the sticky summary focused too: a pre-existing unused dependency in an unrelated package is hidden, while a newly added unused dependency in a changed `package.json` remains visible. If the diff cannot be fetched or read, fallow keeps the existing fail-open behavior and reports all findings.
 
@@ -715,6 +716,7 @@ GitLab setup gotchas:
 - The template sets `GIT_DEPTH: "0"` so `--changed-since` can diff against the MR base SHA without shallow-clone ambiguity.
 - For private GitLab npm registries, create `.npmrc` during the job with `${CI_PROJECT_ID}` and `${CI_JOB_TOKEN}` rather than committing tokens.
 - For pnpm projects with `minimumReleaseAge`, add `fallow` and `@fallow-cli/*` to `minimumReleaseAgeExclude` when you need to consume a just-published fallow release immediately.
+- To run the template against a fallow you install yourself (e.g. a pnpm-catalog pin), set `FALLOW_SKIP_INSTALL: "true"`, override `image:` to your base image, and make sure your install step leaves `fallow` resolvable on the job shell's `PATH`. A bare `pnpm install`/`npm install` only writes `node_modules/.bin/fallow`, which GitLab does **not** add to `PATH` automatically — prepend it in a `before_script` (e.g. `export PATH="$CI_PROJECT_DIR/node_modules/.bin:$PATH"`) or install fallow globally. The job then skips `npm install -g fallow` and runs your exact binary, so CI matches your local lint gate.
 
 ```yaml
 # .gitlab-ci.yml -- full example with rich MR comments

--- a/README.md
+++ b/README.md
@@ -716,7 +716,19 @@ GitLab setup gotchas:
 - The template sets `GIT_DEPTH: "0"` so `--changed-since` can diff against the MR base SHA without shallow-clone ambiguity.
 - For private GitLab npm registries, create `.npmrc` during the job with `${CI_PROJECT_ID}` and `${CI_JOB_TOKEN}` rather than committing tokens.
 - For pnpm projects with `minimumReleaseAge`, add `fallow` and `@fallow-cli/*` to `minimumReleaseAgeExclude` when you need to consume a just-published fallow release immediately.
-- To run the template against a fallow you install yourself (e.g. a pnpm-catalog pin), set `FALLOW_SKIP_INSTALL: "true"`, override `image:` to your base image, and make sure your install step leaves `fallow` resolvable on the job shell's `PATH`. A bare `pnpm install`/`npm install` only writes `node_modules/.bin/fallow`, which GitLab does **not** add to `PATH` automatically — prepend it in a `before_script` (e.g. `export PATH="$CI_PROJECT_DIR/node_modules/.bin:$PATH"`) or install fallow globally. The job then skips `npm install -g fallow` and runs your exact binary, so CI matches your local lint gate.
+- To run the template against a fallow you install yourself (e.g. a pnpm-catalog pin), set `FALLOW_SKIP_INSTALL: "true"`, override `image:` to your base image, and make sure your install step leaves `fallow` resolvable on the job shell's `PATH`. A bare `pnpm install`/`npm install` only writes `node_modules/.bin/fallow`, which GitLab does **not** add to `PATH` automatically, so prepend it yourself. A job that `extends: .fallow` and defines its own `before_script` **replaces** the template's `before_script` (GitLab does not merge them), so compose with `!reference` to keep the template's install + script-prep block:
+
+  ```yaml
+  fallow:
+    extends: .fallow
+    before_script:
+      - export PATH="$CI_PROJECT_DIR/node_modules/.bin:$PATH"
+      - !reference [.fallow, before_script]
+    variables:
+      FALLOW_SKIP_INSTALL: "true"
+  ```
+
+  The job then skips `npm install -g fallow` and runs your exact binary, so CI matches your local lint gate. If you also enable `FALLOW_COMMENT`/`FALLOW_REVIEW` and your binary is a dev build whose `--version` is not an exact release (e.g. `2.3.0-dev`), pin `FALLOW_SCRIPTS_REF` to a real tag or vendor `ci/scripts/` so the MR-integration scripts can still be fetched.
 
 ```yaml
 # .gitlab-ci.yml -- full example with rich MR comments

--- a/ci/gitlab-ci.yml
+++ b/ci/gitlab-ci.yml
@@ -76,6 +76,7 @@ variables:
 
   # Core
   FALLOW_VERSION: ""             # Empty reads package.json fallow dependency, then falls back to latest
+  FALLOW_SKIP_INSTALL: ""        # "true" skips `npm install -g fallow` and uses the fallow already on PATH (e.g. a pnpm-catalog pin installed by a prior `pnpm install`). Fails fast if no fallow is found.
   FALLOW_COMMAND: ""            # dead-code, dupes, health, audit, security, fix, or empty (runs all)
   FALLOW_ROOT: "."
   FALLOW_CONFIG: ""             # Path to .fallowrc.json, .fallowrc.jsonc, fallow.toml, or .fallow.toml
@@ -252,6 +253,27 @@ variables:
       }
       NODE
       }
+
+      # FALLOW_SKIP_INSTALL lets a pipeline reuse a fallow binary that is already
+      # on PATH (e.g. a pnpm-catalog pin installed by a prior `pnpm install`)
+      # instead of `npm install -g fallow` at pipeline time. Default empty
+      # preserves the install behavior below.
+      if [ "$(trim "${FALLOW_SKIP_INSTALL:-}")" = "true" ]; then
+        if ! command -v fallow > /dev/null 2>&1; then
+          echo "ERROR: FALLOW_SKIP_INSTALL=true but no 'fallow' binary is on PATH. Install fallow before this job (e.g. 'pnpm install' so a pinned fallow lands on PATH), or unset FALLOW_SKIP_INSTALL to let the template run 'npm install -g fallow'."
+          exit 2
+        fi
+        installed_version="$(fallow --version 2>/dev/null || echo 'unknown version')"
+        echo "Skipping install; using pre-installed ${installed_version} ($(command -v fallow))"
+        # Let the MR-integration script-prep block pin remote scripts to the
+        # matching release tag when the binary reports an exact semver (parity
+        # with the install path, which writes the resolved spec here).
+        installed_semver="$(printf '%s\n' "$installed_version" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+([-.][a-zA-Z0-9.]+)?' | head -n 1 || true)"
+        if [ -n "$installed_semver" ]; then
+          printf '%s\n' "$installed_semver" > /tmp/fallow-version-spec
+        fi
+        exit 0
+      fi
 
       requested_version="$(trim "${FALLOW_VERSION:-}")"
       root="${FALLOW_ROOT:-.}"

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -157,6 +157,42 @@ else
   fail "install: rejects dash-prefixed extra args in spec" "expected non-zero exit"
 fi
 
+# FALLOW_SKIP_INSTALL: reuse a fallow already on PATH instead of npm install.
+SKIP_BIN="$INSTALL_TMP/skip-bin"
+mkdir -p "$SKIP_BIN"
+cat > "$SKIP_BIN/fallow" <<'SH'
+#!/usr/bin/env bash
+echo "fallow 9.9.9"
+SH
+chmod +x "$SKIP_BIN/fallow"
+
+# FALLOW_INSTALL_DRY_RUN=true stays set so the assertion proves the skip path
+# short-circuits before the npm-install dry-run hook ever runs.
+OUT=$(PATH="$SKIP_BIN:$PATH" FALLOW_ROOT="$INSTALL_TMP/empty" \
+  FALLOW_SKIP_INSTALL=true FALLOW_INSTALL_DRY_RUN=true \
+  /bin/sh -c "$GITLAB_INSTALL_SCRIPT" 2>&1)
+skip_status=$?
+if [ "$skip_status" -eq 0 ]; then
+  pass "install: FALLOW_SKIP_INSTALL succeeds when fallow is on PATH"
+else
+  fail "install: FALLOW_SKIP_INSTALL succeeds when fallow is on PATH" "exit=$skip_status: $OUT"
+fi
+assert_contains "$OUT" "using pre-installed fallow 9.9.9" "install: FALLOW_SKIP_INSTALL reuses fallow on PATH"
+assert_not_contains "$OUT" "DRY RUN: npm install" "install: FALLOW_SKIP_INSTALL skips npm install"
+
+# No fallow on PATH -> clear, early error (controlled PATH keeps this hermetic).
+OUT=$(PATH="/usr/bin:/bin" FALLOW_ROOT="$INSTALL_TMP/empty" \
+  FALLOW_SKIP_INSTALL=true FALLOW_INSTALL_DRY_RUN=true \
+  /bin/sh -c "$GITLAB_INSTALL_SCRIPT" 2>&1)
+skip_status=$?
+if [ "$skip_status" -eq 2 ]; then
+  pass "install: FALLOW_SKIP_INSTALL fails with exit 2 when fallow is missing"
+else
+  fail "install: FALLOW_SKIP_INSTALL fails with exit 2 when fallow is missing" "expected exit 2, got $skip_status"
+fi
+assert_contains "$OUT" "no 'fallow' binary is on PATH" "install: FALLOW_SKIP_INSTALL explains missing binary"
+assert_not_contains "$OUT" "DRY RUN: npm install" "install: missing-binary path never reaches npm install"
+
 SCRIPT_PREP_TMP="$INSTALL_TMP/script-prep"
 mkdir -p "$SCRIPT_PREP_TMP/ci/scripts"
 printf '%s\n' '#!/usr/bin/env bash' 'echo comment' > "$SCRIPT_PREP_TMP/ci/scripts/comment.sh"
@@ -987,6 +1023,7 @@ assert_contains "$(cat "$CI_YAML")" '((.dupes.clone_groups // []) | length)' "co
 assert_contains "$(cat "$CI_YAML")" "project_fallow_spec" "reads package.json fallow pin"
 assert_contains "$(cat "$CI_YAML")" "is_safe_version_spec" "validates fallow install spec"
 assert_contains "$(cat "$CI_YAML")" "FALLOW_INSTALL_DRY_RUN" "supports install dry-run testing"
+assert_contains "$(cat "$CI_YAML")" "FALLOW_SKIP_INSTALL" "supports skip-install for pre-installed fallow"
 assert_contains "$(cat "$CI_YAML")" "GIT_STRATEGY" "overrides shared template git strategy"
 assert_contains "$(cat "$CI_YAML")" "GIT_DEPTH" "fetches full history for changed-since"
 assert_contains "$(cat "$CI_YAML")" "CI_MERGE_REQUEST_DIFF_BASE_SHA" "auto changed-since uses diff base SHA"

--- a/ci/tests/run.sh
+++ b/ci/tests/run.sh
@@ -168,6 +168,7 @@ chmod +x "$SKIP_BIN/fallow"
 
 # FALLOW_INSTALL_DRY_RUN=true stays set so the assertion proves the skip path
 # short-circuits before the npm-install dry-run hook ever runs.
+rm -f /tmp/fallow-version-spec
 OUT=$(PATH="$SKIP_BIN:$PATH" FALLOW_ROOT="$INSTALL_TMP/empty" \
   FALLOW_SKIP_INSTALL=true FALLOW_INSTALL_DRY_RUN=true \
   /bin/sh -c "$GITLAB_INSTALL_SCRIPT" 2>&1)
@@ -179,6 +180,9 @@ else
 fi
 assert_contains "$OUT" "using pre-installed fallow 9.9.9" "install: FALLOW_SKIP_INSTALL reuses fallow on PATH"
 assert_not_contains "$OUT" "DRY RUN: npm install" "install: FALLOW_SKIP_INSTALL skips npm install"
+# The skip path must record the binary's semver to /tmp/fallow-version-spec so the
+# MR-integration script-prep block can pin remote scripts (parity with install path).
+assert_contains "$(cat /tmp/fallow-version-spec 2>/dev/null || true)" "9.9.9" "install: FALLOW_SKIP_INSTALL records binary semver for script-prep parity"
 
 # No fallow on PATH -> clear, early error (controlled PATH keeps this hermetic).
 OUT=$(PATH="/usr/bin:/bin" FALLOW_ROOT="$INSTALL_TMP/empty" \


### PR DESCRIPTION
## Summary

Adds an opt-in `FALLOW_SKIP_INSTALL` variable to the GitLab CI template so a pipeline can reuse a `fallow` binary that is **already on `PATH`** instead of running `npm install -g fallow` at pipeline time. Default is empty — behaviour is unchanged for everyone who doesn't set it.

When `FALLOW_SKIP_INSTALL: "true"`:
- the install `before_script` block skips the `npm install -g` path and uses the `fallow` already resolvable on `PATH`;
- if no `fallow` is found it fails fast with a clear error and **exit 2** (before any npm install runs);
- it records the binary's exact semver to `/tmp/fallow-version-spec` so the existing MR-integration script-prep can still pin remote `comment.sh`/`review.sh` to the matching release tag (parity with the install path).

## Motivation

We run a pnpm monorepo where `fallow` is pinned in our pnpm **catalog** and installed by our shared `pnpm install`; our lint gate and developers use that exact pinned binary. We want the template's MR feedback (Code Quality report + summary comment + inline review), but today the template:

- always `npm install -g fallow` at runtime, which runs a **different** fallow version than our gate/devs (a `catalog:` spec is rejected by `is_safe_version_spec`, so it falls back to `latest`);
- adds runtime supply-chain surface (npm install + a `raw.githubusercontent.com` script fetch).

There was previously **no way** to skip the install and reuse our binary. With this, a consumer can `extends: .fallow` as a separate job, set `FALLOW_SKIP_INSTALL: "true"`, override `image:` to their own base image, run their own install so the pinned `fallow` is on `PATH`, and get the widget + comment + review with their pinned binary.

## Design

Backwards-compatible and opt-in, mirroring the existing internal `FALLOW_INSTALL_DRY_RUN` hook (short-circuit + `exit 0` out of the `bash -eo pipefail` heredoc). The skip block sits before version resolution and only triggers on `FALLOW_SKIP_INSTALL == "true"`; every other path falls through to the unchanged install logic.

The PATH check runs in the same environment the later `script:` block inherits, so a successful `command -v fallow` in the install block means the analysis run resolves the same binary.

`crates/cli/src/ci_template.rs` needs no change — it `include_str!`s `crates/cli/templates/ci/gitlab-ci.yml`, a symlink to the canonical `ci/gitlab-ci.yml`, so the edit flows through to `fallow ci-template gitlab` automatically.

## Files changed

- `ci/gitlab-ci.yml` — new `FALLOW_SKIP_INSTALL` variable + install-block short-circuit.
- `ci/tests/run.sh` — tests: reuse-on-PATH succeeds, npm install is skipped, missing binary exits 2 with a clear error and never reaches the install, plus a template-marker assert.
- `README.md` — variable-table row + a GitLab gotcha noting that `node_modules/.bin` is not auto-added to a GitLab job's `PATH` (prepend it or install globally).
- `CHANGELOG.md` — `Unreleased → Added` entry.

## Testing

- `bash ci/tests/run.sh` — **311 passed, 0 failed**.
- `cargo test -p fallow-cli --bins ci_template` — 3 passed (incl. the `for f in` loop-sync guard).

## Acceptance criteria

1. `FALLOW_SKIP_INSTALL=true` + `fallow` on PATH → analysis runs with the pre-installed binary, no `npm install -g`. ✅
2. `FALLOW_SKIP_INSTALL=true` + no `fallow` on PATH → clear, early error (exit 2). ✅
3. Default (unset) → identical to today. ✅
4. `fallow ci-template gitlab` reflects the new variable; docs + tests updated. ✅

## Follow-up (not in this PR)

An explicit `FALLOW_BIN` (path to the executable) was considered. In GitLab each `bash <<EOF` block is a child process, so an `export PATH` in the install block would not persist to the later `script:` / `comment.sh` / `review.sh` blocks; making `FALLOW_BIN` robust needs image-specific filesystem symlinks. Since the supported workflow only needs the binary on `PATH`, `FALLOW_SKIP_INSTALL` alone covers it; `FALLOW_BIN` can follow if there's demand.
