### PR TITLE
fix(extract): credit Playwright POM methods through mergeTests-wrapping helpers

### DIFF
--- a/crates/core/tests/integration_test/member_detection.rs
+++ b/crates/core/tests/integration_test/member_detection.rs
@@ -368,6 +368,67 @@ fn playwright_factory_wrapping_fixture_const_credits_pom_methods() {
 }
 
 #[test]
+fn playwright_mergetests_wrapping_helper_credits_pom_methods() {
+    // Issue #1795: a helper exported as a function returning `mergeTests(...)` of
+    // two function-wrapped fixtures whose bases are IMPORTED consts, called as
+    // `checkoutTest()(...)`. The chain checkoutTest -> billingTest/ordersUiTest
+    // -> billingBaseFixture/ordersBaseFixture must credit the POM methods used
+    // only through it. Also pins the const-form mergeTests call-arg variant
+    // (fix b) and the imported `.extend` wrap consumed directly (fix a2).
+    let root = fixture_path("issue-1795-playwright-mergetests-helper");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_class_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.member.parent_name, m.member.member_name))
+        .collect();
+
+    // Main repro: mergeTests-in-helper (fix a) + local-var return (fix c) +
+    // imported base `.extend` alias fact (fix a2), consumed as checkoutTest()().
+    assert!(
+        !unused_class_members.contains(&"OrdersPage.placeOrder".to_string()),
+        "OrdersPage.placeOrder should be credited through checkoutTest()() (mergeTests helper), found: {unused_class_members:?}"
+    );
+    assert!(
+        !unused_class_members.contains(&"OrdersPage.cancelOrder".to_string()),
+        "OrdersPage.cancelOrder should be credited through checkoutTest()() (mergeTests helper), found: {unused_class_members:?}"
+    );
+    assert!(
+        !unused_class_members.contains(&"BillingPage.openInvoice".to_string()),
+        "BillingPage.openInvoice should be credited through checkoutTest()() (mergeTests helper), found: {unused_class_members:?}"
+    );
+
+    // Fix b: `const promoMerged = mergeTests(promoTest())` (call-expression arg),
+    // consumed directly as `promoMerged(title, cb)`.
+    assert!(
+        !unused_class_members.contains(&"PromoPage.applyPromo".to_string()),
+        "PromoPage.applyPromo should be credited through the const-form mergeTests call-arg wrapper (fix b), found: {unused_class_members:?}"
+    );
+
+    // Fix a2: a helper wrapping an IMPORTED base const via `.extend({})`,
+    // consumed directly as `shippingTest()(title, cb)` (no mergeTests).
+    assert!(
+        !unused_class_members.contains(&"ShippingPage.trackShipment".to_string()),
+        "ShippingPage.trackShipment should be credited through the imported `.extend` wrap consumed directly (fix a2), found: {unused_class_members:?}"
+    );
+
+    // Positive controls: POM methods reached by NO fixture path must still report.
+    for genuinely_unused in [
+        "OrdersPage.unusedOrderOnly",
+        "BillingPage.unusedBillingOnly",
+        "PromoPage.unusedPromoOnly",
+        "ShippingPage.unusedShippingOnly",
+    ] {
+        assert!(
+            unused_class_members.contains(&genuinely_unused.to_string()),
+            "genuinely unused POM method {genuinely_unused} should still be reported, found: {unused_class_members:?}"
+        );
+    }
+}
+
+#[test]
 fn playwright_helper_function_with_local_setup_fixture_pom_methods_are_credited() {
     let root = fixture_path("issue-586-playwright-helper-local-setup");
     let config = create_config(root);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -779,7 +779,13 @@ use crate::MemberKind;
 /// 230 cache lacks those private-field accesses and would report a member
 /// reached only through a private DI field as `unused-class-member`
 /// cross-module (issue #1821).
-pub(super) const CACHE_VERSION: u32 = 231;
+///
+/// Bumped to 232 for issue #1795: a Playwright helper returning
+/// `mergeTests(...)` (or wrapping an IMPORTED `<base>.extend(...)` const, or
+/// returning a locally-bound `const merge = mergeTests(...)`) now emits
+/// analyze-time fixture-alias facts a warm 231 cache lacks, leaving POM methods
+/// used only through such a helper falsely reported as `unused-class-member`.
+pub(super) const CACHE_VERSION: u32 = 232;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -3396,6 +3396,179 @@ fn non_playwright_merge_tests_does_not_record_fixture_aliases() {
 }
 
 #[test]
+fn playwright_helper_returning_merge_tests_records_arg_base_aliases() {
+    // Issue #1795: a helper returning `mergeTests(a(), b())` aliases the wrapped
+    // factory calls' bare identifier callees, so cross-file expansion inherits
+    // each wrapped fixture's definitions.
+    let info = parse(
+        r"
+            import { mergeTests } from '@playwright/test';
+            import { billingTest } from './billing-fixture';
+            import { ordersUiTest } from './orders-fixture';
+
+            export function checkoutTest() {
+                return mergeTests(billingTest(), ordersUiTest());
+            }
+        ",
+    );
+
+    assert!(
+        has_playwright_fixture_alias_fact(&info, "checkoutTest", "billingTest"),
+        "mergeTests helper should alias the billingTest() call-arg base, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        has_playwright_fixture_alias_fact(&info, "checkoutTest", "ordersUiTest"),
+        "mergeTests helper should alias the ordersUiTest() call-arg base, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
+fn playwright_helper_local_var_return_merge_tests_records_aliases() {
+    // Issue #1795 (fix c): a `const merge = mergeTests(...); return merge;` body
+    // is followed one hop to the const declarator, then aliased like a direct
+    // return.
+    let info = parse(
+        r"
+            import { mergeTests } from '@playwright/test';
+            import { billingTest } from './billing-fixture';
+            import { ordersUiTest } from './orders-fixture';
+
+            export function checkoutTest() {
+                const merge = mergeTests(billingTest(), ordersUiTest());
+                return merge;
+            }
+        ",
+    );
+
+    assert!(
+        has_playwright_fixture_alias_fact(&info, "checkoutTest", "billingTest"),
+        "local-var-return mergeTests helper should alias billingTest, found: {:?}",
+        info.semantic_facts
+    );
+    assert!(
+        has_playwright_fixture_alias_fact(&info, "checkoutTest", "ordersUiTest"),
+        "local-var-return mergeTests helper should alias ordersUiTest, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
+fn playwright_helper_wrapping_imported_base_records_alias_fact() {
+    // Issue #1795 (fix a2): a helper wrapping an IMPORTED base const via
+    // `.extend({})` emits an analyze-time alias fact so the imported base
+    // resolves cross-file.
+    let info = parse(
+        r"
+            import { shippingBaseFixture } from './shipping-base-fixture';
+
+            export function shippingTest() {
+                return shippingBaseFixture.extend({});
+            }
+        ",
+    );
+
+    assert!(
+        has_playwright_fixture_alias_fact(&info, "shippingTest", "shippingBaseFixture"),
+        "helper wrapping an imported `.extend` base should emit a cross-file alias fact, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
+fn playwright_helper_wrapping_raw_test_base_records_no_alias_fact() {
+    // The raw `test` import base carries its fixtures via the type argument, not
+    // an alias; a2 must NOT emit an alias fact for it.
+    let info = parse(
+        r"
+            import { test as base } from '@playwright/test';
+
+            export function rawTest() {
+                return base.extend<{ extra: string }>({});
+            }
+        ",
+    );
+
+    assert!(
+        !has_playwright_fixture_alias_fact(&info, "rawTest", "base"),
+        "the raw `test` base must not emit an alias fact, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
+fn playwright_const_merge_tests_with_call_args_records_aliases() {
+    // Issue #1795 (fix b): `export const x = mergeTests(fnA())` aliases the
+    // call-expression argument's bare identifier callee.
+    let info = parse(
+        r"
+            import { mergeTests } from '@playwright/test';
+            import { promoTest } from './promo-fixture';
+
+            export const promoMerged = mergeTests(promoTest());
+        ",
+    );
+
+    assert!(
+        has_playwright_fixture_alias_fact(&info, "promoMerged", "promoTest"),
+        "const-form mergeTests should alias the promoTest() call-arg base, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
+fn playwright_user_local_merge_tests_helper_records_no_arg_aliases() {
+    // Negative: a user-local `mergeTests` function (not the @playwright/test
+    // import) must not alias its arguments.
+    let info = parse(
+        r"
+            import { billingTest } from './billing-fixture';
+
+            function mergeTests<T>(a: T): T {
+                return a;
+            }
+
+            export function checkoutTest() {
+                return mergeTests(billingTest());
+            }
+        ",
+    );
+
+    assert!(
+        !has_playwright_fixture_alias_fact(&info, "checkoutTest", "billingTest"),
+        "a user-local mergeTests must not alias its call-arg base, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
+fn playwright_helper_let_return_ident_is_not_followed() {
+    // Negative (fix c guard): a `let`-declared return identifier must not be
+    // followed, so the exported helper never inherits the wrapped fixtures. The
+    // inner `let merge = mergeTests(...)` still records an inert alias keyed on
+    // the local binding `merge` (never used as a test callee), but the exported
+    // `checkoutTest` must carry no alias fact.
+    let info = parse(
+        r"
+            import { mergeTests } from '@playwright/test';
+            import { billingTest } from './billing-fixture';
+
+            export function checkoutTest() {
+                let merge = mergeTests(billingTest());
+                return merge;
+            }
+        ",
+    );
+
+    assert!(
+        !has_playwright_fixture_alias_fact(&info, "checkoutTest", "billingTest"),
+        "a let-declared return ident must not be followed to alias the exported helper, found: {:?}",
+        info.semantic_facts
+    );
+}
+
+#[test]
 fn playwright_test_callback_records_fixture_member_uses() {
     let info = parse(
         r"

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -879,17 +879,54 @@ pub(super) fn playwright_test_callee_name(expr: &Expression<'_>) -> Option<Strin
     }
 }
 
-/// Find the call expression returned by a function body.
+/// Find the call expression returned by a function body. A direct
+/// `return <call>` yields the call; a `return <ident>` is followed one hop to a
+/// same-body `const <ident> = <call>` declarator, so a helper whose final
+/// statement returns a locally-bound `mergeTests(...)` / `<base>.extend(...)`
+/// result is captured the same as the direct-return form (issue #1795).
 pub(super) fn extract_function_body_final_return_call<'a, 'b>(
     body: &'b oxc_ast::ast::FunctionBody<'a>,
 ) -> Option<&'b CallExpression<'a>> {
     let Statement::ReturnStatement(ret) = body.statements.last()? else {
         return None;
     };
-    let Expression::CallExpression(call) = ret.argument.as_ref()? else {
-        return None;
-    };
-    Some(call.as_ref())
+    match ret.argument.as_ref()? {
+        Expression::CallExpression(call) => Some(call.as_ref()),
+        Expression::Identifier(ident) => {
+            find_returned_const_declarator_call(body, ident.name.as_str())
+        }
+        _ => None,
+    }
+}
+
+/// Follow a `return <ident>` to the same-body `const <ident> = <call>`
+/// initializer. Only `const` declarators are considered so a reassigned `let`
+/// binding is never followed; the last matching declaration wins (issue #1795).
+fn find_returned_const_declarator_call<'a, 'b>(
+    body: &'b oxc_ast::ast::FunctionBody<'a>,
+    ident_name: &str,
+) -> Option<&'b CallExpression<'a>> {
+    let mut found = None;
+    for stmt in &body.statements {
+        let Statement::VariableDeclaration(decl) = stmt else {
+            continue;
+        };
+        if decl.kind != VariableDeclarationKind::Const {
+            continue;
+        }
+        for declarator in &decl.declarations {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                continue;
+            };
+            if id.name != ident_name {
+                continue;
+            }
+            if let Some(Expression::CallExpression(call)) = declarator.init.as_ref() {
+                found = Some(call.as_ref());
+            }
+        }
+    }
+    found
 }
 
 /// Find the call expression used as an arrow function body.

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -137,10 +137,7 @@ impl ModuleInfoExtractor {
         let mut base_names: Vec<String> = call
             .arguments
             .iter()
-            .filter_map(|argument| match argument {
-                Argument::Identifier(ident) => Some(ident.name.to_string()),
-                _ => None,
-            })
+            .filter_map(playwright_merge_argument_base_name)
             .collect();
         base_names.sort();
         base_names.dedup();
@@ -171,6 +168,18 @@ impl ModuleInfoExtractor {
             self.pending_playwright_factory_aliases
                 .push((test_name.to_string(), base_name.clone()));
 
+            // An IMPORTED base const (`billingBaseFixture.extend({})` where
+            // `billingBaseFixture` comes from a sibling file) cannot resolve
+            // through the same-module `resolve_playwright_factory_call_definitions`
+            // pass, so ALSO emit an analyze-time alias fact for any base that is
+            // not the raw `@playwright/test` `test` import (mirror the gate in
+            // `record_playwright_wrapper_aliases`); the #1210 cross-file
+            // expansion then resolves the imported base to its fixture
+            // definitions. The raw `test` base no-ops. Issue #1795.
+            if !self.is_named_import_from(base_name.as_str(), "@playwright/test", "test") {
+                self.record_playwright_fixture_alias(test_name, &base_name);
+            }
+
             let Some(type_arguments) = call.type_arguments.as_deref() else {
                 return;
             };
@@ -189,6 +198,27 @@ impl ModuleInfoExtractor {
                     base_name,
                     type_bindings: bindings,
                 });
+        } else if let Expression::Identifier(callee) = &call.callee
+            && self.is_named_import_from(callee.name.as_str(), "@playwright/test", "mergeTests")
+        {
+            // A helper returning `mergeTests(billingTest(), ordersUiTest())`
+            // (issue #1795): emit an analyze-time alias fact per argument base so
+            // each wrapped fixture's definitions are inherited cross-file via the
+            // #1210 expansion, and push the same pairs for same-file helper
+            // inheritance. The import gate (handles `mergeTests as merge`) keeps a
+            // user-local `mergeTests` function inert.
+            let mut base_names: Vec<String> = call
+                .arguments
+                .iter()
+                .filter_map(playwright_merge_argument_base_name)
+                .collect();
+            base_names.sort();
+            base_names.dedup();
+            for base_name in base_names {
+                self.record_playwright_fixture_alias(test_name, &base_name);
+                self.pending_playwright_factory_aliases
+                    .push((test_name.to_string(), base_name));
+            }
         } else if let Expression::Identifier(ident) = &call.callee {
             self.pending_playwright_factory_aliases
                 .push((test_name.to_string(), ident.name.to_string()));
@@ -219,5 +249,20 @@ impl ModuleInfoExtractor {
                 is_speculative: true,
             });
         }
+    }
+}
+
+/// The base test name a `mergeTests(...)` argument contributes: a bare fixture
+/// identifier (`mergeTests(testA, testB)`, issue #1210) or a factory call with a
+/// bare identifier callee (`mergeTests(billingTest(), ordersUiTest())`, issue
+/// #1795). Other argument shapes (spreads, member-expression callees) abstain.
+fn playwright_merge_argument_base_name(argument: &Argument<'_>) -> Option<String> {
+    match argument {
+        Argument::Identifier(ident) => Some(ident.name.to_string()),
+        Argument::CallExpression(call) => match &call.callee {
+            Expression::Identifier(callee) => Some(callee.name.to_string()),
+            _ => None,
+        },
+        _ => None,
     }
 }

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/package.json
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "issue-1795-playwright-mergetests-helper",
+  "devDependencies": {
+    "@playwright/test": "^1.0.0"
+  }
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/billing/billing-base-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/billing/billing-base-fixture.ts
@@ -1,0 +1,12 @@
+import { test as base } from '@playwright/test';
+import { BillingPage } from '../../pages/billing-page';
+
+export type BillingFixtures = {
+  billing: BillingPage;
+};
+
+export const billingBaseFixture = base.extend<BillingFixtures>({
+  billing: async ({}, use) => {
+    await use(new BillingPage());
+  },
+});

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/billing/billing-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/billing/billing-fixture.ts
@@ -1,0 +1,6 @@
+import { billingBaseFixture } from './billing-base-fixture';
+
+// Function wrapping an IMPORTED base const via `.extend({})` (no type argument).
+export function billingTest() {
+  return billingBaseFixture.extend({});
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/checkout/checkout-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/checkout/checkout-fixture.ts
@@ -1,0 +1,12 @@
+import { mergeTests } from '@playwright/test';
+import { billingTest } from '../billing/billing-fixture';
+import { ordersUiTest } from '../orders/orders-fixture';
+
+// Function returning a locally-bound `mergeTests(...)` of two function-wrapped
+// fixtures. Exercises the mergeTests-in-helper arm (fix a), the return-ident
+// follow to a `const` declarator (fix c), and the imported `.extend` base alias
+// fact (fix a2). Issue #1795.
+export function checkoutTest() {
+  const merge = mergeTests(billingTest(), ordersUiTest());
+  return merge;
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/orders/orders-base-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/orders/orders-base-fixture.ts
@@ -1,0 +1,18 @@
+import { test as base } from '@playwright/test';
+import { OrdersPage } from '../../pages/orders-page';
+
+export type OrdersUi = {
+  invoke: {
+    orders: OrdersPage;
+  };
+};
+
+export type OrdersUiFixtures = {
+  ordersUi: OrdersUi;
+};
+
+export const ordersBaseFixture = base.extend<OrdersUiFixtures>({
+  ordersUi: async ({}, use) => {
+    await use({ invoke: { orders: new OrdersPage() } });
+  },
+});

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/orders/orders-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/orders/orders-fixture.ts
@@ -1,0 +1,6 @@
+import { ordersBaseFixture } from './orders-base-fixture';
+
+// Function wrapping an IMPORTED base const via `.extend({})` (no type argument).
+export function ordersUiTest() {
+  return ordersBaseFixture.extend({});
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/promo/promo-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/promo/promo-fixture.ts
@@ -1,0 +1,16 @@
+import { test as base } from '@playwright/test';
+import { PromoPage } from '../../pages/promo-page';
+
+export type PromoFixtures = {
+  promo: PromoPage;
+};
+
+// Helper returning a typed `base.extend<T>(...)` directly (issue #491 shape),
+// used as the call-expression argument of a `const` mergeTests below.
+export function promoTest() {
+  return base.extend<PromoFixtures>({
+    promo: async ({}, use) => {
+      await use(new PromoPage());
+    },
+  });
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/promo/promo-merged-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/promo/promo-merged-fixture.ts
@@ -1,0 +1,7 @@
+import { mergeTests } from '@playwright/test';
+import { promoTest } from './promo-fixture';
+
+// `const` mergeTests whose argument is a factory CALL (`promoTest()`), consumed
+// directly as `promoMerged(title, cb)`. Exercises the widened const-form
+// wrapper-argument filter (fix b). Issue #1795.
+export const promoMerged = mergeTests(promoTest());

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/shipping/shipping-base-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/shipping/shipping-base-fixture.ts
@@ -1,0 +1,12 @@
+import { test as base } from '@playwright/test';
+import { ShippingPage } from '../../pages/shipping-page';
+
+export type ShippingFixtures = {
+  shipping: ShippingPage;
+};
+
+export const shippingBaseFixture = base.extend<ShippingFixtures>({
+  shipping: async ({}, use) => {
+    await use(new ShippingPage());
+  },
+});

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/shipping/shipping-fixture.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/fixtures/shipping/shipping-fixture.ts
@@ -1,0 +1,8 @@
+import { shippingBaseFixture } from './shipping-base-fixture';
+
+// Function wrapping an IMPORTED base const via `.extend({})`, consumed directly
+// as `shippingTest()(title, cb)` (no mergeTests). Exercises the imported-base
+// `.extend` alias fact in isolation (fix a2, the row-2 multi-file correction).
+export function shippingTest() {
+  return shippingBaseFixture.extend({});
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/billing-page.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/billing-page.ts
@@ -1,0 +1,9 @@
+export class BillingPage {
+  async openInvoice(invoiceId: string): Promise<void> {
+    return void invoiceId;
+  }
+
+  async unusedBillingOnly(): Promise<void> {
+    return;
+  }
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/orders-page.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/orders-page.ts
@@ -1,0 +1,13 @@
+export class OrdersPage {
+  async placeOrder(orderId: string): Promise<void> {
+    return void orderId;
+  }
+
+  async cancelOrder(orderId: string): Promise<void> {
+    return void orderId;
+  }
+
+  async unusedOrderOnly(): Promise<void> {
+    return;
+  }
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/promo-page.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/promo-page.ts
@@ -1,0 +1,9 @@
+export class PromoPage {
+  async applyPromo(code: string): Promise<void> {
+    return void code;
+  }
+
+  async unusedPromoOnly(): Promise<void> {
+    return;
+  }
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/shipping-page.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/src/pages/shipping-page.ts
@@ -1,0 +1,9 @@
+export class ShippingPage {
+  async trackShipment(shipmentId: string): Promise<void> {
+    return void shipmentId;
+  }
+
+  async unusedShippingOnly(): Promise<void> {
+    return;
+  }
+}

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/tests/checkout.spec.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/tests/checkout.spec.ts
@@ -1,0 +1,10 @@
+import { checkoutTest } from '../src/fixtures/checkout/checkout-fixture';
+
+checkoutTest()(
+  'places and cancels an order, opens an invoice',
+  async ({ ordersUi, billing }) => {
+    await ordersUi.invoke.orders.placeOrder('SYN-001');
+    await ordersUi.invoke.orders.cancelOrder('SYN-001');
+    await billing.openInvoice('SYN-INV-001');
+  },
+);

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/tests/promo.spec.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/tests/promo.spec.ts
@@ -1,0 +1,5 @@
+import { promoMerged } from '../src/fixtures/promo/promo-merged-fixture';
+
+promoMerged('applies a promo code', async ({ promo }) => {
+  await promo.applyPromo('SYN-PROMO');
+});

--- a/tests/fixtures/issue-1795-playwright-mergetests-helper/tests/shipping.spec.ts
+++ b/tests/fixtures/issue-1795-playwright-mergetests-helper/tests/shipping.spec.ts
@@ -1,0 +1,5 @@
+import { shippingTest } from '../src/fixtures/shipping/shipping-fixture';
+
+shippingTest()('tracks a shipment', async ({ shipping }) => {
+  await shipping.trackShipment('SYN-SHIP-001');
+});


### PR DESCRIPTION
Fixture-definition facts never reached a helper function that returns `mergeTests(...)`: the helper capture required a literal `return <call>` as the last statement, the generic identifier-callee arm recorded only a useless extract-local alias to the name `mergeTests`, and a wrapped `<base>.extend(...)` emitted no analyze-time alias fact, so imported base consts never resolved through the cross-file expansion.

The helper capture now (1) emits per-argument `PlaywrightFixtureAlias` facts for `mergeTests` returns (identifier args and call args with bare identifier callees), gated on `@playwright/test` import provenance, (2) emits an analyze-time alias fact in the `.extend` arm so imported base consts resolve cross-file, (3) follows a final `return <ident>` one hop to a same-body const declarator, and (4) widens the const-form `mergeTests` argument filter to call expressions. All additions are additive-credit only. CACHE_VERSION 231 -> 232.

Two corrections to the issue's isolation table, now pinned by fixture variants: a function returning `base.extend` only resolved same-file before this change, and const-form `mergeTests` only resolved with bare identifier args.

Fixes #1795

Tests: extract unit tests per alias shape plus negatives (user-local `mergeTests`, `let`-bound return ident), and an integration fixture mirroring the 8-file repro with four genuinely-unused control members asserted to stay flagged. End-to-end validated with the built binary against the fixture.