### PR TITLE
ci: fix taiki-e/install-action tool selection for audit/shear/llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,7 +565,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # cargo-audit
+      - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-audit
       # RUSTSEC-2026-0097: `rand` 0.9.2 unsoundness with a custom logger via
       # `rand::rng()`. Reaches the tree only through the `proptest` dev-dependency
       # (test-only, never shipped in a fallow binary) and fallow does not use the
@@ -596,7 +598,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # cargo-shear
+      - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-shear
       - run: cargo shear
 
   zizmor:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,9 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # cargo-llvm-cov
+      - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Build CLI binary for e2e tests
         run: cargo build -p fallow-cli


### PR DESCRIPTION
## Problem

`Security Audit` and `Unused Dependencies` (both required checks) are failing on `main` with:

```
error: no such command: audit
error: no such command: shear
```

## Root cause

These steps selected the tool via the **action ref** (the `cargo-audit` / `cargo-shear` tags), which only works when the ref itself is the tool tag. #1686 bumped `taiki-e/install-action` and re-pinned those refs to a version-release SHA, so the ref no longer names a tool, tool detection silently broke, and the binaries were never installed. `coverage.yml` (`cargo-llvm-cov`) had the same latent bug.

## Fix

Pin all three to the same version SHA as `bench.yml` (`v2.82.2`) and select the tool explicitly via `with: tool:`, exactly matching the working `cargo-codspeed` step. This is robust to future SHA re-pins by Dependabot (the tool no longer depends on the ref name).

## Verification

`ci.yml` is in the `rust` path filter, so this PR runs the `Security Audit` and `Unused Dependencies` jobs against the fix. Green here means the tools install and run correctly.

Unblocks the stuck Dependabot PR #1695 (which was red on these same checks, not a stale-base issue).