### PR TITLE
fix(extract): trace conditional and logical dynamic imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Conditional and logical dynamic imports are now traced.** (#1742, contributed
+  by @Jerc92) `import(cond ? './a' : './b')` and `import(x || './b')` previously
+  produced no module-graph edge, so every file reachable only through such an
+  import (and its whole transitive subtree) was falsely reported as
+  `unused-files` / `unused-exports`. Extraction now emits one edge per
+  statically-resolvable branch, including parenthesized and no-substitution
+  template forms, across all dynamic-import shapes: bare expressions,
+  `const x = await import(...)` declarations, `.then()` callbacks,
+  `React.lazy` / `next/dynamic` arrow wrappers, and Angular/Vue route
+  `loadComponent` / `component` callbacks. Genuinely runtime arguments
+  (`import(someVar)`) still yield no edge, and repeated literals across branches
+  deduplicate to a single edge. Note: branches that were previously invisible are
+  now resolved like plain literal imports, so a conditional branch pointing at a
+  missing relative file surfaces as `unresolved-imports` (silence it via a
+  plugin's generated-file patterns, as with plain imports). A conditional that
+  mixes a literal with a pattern branch (a substitution template or path
+  concatenation) credits only the literal branch for now.
+
 - **`fallow health` no longer exits 1 when the config contains a `rules` key.** A bare `#[serde(default)]` on a rule-severity field resolved to `error` when a `rules` object was present (even `{"rules": {}}`), diverging from the documented default. `coverage-gaps` was promoted to `error`, tripping the standalone-health coverage-gap gate on any untested runtime file, so `fallow health` exited 1 with an otherwise-clean report; eight `warn`-default component / store / inject / server-action rules were likewise promoted to `error`, wrongly gating CI on Vue / Svelte / Angular projects. The nine affected defaults are now pinned to their documented values. Thanks [@lightsound](https://github.com/lightsound) for the report. (Closes [#1745](https://github.com/fallow-rs/fallow/issues/1745))
 
 - **Fixed `unused-class-member` false positives on public methods reached through a return-type-annotated factory.** A factory or hook whose body has no `new` value proof but is explicitly typed `: SomeController` (`function useController(): ReadyAppController { return registry.get() as ReadyAppController }`) now credits member reads on `const c = useController(); c.method()` across the module boundary, for both the function-declaration and arrow forms. A genuinely-unused method on the returned class still reports. Thanks [@prosky](https://github.com/prosky) for the report. (Closes [#1744](https://github.com/fallow-rs/fallow/issues/1744))
 
 ## [3.0.0] - 2026-07-04
+
 
 ### Added
 

--- a/crates/core/tests/integration_test/dynamic_imports.rs
+++ b/crates/core/tests/integration_test/dynamic_imports.rs
@@ -289,6 +289,86 @@ fn dynamic_import_pattern_makes_files_reachable() {
 }
 
 #[test]
+fn conditional_dynamic_import_reaches_both_branches() {
+    let root = fixture_path("dynamic-import-conditional");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| {
+            f.file
+                .path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect();
+
+    for reachable in ["m.mjs", "x.mjs", "y.mjs"] {
+        assert!(
+            !unused_file_names.contains(&reachable.to_string()),
+            "{reachable} should be reachable through the dynamic import, unused: {unused_file_names:?}"
+        );
+    }
+    assert!(
+        unused_file_names.contains(&"orphan.mjs".to_string()),
+        "a genuinely-unreferenced file should still be reported, found: {unused_file_names:?}"
+    );
+
+    // The destructured `a` and the conditional-branch `run` (via `backend.run()`)
+    // are consumed, so only the orphan's export remains dead.
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.export
+                    .path
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string(),
+                e.export.export_name.clone(),
+            )
+        })
+        .collect();
+    assert!(
+        !unused_exports
+            .iter()
+            .any(|(file, _)| matches!(file.as_str(), "m.mjs" | "x.mjs" | "y.mjs")),
+        "exports of dynamically-imported modules should be credited, unused: {unused_exports:?}"
+    );
+}
+
+#[test]
+fn fully_dynamic_import_does_not_fabricate_reachability() {
+    let root = fixture_path("dynamic-import-runtime-var");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| {
+            f.file
+                .path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect();
+
+    assert!(
+        unused_file_names.contains(&"real.mjs".to_string()),
+        "a runtime-variable import (import(someVar)) must not reach arbitrary files, unused: {unused_file_names:?}"
+    );
+}
+
+#[test]
 fn vite_glob_makes_files_reachable() {
     let root = fixture_path("vite-glob");
     let config = create_config(root);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -725,7 +725,13 @@ use crate::MemberKind;
 /// records a strict factory-return entry, so its `exported_factory_returns`
 /// output credits `const c = useController(); c.method()` across the module
 /// boundary; a warm 220 cache lacks that entry.
-pub(super) const CACHE_VERSION: u32 = 221;
+///
+/// Bumped to 222 (#1742): conditional and logical dynamic `import()` arguments
+/// (`import(c ? './a' : './b')`, `import(x || './b')`) are now traced, emitting one
+/// `DynamicImportInfo` edge per statically-resolvable branch (plus the wrapper
+/// families: `.then`, `React.lazy`/`next/dynamic`, route `loadComponent`). A warm
+/// cache from 221 lacks the added per-branch dynamic-import entries.
+pub(super) const CACHE_VERSION: u32 = 222;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -418,6 +418,40 @@ fn conditional_route_property_callback_credits_default_on_both_branches() {
 }
 
 #[test]
+fn parenthesized_bare_conditional_dynamic_import_credits_both_branches() {
+    let info = parse_source("async function f() { await import((cond ? './a.mjs' : './b.mjs')); }");
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(
+        sources,
+        vec!["./a.mjs", "./b.mjs"],
+        "a paren-wrapped conditional source must trace exactly like the bare form"
+    );
+}
+
+#[test]
+fn repeated_branch_literal_dedupes_to_one_edge() {
+    let info = parse_source(
+        "async function f() { await import(a ? './x.mjs' : b ? './x.mjs' : './y.mjs'); }",
+    );
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(
+        sources,
+        vec!["./x.mjs", "./y.mjs"],
+        "a literal repeated across branches must yield one edge, not duplicates"
+    );
+}
+
+#[test]
 fn require_context_with_json_regex() {
     let info = parse_source(r"const ctx = require.context('./locale', false, /\.json$/);");
     assert_eq!(info.dynamic_import_patterns.len(), 1);

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -288,6 +288,136 @@ fn dynamic_import_no_duplicate_entries() {
 }
 
 #[test]
+fn conditional_dynamic_import_namespace_credits_both_branches() {
+    let info = parse_source(
+        "async function f() { const backend = await import(target === 'mobile' ? './android.mjs' : './web.mjs'); }",
+    );
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(sources, vec!["./android.mjs", "./web.mjs"]);
+    assert!(
+        info.dynamic_imports
+            .iter()
+            .all(|imp| imp.local_name.as_deref() == Some("backend")),
+        "both branches should carry the namespace binding, got {:?}",
+        info.dynamic_imports
+    );
+}
+
+#[test]
+fn conditional_dynamic_import_destructure_credits_names_on_both_branches() {
+    let info = parse_source(
+        "async function f() { const { run } = await import(cond ? './x.mjs' : './y.mjs'); }",
+    );
+    assert_eq!(info.dynamic_imports.len(), 2);
+    for imp in &info.dynamic_imports {
+        assert!(imp.local_name.is_none());
+        assert_eq!(imp.destructured_names, vec!["run"]);
+    }
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(sources, vec!["./x.mjs", "./y.mjs"]);
+}
+
+#[test]
+fn bare_conditional_dynamic_import_is_side_effect_on_both_branches() {
+    let info = parse_source("async function f() { await import(cond ? './a.mjs' : './b.mjs'); }");
+    assert_eq!(info.dynamic_imports.len(), 2);
+    assert!(
+        info.dynamic_imports
+            .iter()
+            .all(|imp| imp.local_name.is_none() && imp.destructured_names.is_empty()),
+    );
+}
+
+#[test]
+fn logical_fallback_dynamic_import_credits_literal_branch() {
+    let info =
+        parse_source("async function f() { const m = await import(override || './default.mjs'); }");
+    let sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    assert_eq!(sources, vec!["./default.mjs"]);
+    assert_eq!(info.dynamic_imports[0].local_name, Some("m".to_string()));
+}
+
+#[test]
+fn conditional_dynamic_import_with_runtime_branch_credits_only_literal() {
+    let info = parse_source(
+        "async function f() { const m = await import(cond ? './real.mjs' : runtimeVar); }",
+    );
+    let sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    assert_eq!(
+        sources,
+        vec!["./real.mjs"],
+        "the runtime branch is unresolvable and must be skipped, not guessed"
+    );
+}
+
+#[test]
+fn fully_runtime_conditional_dynamic_import_records_nothing() {
+    let info = parse_source("async function f() { const m = await import(cond ? a : b); }");
+    assert!(
+        info.dynamic_imports.is_empty() && info.dynamic_import_patterns.is_empty(),
+        "a conditional of two runtime values stays unresolvable"
+    );
+}
+
+#[test]
+fn conditional_arrow_wrapped_import_credits_default_on_both_branches() {
+    let info = parse_source("const C = React.lazy(() => import(flag ? './A.jsx' : './B.jsx'));");
+    assert_eq!(info.dynamic_imports.len(), 2);
+    for imp in &info.dynamic_imports {
+        assert_eq!(
+            imp.destructured_names,
+            vec!["default"],
+            "a lazy wrapper consumes the default export, which must be credited on every branch"
+        );
+    }
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(sources, vec!["./A.jsx", "./B.jsx"]);
+}
+
+#[test]
+fn conditional_then_callback_credits_member_on_both_branches() {
+    let info = parse_source("import(cond ? './a.mjs' : './b.mjs').then(m => m.Widget);");
+    assert_eq!(info.dynamic_imports.len(), 2);
+    for imp in &info.dynamic_imports {
+        assert_eq!(imp.destructured_names, vec!["Widget"]);
+    }
+}
+
+#[test]
+fn conditional_route_property_callback_credits_default_on_both_branches() {
+    let info = parse_source(
+        "const route = { loadComponent: () => import(mobile ? './m.component.mjs' : './w.component.mjs') };",
+    );
+    assert_eq!(info.dynamic_imports.len(), 2);
+    for imp in &info.dynamic_imports {
+        assert_eq!(imp.destructured_names, vec!["default"]);
+    }
+}
+
+#[test]
 fn require_context_with_json_regex() {
     let info = parse_source(r"const ctx = require.context('./locale', false, /\.json$/);");
     assert_eq!(info.dynamic_import_patterns.len(), 1);

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -8,10 +8,7 @@ use oxc_ast::ast::{
     TSEnumMemberName, TSModuleDeclarationName, VariableDeclarator,
 };
 
-use crate::{
-    DynamicImportInfo, ExportInfo, ExportName, MemberInfo, MemberKind, RequireCallInfo,
-    VisibilityTag,
-};
+use crate::{ExportInfo, ExportName, MemberInfo, MemberKind, RequireCallInfo, VisibilityTag};
 use fallow_types::extract::ClassHeritageInfo;
 
 use super::helpers::{
@@ -375,8 +372,6 @@ impl ModuleInfoExtractor {
         }
     }
 
-    /// Handle `const x = await import('./y')` and `const x = import('./y')` patterns,
-    /// recording the dynamic import and tracking namespace bindings.
     /// Record dynamic-import edges for a `const {..}/x = await import(...)`
     /// declaration. `sources` carries one specifier per statically-resolvable
     /// branch (a conditional/logical `import()` yields several), so each branch
@@ -396,29 +391,13 @@ impl ModuleInfoExtractor {
         match &declarator.id {
             BindingPattern::ObjectPattern(obj_pat) => {
                 let names = extract_destructured_names(obj_pat);
-                for source in sources {
-                    self.dynamic_imports.push(DynamicImportInfo {
-                        source: source.clone(),
-                        span: import_expr.span,
-                        destructured_names: names.clone(),
-                        local_name: None,
-                        is_speculative: false,
-                    });
-                }
+                self.push_dynamic_import_branches(sources, import_expr.span, &names, None);
                 self.handled_import_spans.insert(import_expr.span);
             }
             BindingPattern::BindingIdentifier(id) => {
                 let local = id.name.to_string();
                 self.namespace_binding_names.push(local.clone());
-                for source in sources {
-                    self.dynamic_imports.push(DynamicImportInfo {
-                        source: source.clone(),
-                        span: import_expr.span,
-                        destructured_names: Vec::new(),
-                        local_name: Some(local.clone()),
-                        is_speculative: false,
-                    });
-                }
+                self.push_dynamic_import_branches(sources, import_expr.span, &[], Some(&local));
                 self.handled_import_spans.insert(import_expr.span);
             }
             _ => {}

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -377,34 +377,48 @@ impl ModuleInfoExtractor {
 
     /// Handle `const x = await import('./y')` and `const x = import('./y')` patterns,
     /// recording the dynamic import and tracking namespace bindings.
+    /// Record dynamic-import edges for a `const {..}/x = await import(...)`
+    /// declaration. `sources` carries one specifier per statically-resolvable
+    /// branch (a conditional/logical `import()` yields several), so each branch
+    /// gets an edge crediting the same destructured names / namespace binding.
+    ///
+    /// Every branch is credited with every binding, so branch-correlated use
+    /// (`cond ? m.xOnly() : m.yOnly()`) marks both members on both targets. That
+    /// over-credits in the false-negative direction only (it can hide a dead
+    /// export, never invent an `unused-export`), matching fallow's conservative
+    /// posture; a grouped conditional edge would be needed for branch precision.
     pub(super) fn handle_dynamic_import_declaration(
         &mut self,
         declarator: &VariableDeclarator<'_>,
         import_expr: &ImportExpression<'_>,
-        source: &str,
+        sources: &[String],
     ) {
         match &declarator.id {
             BindingPattern::ObjectPattern(obj_pat) => {
                 let names = extract_destructured_names(obj_pat);
-                self.dynamic_imports.push(DynamicImportInfo {
-                    source: source.to_string(),
-                    span: import_expr.span,
-                    destructured_names: names,
-                    local_name: None,
-                    is_speculative: false,
-                });
+                for source in sources {
+                    self.dynamic_imports.push(DynamicImportInfo {
+                        source: source.clone(),
+                        span: import_expr.span,
+                        destructured_names: names.clone(),
+                        local_name: None,
+                        is_speculative: false,
+                    });
+                }
                 self.handled_import_spans.insert(import_expr.span);
             }
             BindingPattern::BindingIdentifier(id) => {
                 let local = id.name.to_string();
                 self.namespace_binding_names.push(local.clone());
-                self.dynamic_imports.push(DynamicImportInfo {
-                    source: source.to_string(),
-                    span: import_expr.span,
-                    destructured_names: Vec::new(),
-                    local_name: Some(local),
-                    is_speculative: false,
-                });
+                for source in sources {
+                    self.dynamic_imports.push(DynamicImportInfo {
+                        source: source.clone(),
+                        span: import_expr.span,
+                        destructured_names: Vec::new(),
+                        local_name: Some(local.clone()),
+                        is_speculative: false,
+                    });
+                }
                 self.handled_import_spans.insert(import_expr.span);
             }
             _ => {}

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -1925,19 +1925,42 @@ fn try_extract_require<'a, 'b>(
     Some((call, &lit.value))
 }
 
-fn try_extract_dynamic_import<'a, 'b>(
-    init: &'b Expression<'a>,
-) -> Option<(&'b ImportExpression<'a>, &'b str)> {
-    let import_expr = extract_import_expression(init)?;
-    let Expression::StringLiteral(lit) = &import_expr.source else {
-        return None;
-    };
-    Some((import_expr, &lit.value))
+/// Collect every statically-resolvable module specifier from a dynamic
+/// `import()` source expression, following conditional and logical branches so
+/// `import(cond ? './a' : './b')` yields both `./a` and `./b`. String literals
+/// and no-substitution template literals resolve; genuinely runtime branches (a
+/// bare identifier, a call) are skipped, so a mixed
+/// `import(cond ? './a' : runtimeVar)` still credits the literal branch while
+/// `import(runtimeVar)` yields nothing (correctly left unresolvable).
+pub fn collect_static_import_specifiers(source: &Expression<'_>, out: &mut Vec<String>) {
+    match source {
+        Expression::StringLiteral(lit) => out.push(lit.value.to_string()),
+        Expression::TemplateLiteral(tpl)
+            if tpl.expressions.is_empty() && !tpl.quasis.is_empty() =>
+        {
+            let value = tpl.quasis[0].value.raw.to_string();
+            if !value.is_empty() {
+                out.push(value);
+            }
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            collect_static_import_specifiers(&paren.expression, out);
+        }
+        Expression::ConditionalExpression(cond) => {
+            collect_static_import_specifiers(&cond.consequent, out);
+            collect_static_import_specifiers(&cond.alternate, out);
+        }
+        Expression::LogicalExpression(logical) => {
+            collect_static_import_specifiers(&logical.left, out);
+            collect_static_import_specifiers(&logical.right, out);
+        }
+        _ => {}
+    }
 }
 
 fn try_extract_property_callback_import<'a, 'b>(
     prop: &'b ObjectProperty<'a>,
-) -> Option<(&'b ImportExpression<'a>, &'b str)> {
+) -> Option<(&'b ImportExpression<'a>, Vec<String>)> {
     let property_name = prop.key.static_name()?;
     if !matches!(
         property_name.as_ref(),
@@ -1947,10 +1970,12 @@ fn try_extract_property_callback_import<'a, 'b>(
     }
 
     let import_expr = extract_import_from_callable(&prop.value)?;
-    let Expression::StringLiteral(lit) = &import_expr.source else {
+    let mut sources = Vec::new();
+    collect_static_import_specifiers(&import_expr.source, &mut sources);
+    if sources.is_empty() {
         return None;
-    };
-    Some((import_expr, &lit.value))
+    }
+    Some((import_expr, sources))
 }
 
 #[must_use]
@@ -1968,7 +1993,7 @@ pub fn extract_import_expression<'a, 'b>(
 
 fn try_extract_arrow_wrapped_import<'a, 'b>(
     arguments: &'b [Argument<'a>],
-) -> Option<(&'b ImportExpression<'a>, &'b str)> {
+) -> Option<(&'b ImportExpression<'a>, Vec<String>)> {
     for arg in arguments {
         let Some(expr) = arg.as_expression() else {
             continue;
@@ -1976,10 +2001,11 @@ fn try_extract_arrow_wrapped_import<'a, 'b>(
         let Some(import_expr) = extract_import_from_callable(expr) else {
             continue;
         };
-        let Expression::StringLiteral(lit) = &import_expr.source else {
-            continue;
-        };
-        return Some((import_expr, &lit.value));
+        let mut sources = Vec::new();
+        collect_static_import_specifiers(&import_expr.source, &mut sources);
+        if !sources.is_empty() {
+            return Some((import_expr, sources));
+        }
     }
     None
 }
@@ -2026,7 +2052,7 @@ pub fn extract_import_from_callable<'a, 'b>(
 }
 
 struct ImportThenCallback {
-    source: String,
+    sources: Vec<String>,
     import_span: oxc_span::Span,
     destructured_names: Vec<String>,
     local_name: Option<String>,
@@ -2043,17 +2069,20 @@ fn try_extract_import_then_callback(expr: &CallExpression<'_>) -> Option<ImportT
     let Expression::ImportExpression(import_expr) = &member.object else {
         return None;
     };
-    let Expression::StringLiteral(lit) = &import_expr.source else {
+    let mut sources = Vec::new();
+    collect_static_import_specifiers(&import_expr.source, &mut sources);
+    if sources.is_empty() {
         return None;
-    };
-    let source = lit.value.to_string();
+    }
     let import_span = import_expr.span;
 
     match expr.arguments.first()? {
-        Argument::ArrowFunctionExpression(arrow) => arrow_then_callback(arrow, source, import_span),
+        Argument::ArrowFunctionExpression(arrow) => {
+            arrow_then_callback(arrow, sources, import_span)
+        }
         Argument::FunctionExpression(func) => {
             let param = func.params.items.first()?;
-            then_callback_from_pattern(&param.pattern, source, import_span)
+            then_callback_from_pattern(&param.pattern, sources, import_span)
         }
         _ => None,
     }
@@ -2063,7 +2092,7 @@ fn try_extract_import_then_callback(expr: &CallExpression<'_>) -> Option<ImportT
 /// expression-body member-access shape before falling back to the bare param.
 fn arrow_then_callback(
     arrow: &oxc_ast::ast::ArrowFunctionExpression<'_>,
-    source: String,
+    sources: Vec<String>,
     import_span: Span,
 ) -> Option<ImportThenCallback> {
     let param = arrow.params.items.first()?;
@@ -2074,38 +2103,38 @@ fn arrow_then_callback(
             && let Some(names) = extract_member_names_from_expr(&expr_stmt.expression, &param_name)
         {
             return Some(ImportThenCallback {
-                source,
+                sources,
                 import_span,
                 destructured_names: names,
                 local_name: None,
             });
         }
         return Some(ImportThenCallback {
-            source,
+            sources,
             import_span,
             destructured_names: Vec::new(),
             local_name: Some(param_name),
         });
     }
-    then_callback_from_pattern(&param.pattern, source, import_span)
+    then_callback_from_pattern(&param.pattern, sources, import_span)
 }
 
 /// Build an `ImportThenCallback` from a callback param pattern: object pattern
 /// yields destructured names, a bare identifier yields a namespace local.
 fn then_callback_from_pattern(
     pattern: &BindingPattern<'_>,
-    source: String,
+    sources: Vec<String>,
     import_span: Span,
 ) -> Option<ImportThenCallback> {
     match pattern {
         BindingPattern::ObjectPattern(obj_pat) => Some(ImportThenCallback {
-            source,
+            sources,
             import_span,
             destructured_names: extract_destructured_names(obj_pat),
             local_name: None,
         }),
         BindingPattern::BindingIdentifier(id) => Some(ImportThenCallback {
-            source,
+            sources,
             import_span,
             destructured_names: Vec::new(),
             local_name: Some(id.name.to_string()),

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -1931,15 +1931,22 @@ fn try_extract_require<'a, 'b>(
 /// and no-substitution template literals resolve; genuinely runtime branches (a
 /// bare identifier, a call) are skipped, so a mixed
 /// `import(cond ? './a' : runtimeVar)` still credits the literal branch while
-/// `import(runtimeVar)` yields nothing (correctly left unresolvable).
-pub fn collect_static_import_specifiers(source: &Expression<'_>, out: &mut Vec<String>) {
+/// `import(runtimeVar)` yields nothing (correctly left unresolvable). Repeated
+/// literals across branches are deduplicated so one call site never yields two
+/// identical edges (and thus duplicate unresolved-import findings).
+fn collect_static_import_specifiers(source: &Expression<'_>, out: &mut Vec<String>) {
     match source {
-        Expression::StringLiteral(lit) => out.push(lit.value.to_string()),
+        Expression::StringLiteral(lit) => {
+            let value = lit.value.to_string();
+            if !out.contains(&value) {
+                out.push(value);
+            }
+        }
         Expression::TemplateLiteral(tpl)
             if tpl.expressions.is_empty() && !tpl.quasis.is_empty() =>
         {
             let value = tpl.quasis[0].value.raw.to_string();
-            if !value.is_empty() {
+            if !value.is_empty() && !out.contains(&value) {
                 out.push(value);
             }
         }

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -1914,62 +1914,36 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             return;
         }
 
-        match &expr.source {
-            Expression::StringLiteral(lit) => {
-                self.dynamic_imports.push(DynamicImportInfo {
-                    source: lit.value.to_string(),
-                    span: expr.span,
-                    destructured_names: Vec::new(),
-                    local_name: None,
-                    is_speculative: false,
-                });
-            }
-            Expression::TemplateLiteral(tpl)
-                if !tpl.quasis.is_empty() && !tpl.expressions.is_empty() =>
-            {
-                self.record_dynamic_import_template_pattern(tpl, expr.span);
-            }
-            Expression::TemplateLiteral(tpl)
-                if !tpl.quasis.is_empty() && tpl.expressions.is_empty() =>
-            {
-                let value = tpl.quasis[0].value.raw.to_string();
-                if !value.is_empty() {
-                    self.dynamic_imports.push(DynamicImportInfo {
-                        source: value,
-                        span: expr.span,
-                        destructured_names: Vec::new(),
-                        local_name: None,
-                        is_speculative: false,
-                    });
-                }
-            }
-            Expression::BinaryExpression(bin)
-                if bin.operator == oxc_ast::ast::BinaryOperator::Addition =>
-            {
-                if let Some((prefix, suffix)) = extract_concat_parts(bin)
-                    && (prefix.starts_with("./") || prefix.starts_with("../"))
+        // Static specifiers first (string literals, no-substitution templates,
+        // and every statically-resolvable conditional/logical/parenthesized
+        // branch); only when none resolve, fall back to the pattern shapes
+        // (substitution templates and `'./x/' + y` concatenations).
+        let mut sources = Vec::new();
+        collect_static_import_specifiers(&expr.source, &mut sources);
+        if !sources.is_empty() {
+            self.push_dynamic_import_branches(&sources, expr.span, &[], None);
+        } else {
+            match &expr.source {
+                Expression::TemplateLiteral(tpl)
+                    if !tpl.quasis.is_empty() && !tpl.expressions.is_empty() =>
                 {
-                    self.dynamic_import_patterns.push(DynamicImportPattern {
-                        prefix,
-                        suffix,
-                        span: expr.span,
-                    });
+                    self.record_dynamic_import_template_pattern(tpl, expr.span);
                 }
-            }
-            Expression::ConditionalExpression(_) | Expression::LogicalExpression(_) => {
-                let mut sources = Vec::new();
-                collect_static_import_specifiers(&expr.source, &mut sources);
-                for source in sources {
-                    self.dynamic_imports.push(DynamicImportInfo {
-                        source,
-                        span: expr.span,
-                        destructured_names: Vec::new(),
-                        local_name: None,
-                        is_speculative: false,
-                    });
+                Expression::BinaryExpression(bin)
+                    if bin.operator == oxc_ast::ast::BinaryOperator::Addition =>
+                {
+                    if let Some((prefix, suffix)) = extract_concat_parts(bin)
+                        && (prefix.starts_with("./") || prefix.starts_with("../"))
+                    {
+                        self.dynamic_import_patterns.push(DynamicImportPattern {
+                            prefix,
+                            suffix,
+                            span: expr.span,
+                        });
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
 
         walk::walk_import_expression(self, expr);
@@ -1990,15 +1964,12 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.record_graphql_resolver_args_source(&prop.value);
 
         if let Some((import_expr, sources)) = try_extract_property_callback_import(prop) {
-            for source in sources {
-                self.dynamic_imports.push(DynamicImportInfo {
-                    source,
-                    span: import_expr.span,
-                    destructured_names: vec!["default".to_string()],
-                    local_name: None,
-                    is_speculative: false,
-                });
-            }
+            self.push_dynamic_import_branches(
+                &sources,
+                import_expr.span,
+                &["default".to_string()],
+                None,
+            );
             self.handled_import_spans.insert(import_expr.span);
         }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -33,8 +33,8 @@ use super::helpers::{
 };
 use super::{
     BindingTarget, ModuleInfoExtractor, PendingLocalExportSpecifier, SideEffectRegistrationTarget,
-    try_extract_arrow_wrapped_import, try_extract_dynamic_import, try_extract_import_then_callback,
-    try_extract_property_callback_import, try_extract_require,
+    collect_static_import_specifiers, extract_import_expression, try_extract_arrow_wrapped_import,
+    try_extract_import_then_callback, try_extract_property_callback_import, try_extract_require,
 };
 
 #[path = "visit_impl_di.rs"]
@@ -1341,10 +1341,15 @@ impl<'a> ModuleInfoExtractor {
             return;
         }
 
-        let Some((import_expr, source)) = try_extract_dynamic_import(init) else {
+        let Some(import_expr) = extract_import_expression(init) else {
             return;
         };
-        self.handle_dynamic_import_declaration(declarator, import_expr, source);
+        let mut sources = Vec::new();
+        collect_static_import_specifiers(&import_expr.source, &mut sources);
+        if sources.is_empty() {
+            return;
+        }
+        self.handle_dynamic_import_declaration(declarator, import_expr, &sources);
     }
 
     /// Record a CommonJS named export (`module.exports.X = ...` /
@@ -1951,6 +1956,19 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     });
                 }
             }
+            Expression::ConditionalExpression(_) | Expression::LogicalExpression(_) => {
+                let mut sources = Vec::new();
+                collect_static_import_specifiers(&expr.source, &mut sources);
+                for source in sources {
+                    self.dynamic_imports.push(DynamicImportInfo {
+                        source,
+                        span: expr.span,
+                        destructured_names: Vec::new(),
+                        local_name: None,
+                        is_speculative: false,
+                    });
+                }
+            }
             _ => {}
         }
 
@@ -1971,14 +1989,16 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     fn visit_object_property(&mut self, prop: &ObjectProperty<'a>) {
         self.record_graphql_resolver_args_source(&prop.value);
 
-        if let Some((import_expr, source)) = try_extract_property_callback_import(prop) {
-            self.dynamic_imports.push(DynamicImportInfo {
-                source: source.to_string(),
-                span: import_expr.span,
-                destructured_names: vec!["default".to_string()],
-                local_name: None,
-                is_speculative: false,
-            });
+        if let Some((import_expr, sources)) = try_extract_property_callback_import(prop) {
+            for source in sources {
+                self.dynamic_imports.push(DynamicImportInfo {
+                    source,
+                    span: import_expr.span,
+                    destructured_names: vec!["default".to_string()],
+                    local_name: None,
+                    is_speculative: false,
+                });
+            }
             self.handled_import_spans.insert(import_expr.span);
         }
 

--- a/crates/extract/src/visitor/visit_impl_dynamic_imports.rs
+++ b/crates/extract/src/visitor/visit_impl_dynamic_imports.rs
@@ -69,35 +69,51 @@ impl<'a> ModuleInfoExtractor {
         }
     }
 
+    /// Push one `DynamicImportInfo` edge per statically-resolvable branch of a
+    /// dynamic `import()`, every branch sharing the same span and bindings.
+    /// Single choke point for the branch fan-out used by the declaration,
+    /// bare-expression, `.then`, arrow-wrapped, and route-property paths.
+    pub(in crate::visitor) fn push_dynamic_import_branches(
+        &mut self,
+        sources: &[String],
+        span: Span,
+        destructured_names: &[String],
+        local_name: Option<&str>,
+    ) {
+        for source in sources {
+            self.dynamic_imports.push(DynamicImportInfo {
+                source: source.clone(),
+                span,
+                destructured_names: destructured_names.to_vec(),
+                local_name: local_name.map(str::to_string),
+                is_speculative: false,
+            });
+        }
+    }
+
     pub(super) fn record_import_callback_dynamic_imports(&mut self, expr: &CallExpression<'_>) {
         if let Some(then_cb) = try_extract_import_then_callback(expr) {
             if let Some(local) = &then_cb.local_name {
                 self.namespace_binding_names.push(local.clone());
             }
             self.handled_import_spans.insert(then_cb.import_span);
-            for source in then_cb.sources {
-                self.dynamic_imports.push(DynamicImportInfo {
-                    source,
-                    span: then_cb.import_span,
-                    destructured_names: then_cb.destructured_names.clone(),
-                    local_name: then_cb.local_name.clone(),
-                    is_speculative: false,
-                });
-            }
+            self.push_dynamic_import_branches(
+                &then_cb.sources,
+                then_cb.import_span,
+                &then_cb.destructured_names,
+                then_cb.local_name.as_deref(),
+            );
         }
     }
 
     pub(super) fn record_arrow_wrapped_dynamic_import(&mut self, expr: &CallExpression<'_>) {
         if let Some((import_expr, sources)) = try_extract_arrow_wrapped_import(&expr.arguments) {
-            for source in sources {
-                self.dynamic_imports.push(DynamicImportInfo {
-                    source,
-                    span: import_expr.span,
-                    destructured_names: vec!["default".to_string()],
-                    local_name: None,
-                    is_speculative: false,
-                });
-            }
+            self.push_dynamic_import_branches(
+                &sources,
+                import_expr.span,
+                &["default".to_string()],
+                None,
+            );
             self.handled_import_spans.insert(import_expr.span);
 
             // Record the `import()` span when this is a

--- a/crates/extract/src/visitor/visit_impl_dynamic_imports.rs
+++ b/crates/extract/src/visitor/visit_impl_dynamic_imports.rs
@@ -75,25 +75,29 @@ impl<'a> ModuleInfoExtractor {
                 self.namespace_binding_names.push(local.clone());
             }
             self.handled_import_spans.insert(then_cb.import_span);
-            self.dynamic_imports.push(DynamicImportInfo {
-                source: then_cb.source,
-                span: then_cb.import_span,
-                destructured_names: then_cb.destructured_names,
-                local_name: then_cb.local_name,
-                is_speculative: false,
-            });
+            for source in then_cb.sources {
+                self.dynamic_imports.push(DynamicImportInfo {
+                    source,
+                    span: then_cb.import_span,
+                    destructured_names: then_cb.destructured_names.clone(),
+                    local_name: then_cb.local_name.clone(),
+                    is_speculative: false,
+                });
+            }
         }
     }
 
     pub(super) fn record_arrow_wrapped_dynamic_import(&mut self, expr: &CallExpression<'_>) {
-        if let Some((import_expr, source)) = try_extract_arrow_wrapped_import(&expr.arguments) {
-            self.dynamic_imports.push(DynamicImportInfo {
-                source: source.to_string(),
-                span: import_expr.span,
-                destructured_names: vec!["default".to_string()],
-                local_name: None,
-                is_speculative: false,
-            });
+        if let Some((import_expr, sources)) = try_extract_arrow_wrapped_import(&expr.arguments) {
+            for source in sources {
+                self.dynamic_imports.push(DynamicImportInfo {
+                    source,
+                    span: import_expr.span,
+                    destructured_names: vec!["default".to_string()],
+                    local_name: None,
+                    is_speculative: false,
+                });
+            }
             self.handled_import_spans.insert(import_expr.span);
 
             // Record the `import()` span when this is a

--- a/tests/fixtures/dynamic-import-conditional/m.mjs
+++ b/tests/fixtures/dynamic-import-conditional/m.mjs
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/fixtures/dynamic-import-conditional/main.mjs
+++ b/tests/fixtures/dynamic-import-conditional/main.mjs
@@ -1,0 +1,4 @@
+const { a } = await import('./m.mjs');
+const cond = process.argv[2] === 'x';
+const backend = await import(cond ? './x.mjs' : './y.mjs');
+console.log(a, backend.run());

--- a/tests/fixtures/dynamic-import-conditional/orphan.mjs
+++ b/tests/fixtures/dynamic-import-conditional/orphan.mjs
@@ -1,0 +1,1 @@
+export const dead = 'unreachable';

--- a/tests/fixtures/dynamic-import-conditional/package.json
+++ b/tests/fixtures/dynamic-import-conditional/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dynamic-import-conditional",
+  "type": "module",
+  "main": "main.mjs"
+}

--- a/tests/fixtures/dynamic-import-conditional/x.mjs
+++ b/tests/fixtures/dynamic-import-conditional/x.mjs
@@ -1,0 +1,1 @@
+export function run() { return 'x'; }

--- a/tests/fixtures/dynamic-import-conditional/y.mjs
+++ b/tests/fixtures/dynamic-import-conditional/y.mjs
@@ -1,0 +1,1 @@
+export function run() { return 'y'; }

--- a/tests/fixtures/dynamic-import-runtime-var/main.mjs
+++ b/tests/fixtures/dynamic-import-runtime-var/main.mjs
@@ -1,0 +1,3 @@
+const name = process.argv[2];
+const mod = await import(name);
+console.log(mod);

--- a/tests/fixtures/dynamic-import-runtime-var/package.json
+++ b/tests/fixtures/dynamic-import-runtime-var/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dynamic-import-runtime-var",
+  "type": "module",
+  "main": "main.mjs"
+}

--- a/tests/fixtures/dynamic-import-runtime-var/real.mjs
+++ b/tests/fixtures/dynamic-import-runtime-var/real.mjs
@@ -1,0 +1,1 @@
+export function shouldStayUnused() { return 1; }


### PR DESCRIPTION
## What

Follow conditional and logical dynamic `import()` expressions in the module graph.

`import(cond ? './a' : './b')` and `import(x || './b')` were not traced: both
extraction paths required a string-literal argument, so a branching argument produced
no graph edge. Every module reachable only through such an import — and its whole
transitive subtree — was reported as `unused-file` / `unused-export`.

The fix collects every statically-resolvable specifier from the import argument,
recursing conditional/logical branches (plus parenthesized and no-substitution
template forms), and emits one edge per branch:

- `const { a } = await import(c ? './x' : './y')` credits `a` on both targets.
- `const ns = await import(c ? './a' : './b'); ns.run()` credits `run` on both.
- Bare `await import(c ? './a' : './b')` marks both files reachable (side-effect).
- The wrapper families — `.then(m => m.X)`, `React.lazy` / `next/dynamic` arrow
  wrappers, and Angular/Vue route `loadComponent` / `component` callbacks — collect
  branches the same way, preserving their default/named-export credit and the
  `next/dynamic(..., { ssr: false })` client-only security-span exemption on every
  branch.

Genuinely runtime arguments are still left unresolved: `import(someVar)` yields no
edge, and a mixed `import(c ? './a' : runtimeVar)` credits only the literal branch —
reachability is never fabricated.

Bumps `CACHE_VERSION` because extraction now emits more edges for the same source
bytes.

## Why

On a Node ESM project whose single entry lazy-loads its library through
`await import(...)` with a ternary specifier, the whole subtree hanging off the
conditional import cascaded to dead-code false positives (a real report saw ~97% of
files / ~96% of exports falsely flagged, with `unresolved-imports`,
`unlisted-dependencies`, and `circular-dependencies` all zero — i.e. pure
reachability false negatives).

## Test plan

- New extract unit tests (`crates/extract/src/tests/js_ts/dynamic_imports.rs`):
  conditional namespace / destructure / bare-side-effect on both branches, logical
  fallback, mixed runtime branch credits only the literal, fully-runtime records
  nothing, and the three wrapper families (`React.lazy`, `.then`, route
  `loadComponent`) credit default/member on both branches.
- New core integration fixtures + tests (`crates/core/tests/integration_test/dynamic_imports.rs`):
  `dynamic-import-conditional` (0 dead files/exports across the conditional targets,
  orphan still flagged) and `dynamic-import-runtime-var` (`import(someVar)` fabricates
  no reachability).
- `cargo test -p fallow-extract -p fallow-graph -p fallow-core` — all pass.
- `cargo clippy --all-targets` on the changed crates — clean. `cargo fmt --all --check` — clean.

### Known limitation

A conditional that mixes an exact specifier with a runtime glob pattern
(`import(flag ? './fixed' : \`./pages/${name}\`)`) traces only the exact branch; the
pattern branch is not converted to a glob-import pattern. This is strictly better than
the prior behavior (both branches were dead) and is a rare shape. Branch-correlated
member use (`cond ? m.x() : m.y()`) credits both members on both targets — an
over-credit in the false-negative direction only (never invents an `unused-export`),
matching the analyzer's conservative posture.
