### PR TITLE
test: strengthen CI and contributor guidance

### DIFF
--- a/.claude/hooks/pre-bash-guard.py
+++ b/.claude/hooks/pre-bash-guard.py
@@ -61,7 +61,8 @@ def main() -> int:
     if uses_unbounded_workspace_cargo(command, commands):
         deny(
             "Redirect full workspace cargo output to a log and return only the tail, for example "
-            "`cargo test --workspace --all-targets > /tmp/fallow-test.log 2>&1; tail -80 /tmp/fallow-test.log`."
+            "`cargo test --workspace --lib --bins --tests --examples "
+            "> /tmp/fallow-test.log 2>&1; tail -80 /tmp/fallow-test.log`."
         )
         return 0
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,7 +27,8 @@ cargo clippy --workspace --all-targets -- -D warnings
 # 10x / 2x multipliers, so we keep those off the local chain too;
 # they live in CI matrices that are budget-tuned separately).
 # If you want to run the full suite locally before opening a PR:
-#   cargo test --workspace --all-targets
+#   cargo test --workspace --lib --bins --tests --examples
+#   cargo check --workspace --benches
 #   RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items
 #   rustup run nightly cargo miri test -p fallow-types --lib --tests -- --skip proptests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             # gates:
             #   - `cargo test/clippy --features schema-emit` for the
             #     Rust-source -> docs/output-schema.json chain (output schema)
-            #   - `cargo test --workspace --all-targets` (the existing step)
+            #   - `cargo test --workspace --lib --bins --tests --examples`
             #     for the FallowConfig -> schema.json chain (config-input
             #     schema, #440), via a `#[cfg(test)] mod config_schema_drift`
             #     test in `crates/cli/src/init.rs`.
@@ -91,6 +91,7 @@ jobs:
               - 'rust-toolchain.toml'
             vscode:
               - 'editors/vscode/**'
+              - '.github/workflows/ci.yml'
             zed:
               - 'editors/zed/**'
             npm:
@@ -230,13 +231,13 @@ jobs:
         if: matrix.os != 'windows-latest'
         # Benchmark targets exceed this job's timeout and are covered by the
         # dedicated benchmark workflows.
-        run: cargo test --workspace --lib --bins --tests
+        run: cargo test --workspace --lib --bins --tests --examples
 
       - name: Run tests (Windows)
         if: matrix.os == 'windows-latest'
         # Windows push checks catch path and filesystem regressions.
         # Benchmark targets are covered by dedicated benchmark workflows.
-        run: cargo test --workspace --lib --bins --tests
+        run: cargo test --workspace --lib --bins --tests --examples
 
       - name: Run runtime-coverage integration tests (feature-gated stub sidecar)
         run: cargo test -p fallow-cli --features test-sidecar-key --test runtime_coverage_tests
@@ -505,6 +506,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 10.33.0
@@ -513,12 +516,18 @@ jobs:
           node-version: '22'
           cache: pnpm
           cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - name: Cache VS Code test download
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: /tmp/fallow-vscode-test-cache
+          key: vscode-test-${{ runner.os }}-${{ runner.arch }}-vscode-1.96.0
       - run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
       - run: cd editors/vscode && pnpm audit --prod
       - name: Verify generated extension contracts
         run: cd editors/vscode && pnpm run check:contracts
       - run: cd editors/vscode && pnpm lint
