### PR TITLE
fix(members): three false positives in unused-class-members

### DIFF
--- a/crates/core/src/analyze/members/factory.rs
+++ b/crates/core/src/analyze/members/factory.rs
@@ -54,27 +54,17 @@ pub(super) fn credit_factory_return_class_member(
     class_local_name: &str,
     member: &str,
 ) {
-    let factory_local_keys = context.indexes.local_keys(factory_origin_file_id);
-    let Some(class_seed_keys) = factory_local_keys.get(class_local_name) else {
-        return;
-    };
-    for class_seed in class_seed_keys {
-        for class_origin in export_key_with_origins(context.graph, class_seed) {
-            let class_has_members = context
-                .indexes
-                .module_by_id
-                .get(&class_origin.file_id)
-                .is_some_and(|class_module| {
-                    export_is_class_with_members(class_module, class_origin.export_name.as_str())
-                });
-            if class_has_members {
-                context
-                    .accessed_members
-                    .entry(class_origin)
-                    .or_default()
-                    .insert(member.to_string());
-            }
-        }
+    for class_origin in factory_return_class_origins(
+        context.graph,
+        context.indexes,
+        factory_origin_file_id,
+        class_local_name,
+    ) {
+        context
+            .accessed_members
+            .entry(class_origin)
+            .or_default()
+            .insert(member.to_string());
     }
 }
 
@@ -99,51 +89,20 @@ pub(super) fn propagate_factory_fn_accesses(
     indexes: &MemberPassIndexes<'_>,
     accessed_members: &mut FxHashMap<ExportKey, FxHashSet<String>>,
 ) {
-    let mut credit_context = FactoryReturnCreditContext {
-        graph,
-        indexes,
-        accessed_members,
-    };
-
     for resolved in resolved_modules {
         let local_to_export_keys = indexes.local_keys(resolved.file_id);
         for access in factory_fn_member_accesses(resolved) {
             let Some(seed_keys) = local_to_export_keys.get(access.callee_name.as_str()) else {
                 continue;
             };
-            for seed_key in seed_keys {
-                for factory_origin in
-                    walk_re_export_origins(graph, seed_key.file_id, seed_key.export_name.as_str())
-                {
-                    let Some(factory_module) = credit_context
-                        .indexes
-                        .module_by_id
-                        .get(&factory_origin.file_id)
-                    else {
-                        continue;
-                    };
-                    // (2) the origin must declare an exported factory-return for
-                    // this export name, the cross-module over-credit gate.
-                    let Some(factory_return) =
-                        factory_module
-                            .exported_factory_returns
-                            .iter()
-                            .find(|factory_return| {
-                                factory_origin.export_name.as_str()
-                                    == factory_return.export_name.as_str()
-                            })
-                    else {
-                        continue;
-                    };
-                    // (3) resolve the returned class's LOCAL name through the
-                    // factory module's own imports/exports to a class export.
-                    credit_factory_return_class_member(
-                        &mut credit_context,
-                        factory_origin.file_id,
-                        factory_return.class_local_name.as_str(),
-                        access.member.as_str(),
-                    );
-                }
+            let classes = seed_keys
+                .iter()
+                .flat_map(|seed_key| factory_return_classes_for_callee(graph, indexes, seed_key));
+            for class_origin in classes {
+                accessed_members
+                    .entry(class_origin)
+                    .or_default()
+                    .insert(access.member.clone());
             }
         }
     }
@@ -177,9 +136,9 @@ fn factory_return_class_origins(
         .collect()
 }
 
-/// The class a callee's proven exported factory returns, resolved across modules.
-/// `None` for any callee that is not an internal exported factory with a strict,
-/// value-proven return.
+/// The classes a callee's proven exported factory returns, resolved across modules.
+/// Empty for any callee that is not an internal exported factory with a strict,
+/// value-proven return: each link of the chain is an over-credit gate.
 fn factory_return_classes_for_callee(
     graph: &ModuleGraph,
     indexes: &MemberPassIndexes<'_>,

--- a/crates/core/src/analyze/members/factory.rs
+++ b/crates/core/src/analyze/members/factory.rs
@@ -148,3 +148,93 @@ pub(super) fn propagate_factory_fn_accesses(
         }
     }
 }
+
+/// The class exports a proven exported factory returns, resolved from the factory's
+/// own module. Shared by the member-credit and whole-object-suppress passes: each
+/// link is an over-credit gate, so a callee that is not a proven factory yields
+/// nothing.
+fn factory_return_class_origins(
+    graph: &ModuleGraph,
+    indexes: &MemberPassIndexes<'_>,
+    factory_origin_file_id: FileId,
+    class_local_name: &str,
+) -> Vec<ExportKey> {
+    let factory_local_keys = indexes.local_keys(factory_origin_file_id);
+    let Some(class_seed_keys) = factory_local_keys.get(class_local_name) else {
+        return Vec::new();
+    };
+    class_seed_keys
+        .iter()
+        .flat_map(|class_seed| export_key_with_origins(graph, class_seed))
+        .filter(|class_origin| {
+            indexes
+                .module_by_id
+                .get(&class_origin.file_id)
+                .is_some_and(|class_module| {
+                    export_is_class_with_members(class_module, class_origin.export_name.as_str())
+                })
+        })
+        .collect()
+}
+
+/// The class a callee's proven exported factory returns, resolved across modules.
+/// `None` for any callee that is not an internal exported factory with a strict,
+/// value-proven return.
+fn factory_return_classes_for_callee(
+    graph: &ModuleGraph,
+    indexes: &MemberPassIndexes<'_>,
+    seed_key: &ExportKey,
+) -> Vec<ExportKey> {
+    let mut origins = Vec::new();
+    for factory_origin in
+        walk_re_export_origins(graph, seed_key.file_id, seed_key.export_name.as_str())
+    {
+        let Some(factory_module) = indexes.module_by_id.get(&factory_origin.file_id) else {
+            continue;
+        };
+        let Some(factory_return) =
+            factory_module
+                .exported_factory_returns
+                .iter()
+                .find(|factory_return| {
+                    factory_origin.export_name.as_str() == factory_return.export_name.as_str()
+                })
+        else {
+            continue;
+        };
+        origins.extend(factory_return_class_origins(
+            graph,
+            indexes,
+            factory_origin.file_id,
+            factory_return.class_local_name.as_str(),
+        ));
+    }
+    origins
+}
+
+/// Suppress a class whose factory-returned instance is consumed opaquely
+/// (`const { a, ...rest } = importedFactory()`, a computed destructure key).
+///
+/// The consumer can read any property, so no set of member accesses describes what
+/// is used. Crediting only the keys the pattern names would leave every other live
+/// member reported as dead. Mark the export wholly used instead; the member scan
+/// then skips it, exactly as it does for a class whose instance escapes.
+pub(super) fn propagate_factory_fn_whole_object_uses(
+    graph: &ModuleGraph,
+    resolved_modules: &[ResolvedModule],
+    indexes: &MemberPassIndexes<'_>,
+    whole_object_used_exports: &mut FxHashSet<ExportKey>,
+) {
+    for resolved in resolved_modules {
+        let local_to_export_keys = indexes.local_keys(resolved.file_id);
+        for fact in factory_fn_whole_objects(resolved) {
+            let Some(seed_keys) = local_to_export_keys.get(fact.callee_name.as_str()) else {
+                continue;
+            };
+            let classes = seed_keys
+                .iter()
+                .flat_map(|seed_key| factory_return_classes_for_callee(graph, indexes, seed_key));
+            whole_object_used_exports.extend(classes);
+        }
+    }
+}

--- a/crates/core/src/analyze/members/mod.rs
+++ b/crates/core/src/analyze/members/mod.rs
@@ -12,10 +12,11 @@ use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
 use fallow_types::extract::{
-    FactoryCallMemberAccessFact, FactoryFnMemberAccessFact, FluentChainMemberAccessFact,
-    FluentChainNewMemberAccessFact, InstanceExportBindingFact, PlaywrightFixtureAliasFact,
-    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
-    SemanticFactView, TypedPropertyMemberAccessFact, ordinary_whole_object_uses,
+    FactoryCallMemberAccessFact, FactoryFnMemberAccessFact, FactoryFnWholeObjectFact,
+    FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, InstanceExportBindingFact,
+    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+    PlaywrightFixtureUseFact, SemanticFactView, TypedPropertyMemberAccessFact,
+    ordinary_whole_object_uses,
 };
 
 use super::predicates::{is_angular_lifecycle_method, is_react_lifecycle_method};
@@ -670,6 +671,11 @@ fn factory_fn_member_accesses(resolved: &ResolvedModule) -> Vec<FactoryFnMemberA
     view.factory_fn_member_accesses()
 }
 
+fn factory_fn_whole_objects(resolved: &ResolvedModule) -> Vec<FactoryFnWholeObjectFact> {
+    let view = SemanticFactView::new(&resolved.semantic_facts, &resolved.member_accesses);
+    view.factory_fn_whole_objects()
+}
+
 fn typed_property_member_accesses(resolved: &ResolvedModule) -> Vec<TypedPropertyMemberAccessFact> {
     let view = SemanticFactView::new(&resolved.semantic_facts, &resolved.member_accesses);
     view.typed_property_member_accesses()
@@ -1223,6 +1229,14 @@ fn propagate_common_member_accesses(
         input.modules,
         indexes,
         accessed_members,
+        whole_object_used_exports,
+    );
+    // Before the re-export propagation below, so a class suppressed through an
+    // opaque destructure is suppressed at every name it is re-exported under.
+    propagate_factory_fn_whole_object_uses(
+        input.graph,
+        input.resolved_modules,
+        indexes,
         whole_object_used_exports,
     );
     propagate_accesses_through_re_exports(input.graph, accessed_members);

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -354,6 +354,9 @@ mod issue_1707_vue_vfor_class_member;
 #[path = "integration_test/local_subclass_static_class_members.rs"]
 mod local_subclass_static_class_members;
 
+#[path = "integration_test/cross_file_factory_class_members.rs"]
+mod cross_file_factory_class_members;
+
 #[path = "integration_test/issue_1711_vue_props_vfor.rs"]
 mod issue_1711_vue_props_vfor;
 

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -351,6 +351,9 @@ mod issue_1638_tostring_coercion;
 #[path = "integration_test/issue_1707_vue_vfor_class_member.rs"]
 mod issue_1707_vue_vfor_class_member;
 
+#[path = "integration_test/local_subclass_static_class_members.rs"]
+mod local_subclass_static_class_members;
+
 #[path = "integration_test/issue_1711_vue_props_vfor.rs"]
 mod issue_1711_vue_props_vfor;
 

--- a/crates/core/tests/integration_test/cross_file_factory_class_members.rs
+++ b/crates/core/tests/integration_test/cross_file_factory_class_members.rs
@@ -1,0 +1,126 @@
+use super::common::{create_config, fixture_path};
+
+fn unused_members(fixture: &str) -> Vec<String> {
+    let root = fixture_path(fixture);
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    results
+        .unused_class_members
+        .iter()
+        .map(|member| {
+            format!(
+                "{}.{}",
+                member.member.parent_name, member.member.member_name
+            )
+        })
+        .collect()
+}
+
+/// Members read off a cross-module factory result must be credited whatever shape
+/// the consumer uses to read them.
+///
+/// Cross-file factory-return propagation already worked for `const s = f(); s.m`.
+/// It never fired for a chained call (`f().m`) or a destructure
+/// (`const { m } = f()`), because the extractor only recorded a factory-return
+/// candidate for a plain `BindingIdentifier` declarator, and a chained call is not a
+/// declarator at all. Those two shapes are what real composables and singletons use,
+/// so every member of the returned class was reported unused.
+///
+/// The fixture is cross-file on purpose. A same-file factory is skipped wholesale by
+/// the whole-object gate (the returned instance escapes), so a same-file fixture
+/// reports nothing and passes for the wrong reason.
+///
+/// `RESTApi.trulyDead` is the non-vacuous control proving the detector still fires.
+#[test]
+fn cross_file_factory_credits_every_consumer_access_shape() {
+    let unused = unused_members("cross-file-factory-class-members");
+
+    for member in [
+        // Already worked; guards against a regression.
+        "viaSimpleBinding",
+        // `useApi().viaChainedCall`
+        "viaChainedCall",
+        // `useApi().viaChainedCallThenCall()`
+        "viaChainedCallThenCall",
+        // `useApi().viaChainedThenDeep.deep` credits the first level only.
+        "viaChainedThenDeep",
+        // `const { viaDestructure } = useApi()`
+        "viaDestructure",
+        // `const { viaRenamedKey: renamed } = useApi()`
+        "viaRenamedKey",
+        // `const { viaDefaultedKey = 0 } = useApi()`
+        "viaDefaultedKey",
+        // `const { viaNestedKey: { inner } } = useApi()` credits `viaNestedKey`, not
+        // `inner`, which belongs to whatever type that property has.
+        "viaNestedKey",
+        // `useApi()?.viaOptionalChain`
+        "viaOptionalChain",
+    ] {
+        assert!(
+            !unused.contains(&format!("RESTApi.{member}")),
+            "RESTApi.{member} is read off the factory result and must be credited, \
+             found: {unused:?}"
+        );
+    }
+
+    assert!(
+        unused.contains(&"RESTApi.trulyDead".to_string()),
+        "RESTApi.trulyDead is never read and must still be reported, otherwise this \
+         fixture passes vacuously: {unused:?}"
+    );
+
+    // `deep` and `inner` belong to the property's type, not to RESTApi. Crediting
+    // them would credit a same-named member of an unrelated class.
+    for leaked in ["deep", "inner"] {
+        assert!(
+            !unused
+                .iter()
+                .any(|entry| entry == &format!("RESTApi.{leaked}")),
+            "second-level key {leaked} must not be recorded as a RESTApi member"
+        );
+    }
+}
+
+/// A callee that is not a proven factory (`helper().anything`) is read the same way a
+/// factory result is. It must resolve to no exported factory return, credit nothing,
+/// and suppress nothing: the extractor records every `identifier().member`, and only
+/// the analyze layer's strict gate decides which of them mean anything.
+#[test]
+fn a_non_factory_callee_credits_nothing() {
+    let unused = unused_members("cross-file-factory-class-members");
+
+    // `helper` returns an object literal, not a class, so nothing named `anything` may
+    // be credited against RESTApi, and RESTApi must not be suppressed wholesale.
+    assert!(
+        unused.contains(&"RESTApi.trulyDead".to_string()),
+        "a non-factory callee must not suppress the factory's class: {unused:?}"
+    );
+    assert!(
+        !unused.iter().any(|entry| entry.ends_with(".anything")),
+        "`helper().anything` names no class member: {unused:?}"
+    );
+}
+
+/// `const { named, ...rest } = useApi()` can read ANY property through `rest`, so no
+/// set of visible keys describes what is used.
+///
+/// Crediting only `named` would leave every other live member reported as dead --
+/// the exact false positive this change removes. The returned class is marked wholly
+/// used instead, so nothing is reported for it. That is a deliberate false negative:
+/// under-reporting is safe, over-reporting is not.
+#[test]
+fn opaque_destructure_of_a_factory_result_suppresses_the_class() {
+    let unused = unused_members("cross-file-factory-opaque-destructure");
+
+    let rest_api: Vec<&String> = unused
+        .iter()
+        .filter(|entry| entry.starts_with("RESTApi."))
+        .collect();
+
+    assert!(
+        rest_api.is_empty(),
+        "a rest destructure can expose any property, so no RESTApi member may be \
+         reported: {rest_api:?}"
+    );
+}

--- a/crates/core/tests/integration_test/local_subclass_static_class_members.rs
+++ b/crates/core/tests/integration_test/local_subclass_static_class_members.rs
@@ -1,0 +1,92 @@
+use super::common::{create_config, fixture_path};
+
+/// A member reached through a LOCAL (non-exported) subclass must credit the class
+/// that declares it.
+///
+/// `class Sub extends Base {}` never becomes an export, so the analyze layer's
+/// import/export map cannot resolve `Sub.someStatic`, and the heritage
+/// `parent -> children` map is built from exports alone. Every member reached only
+/// through the subclass was therefore reported unused. Exporting the subclass makes
+/// the identical code resolve, which is what pinned the diagnosis.
+///
+/// The fixture is deliberately cross-file: the subclass lives one module away from
+/// the base, which is what real code looks like and what a same-file fixture cannot
+/// exercise. `UrlSyncManager.trulyDead` and `instanceTrulyDead` are the non-vacuous
+/// controls proving the detector still fires.
+fn unused_members(fixture: &str) -> Vec<String> {
+    let root = fixture_path(fixture);
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    results
+        .unused_class_members
+        .iter()
+        .map(|member| {
+            format!(
+                "{}.{}",
+                member.member.parent_name, member.member.member_name
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn local_subclass_credits_members_on_the_declaring_class() {
+    let unused = unused_members("local-subclass-static-class-members");
+
+    for member in [
+        // Static method, static passed as a value, and a static arrow property.
+        // There is no method/arrow divergence: propagation is on member names.
+        "calledViaSub",
+        "passedViaSub",
+        "arrowViaSub",
+        // A two-level local chain.
+        "viaGrandchild",
+        // Reached through the base directly; never affected by this bug.
+        "passedViaBase",
+        // `const instance = new MapUrlSyncManager(); instance.instanceViaSub()`.
+        // This access only exists once `resolve_bound_member_accesses` rewrites the
+        // bound local to its class, so the subclass pass must run after it.
+        "instanceViaSub",
+        // A chain of 18 local classes. Cycle detection, not a depth cap, terminates
+        // the walk; a fixed cap would abstain here and report this falsely.
+        "viaDeepChain",
+        // The subclass declares its own `shadowedOnSub`, so this credit on the base
+        // is an over-credit. It is the accepted direction: a false negative, never a
+        // false positive.
+        "shadowedOnSub",
+    ] {
+        assert!(
+            !unused.contains(&format!("UrlSyncManager.{member}")),
+            "UrlSyncManager.{member} is reached through a local subclass and must be \
+             credited, found: {unused:?}"
+        );
+    }
+
+    for dead in ["trulyDead", "instanceTrulyDead"] {
+        assert!(
+            unused.contains(&format!("UrlSyncManager.{dead}")),
+            "UrlSyncManager.{dead} is never referenced and must still be reported, \
+             otherwise this fixture passes vacuously: {unused:?}"
+        );
+    }
+}
+
+/// `class Sub extends mixin(Base) {}` records no superclass, because a mixin call is
+/// not a bare identifier. The walk abstains and `viaMixin` stays reported.
+///
+/// This is a known, pre-existing false positive, not one this change introduces:
+/// crediting through a mixin would be a guess, since the mixin may redefine what the
+/// subclass exposes. Pinned here so a future change to superclass extraction has to
+/// decide this case deliberately rather than by accident.
+#[test]
+fn mixin_superclass_abstains_rather_than_guessing() {
+    let unused = unused_members("local-subclass-static-class-members");
+
+    assert!(
+        unused.contains(&"UrlSyncManager.viaMixin".to_string()),
+        "a mixin superclass carries no resolvable name, so the walk must abstain; \
+         if this now passes, superclass extraction changed and the abstention should \
+         be revisited: {unused:?}"
+    );
+}

--- a/crates/core/tests/integration_test/local_subclass_static_class_members.rs
+++ b/crates/core/tests/integration_test/local_subclass_static_class_members.rs
@@ -90,3 +90,25 @@ fn mixin_superclass_abstains_rather_than_guessing() {
          be revisited: {unused:?}"
     );
 }
+
+/// `class Sub extends ns.UrlSyncManager {}` walks to the dotted name `ns.UrlSyncManager`,
+/// which the analyze layer cannot resolve: its import/export map keys bare local names,
+/// not namespace-qualified ones. `viaNamespaceBase` therefore stays reported.
+///
+/// This is a pre-existing gap, not one this change introduces, and it is wider than
+/// subclassing: a direct `ns.UrlSyncManager.viaNamespaceBase()` is equally uncredited on
+/// `main`. Closing it means resolving namespace aliases in the analyze layer.
+///
+/// Pinned so that a future change to namespace resolution has to decide this case
+/// deliberately rather than flip it by accident.
+#[test]
+fn namespace_qualified_base_is_a_known_uncredited_gap() {
+    let unused = unused_members("local-subclass-static-class-members");
+
+    assert!(
+        unused.contains(&"UrlSyncManager.viaNamespaceBase".to_string()),
+        "a namespace-qualified base resolves to no bare local name, so this member is \
+         expected to stay reported; if it is now credited, namespace resolution changed \
+         and this gap should be closed deliberately: {unused:?}"
+    );
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -762,7 +762,12 @@ use crate::MemberKind;
 /// `for...in`, and dynamic computed-access paths carry the synthetic
 /// route-loader abstention marker. Warm 227 caches can contain only the raw
 /// local binding and would report loader keys consumed through those paths.
-pub(super) const CACHE_VERSION: u32 = 228;
+///
+/// Bumped to 229 so a member reached through a LOCAL (non-exported) subclass
+/// re-emits the access against the class that declares it. A warm 228 cache
+/// carries only the `Sub.member` access, whose object the analyze layer cannot
+/// resolve, leaving the base's members falsely reported as unused.
+pub(super) const CACHE_VERSION: u32 = 229;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -767,7 +767,13 @@ use crate::MemberKind;
 /// re-emits the access against the class that declares it. A warm 228 cache
 /// carries only the `Sub.member` access, whose object the analyze layer cannot
 /// resolve, leaving the base's members falsely reported as unused.
-pub(super) const CACHE_VERSION: u32 = 229;
+///
+/// Bumped to 230 so a factory result read without a named binding (`f().member`,
+/// `const { member } = f()`) carries the member access, and an opaque destructure
+/// (`{ a, ...rest }`, a computed key) carries the `FactoryFnWholeObject` fact. A warm
+/// 229 cache carries neither, leaving every member of a destructured or chained
+/// factory result falsely reported as unused.
+pub(super) const CACHE_VERSION: u32 = 230;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -56,12 +56,13 @@ pub use fallow_types::extract::{
     AngularComponentFieldArrayTypeFact, AngularTemplateMemberAccessFact, AngularThisSpreadFact,
     ClassHeritageInfo, DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern,
     ExportInfo, ExportName, FactoryCallMemberAccessFact, FactoryFnMemberAccessFact,
-    FactoryReturnExport, FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo,
-    ImportedName, InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo,
-    MemberKind, ModuleInfo, ParseResult, PlaywrightFixtureAliasFact,
-    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
-    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, SourceReadFailure,
-    TypeMemberTypeEntry, TypedPropertyMemberAccessFact, VisibilityTag, compute_line_offsets,
+    FactoryFnWholeObjectFact, FactoryReturnExport, FluentChainMemberAccessFact,
+    FluentChainNewMemberAccessFact, ImportInfo, ImportedName, InstanceExportBindingFact,
+    LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult,
+    PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
+    PlaywrightFixtureUseFact, PublicSignatureTypeReference, ReExportInfo, RequireCallInfo,
+    SemanticFact, SourceReadFailure, TypeMemberTypeEntry, TypedPropertyMemberAccessFact,
+    VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -289,7 +289,7 @@ pub(crate) struct ModuleInfoExtractor {
     factory_whole_object_candidates: Vec<String>,
     /// `(callee, member)` for a factory result read without ever being named:
     /// `f().member`, `const { member } = f()`.
-    factory_inline_accesses: Vec<(String, String)>,
+    factory_unnamed_result_accesses: Vec<(String, String)>,
     factory_return_candidates: Vec<FactoryReturnCandidate>,
     /// Same-file functions whose body returns a bare identifier (e.g.
     /// `useApi() { return api }`). Resolved against `binding_target_names` at
@@ -1586,11 +1586,11 @@ impl ModuleInfoExtractor {
     /// The callee is matched by name and not by scope, so a local binding that shadows
     /// an imported factory is treated as that factory. It can only ADD credit, so the
     /// worst case is a member that stays unreported.
-    fn resolve_factory_inline_accesses(&mut self) {
-        if self.factory_inline_accesses.is_empty() {
+    fn resolve_factory_unnamed_result_accesses(&mut self) {
+        if self.factory_unnamed_result_accesses.is_empty() {
             return;
         }
-        let inline_accesses = std::mem::take(&mut self.factory_inline_accesses);
+        let inline_accesses = std::mem::take(&mut self.factory_unnamed_result_accesses);
         // Indexed once: a file with many `helper().x` reads would otherwise rescan
         // every import per access.
         let imported_locals: FxHashSet<&str> = self
@@ -2078,7 +2078,7 @@ impl ModuleInfoExtractor {
         self.resolve_factory_return_candidates();
         // Separate from the candidate pass, which early-returns when no member
         // candidate exists: an unnamed factory result records no member candidate.
-        self.resolve_factory_inline_accesses();
+        self.resolve_factory_unnamed_result_accesses();
         self.resolve_factory_whole_object_candidates();
         self.record_exported_instance_bindings();
         self.resolve_object_binding_candidates();
@@ -2309,6 +2309,10 @@ impl ModuleInfoExtractor {
 /// can expose properties it does not name: a rest element captures every remaining
 /// property, and a computed key names one that cannot be read from source.
 ///
+/// Contrast `extract_destructured_names`, which silently drops a computed key. Here a
+/// single unnameable key makes the WHOLE pattern opaque, because a caller crediting
+/// class members off it must abstain rather than credit only the keys it can see.
+///
 /// A nested pattern (`{ a: { b } }`) yields `a` only. `b` belongs to whatever type
 /// `a` has, not to the factory's class, and crediting it would credit a same-named
 /// member of an unrelated class.
@@ -2323,6 +2327,12 @@ pub(super) fn destructured_factory_keys(obj_pat: &ObjectPattern<'_>) -> Option<V
         .collect()
 }
 
+/// The statically named keys of a destructuring pattern, SKIPPING any it cannot name.
+///
+/// Deliberately not `destructured_factory_keys`: this one drops a computed key and
+/// keeps the rest, which is what callers tracking local bindings want. A caller that
+/// must know the pattern could expose an unnamed property has to abstain instead, and
+/// wants that function.
 pub(super) fn extract_destructured_names(obj_pat: &ObjectPattern<'_>) -> Vec<String> {
     if obj_pat.rest.is_some() {
         return Vec::new();

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -1647,6 +1647,65 @@ impl ModuleInfoExtractor {
             .map(|(_, object_name)| object_name)
     }
 
+    /// Credit a member reached through a local subclass onto the class that declares it.
+    ///
+    /// `class Sub extends Base {}` without an `export` is never an export, so
+    /// `Sub.someStatic` names nothing the analyze layer can resolve: its import/export
+    /// map holds only imports and exports, and the heritage `parent -> children` map is
+    /// built from exports alone. The static is then reported unused even though it is
+    /// called. Exporting the subclass makes the identical code resolve, which is the
+    /// tell.
+    ///
+    /// Walk the local `extends` chain to the first name that is NOT a locally declared
+    /// class -- the imported or exported base -- and re-emit the access against it.
+    /// Only a bare identifier (or a dotted `ns.Base`) is ever recorded as a superclass;
+    /// `class Sub extends mixin(Base) {}` records `None` and abstains here, which is
+    /// correct because a mixin can redefine what the subclass exposes.
+    ///
+    /// Crediting a base whose subclass shadows the member is a false negative, never a
+    /// false positive, which is the direction this rule must err in.
+    fn propagate_local_subclass_member_accesses(&mut self) {
+        if self.local_class_exports.is_empty() {
+            return;
+        }
+        let additional: Vec<MemberAccess> = self
+            .member_accesses
+            .iter()
+            .filter_map(|access| {
+                let base = self.resolve_local_subclass_base(&access.object)?;
+                Some(MemberAccess {
+                    object: base,
+                    member: access.member.clone(),
+                })
+            })
+            .collect();
+        self.member_accesses.extend(additional);
+    }
+
+    /// The nearest ancestor of a locally declared class that is not itself locally
+    /// declared -- the imported or exported base the members actually live on.
+    ///
+    /// `None` when `name` is not a local class, when the chain reaches a class with no
+    /// `extends`, or when it revisits a name. The `visited` set, rather than a depth
+    /// cap, is what terminates a malformed cyclic `extends`: a depth cap would silently
+    /// abstain on a legitimately deep chain and leave its members falsely reported.
+    fn resolve_local_subclass_base(&self, name: &str) -> Option<String> {
+        let mut visited: FxHashSet<&str> = FxHashSet::default();
+        visited.insert(name);
+        let mut current = self.local_class_exports.get(name)?.super_class.as_deref()?;
+        loop {
+            let Some(info) = self.local_class_exports.get(current) else {
+                // Not locally declared, so it is the imported / exported base.
+                return Some(current.to_string());
+            };
+            if !visited.insert(current) {
+                // Cyclic `extends`; malformed source, credit nothing.
+                return None;
+            }
+            current = info.super_class.as_deref()?;
+        }
+    }
+
     fn resolve_bound_member_accesses(&mut self) {
         if self.binding_target_names.is_empty() {
             return;
@@ -1932,6 +1991,12 @@ impl ModuleInfoExtractor {
         self.resolve_playwright_factory_call_definitions();
         self.resolve_structural_class_calls();
         self.resolve_bound_member_accesses();
+        // AFTER `resolve_bound_member_accesses`, which is what materializes the
+        // class-qualified accesses for `const s = new Sub(); s.member`. Running
+        // earlier would only see the statics written as `Sub.member` in source and
+        // would leave every instance member reached through a local subclass
+        // reported as unused.
+        self.propagate_local_subclass_member_accesses();
         self.map_local_signature_refs_to_exports();
         self.apply_side_effect_registrations();
         self.resolve_typed_react_props();

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -1582,11 +1582,22 @@ impl ModuleInfoExtractor {
     /// A same-file factory binds the class immediately. An imported callee emits the
     /// typed fact the analyze layer resolves through `exported_factory_returns`; any
     /// other callee resolves to no proven factory export and is a no-op there.
+    ///
+    /// The callee is matched by name and not by scope, so a local binding that shadows
+    /// an imported factory is treated as that factory. It can only ADD credit, so the
+    /// worst case is a member that stays unreported.
     fn resolve_factory_inline_accesses(&mut self) {
         if self.factory_inline_accesses.is_empty() {
             return;
         }
         let inline_accesses = std::mem::take(&mut self.factory_inline_accesses);
+        // Indexed once: a file with many `helper().x` reads would otherwise rescan
+        // every import per access.
+        let imported_locals: FxHashSet<&str> = self
+            .imports
+            .iter()
+            .map(|import| import.local_name.as_str())
+            .collect();
         let mut deferred_facts = Vec::new();
         for (callee_name, member) in inline_accesses {
             if let Some(class_name) = self.factory_return_functions.get(&callee_name) {
@@ -1594,11 +1605,7 @@ impl ModuleInfoExtractor {
                 self.member_accesses.push(MemberAccess { object, member });
                 continue;
             }
-            if self
-                .imports
-                .iter()
-                .any(|import| import.local_name == callee_name)
-            {
+            if imported_locals.contains(callee_name.as_str()) {
                 deferred_facts.push((callee_name, member));
             }
         }
@@ -1735,9 +1742,16 @@ impl ModuleInfoExtractor {
     ///
     /// Walk the local `extends` chain to the first name that is NOT a locally declared
     /// class -- the imported or exported base -- and re-emit the access against it.
-    /// Only a bare identifier (or a dotted `ns.Base`) is ever recorded as a superclass;
-    /// `class Sub extends mixin(Base) {}` records `None` and abstains here, which is
-    /// correct because a mixin can redefine what the subclass exposes.
+    ///
+    /// `class Sub extends mixin(Base) {}` records no superclass name and abstains here,
+    /// which is correct: a mixin can redefine what the subclass exposes.
+    ///
+    /// A namespace-qualified base (`class Sub extends ns.Base {}`) re-emits the dotted
+    /// name verbatim. The analyze layer resolves only bare local names, so that access
+    /// is inert and the base's members stay reported. This is NOT a regression: a
+    /// direct `ns.Base.someStatic()` is equally uncredited today, because a
+    /// namespace-imported class is not in the import/export map either. Fixing it means
+    /// resolving namespace aliases in the analyze layer, which is a separate change.
     ///
     /// Crediting a base whose subclass shadows the member is a false negative, never a
     /// false positive, which is the direction this rule must err in.

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -14,7 +14,7 @@ use crate::suppress::ParsedSuppressions;
 use crate::{
     AngularComponentFieldArrayTypeFact, AngularTemplateMemberAccessFact, AngularThisSpreadFact,
     DynamicCustomElementRenderFact, DynamicImportInfo, DynamicImportPattern, ExportInfo,
-    ExportName, FactoryCallMemberAccessFact, FactoryFnMemberAccessFact,
+    ExportName, FactoryCallMemberAccessFact, FactoryFnMemberAccessFact, FactoryFnWholeObjectFact,
     FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
     InstanceExportBindingFact, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
     PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact,
@@ -284,6 +284,12 @@ pub(crate) struct ModuleInfoExtractor {
     /// Same-file functions whose body returns `new Class()`, mapped to the class
     /// name, plus the `const x = fn()` bindings to resolve against them. See #1441.
     factory_return_functions: FxHashMap<String, String>,
+    /// Callees of a factory call destructured opaquely (`const { a, ...rest } = f()`,
+    /// a computed key). The returned class must be credited wholesale.
+    factory_whole_object_candidates: Vec<String>,
+    /// `(callee, member)` for a factory result read without ever being named:
+    /// `f().member`, `const { member } = f()`.
+    factory_inline_accesses: Vec<(String, String)>,
     factory_return_candidates: Vec<FactoryReturnCandidate>,
     /// Same-file functions whose body returns a bare identifier (e.g.
     /// `useApi() { return api }`). Resolved against `binding_target_names` at
@@ -809,6 +815,12 @@ impl ModuleInfoExtractor {
                     member,
                 },
             ));
+    }
+
+    fn record_factory_fn_whole_object_fact(&mut self, callee_name: String) {
+        self.semantic_facts.push(SemanticFact::FactoryFnWholeObject(
+            FactoryFnWholeObjectFact { callee_name },
+        ));
     }
 
     fn record_typed_property_member_fact(
@@ -1559,6 +1571,71 @@ impl ModuleInfoExtractor {
         }
     }
 
+    /// Credit a member read straight off a factory result the source never named
+    /// (`f().member`, `const { member } = f()`).
+    ///
+    /// The callee and the member are both known at capture time, so resolve them
+    /// directly rather than routing through a stand-in local: a stand-in would make
+    /// every `helper().x` in a file a candidate, and candidate resolution rescans
+    /// every member access, which is quadratic on a file full of such calls.
+    ///
+    /// A same-file factory binds the class immediately. An imported callee emits the
+    /// typed fact the analyze layer resolves through `exported_factory_returns`; any
+    /// other callee resolves to no proven factory export and is a no-op there.
+    fn resolve_factory_inline_accesses(&mut self) {
+        if self.factory_inline_accesses.is_empty() {
+            return;
+        }
+        let inline_accesses = std::mem::take(&mut self.factory_inline_accesses);
+        let mut deferred_facts = Vec::new();
+        for (callee_name, member) in inline_accesses {
+            if let Some(class_name) = self.factory_return_functions.get(&callee_name) {
+                let object = class_name.clone();
+                self.member_accesses.push(MemberAccess { object, member });
+                continue;
+            }
+            if self
+                .imports
+                .iter()
+                .any(|import| import.local_name == callee_name)
+            {
+                deferred_facts.push((callee_name, member));
+            }
+        }
+        for (callee_name, member) in deferred_facts {
+            self.record_factory_fn_member_fact(callee_name, member);
+        }
+    }
+
+    /// `const { a, ...rest } = f()` and `const { [k]: v } = f()` can read ANY property
+    /// of the factory result, so no set of visible keys describes what is used.
+    /// Credit the returned class wholesale rather than credit the keys we happen to
+    /// see: crediting only `a` would leave every other live member reported as dead,
+    /// the exact false positive this change removes.
+    fn resolve_factory_whole_object_candidates(&mut self) {
+        if self.factory_whole_object_candidates.is_empty() {
+            return;
+        }
+        let callees = std::mem::take(&mut self.factory_whole_object_candidates);
+        for callee_name in callees {
+            // Same-file factory: the class is known, mark it used wholesale.
+            if let Some(class_name) = self.factory_return_functions.get(&callee_name) {
+                let class_name = class_name.clone();
+                self.whole_object_uses.push(class_name);
+                continue;
+            }
+            // Cross-module: the analyze layer resolves the callee to the class it
+            // returns and suppresses that export.
+            if self
+                .imports
+                .iter()
+                .any(|import| import.local_name == callee_name)
+            {
+                self.record_factory_fn_whole_object_fact(callee_name);
+            }
+        }
+    }
+
     /// Build the cross-module `exported_factory_returns` metadata: join the
     /// strict (all-paths-unanimous) factory map against this module's exports, so
     /// a `const x = useApi()` consumer can credit the returned class across the
@@ -1985,6 +2062,10 @@ impl ModuleInfoExtractor {
         // the typed local, so the `const x = useApi()` candidate below resolves.
         self.resolve_factory_return_aliases();
         self.resolve_factory_return_candidates();
+        // Separate from the candidate pass, which early-returns when no member
+        // candidate exists: an unnamed factory result records no member candidate.
+        self.resolve_factory_inline_accesses();
+        self.resolve_factory_whole_object_candidates();
         self.record_exported_instance_bindings();
         self.resolve_object_binding_candidates();
         self.resolve_factory_call_candidates();
@@ -2208,6 +2289,24 @@ impl ModuleInfoExtractor {
             .append(&mut self.svelte_dispatched_events);
         info.has_dynamic_dispatch |= self.has_dynamic_dispatch;
     }
+}
+
+/// The statically named keys of a destructuring pattern, or `None` when the pattern
+/// can expose properties it does not name: a rest element captures every remaining
+/// property, and a computed key names one that cannot be read from source.
+///
+/// A nested pattern (`{ a: { b } }`) yields `a` only. `b` belongs to whatever type
+/// `a` has, not to the factory's class, and crediting it would credit a same-named
+/// member of an unrelated class.
+pub(super) fn destructured_factory_keys(obj_pat: &ObjectPattern<'_>) -> Option<Vec<String>> {
+    if obj_pat.rest.is_some() {
+        return None;
+    }
+    obj_pat
+        .properties
+        .iter()
+        .map(|prop| prop.key.static_name().map(|name| name.to_string()))
+        .collect()
 }
 
 pub(super) fn extract_destructured_names(obj_pat: &ObjectPattern<'_>) -> Vec<String> {

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -219,20 +219,54 @@ impl ModuleInfoExtractor {
         declarator: &VariableDeclarator<'_>,
         init: &Expression<'_>,
     ) {
-        let BindingPattern::BindingIdentifier(id) = &declarator.id else {
-            return;
-        };
         let Expression::CallExpression(call) = init else {
             return;
         };
         let Expression::Identifier(callee) = &call.callee else {
             return;
         };
-        self.factory_return_candidates
-            .push(super::FactoryReturnCandidate {
-                local_name: id.name.to_string(),
-                callee_name: callee.name.to_string(),
-            });
+        let callee_name = callee.name.to_string();
+
+        match &declarator.id {
+            BindingPattern::BindingIdentifier(id) => {
+                self.factory_return_candidates
+                    .push(super::FactoryReturnCandidate {
+                        local_name: id.name.to_string(),
+                        callee_name,
+                    });
+            }
+            // `const { a, b } = useApi()`. The instance is never named, so stand a
+            // synthetic local in for it and record a member access per key; the
+            // existing candidate resolution then credits the class, same-file or
+            // across modules. Dropping this shape is what reported every member of
+            // a destructured factory result as unused.
+            BindingPattern::ObjectPattern(pattern) => {
+                let Some(keys) = super::destructured_factory_keys(pattern) else {
+                    // A rest element or computed key can read any property.
+                    self.factory_whole_object_candidates.push(callee_name);
+                    return;
+                };
+                for key in keys {
+                    self.factory_inline_accesses
+                        .push((callee_name.clone(), key));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// The callee of a bare `factory()` used directly as the object of a member
+    /// access (`useApi().member`). A member-expression callee (`obj.f().a`) and a
+    /// call-of-a-call (`f()().a`) are deliberately not matched: neither resolves to
+    /// a proven factory export, so crediting through them would be a guess.
+    fn inline_factory_call_callee(object: &Expression<'_>) -> Option<String> {
+        let Expression::CallExpression(call) = object else {
+            return None;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            return None;
+        };
+        Some(callee.name.to_string())
     }
 
     /// Record `const TOKEN = new InjectionToken<Interface>(...)` declarations
@@ -2410,6 +2444,16 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 object: "import.meta.env".to_string(),
                 member: expr.property.name.to_string(),
             });
+        }
+        if let Some(callee_name) = Self::inline_factory_call_callee(&expr.object)
+            && Self::inline_store_factory_receiver(&expr.object).is_none()
+        {
+            // `useApi().member`, with no local ever naming the result. Only this
+            // first-level member belongs to the factory's class: in `f().a.b`, `b` is
+            // read off whatever type `a` has, and the outer member expression's
+            // object is a member expression, not a call, so it never matches here.
+            self.factory_inline_accesses
+                .push((callee_name, expr.property.name.to_string()));
         }
         if let Some(store_factory) = Self::inline_store_factory_receiver(&expr.object) {
             // `useFooStore().member` with no bound local: the generic receiver

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -219,13 +219,9 @@ impl ModuleInfoExtractor {
         declarator: &VariableDeclarator<'_>,
         init: &Expression<'_>,
     ) {
-        let Expression::CallExpression(call) = init else {
+        let Some(callee_name) = Self::bare_call_callee_name(init) else {
             return;
         };
-        let Expression::Identifier(callee) = &call.callee else {
-            return;
-        };
-        let callee_name = callee.name.to_string();
 
         match &declarator.id {
             BindingPattern::BindingIdentifier(id) => {
@@ -235,11 +231,10 @@ impl ModuleInfoExtractor {
                         callee_name,
                     });
             }
-            // `const { a, b } = useApi()`. The instance is never named, so stand a
-            // synthetic local in for it and record a member access per key; the
-            // existing candidate resolution then credits the class, same-file or
-            // across modules. Dropping this shape is what reported every member of
-            // a destructured factory result as unused.
+            // `const { a, b } = useApi()`. The instance is never named, so queue one
+            // direct factory-result access per statically named key. Dropping this
+            // shape is what reported every member of a destructured factory result
+            // as unused.
             BindingPattern::ObjectPattern(pattern) => {
                 let Some(keys) = super::destructured_factory_keys(pattern) else {
                     // A rest element or computed key can read any property.
@@ -247,7 +242,7 @@ impl ModuleInfoExtractor {
                     return;
                 };
                 for key in keys {
-                    self.factory_inline_accesses
+                    self.factory_unnamed_result_accesses
                         .push((callee_name.clone(), key));
                 }
             }
@@ -255,12 +250,12 @@ impl ModuleInfoExtractor {
         }
     }
 
-    /// The callee of a bare `factory()` used directly as the object of a member
-    /// access (`useApi().member`). A member-expression callee (`obj.f().a`) and a
-    /// call-of-a-call (`f()().a`) are deliberately not matched: neither resolves to
-    /// a proven factory export, so crediting through them would be a guess.
-    fn inline_factory_call_callee(object: &Expression<'_>) -> Option<String> {
-        let Expression::CallExpression(call) = object else {
+    /// The callee of a bare `identifier(...)` call. A member-expression callee
+    /// (`obj.f()`) and a call-of-a-call (`f()()`) are deliberately not matched:
+    /// neither resolves to a proven factory export, so crediting through them would
+    /// be a guess.
+    fn bare_call_callee_name(expression: &Expression<'_>) -> Option<String> {
+        let Expression::CallExpression(call) = expression else {
             return None;
         };
         let Expression::Identifier(callee) = &call.callee else {
@@ -2445,14 +2440,14 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 member: expr.property.name.to_string(),
             });
         }
-        if let Some(callee_name) = Self::inline_factory_call_callee(&expr.object)
+        if let Some(callee_name) = Self::bare_call_callee_name(&expr.object)
             && Self::inline_store_factory_receiver(&expr.object).is_none()
         {
             // `useApi().member`, with no local ever naming the result. Only this
             // first-level member belongs to the factory's class: in `f().a.b`, `b` is
             // read off whatever type `a` has, and the outer member expression's
             // object is a member expression, not a call, so it never matches here.
-            self.factory_inline_accesses
+            self.factory_unnamed_result_accesses
                 .push((callee_name, expr.property.name.to_string()));
         }
         if let Some(store_factory) = Self::inline_store_factory_receiver(&expr.object) {

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1514,6 +1514,14 @@ pub enum SemanticFact {
     InstanceExportBinding(InstanceExportBindingFact),
     /// A dynamic custom-element tag render that makes static Lit tag credit opaque.
     DynamicCustomElementRender(DynamicCustomElementRenderFact),
+    /// A factory-returned value consumed in a way that can expose ANY property
+    /// (`const { a, ...rest } = importedFactory()`, a computed destructure key).
+    /// The returned class must be treated as wholly used: crediting only the
+    /// visible keys would leave a live member reported as dead.
+    ///
+    /// Appended, never inserted: `bitcode` encodes an enum by ordinal, so moving an
+    /// existing variant would make an old cache decode one fact as another.
+    FactoryFnWholeObject(FactoryFnWholeObjectFact),
 }
 
 /// Iterate Angular template member names from typed semantic facts.
@@ -1646,6 +1654,13 @@ impl<'a> SemanticFactView<'a> {
             .collect()
     }
 
+    /// Collect factory-return whole-object consumption facts.
+    pub fn factory_fn_whole_objects(self) -> Vec<FactoryFnWholeObjectFact> {
+        factory_fn_whole_object_facts(self.semantic_facts)
+            .cloned()
+            .collect()
+    }
+
     /// Collect typed-property-hop member facts.
     pub fn typed_property_member_accesses(self) -> Vec<TypedPropertyMemberAccessFact> {
         typed_property_member_access_facts(self.semantic_facts)
@@ -1746,6 +1761,18 @@ fn factory_fn_member_access_facts(
     semantic_facts.iter().filter_map(|fact| {
         if let SemanticFact::FactoryFnMemberAccess(access) = fact {
             Some(access)
+        } else {
+            None
+        }
+    })
+}
+
+fn factory_fn_whole_object_facts(
+    semantic_facts: &[SemanticFact],
+) -> impl Iterator<Item = &FactoryFnWholeObjectFact> {
+    semantic_facts.iter().filter_map(|fact| {
+        if let SemanticFact::FactoryFnWholeObject(fact) = fact {
+            Some(fact)
         } else {
             None
         }
@@ -1893,6 +1920,15 @@ pub struct FactoryFnMemberAccessFact {
     pub callee_name: String,
     /// Member accessed on the returned instance-like object.
     pub member: String,
+}
+
+/// A factory-returned value consumed opaquely, so every member of the class it
+/// returns must be treated as used.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FactoryFnWholeObjectFact {
+    /// Local imported function used as the factory callee.
+    pub callee_name: String,
 }
 
 /// A member access reached through a typed property hop that the extraction

--- a/tests/fixtures/cross-file-factory-class-members/package.json
+++ b/tests/fixtures/cross-file-factory-class-members/package.json
@@ -1,0 +1,1 @@
+{ "name": "cross-file-factory-class-members", "version": "1.0.0" }

--- a/tests/fixtures/cross-file-factory-class-members/src/api.ts
+++ b/tests/fixtures/cross-file-factory-class-members/src/api.ts
@@ -1,0 +1,12 @@
+export class RESTApi {
+  public viaSimpleBinding = 1
+  public viaChainedCall = 2
+  public viaChainedCallThenCall = () => 3
+  public viaDestructure = 4
+  public viaRenamedKey = 5
+  public viaDefaultedKey = 6
+  public viaNestedKey = { inner: 7 }
+  public viaChainedThenDeep = { deep: 8 }
+  public viaOptionalChain = 9
+  public trulyDead = 10
+}

--- a/tests/fixtures/cross-file-factory-class-members/src/main.ts
+++ b/tests/fixtures/cross-file-factory-class-members/src/main.ts
@@ -1,0 +1,21 @@
+import { helper, useApi } from './useApi'
+
+const bound = useApi()
+console.log(bound.viaSimpleBinding)
+
+console.log(useApi().viaChainedCall)
+console.log(useApi().viaChainedCallThenCall())
+console.log(useApi().viaChainedThenDeep.deep)
+
+const { viaDestructure } = useApi()
+const { viaRenamedKey: renamed } = useApi()
+const { viaDefaultedKey = 0 } = useApi()
+const { viaNestedKey: { inner } } = useApi()
+
+console.log(viaDestructure, renamed, viaDefaultedKey, inner)
+
+console.log(useApi()?.viaOptionalChain)
+
+// A non-factory callee read the same way. It resolves to no proven factory export,
+// so it credits nothing and cannot suppress anything.
+console.log(helper().anything)

--- a/tests/fixtures/cross-file-factory-class-members/src/useApi.ts
+++ b/tests/fixtures/cross-file-factory-class-members/src/useApi.ts
@@ -1,0 +1,16 @@
+import { RESTApi } from './api'
+
+let api: RESTApi | undefined
+
+export function useApi(): RESTApi {
+  if (!api) {
+    api = new RESTApi()
+  }
+  return api
+}
+
+/// Not a factory: returns no class instance. `helper().anything` must resolve to no
+/// proven factory export and credit nothing.
+export function helper(): { anything: number } {
+  return { anything: 1 }
+}

--- a/tests/fixtures/cross-file-factory-class-members/tsconfig.json
+++ b/tests/fixtures/cross-file-factory-class-members/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target": "ES2020", "module": "ESNext", "moduleResolution": "bundler", "strict": true }, "include": ["src"] }

--- a/tests/fixtures/cross-file-factory-opaque-destructure/package.json
+++ b/tests/fixtures/cross-file-factory-opaque-destructure/package.json
@@ -1,0 +1,1 @@
+{ "name": "cross-file-factory-opaque-destructure", "version": "1.0.0" }

--- a/tests/fixtures/cross-file-factory-opaque-destructure/src/api.ts
+++ b/tests/fixtures/cross-file-factory-opaque-destructure/src/api.ts
@@ -1,0 +1,5 @@
+export class RESTApi {
+  public named = 1
+  public reachableOnlyViaRest = 2
+  public alsoOnlyViaRest = 3
+}

--- a/tests/fixtures/cross-file-factory-opaque-destructure/src/main.ts
+++ b/tests/fixtures/cross-file-factory-opaque-destructure/src/main.ts
@@ -1,0 +1,5 @@
+import { useApi } from './useApi'
+
+const { named, ...rest } = useApi()
+
+console.log(named, rest)

--- a/tests/fixtures/cross-file-factory-opaque-destructure/src/useApi.ts
+++ b/tests/fixtures/cross-file-factory-opaque-destructure/src/useApi.ts
@@ -1,0 +1,10 @@
+import { RESTApi } from './api'
+
+let api: RESTApi | undefined
+
+export function useApi(): RESTApi {
+  if (!api) {
+    api = new RESTApi()
+  }
+  return api
+}

--- a/tests/fixtures/cross-file-factory-opaque-destructure/tsconfig.json
+++ b/tests/fixtures/cross-file-factory-opaque-destructure/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target": "ES2020", "module": "ESNext", "moduleResolution": "bundler", "strict": true }, "include": ["src"] }

--- a/tests/fixtures/local-subclass-static-class-members/package.json
+++ b/tests/fixtures/local-subclass-static-class-members/package.json
@@ -1,0 +1,1 @@
+{ "name": "local-subclass-static-class-members", "version": "1.0.0" }

--- a/tests/fixtures/local-subclass-static-class-members/src/base.ts
+++ b/tests/fixtures/local-subclass-static-class-members/src/base.ts
@@ -29,6 +29,10 @@ export class UrlSyncManager {
     return value
   }
 
+  public static viaNamespaceBase(value: string): string {
+    return value
+  }
+
   public static trulyDead(value: string): string {
     return value
   }

--- a/tests/fixtures/local-subclass-static-class-members/src/base.ts
+++ b/tests/fixtures/local-subclass-static-class-members/src/base.ts
@@ -1,0 +1,47 @@
+export class UrlSyncManager {
+  public static calledViaSub(value: string): string {
+    return value
+  }
+
+  public static passedViaSub(value: string): string {
+    return value
+  }
+
+  public static passedViaBase(value: string): string {
+    return value
+  }
+
+  public static arrowViaSub = (value: string): string => value
+
+  public static viaGrandchild(value: string): string {
+    return value
+  }
+
+  public static viaDeepChain(value: string): string {
+    return value
+  }
+
+  public static shadowedOnSub(value: string): string {
+    return value
+  }
+
+  public static viaMixin(value: string): string {
+    return value
+  }
+
+  public static trulyDead(value: string): string {
+    return value
+  }
+
+  public instanceViaSub(): number {
+    return 1
+  }
+
+  public instanceTrulyDead(): number {
+    return 2
+  }
+}
+
+export function mixin<T>(target: T): T {
+  return target
+}

--- a/tests/fixtures/local-subclass-static-class-members/src/main.ts
+++ b/tests/fixtures/local-subclass-static-class-members/src/main.ts
@@ -1,0 +1,3 @@
+import { config } from './sub'
+
+console.log(config)

--- a/tests/fixtures/local-subclass-static-class-members/src/sub.ts
+++ b/tests/fixtures/local-subclass-static-class-members/src/sub.ts
@@ -1,3 +1,4 @@
+import * as ns from './base'
 import { UrlSyncManager, mixin } from './base'
 
 class MapUrlSyncManager extends UrlSyncManager {}
@@ -40,6 +41,12 @@ class ShadowUrlSyncManager extends UrlSyncManager {
   }
 }
 
+// A namespace-qualified base. The walk re-emits the dotted `ns.UrlSyncManager`
+// verbatim, and the analyze layer resolves only bare local names, so this is inert
+// and `viaNamespaceBase` stays reported. Pre-existing: a direct
+// `ns.UrlSyncManager.viaNamespaceBase()` is equally uncredited on main.
+class NamespaceUrlSyncManager extends ns.UrlSyncManager {}
+
 const instance = new MapUrlSyncManager()
 
 export const config = {
@@ -52,4 +59,5 @@ export const config = {
   g: Deep17.viaDeepChain('deep'),
   h: MixedUrlSyncManager.viaMixin('mixed'),
   i: ShadowUrlSyncManager.shadowedOnSub('shadow'),
+  j: NamespaceUrlSyncManager.viaNamespaceBase('ns'),
 }

--- a/tests/fixtures/local-subclass-static-class-members/src/sub.ts
+++ b/tests/fixtures/local-subclass-static-class-members/src/sub.ts
@@ -1,0 +1,55 @@
+import { UrlSyncManager, mixin } from './base'
+
+class MapUrlSyncManager extends UrlSyncManager {}
+
+class MidUrlSyncManager extends UrlSyncManager {}
+class DeepUrlSyncManager extends MidUrlSyncManager {}
+
+// A chain longer than any fixed depth cap. Cycle detection, not a depth bound, is
+// what terminates the walk; a cap would abstain here and falsely report
+// `viaDeepChain`.
+class Deep0 extends UrlSyncManager {}
+class Deep1 extends Deep0 {}
+class Deep2 extends Deep1 {}
+class Deep3 extends Deep2 {}
+class Deep4 extends Deep3 {}
+class Deep5 extends Deep4 {}
+class Deep6 extends Deep5 {}
+class Deep7 extends Deep6 {}
+class Deep8 extends Deep7 {}
+class Deep9 extends Deep8 {}
+class Deep10 extends Deep9 {}
+class Deep11 extends Deep10 {}
+class Deep12 extends Deep11 {}
+class Deep13 extends Deep12 {}
+class Deep14 extends Deep13 {}
+class Deep15 extends Deep14 {}
+class Deep16 extends Deep15 {}
+class Deep17 extends Deep16 {}
+
+// A mixin superclass is not a bare identifier, so no superclass is recorded and the
+// walk abstains. `viaMixin` stays reported: a mixin may redefine what the subclass
+// exposes, so crediting through it would be a guess.
+class MixedUrlSyncManager extends mixin(UrlSyncManager) {}
+
+// Declares its own static with a base static's name. Crediting the base too is the
+// accepted false negative: over-crediting is safe, under-crediting is not.
+class ShadowUrlSyncManager extends UrlSyncManager {
+  public static shadowedOnSub(value: string): string {
+    return value
+  }
+}
+
+const instance = new MapUrlSyncManager()
+
+export const config = {
+  a: MapUrlSyncManager.calledViaSub('x'),
+  b: MapUrlSyncManager.passedViaSub,
+  c: UrlSyncManager.passedViaBase,
+  d: MapUrlSyncManager.arrowViaSub('y'),
+  e: DeepUrlSyncManager.viaGrandchild('z'),
+  f: instance.instanceViaSub(),
+  g: Deep17.viaDeepChain('deep'),
+  h: MixedUrlSyncManager.viaMixin('mixed'),
+  i: ShadowUrlSyncManager.shadowedOnSub('shadow'),
+}

--- a/tests/fixtures/local-subclass-static-class-members/tsconfig.json
+++ b/tests/fixtures/local-subclass-static-class-members/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target": "ES2020", "module": "ESNext", "moduleResolution": "bundler", "strict": true }, "include": ["src"] }


### PR DESCRIPTION
## What

Three confirmed false positives in `unused-class-members`, all reproduced against a freshly built `main` (3.3.0) before any code was written, each pinned by a **cross-file** regression fixture with a positive control.

**1. A member reached through a local (non-exported) subclass.**

```ts
// base.ts
export abstract class Base { static someStatic(v: string) { return v } }
// sub.ts
class Sub extends Base {}                 // not exported
export const config = { a: Sub.someStatic('x') }
```

`Base.someStatic` was reported unused. `Sub` never becomes an export, so the analyze layer's import/export map cannot resolve the object `Sub`, and `build_parent_to_children` is built from exports alone. Exporting `Sub` makes the identical code resolve — that is the tell. Fixed in extract, by walking the local `extends` chain to the first name that is not locally declared and re-emitting the access against it. No synthetic export keys: an `ExportKey` for a non-export is semantically wrong and collides across files.

**2 and 3. A factory result read without a named binding.**

```ts
useApi().member                 // chained call
const { member } = useApi()     // destructure
```

Cross-module factory-return propagation already worked for `const s = f(); s.m`. It never fired for these two, because the extractor recorded a candidate only for a plain `BindingIdentifier` declarator, and a chained call is not a declarator at all. Those two shapes are what real composables and singletons use, so every member of the returned class was reported unused.

Both now record `(callee, member)` directly. A same-file factory binds the class; an imported callee emits the typed fact the analyze layer resolves through the strict, value-proven `exported_factory_returns` gate. Any other callee resolves to no proven factory export and credits nothing, so recording every `identifier().member` is safe.

Only the **first level** of the result belongs to the factory's class. `f().a.b` credits `a`; `b` is read off whatever type `a` has. `{ a: { b } }` credits `a` for the same reason.

**The opaque-destructure trap.** `const { a, ...rest } = f()` and a computed key can read *any* property. Crediting only the visible keys would leave every other live member reported — the same false positive, narrowed. The returned class is marked wholly used instead, via a new `FactoryFnWholeObject` fact resolved through the same gate. Reporting nothing for that class is a deliberate false negative.

The final commit is a pure refactor: the `callee -> re-export origins -> exported_factory_returns -> class-with-members` chain existed in three copies, and every link of it is an over-credit gate, so three copies are three places for the gates to drift apart.

## Why

Every fix here is **additive credit**: it can turn a reported member into an unreported one, never the reverse. Neither can introduce a new false positive. That is the direction this rule must err in — a false positive is what makes it untrustworthy, and it was disabled downstream because 81% of its findings were false positives.

### Corrections to the original report

Two of the three diagnoses in the bug report were wrong, and following them would have produced the wrong fix:

- The chained-call/destructure bug is **not** missing cross-file factory propagation. That works. Every repro in the report happened to use only the two unsupported consumer shapes, which is why an explicit `getState(): State` return type looked ignored. It never was.
- The subclass bug's discriminator is **not** "static method vs static arrow property". That divergence does not exist — `static arrowViaSub = (v) => v` is flagged identically. The discriminator is that the subclass is not exported.

### Deliberately not fixed

Each is pinned by a test, so a future change has to decide the case rather than flip it by accident:

- `class Sub extends mixin(Base)` — no superclass name is recorded; a mixin may redefine what the subclass exposes, so crediting through it would be a guess.
- `class Sub extends ns.Base` — the dotted name resolves to no bare local. **Pre-existing, and wider than subclassing**: a direct `ns.Base.someStatic()` is equally uncredited on `main`, verified by running both binaries against the same fixture. Closing it means resolving namespace aliases in the analyze layer.
- A member access through an **inferred** property hop (`computed(() => new C()).value.m`, or a plain `{ value: new C() }` wrapper). Annotated hops already work via the typed-property path; inferred ones and generic type arguments (`Ref<T>` / `ComputedRef<T>`) do not. Not Vue-specific; Vue just makes it ubiquitous.
- The same-file abstain: a class whose instance escapes through a same-file factory is skipped wholesale by the whole-object gate, so genuinely dead members go unreported. It under-reports rather than over-reports, and widening it would manufacture findings in exactly the rule that was disabled for being noisy.

Happy to take any of these on in a follow-up.

## Test plan

- **Two new cross-file fixtures** with positive controls, plus a third pinning the opaque destructure. Fixtures are cross-file on purpose: a same-file factory is skipped by the whole-object gate, so a same-file fixture reports nothing and **passes for the wrong reason**. That is why the fixture added with the previous fix for this bug went green while the reported bug stayed live.
- Covered and asserted: static method, static passed as a value, static arrow property, a two-level local chain, an 18-deep local chain (cycle detection, not a depth cap — a cap would abstain and report the member falsely), an instance member through a local subclass, chained call, chained-then-call, chained-then-deep (first level only), destructure, renamed key, defaulted key, nested key (first level only), optional chaining, a non-factory callee crediting and suppressing nothing, and the opaque destructure suppressing the class.
- Also asserted: `deep` and `inner` (second-level keys) never become members of the factory's class.
- `cargo test --workspace --lib --bins --tests` — 58 test binaries, 0 failures. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean. `generate:contracts:check` and a `--features schema-emit` build both pass.
- Both commits that change extraction semantics bump `CACHE_VERSION` (227 -> 228 -> 229); stale cached modules would otherwise carry pre-fix facts. The new `SemanticFact` variant is **appended**, never inserted: bitcode encodes an enum by ordinal, so moving an existing variant would make an old cache decode one fact as another.

The change was reviewed by four independent adversarial passes — on the plan, on the first commit, on the branch, and for redundancy. Findings acted on include: replacing a depth cap that was itself a false-positive source; moving the subclass pass after `resolve_bound_member_accesses`, which is what materializes the access for `const s = new Sub(); s.member`; appending rather than inserting the enum variant; and removing a stand-in-local mechanism that made every `helper().x` a resolution candidate.

Note: the commits are unsigned — no GPG key on the machine they were authored on. Happy to re-sign if that blocks merge.
