### PR TITLE
perf: share parsed modules across warm sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--format` run. v1 renders the two GitHub formats and dispatches on the
   envelope's `kind` (dead-code, dupes, health, audit, security, combined).
 
+### Changed
+
+- **Reusable analysis sessions share immutable parsed-module storage across
+  warm queries.** Internal dead-code, feature-flag, and trace paths can retain
+  parser artifacts through an `Arc`-backed contract instead of deep-cloning
+  every `ModuleInfo`. Existing owned APIs remain compatible, and detector facts
+  are prepared before modules become immutable.
+
 ## [3.3.0] - 2026-07-09
 
 ### Added

--- a/crates/benchmarks/benches/component_engine.rs
+++ b/crates/benchmarks/benches/component_engine.rs
@@ -14,10 +14,16 @@ use fallow_engine::{project_analysis::ProjectAnalysisArtifactOptions, session::A
 use tempfile::TempDir;
 
 const FILE_COUNT: usize = 32;
+const WARM_FILE_COUNT: usize = 256;
 
 struct EngineFixture {
     _temp_dir: TempDir,
     root: PathBuf,
+}
+
+struct WarmEngineFixture {
+    _fixture: EngineFixture,
+    session: AnalysisSession,
 }
 
 fn write_file(root: &Path, path: &str, source: impl AsRef<str>) {
@@ -27,6 +33,10 @@ fn write_file(root: &Path, path: &str, source: impl AsRef<str>) {
 }
 
 fn create_engine_fixture() -> EngineFixture {
+    create_engine_fixture_with_file_count(FILE_COUNT)
+}
+
+fn create_engine_fixture_with_file_count(file_count: usize) -> EngineFixture {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
     write_file(
@@ -37,7 +47,7 @@ fn create_engine_fixture() -> EngineFixture {
 
     let mut imports = String::new();
     let mut uses = String::new();
-    for index in 0..FILE_COUNT {
+    for index in 0..file_count {
         write_file(
             &root,
             &format!("src/module-{index}.ts"),
@@ -68,6 +78,18 @@ export function compute{index}(input: number): number {{
     EngineFixture {
         _temp_dir: temp_dir,
         root,
+    }
+}
+
+fn create_warm_engine_fixture() -> WarmEngineFixture {
+    let fixture = create_engine_fixture_with_file_count(WARM_FILE_COUNT);
+    let session = AnalysisSession::load_default(&fixture.root);
+    session
+        .analyze_dead_code_with_complexity()
+        .expect("warm-up analysis succeeds");
+    WarmEngineFixture {
+        _fixture: fixture,
+        session,
     }
 }
 
@@ -117,10 +139,42 @@ fn component_engine_project_analysis_artifacts(c: &mut Criterion) {
     });
 }
 
+fn component_engine_warm_session_dead_code_large(c: &mut Criterion) {
+    let fixture = create_warm_engine_fixture();
+    c.bench_function("component_engine_warm_session_dead_code_large", |bencher| {
+        bencher.iter(|| fixture.session.analyze_dead_code());
+    });
+}
+
+fn component_engine_warm_session_complexity_owned(c: &mut Criterion) {
+    let fixture = create_warm_engine_fixture();
+    c.bench_function(
+        "component_engine_warm_session_complexity_owned",
+        |bencher| bencher.iter(|| fixture.session.analyze_dead_code_with_complexity()),
+    );
+}
+
+fn component_engine_warm_session_complexity_shared(c: &mut Criterion) {
+    let fixture = create_warm_engine_fixture();
+    c.bench_function(
+        "component_engine_warm_session_complexity_shared",
+        |bencher| {
+            bencher.iter(|| {
+                fixture
+                    .session
+                    .analyze_dead_code_with_shared_artifacts(true, false)
+            });
+        },
+    );
+}
+
 criterion_group!(
     benches,
     component_engine_session_load,
     component_engine_parsed_parts,
-    component_engine_project_analysis_artifacts
+    component_engine_project_analysis_artifacts,
+    component_engine_warm_session_dead_code_large,
+    component_engine_warm_session_complexity_owned,
+    component_engine_warm_session_complexity_shared
 );
 criterion_main!(benches);

--- a/crates/engine/src/flags.rs
+++ b/crates/engine/src/flags.rs
@@ -1,6 +1,6 @@
 //! Feature flag analysis owned by the engine boundary.
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use fallow_config::ResolvedConfig;
 use fallow_types::discover::DiscoveredFile;
@@ -21,11 +21,11 @@ pub struct FeatureFlagsAnalysis {
 /// Run feature flag analysis with a reusable analysis session.
 #[must_use]
 pub fn analyze_feature_flags_with_session(session: &AnalysisSession) -> FeatureFlagsAnalysis {
-    let parsed = session.parsed_parts(false);
-    let flags = collect_flags_for_modules(session, &parsed.files, &parsed.modules);
+    let modules = session.shared_parsed_modules(false);
+    let flags = collect_flags_for_modules(session, session.files(), &modules);
     FeatureFlagsAnalysis {
         flags,
-        files_scanned: parsed.files.len(),
+        files_scanned: session.files().len(),
     }
 }
 
@@ -44,7 +44,7 @@ pub fn builtin_sdk_providers() -> Vec<&'static str> {
 fn collect_flags_for_modules(
     session: &AnalysisSession,
     files: &[DiscoveredFile],
-    modules: &[ModuleInfo],
+    modules: &Arc<[ModuleInfo]>,
 ) -> Vec<FeatureFlag> {
     let mut flags = collect_flags_from_modules(session.config(), files, modules);
     correlate_flags_with_dead_code(&mut flags, session, modules);
@@ -54,9 +54,10 @@ fn collect_flags_for_modules(
 fn correlate_flags_with_dead_code(
     flags: &mut [FeatureFlag],
     session: &AnalysisSession,
-    modules: &[ModuleInfo],
+    modules: &Arc<[ModuleInfo]>,
 ) {
-    if let Ok(analysis_output) = session.analyze_dead_code_with_parsed_modules(modules) {
+    if let Ok(analysis_output) = session.analyze_dead_code_with_shared_modules(Arc::clone(modules))
+    {
         correlate_with_dead_code(flags, &analysis_output.results);
     }
 }

--- a/crates/engine/src/results.rs
+++ b/crates/engine/src/results.rs
@@ -6,6 +6,7 @@
 )]
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use fallow_config::ResolvedConfig;
@@ -91,6 +92,46 @@ pub struct DeadCodeAnalysisArtifacts {
     pub files: Option<Vec<DiscoveredFile>>,
     pub script_used_packages: FxHashSet<String>,
     pub file_hashes: FxHashMap<PathBuf, u64>,
+}
+
+/// Shared parser artifacts for workspace-internal session consumers.
+///
+/// This additive contract lets internal callers retain immutable parsed
+/// modules without deep-cloning the session cache. Stable owned APIs continue
+/// to return [`DeadCodeAnalysisArtifacts`].
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct SharedDeadCodeAnalysisArtifacts {
+    pub results: AnalysisResults,
+    pub timings: Option<trace::PipelineTimings>,
+    pub graph: Option<module_graph::RetainedModuleGraph>,
+    pub modules: Option<Arc<[ModuleInfo]>>,
+    pub files: Option<Vec<DiscoveredFile>>,
+    pub script_used_packages: FxHashSet<String>,
+    pub file_hashes: FxHashMap<PathBuf, u64>,
+}
+
+impl SharedDeadCodeAnalysisArtifacts {
+    /// Convert shared parser artifacts to the stable owned result contract.
+    #[must_use]
+    pub fn into_owned(self) -> DeadCodeAnalysisArtifacts {
+        let modules = self.modules.map(|modules| {
+            let mut owned = modules.to_vec();
+            for module in &mut owned {
+                module.release_resolution_payload();
+            }
+            owned
+        });
+        DeadCodeAnalysisArtifacts {
+            results: self.results,
+            timings: self.timings,
+            graph: self.graph,
+            modules,
+            files: self.files,
+            script_used_packages: self.script_used_packages,
+            file_hashes: self.file_hashes,
+        }
+    }
 }
 
 /// Typed project analysis result combining dead-code and duplication outputs.

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -1,7 +1,7 @@
 //! Engine-owned analysis session orchestration.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use fallow_config::{DuplicatesConfig, ResolvedConfig, WorkspaceInfo};
@@ -19,6 +19,7 @@ use crate::{
     project_config::{ProjectConfig, config_for_project, default_project_config},
     results::{
         DeadCodeAnalysis, DeadCodeAnalysisArtifacts, DeadCodeAnalysisOutput, DuplicationAnalysis,
+        SharedDeadCodeAnalysisArtifacts,
     },
 };
 
@@ -42,7 +43,7 @@ pub struct AnalysisSession {
 struct ParsedModuleCache {
     need_complexity: bool,
     fingerprints: Vec<SourceFingerprint>,
-    modules: Vec<ModuleInfo>,
+    modules: Arc<[ModuleInfo]>,
 }
 
 /// Owned session parts for runners that need to continue an existing pipeline.
@@ -311,8 +312,19 @@ impl AnalysisSession {
     /// Parse discovered files without consuming the session.
     #[must_use]
     pub fn parsed_parts(&self, need_complexity: bool) -> ParsedAnalysisSessionParts {
-        let ParsedModules { modules, metrics } = self.parse_modules(need_complexity);
-        self.parsed_parts_from_modules(modules, metrics)
+        let SharedParsedModules { modules, metrics } = self.parse_modules(need_complexity);
+        self.parsed_parts_from_modules(modules.to_vec(), metrics)
+    }
+
+    /// Return immutable parsed modules backed by the reusable session cache.
+    ///
+    /// Workspace-owned consumers use this additive path when they only need
+    /// parsed modules and can borrow discovery and config directly from the
+    /// session. Stable owned callers can continue using [`Self::parsed_parts`].
+    #[doc(hidden)]
+    #[must_use]
+    pub fn shared_parsed_modules(&self, need_complexity: bool) -> Arc<[ModuleInfo]> {
+        self.parse_modules(need_complexity).modules
     }
 
     /// Parse discovered files without consuming the session or retaining parser
@@ -380,6 +392,25 @@ impl AnalysisSession {
         need_complexity: bool,
         retain_graph: bool,
     ) -> EngineResult<DeadCodeAnalysisArtifacts> {
+        self.analyze_dead_code_with_shared_artifacts(need_complexity, retain_graph)
+            .map(SharedDeadCodeAnalysisArtifacts::into_owned)
+    }
+
+    /// Run dead-code analysis with shared immutable parser artifacts.
+    ///
+    /// Workspace-owned consumers use this additive path to retain warm parser
+    /// modules without deep-cloning the session cache. External callers can
+    /// continue using [`Self::analyze_dead_code_with_artifacts`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if parsing or analysis fails.
+    #[doc(hidden)]
+    pub fn analyze_dead_code_with_shared_artifacts(
+        &self,
+        need_complexity: bool,
+        retain_graph: bool,
+    ) -> EngineResult<SharedDeadCodeAnalysisArtifacts> {
         self.analyze_dead_code_with_reuse_artifacts(need_complexity, retain_graph, need_complexity)
     }
 
@@ -395,6 +426,7 @@ impl AnalysisSession {
         retain_graph: bool,
     ) -> EngineResult<DeadCodeAnalysisArtifacts> {
         self.analyze_dead_code_with_reuse_artifacts(need_complexity, retain_graph, true)
+            .map(SharedDeadCodeAnalysisArtifacts::into_owned)
     }
 
     /// Run dead-code analysis from modules already parsed through this session.
@@ -409,16 +441,30 @@ impl AnalysisSession {
         &self,
         modules: &[ModuleInfo],
     ) -> EngineResult<DeadCodeAnalysisArtifacts> {
+        self.analyze_dead_code_with_shared_modules(Arc::from(modules))
+    }
+
+    /// Run dead-code analysis from shared immutable parser modules.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if graph construction or analysis fails.
+    #[doc(hidden)]
+    pub fn analyze_dead_code_with_shared_modules(
+        &self,
+        modules: Arc<[ModuleInfo]>,
+    ) -> EngineResult<DeadCodeAnalysisArtifacts> {
         run_engine_owned_dead_code_pipeline(EngineDeadCodePipelineInput {
             config: &self.config,
             discovery: &self.discovery,
-            modules: modules.to_vec(),
+            modules,
             metrics: reused_parse_metrics(),
             collect_usages: true,
             retain_graph: true,
             retain_modules: false,
             retain_files: false,
         })
+        .map(SharedDeadCodeAnalysisArtifacts::into_owned)
     }
 
     fn analyze_dead_code_with_reuse_artifacts(
@@ -426,8 +472,8 @@ impl AnalysisSession {
         need_complexity: bool,
         retain_graph: bool,
         retain_files: bool,
-    ) -> EngineResult<DeadCodeAnalysisArtifacts> {
-        let ParsedModules { modules, metrics } = self.parse_modules(need_complexity);
+    ) -> EngineResult<SharedDeadCodeAnalysisArtifacts> {
+        let SharedParsedModules { modules, metrics } = self.parse_modules(need_complexity);
         run_engine_owned_dead_code_pipeline(EngineDeadCodePipelineInput {
             config: &self.config,
             discovery: &self.discovery,
@@ -571,12 +617,12 @@ impl AnalysisSession {
         )
     }
 
-    fn parse_modules(&self, need_complexity: bool) -> ParsedModules {
+    fn parse_modules(&self, need_complexity: bool) -> SharedParsedModules {
         let fingerprints = source_fingerprints_for_files(self.files());
         if let Some(fingerprints) = fingerprints.as_ref()
             && let Some(modules) = self.cached_modules(need_complexity, fingerprints)
         {
-            return ParsedModules {
+            return SharedParsedModules {
                 modules,
                 metrics: core_backend::ParseMetrics {
                     parse_ms: 0.0,
@@ -588,31 +634,33 @@ impl AnalysisSession {
             };
         }
 
-        let parsed = parse_files_with_config(&self.config, self.files(), need_complexity);
+        let ParsedModules { modules, metrics } =
+            parse_files_with_config(&self.config, self.files(), need_complexity);
+        let modules: Arc<[ModuleInfo]> = modules.into();
         if let Some(fingerprints) = fingerprints
             && let Ok(mut cache) = self.parsed_cache.lock()
         {
             *cache = Some(ParsedModuleCache {
                 need_complexity,
                 fingerprints,
-                modules: parsed.modules.clone(),
+                modules: Arc::clone(&modules),
             });
         }
-        parsed
+        SharedParsedModules { modules, metrics }
     }
 
     fn cached_modules(
         &self,
         need_complexity: bool,
         fingerprints: &[SourceFingerprint],
-    ) -> Option<Vec<ModuleInfo>> {
+    ) -> Option<Arc<[ModuleInfo]>> {
         let Ok(cache) = self.parsed_cache.lock() else {
             return None;
         };
         let cache = cache.as_ref()?;
         let complexity_mode_satisfies_request = cache.need_complexity || !need_complexity;
         if complexity_mode_satisfies_request && cache.fingerprints == fingerprints {
-            return Some(cache.modules.clone());
+            return Some(Arc::clone(&cache.modules));
         }
         None
     }
@@ -638,6 +686,11 @@ struct ParsedModules {
     metrics: core_backend::ParseMetrics,
 }
 
+struct SharedParsedModules {
+    modules: Arc<[ModuleInfo]>,
+    metrics: core_backend::ParseMetrics,
+}
+
 fn parse_files_with_config(
     config: &ResolvedConfig,
     files: &[DiscoveredFile],
@@ -655,8 +708,12 @@ fn parse_files_with_config(
         )
     };
     let parse_result = crate::source::parse_all_files(files, cache.as_ref(), need_complexity);
+    let mut modules = parse_result.modules;
+    for module in &mut modules {
+        module.prepare_analysis_facts();
+    }
     let parse_ms = parse_start.elapsed().as_secs_f64() * 1000.0;
-    let cache_ms = update_parse_cache_if_enabled(config, &mut cache, &parse_result.modules, files);
+    let cache_ms = update_parse_cache_if_enabled(config, &mut cache, &modules, files);
     let metrics = core_backend::ParseMetrics {
         parse_ms,
         cache_ms,
@@ -664,10 +721,7 @@ fn parse_files_with_config(
         cache_misses: parse_result.cache_misses,
         parse_cpu_ms: parse_result.parse_cpu_ms,
     };
-    ParsedModules {
-        modules: parse_result.modules,
-        metrics,
-    }
+    ParsedModules { modules, metrics }
 }
 
 fn reused_parse_metrics() -> core_backend::ParseMetrics {
@@ -759,7 +813,7 @@ fn source_fingerprint(path: &Path) -> SourceFingerprint {
 struct EngineDeadCodePipelineInput<'a> {
     config: &'a ResolvedConfig,
     discovery: &'a crate::discover::AnalysisDiscovery,
-    modules: Vec<ModuleInfo>,
+    modules: Arc<[ModuleInfo]>,
     metrics: core_backend::ParseMetrics,
     collect_usages: bool,
     retain_graph: bool,
@@ -769,11 +823,11 @@ struct EngineDeadCodePipelineInput<'a> {
 
 fn run_engine_owned_dead_code_pipeline(
     input: EngineDeadCodePipelineInput<'_>,
-) -> EngineResult<DeadCodeAnalysisArtifacts> {
+) -> EngineResult<SharedDeadCodeAnalysisArtifacts> {
     let EngineDeadCodePipelineInput {
         config,
         discovery,
-        mut modules,
+        modules,
         metrics,
         collect_usages,
         retain_graph,
@@ -784,10 +838,6 @@ fn run_engine_owned_dead_code_pipeline(
     let prelude_timings = prelude.timings();
     let entry_points = core_backend::discover_dead_code_entry_points(&prelude);
     let (resolved, graph) = resolve_or_build_dead_code_graph(&prelude, &entry_points, &modules);
-
-    for module in &mut modules {
-        module.release_resolution_payload();
-    }
 
     let detector = core_backend::run_dead_code_detectors(
         &prelude,
@@ -815,7 +865,7 @@ fn run_engine_owned_dead_code_pipeline(
     prelude.finish();
     let file_hashes = collect_file_hashes(&modules, discovery.files());
 
-    Ok(DeadCodeAnalysisArtifacts {
+    Ok(SharedDeadCodeAnalysisArtifacts {
         results: detector.results,
         timings: profile.timings,
         graph: retain_graph.then_some(graph.graph),
@@ -868,18 +918,28 @@ pub(crate) fn analyze_dead_code_with_parse_result_from_config(
     run_engine_owned_dead_code_pipeline(EngineDeadCodePipelineInput {
         config,
         discovery: &discovery,
-        modules: modules.to_vec(),
+        modules: Arc::from(modules),
         metrics: reused_parse_metrics(),
         collect_usages: true,
         retain_graph: true,
         retain_modules: false,
         retain_files: false,
     })
+    .map(SharedDeadCodeAnalysisArtifacts::into_owned)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn session_with_source(source: &str) -> (tempfile::TempDir, AnalysisSession) {
+        let project = tempfile::tempdir().expect("project");
+        let root = project.path();
+        std::fs::create_dir(root.join("src")).expect("create source directory");
+        std::fs::write(root.join("src/index.ts"), source).expect("write source");
+        let session = AnalysisSession::load_default(root);
+        (project, session)
+    }
 
     #[test]
     fn session_retains_workspace_metadata_from_config_load() {
@@ -905,6 +965,77 @@ mod tests {
                 .iter()
                 .any(|workspace| workspace.name == "pkg-a"),
             "session must retain workspace metadata discovered during config load"
+        );
+    }
+
+    #[test]
+    fn warm_parse_cache_reuses_module_storage() {
+        let (_project, session) = session_with_source("export function value() { return 1; }\n");
+        let first = session.parse_modules(true);
+        let second = session.parse_modules(false);
+
+        assert!(
+            Arc::ptr_eq(&first.modules, &second.modules),
+            "warm session queries must share parsed module storage"
+        );
+    }
+
+    #[test]
+    fn shared_parsed_modules_reuse_public_session_storage() {
+        let (_project, session) = session_with_source("export const value = 1;\n");
+        let first = session.shared_parsed_modules(true);
+        let second = session.shared_parsed_modules(false);
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn warm_complexity_artifacts_reuse_cached_module_storage() {
+        let (_project, session) = session_with_source("export function value() { return 1; }\n");
+        let cached = session.parse_modules(true);
+        let artifacts = session
+            .analyze_dead_code_with_reuse_artifacts(true, true, false)
+            .expect("analysis succeeds");
+        let retained = artifacts.modules.expect("complexity modules retained");
+
+        assert!(
+            Arc::ptr_eq(&cached.modules, &retained),
+            "warm complexity artifacts must share parsed module storage"
+        );
+    }
+
+    #[test]
+    fn shared_and_owned_artifacts_preserve_output_bytes() {
+        let (_project, session) = session_with_source(
+            "export const used = 1;\nexport const unused = 2;\nconsole.log(used);\n",
+        );
+        let owned = session
+            .analyze_dead_code_with_artifacts(true, true)
+            .expect("owned analysis succeeds");
+        let shared = session
+            .analyze_dead_code_with_shared_artifacts(true, true)
+            .expect("shared analysis succeeds");
+
+        assert_eq!(
+            serde_json::to_vec(&owned.results).expect("serialize owned results"),
+            serde_json::to_vec(&shared.results).expect("serialize shared results")
+        );
+        assert_eq!(owned.file_hashes, shared.file_hashes);
+        assert_eq!(
+            owned
+                .modules
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|module| module.content_hash)
+                .collect::<Vec<_>>(),
+            shared
+                .modules
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|module| module.content_hash)
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/crates/engine/src/trace_chain.rs
+++ b/crates/engine/src/trace_chain.rs
@@ -37,7 +37,7 @@ pub fn trace_symbol_chain_with_session(
     session: &AnalysisSession,
     query: SymbolChainQuery<'_>,
 ) -> EngineResult<Option<SymbolChainTrace>> {
-    let output = session.analyze_dead_code_with_artifacts(true, true)?;
+    let output = session.analyze_dead_code_with_shared_artifacts(true, true)?;
     let graph = output
         .graph
         .as_ref()

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -174,11 +174,11 @@ pub struct ModuleInfo {
     pub has_dynamic_provide: bool,
     /// Local names of import bindings that ARE referenced somewhere in this file
     /// (script value/type position OR template/markup). The complement of
-    /// `unused_import_bindings` among `imports`. Derived in
-    /// `release_resolution_payload` (where both `imports` and
-    /// `unused_import_bindings` are still present) so it survives the release and
-    /// is readable by the analyze layer; it is never cached (recomputed on every
-    /// cache load). Consumed by the `unrendered-component` detector to credit a
+    /// `unused_import_bindings` among `imports`. Derived by
+    /// `prepare_analysis_facts` while both source vectors are still present, so
+    /// it remains readable after the owned release path clears them. It is never
+    /// cached and is recomputed on every cache load. Consumed by the
+    /// `unrendered-component` detector to credit a
     /// Vue/Svelte SFC that some file actually imports-and-uses, distinguishing it
     /// from a component reachable only through a barrel re-export.
     pub referenced_import_bindings: Vec<String>,
@@ -292,11 +292,10 @@ pub struct ModuleInfo {
     /// `true` when this file uses the whole `page.data` / `$page.data` store
     /// object opaquely (e.g. `Object.values(page.data)`, `{...$page.data}`), so a
     /// reflective read could consume any route's key. Drives the
-    /// `unused-load-data-key` detector's project-wide abstain. Derived in
-    /// `release_resolution_payload` from `whole_object_uses` BEFORE that vector is
-    /// released (mirroring `referenced_import_bindings`), so it survives the
-    /// release the detector runs after; it is never cached (recomputed each run
-    /// from the cached `whole_object_uses`). Reassignment forms
+    /// `unused-load-data-key` detector's project-wide abstain. Derived by
+    /// `prepare_analysis_facts` from `whole_object_uses` before the owned release
+    /// path clears that vector. It is never cached and is recomputed each run from
+    /// the cached `whole_object_uses`. Reassignment forms
     /// (`const all = $page.data`) are not whole-object-tracked and stay out of
     /// scope, matching the syntactic analyzer's conservative posture.
     pub has_page_data_store_whole_use: bool,
@@ -337,16 +336,15 @@ pub struct ModuleInfo {
 }
 
 impl ModuleInfo {
-    /// Release extraction payload that resolution has already copied into the graph.
+    /// Derive compact detector facts from resolution payload before sharing.
     ///
-    /// This keeps fields needed by analysis, health, security, LSP, coverage,
-    /// and hash drift checks, while dropping vectors that otherwise duplicate
-    /// data owned by `ResolvedModule` or already credited into the module graph.
-    pub fn release_resolution_payload(&mut self) {
-        // Derive the referenced-binding set BEFORE releasing `unused_import_bindings`:
-        // the analyze-layer `unrendered-component` detector needs "which imports are
-        // actually used" but runs after this release, so capture the compact
-        // complement here. Skip empty local names (side-effect imports).
+    /// Shared analysis sessions keep the source payload for later graph runs,
+    /// but detectors still require the same derived facts that the owned
+    /// release path computes before clearing that payload.
+    #[doc(hidden)]
+    pub fn prepare_analysis_facts(&mut self) {
+        // The analyze-layer `unrendered-component` detector needs the compact
+        // complement of imports and unused bindings after resolution.
         self.referenced_import_bindings = self
             .imports
             .iter()
@@ -356,15 +354,21 @@ impl ModuleInfo {
         self.referenced_import_bindings.sort_unstable();
         self.referenced_import_bindings.dedup();
 
-        // Derive the project-wide page-data-store whole-use signal BEFORE
-        // releasing `whole_object_uses`: the `unused-load-data-key` detector runs
-        // after this release and needs to know whether ANY module reflectively
-        // consumes the whole `page.data` / `$page.data` store.
+        // The `unused-load-data-key` detector needs the project-wide signal
+        // after `whole_object_uses` is released from owned artifacts.
         self.has_page_data_store_whole_use = self
             .whole_object_uses
             .iter()
             .any(|name| name == "page.data" || name == "$page.data");
+    }
 
+    /// Release extraction payload that resolution has already copied into the graph.
+    ///
+    /// This keeps fields needed by analysis, health, security, LSP, coverage,
+    /// and hash drift checks, while dropping vectors that otherwise duplicate
+    /// data owned by `ResolvedModule` or already credited into the module graph.
+    pub fn release_resolution_payload(&mut self) {
+        self.prepare_analysis_facts();
         Self::release_vec(&mut self.dynamic_imports);
         Self::release_vec(&mut self.require_calls);
         Self::release_boxed_slice(&mut self.package_path_references);


### PR DESCRIPTION
## Summary

- store reusable parsed modules in immutable Arc-backed session cache entries
- add workspace-internal shared artifact paths while preserving existing owned APIs
- prepare compact detector facts before modules become immutable
- add warm-session benchmarks covering owned and shared retained artifacts

## Validation

- full workspace tests, clippy, formatting, rustdoc, typos, Miri, and benchmark compilation pass locally
- shared and owned result bytes and file hashes remain identical
- real-project session smoke passes on zod, preact, vite, and the fallow workspace
- paired local Criterion runs show about 5 to 6 percent lower warm retained-artifact latency for the shared path
- uncached dogfood audit reports no introduced findings