### PR TITLE
fix(ci): remove an unfulfilled clippy::too_many_lines expectation

### DIFF
--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -4694,10 +4694,6 @@ fn health_css_human_section_survives_empty_complexity_section() {
 /// CSS-in-JS library never analyzes its JS/TS files (no `files_analyzed`
 /// inflation).
 #[test]
-#[expect(
-    clippy::too_many_lines,
-    reason = "test fixture; linear setup/assert, length is not a maintainability concern"
-)]
 fn health_css_lifts_css_in_js_tagged_templates() {
     let dir = tempdir().unwrap();
     let root = dir.path();


### PR DESCRIPTION
## What

Removes an `#[expect(clippy::too_many_lines)]` on `health_css_lifts_css_in_js_tagged_templates` (added in #1668) that clippy reports as **unfulfilled**: clippy's line count for the function is under the threshold, so the lint never fires, and `-D unfulfilled-lint-expectations` (implied by `-D warnings`) fails the clippy gate on every open PR.

The function does not trigger `too_many_lines`, so it needs no suppression. Removing the attribute clears the gate. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` pass locally.
