### PR TITLE
fix: credit iteration binding followups

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -692,18 +692,25 @@ impl AngularTemplateRefContext<'_, '_> {
     }
 }
 
-fn component_instance_bindings(
+fn component_bindings(
+    resolved: &ResolvedModule,
     class_heritage: &[fallow_types::extract::ClassHeritageInfo],
-) -> FxHashMap<&str, &str> {
-    class_heritage
+) -> FxHashMap<String, String> {
+    let mut bindings: FxHashMap<String, String> = class_heritage
         .iter()
         .flat_map(|heritage| {
             heritage
                 .instance_bindings
                 .iter()
-                .map(|(local, ty)| (local.as_str(), ty.as_str()))
+                .map(|(local, ty)| (local.clone(), ty.clone()))
         })
-        .collect()
+        .collect();
+    for field in SemanticFactView::new(&resolved.semantic_facts, &resolved.member_accesses)
+        .angular_component_field_array_types()
+    {
+        bindings.entry(field.field).or_insert(field.element_class);
+    }
+    bindings
 }
 
 struct MemberHeritageContext<'a> {
@@ -824,8 +831,8 @@ struct AngularTemplateChainContext<'a, 'b> {
     accessed_members: &'b mut FxHashMap<ExportKey, FxHashSet<String>>,
 }
 
-struct AngularTemplateComponentContext<'a, 'b> {
-    component_bindings: FxHashMap<&'a str, &'a str>,
+struct AngularTemplateComponentContext<'b> {
+    component_bindings: FxHashMap<String, String>,
     local_to_export_keys: FxHashMap<&'b str, Vec<ExportKey>>,
 }
 
@@ -833,10 +840,10 @@ impl<'a> AngularTemplateChainContext<'a, '_> {
     fn credit_members(
         &mut self,
         chains: &[(&str, &str)],
-        component: &AngularTemplateComponentContext<'a, '_>,
+        component: &AngularTemplateComponentContext<'_>,
     ) {
         for (object, member) in chains {
-            let Some(type_name) = component.component_bindings.get(object) else {
+            let Some(type_name) = component.component_bindings.get(*object) else {
                 continue;
             };
             credit_angular_token_chain_member(&mut AngularTokenChainCreditInput {
@@ -860,11 +867,8 @@ impl<'a> AngularTemplateChainContext<'a, '_> {
             let Some(class_heritage) = self.class_heritage_by_file.get(&resolved.file_id) else {
                 continue;
             };
-            if class_heritage.is_empty() {
-                continue;
-            }
             let component = AngularTemplateComponentContext {
-                component_bindings: component_instance_bindings(class_heritage),
+                component_bindings: component_bindings(resolved, class_heritage),
                 local_to_export_keys: build_local_to_export_keys(resolved),
             };
             if component.component_bindings.is_empty() {

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -836,7 +836,7 @@ struct AngularTemplateComponentContext<'b> {
     local_to_export_keys: FxHashMap<&'b str, Vec<ExportKey>>,
 }
 
-impl<'a> AngularTemplateChainContext<'a, '_> {
+impl AngularTemplateChainContext<'_, '_> {
     fn credit_members(
         &mut self,
         chains: &[(&str, &str)],

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -354,6 +354,15 @@ mod issue_1707_vue_vfor_class_member;
 #[path = "integration_test/issue_1711_vue_props_vfor.rs"]
 mod issue_1711_vue_props_vfor;
 
+#[path = "integration_test/issue_1716_vue_ref_store_vfor.rs"]
+mod issue_1716_vue_ref_store_vfor;
+
+#[path = "integration_test/issue_1717_angular_template_url_class_member.rs"]
+mod issue_1717_angular_template_url_class_member;
+
+#[path = "integration_test/issue_1718_function_local_iteration.rs"]
+mod issue_1718_function_local_iteration;
+
 #[path = "integration_test/iteration_binding_element_types.rs"]
 mod iteration_binding_element_types;
 

--- a/crates/core/tests/integration_test/issue_1716_vue_ref_store_vfor.rs
+++ b/crates/core/tests/integration_test/issue_1716_vue_ref_store_vfor.rs
@@ -1,0 +1,33 @@
+use super::common::{create_config, fixture_path};
+
+/// Issue #1716: Vue `v-for` sources such as `items.value` and `store.entries`
+/// must carry the source array element type to the loop item.
+#[test]
+fn vue_ref_value_and_store_member_vfor_credit_class_member_accesses() {
+    let root = fixture_path("issue-1716-vue-ref-store-vfor");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|member| {
+            format!(
+                "{}.{}",
+                member.member.parent_name, member.member.member_name
+            )
+        })
+        .collect();
+
+    for member in ["property", "getter", "hello"] {
+        assert!(
+            !unused_members.contains(&format!("Util.{member}")),
+            "Util.{member} is accessed via a v-for item and must be credited, found: {unused_members:?}"
+        );
+    }
+
+    assert!(
+        unused_members.contains(&"Util.unusedMethod".to_string()),
+        "Util.unusedMethod is never accessed and must still be reported, found: {unused_members:?}"
+    );
+}

--- a/crates/core/tests/integration_test/issue_1717_angular_template_url_class_member.rs
+++ b/crates/core/tests/integration_test/issue_1717_angular_template_url_class_member.rs
@@ -1,0 +1,33 @@
+use super::common::{create_config, fixture_path};
+
+/// Issue #1717: Angular external `templateUrl` loops must credit class members
+/// accessed through `@for` / `*ngFor` loop items over a typed component field.
+#[test]
+fn angular_external_template_for_loop_variable_credits_class_member_accesses() {
+    let root = fixture_path("issue-1717-angular-template-url-class-member");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|member| {
+            format!(
+                "{}.{}",
+                member.member.parent_name, member.member.member_name
+            )
+        })
+        .collect();
+
+    for member in ["property", "getter", "getName"] {
+        assert!(
+            !unused_members.contains(&format!("Util.{member}")),
+            "Util.{member} is accessed via an external-template loop item and must be credited, found: {unused_members:?}"
+        );
+    }
+
+    assert!(
+        unused_members.contains(&"Util.unusedMethod".to_string()),
+        "Util.unusedMethod is never accessed and must still be reported, found: {unused_members:?}"
+    );
+}

--- a/crates/core/tests/integration_test/issue_1718_function_local_iteration.rs
+++ b/crates/core/tests/integration_test/issue_1718_function_local_iteration.rs
@@ -1,0 +1,33 @@
+use super::common::{create_config, fixture_path};
+
+/// Issue #1718: function-local typed arrays must type `.map` callbacks and
+/// `for...of` loop variables in the same function body.
+#[test]
+fn function_local_array_iteration_credits_class_member_accesses() {
+    let root = fixture_path("issue-1718-function-local-iteration");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|member| {
+            format!(
+                "{}.{}",
+                member.member.parent_name, member.member.member_name
+            )
+        })
+        .collect();
+
+    for member in ["property", "getter", "hello"] {
+        assert!(
+            !unused_members.contains(&format!("Util.{member}")),
+            "Util.{member} is accessed through function-local iteration and must be credited, found: {unused_members:?}"
+        );
+    }
+
+    assert!(
+        unused_members.contains(&"Util.unusedMethod".to_string()),
+        "Util.unusedMethod is never accessed and must still be reported, found: {unused_members:?}"
+    );
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -731,7 +731,12 @@ use crate::MemberKind;
 /// `DynamicImportInfo` edge per statically-resolvable branch (plus the wrapper
 /// families: `.then`, `React.lazy`/`next/dynamic`, route `loadComponent`). A warm
 /// cache from 221 lacks the added per-branch dynamic-import entries.
-pub(super) const CACHE_VERSION: u32 = 222;
+///
+/// Bumped to 223 for issues #1716, #1717, and #1718: iterable element-type
+/// crediting now includes Vue `ref.value` / object-member `v-for` sources,
+/// function-local JS array receivers, and Angular external `templateUrl`
+/// loop-item remapping through component field array facts.
+pub(super) const CACHE_VERSION: u32 = 223;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -53,14 +53,15 @@ use cache::CacheStore;
 use fallow_types::discover::{DiscoveredFile, FileId};
 
 pub use fallow_types::extract::{
-    AngularTemplateMemberAccessFact, AngularThisSpreadFact, ClassHeritageInfo,
-    DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
-    ExportName, FactoryCallMemberAccessFact, FactoryFnMemberAccessFact, FactoryReturnExport,
-    FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
-    InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, ParseResult, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
-    ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag, compute_line_offsets,
+    AngularComponentFieldArrayTypeFact, AngularTemplateMemberAccessFact, AngularThisSpreadFact,
+    ClassHeritageInfo, DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern,
+    ExportInfo, ExportName, FactoryCallMemberAccessFact, FactoryFnMemberAccessFact,
+    FactoryReturnExport, FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo,
+    ImportedName, InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo,
+    MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureAliasFact,
+    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
+    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
+    compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -109,6 +109,7 @@ pub use parse::parse_source_to_module;
 /// without BOM; line offsets are computed against the post-BOM view; the BOM,
 /// if present on input, is preserved on output by `fallow fix`."
 const BOM_CHAR: char = '\u{FEFF}';
+const PARALLEL_PARSE_FILE_THRESHOLD: usize = 32;
 
 /// Strip the leading UTF-8 BOM if present.
 ///
@@ -133,10 +134,17 @@ pub fn parse_all_files(
     cache: Option<&CacheStore>,
     need_complexity: bool,
 ) -> ParseResult {
-    let results: Vec<ParseFileResult> = files
-        .par_iter()
-        .map(|file| parse_single_file_cached(file, cache, need_complexity))
-        .collect();
+    let results: Vec<ParseFileResult> = if files.len() <= PARALLEL_PARSE_FILE_THRESHOLD {
+        files
+            .iter()
+            .map(|file| parse_single_file_cached(file, cache, need_complexity))
+            .collect()
+    } else {
+        files
+            .par_iter()
+            .map(|file| parse_single_file_cached(file, cache, need_complexity))
+            .collect()
+    };
 
     let mut modules = Vec::with_capacity(results.len());
     let mut hits = 0usize;

--- a/crates/extract/src/sfc_template/angular.rs
+++ b/crates/extract/src/sfc_template/angular.rs
@@ -134,7 +134,7 @@ static CONTROL_FOR_RE: LazyLock<regex::Regex> =
 /// `obj.member` chains where `obj` is an unresolved identifier. Together these
 /// represent potential component class member references.
 pub fn collect_angular_template_refs(source: &str) -> AngularTemplateRefs {
-    collect_angular_template_refs_with_field_types(source, &FxHashMap::default())
+    collect_angular_template_refs_inner(source, &FxHashMap::default(), true)
 }
 
 /// As [`collect_angular_template_refs`], additionally typing each `@for` /
@@ -147,8 +147,21 @@ pub fn collect_angular_template_refs_with_field_types(
     source: &str,
     component_field_array_types: &FxHashMap<String, String>,
 ) -> AngularTemplateRefs {
+    collect_angular_template_refs_inner(source, component_field_array_types, false)
+}
+
+fn collect_angular_template_refs_inner(
+    source: &str,
+    component_field_array_types: &FxHashMap<String, String>,
+    preserve_untyped_iteration_sources: bool,
+) -> AngularTemplateRefs {
     let source = strip_html_comments_preserve_offsets(source);
-    AngularTemplateScanner::new(&source, component_field_array_types).scan()
+    AngularTemplateScanner::new(
+        &source,
+        component_field_array_types,
+        preserve_untyped_iteration_sources,
+    )
+    .scan()
 }
 
 struct AngularTemplateScanner<'a> {
@@ -163,16 +176,28 @@ struct AngularTemplateScanner<'a> {
     /// blocks are entered. A member access on such a loop variable is remapped
     /// onto the element class in the finalize pass.
     iteration_element_types: FxHashMap<String, String>,
+    /// Loop variable name -> iterable field name for external templates that do
+    /// not know component field types during scanning. A member access on the
+    /// item is remapped onto the iterable field (`util.getName` -> `utils.getName`)
+    /// so core can resolve `utils -> Util` from the owning component.
+    iteration_iterable_sources: FxHashMap<String, String>,
+    preserve_untyped_iteration_sources: bool,
 }
 
 impl<'a> AngularTemplateScanner<'a> {
-    fn new(source: &'a str, component_field_array_types: &'a FxHashMap<String, String>) -> Self {
+    fn new(
+        source: &'a str,
+        component_field_array_types: &'a FxHashMap<String, String>,
+        preserve_untyped_iteration_sources: bool,
+    ) -> Self {
         Self {
             source,
             refs: AngularTemplateRefs::default(),
             scopes: vec![Vec::new()],
             component_field_array_types,
             iteration_element_types: FxHashMap::default(),
+            iteration_iterable_sources: FxHashMap::default(),
+            preserve_untyped_iteration_sources,
         }
     }
 
@@ -181,7 +206,11 @@ impl<'a> AngularTemplateScanner<'a> {
         while index < self.source.len() {
             index = self.scan_next(index);
         }
-        remap_iteration_member_accesses(&mut self.refs, &self.iteration_element_types);
+        remap_iteration_member_accesses(
+            &mut self.refs,
+            &self.iteration_element_types,
+            &self.iteration_iterable_sources,
+        );
         self.refs
     }
 
@@ -211,6 +240,8 @@ impl<'a> AngularTemplateScanner<'a> {
         let mut iter_ctx = IterationTypingCtx {
             component_field_array_types: self.component_field_array_types,
             iteration_element_types: &mut self.iteration_element_types,
+            iteration_iterable_sources: &mut self.iteration_iterable_sources,
+            preserve_untyped_iteration_sources: self.preserve_untyped_iteration_sources,
         };
         handle_control_flow(
             self.source,
@@ -236,6 +267,8 @@ impl<'a> AngularTemplateScanner<'a> {
         let mut iter_ctx = IterationTypingCtx {
             component_field_array_types: self.component_field_array_types,
             iteration_element_types: &mut self.iteration_element_types,
+            iteration_iterable_sources: &mut self.iteration_iterable_sources,
+            preserve_untyped_iteration_sources: self.preserve_untyped_iteration_sources,
         };
         process_tag(tag, index, &mut self.scopes, &mut self.refs, &mut iter_ctx);
         next_index
@@ -249,9 +282,15 @@ impl<'a> AngularTemplateScanner<'a> {
 struct IterationTypingCtx<'a> {
     component_field_array_types: &'a FxHashMap<String, String>,
     iteration_element_types: &'a mut FxHashMap<String, String>,
+    iteration_iterable_sources: &'a mut FxHashMap<String, String>,
+    preserve_untyped_iteration_sources: bool,
 }
 
 impl IterationTypingCtx<'_> {
+    fn preserves_untyped_iteration_sources(&self) -> bool {
+        self.preserve_untyped_iteration_sources
+    }
+
     /// If `iterable` is a bare-identifier component field with a known element
     /// class, record `binding -> class` and return `true` so the caller can keep
     /// the loop variable OUT of the block locals (its member accesses then
@@ -265,6 +304,11 @@ impl IterationTypingCtx<'_> {
             return false;
         }
         let Some(class) = self.component_field_array_types.get(iterable) else {
+            if self.preserve_untyped_iteration_sources {
+                self.iteration_iterable_sources
+                    .entry(binding.to_string())
+                    .or_insert_with(|| iterable.to_string());
+            }
             return false;
         };
         self.iteration_element_types
@@ -294,17 +338,23 @@ fn is_bare_identifier(name: &str) -> bool {
 fn remap_iteration_member_accesses(
     refs: &mut AngularTemplateRefs,
     iteration_element_types: &FxHashMap<String, String>,
+    iteration_iterable_sources: &FxHashMap<String, String>,
 ) {
-    if iteration_element_types.is_empty() {
+    if iteration_element_types.is_empty() && iteration_iterable_sources.is_empty() {
         return;
     }
     for access in &mut refs.member_accesses {
         if let Some(class) = iteration_element_types.get(&access.object) {
             access.object = class.clone();
+        } else if let Some(iterable) = iteration_iterable_sources.get(&access.object) {
+            access.object = iterable.clone();
         }
     }
     dedup_member_accesses(&mut refs.member_accesses);
     for name in iteration_element_types.keys() {
+        refs.identifiers.remove(name);
+    }
+    for name in iteration_iterable_sources.keys() {
         refs.identifiers.remove(name);
     }
 }
@@ -555,7 +605,11 @@ fn handle_for_control_flow(
         // #1712), keep it OUT of the block locals so `util.getName` survives as a
         // member access and remaps onto `Util` in the finalize pass; otherwise it
         // is a normal local shadowing any same-named component member.
-        if !iter_ctx.try_type_loop_variable(binding, iterable) {
+        let typed = iter_ctx.try_type_loop_variable(binding, iterable);
+        if !typed
+            && (!is_bare_identifier(binding.trim())
+                || !iter_ctx.preserves_untyped_iteration_sources())
+        {
             locals_for_scope.push(binding.to_string());
         }
         for implicit in &["$index", "$first", "$last", "$even", "$odd", "$count"] {
@@ -801,7 +855,10 @@ fn handle_ng_for(
             // `ng_for_locals` so `items` (not `item`) is the credited reference.
             let typed = iter_ctx.try_type_loop_variable(binding, iterable);
             ng_for_locals.push(binding.to_string());
-            if !typed {
+            if !typed
+                && (!is_bare_identifier(binding.trim())
+                    || !iter_ctx.preserves_untyped_iteration_sources())
+            {
                 new_scope_locals.push(binding.to_string());
             }
             collect_expression_refs(iterable, &ng_for_locals, refs);

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -12,13 +12,13 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::suppress::ParsedSuppressions;
 use crate::{
-    AngularTemplateMemberAccessFact, AngularThisSpreadFact, DynamicCustomElementRenderFact,
-    DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, FactoryCallMemberAccessFact,
-    FactoryFnMemberAccessFact, FluentChainMemberAccessFact, FluentChainNewMemberAccessFact,
-    ImportInfo, ImportedName, InstanceExportBindingFact, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo,
-    SemanticFact, VisibilityTag,
+    AngularComponentFieldArrayTypeFact, AngularTemplateMemberAccessFact, AngularThisSpreadFact,
+    DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
+    ExportName, FactoryCallMemberAccessFact, FactoryFnMemberAccessFact,
+    FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
+    InstanceExportBindingFact, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
+    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+    PlaywrightFixtureUseFact, ReExportInfo, RequireCallInfo, SemanticFact, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, AngularInputMember, AngularOutputMember, CalleeUse,
@@ -218,6 +218,11 @@ pub(crate) struct ModuleInfoExtractor {
     /// (`{{ util.getter }}`) credit the class. Transient extractor state, not a
     /// cached `ModuleInfo` field (mirrors `binding_target_names`).
     array_binding_element_types: FxHashMap<String, String>,
+    /// Block/function-scoped array element types for local iteration receivers.
+    /// This lets `const utils: Util[]` inside a function type `.map((util) => …)`
+    /// and `for (const util of utils)` in the same lexical scope without leaking
+    /// the binding to sibling functions.
+    scoped_array_binding_element_types: Vec<FxHashMap<String, String>>,
     object_binding_candidates: Vec<ObjectBindingCandidate>,
     local_declaration_names: FxHashSet<String>,
     pending_local_export_specifiers: Vec<PendingLocalExportSpecifier>,
@@ -695,6 +700,20 @@ impl ModuleInfoExtractor {
         self.semantic_facts
             .push(SemanticFact::AngularTemplateMemberAccess(
                 AngularTemplateMemberAccessFact { member },
+            ));
+    }
+
+    pub(crate) fn record_angular_component_field_array_type_fact(
+        &mut self,
+        field: String,
+        element_class: String,
+    ) {
+        self.semantic_facts
+            .push(SemanticFact::AngularComponentFieldArrayType(
+                AngularComponentFieldArrayTypeFact {
+                    field,
+                    element_class,
+                },
             ));
     }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -22,9 +22,9 @@ use crate::asset_url::normalize_asset_url;
 use crate::html::is_remote_url;
 
 use super::helpers::{
-    extract_angular_component_metadata, extract_angular_inputs_outputs,
-    extract_angular_signal_query, extract_class_members, extract_concat_parts,
-    extract_custom_element_tag_reference, extract_custom_elements_define,
+    array_element_type_from_type, extract_angular_component_metadata,
+    extract_angular_inputs_outputs, extract_angular_signal_query, extract_class_members,
+    extract_concat_parts, extract_custom_element_tag_reference, extract_custom_elements_define,
     extract_implemented_interface_names, extract_nested_type_bindings,
     extract_query_list_element_type, extract_super_class_name, extract_type_annotation_name,
     has_angular_class_decorator, has_angular_plural_query_decorator,
@@ -444,7 +444,66 @@ impl ModuleInfoExtractor {
         self.iterable_element_types
             .get(receiver_name)
             .or_else(|| self.array_binding_element_types.get(receiver_name))
+            .or_else(|| {
+                self.scoped_array_binding_element_types
+                    .iter()
+                    .rev()
+                    .find_map(|scope| scope.get(receiver_name))
+            })
             .cloned()
+    }
+
+    fn record_array_binding_element_type(&mut self, binding: String, element: String) {
+        if self.is_module_scope() {
+            self.array_binding_element_types.insert(binding, element);
+        } else if let Some(scope) = self.scoped_array_binding_element_types.last_mut() {
+            scope.insert(binding, element);
+        }
+    }
+
+    fn record_vue_ref_value_array_binding_type(
+        &mut self,
+        binding: &str,
+        init: &Expression<'_>,
+        element: &str,
+    ) {
+        let Expression::CallExpression(call) = init else {
+            return;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            return;
+        };
+        if matches!(callee.name.as_str(), "ref" | "shallowRef" | "computed") {
+            self.record_array_binding_element_type(format!("{binding}.value"), element.to_string());
+        }
+    }
+
+    fn record_object_array_member_binding_types(
+        &mut self,
+        binding: &str,
+        type_annotation: Option<&TSTypeAnnotation<'_>>,
+    ) {
+        let Some(type_annotation) = type_annotation else {
+            return;
+        };
+        let TSType::TSTypeLiteral(literal) = &type_annotation.type_annotation else {
+            return;
+        };
+        for member in &literal.members {
+            let TSSignature::TSPropertySignature(prop) = member else {
+                continue;
+            };
+            let Some(property_name) = prop.key.static_name() else {
+                continue;
+            };
+            let Some(property_type) = prop.type_annotation.as_deref() else {
+                continue;
+            };
+            let Some(element) = array_element_type_from_type(&property_type.type_annotation) else {
+                continue;
+            };
+            self.record_array_binding_element_type(format!("{binding}.{property_name}"), element);
+        }
     }
 
     /// Bind a `for (const util of utils)` loop variable to the element class of
@@ -1276,18 +1335,26 @@ impl<'a> ModuleInfoExtractor {
                 .entry(id.name.to_string())
                 .or_default()
                 .push(classify_factory_assigned_value(init));
+        }
 
-            // Type a module-scope array / reactive-array binding to its element
-            // class so the Vue SFC template scanner can credit `v-for`
-            // loop-variable member accesses (`{{ util.getter }}`). Over-credit
-            // only (never adds a finding); consumed solely by the Vue template
-            // scan. See issue #1707.
-            if let Some(element) =
+        // Type array / reactive-array bindings to their element class so
+        // iteration callbacks and `for...of` loops can credit item member
+        // accesses. Module-scope entries remain visible to template scanners;
+        // function/block locals stay scoped to the active visitor stack.
+        if let BindingPattern::BindingIdentifier(id) = &declarator.id
+            && let Some(element) =
                 infer_array_binding_element_type(declarator.type_annotation.as_deref(), Some(init))
-            {
-                self.array_binding_element_types
-                    .insert(id.name.to_string(), element);
-            }
+        {
+            let binding = id.name.to_string();
+            self.record_vue_ref_value_array_binding_type(&binding, init, &element);
+            self.record_array_binding_element_type(binding, element);
+        }
+
+        if let BindingPattern::BindingIdentifier(id) = &declarator.id {
+            self.record_object_array_member_binding_types(
+                id.name.as_str(),
+                declarator.type_annotation.as_deref(),
+            );
         }
 
         // FP-1 (unused-load-data-key): `const X = data` passes the whole
@@ -1586,6 +1653,12 @@ impl<'a> ModuleInfoExtractor {
             });
     }
 
+    fn record_angular_component_field_array_types(&mut self, class: &Class<'_>) {
+        for (field, element_class) in super::helpers::collect_component_field_array_types(class) {
+            self.record_angular_component_field_array_type_fact(field, element_class);
+        }
+    }
+
     /// Record Angular `host:` binding and `inputs:` / `outputs:` member refs as
     /// typed template member facts.
     fn record_angular_template_members(&mut self, meta: &super::helpers::AngularComponentMetadata) {
@@ -1691,6 +1764,8 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.block_depth += 1;
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.push(FxHashSet::default());
+            self.scoped_array_binding_element_types
+                .push(FxHashMap::default());
             self.sanitizer_binding_stack.push(FxHashMap::default());
             self.literal_allowlist_binding_stack
                 .push(FxHashMap::default());
@@ -1706,6 +1781,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.pop();
+            self.scoped_array_binding_element_types.pop();
             self.sanitizer_binding_stack.pop();
             self.literal_allowlist_binding_stack.pop();
             self.risky_regex_binding_stack.pop();
@@ -1748,11 +1824,18 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_function_body(&mut self, body: &FunctionBody<'a>) {
+        if self.namespace_depth == 0 {
+            self.scoped_array_binding_element_types
+                .push(FxHashMap::default());
+        }
         for statement in &body.statements {
             self.visit_statement(statement);
             if self.namespace_depth == 0 {
                 self.record_fail_closed_guard_after_statement(statement);
             }
+        }
+        if self.namespace_depth == 0 {
+            self.scoped_array_binding_element_types.pop();
         }
     }
 
@@ -2347,6 +2430,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
 
         if let Some(meta) = extract_angular_component_metadata(class) {
             self.record_angular_selector(class, &meta);
+            self.record_angular_component_field_array_types(class);
             self.record_angular_template_assets(&meta);
             self.record_angular_inline_template(class, &meta);
             self.record_angular_template_members(&meta);

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1434,6 +1434,8 @@ pub enum SemanticFact {
     /// A class member referenced from an Angular template, host binding, or
     /// component metadata entry.
     AngularTemplateMemberAccess(AngularTemplateMemberAccessFact),
+    /// An Angular component field whose value is an array of a class.
+    AngularComponentFieldArrayType(AngularComponentFieldArrayTypeFact),
     /// An Angular component spreads `this` into an object literal, so component
     /// input/output usage is opaque.
     AngularThisSpread(AngularThisSpreadFact),
@@ -1543,6 +1545,13 @@ impl<'a> SemanticFactView<'a> {
         angular_template_member_names_from_parts(self.semantic_facts)
     }
 
+    /// Collect Angular component field array-type facts.
+    pub fn angular_component_field_array_types(self) -> Vec<AngularComponentFieldArrayTypeFact> {
+        angular_component_field_array_type_facts(self.semantic_facts)
+            .cloned()
+            .collect()
+    }
+
     /// Return true when any Angular template member reference exists.
     #[must_use]
     pub fn has_angular_template_members(self) -> bool {
@@ -1637,6 +1646,18 @@ fn instance_export_binding_facts(
 ) -> impl Iterator<Item = &InstanceExportBindingFact> {
     semantic_facts.iter().filter_map(|fact| {
         if let SemanticFact::InstanceExportBinding(access) = fact {
+            Some(access)
+        } else {
+            None
+        }
+    })
+}
+
+fn angular_component_field_array_type_facts(
+    semantic_facts: &[SemanticFact],
+) -> impl Iterator<Item = &AngularComponentFieldArrayTypeFact> {
+    semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::AngularComponentFieldArrayType(access) = fact {
             Some(access)
         } else {
             None
@@ -1754,6 +1775,16 @@ fn playwright_fixture_type_facts(
 pub struct AngularTemplateMemberAccessFact {
     /// Referenced class member name.
     pub member: String,
+}
+
+/// A typed Angular component field that exposes array elements to templates.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AngularComponentFieldArrayTypeFact {
+    /// Component field name used as the template iterable.
+    pub field: String,
+    /// Array element class name.
+    pub element_class: String,
 }
 
 /// Opaque Angular `{ ...this }` forwarding marker.

--- a/tests/fixtures/issue-1716-vue-ref-store-vfor/package.json
+++ b/tests/fixtures/issue-1716-vue-ref-store-vfor/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-1716-vue-ref-store-vfor",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "vue": "^3.5.0"
+  }
+}

--- a/tests/fixtures/issue-1716-vue-ref-store-vfor/src/App.vue
+++ b/tests/fixtures/issue-1716-vue-ref-store-vfor/src/App.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Util } from './utils/Util'
+
+const items = ref<Util[]>([new Util()])
+const store: { entries: Util[] } = { entries: [new Util()] }
+</script>
+
+<template>
+  <template v-for="(util, index) of items.value" :key="index">
+    {{ util.getter }} {{ util.hello() }}
+  </template>
+  <template v-for="entry of store.entries" :key="entry.property">
+    {{ entry.property }}
+  </template>
+</template>

--- a/tests/fixtures/issue-1716-vue-ref-store-vfor/src/main.ts
+++ b/tests/fixtures/issue-1716-vue-ref-store-vfor/src/main.ts
@@ -1,0 +1,3 @@
+import App from './App.vue'
+
+export { App }

--- a/tests/fixtures/issue-1716-vue-ref-store-vfor/src/utils/Util.ts
+++ b/tests/fixtures/issue-1716-vue-ref-store-vfor/src/utils/Util.ts
@@ -1,0 +1,15 @@
+export class Util {
+  public property = 'x'
+
+  public get getter() {
+    return this.property
+  }
+
+  public hello() {
+    return this.getter
+  }
+
+  public unusedMethod() {
+    return 'unused'
+  }
+}

--- a/tests/fixtures/issue-1716-vue-ref-store-vfor/tsconfig.json
+++ b/tests/fixtures/issue-1716-vue-ref-store-vfor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/issue-1717-angular-template-url-class-member/package.json
+++ b/tests/fixtures/issue-1717-angular-template-url-class-member/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-1717-angular-template-url-class-member",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@angular/core": "^20.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/tests/fixtures/issue-1717-angular-template-url-class-member/src/app.component.html
+++ b/tests/fixtures/issue-1717-angular-template-url-class-member/src/app.component.html
@@ -1,0 +1,8 @@
+<ul>
+  @for (util of utils; track util) {
+    <li>{{ util.getName() }} {{ util.getter }}</li>
+  }
+</ul>
+<ul>
+  <li *ngFor="let util of utils">{{ util.property }}</li>
+</ul>

--- a/tests/fixtures/issue-1717-angular-template-url-class-member/src/app.component.ts
+++ b/tests/fixtures/issue-1717-angular-template-url-class-member/src/app.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core'
+import { Util } from './utils/Util'
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  templateUrl: './app.component.html',
+})
+export class AppComponent {
+  utils: Util[] = [new Util()]
+}

--- a/tests/fixtures/issue-1717-angular-template-url-class-member/src/main.ts
+++ b/tests/fixtures/issue-1717-angular-template-url-class-member/src/main.ts
@@ -1,0 +1,3 @@
+import { AppComponent } from './app.component'
+
+export { AppComponent }

--- a/tests/fixtures/issue-1717-angular-template-url-class-member/src/utils/Util.ts
+++ b/tests/fixtures/issue-1717-angular-template-url-class-member/src/utils/Util.ts
@@ -1,0 +1,15 @@
+export class Util {
+  public property = 'x'
+
+  public get getter() {
+    return this.property
+  }
+
+  public getName() {
+    return this.getter
+  }
+
+  public unusedMethod() {
+    return 'unused'
+  }
+}

--- a/tests/fixtures/issue-1717-angular-template-url-class-member/tsconfig.json
+++ b/tests/fixtures/issue-1717-angular-template-url-class-member/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "experimentalDecorators": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/issue-1718-function-local-iteration/package.json
+++ b/tests/fixtures/issue-1718-function-local-iteration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-1718-function-local-iteration",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/tests/fixtures/issue-1718-function-local-iteration/src/main.ts
+++ b/tests/fixtures/issue-1718-function-local-iteration/src/main.ts
@@ -1,0 +1,12 @@
+import { Util } from './utils/Util'
+
+export function render() {
+  const utils: Util[] = [new Util()]
+  const names = utils.map((util) => `${util.getter} ${util.hello()}`)
+
+  for (const util of utils) {
+    names.push(util.property)
+  }
+
+  return names.join(',')
+}

--- a/tests/fixtures/issue-1718-function-local-iteration/src/utils/Util.ts
+++ b/tests/fixtures/issue-1718-function-local-iteration/src/utils/Util.ts
@@ -1,0 +1,15 @@
+export class Util {
+  public property = 'x'
+
+  public get getter() {
+    return this.property
+  }
+
+  public hello() {
+    return this.getter
+  }
+
+  public unusedMethod() {
+    return 'unused'
+  }
+}

--- a/tests/fixtures/issue-1718-function-local-iteration/tsconfig.json
+++ b/tests/fixtures/issue-1718-function-local-iteration/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Credit Vue v-for class-member usage through ref.value and typed member iteration sources.
- Credit Angular external templateUrl loop item accesses through component field array types.
- Credit function-local array iteration callbacks and for...of loop variables.

## Issues
Closes #1716
Closes #1717
Closes #1718

## Verification
- Focused issue repros pass.
- Workspace Rust tests pass.
- Changed-code audit passes.
- Real Vue smoke completed.
