### PR TITLE
ci: move cross-platform checks to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,26 +195,13 @@ jobs:
           test "$clean_code" -eq 0
 
   check:
-    name: Check (${{ matrix.os }})
+    name: Check
     needs: changes
     if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
-    runs-on: ${{ matrix.os }}
-    # Cold Windows test and NAPI builds can take just over 30 minutes.
-    timeout-minutes: 40
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        # PR runs ubuntu only (fast feedback, free for public repos).
-        # Push to main also runs windows-latest as a pre-release safety net so
-        # Windows path bugs (backslash separators, UNC paths, long-path `\\?\`,
-        # case insensitivity) surface before a release tag is cut rather than
-        # via user reports. Same structural pattern as the `zed` job below.
-        # macOS minutes are 10x quota multiplier on GitHub Free org plans;
-        # Windows is 2x. macOS coverage is via local pre-release runs.
-        # Refs #447.
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -224,7 +211,6 @@ jobs:
           components: clippy, rustfmt
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        if: matrix.os == 'ubuntu-latest'
         with:
           version: 10.33.0
 
@@ -233,15 +219,8 @@ jobs:
           node-version: '22'
 
       - name: Run tests
-        if: matrix.os != 'windows-latest'
         # Benchmark targets exceed this job's timeout and are covered by the
         # dedicated benchmark workflows.
-        run: cargo test --workspace --lib --bins --tests --examples
-
-      - name: Run tests (Windows)
-        if: matrix.os == 'windows-latest'
-        # Windows push checks catch path and filesystem regressions.
-        # Benchmark targets are covered by dedicated benchmark workflows.
         run: cargo test --workspace --lib --bins --tests --examples
 
       - name: Run runtime-coverage integration tests (feature-gated stub sidecar)
@@ -251,15 +230,12 @@ jobs:
         run: cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit
 
       - name: Install contract bundle dependencies
-        if: matrix.os == 'ubuntu-latest'
         run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run staged subgenerator integration tests
-        if: matrix.os == 'ubuntu-latest'
         run: node --test scripts/subgenerator-staging.test.mjs
 
       - name: Run contract bundle drift gate
-        if: matrix.os == 'ubuntu-latest'
         run: CI=true npm run generate:contracts:check
 
       - name: Clippy
@@ -541,22 +517,13 @@ jobs:
       - run: cd editors/vscode && pnpm package
 
   zed:
-    name: Zed Extension (${{ matrix.os }})
+    name: Zed Extension
     needs: changes
-    if: needs.changes.outputs.zed == 'true' || github.event_name == 'push'
-    runs-on: ${{ matrix.os }}
+    if: needs.changes.outputs.zed == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        # PR runs ubuntu only (fast feedback, free for public repos).
-        # Push to main runs the full matrix as a pre-release safety net.
-        # macOS minutes are 10x quota multiplier on GitHub Free org plans;
-        # Windows is 2x. The April 2026 quota overshoot was driven by this
-        # matrix running on every PR push.
-        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-rust
@@ -569,69 +536,6 @@ jobs:
         run: cargo build --target wasm32-wasip2 --manifest-path editors/zed/Cargo.toml
       - name: Format
         run: cargo fmt --check --manifest-path editors/zed/Cargo.toml
