### PR TITLE
fix(review): grammar + tighter wording for walkthrough decision facts

### DIFF
--- a/crates/cli/src/audit_decision_surface.rs
+++ b/crates/cli/src/audit_decision_surface.rs
@@ -206,7 +206,7 @@ fn boundary_question(from_zone: &str, to_zone: &str) -> String {
 /// Frame the (batch-consolidated, R1) public-API-surface decision.
 fn public_api_question(count: usize) -> String {
     format!(
-        "This change widens the public API surface by {count} export{}. These become maintained contracts. Intended surface, or should they stay internal?",
+        "This change adds {count} export{} to the public API surface. Intended as maintained contracts, or should they stay internal?",
         if count == 1 { "" } else { "s" }
     )
 }
@@ -214,7 +214,12 @@ fn public_api_question(count: usize) -> String {
 /// Frame a coordination-gap (contract consumed outside the diff) decision.
 fn coordination_question(changed_file: &str, symbols: &[String], consumers: u64) -> String {
     format!(
-        "`{changed_file}` changes exports ({}) imported by {consumers} {} outside this PR. Does this change break or alter what those callers expect?",
+        "`{changed_file}` changes {} ({}) imported by {consumers} {} outside this PR. Does this change break or alter what those callers expect?",
+        if symbols.len() == 1 {
+            "export"
+        } else {
+            "exports"
+        },
         symbols.join(", "),
         if consumers == 1 { "file" } else { "files" }
     )

--- a/crates/output/src/walkthrough_render.rs
+++ b/crates/output/src/walkthrough_render.rs
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn single_member_prose_parenthetical_is_kept_question_dropped() {
-        let q = "`src/lib/env.ts` changes exports (env) imported by 22 files outside this PR. Does this change break or alter what those callers expect?";
+        let q = "`src/lib/env.ts` changes export (env) imported by 22 files outside this PR. Does this change break or alter what those callers expect?";
         let out = clean_decision_fact(q, "src/lib/env.ts", 6);
         assert!(out.contains("(env)"), "single member kept: {out}");
         assert!(!out.contains('?'), "trailing question dropped: {out}");
@@ -414,6 +414,16 @@ mod tests {
         let q = "`ui` now imports `db` for the first time. Intended coupling, or should this edge not exist?";
         let out = clean_decision_fact(q, "src/ui/page.ts", 6);
         assert_eq!(out, "`ui` now imports `db` for the first time.");
+    }
+
+    #[test]
+    fn public_api_surface_question_drops_to_one_sentence() {
+        // The consolidated public-API-surface decision has no leading path and no
+        // member parenthetical; the tour keeps only the one observation sentence,
+        // dropping the trailing "Intended as maintained contracts ...?" question.
+        let q = "This change adds 3 exports to the public API surface. Intended as maintained contracts, or should they stay internal?";
+        let out = clean_decision_fact(q, "src/lib/id.ts", 6);
+        assert_eq!(out, "This change adds 3 exports to the public API surface.");
     }
 
     #[test]


### PR DESCRIPTION
## What

Two grammar / wording nits surfaced by smoke-testing the contract-change walkthrough copy:

- **Singular/plural**: a single changed export rendered "changes exports (createBeaconLifecycle)". Pluralize the noun by symbol count: one export reads "changes export (X)", several read "changes exports (...)".
- **Tighter public-API-surface question**: it carried a generic filler sentence ("These become maintained contracts.") that, with the question dropped in the tour, left a wordy two-sentence fact. Folded it into the question ("This change adds N exports to the public API surface. Intended as maintained contracts, or should they stay internal?"), so the tour fact is one clean sentence.

## Verification

Rendered on real diffs (#388, #389) and a synthetic diff (a new cross-zone import + new exports) to confirm the coordination (singular + plural) and boundary facts read cleanly; added a unit test pinning the public-API-surface tour fact. Decision-question wording only; the schemas and the agent contract are unchanged. `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, and the test suites pass locally.
