### PR TITLE
fix(health): pluralize the large-functions unit-size footer

### DIFF
--- a/crates/cli/src/report/human/health.rs
+++ b/crates/cli/src/report/human/health.rs
@@ -1460,11 +1460,12 @@ fn render_large_functions(
             format!("{:>3}", entry.line_count).red().bold(),
         ));
     }
+    let unit_ceiling = report.summary.max_unit_size_threshold;
+    let unit_word = if unit_ceiling == 1 { "line" } else { "lines" };
     lines.push(format!(
         "  {}",
         format!(
-            "Functions exceeding {} lines of code (very high risk): {DOCS_HEALTH}#unit-size",
-            report.summary.max_unit_size_threshold
+            "Functions exceeding {unit_ceiling} {unit_word} of code (very high risk): {DOCS_HEALTH}#unit-size"
         )
         .dimmed()
     ));


### PR DESCRIPTION
The human "Large functions" footer added in #1750 renders "Functions exceeding {max_unit_size_threshold} lines of code". When `health.maxUnitSize` is set to 1 it reads "exceeding 1 lines"; this guards the noun so a ceiling of 1 renders "exceeding 1 line" (every other value, including 0, stays plural).

Follow-up to #1750 / #1752. No behavior change beyond the footer wording.

Refs #1750.