### PR TITLE
feat(action): post PR output as the branded Fallow app

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ on:
 permissions:
   contents: read
   pull-requests: write # needed for comment/review-comments
+  id-token: write # optional: post PR comments as the branded Fallow app
 
 jobs:
   fallow:
@@ -509,6 +510,8 @@ jobs:
           comment: true
           review-comments: true
 ```
+
+With `id-token: write`, PR comments and reviews are posted by the Fallow app (a branded bot) once the app is installed on the repository. Without it, or if the app is not installed, output posts under the default `github-actions` bot, no configuration needed and no account required.
 
 `command: audit` is the PR gate. In pull requests, the Action auto-scopes to the PR base SHA when `changed-since` is not set, derives a unified diff for line-level filtering, and emits a verdict: **pass**, **warn**, or **fail**. With the default `fail-on-issues: true`, audit fails the job only on verdict `fail`; warn-tier findings stay visible without blocking merge.
 

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,14 @@ inputs:
     description: 'GitHub token for PR comments and SARIF upload'
     required: false
     default: ${{ github.token }}
+  branded-token:
+    description: 'Post PR comments and reviews as the Fallow app (branded) when the workflow grants `permissions: id-token: write`. Set to false to always post with github-token. Falls back to github-token automatically when id-token is unavailable.'
+    required: false
+    default: 'true'
+  broker-url:
+    description: 'Base URL of the Fallow token broker used to mint the branded app token. Defaults to Fallow Cloud.'
+    required: false
+    default: 'https://api.fallow.cloud'
   annotations:
     description: 'Emit findings as inline PR annotations via workflow commands (no Advanced Security required)'
     required: false
@@ -321,6 +329,14 @@ runs:
         INPUT_ROOT: ${{ inputs.root }}
       run: bash ${{ github.action_path }}/action/scripts/install.sh
 
+    - name: Fallow branded token
+      id: fallow-token
+      shell: bash
+      env:
+        BRANDED_TOKEN: ${{ inputs.branded-token }}
+        BROKER_URL: ${{ inputs.broker-url }}
+      run: bash ${{ github.action_path }}/action/scripts/broker-token.sh
+
     - name: Cache analysis results
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
       with:
@@ -472,7 +488,7 @@ runs:
         steps.analyze.outputs.issues != ''
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ steps.fallow-token.outputs.token || inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         GH_REPO: ${{ github.repository }}
         FALLOW_COMMAND: ${{ steps.analyze.outputs.command }}
@@ -501,7 +517,7 @@ runs:
         steps.analyze.outputs.issues != ''
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ steps.fallow-token.outputs.token || inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         GH_REPO: ${{ github.repository }}

--- a/action/scripts/broker-token.sh
+++ b/action/scripts/broker-token.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Mint a Fallow-branded GitHub App installation token from the Fallow token
+# broker so PR comments and reviews are authored by the Fallow app instead of
+# github-actions. Fails safe: on any problem it emits branded=false and the
+# action posts with the default GITHUB_TOKEN. Never exits non-zero, so a broker
+# outage or a workflow without id-token permission never breaks the check.
+set -uo pipefail
+
+emit_fallback() {
+  echo "fallow: posting unbranded via GITHUB_TOKEN ($1)" >&2
+  echo "branded=false" >>"$GITHUB_OUTPUT"
+  exit 0
+}
+
+[ "${BRANDED_TOKEN:-true}" = "false" ] && emit_fallback "branded token disabled"
+[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || emit_fallback "no id-token permission (add 'permissions: id-token: write')"
+[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || emit_fallback "no id-token permission"
+command -v jq >/dev/null 2>&1 || emit_fallback "jq unavailable"
+
+broker="${BROKER_URL:-https://api.fallow.cloud}"
+audience="fallow-ci"
+
+oidc_json=$(curl -sf --max-time 10 \
+  -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+  "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience}") || emit_fallback "OIDC request failed"
+oidc=$(printf '%s' "$oidc_json" | jq -r '.value // empty')
+[ -n "$oidc" ] || emit_fallback "empty OIDC token"
+echo "::add-mask::${oidc}"
+
+# POST body via stdin so the OIDC token never lands in the process argv.
+resp=$(jq -nc --arg t "$oidc" '{token: $t}' |
+  curl -sf --max-time 10 -X POST "${broker%/}/v1/ci/github-token" \
+    -H 'content-type: application/json' --data @-) || emit_fallback "broker unavailable or declined"
+token=$(printf '%s' "$resp" | jq -r '.data.token // empty')
+[ -n "$token" ] || emit_fallback "broker returned no token"
+echo "::add-mask::${token}"
+
+{
+  echo "token=${token}"
+  echo "branded=true"
+} >>"$GITHUB_OUTPUT"
+echo "fallow: posting as the Fallow app (branded)" >&2


### PR DESCRIPTION
When a workflow grants `id-token: write` and the Fallow app is installed on the repo, the action requests a short-lived GitHub OIDC token, exchanges it for a repo-scoped app installation token, and posts PR comments and reviews with it, so they are authored by the Fallow app instead of `github-actions`.

- New composite step `broker-token.sh` mints the token (OIDC -> app token), masks it, and exposes it as `steps.fallow-token.outputs.token`. The comment and review steps use `steps.fallow-token.outputs.token || inputs.github-token`.
- **Fails safe**: no `id-token` permission, app not installed, or any error -> falls back to the default `github-token` exactly as before. The check never breaks, and no account is required for the default (unbranded) path.
- SARIF upload stays on `github-token` (needs `security-events` scope). New inputs: `branded-token` (default `true`) and `broker-url`.

Docs: README usage example now shows the optional `id-token: write` permission.

Verified: valid YAML, shellcheck clean, `bash -n` ok, cargo fmt/clippy/typos hooks pass.