### PR TITLE
fix(review): allowlist capture URL schemes and wire app CI

### DIFF
--- a/.github/workflows/review-electron.yml
+++ b/.github/workflows/review-electron.yml
@@ -1,0 +1,51 @@
+name: Review Electron
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/review-electron/**'
+      - '.github/workflows/review-electron.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/review-electron/**'
+      - '.github/workflows/review-electron.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: review-electron-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test:
+    name: Typecheck, lint, and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/review-electron
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/review-electron/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test

--- a/apps/review-electron/src/main/capture.test.ts
+++ b/apps/review-electron/src/main/capture.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { isCapturableUrl } from "./capture";
+
+describe("isCapturableUrl", () => {
+  it("accepts http URLs", () => {
+    expect(isCapturableUrl("http://localhost:5173/x")).toBe(true);
+  });
+
+  it("accepts https URLs", () => {
+    expect(isCapturableUrl("https://example.test/")).toBe(true);
+  });
+
+  it("rejects file: URLs", () => {
+    expect(isCapturableUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects chrome: URLs", () => {
+    expect(isCapturableUrl("chrome://settings")).toBe(false);
+  });
+
+  it("rejects data: URLs", () => {
+    expect(isCapturableUrl("data:text/html,x")).toBe(false);
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(isCapturableUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isCapturableUrl("")).toBe(false);
+  });
+
+  it("rejects garbage input", () => {
+    expect(isCapturableUrl("not a url at all")).toBe(false);
+  });
+});

--- a/apps/review-electron/src/main/capture.ts
+++ b/apps/review-electron/src/main/capture.ts
@@ -6,12 +6,30 @@ import { describeLoadError } from "./errors";
 
 export type Capture = { dataUrl: string; path: string };
 
+/** Only web schemes may be captured; file:, chrome:, data: etc. are rejected. */
+export const isCapturableUrl = (url: string): boolean => {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Load `url` in a hidden window and capture it to a PNG under `.fallow-review/
  * shots/`. Returns a data URL (for the renderer canvas) + the saved path.
  */
 export const captureUrl = async (root: string, url: string, at: number): Promise<Capture> => {
-  const win = new BrowserWindow({ width: 1024, height: 768, show: false });
+  if (!isCapturableUrl(url)) {
+    throw new Error(`Couldn't load ${url}: only http and https URLs can be captured.`);
+  }
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    show: false,
+    webPreferences: { sandbox: true, contextIsolation: true, nodeIntegration: false },
+  });
   try {
     await win.loadURL(url).catch((e: unknown) => {
       throw describeLoadError(e, url);


### PR DESCRIPTION
The shot-capture window loaded a renderer-supplied URL with default webPreferences and no scheme validation, so non-web schemes (file:, chrome:, data:) were loadable in a hidden window. captureUrl now rejects everything except http/https via an exported isCapturableUrl guard (unit-tested accept/reject table) and creates the window with explicit sandbox, contextIsolation, and nodeIntegration settings, matching the hardening the rest of the app already declares.

Also wires apps/review-electron into CI for the first time: a path-filtered workflow runs npm ci, typecheck, oxlint, and the vitest unit suite (Playwright e2e deliberately excluded, it needs a display runner). Deny-all top-level permissions, SHA-pinned actions matching the pins used repo-wide.