### PR TITLE
feat(coverage): emit per-function complexity and per-file churn in inventory upload

### DIFF
--- a/crates/cli/src/coverage/upload_inventory.rs
+++ b/crates/cli/src/coverage/upload_inventory.rs
@@ -15,15 +15,16 @@
 //! This subcommand is a paid-tier workflow. It runs only when the user
 //! invokes it explicitly; no other fallow command touches the network.
 
+use std::collections::BTreeMap;
 use std::fmt::{self, Write as _};
 use std::path::Path;
 use std::process::ExitCode;
 
 use fallow_config::ResolvedConfig;
 use fallow_cov_protocol::{FunctionIdentity, IdentityResolution, function_identity_id};
-use fallow_engine::{
-    discover, extract::inventory::InventoryEntry, extract::inventory::walk_source,
-};
+use fallow_engine::churn::{ChurnResult, ChurnTrend, FileChurn, analyze_churn_cached, parse_since};
+use fallow_engine::extract::inventory::{InventoryComplexity, InventoryEntry};
+use fallow_engine::{discover, extract::inventory::walk_source_with_complexity};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
@@ -42,10 +43,26 @@ use crate::coverage::upload_common;
 /// by sibling commands so CI log parsers can anchor on it.
 const LOG_PREFIX: &str = "fallow coverage upload-inventory";
 
-/// Server-enforced cap on inventory size. Mirrors `INVENTORY_MAX_FUNCTIONS` in
-/// `fallow-cloud/src/services/inventory.ts`. Validated client-side so users
-/// see a specific error before a 400 round-trip.
+/// Client-side mirror of the server cap on inventory size. Validated here so
+/// users see a specific error before a 400 round-trip.
 const INVENTORY_MAX_FUNCTIONS: usize = 200_000;
+
+/// Wire version of the inventory upload payload. Bumped from the implicit v1
+/// (no version field, identity-only functions) to v2 the moment the payload
+/// began carrying per-function complexity and a per-file churn map. The field
+/// is informational and additive: the server reads the new fields by presence,
+/// not by branching on the version, so a v1-shaped body (no version, no new
+/// fields) still validates. Older servers ignore the unknown `version` and the
+/// extra fields, so a newer CLI keeps uploading successfully.
+const INVENTORY_BLOB_VERSION: u8 = 2;
+
+/// Git-history window used to compute the per-file churn shipped alongside the
+/// inventory. Matches the default window the local hotspot analysis uses, so
+/// the uploaded churn lines up with what `fallow` reports locally. The signal
+/// is recency-weighted (90-day half-life), so a longer window mostly adds
+/// near-zero-weight history; six months captures the active hot files without
+/// dragging in stale churn.
+const CHURN_SINCE: &str = "6m";
 
 /// HTTP timeouts for the upload. The body is small (<=200k function entries)
 /// but can take longer than license's 10s global cap on congested networks.
@@ -173,6 +190,7 @@ fn run_inner(args: &UploadInventoryArgs, root: &Path) -> Result<(), UploadError>
     let config = load_resolved_config(root)?;
     let exclude_matcher = compile_exclude_matcher(&args.exclude_paths)?;
     let functions = collect_inventory(&config, &exclude_matcher, path_prefix.as_deref());
