### PR TITLE
fix(ci): lint Windows MCP lifecycle code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,9 +596,9 @@ jobs:
     # WaitForSingleObject implementation, and `ReusableWorktreeLock` uses
     # NTFS LockFileEx whose semantics differ from POSIX flock. This job runs
     # the focused lifecycle tests on every Rust-touching PR so those Windows-only
-    # paths are validated before a release tag is cut. This also exercises MCP
-    # Job Object cleanup for a timed-out process and its descendant. Narrower
-    # than the full Windows matrix (#447). Refs #489, #472.
+    # paths are validated before a release tag is cut. It also lints the MCP test
+    # target and exercises Job Object cleanup for a timed-out process and its
+    # descendant. Narrower than the full Windows matrix (#447). Refs #489, #472.
     if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: windows-latest
     timeout-minutes: 20
@@ -609,6 +609,8 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: windows-audit-smoke
+      - name: Lint MCP Windows lifecycle code
+        run: cargo clippy -p fallow-mcp --bin fallow-mcp --tests -- -D warnings
       - name: Run audit orphan-sweep + lock lifecycle tests
         run: >
           cargo test -p fallow-cli --lib --

--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -627,7 +627,7 @@ async fn run_fallow_timeout_terminates_and_reaps_windows_job_tree() {
     let direct_pid_path = temp.path().join("direct.pid");
     let descendant_pid_path = temp.path().join("descendant.pid");
     let script_path = temp.path().join("process-tree-fixture.ps1");
-    let script = r#"
+    let script = r"
 param(
     [Parameter(Mandatory = $true)][string]$DirectPidPath,
     [Parameter(Mandatory = $true)][string]$DescendantPidPath
@@ -636,7 +636,7 @@ $PID | Set-Content -NoNewline -LiteralPath $DirectPidPath
 $child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' -PassThru
 $child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
 Start-Sleep -Seconds 30
-"#;
+";
     std::fs::write(&script_path, script).expect("PowerShell fixture script");
 
     let result = run_fallow_with_timeout(

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -34,6 +34,16 @@ test("workflow block parser rejects missing keys", () => {
   assert.throws(() => indentedBlock("root:\n  value: true", "missing", 0), /missing missing block/);
 });
 
+test("Windows lifecycle PR gate lints MCP test code", () => {
+  const workflow = readWorkflow(".github/workflows/ci.yml");
+  const windowsLifecycleJob = indentedBlock(workflow, "windows-audit-smoke", 2);
+
+  assert.match(
+    windowsLifecycleJob,
+    /name: Lint MCP Windows lifecycle code\n\s+run: cargo clippy -p fallow-mcp --bin fallow-mcp --tests -- -D warnings/,
+  );
+});
+
 test("VS Code CI runs the extension-host integration suite with a pinned cached download", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const vscodeJob = indentedBlock(workflow, "vscode", 2);


### PR DESCRIPTION
## Summary

- repair the Windows-only MCP Clippy failure
- add the focused Windows Clippy command to the pull request lifecycle gate
- protect the workflow contract with a policy test

## Validation

- workflow policy regression test passes
- focused MCP Clippy and process lifecycle test pass
- workspace check, Clippy, tests, benchmark compilation, rustdoc, formatting, linting, typos, and changed-code audit pass