### PR TITLE
test(core,engine): drop timing-dependent asserts and profiling pseudo-test

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,7 +40,6 @@ ignore = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
-tempfile = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
@@ -65,6 +64,7 @@ schema = ["fallow-types/schema"]
 criterion2 = { workspace = true }
 proptest = { workspace = true }
 dhat = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/core/tests/integration_test/graph_cache_transparency.rs
+++ b/crates/core/tests/integration_test/graph_cache_transparency.rs
@@ -139,13 +139,10 @@ fn source_change_misses_cache_and_reflects_change() {
     let unused_before = before.unused_exports.len();
 
     // Mutate a source file: add a brand-new export that nothing imports. This
-    // changes the file's size (and mtime), so its SourceFingerprint changes and
-    // the persisted manifest no longer matches the current inputs.
+    // changes the file's size, so its SourceFingerprint changes and the
+    // persisted manifest no longer matches the current inputs.
     let target = root.join("src/module-a.ts");
     let original = std::fs::read_to_string(&target).expect("read module-a");
-    // Sleep a touch so the mtime is guaranteed to differ on coarse-resolution
-    // filesystems even though the size change alone already misses.
-    std::thread::sleep(std::time::Duration::from_millis(10));
     std::fs::write(
         &target,
         format!("{original}\nexport const brandNewDeadExport = 42;\n"),

--- a/crates/engine/tests/dupes_profile.rs
+++ b/crates/engine/tests/dupes_profile.rs
@@ -129,6 +129,7 @@ fn profile_scenario(name: &str, data: &DupeInput, runs: usize) {
 }
 
 #[test]
+#[ignore = "profiling harness, run manually with -- --ignored"]
 fn profile_dupe_detection() {
     if std::env::var("FALLOW_PROFILE").is_ok() {
         tracing_subscriber::fmt()

--- a/crates/engine/tests/dupes_stress_test.rs
+++ b/crates/engine/tests/dupes_stress_test.rs
@@ -7,7 +7,6 @@
 //! Adversarial stress tests for the suffix array + LCP clone detection engine.
 
 use std::path::PathBuf;
-use std::time::Instant;
 
 use fallow_config::DetectionMode;
 use fallow_engine::duplicates::detect::CloneDetector;
@@ -79,14 +78,7 @@ fn two_identical_large_files_single_group_no_quadratic_blowup() {
         .collect();
 
     let detector = CloneDetector::new(5, 1, false);
-    let start = Instant::now();
     let report = detector.detect(data);
-    let elapsed = start.elapsed();
-
-    assert!(
-        elapsed.as_secs() < 5,
-        "Detection on 2x{count} tokens took {elapsed:?}, expected < 5s"
-    );
 
     assert!(
         !report.clone_groups.is_empty(),
@@ -414,14 +406,7 @@ fn all_identical_tokens_does_not_hang() {
     ];
 
     let detector = CloneDetector::new(5, 1, false);
-    let start = Instant::now();
     let report = detector.detect(data);
-    let elapsed = start.elapsed();
-
-    assert!(
-        elapsed.as_secs() < 5,
-        "All-identical-token input took {elapsed:?}, should not hang"
-    );
 
     assert!(
         !report.clone_groups.is_empty(),


### PR DESCRIPTION
Three timing-dependence removals plus one dependency-table fix. The dupes profiling harness ran on every cargo test invocation while asserting nothing; it now carries #[ignore] and stays runnable on demand. The two wall-clock elapsed < 5s asserts in the dupes stress tests could fail a loaded CI runner on timing alone; the functional asserts stay and the perf-regression signal remains with the bench workflows. The graph-cache transparency test slept 10ms to force an mtime delta; the size-differing rewrite already misses the cache deterministically, verified across consecutive runs.

tempfile moves from fallow-core's [dependencies] to [dev-dependencies]: every usage is cfg(test)-gated, so release consumers no longer pull it through this crate.