### PR TITLE
fix(extract): credit member access through private class fields

### DIFF
--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -219,6 +219,8 @@ mod issue_1640_commit_and_tag_version_updater;
 mod issue_1785_typed_property_hop;
 #[path = "integration_test/issue_1788_local_class_options.rs"]
 mod issue_1788_local_class_options;
+#[path = "integration_test/issue_1821_private_field_di.rs"]
+mod issue_1821_private_field_di;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_1821_private_field_di.rs
+++ b/crates/core/tests/integration_test/issue_1821_private_field_di.rs
@@ -1,0 +1,51 @@
+use super::common::{create_config, fixture_path};
+
+fn unused_member_names(root: std::path::PathBuf) -> Vec<String> {
+    let mut config = create_config(root);
+    config.rules.unused_class_members = fallow_config::Severity::Error;
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.member.parent_name, m.member.member_name))
+        .collect()
+}
+
+#[test]
+fn private_field_di_credits_member_cross_module() {
+    // Issue #1821 (Fix A): a member reached through a `#`-private DI field
+    // (`this.#dep.m()`) on a class in ANOTHER module must be credited, the same
+    // way a public `this.dep.m()` receiver already is. Consumers live in
+    // separate files from the dep classes on purpose: a same-file fixture would
+    // pass for the wrong reason via the file-level self-access map. Three
+    // receiver shapes are covered:
+    //   - inline-new `readonly #dep = new Dep()`
+    //   - bare `#dep` + ctor `this.#dep = new Dep()`
+    //   - interface-typed `#svc: IDep` crediting the implementer
+    // Every dep class also carries a genuinely-dead control member that must
+    // STAY flagged, proving the fix credits precisely and never over-credits.
+    let unused = unused_member_names(fixture_path("issue-1821-private-field-di"));
+
+    for credited in [
+        "DepInlineNew.inlineM",
+        "DepCtorNew.ctorNewM",
+        "DepIface.ifaceM",
+    ] {
+        assert!(
+            !unused.contains(&credited.to_string()),
+            "{credited} is reached through a `#`-private DI field and must be credited \
+             (issue #1821), found: {unused:?}"
+        );
+    }
+    for control in [
+        "DepInlineNew.deadOnInlineNew",
+        "DepCtorNew.deadOnCtorNew",
+        "DepIface.deadOnDepIface",
+    ] {
+        assert!(
+            unused.contains(&control.to_string()),
+            "{control} has no call site and must stay flagged (no blanket over-credit), \
+             found: {unused:?}"
+        );
+    }
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -773,7 +773,13 @@ use crate::MemberKind;
 /// (`{ a, ...rest }`, a computed key) carries the `FactoryFnWholeObject` fact. A warm
 /// 229 cache carries neither, leaving every member of a destructured or chained
 /// factory result falsely reported as unused.
-pub(super) const CACHE_VERSION: u32 = 230;
+///
+/// Bumped to 231 so `#`-private field receivers (`this.#dep.m()`) record the
+/// binding-key + `member_accesses` pair public fields already produce. A warm
+/// 230 cache lacks those private-field accesses and would report a member
+/// reached only through a private DI field as `unused-class-member`
+/// cross-module (issue #1821).
+pub(super) const CACHE_VERSION: u32 = 231;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -4022,6 +4022,119 @@ fn this_field_builtin_constructor_not_tracked() {
 }
 
 #[test]
+fn private_field_inline_new_maps_member_access() {
+    // Issue #1821: `readonly #dep = new Dep()` + `this.#dep.m()` must record the
+    // same class-qualified access a public `dep = new Dep()` produces.
+    let info = parse(
+        r"
+            import { DepInline } from './dep';
+            class Consumer {
+                readonly #dep = new DepInline();
+                run() { this.#dep.inlineM(); }
+            }
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "DepInline" && a.member == "inlineM"),
+        "inline-new private field should map this.#dep.inlineM() to DepInline.inlineM, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn private_field_ctor_new_assignment_maps_member_access() {
+    // Issue #1821 (Fix A3): a bare `#dep` field assigned `this.#dep = new Dep()`
+    // in the constructor must reach the instance-binding propagation, so the
+    // access resolves even with no field type annotation.
+    let info = parse(
+        r"
+            import { DepCtorNew } from './dep';
+            class Consumer {
+                #dep;
+                constructor() { this.#dep = new DepCtorNew(); }
+                run() { this.#dep.ctorNewM(); }
+            }
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "DepCtorNew" && a.member == "ctorNewM"),
+        "ctor `this.#dep = new Dep()` should map this.#dep.ctorNewM() to DepCtorNew.ctorNewM, \
+         found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn private_field_interface_typed_maps_to_interface_name() {
+    // Issue #1821 (Fix A2 typed arm): `#dep: IDep` records `this.#dep -> IDep`,
+    // so the extract-time access resolves to the interface name (the analyze
+    // layer then credits every implementer through interface heritage).
+    let info = parse(
+        r"
+            import { IDep } from './dep';
+            class Consumer {
+                readonly #dep: IDep;
+                constructor(dep: IDep) { this.#dep = dep; }
+                run() { this.#dep.ifaceM(); }
+            }
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "IDep" && a.member == "ifaceM"),
+        "interface-typed private field should map this.#dep.ifaceM() to IDep.ifaceM, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn private_field_readonly_new_maps_member_access() {
+    // Issue #1821 (Fix A2 inline-new arm, `readonly` variant): the `readonly`
+    // modifier must not change the binding-key derivation.
+    let info = parse(
+        r"
+            import { DepReadonly } from './dep';
+            class Consumer {
+                readonly #dep = new DepReadonly();
+                run() { this.#dep.roM(); }
+            }
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "DepReadonly" && a.member == "roM"),
+        "readonly private field should map this.#dep.roM() to DepReadonly.roM, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn private_field_without_member_call_records_no_access() {
+    // Issue #1821 negative control: a private DI field with no `this.#dep.m()`
+    // call site records the binding but never fabricates a member access.
+    let info = parse(
+        r"
+            import { DepUnused } from './dep';
+            class Consumer {
+                readonly #dep = new DepUnused();
+                run() { return 1; }
+            }
+        ",
+    );
+    assert!(
+        !info.member_accesses.iter().any(|a| a.object == "DepUnused"),
+        "private field with no member call must not record a DepUnused access, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
 fn module_exports_object_extracts_keys() {
     let info = parse("module.exports = { foo: 1, bar: 2 };");
     assert!(info.has_cjs_exports);

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -1601,36 +1601,40 @@ impl<'a> ModuleInfoExtractor {
         }
     }
 
-    /// Handle `this.member = ...` assignments: record the member access and
-    /// propagate the instance-binding target name from a `new Class()` RHS, an
-    /// identifier bound to a known class, and nested binding targets.
+    /// Handle `this.member = ...` / `this.#member = ...` assignments: record the
+    /// member access and propagate the instance-binding target name from a
+    /// `new Class()` RHS, an identifier bound to a known class, and nested
+    /// binding targets. `member_name` is the property spelling (`dep` for a
+    /// public field, `#dep` for a `#`-private field, issue #1821), so the
+    /// recorded key is `this.<member_name>` and matches the receiver key
+    /// `static_member_object_name` produces for the same field.
     fn handle_this_member_assignment(
         &mut self,
-        member: &StaticMemberExpression<'a>,
+        member_name: &str,
         expr: &AssignmentExpression<'a>,
     ) {
         self.member_accesses.push(MemberAccess {
             object: "this".to_string(),
-            member: member.property.name.to_string(),
+            member: member_name.to_string(),
         });
         if let Expression::NewExpression(new_expr) = &expr.right
             && let Expression::Identifier(callee) = &new_expr.callee
             && !super::helpers::is_builtin_constructor(callee.name.as_str())
         {
             self.insert_class_binding_target(
-                format!("this.{}", member.property.name),
+                format!("this.{member_name}"),
                 callee.name.to_string(),
             );
         } else if let Expression::Identifier(ident) = &expr.right
             && let Some(target_name) = self.binding_target_names.get(ident.name.as_str()).cloned()
         {
             self.binding_target_names
-                .insert(format!("this.{}", member.property.name), target_name);
+                .insert(format!("this.{member_name}"), target_name);
         }
         if let Expression::Identifier(ident) = &expr.right {
             self.copy_nested_binding_targets(
                 ident.name.as_str(),
-                format!("this.{}", member.property.name).as_str(),
+                format!("this.{member_name}").as_str(),
             );
         }
     }
@@ -1848,7 +1852,20 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
-        if let Some(name) = prop.key.static_name() {
+        // Effective member key: a static name (`dep`) or a `#`-private field
+        // (`#dep`, spelled with the leading `#` so the binding key is
+        // `this.#dep`). Private-field receivers must record the same
+        // binding-key + member-access pair public fields do, so `this.#dep.m()`
+        // credits the imported class member cross-module (issue #1821).
+        let member_key = prop.key.static_name().map_or_else(
+            || match &prop.key {
+                PropertyKey::PrivateIdentifier(id) => Some(format!("#{}", id.name)),
+                _ => None,
+            },
+            |name| Some(name.to_string()),
+        );
+
+        if let Some(name) = member_key.as_deref() {
             if let Some(type_annotation) = prop.type_annotation.as_deref() {
                 self.record_typed_binding(format!("this.{name}").as_str(), type_annotation);
 
@@ -1883,10 +1900,15 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     self.insert_class_binding_target(call_key, query.type_arg);
                 }
             }
+        }
 
-            if let Some(value) = prop.value.as_ref() {
-                self.capture_hardcoded_secret_literal_sink(name.as_ref(), value, prop.span);
-            }
+        // The hardcoded-secret sink stays gated on `static_name()` only: a
+        // `#`-private field is never a security-detector secret target, so
+        // widening the sink here is out of scope for the DI-credit fix.
+        if let Some(name) = prop.key.static_name()
+            && let Some(value) = prop.value.as_ref()
+        {
+            self.capture_hardcoded_secret_literal_sink(name.as_ref(), value, prop.span);
         }
 
         walk::walk_property_definition(self, prop);
@@ -2426,8 +2448,17 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if let AssignmentTarget::StaticMemberExpression(member) = &expr.left {
             self.handle_cjs_member_export(member, expr);
             if matches!(member.object, Expression::ThisExpression(_)) {
-                self.handle_this_member_assignment(member, expr);
+                self.handle_this_member_assignment(member.property.name.as_str(), expr);
             }
+        }
+        // `this.#dep = new Dep()` / `this.#dep = dep`: oxc routes a `#`-private
+        // assignment target through the `PrivateFieldExpression` variant, so it
+        // needs its own arm to reach the same instance-binding propagation as a
+        // public `this.dep = ...` assignment (issue #1821).
+        if let AssignmentTarget::PrivateFieldExpression(member) = &expr.left
+            && matches!(member.object, Expression::ThisExpression(_))
+        {
+            self.handle_this_member_assignment(format!("#{}", member.field.name).as_str(), expr);
         }
         self.capture_member_assign_sink(expr);
         walk::walk_assignment_expression(self, expr);
@@ -3218,6 +3249,15 @@ fn static_member_object_name(expr: &Expression<'_>) -> Option<String> {
             "{}.{}",
             static_member_object_name(&member.object)?,
             member.property.name
+        )),
+        // `#`-private field receiver (`this.#dep`): oxc's `PrivateIdentifier.name`
+        // excludes the leading `#`, so spell the key `this.#dep` to match the
+        // binding key `visit_property_definition` / the assignment arms record
+        // for private fields (issue #1821).
+        Expression::PrivateFieldExpression(member) => Some(format!(
+            "{}.#{}",
+            static_member_object_name(&member.object)?,
+            member.field.name
         )),
         Expression::CallExpression(call) if call.arguments.is_empty() => {
             Some(format!("{}()", static_member_object_name(&call.callee)?))

--- a/tests/fixtures/issue-1821-private-field-di/package.json
+++ b/tests/fixtures/issue-1821-private-field-di/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "issue-1821-private-field-di",
+  "private": true,
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/issue-1821-private-field-di/src/consumer-ctor-new.ts
+++ b/tests/fixtures/issue-1821-private-field-di/src/consumer-ctor-new.ts
@@ -1,0 +1,15 @@
+import { DepCtorNew } from './dep';
+
+// Bare `#`-private field assigned `this.#dep = new Dep()` in the constructor
+// (Fix A3 assignment arm; no field type annotation).
+export class ConsumerCtorNew {
+  #dep;
+
+  constructor() {
+    this.#dep = new DepCtorNew();
+  }
+
+  run(): void {
+    this.#dep.ctorNewM();
+  }
+}

--- a/tests/fixtures/issue-1821-private-field-di/src/consumer-iface.ts
+++ b/tests/fixtures/issue-1821-private-field-di/src/consumer-iface.ts
@@ -1,0 +1,15 @@
+import type { IDep } from './dep';
+
+// Interface-typed `#`-private field (Fix A2 typed arm); the analyze layer
+// credits every implementer of IDep through interface heritage.
+export class ConsumerIface {
+  readonly #svc: IDep;
+
+  constructor(svc: IDep) {
+    this.#svc = svc;
+  }
+
+  run(): void {
+    this.#svc.ifaceM();
+  }
+}

--- a/tests/fixtures/issue-1821-private-field-di/src/consumer-inline.ts
+++ b/tests/fixtures/issue-1821-private-field-di/src/consumer-inline.ts
@@ -1,0 +1,10 @@
+import { DepInlineNew } from './dep';
+
+// Inline-new `#`-private field (Fix A2 inline-new arm).
+export class ConsumerInline {
+  readonly #dep = new DepInlineNew();
+
+  run(): void {
+    this.#dep.inlineM();
+  }
+}

--- a/tests/fixtures/issue-1821-private-field-di/src/dep.ts
+++ b/tests/fixtures/issue-1821-private-field-di/src/dep.ts
@@ -1,0 +1,18 @@
+export class DepInlineNew {
+  inlineM(): void {}
+  deadOnInlineNew(): void {}
+}
+
+export class DepCtorNew {
+  ctorNewM(): void {}
+  deadOnCtorNew(): void {}
+}
+
+export interface IDep {
+  ifaceM(): void;
+}
+
+export class DepIface implements IDep {
+  ifaceM(): void {}
+  deadOnDepIface(): void {}
+}

--- a/tests/fixtures/issue-1821-private-field-di/src/index.ts
+++ b/tests/fixtures/issue-1821-private-field-di/src/index.ts
@@ -1,0 +1,8 @@
+import { DepIface } from './dep';
+import { ConsumerInline } from './consumer-inline';
+import { ConsumerCtorNew } from './consumer-ctor-new';
+import { ConsumerIface } from './consumer-iface';
+
+new ConsumerInline().run();
+new ConsumerCtorNew().run();
+new ConsumerIface(new DepIface()).run();


### PR DESCRIPTION
Members consumed only through a `#`-private class field were never credited cross-module: `static_member_object_name` had no `PrivateFieldExpression` arm, `visit_property_definition` gated on `static_name()` (None for private identifiers), and `visit_assignment_expression` missed `AssignmentTarget::PrivateFieldExpression`. All three arms now produce the same binding-key plus member-access pair public fields already produce, so `this.#dep = new Dep()`, `#dep: Dep`, `#dep = new Dep()`, and `#dep: IDep` receivers credit the target class members.

Additive-credit only: it can suppress findings, never create them. The hardcoded-secret sink stays gated on `static_name()` so security detection is untouched. CACHE_VERSION 230 -> 231.

Covers the private-field receiver gap in #1821 (the dominant reported case). The same-file field-name collision (the issue's `privParam` row and Gap 2) is a separate module-flat `binding_target_names` bug, tracked as a follow-up in that issue.

Tests: extract unit tests per shape plus a cross-module integration fixture (`issue-1821-private-field-di`) with genuinely-dead control members asserted to stay flagged.