### PR TITLE
perf(audit): skip clean-tree worktree sweep

### DIFF
--- a/crates/api/src/runtime/mod.rs
+++ b/crates/api/src/runtime/mod.rs
@@ -68,7 +68,7 @@ impl ProgrammaticHealthAnalysis {
     }
 }
 
-/// Health runner output shared by API, NAPI, and compatibility adapters.
+/// Health runner output shared by API, NAPI, and alternate runners.
 ///
 /// Runtime-only presentation probes stay explicit so the API boundary, not the
 /// concrete runner, owns the final programmatic report assembly.
@@ -82,7 +82,7 @@ pub struct ProgrammaticHealthRun {
 /// Runner boundary for programmatic health.
 ///
 /// This keeps embedders on the typed API contract while still allowing tests
-/// and compatibility adapters to provide a custom health runner.
+/// and host integrations to provide a custom health runner.
 pub trait ProgrammaticHealthRunner {
     /// Run health analysis for public programmatic options.
     ///
@@ -101,7 +101,7 @@ pub trait ProgrammaticHealthRunner {
 /// This runs the command-neutral health pipeline through the engine health
 /// runner without touching the CLI crate: the programmatic
 /// path never groups (`--group-by`), never drives the runtime coverage sidecar,
-/// and never records CLI telemetry, so the seams are inert no-ops. NAPI and
+/// and never records CLI telemetry, so the runner hooks are inert. NAPI and
 /// future Rust embedders use this runner; the CLI keeps its own runner for the
 /// `fallow health` command path.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1106,15 +1106,6 @@ pub fn execute_audit(opts: &AuditOptions<'_>) -> Result<AuditResult, ExitCode> {
 
     let (base_ref, base_description) = resolve_base_ref(opts)?;
 
-    // Always sweep: prunable orphans (cache dir externally reaped, git admin
-    // entry left behind) are reclaimed regardless of the age threshold, so the
-    // sweep runs even when age-based GC is disabled (`max_age` is `None`).
-    sweep_old_reusable_caches(
-        opts.root,
-        resolve_cache_max_age(opts.root, opts.config_path.as_ref()),
-        opts.quiet,
-    );
-
     let Some(changed_files) = crate::check::get_changed_files(opts.root, &base_ref) else {
         return Err(emit_error(
             &format!(
@@ -1134,6 +1125,15 @@ pub fn execute_audit(opts: &AuditOptions<'_>) -> Result<AuditResult, ExitCode> {
             start.elapsed(),
         ));
     }
+
+    // Sweep only once audit will do real changed-code work. A clean tree never
+    // creates or reuses a base worktree, so keeping the no-change fast path
+    // free of worktree-listing IO is both safe and visibly cheaper.
+    sweep_old_reusable_caches(
+        opts.root,
+        resolve_cache_max_age(opts.root, opts.config_path.as_ref()),
+        opts.quiet,
+    );
 
     let changed_since = Some(base_ref.as_str());
 

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -49,9 +49,9 @@ pub struct ParsedAnalysisSessionParts {
     pub parse_cpu_ms: f64,
 }
 
-/// Borrowed session view for callers that still expose `&ResolvedConfig`.
+/// Borrowed session view for callers that expose `&ResolvedConfig`.
 ///
-/// This keeps legacy helper signatures intact while routing discovery and
+/// This keeps existing helper signatures intact while routing discovery and
 /// analysis through the same session-owned orchestration shape as
 /// [`AnalysisSession`].
 struct AnalysisSessionView<'a> {

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -3,8 +3,9 @@
 //! This crate owns stable report DTOs that are not tied to CLI rendering.
 //! Higher-level output assemblers live above this crate in `fallow-api` or the
 //! CLI, while this crate remains the shared typed boundary those builders and
-//! non-CLI consumers can use. Shared selectors such as `OutputFormat` live in
-//! `fallow-types` and are re-exported here for compatibility.
+//! non-CLI consumers can use. Shared selectors such as `OutputFormat` stay in
+//! `fallow-types`; this crate re-exports only the selectors needed to keep
+//! output builders on one contract surface.
 #![cfg_attr(
     test,
     allow(


### PR DESCRIPTION
Move reusable audit worktree cleanup after changed-file discovery so clean-tree audit exits without listing or pruning base worktrees. Changed-code audit still sweeps before any base snapshot work, preserving stale worktree cleanup for real analysis runs.

This keeps the no-change fast path focused on base-ref resolution and changed-file detection while leaving new-only attribution and base snapshot behavior unchanged. It also tightens architecture boundary comments that still referenced compatibility adapters.

Validation:
- cargo build --workspace
- cargo test --workspace --lib --bins --tests --examples
- clean/no-change audit hyperfine comparison
- changed-code audit hyperfine comparison