### PR TITLE
test(license): use deterministic keypair, drop rand dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,6 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
  "subtle",
@@ -1209,7 +1208,6 @@ version = "2.103.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "rand 0.8.6",
  "serde",
  "serde_json",
 ]
@@ -3001,7 +2999,7 @@ dependencies = [
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3036,8 +3034,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3047,18 +3043,8 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/crates/license/Cargo.toml
+++ b/crates/license/Cargo.toml
@@ -21,8 +21,7 @@ base64 = "0.22"
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "pkcs8", "pem"] }
 
 [dev-dependencies]
-ed25519-dalek = { version = "2", features = ["rand_core"] }
-rand = "0.8"
+ed25519-dalek = { version = "2" }
 
 [lints]
 workspace = true

--- a/crates/license/src/lib.rs
+++ b/crates/license/src/lib.rs
@@ -591,11 +591,9 @@ mod tests {
     use super::*;
 
     use ed25519_dalek::{Signer, SigningKey};
-    use rand::rngs::OsRng;
 
     fn fixed_keypair() -> (SigningKey, VerifyingKey) {
-        let mut csprng = OsRng;
-        let signing = SigningKey::generate(&mut csprng);
+        let signing = SigningKey::from_bytes(&[42u8; 32]);
         let verifying = signing.verifying_key();
         (signing, verifying)
     }


### PR DESCRIPTION
## Summary

Supersedes #1694. Dependabot bumped `rand` from 0.8 to 0.9 in `crates/license` dev-dependencies, but that breaks compilation: ed25519-dalek 2.x binds `SigningKey::generate()` to `rand_core` 0.6, while rand 0.9 ships `rand_core` 0.9. The bump is not viable until ed25519-dalek 3.0.

The `fixed_keypair()` test helper was generating a *random* keypair via `OsRng` despite its name. The tests only need a valid keypair, not entropy, so this switches to a deterministic `SigningKey::from_bytes` seed. That:

- makes the helper actually deterministic (matches its name)
- drops the `rand` dev-dependency entirely
- permanently resolves the recurring incompatible `rand` bump

## Validation

- `cargo test -p fallow-license` passes
- `cargo check -p fallow-extract` passes (verifies the lockfile feature-unification shift, rand 0.8.6 stays only as a transitive build-dep of lightningcss/phf_generator)
- fmt + clippy clean

Closes #1694