### PR TITLE
fix(review): validate origin, cap body, and schema-check the inspect bridge

### DIFF
--- a/apps/review-electron/src/main/diff.test.ts
+++ b/apps/review-electron/src/main/diff.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeRef } from "./diff";
+
+describe("sanitizeRef", () => {
+  it("accepts well-formed refs unchanged", () => {
+    expect(sanitizeRef("HEAD")).toBe("HEAD");
+    expect(sanitizeRef("HEAD~2")).toBe("HEAD~2");
+    expect(sanitizeRef("HEAD^")).toBe("HEAD^");
+    expect(sanitizeRef("main")).toBe("main");
+    expect(sanitizeRef("origin/main")).toBe("origin/main");
+    expect(sanitizeRef("feature/foo-bar")).toBe("feature/foo-bar");
+    expect(sanitizeRef("v1.2.3")).toBe("v1.2.3");
+    expect(sanitizeRef("a1b2c3d")).toBe("a1b2c3d");
+    expect(sanitizeRef("a1b2c3d4e5f6789012345678901234567890abcd")).toBe(
+      "a1b2c3d4e5f6789012345678901234567890abcd",
+    );
+  });
+
+  it("falls back to HEAD for option-injection attempts (a ref beginning with '-')", () => {
+    expect(sanitizeRef("--output=/tmp/x")).toBe("HEAD");
+    expect(sanitizeRef("-rf")).toBe("HEAD");
+    expect(sanitizeRef("--upload-pack=evil")).toBe("HEAD");
+  });
+
+  it("falls back to HEAD for empty input", () => {
+    expect(sanitizeRef("")).toBe("HEAD");
+  });
+});

--- a/apps/review-electron/src/main/diff.ts
+++ b/apps/review-electron/src/main/diff.ts
@@ -5,13 +5,23 @@ const run = promisify(execFile);
 
 export type FileDiff = { patch: string; binary: boolean };
 
