### PR TITLE
test(types): normalize source-read path assertion

### DIFF
--- a/crates/types/src/workspace.rs
+++ b/crates/types/src/workspace.rs
@@ -341,7 +341,10 @@ mod tests {
         assert_eq!(json["kind"], "source-read-failure");
         assert_eq!(
             json["path"],
-            root.join("src/removed.ts").display().to_string()
+            root.join("src/removed.ts")
+                .display()
+                .to_string()
+                .replace('\\', "/")
         );
         assert_eq!(json["error"], "No such file or directory");
         assert!(


### PR DESCRIPTION
## Summary

- normalize the source-read diagnostic path expectation to the serializer wire format
- keep the assertion portable across Unix and Windows

## Verification

- focused fallow-types regression test
- fallow-types all-target clippy
- cargo fmt check