-
-  windows-arm64:
-    name: Windows ARM64 Native Compile
-    needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.npm == 'true' || needs.changes.outputs.actions == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
-    runs-on: windows-11-arm
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: ./.github/actions/setup-rust
-        with:
-          targets: aarch64-pc-windows-msvc
-          cache-key: windows-arm64
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '22'
-      - name: Check Windows ARM64 compilation
-        run: cargo check -p fallow-cli -p fallow-lsp -p fallow-mcp -p fallow-node --target aarch64-pc-windows-msvc
-      - name: Build NAPI addon for Windows ARM64
-        run: |
-          cd crates/napi
-          npm ci --omit=optional --ignore-scripts
-          npx napi build --platform --profile napi-release --target aarch64-pc-windows-msvc
-
-  windows-audit-smoke:
-    name: Windows Process Lifecycle Smoke
-    needs: changes
-    # The `check` matrix only runs the full test suite on windows-latest for
-    # push/merge_group, so PRs never execute these audit lifecycle paths on
-    # Windows. PR #489 replaced the `process_is_alive` stub (which made the
-    # orphan sweep a no-op on Windows) with a real Win32 OpenProcess /
-    # WaitForSingleObject implementation, and `ReusableWorktreeLock` uses
-    # NTFS LockFileEx whose semantics differ from POSIX flock. This job runs
-    # the focused lifecycle tests on every Rust-touching PR so those Windows-only
-    # paths are validated before a release tag is cut. It also lints the MCP test
-    # target and exercises Job Object cleanup for a timed-out process and its
-    # descendant. Narrower than the full Windows matrix (#447). Refs #489, #472.
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
-    runs-on: windows-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: ./.github/actions/setup-rust
-        with:
-          cache-key: windows-audit-smoke
-      - name: Lint MCP Windows lifecycle code
-        run: cargo clippy -p fallow-mcp --bin fallow-mcp --tests -- -D warnings
-      - name: Run audit orphan-sweep + lock lifecycle tests
-        run: >
-          cargo test -p fallow-cli --lib --
-          --exact
-          audit::tests::audit_orphan_sweep_removes_dead_pid_worktree
-          audit::tests::audit_orphan_sweep_keeps_live_pid_worktree
-          audit::tests::reusable_worktree_lock_excludes_concurrent_acquires
-      - name: Run MCP timeout process-tree lifecycle test
-        run: >
-          cargo test -p fallow-mcp --bin fallow-mcp
-          server::tests::run::run_fallow_timeout_terminates_and_reaps_windows_job_tree
-          -- --exact
 
   test-gitlab-ci:
     name: Test GitLab CI scripts
