### PR TITLE
chore(deps): migrate MCP server to rmcp 2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -3215,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -17,7 +17,7 @@ name = "fallow-mcp"
 path = "src/main.rs"
 
 [dependencies]
-rmcp = { version = "1.7", features = ["transport-io"] }
+rmcp = { version = "2.0", features = ["transport-io"] }
 rquickjs = "0.12"
 fallow-api.workspace = true
 fallow-types.workspace = true

--- a/crates/mcp/src/server/mod.rs
+++ b/crates/mcp/src/server/mod.rs
@@ -1,6 +1,6 @@
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_router};
 
 use crate::params::{
@@ -82,8 +82,8 @@ impl FallowMcp {
             .await
             .map_err(|err| McpError::internal_error(format!("code mode task failed: {err}"), None))
             .map(|result| match result {
-                Ok(output) => CallToolResult::success(vec![Content::text(output)]),
-                Err(output) => CallToolResult::error(vec![Content::text(output)]),
+                Ok(output) => CallToolResult::success(vec![ContentBlock::text(output)]),
+                Err(output) => CallToolResult::error(vec![ContentBlock::text(output)]),
             })
     }
 

--- a/crates/mcp/src/server/tests/e2e.rs
+++ b/crates/mcp/src/server/tests/e2e.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use rmcp::model::RawContent;
+use rmcp::model::ContentBlock;
 
 use crate::tools::{
     build_analyze_args, build_health_args, build_project_info_args, build_security_candidates_args,
@@ -46,8 +46,8 @@ fn fixture_path(name: &str) -> PathBuf {
 
 /// Extract the text content from a `CallToolResult`.
 fn extract_text(result: &rmcp::model::CallToolResult) -> &str {
-    match &result.content[0].raw {
-        RawContent::Text(t) => &t.text,
+    match &result.content[0] {
+        ContentBlock::Text(t) => &t.text,
         _ => panic!("expected text content"),
     }
 }

--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -12,8 +12,8 @@ use super::super::resolve_binary;
 /// Extract the text content from a `CallToolResult`.
 #[cfg(unix)]
 fn extract_text(result: &CallToolResult) -> &str {
-    match &result.content[0].raw {
-        RawContent::Text(t) => &t.text,
+    match &result.content[0] {
+        ContentBlock::Text(t) => &t.text,
         _ => panic!("expected text content"),
     }
 }

--- a/crates/mcp/src/tools/analyze.rs
+++ b/crates/mcp/src/tools/analyze.rs
@@ -8,7 +8,7 @@ use fallow_api::{
     serialize_circular_dependencies_programmatic_json, serialize_dead_code_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     ISSUE_TYPE_FLAGS,
@@ -27,14 +27,14 @@ pub async fn run_analyze(binary: &str, params: AnalyzeParams) -> Result<CallTool
     if requires_cli_fallback(&params) {
         return match build_analyze_args(&params) {
             Ok(args) => run_tool(binary, "analyze", &args).await,
-            Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+            Err(msg) => Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
         };
     }
 
     let family = analyze_family(&params);
     let options = match dead_code_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
 
     let result = run_api_blocking("analyze", move || match family {
@@ -48,7 +48,7 @@ pub async fn run_analyze(binary: &str, params: AnalyzeParams) -> Result<CallTool
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -256,7 +256,7 @@ fn push_analyze_issue_type_flags(
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -419,8 +419,8 @@ mod tests {
         .expect("api result");
 
         assert_eq!(result.is_error, Some(false));
-        let text = match &result.content[0].raw {
-            RawContent::Text(text) => &text.text,
+        let text = match &result.content[0] {
+            ContentBlock::Text(text) => &text.text,
             _ => panic!("expected text content"),
         };
         let json: serde_json::Value = serde_json::from_str(text).expect("json");
@@ -453,8 +453,8 @@ mod tests {
         .expect("api result");
 
         assert_eq!(result.is_error, Some(false));
-        let text = match &result.content[0].raw {
-            RawContent::Text(text) => &text.text,
+        let text = match &result.content[0] {
+            ContentBlock::Text(text) => &text.text,
             _ => panic!("expected text content"),
         };
         let json: serde_json::Value = serde_json::from_str(text).expect("json");

--- a/crates/mcp/src/tools/api_runtime.rs
+++ b/crates/mcp/src/tools/api_runtime.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use fallow_api::ProgrammaticError;
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde::Serialize;
 
 pub(super) async fn run_api_blocking<T, F>(
@@ -72,7 +72,7 @@ pub(super) fn non_empty_string(value: Option<&str>) -> Option<String> {
 
 pub(super) fn json_success(value: &impl Serialize) -> CallToolResult {
     let text = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string());
-    CallToolResult::success(vec![Content::text(text)])
+    CallToolResult::success(vec![ContentBlock::text(text)])
 }
 
 pub(super) fn programmatic_error_body(error: &ProgrammaticError) -> String {

--- a/crates/mcp/src/tools/audit.rs
+++ b/crates/mcp/src/tools/audit.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     serialize_audit_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     VALID_AUDIT_GATES,
@@ -23,14 +23,14 @@ pub async fn run_audit(binary: &str, params: AuditParams) -> Result<CallToolResu
     if !requires_cli_fallback(&params) {
         let options = match audit_options_from_params(&params) {
             Ok(options) => options,
-            Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+            Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
         };
         let result = run_api_blocking("audit", move || {
             run_audit_api(&options).and_then(serialize_audit_programmatic_json)
         })
         .await?
         .map_or_else(
-            |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+            |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
             |value| json_success(&value),
         );
         return Ok(result);
@@ -38,7 +38,7 @@ pub async fn run_audit(binary: &str, params: AuditParams) -> Result<CallToolResu
 
     match build_audit_args(&params) {
         Ok(args) => run_tool(binary, "audit", &args).await,
-        Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     }
 }
 
@@ -212,7 +212,7 @@ fn audit_gate_from_param(value: Option<&str>) -> Result<AuditGate, String> {
 mod tests {
     use std::process::Command;
 
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -277,8 +277,8 @@ mod tests {
         .expect("api result");
 
         assert_eq!(result.is_error, Some(false));
-        let text = match &result.content[0].raw {
-            RawContent::Text(text) => &text.text,
+        let text = match &result.content[0] {
+            ContentBlock::Text(text) => &text.text,
             _ => panic!("expected text content"),
         };
         let json: serde_json::Value = serde_json::from_str(text).expect("json");
@@ -304,8 +304,8 @@ mod tests {
         .expect("api result");
 
         assert_eq!(result.is_error, Some(false));
-        let text = match &result.content[0].raw {
-            RawContent::Text(text) => &text.text,
+        let text = match &result.content[0] {
+            ContentBlock::Text(text) => &text.text,
             _ => panic!("expected text content"),
         };
         let json: serde_json::Value = serde_json::from_str(text).expect("json");

--- a/crates/mcp/src/tools/check_changed.rs
+++ b/crates/mcp/src/tools/check_changed.rs
@@ -3,7 +3,7 @@ use fallow_api::{
     serialize_dead_code_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use crate::params::CheckChangedParams;
 
@@ -34,7 +34,7 @@ pub async fn run_check_changed(
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -137,7 +137,7 @@ fn check_changed_options_from_params(params: &CheckChangedParams) -> DeadCodeOpt
 mod tests {
     use std::process::Command;
 
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -198,7 +198,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");

--- a/crates/mcp/src/tools/decision_surface.rs
+++ b/crates/mcp/src/tools/decision_surface.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     serialize_decision_surface_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::api_runtime::{
     changed_since_from_param, env_diff_file, json_success, non_empty_path, non_empty_string,
@@ -23,7 +23,7 @@ pub async fn run_decision_surface(
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -50,7 +50,7 @@ fn decision_surface_options_from_params(params: &DecisionSurfaceParams) -> Decis
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     #[test]
     fn default_decision_surface_maps_to_programmatic_api_options() {
@@ -101,8 +101,8 @@ mod tests {
         .expect("api result");
 
         assert_eq!(result.is_error, Some(false));
-        let text = match &result.content[0].raw {
-            RawContent::Text(text) => &text.text,
+        let text = match &result.content[0] {
+            ContentBlock::Text(text) => &text.text,
             _ => panic!("expected text content"),
         };
         let json: serde_json::Value = serde_json::from_str(text).expect("json");

--- a/crates/mcp/src/tools/dupes.rs
+++ b/crates/mcp/src/tools/dupes.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     serialize_duplication_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     VALID_DUPES_MODES,
@@ -26,13 +26,13 @@ pub async fn run_find_dupes(
     if requires_cli_fallback(&params) {
         return match build_find_dupes_args(&params) {
             Ok(args) => run_tool(binary, "find_dupes", &args).await,
-            Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+            Err(msg) => Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
         };
     }
 
     let options = match duplication_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
 
     let result = run_api_blocking("find_dupes", move || {
@@ -40,7 +40,7 @@ pub async fn run_find_dupes(
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -215,7 +215,7 @@ fn push_dupes_toggle_flags(args: &mut Vec<String>, params: &FindDupesParams) {
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -334,8 +334,8 @@ mod tests {
         .expect("api result");
 
         assert_eq!(result.is_error, Some(false));
-        let text = match &result.content[0].raw {
-            RawContent::Text(text) => &text.text,
+        let text = match &result.content[0] {
+            ContentBlock::Text(text) => &text.text,
             _ => panic!("expected text content"),
         };
         let json: serde_json::Value = serde_json::from_str(text).expect("json");

--- a/crates/mcp/src/tools/explain.rs
+++ b/crates/mcp/src/tools/explain.rs
@@ -10,9 +10,9 @@ use super::api_runtime::{json_success, programmatic_error_body};
 pub async fn run_explain(_binary: &str, params: ExplainParams) -> Result<CallToolResult, McpError> {
     match serialize_explain_programmatic_json(&params.issue_type, RootEnvelopeMode::Tagged, None) {
         Ok(value) => Ok(json_success(&value)),
-        Err(error) => Ok(CallToolResult::error(vec![rmcp::model::Content::text(
-            programmatic_error_body(&error),
-        )])),
+        Err(error) => Ok(CallToolResult::error(vec![
+            rmcp::model::ContentBlock::text(programmatic_error_body(&error)),
+        ])),
     }
 }
 
@@ -29,7 +29,7 @@ pub fn build_explain_args(params: &ExplainParams) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -48,7 +48,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");
@@ -71,7 +71,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");

--- a/crates/mcp/src/tools/flags.rs
+++ b/crates/mcp/src/tools/flags.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     serialize_feature_flags_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::api_runtime::{
     changed_since_from_param, env_diff_file, json_success, non_empty_path, non_empty_string,
@@ -23,7 +23,7 @@ pub async fn run_feature_flags(
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -96,7 +96,7 @@ fn feature_flags_options_from_params(params: &FeatureFlagsParams) -> FeatureFlag
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -130,7 +130,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");
@@ -172,7 +172,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");

--- a/crates/mcp/src/tools/health.rs
+++ b/crates/mcp/src/tools/health.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     run_health as run_api_health, serialize_health_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     api_runtime::{
@@ -28,7 +28,7 @@ pub async fn run_health(binary: &str, params: HealthParams) -> Result<CallToolRe
 
     let options = match health_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
 
     let result = run_api_blocking("check_health", move || {
@@ -36,7 +36,7 @@ pub async fn run_health(binary: &str, params: HealthParams) -> Result<CallToolRe
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -387,7 +387,7 @@ fn target_effort_from_param(value: Option<&str>) -> Result<Option<TargetEffort>,
 mod tests {
     use std::path::PathBuf;
 
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -566,7 +566,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");

--- a/crates/mcp/src/tools/inspect_target.rs
+++ b/crates/mcp/src/tools/inspect_target.rs
@@ -1,5 +1,5 @@
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use crate::params::{InspectTarget, InspectTargetParams};
 
@@ -14,7 +14,7 @@ pub async fn inspect_target(
 ) -> Result<CallToolResult, McpError> {
     match build_inspect_args(params) {
         Ok(args) => run_tool(binary, TOOL, &args).await,
-        Err(message) => Ok(CallToolResult::error(vec![Content::text(
+        Err(message) => Ok(CallToolResult::error(vec![ContentBlock::text(
             validation_error_body(message),
         )])),
     }

--- a/crates/mcp/src/tools/list_boundaries.rs
+++ b/crates/mcp/src/tools/list_boundaries.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     serialize_list_boundaries_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     api_runtime::{
@@ -26,7 +26,7 @@ pub async fn run_list_boundaries(
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -82,7 +82,7 @@ fn list_boundaries_options_from_params(params: &ListBoundariesParams) -> ListBou
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -137,7 +137,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -62,7 +62,7 @@ use std::time::Duration;
 
 pub use fallow_types::issue_meta::MCP_ISSUE_TYPE_FLAGS as ISSUE_TYPE_FLAGS;
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content, RawContent};
+use rmcp::model::{CallToolResult, ContentBlock};
 use tokio::process::Command;
 
 /// Default subprocess timeout in seconds.
@@ -231,12 +231,12 @@ async fn spawn_fallow(
     }
 
     if stdout.is_empty() {
-        return Ok(CallToolResult::success(vec![Content::text(
+        return Ok(CallToolResult::success(vec![ContentBlock::text(
             "{}".to_string(),
         )]));
     }
 
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         stdout.to_string(),
     )]))
 }
@@ -251,11 +251,11 @@ fn non_success_result(exit_code: i32, stdout: &str, stderr: &str) -> CallToolRes
         } else {
             stdout.to_string()
         };
-        return CallToolResult::success(vec![Content::text(text)]);
+        return CallToolResult::success(vec![ContentBlock::text(text)]);
     }
 
     if !stdout.is_empty() && serde_json::from_str::<serde_json::Value>(stdout).is_ok() {
-        return CallToolResult::error(vec![Content::text(stdout.to_string())]);
+        return CallToolResult::error(vec![ContentBlock::text(stdout.to_string())]);
     }
 
     let message = if stderr.is_empty() {
@@ -270,7 +270,7 @@ fn non_success_result(exit_code: i32, stdout: &str, stderr: &str) -> CallToolRes
         "exit_code": exit_code,
     });
 
-    CallToolResult::error(vec![Content::text(error_json.to_string())])
+    CallToolResult::error(vec![ContentBlock::text(error_json.to_string())])
 }
 
 fn timeout_result(timeout: Duration) -> CallToolResult {
@@ -282,7 +282,7 @@ fn timeout_result(timeout: Duration) -> CallToolResult {
         "help": "Set FALLOW_TIMEOUT_SECS to increase the limit.",
         "context": "subprocess",
     });
-    CallToolResult::error(vec![Content::text(error_json.to_string())])
+    CallToolResult::error(vec![ContentBlock::text(error_json.to_string())])
 }
 
 /// Execute fallow and ensure successful JSON responses have a top-level
@@ -316,7 +316,7 @@ fn ensure_top_level_warnings(result: CallToolResult) -> CallToolResult {
     let Some(content) = result.content.first() else {
         return result;
     };
-    let RawContent::Text(text) = &content.raw else {
+    let ContentBlock::Text(text) = content else {
         return result;
     };
     let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&text.text) else {
@@ -330,5 +330,5 @@ fn ensure_top_level_warnings(result: CallToolResult) -> CallToolResult {
         .or_insert_with(|| serde_json::Value::Array(Vec::new()));
 
     let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| text.text.clone());
-    CallToolResult::success(vec![Content::text(text)])
+    CallToolResult::success(vec![ContentBlock::text(text)])
 }

--- a/crates/mcp/src/tools/project_info.rs
+++ b/crates/mcp/src/tools/project_info.rs
@@ -5,7 +5,7 @@ use fallow_api::{
     serialize_project_info_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     api_runtime::{
@@ -26,7 +26,7 @@ pub async fn run_project_info(
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -98,7 +98,7 @@ fn project_info_options_from_params(params: &ProjectInfoParams) -> ProjectInfoOp
 
 #[cfg(test)]
 mod tests {
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
 
     use super::*;
 
@@ -132,7 +132,7 @@ mod tests {
         let [content] = result.content.as_slice() else {
             panic!("expected one content item");
         };
-        let RawContent::Text(text) = &content.raw else {
+        let ContentBlock::Text(text) = content else {
             panic!("expected text content");
         };
         let json: serde_json::Value = serde_json::from_str(&text.text).expect("json");

--- a/crates/mcp/src/tools/security.rs
+++ b/crates/mcp/src/tools/security.rs
@@ -1,7 +1,7 @@
 use crate::params::SecurityCandidatesParams;
 
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{push_global, push_str_flag, run_tool, validation_error_body};
 
@@ -19,7 +19,7 @@ pub async fn run_security_candidates(
 ) -> Result<CallToolResult, McpError> {
     match build_security_candidates_args(&params) {
         Ok(args) => run_tool(binary, "security_candidates", &args).await,
-        Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     }
 }
 

--- a/crates/mcp/src/tools/trace.rs
+++ b/crates/mcp/src/tools/trace.rs
@@ -8,7 +8,7 @@ use fallow_api::{
     serialize_trace_export_programmatic_json, serialize_trace_file_programmatic_json,
 };
 use rmcp::ErrorData as McpError;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::{
     VALID_DUPES_MODES,
@@ -23,14 +23,14 @@ use super::{
 pub async fn run_trace_export_tool(params: TraceExportParams) -> Result<CallToolResult, McpError> {
     let options = match trace_export_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
     let result = run_api_blocking("trace_export", move || {
         run_trace_export(&options).and_then(serialize_trace_export_programmatic_json)
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -40,14 +40,14 @@ pub async fn run_trace_export_tool(params: TraceExportParams) -> Result<CallTool
 pub async fn run_trace_file_tool(params: TraceFileParams) -> Result<CallToolResult, McpError> {
     let options = match trace_file_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
     let result = run_api_blocking("trace_file", move || {
         run_trace_file(&options).and_then(serialize_trace_file_programmatic_json)
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -59,14 +59,14 @@ pub async fn run_trace_dependency_tool(
 ) -> Result<CallToolResult, McpError> {
     let options = match trace_dependency_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
     let result = run_api_blocking("trace_dependency", move || {
         run_trace_dependency(&options).and_then(serialize_trace_dependency_programmatic_json)
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)
@@ -76,14 +76,14 @@ pub async fn run_trace_dependency_tool(
 pub async fn run_trace_clone_tool(params: TraceCloneParams) -> Result<CallToolResult, McpError> {
     let options = match trace_clone_options_from_params(&params) {
         Ok(options) => options,
-        Err(msg) => return Ok(CallToolResult::error(vec![Content::text(msg)])),
+        Err(msg) => return Ok(CallToolResult::error(vec![ContentBlock::text(msg)])),
     };
     let result = run_api_blocking("trace_clone", move || {
         run_trace_clone(&options).and_then(serialize_trace_clone_programmatic_json)
     })
     .await?
     .map_or_else(
-        |err| CallToolResult::error(vec![Content::text(programmatic_error_body(&err))]),
+        |err| CallToolResult::error(vec![ContentBlock::text(programmatic_error_body(&err))]),
         |value| json_success(&value),
     );
     Ok(result)


### PR DESCRIPTION
Migrates `crates/mcp` from rmcp 1.8 to 2.1, resolving the major-version bump Dependabot proposed in #1773 (which couldn't compile as a bare lockfile bump).

## What changed in rmcp 2.0
The model layer was reorganized. The content type `Content` (an `Annotated<RawContent>` with a `.raw` field) became the flat `ContentBlock` enum, and the `RawContent` enum was removed.

## Migration
- `rmcp::model::Content` -> `ContentBlock`; `Content::text(..)` -> `ContentBlock::text(..)`
- `let RawContent::Text(t) = &content.raw` -> `let ContentBlock::Text(t) = content`
- `match &result.content[0].raw { RawContent::Text(t) => .. }` -> `match &result.content[0] { ContentBlock::Text(t) => .. }`

The tool-router surface (`#[tool]`, `tool_router`, `tool_handler`), `ServerHandler`, `Parameters`, and stdio transport are unchanged across the major, so tool definitions and routing needed no edits. `crates/mcp` is the only rmcp consumer (the references in `crates/types/src/mcp_manifest.rs` are doc comments).

## Verification
- `cargo build -p fallow-mcp` and `cargo clippy -p fallow-mcp --all-targets`: clean
- Full `crates/mcp` test suite: passes
- Live stdio session against the built binary: `initialize` -> `tools/list` (29 tools) -> `tools/call fallow_explain` returns a correct `ContentBlock` text result (`kind: explain`)
- `cargo deny check advisories`: `advisories ok`

Closes #1773.