### PR TITLE
fix(review): clearer walkthrough copy (stage labels + contract-change wording)

### DIFF
--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -2055,8 +2055,8 @@ fn write_metric_legend(out: &mut String, report: &fallow_output::HealthReport) {
 
 /// Build a paste-into-PR markdown rendering of the existing walkthrough guide.
 ///
-/// Mirrors the human terminal tour: a Focus line, Stage 1 (load-bearing) and
-/// Stage 2 (mechanical) sections partitioned by `concern_lens`, with synthesized
+/// Mirrors the human terminal tour: a Focus line, Stage 1 (affects code outside the
+/// PR) and Stage 2 (self-contained) sections partitioned by `concern_lens`, with synthesized
 /// badges as inline code spans, then a collapsible Cleared panel. The JSON guide
 /// path is untouched; this is the only NEW walkthrough markdown surface. No ANSI.
 ///
@@ -2083,14 +2083,14 @@ pub fn build_walkthrough_markdown(
     let (stage1, stage2) = partition_walkthrough_stages(guide, viewed);
     push_walkthrough_stage(
         &mut out,
-        "Stage 1 \u{00b7} Load-bearing",
+        "Stage 1 \u{00b7} Affects code outside this PR",
         &stage1,
         guide,
         root,
     );
     push_walkthrough_stage(
         &mut out,
-        "Stage 2 \u{00b7} Mechanical",
+        "Stage 2 \u{00b7} Self-contained",
         &stage2,
         guide,
         root,

--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -2502,11 +2502,11 @@ mod walkthrough_markdown_tests {
     }
 
     // F5/F7: a coordination question must NOT re-print the anchor path inside the
-    // fact text, must NOT emit a backslash-backtick sequence, and must cap the
-    // contract member list while keeping the trailing guidance question.
+    // fact text, must NOT emit a backslash-backtick sequence, must cap the
+    // contract member list, and drops the trailing question in the tour.
     #[test]
     fn fact_does_not_reprint_path_or_emit_escaped_backticks() {
-        let q = "`src/page.ts` changes a contract (a, b, c, d, e, f, g, h, i) consumed by 9 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+        let q = "`src/page.ts` changes exports (a, b, c, d, e, f, g, h, i) imported by 9 files outside this PR. Does this change break or alter what those callers expect?";
         let guide = guide_with_question("src/page.ts", q);
         let md = build_walkthrough_markdown(&guide, Path::new("/project"), &[]);
         // No backslash-backtick anywhere (the F5 corruption).
@@ -2516,15 +2516,15 @@ mod walkthrough_markdown_tests {
         );
         // The path is printed once (the bullet lead), not a second time in the fact.
         assert!(
-            !md.contains("`src/page.ts` changes a contract"),
+            !md.contains("`src/page.ts` changes exports"),
             "fact must not re-print the path: {md}"
         );
         // The member list is capped with a "+N more".
         assert!(md.contains("+3 more"), "member list capped: {md}");
-        // The trailing actionable question survives in full.
+        // The trailing decision question is dropped in the tour (it lives in the brief).
         assert!(
-            md.contains("Coordinate the change, or is the contract stable?"),
-            "trailing guidance must survive: {md}"
+            !md.contains("break or alter"),
+            "the per-file question must be dropped in the tour: {md}"
         );
         // The raw "(score N)" is gone.
         assert!(!md.contains("(score "), "raw score removed: {md}");

--- a/crates/cli/src/audit_decision_surface.rs
+++ b/crates/cli/src/audit_decision_surface.rs
@@ -214,9 +214,9 @@ fn public_api_question(count: usize) -> String {
 /// Frame a coordination-gap (contract consumed outside the diff) decision.
 fn coordination_question(changed_file: &str, symbols: &[String], consumers: u64) -> String {
     format!(
-        "`{changed_file}` changes a contract ({}) consumed by {consumers} module{} NOT in this diff. Coordinate the change, or is the contract stable?",
+        "`{changed_file}` changes exports ({}) imported by {consumers} {} outside this PR. Does this change break or alter what those callers expect?",
         symbols.join(", "),
-        if consumers == 1 { "" } else { "s" }
+        if consumers == 1 { "file" } else { "files" }
     )
 }
 

--- a/crates/cli/src/report/human/walkthrough.rs
+++ b/crates/cli/src/report/human/walkthrough.rs
@@ -11,9 +11,9 @@
 //! The guide has no literal stage array, so two ordered stages are synthesized
 //! from `direction.units` partitioned by `concern_lens`, preserving
 //! `direction.order` within each:
-//!   - **Stage 1, load-bearing** (`concern_lens == "contract-break"`): units with
-//!     out-of-diff consumers.
-//!   - **Stage 2, mechanical** (the rest): orientation-only units.
+//!   - **Stage 1, affects code outside this PR** (`concern_lens == "contract-break"`):
+//!     units with out-of-diff consumers.
+//!   - **Stage 2, self-contained** (the rest): units with no out-of-diff consumers.
 //!
 //! ## Badges
 //!
@@ -71,18 +71,12 @@ pub(in crate::report) fn build_walkthrough_human_lines(
     let (stage1, stage2) = partition_stages(guide, &viewed);
     push_stage(
         &mut lines,
-        "Stage 1: Load-bearing (contract-break)",
+        "Stage 1: Affects code outside this PR",
         &stage1,
         input,
         true,
     );
-    push_stage(
-        &mut lines,
-        "Stage 2: Mechanical (orientation)",
-        &stage2,
-        input,
-        false,
-    );
+    push_stage(&mut lines, "Stage 2: Self-contained", &stage2, input, false);
     push_cleared_panel(&mut lines, input);
 
     lines
@@ -676,15 +670,18 @@ mod tests {
             show_cleared: false,
         });
         let text = plain(&lines);
-        assert!(text.contains("Stage 1: Load-bearing"), "got: {text}");
-        assert!(text.contains("Stage 2: Mechanical"), "got: {text}");
+        assert!(
+            text.contains("Stage 1: Affects code outside this PR"),
+            "got: {text}"
+        );
+        assert!(text.contains("Stage 2: Self-contained"), "got: {text}");
         assert!(text.contains("page.ts"));
         assert!(text.contains("util.ts"));
         // Stage 1 appears before Stage 2.
         let s1 = text.find("Stage 1").unwrap();
         let s2 = text.find("Stage 2").unwrap();
         assert!(s1 < s2);
-        // The coupling decision badge renders on the load-bearing file.
+        // The coupling decision badge renders on the Stage 1 file.
         assert!(text.contains("COUPLING"), "got: {text}");
         assert!(text.contains("OUT-OF-DIFF"), "got: {text}");
     }

--- a/crates/cli/src/report/human/walkthrough.rs
+++ b/crates/cli/src/report/human/walkthrough.rs
@@ -967,14 +967,14 @@ mod tests {
         assert!(status.contains("1 file across 1 stage"), "status: {status}");
     }
 
-    // F4/F5/F7: the contract member list is capped and the trailing guidance
-    // question survives (not truncated away); no raw score is shown.
+    // F4/F5/F7: the contract member list is capped and the trailing decision
+    // question is dropped in the tour (it lives in the brief); no raw score is shown.
     #[test]
-    fn contract_question_keeps_trailing_guidance_and_caps_members() {
+    fn contract_question_drops_in_tour_and_caps_members() {
         let members =
             "alertRules, apiKeys, auditLog, budgetAlerts, coverageAlerts, deployments, users, orgs";
         let question = format!(
-            "`src/db/schema.ts` changes a contract ({members}) consumed by 32 modules NOT in this diff. Coordinate the change, or is the contract stable?"
+            "`src/db/schema.ts` changes exports ({members}) imported by 32 files outside this PR. Does this change break or alter what those callers expect?"
         );
         let mut decision = coupling_decision("src/db/schema.ts");
         decision.question = question;
@@ -996,16 +996,20 @@ mod tests {
             viewed: &viewed,
             show_cleared: false,
         }));
-        // The trailing actionable question is NOT truncated away.
+        // The trailing decision question is dropped in the tour (it lives in the brief).
         assert!(
-            body.contains("Coordinate the change, or is the contract stable?"),
-            "trailing guidance must survive: {body}"
+            !body.contains("break or alter"),
+            "the per-file question must be dropped in the tour: {body}"
+        );
+        assert!(
+            body.contains("imported by 32 files outside this PR"),
+            "the observation survives: {body}"
         );
         // The member list is capped with a "+N more".
         assert!(body.contains("+2 more"), "member list capped: {body}");
         // The leading path is not re-printed inside the fact text.
         assert!(
-            !body.contains("`src/db/schema.ts` changes a contract"),
+            !body.contains("`src/db/schema.ts` changes exports"),
             "fact must not re-print the path: {body}"
         );
         // The contradictory raw "(score N)" is gone.

--- a/crates/output/src/walkthrough_render.rs
+++ b/crates/output/src/walkthrough_render.rs
@@ -89,18 +89,22 @@ impl WalkthroughAccounting {
     }
 }
 
-/// The clean, surface-agnostic fact text for a coordination decision question.
+/// The clean, surface-agnostic fact text for a decision question, for the tour.
 ///
 /// The raw wire `question` leads with `` `<anchor_file>` `` (which every render
-/// surface ALREADY shows as the row's leading path) and inlines the full,
-/// unbounded contract-member list. This strips the redundant leading path and
-/// caps the member list to `max_members` names + "+N more", PRESERVING the
-/// trailing guidance sentence. The result is plain prose (no backticks), so a
-/// markdown surface needs no escaping and a human surface needs no truncation.
+/// surface ALREADY shows as the row's leading path), inlines the full, unbounded
+/// contract-member list, and ends with the decision's open question. For a guided
+/// tour this: strips the redundant leading path, caps the member list to
+/// `max_members` names + "+N more", and DROPS the trailing question (the section
+/// header frames the action once, and the question is still carried in the
+/// decisions brief and the JSON, where each decision stands alone). The result is
+/// plain prose (no backticks), so a markdown surface needs no escaping and a human
+/// surface needs no truncation.
 #[must_use]
 pub fn clean_decision_fact(question: &str, anchor_file: &str, max_members: usize) -> String {
     let stripped = strip_leading_path(question, anchor_file);
-    cap_member_list(&stripped, max_members)
+    let capped = cap_member_list(&stripped, max_members);
+    drop_trailing_question(&capped)
 }
 
 /// Drop a leading `` `<anchor_file>` `` token (with one trailing space) from the
@@ -137,6 +141,30 @@ fn cap_member_list(text: &str, max_members: usize) -> String {
         &text[..open],
         &text[close + 1..]
     )
+}
+
+/// Drop a trailing decision question (a sentence ending in `?`) so a guided tour
+/// shows the plain observation, not a per-file question. The decision's open
+/// question is still carried in the decisions brief and the JSON, where each
+/// decision stands alone; in the tour the section header frames the action once,
+/// so a question repeated on every row reads as a wall of the same sentence.
+fn drop_trailing_question(text: &str) -> String {
+    let parts: Vec<&str> = text.split(". ").collect();
+    let mut end = parts.len();
+    while end > 0 && parts[end - 1].trim_end().ends_with('?') {
+        end -= 1;
+    }
+    // Nothing trailing was a question (end unchanged), or the whole text is a
+    // question (end hit 0): leave it as-is rather than emit an empty fragment.
+    if end == parts.len() || end == 0 {
+        return text.to_string();
+    }
+    let kept = parts[..end].join(". ");
+    if kept.ends_with(['.', '!', '?']) {
+        kept
+    } else {
+        format!("{kept}.")
+    }
 }
 
 /// Cap an arbitrary list of names for inline display: first `max` names, then a
@@ -337,8 +365,8 @@ mod tests {
     }
 
     #[test]
-    fn strips_leading_path_and_caps_members() {
-        let q = "`src/db/schema.ts` changes a contract (a, b, c, d, e, f, g, h) consumed by 32 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+    fn strips_leading_path_caps_members_and_drops_question() {
+        let q = "`src/db/schema.ts` changes exports (a, b, c, d, e, f, g, h) imported by 32 files outside this PR. Does this change break or alter what those callers expect?";
         let out = clean_decision_fact(q, "src/db/schema.ts", 3);
         // The leading path is gone (printed once by the row).
         assert!(
@@ -347,40 +375,45 @@ mod tests {
         );
         // The member list is capped with a "+N more".
         assert!(out.contains("(a, b, c, +5 more)"), "got: {out}");
-        // The trailing guidance survives in full.
+        // The trailing decision question is dropped in the tour (it lives in the brief).
         assert!(
-            out.ends_with("Coordinate the change, or is the contract stable?"),
-            "trailing question must survive: {out}"
+            !out.contains('?'),
+            "trailing question must be dropped: {out}"
+        );
+        assert!(
+            out.ends_with("outside this PR."),
+            "the observation survives, ending cleanly: {out}"
         );
         // No backticks remain to be escaped.
         assert!(!out.contains('`'), "no backticks remain: {out}");
     }
 
     #[test]
-    fn short_member_list_is_untouched() {
-        let q = "`src/lib/r2.ts` changes a contract (getR2, getR2Text) consumed by 6 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+    fn short_member_list_is_kept_and_question_dropped() {
+        let q = "`src/lib/r2.ts` changes exports (getR2, getR2Text) imported by 6 files outside this PR. Does this change break or alter what those callers expect?";
         let out = clean_decision_fact(q, "src/lib/r2.ts", 6);
         assert_eq!(
             out,
-            "changes a contract (getR2, getR2Text) consumed by 6 modules NOT in this diff. Coordinate the change, or is the contract stable?"
+            "changes exports (getR2, getR2Text) imported by 6 files outside this PR."
         );
     }
 
     #[test]
-    fn single_member_prose_parenthetical_is_untouched() {
-        let q = "`src/lib/env.ts` changes a contract (env) consumed by 22 modules NOT in this diff. Coordinate the change, or is the contract stable?";
+    fn single_member_prose_parenthetical_is_kept_question_dropped() {
+        let q = "`src/lib/env.ts` changes exports (env) imported by 22 files outside this PR. Does this change break or alter what those callers expect?";
         let out = clean_decision_fact(q, "src/lib/env.ts", 6);
         assert!(out.contains("(env)"), "single member kept: {out}");
-        assert!(out.ends_with("stable?"), "trailing kept: {out}");
+        assert!(!out.contains('?'), "trailing question dropped: {out}");
+        assert!(out.ends_with("outside this PR."), "observation kept: {out}");
     }
 
     #[test]
-    fn non_anchor_question_keeps_its_own_path() {
-        // A boundary question names a DIFFERENT path than the anchor; it must not
-        // be stripped (the leading token is not the anchor file).
+    fn non_anchor_path_is_kept_but_question_dropped() {
+        // A boundary question names a DIFFERENT path than the anchor; its leading
+        // token is not stripped, but the tour still drops the trailing question.
         let q = "`ui` now imports `db` for the first time. Intended coupling, or should this edge not exist?";
         let out = clean_decision_fact(q, "src/ui/page.ts", 6);
-        assert_eq!(out, q, "non-matching leading token is preserved");
+        assert_eq!(out, "`ui` now imports `db` for the first time.");
     }
 
     #[test]


### PR DESCRIPTION
## What

Two copy improvements to the `fallow review --walkthrough` output.

### 1. Plainer stage labels
- **Stage 1**: "Affects code outside this PR" (was "Load-bearing (contract-break)")
- **Stage 2**: "Self-contained" (was "Mechanical (orientation)")

Each stage orders by, and shows, the concrete count it encodes; "load-bearing" / "mechanical" were jargon / meta-labels.

### 2. Clearer contract-change wording
The contract-change decision read as a wall of one repeated, awkward sentence on every flagged file ("...consumed by N modules NOT in this diff. Coordinate the change, or is the contract stable?").

- The decision question (decision surface, shared with the brief and the JSON) is reworded: plain "changes exports (...) imported by N files outside this PR" and a single open question "Does this change break or alter what those callers expect?".
- In the tour, the per-file line now shows just the observation; the section header frames the action once, and the open question stays in the decisions brief and the JSON (where each decision stands alone). The rows read as distinct facts, not a repeated sentence.

## Scope

Display plus decision-question wording only. `concern_lens` wire values are unchanged; the `question` text is free-text framing (`deterministic: false`); the guide/brief/JSON schema and the agent contract are unchanged, and `--walkthrough --format json` stays byte-identical to `--walkthrough-guide`.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, and the fallow-cli / fallow-output / fallow-api test suites all pass locally. Rendered on a real multi-file diff to confirm the tour shows distinct facts and the brief keeps the open question.