+/** Refs and revision expressions git accepts: SHAs, branch names, `HEAD`, `HEAD~2`, `origin/main`. */
+const SAFE_REF = /^[A-Za-z0-9][A-Za-z0-9._/^~-]*$/;
+
+/**
+ * Reject anything that isn't a well-formed git ref, falling back to `HEAD`.
+ * Guards against option injection (a ref beginning with `-`, e.g.
+ * `--output=/tmp/x`, would otherwise be parsed by git as a flag).
+ */
+export const sanitizeRef = (ref: string): string => (SAFE_REF.test(ref) ? ref : "HEAD");
+
 /**
  * Unified `git diff <base> -- <file>` for a changed file (base = the review's
  * merge-base). New-since-base files show as all-additions; binary files are
  * flagged. Errors degrade to an empty patch (the UI shows "no textual diff").
  */
 export const getFileDiff = async (root: string, base: string, file: string): Promise<FileDiff> => {
-  const ref = base || "HEAD";
+  const ref = sanitizeRef(base || "HEAD");
   try {
     const { stdout } = await run("git", ["diff", ref, "--", file], {
       cwd: root,
@@ -29,7 +39,7 @@ export const getFileDiff = async (root: string, base: string, file: string): Pro
  * the multi-file patch into per-file sections.
  */
 export const getAllDiffs = async (root: string, base: string): Promise<{ patch: string }> => {
-  const ref = base || "HEAD";
+  const ref = sanitizeRef(base || "HEAD");
   try {
     const { stdout } = await run("git", ["diff", ref], {
       cwd: root,

--- a/apps/review-electron/src/main/inspectServer.test.ts
+++ b/apps/review-electron/src/main/inspectServer.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  startInspectServer,
+  isLoopbackHost,
+  isAllowedOrigin,
+  parseSelection,
+} from "./inspectServer";
+import { feedPath } from "./feed";
+
+let server: Server | undefined;
+
+afterEach(() => {
+  server?.close();
+  server = undefined;
+});
+
+const bootServer = async (root: string): Promise<{ url: string; port: number }> => {
+  server = startInspectServer(
+    () => null,
+    () => undefined,
+    root,
+    0,
+  );
+  const started = server;
+  await new Promise<void>((resolvePromise) => started.once("listening", resolvePromise));
+  const { port } = started.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}/fallow-select`, port };
+};
+
+const feedLineCount = (root: string): number => {
+  if (!existsSync(feedPath(root))) return 0;
+  return readFileSync(feedPath(root), "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0).length;
+};
+
+const validBody = JSON.stringify({ file: "src/App.tsx", line: 3, component: "App" });
+
+describe("startInspectServer", () => {
+  it("accepts a valid POST with no Origin header (e2e-compatibility case)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-noorigin-"));
+    const { url } = await bootServer(root);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: validBody,
+    });
+    expect(res.status).toBe(200);
+    expect(feedLineCount(root)).toBe(1);
+  });
+
+  it("accepts a valid POST from a loopback Origin and echoes it back", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-origin-"));
+    const { url } = await bootServer(root);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "http://localhost:5173" },
+      body: validBody,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:5173");
+    expect(feedLineCount(root)).toBe(1);
+  });
+
+  it("rejects a POST from a non-loopback Origin", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-evil-origin-"));
+    const { url } = await bootServer(root);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://evil.example" },
+      body: validBody,
+    });
+    expect(res.status).toBe(403);
+    expect(feedLineCount(root)).toBe(0);
+  });
+
+  it("rejects a POST with a non-loopback Host (DNS-rebinding)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-evil-host-"));
+    const { port } = await bootServer(root);
+    // fetch() derives Host from the URL; talk raw HTTP so we can force a bogus Host.
+    const net = await import("node:net");
+    const response = await new Promise<string>((resolvePromise, reject) => {
+      const socket = net.connect(port, "127.0.0.1", () => {
+        const payload = validBody;
+        socket.write(
+          `POST /fallow-select HTTP/1.1\r\n` +
+            `Host: evil.example\r\n` +
+            `Content-Type: application/json\r\n` +
+            `Content-Length: ${Buffer.byteLength(payload)}\r\n` +
+            `Connection: close\r\n\r\n${payload}`,
+        );
+      });
+      let data = "";
+      socket.on("data", (chunk) => {
+        data += chunk.toString();
+      });
+      socket.on("end", () => resolvePromise(data));
+      socket.on("error", reject);
+    });
+    expect(response.startsWith("HTTP/1.1 403")).toBe(true);
+    expect(feedLineCount(root)).toBe(0);
+  });
+
+  it("rejects a body larger than 64 KiB", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-toolarge-"));
+    const { url } = await bootServer(root);
+    const bigComponent = "x".repeat(70 * 1024);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: "src/App.tsx", line: 1, component: bigComponent }),
+    });
+    expect(res.status).toBe(413);
+    expect(feedLineCount(root)).toBe(0);
+  });
+
+  it("rejects malformed JSON with 400", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-badjson-"));
+    const { url } = await bootServer(root);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    });
+    expect(res.status).toBe(400);
+    expect(feedLineCount(root)).toBe(0);
+  });
+
+  it("rejects a payload with the wrong shape with 400", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-badshape-"));
+    const { url } = await bootServer(root);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ file: 42 }),
+    });
+    expect(res.status).toBe(400);
+    expect(feedLineCount(root)).toBe(0);
+  });
+
+  it("answers OPTIONS from a loopback origin with 204", async () => {
+    const root = mkdtempSync(join(tmpdir(), "inspect-options-"));
+    const { url } = await bootServer(root);
+    const res = await fetch(url, {
+      method: "OPTIONS",
+      headers: { origin: "http://localhost:5173" },
+    });
+    expect(res.status).toBe(204);
+  });
+});
+
+describe("isLoopbackHost", () => {
+  it("accepts bare loopback hostnames", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+  });
+
+  it("accepts loopback hostnames with a port, including bracketed IPv6", () => {
+    expect(isLoopbackHost("[::1]:7787")).toBe(true);
+    expect(isLoopbackHost("localhost:0")).toBe(true);
+  });
+
+  it("rejects non-loopback hosts, the literal 'null', and empty/undefined input", () => {
+    expect(isLoopbackHost("evil.example")).toBe(false);
+    expect(isLoopbackHost("null")).toBe(false);
+    expect(isLoopbackHost("")).toBe(false);
+    expect(isLoopbackHost(undefined)).toBe(false);
+  });
+});
+
+describe("isAllowedOrigin", () => {
+  it("allows an absent Origin header (non-browser clients)", () => {
+    expect(isAllowedOrigin(undefined)).toBe(true);
+  });
+
+  it("allows loopback http/https origins at any port", () => {
+    expect(isAllowedOrigin("http://localhost:5173")).toBe(true);
+    expect(isAllowedOrigin("http://127.0.0.1:3000")).toBe(true);
+    expect(isAllowedOrigin("http://[::1]:8080")).toBe(true);
+  });
+
+  it("rejects non-loopback origins, the literal 'null', and malformed input", () => {
+    expect(isAllowedOrigin("https://evil.example")).toBe(false);
+    expect(isAllowedOrigin("null")).toBe(false);
+    expect(isAllowedOrigin("")).toBe(false);
+    expect(isAllowedOrigin("localhost:0")).toBe(false);
+  });
+});
+
+describe("parseSelection", () => {
+  it("parses a valid selection", () => {
+    expect(parseSelection(validBody)).toEqual({ file: "src/App.tsx", line: 3, component: "App" });
+  });
+
+  it("rejects malformed JSON", () => {
+    expect(parseSelection("not json")).toBeNull();
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(parseSelection("42")).toBeNull();
+    expect(parseSelection("null")).toBeNull();
+  });
+
+  it("rejects an out-of-range or wrong-typed field", () => {
+    expect(parseSelection(JSON.stringify({ file: 42, line: 1 }))).toBeNull();
+    expect(parseSelection(JSON.stringify({ file: "", line: 1 }))).toBeNull();
+    expect(parseSelection(JSON.stringify({ file: "a.tsx", line: -1 }))).toBeNull();
+    expect(parseSelection(JSON.stringify({ file: "a.tsx", line: 1.5 }))).toBeNull();
+    expect(parseSelection(JSON.stringify({ file: "a.tsx", line: 1, column: -1 }))).toBeNull();
+    expect(
+      parseSelection(JSON.stringify({ file: "a.tsx", line: 1, component: "x".repeat(257) })),
+    ).toBeNull();
+  });
+});

--- a/apps/review-electron/src/main/inspectServer.ts
+++ b/apps/review-electron/src/main/inspectServer.ts
@@ -6,15 +6,97 @@ import type { WalkthroughDocument } from "../model/walkthrough";
 export const INSPECT_PORT = 7787;
 const SELECT_PATH = "/fallow-select";
 
-const CORS = {
-  "access-control-allow-origin": "*",
+/** Max accepted request body size for the inspect bridge (bytes). */
+const MAX_BODY_BYTES = 64 * 1024;
+
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "::1"]);
+
+const stripBrackets = (hostname: string): string =>
+  hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+
+/** Strip the `:port` suffix from a `Host` header value, honoring IPv6 brackets. */
+const hostnameOf = (host: string): string => {
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    return end === -1 ? host : host.slice(1, end);
+  }
+  const colon = host.lastIndexOf(":");
+  return colon === -1 ? host : host.slice(0, colon);
+};
+
+/**
+ * True when the `Host` header names a loopback address. Guards against
+ * DNS-rebinding (a browser resolves an attacker-controlled name to
+ * 127.0.0.1, then sends that name back as `Host`).
+ */
+export const isLoopbackHost = (host: string | undefined): boolean => {
+  if (!host) return false;
+  return LOOPBACK_HOSTNAMES.has(hostnameOf(host));
+};
+
+/**
+ * True when `origin` is absent (non-browser clients: e2e fetches, curl) or
+ * is a loopback `http:`/`https:` origin, any port. False for everything
+ * else, including the literal string `"null"` (sent for opaque origins).
+ */
+export const isAllowedOrigin = (origin: string | undefined): boolean => {
+  if (origin === undefined) return true;
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    return LOOPBACK_HOSTNAMES.has(stripBrackets(url.hostname));
+  } catch {
+    return false;
+  }
+};
+
+const corsHeaders = (origin: string | undefined): Record<string, string> => ({
+  "access-control-allow-origin": origin ?? "*",
   "access-control-allow-methods": "POST, OPTIONS",
   "access-control-allow-headers": "content-type",
+});
+
+/**
+ * Validate and parse a raw request body into a {@link Selection}. Returns
+ * `null` for malformed JSON or any field that violates the expected shape,
+ * rather than trusting a blind type assertion.
+ */
+export const parseSelection = (body: string): Selection | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const { file, line, column, component } = parsed as Record<string, unknown>;
+
+  if (typeof file !== "string" || file.length === 0 || file.length > 1024) return null;
+  if (typeof line !== "number" || !Number.isInteger(line) || line < 0) return null;
+  if (
+    column !== undefined &&
+    (typeof column !== "number" || !Number.isInteger(column) || column < 0)
+  ) {
+    return null;
+  }
+  if (component !== undefined && (typeof component !== "string" || component.length > 256)) {
+    return null;
+  }
+
+  const sel: Selection = { file, line };
+  if (column !== undefined) sel.column = column;
+  if (component !== undefined) sel.component = component;
+  return sel;
 };
 
 /**
  * Localhost bridge: the in-page picker POSTs a {@link Selection}; we enrich it
  * with grounded facts, push the card to the renderer, and log it to the feed.
+ *
+ * Trust model: loopback-only transport (bind + `Host` check, closing
+ * DNS-rebinding) AND loopback-only browser origins AND schema-valid payloads.
+ * Non-browser clients (no `Origin` header, e.g. the e2e fetches and curl) are
+ * allowed by design; CORS headers are meaningless for them.
  */
 export const startInspectServer = (
   getDoc: () => WalkthroughDocument | null,
@@ -23,22 +105,51 @@ export const startInspectServer = (
   port: number = INSPECT_PORT,
 ): Server => {
   const server = createServer((req, res) => {
+    const origin = req.headers.origin;
+    const allowed = isLoopbackHost(req.headers.host) && isAllowedOrigin(origin);
+
     if (req.method === "OPTIONS") {
-      res.writeHead(204, CORS).end();
+      if (!allowed) {
+        res.writeHead(403).end();
+        return;
+      }
+      res.writeHead(204, corsHeaders(origin)).end();
       return;
     }
+
     if (req.method !== "POST" || req.url !== SELECT_PATH) {
-      res.writeHead(404, CORS).end();
+      res.writeHead(404).end();
       return;
     }
+
+    if (!allowed) {
+      res.writeHead(403).end();
+      return;
+    }
+
     let body = "";
-    req.on("data", (chunk) => {
+    let bytes = 0;
+    let rejected = false;
+    req.on("data", (chunk: Buffer) => {
+      if (rejected) return;
+      bytes += chunk.length;
+      if (bytes > MAX_BODY_BYTES) {
+        rejected = true;
+        res.writeHead(413, corsHeaders(origin)).end();
+        req.destroy();
+        return;
+      }
       body += chunk;
     });
     req.on("end", () => {
+      if (rejected) return;
       void (async () => {
+        const sel = parseSelection(body);
+        if (!sel) {
+          res.writeHead(400, corsHeaders(origin)).end();
+          return;
+        }
         try {
-          const sel = JSON.parse(body) as Selection;
           const card = buildInspectorCard(getDoc(), sel);
           send(card);
           await appendFeedItem(root, {
@@ -47,10 +158,10 @@ export const startInspectServer = (
             at: new Date().toISOString(),
           });
           res
-            .writeHead(200, { "content-type": "application/json", ...CORS })
+            .writeHead(200, { "content-type": "application/json", ...corsHeaders(origin) })
             .end(JSON.stringify(card));
         } catch (err) {
-          res.writeHead(400, CORS).end(String(err));
+          res.writeHead(400, corsHeaders(origin)).end(String(err));
         }
       })();
     });


### PR DESCRIPTION
The review-electron inspect bridge accepted cross-origin POSTs from any web page (wildcard CORS, no Origin/Host validation, unbounded body accumulation, blind JSON type assertion) and appended them to the reviewer feed that downstream tooling ingests as context. A malicious page open in the user's browser could write arbitrary text into that feed while the app was running.

The handler now rejects non-loopback Host and Origin headers on the request itself (simple requests skip preflight, so gating OPTIONS alone is not enough; the Host check also closes DNS rebinding), caps the body at 64 KiB, validates the Selection payload shape field by field, and echoes only validated loopback origins instead of the wildcard. git diff refs coming from walkthrough documents are sanitized against option injection. Origin-less local clients (the e2e fetches, curl) keep working unchanged, verified by the new inspectServer test suite.