### PR TITLE
docs(extract): unlink private submodules in css_in_js module doc

### DIFF
--- a/crates/extract/src/css_in_js/mod.rs
+++ b/crates/extract/src/css_in_js/mod.rs
@@ -2,14 +2,14 @@
 //!
 //! Three front-ends feed the shared styling-analytics pipeline, converging on the
 //! same virtual-stylesheet output that `compute_css_analytics` consumes:
-//! - [`template`]: the Phase 3b lexical lifter for `` styled.div`...` `` tagged
+//! - `template`: the Phase 3b lexical lifter for `` styled.div`...` `` tagged
 //!   templates.
-//! - [`object`]: the Phase 3c AST object-to-CSS serializer (`style({...})`,
+//! - `object`: the Phase 3c AST object-to-CSS serializer (`style({...})`,
 //!   `stylex.create({...})`, ...).
-//! - [`tokens`]: the Phase 3d design-token definition extraction + cross-module
+//! - `tokens`: the Phase 3d design-token definition extraction + cross-module
 //!   consumer scan (StyleX `defineVars`, vanilla-extract `createTheme`).
 //!
-//! [`shared`] holds the small invariants the front-ends agree on (the synthetic
+//! `shared` holds the small invariants the front-ends agree on (the synthetic
 //! wrapper selector, the newline counter).
 
 mod object;


### PR DESCRIPTION
## Problem

The `Documentation` job (required check) is failing on `main`:

```
error: public documentation for `css_in_js` links to private item `template`
error: public documentation for `css_in_js` links to private item `object`
error: public documentation for `css_in_js` links to private item `tokens`
error: public documentation for `css_in_js` links to private item `shared`
error: could not document `fallow-extract`
```

## Cause

`crates/extract/src/css_in_js/mod.rs` documents its three front-ends by intra-doc-linking the private submodules (`[`template`]`, `[`object`]`, `[`tokens`]`, `[`shared`]`). Because `css_in_js` is `pub mod`, rustdoc's `private_intra_doc_links` lint fires under the job's `RUSTDOCFLAGS: -D warnings`, so `cargo doc --workspace --document-private-items` fails. This blocks every Rust-touching PR (e.g. #1695).

## Fix

Reference the private front-end modules as inline code instead of intra-doc links. No behavior change, doc comments only.

## Verification

`RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items` now exits 0 (previously errored).