### PR TITLE
refactor(ci): make vendor-skills main testable and quiet diff output in tests

### DIFF
--- a/scripts/vendor-skills.mjs
+++ b/scripts/vendor-skills.mjs
@@ -108,7 +108,7 @@ const resolveCanonical = () => {
   return { tree, present: existsSync(join(tree, "SKILL.md")), explicit: Boolean(explicit) };
 };
 
-export const runCheck = (canonical, vendored = VENDORED_TREE) => {
+export const runCheck = (canonical, vendored = VENDORED_TREE, { renderDiffs = true } = {}) => {
   const { missing, extra, changed } = diffTrees(canonical, vendored);
   if (missing.length === 0 && extra.length === 0 && changed.length === 0) {
     console.log("vendor-skills: npm/fallow/skills is in sync with canonical fallow-skills");
@@ -125,8 +125,12 @@ export const runCheck = (canonical, vendored = VENDORED_TREE) => {
     console.error(`  differs: ${f}`);
   }
   console.error("\nRe-vendor with: node scripts/vendor-skills.mjs\n");
-  for (const f of changed) {
-    showDiff(canonical, vendored, f);
+  // renderDiffs spawns `git diff` per changed file (helpful for a human running
+  // the gate); tests pass false to keep git output out of the TAP stream.
+  if (renderDiffs) {
+    for (const f of changed) {
+      showDiff(canonical, vendored, f);
+    }
   }
   return 1;
 };
@@ -150,18 +154,32 @@ export const runVendor = (canonical, vendored = VENDORED_TREE) => {
   return 0;
 };
 
-const main = (argv = process.argv.slice(2)) => {
+/** Pure dispatch for main() given the resolved canonical state. `skip` is the
+ * contributor-without-the-sibling-repo case (drift check only); `error` when the
+ * canonical tree is missing and skipping is not allowed. */
+export const decide = ({ present, explicit, check }) => {
+  if (!present) {
+    return check && !explicit ? { action: "skip" } : { action: "error" };
+  }
+  return { action: check ? "check" : "vendor" };
+};
+
+export const main = (argv = process.argv.slice(2)) => {
   const check = argv.includes("--check");
   const { tree, present, explicit } = resolveCanonical();
-  if (!present) {
-    const message = `canonical fallow-skills not found at ${tree}`;
-    if (check && !explicit) {
-      console.warn(`vendor-skills: ${message}; skipping drift check`);
-      return 0;
-    }
-    throw new Error(`${message}${explicit ? " (FALLOW_SKILLS_DIR is set)" : ""}`);
+  const { action } = decide({ present, explicit, check });
+  if (action === "skip") {
+    console.warn(
+      `vendor-skills: canonical fallow-skills not found at ${tree}; skipping drift check`,
+    );
+    return 0;
   }
-  return check ? runCheck(tree) : runVendor(tree);
+  if (action === "error") {
+    throw new Error(
+      `canonical fallow-skills not found at ${tree}${explicit ? " (FALLOW_SKILLS_DIR is set)" : ""}`,
+    );
+  }
+  return action === "check" ? runCheck(tree) : runVendor(tree);
 };
 
 // Only run when executed directly (not when imported by the test), so importing

--- a/scripts/vendor-skills.test.mjs
+++ b/scripts/vendor-skills.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
 
-import { diffTrees, listFiles, runCheck, runVendor } from "./vendor-skills.mjs";
+import { decide, diffTrees, listFiles, main, runCheck, runVendor } from "./vendor-skills.mjs";
 
 /** Materialize { "rel/path": "contents" } into a fresh temp dir; returns its path. */
 const makeTree = (files) => {
@@ -88,8 +88,8 @@ test("runCheck returns 1 on drift and 0 when in sync", () => {
   const canonical = makeTree({ "SKILL.md": "x" });
   const drifted = makeTree({ "SKILL.md": "y" });
   const identical = makeTree({ "SKILL.md": "x" });
-  assert.equal(runCheck(canonical, drifted), 1);
-  assert.equal(runCheck(canonical, identical), 0);
+  assert.equal(runCheck(canonical, drifted, { renderDiffs: false }), 1);
+  assert.equal(runCheck(canonical, identical, { renderDiffs: false }), 0);
   for (const d of [canonical, drifted, identical]) {
     rmSync(d, { recursive: true });
   }
@@ -107,4 +107,27 @@ test("runVendor mirrors canonical into vendored: adds, updates, removes extras",
   assert.equal(existsSync(join(vendored, "stale.md")), false);
   rmSync(canonical, { recursive: true });
   rmSync(vendored, { recursive: true });
+});
+
+test("decide dispatches skip / error / check / vendor by resolved state", () => {
+  assert.equal(decide({ present: false, explicit: false, check: true }).action, "skip");
+  assert.equal(decide({ present: false, explicit: true, check: true }).action, "error");
+  assert.equal(decide({ present: false, explicit: false, check: false }).action, "error");
+  assert.equal(decide({ present: true, explicit: false, check: true }).action, "check");
+  assert.equal(decide({ present: true, explicit: false, check: false }).action, "vendor");
+});
+
+test("main throws when FALLOW_SKILLS_DIR is set but missing (both modes)", () => {
+  const prev = process.env.FALLOW_SKILLS_DIR;
+  process.env.FALLOW_SKILLS_DIR = join(tmpdir(), "vendor-skills-nonexistent-canonical");
+  try {
+    assert.throws(() => main(["--check"]), /FALLOW_SKILLS_DIR is set/);
+    assert.throws(() => main([]), /not found/);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.FALLOW_SKILLS_DIR;
+    } else {
+      process.env.FALLOW_SKILLS_DIR = prev;
+    }
+  }
 });


### PR DESCRIPTION
Follow-up polish on `scripts/vendor-skills.mjs` (from #1782):

- Extract the dispatch branch into a pure `decide()` and export `main()` so both are unit-testable.
- Add a `renderDiffs` option to `runCheck` so the changed-file drift test no longer spawns `git diff` into the TAP stream (was harmless `#`-prefixed noise).
- Tests: `decide` (all four branches) and `main` (throws on explicit-missing canonical, without touching the real vendored tree).

32 tests pass in multi-file mode; oxfmt + oxlint clean. No behavior change to the gate.