@@ -798,7 +702,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, doc, typos, js-lint, npm-package, fallow-self-analyze, vscode, test-gitlab-ci, windows-audit-smoke, audit, deny, shear, zizmor, msrv, miri, skills-vendor]
+    needs: [check, doc, typos, js-lint, npm-package, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish-crates:
     name: Publish Rust crates
-    needs: build
+    needs: release-verified
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -392,9 +392,118 @@ jobs:
           name: napi-${{ matrix.npm_dir }}
           path: crates/napi/fallow-node.${{ matrix.npm_dir }}.node
 
+  windows-verify:
+    name: Windows correctness and lifecycle
+    runs-on: windows-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy, rustfmt
+          cache-key: release-windows-verify
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+
+      - name: Run workspace tests
+        run: cargo test --workspace --lib --bins --tests --examples
+
+      - name: Run runtime-coverage integration tests
+        run: cargo test -p fallow-cli --features test-sidecar-key --test runtime_coverage_tests
+
+      - name: Run schema drift gate
+        run: cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit
+
+      - name: Install contract bundle dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run staged subgenerator integration tests
+        run: node --test scripts/subgenerator-staging.test.mjs
+
+      - name: Run contract bundle drift gate
+        run: npm run generate:contracts:check
+        env:
+          CI: true
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Clippy (test-sidecar-key feature)
+        run: cargo clippy -p fallow-cli --features test-sidecar-key --all-targets -- -D warnings
+
+      - name: Clippy (schema-emit feature)
+        run: cargo clippy -p fallow-cli --features schema-emit --bin fallow-schema-emit --tests -- -D warnings
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Install NAPI package dependencies
+        run: cd crates/napi && npm ci --omit=optional --ignore-scripts
+
+      - name: Build NAPI package
+        run: cd crates/napi && npx napi build --platform --profile napi-release && npm run publish:prepare
+
+      - name: Run NAPI smoke test
+        run: cd crates/napi && npm test
+
+      - name: Run audit orphan-sweep and lock lifecycle tests
+        run: >
+          cargo test -p fallow-cli --lib --
+          --exact
+          audit::tests::audit_orphan_sweep_removes_dead_pid_worktree
+          audit::tests::audit_orphan_sweep_keeps_live_pid_worktree
+          audit::tests::reusable_worktree_lock_excludes_concurrent_acquires
+
+      - name: Run MCP timeout process-tree lifecycle test
+        run: >
+          cargo test -p fallow-mcp --bin fallow-mcp
+          server::tests::run::run_fallow_timeout_terminates_and_reaps_windows_job_tree
+          -- --exact
+
+      - name: Check for uncommitted changes
+        run: git diff --exit-code
+
+  zed-verify:
+    name: Zed verification (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt
+          targets: wasm32-wasip2
+      - name: Run tests
+        run: cargo test --manifest-path editors/zed/Cargo.toml
+      - name: Build wasm extension
+        run: cargo build --target wasm32-wasip2 --manifest-path editors/zed/Cargo.toml
+      - name: Format
+        run: cargo fmt --check --manifest-path editors/zed/Cargo.toml
+
   release:
     name: Create Release
-    needs: build
+    needs: release-verified
     runs-on: ubuntu-latest
     permissions:
       # Required to create GitHub Releases and to push the rolling v1 action
@@ -474,6 +583,14 @@ jobs:
 
       - name: Verify generated contract bundle
         run: CI=true npm run generate:contracts:check
+
+  release-verified:
+    name: Release verified
+    needs: [build, check-codegen, windows-verify, zed-verify]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: echo "Release artifacts and cross-platform checks passed"
 
   # Build the npm publish tree (versioned package.json files, binaries, NAPI
   # addons, schema) into immutable tarballs. This job runs no publish
@@ -745,7 +862,7 @@ jobs:
     # - --ignore-scripts on every publish blocks lifecycle scripts inside the
     #   tarballs from executing here.
     # Anything that needs `npm ci` or runs dependency code belongs in npm-prep.
-    needs: [npm-prep, release, check-codegen]
+    needs: [npm-prep, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -938,7 +1055,7 @@ jobs:
 
   vscode-publish:
     name: Publish VS Code Extension
-    needs: [vscode-prep, release, check-codegen]
+    needs: [vscode-prep, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/superpowers/specs/2026-07-11-release-only-cross-platform-ci-design.md
+++ b/docs/superpowers/specs/2026-07-11-release-only-cross-platform-ci-design.md
@@ -1,0 +1,121 @@
+# Release-only cross-platform CI design
+
+## Status
+
+Approved in conversation on 2026-07-11. This document is the written design checkpoint before implementation planning.
+
+## Goal
+
+Keep pull request and `main` CI as fast as reasonably possible without weakening the checks that provide rapid, high-value feedback. Run regular CI on Ubuntu only. Move expensive Windows and macOS correctness checks into the release workflow, where every cross-platform gate must pass before any package is published or release is created.
+
+## Current problem
+
+Regular CI currently expands some jobs on pushes to `main`:
+
+- The primary Rust and NAPI `check` job adds `windows-latest`.
+- The Zed extension job adds macOS and Windows.
+- Dedicated Windows ARM64 compilation and Windows audit lifecycle smoke jobs run in CI.
+
+The Windows primary check can take more than 30 minutes. This slows completion of `main` CI even though the release workflow already builds Windows and macOS artifacts. The release workflow does not yet replace all correctness coverage that would be removed from regular CI.
+
+## Proposed workflow split
+
+### Regular CI
+
+`.github/workflows/ci.yml` will use Ubuntu runners only.
+
+The primary `check` job will become a single Ubuntu job. It will retain the existing high-value suite:
+
+- Workspace tests, examples, and runtime coverage.
+- Schema, generated contract, and documentation drift checks.
+- Clippy for the default workspace and feature combinations.
+- Rust formatting.
+- NAPI dependency installation, addon build, declaration generation, package smoke tests, and generated-file drift checks.
+
+Its timeout will be reduced from the Windows-sized 40-minute budget to 20 minutes. This leaves headroom above normal Ubuntu runtime while still detecting hangs promptly.
+
+The Zed job will run on Ubuntu only for pull requests, merge groups, and pushes to `main`. The conditional Windows and macOS matrix will be removed.
+
+The following dedicated cross-platform jobs will be removed from regular CI:
+
+- Windows ARM64 native compilation.
+- Windows audit process and lock lifecycle smoke tests.
+
+The aggregate required `CI` job will no longer depend on Windows-only jobs. Branch protection can continue requiring the stable aggregate `CI` check without waiting for cross-platform runners.
+
+Other Ubuntu jobs and specialized scheduled or manual workflows are unchanged.
+
+### Release verification
+
+`.github/workflows/release.yml` will remain the cross-platform artifact build workflow. Its existing matrix will continue building the CLI, LSP, MCP server, and NAPI addon for supported Linux, macOS, Windows x64, and Windows ARM64 targets.
+
+Release will add unprivileged verification jobs before publishing:
+
+1. A Windows x64 correctness job will run the coverage moved out of regular CI:
+   - Workspace tests and examples.
+   - Runtime-coverage tests.
+   - Schema and generated-contract drift checks.
+   - Default and feature-specific Clippy checks.
+   - Rust formatting.
+   - NAPI install, native build, declaration generation, package smoke tests, and generated-file drift checks.
+   - Focused audit lock, orphan cleanup, process-tree, and Windows lifecycle tests.
+
+2. A release-only Zed matrix will run the extension tests, build, and formatting checks on macOS and Windows. Ubuntu Zed coverage remains in regular CI and does not need to be repeated during release.
+
+The existing Windows ARM64 release matrix entry remains responsible for native Windows ARM64 compilation and NAPI addon production.
+
+Verification jobs will have only read access to repository contents. They will not receive publishing credentials, OIDC permissions, or release tokens.
+
+## Release dependency gate
+
+All privileged or externally visible release paths must depend on the cross-platform verification jobs, either directly or through a single explicit release gate. This includes:
+
+- crates.io publication.
+- npm package publication.
+- GitHub release creation and artifact attachment.
+- Any downstream release completion or notification job that assumes publication succeeded.
+
+The implementation plan will map the existing dependency graph and choose the smallest clear dependency change. The preferred shape is one unprivileged aggregate verification job that depends on artifact builds, Windows correctness, and release-only Zed checks. Publish jobs then depend on that gate. A failing cross-platform check must stop the release before credentials are used or packages become visible.
+
+## Policy tests
+
+`scripts/workflow-policy.test.mjs` will enforce the split structurally:
+
+- Regular CI must not use Windows or macOS runners for the primary check, Zed, Windows ARM64, or lifecycle coverage.
+- The regular primary check must retain its important Ubuntu commands and its reduced timeout.
+- Release must retain Windows x64 and Windows ARM64 artifact builds.
+- Release must contain the Windows correctness, lifecycle, and NAPI smoke commands moved from CI.
+- Release must contain macOS and Windows Zed verification.
+- Every privileged publish or release path must depend on the aggregate release verification gate.
+- Verification jobs must remain unprivileged.
+
+Tests will be added before workflow changes so the initial failure proves the new policy is not already satisfied.
+
+## Failure behavior
+
+- Pull request and `main` failures remain fast and Linux-focused.
+- Cross-platform regressions fail the release workflow before publication.
+- A failed release verification can be fixed on `main` and retried with a new release tag according to the existing release process.
+- The workflow will not allow a verification failure to be skipped by a successful matrix sibling or an unrelated publish dependency.
+
+## Scope boundaries
+
+This change does not:
+
+- Change product code or supported platforms.
+- Remove any release artifact target.
+- Add third-party dependencies.
+- Change specialized scheduled or manually dispatched workflows.
+- Change branch protection beyond preserving the existing aggregate `CI` check contract.
+- Redesign the release process outside the dependency changes required to gate publication.
+
+## Acceptance criteria
+
+- Pull request, merge-group, and `main` CI use Ubuntu only for the affected regular checks.
+- The aggregate `CI` check remains stable and includes all regular required jobs.
+- Release builds all currently supported platform artifacts.
+- Windows correctness, lifecycle, and NAPI smoke checks run before publishing.
+- macOS and Windows Zed checks run before publishing.
+- No publish or GitHub release path can start until cross-platform verification passes.
+- Workflow policy tests fail on the old structure and pass on the new structure.
+- YAML validation, workflow policy tests, and relevant local verification pass.

--- a/docs/superpowers/specs/2026-07-11-release-only-cross-platform-ci-design.md
+++ b/docs/superpowers/specs/2026-07-11-release-only-cross-platform-ci-design.md
@@ -41,7 +41,7 @@ The following dedicated cross-platform jobs will be removed from regular CI:
 - Windows ARM64 native compilation.
 - Windows audit process and lock lifecycle smoke tests.
 
-The aggregate required `CI` job will no longer depend on Windows-only jobs. Branch protection can continue requiring the stable aggregate `CI` check without waiting for cross-platform runners.
+The aggregate required `CI` job will no longer depend on Windows-only jobs. Branch protection will continue requiring the stable aggregate `CI` check without waiting for cross-platform runners. The obsolete separately required `Windows ARM64 Native Compile` context will be removed from branch protection after the workflow lands; every other required context remains unchanged.
 
 Other Ubuntu jobs and specialized scheduled or manual workflows are unchanged.
 
@@ -106,13 +106,14 @@ This change does not:
 - Remove any release artifact target.
 - Add third-party dependencies.
 - Change specialized scheduled or manually dispatched workflows.
-- Change branch protection beyond preserving the existing aggregate `CI` check contract.
+- Change branch protection beyond removing the obsolete `Windows ARM64 Native Compile` context and preserving every other required check.
 - Redesign the release process outside the dependency changes required to gate publication.
 
 ## Acceptance criteria
 
 - Pull request, merge-group, and `main` CI use Ubuntu only for the affected regular checks.
 - The aggregate `CI` check remains stable and includes all regular required jobs.
+- Branch protection no longer requires the removed `Windows ARM64 Native Compile` job and retains every other required context.
 - Release builds all currently supported platform artifacts.
 - Windows correctness, lifecycle, and NAPI smoke checks run before publishing.
 - macOS and Windows Zed checks run before publishing.

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -34,21 +34,72 @@ test("workflow block parser rejects missing keys", () => {
   assert.throws(() => indentedBlock("root:\n  value: true", "missing", 0), /missing missing block/);
 });
 
-test("Windows lifecycle PR gate lints MCP test code", () => {
-  const workflow = readWorkflow(".github/workflows/ci.yml");
-  const windowsLifecycleJob = indentedBlock(workflow, "windows-audit-smoke", 2);
-
-  assert.match(
-    windowsLifecycleJob,
-    /name: Lint MCP Windows lifecycle code\n\s+run: cargo clippy -p fallow-mcp --bin fallow-mcp --tests -- -D warnings/,
-  );
-});
-
-test("cross-platform check job reserves enough time for a cold Windows build", () => {
+test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const checkJob = indentedBlock(workflow, "check", 2);
+  const zedJob = indentedBlock(workflow, "zed", 2);
+  const aggregateJob = indentedBlock(workflow, "ci-ok", 2);
 
-  assert.match(checkJob, /timeout-minutes: 40/);
+  assert.doesNotMatch(workflow, /windows-latest|windows-11-arm|macos-latest/);
+  assert.match(checkJob, /runs-on: ubuntu-latest/);
+  assert.match(checkJob, /timeout-minutes: 20/);
+  assert.doesNotMatch(checkJob, /matrix\.|windows-latest|macos-latest/);
+  assert.match(zedJob, /runs-on: ubuntu-latest/);
+  assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);
+  assert.throws(() => indentedBlock(workflow, "windows-arm64", 2), /missing windows-arm64 block/);
+  assert.throws(
+    () => indentedBlock(workflow, "windows-audit-smoke", 2),
+    /missing windows-audit-smoke block/,
+  );
+  assert.doesNotMatch(aggregateJob, /windows-audit-smoke|windows-arm64/);
+});
+
+test("release runs Windows correctness and lifecycle verification without credentials", () => {
+  const workflow = readWorkflow(".github/workflows/release.yml");
+  const job = indentedBlock(workflow, "windows-verify", 2);
+  const buildJob = indentedBlock(workflow, "build", 2);
+
+  assert.match(buildJob, /target: x86_64-pc-windows-msvc/);
+  assert.match(buildJob, /target: aarch64-pc-windows-msvc/);
+  assert.match(buildJob, /os: windows-11-arm/);
+  assert.match(job, /runs-on: windows-latest/);
+  assert.match(job, /permissions:\n\s+contents: read/);
+  assert.doesNotMatch(job, /id-token: write|contents: write|secrets\./);
+  assert.match(job, /cargo test --workspace --lib --bins --tests --examples/);
+  assert.match(job, /cargo clippy --workspace --all-targets -- -D warnings/);
+  assert.match(job, /cargo fmt --all -- --check/);
+  assert.match(job, /npm run publish:prepare/);
+  assert.match(job, /cd crates\/napi && npm test/);
+  assert.match(job, /audit_orphan_sweep_removes_dead_pid_worktree/);
+  assert.match(job, /run_fallow_timeout_terminates_and_reaps_windows_job_tree/);
+});
+
+test("release runs Zed verification on macOS and Windows without credentials", () => {
+  const workflow = readWorkflow(".github/workflows/release.yml");
+  const job = indentedBlock(workflow, "zed-verify", 2);
+
+  assert.match(job, /os: \[macos-latest, windows-latest\]/);
+  assert.match(job, /permissions:\n\s+contents: read/);
+  assert.doesNotMatch(job, /id-token: write|contents: write|secrets\./);
+  assert.match(job, /cargo test --manifest-path editors\/zed\/Cargo.toml/);
+  assert.match(job, /cargo build --target wasm32-wasip2 --manifest-path editors\/zed\/Cargo.toml/);
+  assert.match(job, /cargo fmt --check --manifest-path editors\/zed\/Cargo.toml/);
+});
+
+test("release publication waits for the aggregate verification gate", () => {
+  const workflow = readWorkflow(".github/workflows/release.yml");
+  const gate = indentedBlock(workflow, "release-verified", 2);
+  const publishCrates = indentedBlock(workflow, "publish-crates", 2);
+  const release = indentedBlock(workflow, "release", 2);
+  const npmPublish = indentedBlock(workflow, "npm-publish", 2);
+  const vscodePublish = indentedBlock(workflow, "vscode-publish", 2);
+
+  assert.match(gate, /needs: \[build, check-codegen, windows-verify, zed-verify\]/);
+  assert.match(gate, /permissions: \{\}/);
+  assert.match(publishCrates, /needs: release-verified/);
+  assert.match(release, /needs: release-verified/);
+  assert.match(npmPublish, /needs: \[npm-prep, release\]/);
+  assert.match(vscodePublish, /needs: \[vscode-prep, release\]/);
 });
 
 test("VS Code CI runs the extension-host integration suite with a pinned cached download", () => {


### PR DESCRIPTION
## Summary
- Keep regular pull request and main CI on Ubuntu.
- Move Windows correctness, lifecycle, NAPI, ARM64, and macOS or Windows Zed coverage ahead of release publication.
- Gate every privileged release path behind token-free cross-platform verification.
- Remove the obsolete Windows ARM64 required context after merge while preserving every other branch rule.

## Verification
- [x] Workflow policy and script tests
- [x] YAML and actionlint validation
- [x] Pinned zizmor security analysis
- [x] Workspace check, build, tests, Clippy, formatting, typos, and docs
- [x] Fallow audit