-      - run: cd editors/vscode && pnpm build
+      - name: Run VS Code extension-host integration tests
+        run: cd editors/vscode && xvfb-run -a pnpm test:integration
       - run: cd editors/vscode && pnpm test:unit
       - run: cd editors/vscode && pnpm package
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,7 @@ name: Coverage
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -19,9 +20,14 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      badge_color: ${{ steps.badge.outputs.color }}
+      percentage: ${{ steps.compute.outputs.percentage }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
 
@@ -40,6 +46,7 @@ jobs:
           cargo llvm-cov --workspace --lcov --output-path coverage/lcov.info
 
       - name: Compute coverage
+        id: compute
         run: |
           COVERAGE=$(awk -F: '
             /^LF:/ { total += $2 }
@@ -47,6 +54,7 @@ jobs:
             END { if (total > 0) printf "%.1f", (hit/total)*100; else print "0" }
           ' coverage/lcov.info)
           echo "COVERAGE=$COVERAGE" >> "$GITHUB_ENV"
+          echo "percentage=$COVERAGE" >> "$GITHUB_OUTPUT"
           echo "Coverage: $COVERAGE%"
 
       - name: Enforce coverage floor
@@ -63,6 +71,7 @@ jobs:
           }'
 
       - name: Compute badge color
+        id: badge
         run: |
           int=${COVERAGE%.*}
           if [ "$int" -ge 90 ]; then color="brightgreen"
@@ -73,6 +82,7 @@ jobs:
           else color="red"
           fi
           echo "BADGE_COLOR=$color" >> "$GITHUB_ENV"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
 
       - name: Write coverage metrics
         run: |
@@ -81,6 +91,36 @@ jobs:
           data = [{'name': 'Code Coverage', 'unit': '%', 'value': float('${COVERAGE:-0}')}]
           print(json.dumps(data, indent=2))
           " > coverage-bench.json
+
+      - name: Upload coverage publication input
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-publication
+          path: coverage-bench.json
+          retention-days: 1
+
+  publish:
+    name: Publish coverage
+    needs: coverage
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      BADGE_COLOR: ${{ needs.coverage.outputs.badge_color }}
+      COVERAGE: ${{ needs.coverage.outputs.percentage }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download coverage publication input
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: coverage-publication
 
       - name: Store coverage metrics
         uses: ./.github/actions/store-benchmark

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ Pipeline: Config → File Discovery → Incremental Parallel Parsing (rayon + ox
 ```bash
 git config core.hooksPath .githooks  # Enable pre-commit hooks (fmt + clippy)
 cargo build --workspace
-cargo test --workspace --all-targets
+cargo test --workspace --lib --bins --tests --examples
+cargo check --workspace --benches
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all -- --check
 cargo run --bin fallow                       # Run all analyses (dead-code + dupes + health)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,21 +63,39 @@ cd benchmarks && npm run generate:circular && npm run bench:circular  # vs madge
 
 ## Project structure
 
-```
-crates/
-  cli/      — CLI binary and output formatting
-  config/   — Configuration types, presets, workspace discovery
-  core/     — Analysis engine: plugins, discovery, parsing, resolution, graph, detection
-  extract/  — AST extraction (JS/TS, Vue/Svelte SFC, Astro, MDX, CSS)
-  graph/    — Module graph construction and resolution
-  types/    — Shared types across crates
-  lsp/      — LSP server
-  mcp/      — MCP server for AI agents
-editors/
-  vscode/   — VS Code extension
-npm/
-  fallow/   — npm wrapper package
-```
+The workspace follows the ownership boundaries in
+[`docs/architecture-invariants.md`](docs/architecture-invariants.md):
+
+| Path | Responsibility |
+| --- | --- |
+| `crates/types/` | Shared typed contracts, issue metadata, suppressions, and envelope data. |
+| `crates/config/` | Configuration loading, typed configuration, presets, and workspace discovery. |
+| `crates/extract/` | Parser-facing facts for JavaScript, TypeScript, framework files, MDX, and CSS. |
+| `crates/graph/` | Module graph construction, import resolution, dependency traversal, cycles, and impact facts. |
+| `crates/security/` | Shared security matcher catalogue and candidate helpers. |
+| `crates/core/` | Internal detector backend used by `fallow-engine` for private detector phases. It is not the supported embedder surface. |
+| `crates/engine/` | Analysis sessions, discovery, parsing, graph construction, and typed analysis orchestration. |
+| `crates/output/` | Shared output contracts, action builders, summaries, SARIF builders, and reusable formatter pieces. |
+| `crates/api/` | Supported Rust facade and programmatic workflow adapters. |
+| `crates/cli/` | CLI protocol adapter, command dispatch, terminal interaction, and protocol-specific serialization. |
+| `crates/lsp/` | LSP adapter for diagnostics, code actions, hover, and code lens. |
+| `crates/mcp/` | MCP adapter exposing fallow as typed tools for AI agents. |
+| `crates/napi/` | NAPI adapter and Node.js bindings over the supported Rust facade. |
+| `crates/license/` | Offline signed-license verification used by licensed CLI capabilities. |
+| `crates/v8-coverage/` | V8 coverage parsing and source-offset mapping. |
+| `crates/benchmarks/` | CodSpeed and Criterion benchmark suites for the Rust workspace. |
+| `editors/vscode/` | VS Code extension and generated TypeScript contract consumer. |
+| `editors/zed/` | Zed extension. |
+| `editors/nvim/` | Neovim integration documentation. |
+| `npm/fallow/` | npm wrapper, launchers, generated types, and bundled agent skill. |
+| `npm/<platform>/` | Platform-specific native binary packages consumed by the npm wrapper. |
+
+Dependency direction is deliberate. Foundation and analysis crates do not
+depend on protocol adapters. `fallow-core` remains an internal detector backend
+behind `fallow-engine`; `fallow-output` shapes reusable contracts without
+starting analysis; `fallow-api` provides the supported Rust facade. The CLI,
+LSP, MCP, and NAPI adapters translate their protocol options and call
+`fallow-api` or `fallow-engine` rather than calling `fallow-core` directly.
 
 ## Adding a framework plugin
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,9 +44,14 @@ Broader bets, still being scoped.
 
 Safe removals (unused exports, enum members, dependencies) are already auto-fixable. The open question is the judgment calls: deleting files, consolidating duplicates, restructuring modules. The bet: structured MCP output plus the right review workflow lets an agent propose those changes, a human approves the PR, and fallow verifies nothing regressed.
 
-### Codebase health grade
+### Health score calibration and adoption
 
-One letter (A-F) per project, derived from dead code ratio, duplication, complexity density, and dependency hygiene. Visible as a badge, tracked in vital signs snapshots, trended over time. Managers understand it, developers trust it, agents optimize for it. The risk is that a single grade collapses signal the existing health score already surfaces more precisely; scoping needs to show it adds value over the current score.
+Shipped today: `fallow health` provides a 0-100 score, an A-F letter grade,
+badge output, saved vital-sign snapshots, and trend comparisons. Planned work
+focuses on calibrating the formula against a broad real-world corpus, explaining
+how its multiple signals contribute to each result, and helping teams adopt
+baselines and thresholds that fit their project context. This direction improves
+confidence and multi-signal explainability rather than adding another grade.
 
 ### Visualization
 

--- a/crates/cli/src/architecture_boundaries.rs
+++ b/crates/cli/src/architecture_boundaries.rs
@@ -80,6 +80,75 @@ fn architecture_invariants_doc_tracks_guarded_boundaries() {
 }
 
 #[test]
+fn contributor_architecture_map_and_roadmap_track_current_ownership() {
+    let contributing = std::fs::read_to_string(workspace_root().join("CONTRIBUTING.md"))
+        .expect("read contributing guide");
+    let project_structure = contributing
+        .split_once("## Project structure")
+        .and_then(|(_, rest)| rest.split_once("\n## ").map(|(section, _)| section))
+        .expect("find project structure section");
+
+    for manifest_path in workspace_crate_manifests() {
+        let crate_path = manifest_path
+            .strip_suffix("Cargo.toml")
+            .expect("workspace manifest path ends in Cargo.toml");
+        let documented_path = format!("`{crate_path}`");
+        assert!(
+            project_structure.contains(&documented_path),
+            "CONTRIBUTING project map must include workspace crate {documented_path}"
+        );
+    }
+
+    for required in [
+        "Internal detector backend used by `fallow-engine`",
+        "Analysis sessions, discovery, parsing, graph construction",
+        "Shared output contracts",
+        "Supported Rust facade",
+        "CLI protocol adapter",
+        "LSP adapter",
+        "MCP adapter",
+        "NAPI adapter",
+        "`editors/vscode/`",
+        "`editors/zed/`",
+        "`editors/nvim/`",
+        "`npm/fallow/`",
+        "`npm/<platform>/`",
+    ] {
+        assert!(
+            project_structure.contains(required),
+            "CONTRIBUTING project map must preserve current ownership: {required}"
+        );
+    }
+    assert!(
+        !project_structure
+            .contains("Analysis engine: plugins, discovery, parsing, resolution, graph, detection"),
+        "CONTRIBUTING must not assign engine orchestration to fallow-core"
+    );
+
+    let roadmap =
+        std::fs::read_to_string(workspace_root().join("ROADMAP.md")).expect("read roadmap");
+    assert!(
+        !roadmap.contains("### Codebase health grade"),
+        "ROADMAP must not present the shipped health grade as planned work"
+    );
+    for required in [
+        "### Health score calibration and adoption",
+        "Shipped today",
+        "0-100 score",
+        "A-F letter grade",
+        "badge output",
+        "saved vital-sign snapshots",
+        "trend comparisons",
+        "multi-signal explainability",
+    ] {
+        assert!(
+            roadmap.contains(required),
+            "ROADMAP must distinguish shipped health scoring from planned calibration: {required}"
+        );
+    }
+}
+
+#[test]
 fn api_consumers_depend_on_api_not_engine_cli_or_core() {
     for manifest in [
         "crates/lsp/Cargo.toml",

--- a/editors/vscode/test/integration/runTest.ts
+++ b/editors/vscode/test/integration/runTest.ts
@@ -284,6 +284,7 @@ const main = async (): Promise<void> => {
         `--extensions-dir=${extensionsDir}`,
         `--user-data-dir=${userDataDir}`,
       ],
+      version: "1.96.0",
     });
   } catch (error) {
     console.error("Failed to run extension tests");

--- a/scripts/scaffold-analyzer-plan.mjs
+++ b/scripts/scaffold-analyzer-plan.mjs
@@ -96,7 +96,8 @@ Status: draft
 
 ## Verification
 
-- [ ] \`cargo test --workspace --all-targets\`
+- [ ] \`cargo test --workspace --lib --bins --tests --examples\`
+- [ ] \`cargo check --workspace --benches\`
 - [ ] \`npm run generate:contracts:check\`
 - [ ] Real project smoke with \`--format json --quiet\`
 `;

--- a/scripts/test-command-policy.test.mjs
+++ b/scripts/test-command-policy.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ciWorkflowRelativePath = ".github/workflows/ci.yml";
+const requiredPolicyPaths = [
+  "CLAUDE.md",
+  ".claude/hooks/pre-bash-guard.py",
+  ".githooks/pre-push",
+  ciWorkflowRelativePath,
+  "scripts/scaffold-analyzer-plan.mjs",
+];
+const optionalPolicyPaths = [
+  ".codex/references/quality-gates.md",
+  ".codex/hooks/pre-bash-guard.py",
+];
+const fullValidationPaths = [
+  "CLAUDE.md",
+  ".githooks/pre-push",
+  "scripts/scaffold-analyzer-plan.mjs",
+  ".codex/references/quality-gates.md",
+];
+
+const normalTestCommand = "cargo test --workspace --lib --bins --tests --examples";
+const benchCompileCommand = "cargo check --workspace --benches";
+
+const existingPaths = (root, paths) =>
+  paths.map((relativePath) => join(root, relativePath)).filter(existsSync);
+
+const policyPaths = (root) => [
+  ...requiredPolicyPaths.map((relativePath) => join(root, relativePath)),
+  ...existingPaths(root, optionalPolicyPaths),
+];
+
+const validationPaths = (root) => existingPaths(root, fullValidationPaths);
+
+const leadingSpaces = (line) => line.length - line.trimStart().length;
+const isBlank = (line) => line.trim() === "";
+
+const parseRunLine = (line) => {
+  const match = line.match(/^(\s*)(?:-\s+)?run:\s*(.*?)\s*$/u);
+  return match ? { indent: match[1].length, value: match[2] } : null;
+};
+
+const blockStyle = (value) => value.match(/^([|>])[+-]?(?:\s+#.*)?$/u)?.[1] ?? null;
+
+const isBlockLine = (line, runIndent) => isBlank(line) || leadingSpaces(line) > runIndent;
+
+const collectBlockLines = (lines, startIndex, runIndent) => {
+  const relativeEnd = lines.slice(startIndex).findIndex((line) => !isBlockLine(line, runIndent));
+  const endIndex = relativeEnd === -1 ? lines.length : startIndex + relativeEnd;
+  return { lines: lines.slice(startIndex, endIndex), nextIndex: endIndex };
+};
+
+const minimumContentIndent = (lines) =>
+  lines.reduce(
+    (minimum, line) => (isBlank(line) ? minimum : Math.min(minimum, leadingSpaces(line))),
+    Number.POSITIVE_INFINITY,
+  );
+
+const stripCommonIndent = (lines) => {
+  const indent = minimumContentIndent(lines);
+  return lines.map((line) => line.slice(Math.min(indent, line.length)));
+};
+
+const renderBlockScalar = (lines, style) => {
+  const separator = style === ">" ? " " : "\n";
+  return stripCommonIndent(lines).join(separator).trim();
+};
+
+const runCommandAt = (lines, index) => {
+  const run = parseRunLine(lines[index]);
+  if (!run) {
+    return { command: null, nextIndex: index + 1 };
+  }
+
+  const style = blockStyle(run.value);
+  if (!style) {
+    return { command: run.value || null, nextIndex: index + 1 };
+  }
+
+  const block = collectBlockLines(lines, index + 1, run.indent);
+  return {
+    command: renderBlockScalar(block.lines, style),
+    nextIndex: block.nextIndex,
+  };
+};
+
+const yamlRunCommands = (text) => {
+  const lines = text.split("\n");
+  const commands = [];
+  let index = 0;
+  while (index < lines.length) {
+    const parsed = runCommandAt(lines, index);
+    if (parsed.command) {
+      commands.push(parsed.command);
+    }
+    index = parsed.nextIndex;
+  }
+
+  return commands;
+};
+
+const assertCiWorkspaceTestCommands = (text) => {
+  const workspaceTestCommands = yamlRunCommands(text).filter(
+    (command) => command.includes("cargo test") && command.includes("--workspace"),
+  );
+
+  assert.notEqual(workspaceTestCommands.length, 0, "CI must execute workspace tests");
+  for (const command of workspaceTestCommands) {
+    assert.equal(command, normalTestCommand, `unsafe CI workspace test command: ${command}`);
+  }
+};
+
+test("tracked command-policy files are present", () => {
+  for (const filePath of requiredPolicyPaths.map((relativePath) => join(repoRoot, relativePath))) {
+    assert.equal(existsSync(filePath), true, `missing tracked policy file: ${filePath}`);
+  }
+});
+
+test("normal test guidance never executes benchmark targets", () => {
+  for (const filePath of policyPaths(repoRoot)) {
+    const lines = readFileSync(filePath, "utf8").split("\n");
+    const benchmarkRunningLines = lines.filter(
+      (line) => line.includes("cargo test") && line.includes("--all-targets"),
+    );
+    assert.deepEqual(
+      benchmarkRunningLines,
+      [],
+      `${relative(repoRoot, filePath)} must not recommend benchmark-running tests`,
+    );
+  }
+});
+
+test("normal test guidance selects only non-benchmark targets", () => {
+  for (const filePath of policyPaths(repoRoot)) {
+    if (relative(repoRoot, filePath) === ciWorkflowRelativePath) {
+      continue;
+    }
+    assert.match(
+      readFileSync(filePath, "utf8"),
+      new RegExp(normalTestCommand),
+      `${relative(repoRoot, filePath)} must use the normal non-benchmark target set`,
+    );
+  }
+});
+
+test("CI executable workspace tests use the normal non-benchmark target set", () => {
+  const ciWorkflowPath = join(repoRoot, ciWorkflowRelativePath);
+  assertCiWorkspaceTestCommands(readFileSync(ciWorkflowPath, "utf8"));
+});
+
+test("CI executable policy rejects unsafe multiline workspace tests", () => {
+  for (const blockHeader of ["|", ">-"]) {
+    const mixedShapeWorkflow = `steps:
+  - name: Safe inline test
+    run: ${normalTestCommand}
+  - name: Unsafe multiline test
+    run: ${blockHeader}
+      cargo test --workspace --all-targets
+`;
+
+    assert.throws(
+      () => assertCiWorkspaceTestCommands(mixedShapeWorkflow),
+      /unsafe CI workspace test command: cargo test --workspace --all-targets/u,
+    );
+  }
+});
+
+test("full validation compiles benchmarks separately", () => {
+  for (const filePath of validationPaths(repoRoot)) {
+    assert.match(
+      readFileSync(filePath, "utf8"),
+      new RegExp(benchCompileCommand),
+      `${relative(repoRoot, filePath)} must compile benchmarks explicitly`,
+    );
+  }
+});
+
+test("benchmark test guidance is compile-only", () => {
+  for (const filePath of policyPaths(repoRoot)) {
+    const lines = readFileSync(filePath, "utf8").split("\n");
+    const benchmarkTestLines = lines.filter(
+      (line) =>
+        line.includes("cargo test") && line.includes("--benches") && !line.includes("--no-run"),
+    );
+    assert.deepEqual(
+      benchmarkTestLines,
+      [],
+      `${relative(repoRoot, filePath)} must never execute benchmark targets for coverage`,
+    );
+  }
+});
+
+test("optional Codex policy files may be absent in a clean checkout", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "fallow-command-policy-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  for (const relativePath of requiredPolicyPaths) {
+    mkdirSync(dirname(join(root, relativePath)), { recursive: true });
+    const command = fullValidationPaths.includes(relativePath)
+      ? `${normalTestCommand}\n${benchCompileCommand}\n`
+      : `${normalTestCommand}\n`;
+    writeFileSync(join(root, relativePath), command);
+  }
+
+  assert.deepEqual(
+    policyPaths(root).map((filePath) => relative(root, filePath)),
+    requiredPolicyPaths,
+  );
+  assert.deepEqual(
+    validationPaths(root).map((filePath) => relative(root, filePath)),
+    ["CLAUDE.md", ".githooks/pre-push", "scripts/scaffold-analyzer-plan.mjs"],
+  );
+});

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const readWorkflow = (path) => readFileSync(path, "utf8");
+
+const isIgnoredLine = (line) => line.trim() === "" || line.trimStart().startsWith("#");
+
+const indentationOf = (line) => line.length - line.trimStart().length;
+
+const isBlockBoundary = (line, indent) => !isIgnoredLine(line) && indentationOf(line) <= indent;
+
+const findBlockEnd = (lines, start, indent) => {
+  const relativeEnd = lines.slice(start + 1).findIndex((line) => isBlockBoundary(line, indent));
+  return relativeEnd === -1 ? lines.length : start + 1 + relativeEnd;
+};
+
+const indentedBlock = (source, key, indent) => {
+  const lines = source.split(/\r?\n/);
+  const prefix = " ".repeat(indent);
+  const start = lines.findIndex((line) => line === `${prefix}${key}:`);
+  assert.notEqual(start, -1, `missing ${key} block`);
+  const end = findBlockEnd(lines, start, indent);
+  return lines.slice(start, end).join("\n");
+};
+
+test("workflow block parser ignores blank lines and comments before a sibling", () => {
+  const source = ["root:", "  value: true", "", "# note", "sibling:", "  value: false"].join("\n");
+
+  assert.equal(indentedBlock(source, "root", 0), "root:\n  value: true\n\n# note");
+});
+
+test("workflow block parser rejects missing keys", () => {
+  assert.throws(() => indentedBlock("root:\n  value: true", "missing", 0), /missing missing block/);
+});
+
+test("VS Code CI runs the extension-host integration suite with a pinned cached download", () => {
+  const workflow = readWorkflow(".github/workflows/ci.yml");
+  const vscodeJob = indentedBlock(workflow, "vscode", 2);
+  const changesJob = indentedBlock(workflow, "changes", 2);
+  const vscodeFilter = indentedBlock(changesJob, "vscode", 12);
+
+  assert.match(workflow, /^  pull_request:$/m, "CI must run for pull requests");
+  assert.match(vscodeJob, /needs\.changes\.outputs\.vscode == 'true'/);
+  assert.match(vscodeJob, /persist-credentials: false/);
+  assert.match(vscodeFilter, /editors\/vscode\/\*\*/);
+  assert.match(vscodeFilter, /\.github\/workflows\/ci\.yml/);
+  assert.match(
+    vscodeJob,
+    /name: Cache VS Code test download[\s\S]*uses: actions\/cache@[0-9a-f]{40}[\s\S]*path: \/tmp\/fallow-vscode-test-cache[\s\S]*key: .*vscode-1\.96\.0/,
+  );
+  assert.match(
+    vscodeJob,
+    /name: Run VS Code extension-host integration tests\n\s+run: cd editors\/vscode && xvfb-run -a pnpm test:integration/,
+  );
+
+  const harness = readFileSync("editors/vscode/test/integration/runTest.ts", "utf8");
+  assert.match(harness, /version: "1\.96\.0"/);
+});
+
+test("coverage floor runs with read-only permissions on pull requests and pushes", () => {
+  const workflow = readWorkflow(".github/workflows/coverage.yml");
+  const coverageJob = indentedBlock(workflow, "coverage", 2);
+  const pushTrigger = indentedBlock(workflow, "push", 2);
+
+  assert.match(workflow, /^  pull_request:$/m, "coverage must run for pull requests");
+  assert.match(workflow, /^  push:$/m, "coverage must run for pushes");
+  assert.match(pushTrigger, /branches: \[main\]/);
+  assert.match(coverageJob, /permissions:\n\s+contents: read/);
+  assert.match(coverageJob, /persist-credentials: false/);
+  assert.match(coverageJob, /name: Enforce coverage floor/);
+  assert.match(
+    coverageJob,
+    /name: Upload coverage publication input\n\s+if: >-[\s\S]*github\.event_name == 'push'[\s\S]*github\.ref == 'refs\/heads\/main'[\s\S]*github\.event_name == 'workflow_dispatch'/,
+  );
+  assert.match(coverageJob, /badge_color: \$\{\{ steps\.badge\.outputs\.color \}\}/);
+  assert.doesNotMatch(coverageJob, /name: Store coverage metrics/);
+  assert.doesNotMatch(coverageJob, /name: Update coverage badge/);
+});
+
+test("coverage publication is isolated to trusted events and write permissions", () => {
+  const workflow = readWorkflow(".github/workflows/coverage.yml");
+  const publishJob = indentedBlock(workflow, "publish", 2);
+
+  assert.match(publishJob, /permissions:\n\s+contents: write/);
+  assert.match(publishJob, /needs: coverage/);
+  assert.match(publishJob, /github\.event_name == 'push'/);
+  assert.match(publishJob, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(publishJob, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(publishJob, /BADGE_COLOR: \$\{\{ needs\.coverage\.outputs\.badge_color \}\}/);
+  assert.match(publishJob, /name: Store coverage metrics/);
+  assert.match(publishJob, /name: Update coverage badge/);
+  assert.doesNotMatch(publishJob, /\b(?:cargo|npm|pnpm)\b/);
+});


### PR DESCRIPTION
## Summary

- Add pull-request coverage and VS Code extension-host regression gates.
- Separate coverage verification from badge publication permissions.
- Replace benchmark-executing test guidance with explicit normal-test and benchmark-compile commands.
- Refresh contributor architecture and roadmap documentation.

## Verification

- [x] Workflow syntax and policy regression tests
- [x] VS Code unit and extension-host integration suites
- [x] Coverage workflow permission and publication policy checks
- [x] Rust formatting, clippy, tests, rustdoc, and benchmark compilation
- [x] JavaScript formatting and lint
- [x] Documentation and repository drift checks
- [x] Uncached fallow audit with no introduced findings

CI is running the pull-request coverage floor and extension-host jobs on the pushed commit.