### PR TITLE
fix(report): singular nouns for one-finding GitHub format headlines

### DIFF
--- a/crates/cli/src/report/github.rs
+++ b/crates/cli/src/report/github.rs
@@ -129,8 +129,13 @@ pub fn sort_annotations(annotations: &mut [Annotation]) {
 #[must_use]
 pub fn budget_notice(total: usize) -> Option<String> {
     (total > 0).then(|| {
+        let noun = if total == 1 {
+            "annotation"
+        } else {
+            "annotations"
+        };
         format!(
-            "::notice::fallow emitted {total} annotations; GitHub shows at most 10 per type per step"
+            "::notice::fallow emitted {total} {noun}; GitHub shows at most 10 per type per step"
         )
     })
 }
@@ -478,6 +483,16 @@ mod tests {
             budget_notice(12).as_deref(),
             Some(
                 "::notice::fallow emitted 12 annotations; GitHub shows at most 10 per type per step"
+            )
+        );
+    }
+
+    #[test]
+    fn budget_notice_uses_singular_noun_for_one_annotation() {
+        assert_eq!(
+            budget_notice(1).as_deref(),
+            Some(
+                "::notice::fallow emitted 1 annotation; GitHub shows at most 10 per type per step"
             )
         );
     }

--- a/crates/cli/src/report/github_summary.rs
+++ b/crates/cli/src/report/github_summary.rs
@@ -991,7 +991,8 @@ fn check_tips(env: &Value) -> String {
 #[must_use]
 pub fn render_check_summary(env: &Value) -> String {
     let elapsed = num(env, "elapsed_ms");
-    if u(env, "total_issues") == 0 {
+    let total_issues = u(env, "total_issues");
+    if total_issues == 0 {
         return format!(
             "# Fallow Analysis\n\n> [!NOTE]\n> **No issues found** \u{b7} {elapsed}ms\n\nAll exports are used, all dependencies are declared, and no issues were detected."
         );
@@ -1007,9 +1008,9 @@ pub fn render_check_summary(env: &Value) -> String {
             sections.push_str(&render_check_section(env, spec));
         }
     }
+    let issue_noun = if total_issues == 1 { "issue" } else { "issues" };
     format!(
-        "# Fallow Analysis\n\n> [!WARNING]\n> **{} issues** found \u{b7} {elapsed}ms\n\n| Category | Count |\n|----------|------:|\n{}\n\n---\n{sections}{}",
-        num(env, "total_issues"),
+        "# Fallow Analysis\n\n> [!WARNING]\n> **{total_issues} {issue_noun}** found \u{b7} {elapsed}ms\n\n| Category | Count |\n|----------|------:|\n{}\n\n---\n{sections}{}",
         dead_code_category_table(env),
         check_tips(env),
     )

--- a/crates/cli/tests/github_format_tests.rs
+++ b/crates/cli/tests/github_format_tests.rs
@@ -419,6 +419,24 @@ fn annotations_end_with_budget_notice() {
 }
 
 #[test]
+fn annotations_single_finding_notice_uses_singular_noun() {
+    let rendered = render_annotations(
+        EnvelopeKind::DeadCode,
+        &json!({
+            "kind": "dead-code",
+            "total_issues": 1,
+            "unused_files": [{ "path": "src/orphan.ts" }]
+        }),
+        &plain_options(),
+    );
+    let last = rendered.lines().last().expect("non-empty");
+    assert_eq!(
+        last,
+        "::notice::fallow emitted 1 annotation; GitHub shows at most 10 per type per step"
+    );
+}
+
+#[test]
 fn annotations_empty_run_renders_nothing() {
     let rendered = render_annotations(
         EnvelopeKind::DeadCode,
@@ -563,6 +581,24 @@ fn github_summary_check_clean_snapshot() {
         &LinkContext::default(),
     );
     insta::assert_snapshot!("github_summary_check_clean", rendered);
+}
+
+#[test]
+fn github_summary_single_issue_uses_singular_noun() {
+    let rendered = render_summary(
+        EnvelopeKind::DeadCode,
+        &json!({
+            "kind": "dead-code",
+            "total_issues": 1,
+            "elapsed_ms": 45,
+            "unused_files": [{ "path": "src/orphan.ts" }]
+        }),
+        &LinkContext::default(),
+    );
+    assert!(
+        rendered.contains("> **1 issue** found"),
+        "headline should use the singular noun: {rendered}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Smoke testing the unreleased GitHub-native formats surfaced two count==1 grammar defects: the annotations budget notice rendered "fallow emitted 1 annotations" and the job-summary headline rendered "**1 issues** found". A pull request that introduces exactly one issue is the most common CI case, so both strings now branch on the count.

No CHANGELOG entry: the formats are still unreleased, so the existing [Unreleased] entry already describes the shipped behavior. Golden snapshots are unchanged (their fixtures are plural); new unit and integration tests pin the singular forms.