### PR TITLE
fix(ci): skills-vendor gate ignores version-string lines; add vendor-skills unit tests

### DIFF
--- a/scripts/vendor-skills.mjs
+++ b/scripts/vendor-skills.mjs
@@ -27,7 +27,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const VENDORED_TREE = join(REPO_ROOT, "npm", "fallow", "skills", "fallow");
@@ -36,7 +36,7 @@ const SKILL_SUBPATH = join("fallow", "skills", "fallow");
 /** Recursively list files under `dir` as base-relative POSIX paths, sorted.
  * Dotfiles (e.g. `.DS_Store`) are ignored so incidental local cruft on one
  * side never trips the gate. */
-const listFiles = (dir, base = dir) => {
+export const listFiles = (dir, base = dir) => {
   const out = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.name.startsWith(".")) {
@@ -54,16 +54,27 @@ const listFiles = (dir, base = dir) => {
 
 const bytes = (root, relPath) => readFileSync(join(root, relPath));
 
+/** `"version": "x.y.z"` strings (in example JSON inside the reference docs) track
+ * the fallow release version and are bumped on a staggered cadence at release
+ * time: `/fallow-release` step 5c bumps the vendored copy inline while canonical
+ * catches up later (step 10a-pre). The drift gate ignores those lines so it does
+ * not false-fail on that transient window; content drift (plugin counts,
+ * descriptions, commands, flags) is unaffected. The release's own step-10c
+ * byte-identical `diff -r` stays the authoritative version-sync check. */
+const VERSION_STRING = /"version":\s*"[^"]*"/g;
+const normalize = (buf) => buf.toString("utf8").replace(VERSION_STRING, '"version": "<v>"');
+
 /** Compare the two trees. Returns { missing, extra, changed } relative-path
  * lists: `missing` exists in canonical but not vendored, `extra` exists in
- * vendored but not canonical, `changed` exists in both with differing bytes. */
-const diffTrees = (canonical, vendored) => {
+ * vendored but not canonical, `changed` exists in both with differing content
+ * (byte-for-byte, except `"version"` strings; see `normalize`). */
+export const diffTrees = (canonical, vendored) => {
   const canonicalFiles = new Set(listFiles(canonical));
   const vendoredFiles = existsSync(vendored) ? new Set(listFiles(vendored)) : new Set();
   const missing = [...canonicalFiles].filter((f) => !vendoredFiles.has(f));
   const extra = [...vendoredFiles].filter((f) => !canonicalFiles.has(f));
   const changed = [...canonicalFiles].filter(
-    (f) => vendoredFiles.has(f) && !bytes(canonical, f).equals(bytes(vendored, f)),
+    (f) => vendoredFiles.has(f) && normalize(bytes(canonical, f)) !== normalize(bytes(vendored, f)),
   );
   return { missing, extra, changed };
 };
@@ -97,8 +108,8 @@ const resolveCanonical = () => {
   return { tree, present: existsSync(join(tree, "SKILL.md")), explicit: Boolean(explicit) };
 };
 
-const runCheck = (canonical) => {
-  const { missing, extra, changed } = diffTrees(canonical, VENDORED_TREE);
+export const runCheck = (canonical, vendored = VENDORED_TREE) => {
+  const { missing, extra, changed } = diffTrees(canonical, vendored);
   if (missing.length === 0 && extra.length === 0 && changed.length === 0) {
     console.log("vendor-skills: npm/fallow/skills is in sync with canonical fallow-skills");
     return 0;
@@ -115,20 +126,20 @@ const runCheck = (canonical) => {
   }
   console.error("\nRe-vendor with: node scripts/vendor-skills.mjs\n");
   for (const f of changed) {
-    showDiff(canonical, VENDORED_TREE, f);
+    showDiff(canonical, vendored, f);
   }
   return 1;
 };
 
-const runVendor = (canonical) => {
-  const { missing, extra, changed } = diffTrees(canonical, VENDORED_TREE);
+export const runVendor = (canonical, vendored = VENDORED_TREE) => {
+  const { missing, extra, changed } = diffTrees(canonical, vendored);
   for (const relPath of [...missing, ...changed]) {
-    const dest = join(VENDORED_TREE, relPath);
+    const dest = join(vendored, relPath);
     mkdirSync(dirname(dest), { recursive: true });
     writeFileSync(dest, bytes(canonical, relPath));
   }
   for (const relPath of extra) {
-    rmSync(join(VENDORED_TREE, relPath));
+    rmSync(join(vendored, relPath));
   }
   const touched = missing.length + changed.length + extra.length;
   console.log(
@@ -153,9 +164,13 @@ const main = (argv = process.argv.slice(2)) => {
   return check ? runCheck(tree) : runVendor(tree);
 };
 
-try {
-  process.exitCode = main();
-} catch (error) {
-  console.error(`vendor-skills: ${error.message}`);
-  process.exitCode = 2;
+// Only run when executed directly (not when imported by the test), so importing
+// never triggers a re-vendor or a "canonical not found" throw.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(`vendor-skills: ${error.message}`);
+    process.exitCode = 2;
+  }
 }

--- a/scripts/vendor-skills.test.mjs
+++ b/scripts/vendor-skills.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+import { diffTrees, listFiles, runCheck, runVendor } from "./vendor-skills.mjs";
+
+/** Materialize { "rel/path": "contents" } into a fresh temp dir; returns its path. */
+const makeTree = (files) => {
+  const dir = mkdtempSync(join(tmpdir(), "vendor-skills-"));
+  for (const [rel, contents] of Object.entries(files)) {
+    const dest = join(dir, rel);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, contents);
+  }
+  return dir;
+};
+
+test("listFiles is recursive, sorted, and skips dotfiles", () => {
+  const dir = makeTree({
+    "SKILL.md": "a",
+    "references/mcp.md": "b",
+    "references/cli.md": "c",
+    ".DS_Store": "junk",
+    "references/.hidden": "junk",
+  });
+  assert.deepEqual(listFiles(dir), ["SKILL.md", "references/cli.md", "references/mcp.md"]);
+  rmSync(dir, { recursive: true });
+});
+
+test("diffTrees reports missing, extra, and changed by relative path", () => {
+  const canonical = makeTree({
+    "SKILL.md": "same",
+    "references/mcp.md": "canonical",
+    "only-canonical.md": "x",
+  });
+  const vendored = makeTree({
+    "SKILL.md": "same",
+    "references/mcp.md": "vendored",
+    "only-vendored.md": "y",
+  });
+  const { missing, extra, changed } = diffTrees(canonical, vendored);
+  assert.deepEqual(missing, ["only-canonical.md"]);
+  assert.deepEqual(extra, ["only-vendored.md"]);
+  assert.deepEqual(changed, ["references/mcp.md"]);
+  rmSync(canonical, { recursive: true });
+  rmSync(vendored, { recursive: true });
+});
+
+test("diffTrees is empty when the trees are byte-identical", () => {
+  const canonical = makeTree({ "SKILL.md": "x", "references/mcp.md": "y" });
+  const vendored = makeTree({ "SKILL.md": "x", "references/mcp.md": "y" });
+  const { missing, extra, changed } = diffTrees(canonical, vendored);
+  assert.deepEqual([missing, extra, changed], [[], [], []]);
+  rmSync(canonical, { recursive: true });
+  rmSync(vendored, { recursive: true });
+});
+
+test('diffTrees ignores `"version"` string differences (staggered release bump)', () => {
+  const canonical = makeTree({ "references/cli.md": 'before\n  "version": "3.2.0",\nafter' });
+  const vendored = makeTree({ "references/cli.md": 'before\n  "version": "3.3.0",\nafter' });
+  const { missing, extra, changed } = diffTrees(canonical, vendored);
+  assert.deepEqual([missing, extra, changed], [[], [], []]);
+  rmSync(canonical, { recursive: true });
+  rmSync(vendored, { recursive: true });
+});
+
+test("diffTrees still catches content drift alongside a version diff", () => {
+  // The exact rot the gate exists to prevent: a plugin-count drift that also
+  // happens to carry a version-string difference must NOT be masked.
+  const canonical = makeTree({ "SKILL.md": '114 framework plugins\n  "version": "3.2.0"' });
+  const vendored = makeTree({ "SKILL.md": '97 framework plugins\n  "version": "3.3.0"' });
+  assert.deepEqual(diffTrees(canonical, vendored).changed, ["SKILL.md"]);
+  rmSync(canonical, { recursive: true });
+  rmSync(vendored, { recursive: true });
+});
+
+test("diffTrees treats a missing vendored tree as all-missing (not a crash)", () => {
+  const canonical = makeTree({ "SKILL.md": "x" });
+  const { missing, extra, changed } = diffTrees(canonical, join(canonical, "does-not-exist"));
+  assert.deepEqual(missing, ["SKILL.md"]);
+  assert.deepEqual([extra, changed], [[], []]);
+  rmSync(canonical, { recursive: true });
+});
+
+test("runCheck returns 1 on drift and 0 when in sync", () => {
+  const canonical = makeTree({ "SKILL.md": "x" });
+  const drifted = makeTree({ "SKILL.md": "y" });
+  const identical = makeTree({ "SKILL.md": "x" });
+  assert.equal(runCheck(canonical, drifted), 1);
+  assert.equal(runCheck(canonical, identical), 0);
+  for (const d of [canonical, drifted, identical]) {
+    rmSync(d, { recursive: true });
+  }
+});
+
+test("runVendor mirrors canonical into vendored: adds, updates, removes extras", () => {
+  const canonical = makeTree({ "SKILL.md": "new", "references/mcp.md": "added" });
+  const vendored = makeTree({ "SKILL.md": "old", "stale.md": "remove-me" });
+  assert.equal(runVendor(canonical, vendored), 0);
+  // vendored is now byte-identical to canonical
+  const { missing, extra, changed } = diffTrees(canonical, vendored);
+  assert.deepEqual([missing, extra, changed], [[], [], []]);
+  assert.equal(readFileSync(join(vendored, "SKILL.md"), "utf8"), "new");
+  assert.equal(readFileSync(join(vendored, "references/mcp.md"), "utf8"), "added");
+  assert.equal(existsSync(join(vendored, "stale.md")), false);
+  rmSync(canonical, { recursive: true });
+  rmSync(vendored, { recursive: true });
+});


### PR DESCRIPTION
## What

Make the `skills-vendor` drift gate (added in #1781) ignore `"version": "x.y.z"` lines when comparing `npm/fallow/skills` to canonical `fallow-skills`, and add unit tests for `scripts/vendor-skills.mjs`.

## Why

The vendored `references/cli-reference.md` carries the fallow release version in example JSON (`"version": "3.2.0"`). `/fallow-release` step 5c bumps the **vendored** copy inline while canonical catches up later (step 10a-pre), so the two trees legitimately diverge on version-string lines during the release window. A strict byte-identical gate would false-fail the release commit's CI on that transient gap. This mirrors the exclusion the release's own `diff -r` check already applies.

Content drift (plugin counts, descriptions, commands, flags) is unaffected: a test asserts the "97 vs 114 plugins" rot is still caught even alongside a version diff. The release's step-10c full byte-identical `diff -r` stays the authoritative version-sync check.

## Testing

- 8 unit tests (missing/extra/changed, version-tolerance, content-drift-not-masked, missing-tree, mirror copy), all pass.
- Simulated a release-window version bump: `vendor-skills --check` now passes instead of false-failing.
- oxfmt + oxlint clean. No Rust changed.
