### PR TITLE
fix(ci): allow cold Windows checks to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Cold Windows test and NAPI builds can take just over 30 minutes.
+    timeout-minutes: 40
     permissions:
       contents: read
     strategy:

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -44,6 +44,13 @@ test("Windows lifecycle PR gate lints MCP test code", () => {
   );
 });
 
+test("cross-platform check job reserves enough time for a cold Windows build", () => {
+  const workflow = readWorkflow(".github/workflows/ci.yml");
+  const checkJob = indentedBlock(workflow, "check", 2);
+
+  assert.match(checkJob, /timeout-minutes: 40/);
+});
+
 test("VS Code CI runs the extension-host integration suite with a pinned cached download", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const vscodeJob = indentedBlock(workflow, "vscode", 2);


### PR DESCRIPTION
## Summary

- raise the cross-platform check job budget from 30 to 40 minutes
- document the cold Windows test and NAPI build timing
- add a workflow policy regression guard

## Verification

- workflow policy tests pass
- repository script tests pass
- JavaScript lint and formatting pass
- actionlint passes