### PR TITLE
chore(schema): regenerate output-schema and TS contracts after health-error refactor

### DIFF
--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -4181,7 +4181,7 @@
         "auto_fixable",
         "description"
       ],
-      "description": "Per-action wire shape attached to each `CloneGroupFinding` and\n`AttributedCloneGroupFinding`. Mirrors the action types previously\nemitted by `inject_dupes_actions::build_clone_group_actions` in\n`crates/cli/src/report/json.rs`: `extract-shared` plus `suppress-line`."
+      "description": "Per-action wire shape attached to each `CloneGroupFinding` and\n`AttributedCloneGroupFinding` (see `crates/api/src/dupes_output.rs`):\n`extract-shared` plus `suppress-line`. The typed wrappers replaced the\nlegacy JSON post-pass injection that used to live in the CLI report layer."
     },
     "UnusedFile": {
       "type": "object",
@@ -10301,7 +10301,7 @@
         "fingerprint",
         "actions"
       ],
-      "description": "Wire-shape envelope for a [`CloneGroup`] finding. Flattens the bare\ngroup via `#[serde(flatten)]` and carries a typed `actions` array plus\nthe optional audit-mode `introduced` flag. Replaces the legacy\npost-pass injection in `crates/cli/src/report/json.rs::inject_dupes_actions`."
+      "description": "Wire-shape envelope for a [`CloneGroup`] finding. Flattens the bare\ngroup via `#[serde(flatten)]` and carries a typed `actions` array plus\nthe optional audit-mode `introduced` flag. The typed envelope replaced\nthe legacy JSON post-pass injection; a guard test in\n`crates/cli/src/report/json.rs` rejects any reintroduced post-pass."
     },
     "DupesReportPayload": {
       "type": "object",

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -3752,8 +3752,9 @@ stats: DuplicationStats
 /**
  * Wire-shape envelope for a [`CloneGroup`] finding. Flattens the bare
  * group via `#[serde(flatten)]` and carries a typed `actions` array plus
- * the optional audit-mode `introduced` flag. Replaces the legacy
- * post-pass injection in `crates/cli/src/report/json.rs::inject_dupes_actions`.
+ * the optional audit-mode `introduced` flag. The typed envelope replaced
+ * the legacy JSON post-pass injection; a guard test in
+ * `crates/cli/src/report/json.rs` rejects any reintroduced post-pass.
  */
 export interface CloneGroupFinding {
 /**
@@ -3827,9 +3828,9 @@ fragment: string
 }
 /**
  * Per-action wire shape attached to each `CloneGroupFinding` and
- * `AttributedCloneGroupFinding`. Mirrors the action types previously
- * emitted by `inject_dupes_actions::build_clone_group_actions` in
- * `crates/cli/src/report/json.rs`: `extract-shared` plus `suppress-line`.
+ * `AttributedCloneGroupFinding` (see `crates/api/src/dupes_output.rs`):
+ * `extract-shared` plus `suppress-line`. The typed wrappers replaced the
+ * legacy JSON post-pass injection that used to live in the CLI report layer.
  */
 export interface CloneGroupAction {
 type: CloneGroupActionType

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -3752,8 +3752,9 @@ stats: DuplicationStats
 /**
  * Wire-shape envelope for a [`CloneGroup`] finding. Flattens the bare
  * group via `#[serde(flatten)]` and carries a typed `actions` array plus
- * the optional audit-mode `introduced` flag. Replaces the legacy
- * post-pass injection in `crates/cli/src/report/json.rs::inject_dupes_actions`.
+ * the optional audit-mode `introduced` flag. The typed envelope replaced
+ * the legacy JSON post-pass injection; a guard test in
+ * `crates/cli/src/report/json.rs` rejects any reintroduced post-pass.
  */
 export interface CloneGroupFinding {
 /**
@@ -3827,9 +3828,9 @@ fragment: string
 }
 /**
  * Per-action wire shape attached to each `CloneGroupFinding` and
- * `AttributedCloneGroupFinding`. Mirrors the action types previously
- * emitted by `inject_dupes_actions::build_clone_group_actions` in
- * `crates/cli/src/report/json.rs`: `extract-shared` plus `suppress-line`.
+ * `AttributedCloneGroupFinding` (see `crates/api/src/dupes_output.rs`):
+ * `extract-shared` plus `suppress-line`. The typed wrappers replaced the
+ * legacy JSON post-pass injection that used to live in the CLI report layer.
  */
 export interface CloneGroupAction {
 type: CloneGroupActionType


### PR DESCRIPTION
The health-error printing refactor (d79cec879 / e472d5b13 / 18e3acb22) changed the health JSON output shape but did not run `generate:contracts`, leaving `docs/output-schema.json` and the derived TS output contracts (`output-contract.d.ts`) stale. This turned the contract-bundle drift gate (`generate:contracts:check`) red on main.

Regenerated from the current binary; no source change. `generate:contracts:check` is green after this.