+    let churn_by_path = collect_churn(&config, path_prefix.as_deref());
 
     if functions.is_empty() {
         return Err(UploadError::Validation(
@@ -194,8 +212,10 @@ fn run_inner(args: &UploadInventoryArgs, root: &Path) -> Result<(), UploadError>
     }
 
     let payload = InventoryRequest {
+        version: INVENTORY_BLOB_VERSION,
         git_sha: &git_sha,
         functions: &functions,
+        churn_by_path,
     };
 
     if args.dry_run {
@@ -303,15 +323,21 @@ fn collect_inventory(
             Some(prefix) => format!("{prefix}/{repo_relative}"),
             None => repo_relative.clone(),
         };
-        for entry in walk_source(&file.path, &source) {
+        let (entries, complexity) = walk_source_with_complexity(&file.path, &source);
+        for entry in entries {
             let dedupe_key = (posix_path.clone(), entry.name.clone(), entry.line);
             if !seen.insert(dedupe_key) {
                 continue;
             }
+            // Complexity is paired by `source_hash`, which both the inventory
+            // walker and the complexity visitor derive from the identical
+            // full-span slice over the same parse, so the lookup is exact.
+            let metrics = complexity.get(&entry.source_hash).copied();
             out.push(InventoryFunction::from_entry(
                 &posix_path,
                 &repo_relative,
                 entry,
+                metrics,
             ));
         }
     }
@@ -320,6 +346,56 @@ fn collect_inventory(
             .cmp(&b.file_path)
             .then(a.line_number.cmp(&b.line_number))
     });
+    out
+}
+
+/// Compute per-file git churn for the walked tree and key it by the SAME
+/// `filePath` shape [`collect_inventory`] emits (repo-relative posix, with
+/// `--path-prefix` applied), so the server can join a runtime file path to its
+/// churn without any path-shape guessing.
+///
+/// Churn is best-effort context: a non-git root, a shallow clone, or any git
+/// failure yields an empty map and never an error. The walked tree's ignore
+/// rules don't apply to git history, so the result is filtered to files that
+/// actually live under the project root and survive a posix normalization.
+fn collect_churn(
+    config: &ResolvedConfig,
+    path_prefix: Option<&str>,
+) -> BTreeMap<String, FileChurnPayload> {
+    let Ok(since) = parse_since(CHURN_SINCE) else {
+        return BTreeMap::new();
+    };
+    let Some((result, _cache_hit)) =
+        analyze_churn_cached(&config.root, &since, &config.cache_dir, config.no_cache)
+    else {
+        return BTreeMap::new();
+    };
+    churn_to_payload(&config.root, &result, path_prefix)
+}
+
+/// Map an absolute-path-keyed [`ChurnResult`] to a posix-path-keyed payload map.
+/// Files outside the project root are dropped (they can't join a runtime path
+/// that is reported relative to the deployed tree).
+fn churn_to_payload(
+    root: &Path,
+    result: &ChurnResult,
+    path_prefix: Option<&str>,
+) -> BTreeMap<String, FileChurnPayload> {
+    let mut out: BTreeMap<String, FileChurnPayload> = BTreeMap::new();
+    for file in result.files.values() {
+        let Ok(rel) = file.path.strip_prefix(root) else {
+            continue;
+        };
+        let repo_relative = to_posix_string(rel);
+        if repo_relative.is_empty() {
+            continue;
+        }
+        let key = match path_prefix {
+            Some(prefix) => format!("{prefix}/{repo_relative}"),
+            None => repo_relative,
+        };
+        out.insert(key, FileChurnPayload::from_file_churn(file));
+    }
     out
 }
 
@@ -412,10 +488,25 @@ struct InventoryFunction {
     /// would diverge and the join would silently break. `--path-prefix` only
     /// affects the legacy `filePath`, never the identity hash.
     identity: FunctionIdentity,
+    /// `McCabe` cyclomatic complexity (1 + decision points). Optional so a
+    /// function whose span slice could not be paired to a complexity result,
+    /// and any future producer that skips complexity, simply omits the field.
+    /// Descriptive context for downstream importance weighting; never a gate.
+    #[serde(rename = "cyclomatic", skip_serializing_if = "Option::is_none")]
+    cyclomatic: Option<u16>,
+    /// `SonarSource` cognitive complexity (structural + nesting penalty).
+    /// Optional with the same omit-when-absent semantics as `cyclomatic`.
+    #[serde(rename = "cognitive", skip_serializing_if = "Option::is_none")]
+    cognitive: Option<u16>,
 }
 
 impl InventoryFunction {
-    fn from_entry(posix_path: &str, repo_relative: &str, entry: InventoryEntry) -> Self {
+    fn from_entry(
+        posix_path: &str,
+        repo_relative: &str,
+        entry: InventoryEntry,
+        complexity: Option<InventoryComplexity>,
+    ) -> Self {
         let stable_id = function_identity_id(repo_relative, &entry.name, entry.line);
         let identity = FunctionIdentity {
             file: repo_relative.to_owned(),
@@ -433,15 +524,76 @@ impl InventoryFunction {
             function_name: entry.name,
             line_number: entry.line,
             identity,
+            cyclomatic: complexity.map(|c| c.cyclomatic),
+            cognitive: complexity.map(|c| c.cognitive),
         }
     }
 }
 
 #[derive(Debug, Serialize)]
 struct InventoryRequest<'a> {
+    version: u8,
     #[serde(rename = "gitSha")]
     git_sha: &'a str,
     functions: &'a [InventoryFunction],
+    /// Per-file git churn keyed by the same `filePath` shape `functions` use
+    /// (repo-relative posix, `--path-prefix` applied). Skipped entirely when
+    /// empty (non-git root, shallow clone, or git failure) so older servers and
+    /// non-git uploads keep the exact pre-enrichment wire shape.
+    #[serde(rename = "churnByPath", skip_serializing_if = "BTreeMap::is_empty")]
+    churn_by_path: BTreeMap<String, FileChurnPayload>,
+}
+
+/// Wire form of a single file's churn. All fields optional so a future
+/// producer can ship a subset and so the server treats each independently as
+/// best-effort context. `trend` serializes as the same snake-case strings the
+/// rest of fallow uses (`accelerating` / `stable` / `cooling`).
+#[derive(Debug, Serialize)]
+struct FileChurnPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commits: Option<u32>,
+    #[serde(rename = "weightedCommits", skip_serializing_if = "Option::is_none")]
+    weighted_commits: Option<f64>,
+    #[serde(rename = "linesAdded", skip_serializing_if = "Option::is_none")]
+    lines_added: Option<u32>,
+    #[serde(rename = "linesDeleted", skip_serializing_if = "Option::is_none")]
+    lines_deleted: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trend: Option<&'static str>,
+    /// Distinct-author count for this file (number of authors touching it in the
+    /// window). This is NOT an ownership signal: ownership is defined by
+    /// CODEOWNERS and resolved separately. It is churn context only.
+    #[serde(rename = "authorCount", skip_serializing_if = "Option::is_none")]
+    author_count: Option<u32>,
+    /// Most recent commit timestamp touching this file, epoch SECONDS, derived
+    /// as the max over the file's per-author last-commit timestamps.
+    #[serde(rename = "lastCommitTs", skip_serializing_if = "Option::is_none")]
+    last_commit_ts: Option<u64>,
+}
+
+impl FileChurnPayload {
+    fn from_file_churn(file: &FileChurn) -> Self {
+        let trend = match file.trend {
+            ChurnTrend::Accelerating => "accelerating",
+            ChurnTrend::Stable => "stable",
+            ChurnTrend::Cooling => "cooling",
+        };
+        let author_count = u32::try_from(file.authors.len()).ok();
+        let last_commit_ts = file
+            .authors
+            .values()
+            .map(|author| author.last_commit_ts)
+            .max();
+        Self {
+            commits: Some(file.commits),
+            weighted_commits: Some(file.weighted_commits),
+            lines_added: Some(file.lines_added),
+            lines_deleted: Some(file.lines_deleted),
+            trend: Some(trend),
+            author_count,
+            last_commit_ts,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1231,8 +1383,12 @@ mod tests {
 
     #[test]
     fn identity_stable_id_is_repo_relative_not_prefixed() {
-        let func =
-            InventoryFunction::from_entry("/app/src/render.tsx", "src/render.tsx", sample_entry());
+        let func = InventoryFunction::from_entry(
+            "/app/src/render.tsx",
+            "src/render.tsx",
+            sample_entry(),
+            None,
+        );
         assert_eq!(func.file_path, "/app/src/render.tsx");
         assert_eq!(func.identity.file, "src/render.tsx");
         assert_eq!(
@@ -1243,10 +1399,14 @@ mod tests {
 
     #[test]
     fn identity_stable_id_unchanged_by_path_prefix() {
-        let with_prefix =
-            InventoryFunction::from_entry("/app/src/render.tsx", "src/render.tsx", sample_entry());
+        let with_prefix = InventoryFunction::from_entry(
+            "/app/src/render.tsx",
+            "src/render.tsx",
+            sample_entry(),
+            None,
+        );
         let without_prefix =
-            InventoryFunction::from_entry("src/render.tsx", "src/render.tsx", sample_entry());
+            InventoryFunction::from_entry("src/render.tsx", "src/render.tsx", sample_entry(), None);
         assert_ne!(with_prefix.file_path, without_prefix.file_path);
         assert_eq!(
             with_prefix.identity.stable_id,
@@ -1265,7 +1425,7 @@ mod tests {
 
     #[test]
     fn inventory_function_emits_resolved_columns() {
-        let func = InventoryFunction::from_entry("src/a.ts", "src/a.ts", sample_entry());
+        let func = InventoryFunction::from_entry("src/a.ts", "src/a.ts", sample_entry(), None);
         assert_eq!(func.identity.resolution, IdentityResolution::Resolved);
         assert_eq!(func.identity.start_column, Some(1));
         assert_eq!(func.identity.end_line, Some(50));
@@ -1273,6 +1433,51 @@ mod tests {
         assert_eq!(
             func.identity.source_hash.as_deref(),
             Some("0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn inventory_function_carries_complexity_when_paired() {
+        let metrics = InventoryComplexity {
+            cyclomatic: 7,
+            cognitive: 4,
+        };
+        let func =
+            InventoryFunction::from_entry("src/a.ts", "src/a.ts", sample_entry(), Some(metrics));
+        assert_eq!(func.cyclomatic, Some(7));
+        assert_eq!(func.cognitive, Some(4));
+    }
+
+    #[test]
+    fn inventory_function_omits_complexity_when_unpaired() {
+        let func = InventoryFunction::from_entry("src/a.ts", "src/a.ts", sample_entry(), None);
+        assert_eq!(func.cyclomatic, None);
+        assert_eq!(func.cognitive, None);
+        // Optional + skip-if-none means the field is absent from the wire form,
+        // so an older server and a non-complexity producer stay byte-compatible.
+        let json = serde_json::to_string(&func).expect("serialize");
+        assert!(
+            !json.contains("cyclomatic"),
+            "unpaired complexity must not appear on the wire: {json}"
+        );
+    }
+
+    #[test]
+    fn complexity_populates_from_real_walk() {
+        // Drive the actual walk+complexity pairing over a branchy function so a
+        // regression in the source_hash join surfaces as a missing metric.
+        let project = project_with_branchy_function();
+        let config = load_resolved_config(project.path()).unwrap();
+        let include_all = compile_exclude_matcher(&[]).unwrap();
+        let functions = collect_inventory(&config, &include_all, None);
+        let branchy = functions
+            .iter()
+            .find(|f| f.function_name == "branchy")
+            .expect("branchy function present");
+        let cyclomatic = branchy.cyclomatic.expect("cyclomatic populated from walk");
+        assert!(
+            cyclomatic >= 3,
+            "branchy has multiple decision points, got cyclomatic {cyclomatic}"
         );
     }
 
@@ -1287,6 +1492,141 @@ mod tests {
         )
         .unwrap();
         dir
+    }
+
+    fn project_with_branchy_function() -> TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("package.json"), r#"{"name":"inv"}"#).unwrap();
+        std::fs::write(
+            root.join("src/index.ts"),
+            "export function branchy(x: number) {\n  if (x > 0) {\n    return 1;\n  } else if (x < 0) {\n    return -1;\n  }\n  return 0;\n}\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    /// Build a committed single-file git repo so `analyze_churn_cached` has real
+    /// history to read. Returns the temp dir; the committed file is `src/a.ts`.
+    fn git_repo_with_history() -> TempDir {
+        let dir = tempfile::tempdir().expect("create temp repo");
+        let root = dir.path();
+        run_git(root, &["init", "-q"]);
+        run_git(root, &["config", "commit.gpgsign", "false"]);
+        run_git(root, &["config", "user.email", "review@example.com"]);
+        run_git(root, &["config", "user.name", "Reviewer"]);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("package.json"), r#"{"name":"inv"}"#).unwrap();
+        std::fs::write(
+            root.join("src/a.ts"),
+            "export function one() {\n  return 1;\n}\n",
+        )
+        .unwrap();
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-qm", "first"]);
+        std::fs::write(
+            root.join("src/a.ts"),
+            "export function one() {\n  return 2;\n}\n",
+        )
+        .unwrap();
+        run_git(root, &["add", "."]);
+        run_git(root, &["commit", "-qm", "second"]);
+        dir
+    }
+
+    #[test]
+    fn churn_by_path_keys_match_prefixed_file_path() {
+        let repo = git_repo_with_history();
+        let config = load_resolved_config(repo.path()).unwrap();
+        let churn = collect_churn(&config, Some("/app"));
+        // A committed, twice-edited file must appear keyed by the SAME prefixed
+        // posix path the inventory functions carry, so the server can join them.
+        let entry = churn
+            .get("/app/src/a.ts")
+            .expect("committed file present in churn map keyed by prefixed path");
+        assert!(
+            entry.commits.unwrap_or(0) >= 2,
+            "two commits touched the file"
+        );
+        assert!(entry.author_count.unwrap_or(0) >= 1, "one author present");
+        assert!(entry.last_commit_ts.is_some(), "recency timestamp present");
+        assert!(entry.trend.is_some(), "trend present");
+        // The prefixed inventory path and the churn key must use the same shape.
+        let include_all = compile_exclude_matcher(&[]).unwrap();
+        let functions = collect_inventory(&config, &include_all, Some("/app"));
+        let a_fn = functions
+            .iter()
+            .find(|f| f.file_path == "/app/src/a.ts")
+            .expect("inventory function for src/a.ts");
+        assert!(
+            churn.contains_key(&a_fn.file_path),
+            "inventory filePath {} must be a churn key",
+            a_fn.file_path
+        );
+    }
+
+    #[test]
+    fn churn_is_empty_and_errorless_on_non_git_root() {
+        // No `git init`: a plain directory must yield an empty churn map and no
+        // error, so the enrichment degrades gracefully off a version-control
+        // host.
+        let project = project_with_one_function();
+        let config = load_resolved_config(project.path()).unwrap();
+        let churn = collect_churn(&config, None);
+        assert!(churn.is_empty(), "non-git root must produce empty churn");
+    }
+
+    #[test]
+    fn request_serializes_v2_version_and_churn_when_present() {
+        let repo = git_repo_with_history();
+        let config = load_resolved_config(repo.path()).unwrap();
+        let include_all = compile_exclude_matcher(&[]).unwrap();
+        let functions = collect_inventory(&config, &include_all, None);
+        let churn_by_path = collect_churn(&config, None);
+        let request = InventoryRequest {
+            version: INVENTORY_BLOB_VERSION,
+            git_sha: "deadbeef",
+            functions: &functions,
+            churn_by_path,
+        };
+        let json = serde_json::to_value(&request).expect("serialize request");
+        assert_eq!(json["version"], 2, "v2 version field present on the wire");
+        assert_eq!(json["gitSha"], "deadbeef");
+        assert!(
+            json["churnByPath"].is_object(),
+            "churnByPath present when git history exists"
+        );
+        let file_churn = &json["churnByPath"]["src/a.ts"];
+        assert!(file_churn["commits"].is_number(), "commits emitted");
+        assert!(
+            file_churn["weightedCommits"].is_number(),
+            "weightedCommits emitted"
+        );
+        assert!(file_churn["authorCount"].is_number(), "authorCount emitted");
+        assert!(
+            file_churn["lastCommitTs"].is_number(),
+            "lastCommitTs emitted"
+        );
+        assert!(file_churn["trend"].is_string(), "trend emitted as a string");
+    }
+
+    #[test]
+    fn request_omits_churn_when_empty() {
+        // A v2 request built off a non-git root must not emit `churnByPath` at
+        // all, keeping the pre-enrichment wire shape for non-git uploads.
+        let functions: Vec<InventoryFunction> = Vec::new();
+        let request = InventoryRequest {
+            version: INVENTORY_BLOB_VERSION,
+            git_sha: "deadbeef",
+            functions: &functions,
+            churn_by_path: BTreeMap::new(),
+        };
+        let json = serde_json::to_value(&request).expect("serialize request");
+        assert!(
+            json.get("churnByPath").is_none(),
+            "empty churn must be omitted from the wire"
+        );
     }
 
     fn dry_run_args() -> UploadInventoryArgs {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -73,7 +73,9 @@ pub mod vital_signs;
 /// Extracted semantic types exposed through the engine boundary.
 pub mod extract {
     pub mod inventory {
-        pub use fallow_extract::inventory::{InventoryEntry, walk_source};
+        pub use fallow_extract::inventory::{
+            InventoryComplexity, InventoryEntry, walk_source, walk_source_with_complexity,
+        };
     }
 
     pub use fallow_extract::css::{

--- a/crates/extract/src/inventory.rs
+++ b/crates/extract/src/inventory.rs
@@ -34,6 +34,7 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_semantic::ScopeFlags;
 use oxc_span::{SourceType, Span};
+use rustc_hash::FxHashMap;
 
 /// A single static-inventory entry for one function.
 ///
@@ -204,6 +205,22 @@ impl<'ast> Visit<'ast> for InventoryVisitor<'_> {
     }
 }
 
+/// Per-function static complexity collected alongside the inventory walk.
+///
+/// Keyed to an [`InventoryEntry`] by its `source_hash`, which both this and the
+/// inventory walk derive from the identical full-span byte slice over the same
+/// parsed program (see [`InventoryEntry::source_hash`]). The hash is stable
+/// across line moves, so the pairing survives reformatting that shifts line
+/// numbers. `cyclomatic` and `cognitive` are descriptive context for downstream
+/// importance weighting, never thresholds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InventoryComplexity {
+    /// `McCabe` cyclomatic complexity (1 + decision points).
+    pub cyclomatic: u16,
+    /// `SonarSource` cognitive complexity (structural + nesting penalty).
+    pub cognitive: u16,
+}
+
 /// Parse `source` at `path` and return every function as an [`InventoryEntry`].
 ///
 /// Only plain JS/TS/JSX/TSX sources are supported. Callers should skip SFC,
@@ -215,30 +232,75 @@ impl<'ast> Visit<'ast> for InventoryVisitor<'_> {
 /// results.
 #[must_use]
 pub fn walk_source(path: &Path, source: &str) -> Vec<InventoryEntry> {
+    walk_source_with_complexity(path, source).0
+}
+
+/// Parse `source` at `path` once and return every function as an
+/// [`InventoryEntry`] together with a `source_hash -> InventoryComplexity` map.
+///
+/// Both the inventory entries and the complexity map come from the SAME parse
+/// (including the JSX fallback retry), so the per-function `source_hash` values
+/// line up exactly and a caller can enrich each entry's metrics by a hash
+/// lookup. Functions whose span slice could not be sliced share the empty-input
+/// hash and simply don't pair; that degrades to "no metrics", never a panic.
+///
+/// Errors are swallowed, matching [`walk_source`]: the returned data covers
+/// whatever could be parsed.
+#[must_use]
+pub fn walk_source_with_complexity(
+    path: &Path,
+    source: &str,
+) -> (Vec<InventoryEntry>, FxHashMap<String, InventoryComplexity>) {
     let source_type = SourceType::from_path(path).unwrap_or_default();
-    let allocator = Allocator::default();
-    let parser_return = Parser::new(&allocator, source, source_type).parse();
-
     let line_offsets = fallow_types::extract::compute_line_offsets(source);
-    let mut visitor = InventoryVisitor::new(source, &line_offsets);
-    visitor.visit_program(&parser_return.program);
 
-    if visitor.entries.is_empty() && !source_type.is_jsx() {
+    let primary = walk_one_parse(source, source_type, &line_offsets);
+    if primary.0.is_empty() && !source_type.is_jsx() {
         let jsx_type = if source_type.is_typescript() {
             SourceType::tsx()
         } else {
             SourceType::jsx()
         };
-        let allocator2 = Allocator::default();
-        let retry_return = Parser::new(&allocator2, source, jsx_type).parse();
-        let mut retry_visitor = InventoryVisitor::new(source, &line_offsets);
-        retry_visitor.visit_program(&retry_return.program);
-        if !retry_visitor.entries.is_empty() {
-            return retry_visitor.entries;
+        let retry = walk_one_parse(source, jsx_type, &line_offsets);
+        if !retry.0.is_empty() {
+            return retry;
         }
     }
 
-    visitor.entries
+    primary
+}
+
+/// Run both the inventory and complexity visitors over a single parse of
+/// `source` under `source_type`, pairing them by `source_hash`.
+fn walk_one_parse(
+    source: &str,
+    source_type: SourceType,
+    line_offsets: &[u32],
+) -> (Vec<InventoryEntry>, FxHashMap<String, InventoryComplexity>) {
+    let allocator = Allocator::default();
+    let parser_return = Parser::new(&allocator, source, source_type).parse();
+
+    let mut visitor = InventoryVisitor::new(source, line_offsets);
+    visitor.visit_program(&parser_return.program);
+
+    let complexity =
+        crate::complexity::compute_complexity(&parser_return.program, source, line_offsets);
+    let metrics: FxHashMap<String, InventoryComplexity> = complexity
+        .into_iter()
+        .filter_map(|fc| {
+            fc.source_hash.map(|hash| {
+                (
+                    hash,
+                    InventoryComplexity {
+                        cyclomatic: fc.cyclomatic,
+                        cognitive: fc.cognitive,
+                    },
+                )
+            })
+        })
+        .collect();
+
+    (visitor.entries, metrics)
 }
 
 #[cfg(all(test, not(miri)))]


### PR DESCRIPTION
## What

The uploaded function inventory carries only function identity today, while the analyzer computes a much richer static + history signal set locally that never leaves the machine. This enriches the inventory upload (now a versioned v2 payload) so a consuming runtime-intelligence backend can weight function importance with real complexity and churn instead of invocation traffic alone.

- `InventoryRequest` gains `version` (=2) and a top-level `churnByPath` map (per-file, keyed by the same prefixed path as `functions[]`).
- Each `InventoryFunction` gains optional `cyclomatic` + `cognitive` (u16), paired per-function by `source_hash` over the same parse the inventory walk already performs.
- `FileChurnPayload` carries `commits`, `weightedCommits`, `linesAdded`, `linesDeleted`, `trend`, `authorCount` (distinct git authors, **not** ownership), and `lastCommitTs` (per-file recency).
- Churn comes from the existing churn analysis and degrades to an empty map (never errors) on a non-git or shallow checkout.

## Compatibility

Every new field is optional, so older servers ignore them and the payload stays backward compatible. The upload structs derive only `Serialize`, so the analysis-report schema and its drift tests are unaffected (verified green).

## Tests

New unit tests: complexity populating from a real walk, `churnByPath` keys matching the prefixed file path and carrying all fields, graceful empty-and-errorless churn on a non-git root, the `version` field, and identity stability. `cargo fmt`, `clippy -D warnings`, and the targeted test suites pass.