### PR TITLE
fix(extract): credit iteration bindings over array-typed params and Promise.all results

### DIFF
--- a/crates/core/tests/integration_test/iteration_binding_element_types.rs
+++ b/crates/core/tests/integration_test/iteration_binding_element_types.rs
@@ -37,6 +37,34 @@ fn js_iteration_bindings_credit_class_member_accesses() {
     );
 }
 
+/// Issue #1793: the reporter's entry-script repro (Promise.all + for-of over a
+/// class-array), with DISTINCT binding names for the for-of variable and the map
+/// callback param so each part is individually load-bearing. Part 1 (array-typed
+/// `resetSchemas` param + for-of on `dbReset`) credits `resetSchema`; Part 2
+/// (Promise.all element inference + `.map` callback on `dbMapped`) credits
+/// `writeSchemaData` / `writeGraphDiagram` / `writeSchemaTyped`. `deadMethod`
+/// stays flagged, proving the detector still fires.
+#[test]
+fn entry_script_iteration_credits_writer_methods_issue_1793() {
+    let unused = unused_members("issue-1793-entry-script-iteration");
+
+    for member in [
+        "resetSchema",
+        "writeSchemaData",
+        "writeGraphDiagram",
+        "writeSchemaTyped",
+    ] {
+        assert!(
+            !unused.contains(&format!("SyntheticSchemaWriter.{member}")),
+            "SyntheticSchemaWriter.{member} is called through the entry-script iteration and must be credited, found: {unused:?}"
+        );
+    }
+    assert!(
+        unused.contains(&"SyntheticSchemaWriter.deadMethod".to_string()),
+        "SyntheticSchemaWriter.deadMethod is never called and must still report, found: {unused:?}"
+    );
+}
+
 /// Family 1 (#1707 follow-up): a Svelte `{#each utils as util}` item typed to the
 /// element class credits member accesses on the item.
 #[test]

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -785,7 +785,13 @@ use crate::MemberKind;
 /// returning a locally-bound `const merge = mergeTests(...)`) now emits
 /// analyze-time fixture-alias facts a warm 231 cache lacks, leaving POM methods
 /// used only through such a helper falsely reported as `unused-class-member`.
-pub(super) const CACHE_VERSION: u32 = 232;
+///
+/// Bumped to 233 for issue #1793: an array-typed formal parameter
+/// (`items: Item[]`) and a `Promise.all(arr.map(cb))` result now type their
+/// iteration variable to the element class, so `for...of` / `.map` / `.forEach`
+/// member accesses on the item credit the class. Warm 232 caches lack the added
+/// `member_accesses`, leaving those methods falsely reported as unused.
+pub(super) const CACHE_VERSION: u32 = 233;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/member_access.rs
+++ b/crates/extract/src/tests/js_ts/member_access.rs
@@ -321,3 +321,162 @@ fn nested_plain_template_in_tagged_credits_to_string() {
         info.member_accesses,
     );
 }
+
+// Issue #1793: array-typed formal parameter iteration binding. The TOP-LEVEL
+// function shape is load-bearing: recording the element type from the function
+// declaration scope (not `visit_formal_parameter`) is required because the
+// function-body scoped frame is not yet pushed at param-visit time, so a
+// top-level function's params would otherwise be silently dropped.
+
+#[test]
+fn top_level_fn_array_param_for_of_credits_element_class_member() {
+    let info = parse_source(
+        "class Item { used() {} }\n\
+         function run(items: Item[]) {\n\
+           for (const item of items) {\n\
+             item.used();\n\
+           }\n\
+         }",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Item" && a.member == "used"),
+        "a for-of over an array-typed top-level fn param must credit Item.used; got {:?}",
+        info.member_accesses,
+    );
+}
+
+#[test]
+fn top_level_fn_array_param_map_callback_credits_element_class_member() {
+    let info = parse_source(
+        "class Item { used() {} }\n\
+         function run(items: Item[]) {\n\
+           items.forEach((item) => item.used());\n\
+         }",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Item" && a.member == "used"),
+        "a .forEach callback over an array-typed top-level fn param must credit Item.used; got {:?}",
+        info.member_accesses,
+    );
+}
+
+#[test]
+fn top_level_fn_builtin_array_param_records_no_class_binding() {
+    // `number[]` has a builtin element, so the loop variable must NOT bind to
+    // any class; `Item.used` must not appear.
+    let info = parse_source(
+        "class Item { used() {} }\n\
+         function run(items: number[]) {\n\
+           for (const item of items) {\n\
+             item.used();\n\
+           }\n\
+         }",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Item" && a.member == "used"),
+        "a number[] element must not bind the loop variable to a class; got {:?}",
+        info.member_accesses,
+    );
+}
+
+// Issue #1793: `Promise.all(arr.map(cb))` element inference.
+
+#[test]
+fn promise_all_map_credits_element_from_return_type_declared_after_consumer() {
+    // `makeThing` is declared AFTER `consume`, proving the pre-pass makes the
+    // inference declaration-order independent.
+    let info = parse_source(
+        "class Thing { greet() {} }\n\
+         async function consume() {\n\
+           const xs = await Promise.all(['a', 'b'].map(async (n) => makeThing(n)));\n\
+           xs.forEach((x) => x.greet());\n\
+         }\n\
+         async function makeThing(n: string): Promise<Thing> {\n\
+           return new Thing();\n\
+         }",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Thing" && a.member == "greet"),
+        "Promise.all(arr.map(async n => makeThing(n))) must type xs as Thing[] via makeThing's Promise<Thing> return; got {:?}",
+        info.member_accesses,
+    );
+}
+
+#[test]
+fn promise_all_settled_map_records_no_element_binding() {
+    let info = parse_source(
+        "class Thing { greet() {} }\n\
+         async function consume() {\n\
+           const xs = await Promise.allSettled(['a'].map(async (n) => makeThing(n)));\n\
+           xs.forEach((x) => x.greet());\n\
+         }\n\
+         async function makeThing(n: string): Promise<Thing> {\n\
+           return new Thing();\n\
+         }",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Thing" && a.member == "greet"),
+        "Promise.allSettled must not type xs (only `all` yields the resolved element array); got {:?}",
+        info.member_accesses,
+    );
+}
+
+#[test]
+fn promise_all_map_imported_callee_records_no_element_binding() {
+    // An imported callee has no local return type in the pre-pass map.
+    let info = parse_source(
+        "import { makeThing } from './factory';\n\
+         class Thing { greet() {} }\n\
+         async function consume() {\n\
+           const xs = await Promise.all(['a'].map(async (n) => makeThing(n)));\n\
+           xs.forEach((x) => x.greet());\n\
+         }",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Thing" && a.member == "greet"),
+        "an imported map-callback callee must not credit an element class; got {:?}",
+        info.member_accesses,
+    );
+}
+
+#[test]
+fn promise_all_map_multi_statement_callback_records_no_element_binding() {
+    let info = parse_source(
+        "class Thing { greet() {} }\n\
+         async function consume() {\n\
+           const xs = await Promise.all(['a'].map(async (n) => {\n\
+             if (n) {\n\
+               return makeThing(n);\n\
+             }\n\
+             return makeThing(n);\n\
+           }));\n\
+           xs.forEach((x) => x.greet());\n\
+         }\n\
+         async function makeThing(n: string): Promise<Thing> {\n\
+           return new Thing();\n\
+         }",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Thing" && a.member == "greet"),
+        "a multi-statement conditional-return callback must not credit an element class; got {:?}",
+        info.member_accesses,
+    );
+}

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -660,8 +660,33 @@ fn infer_array_element_from_init(expr: &Expression<'_>) -> Option<String> {
         Expression::ParenthesizedExpression(paren) => {
             infer_array_element_from_init(&paren.expression)
         }
+        // `const xs = await computed(() => [new Foo()])`: an awaited array-shaped
+        // initializer types the binding to its element class. See issue #1793.
+        Expression::AwaitExpression(await_expr) => {
+            infer_array_element_from_init(&await_expr.argument)
+        }
         Expression::ArrayExpression(arr) => array_literal_element_type(arr),
         Expression::CallExpression(call) => reactivity_wrapper_element_type(call),
+        _ => None,
+    }
+}
+
+/// The non-builtin class name from a function return type annotation of the
+/// shape `Promise<T>` (an async factory) or a direct `T`. Returns `None` for a
+/// builtin element and any non-reference shape. Used by the issue #1793
+/// `Promise.all(arr.map(cb))` inference pre-pass.
+pub(super) fn return_type_element_name(ty: &TSType<'_>) -> Option<String> {
+    match ty {
+        TSType::TSParenthesizedType(paren) => return_type_element_name(&paren.type_annotation),
+        TSType::TSTypeReference(type_ref) => {
+            let name = extract_type_name(&type_ref.type_name)?;
+            if name == "Promise" {
+                let first = type_ref.type_arguments.as_deref()?.params.first()?;
+                return extract_type_reference_name(first)
+                    .filter(|inner| !is_builtin_constructor(inner));
+            }
+            (!is_builtin_constructor(&name)).then_some(name)
+        }
         _ => None,
     }
 }

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -252,6 +252,12 @@ pub(crate) struct ModuleInfoExtractor {
     /// and `for (const util of utils)` in the same lexical scope without leaking
     /// the binding to sibling functions.
     scoped_array_binding_element_types: Vec<FxHashMap<String, String>>,
+    /// Top-level local function name -> declared return element class
+    /// (`Promise<T>` / `T`, non-builtin). Populated by a `visit_program` pre-pass
+    /// so `Promise.all(arr.map(cb))` can type its result from a map callback whose
+    /// callee is declared after the consumer. Transient extractor state, not a
+    /// cached `ModuleInfo` field. See issue #1793.
+    local_function_return_types: FxHashMap<String, String>,
     object_binding_candidates: Vec<ObjectBindingCandidate>,
     local_declaration_names: FxHashSet<String>,
     pending_local_export_specifiers: Vec<PendingLocalExportSpecifier>,

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -29,7 +29,8 @@ use super::helpers::{
     extract_query_list_element_type, extract_super_class_name, extract_type_annotation_name,
     has_angular_class_decorator, has_angular_plural_query_decorator,
     infer_array_binding_element_type, is_meta_url_arg, lit_custom_element_decorator,
-    lit_custom_element_tag, regex_pattern_to_suffix, ts_import_type_qualifier_root,
+    lit_custom_element_tag, regex_pattern_to_suffix, return_type_element_name,
+    ts_import_type_qualifier_root,
 };
 use super::{
     BindingTarget, ModuleInfoExtractor, PendingLocalExportSpecifier, ROUTE_LOADER_DATA_OBJECT,
@@ -1099,6 +1100,112 @@ impl<'a> ModuleInfoExtractor {
         }
     }
 
+    /// Pre-pass over top-level declarations recording each local function's
+    /// declared return element class (`Promise<T>` / `T`, non-builtin) keyed by
+    /// name, so `promise_all_map_element_type` resolves a map callback's callee
+    /// even when it is declared AFTER its consumer (declaration-order
+    /// independence: the repro's `createDb` follows `generate`). See issue #1793.
+    fn record_local_function_return_types(&mut self, program: &Program<'a>) {
+        for statement in &program.body {
+            match statement {
+                Statement::FunctionDeclaration(function) => {
+                    self.record_local_function_return_type(function);
+                }
+                Statement::VariableDeclaration(decl) => {
+                    for declarator in &decl.declarations {
+                        self.record_local_const_function_return_type(declarator);
+                    }
+                }
+                Statement::ExportNamedDeclaration(export) if export.source.is_none() => {
+                    match &export.declaration {
+                        Some(Declaration::FunctionDeclaration(function)) => {
+                            self.record_local_function_return_type(function);
+                        }
+                        Some(Declaration::VariableDeclaration(decl)) => {
+                            for declarator in &decl.declarations {
+                                self.record_local_const_function_return_type(declarator);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                Statement::ExportDefaultDeclaration(export) => {
+                    if let ExportDefaultDeclarationKind::FunctionDeclaration(function) =
+                        &export.declaration
+                    {
+                        self.record_local_function_return_type(function);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn record_local_function_return_type(&mut self, function: &Function<'_>) {
+        let Some(id) = function.id.as_ref() else {
+            return;
+        };
+        let Some(return_type) = function.return_type.as_deref() else {
+            return;
+        };
+        if let Some(element) = return_type_element_name(&return_type.type_annotation) {
+            self.local_function_return_types
+                .entry(id.name.to_string())
+                .or_insert(element);
+        }
+    }
+
+    fn record_local_const_function_return_type(&mut self, declarator: &VariableDeclarator<'_>) {
+        let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+            return;
+        };
+        let return_type = match declarator.init.as_ref() {
+            Some(Expression::ArrowFunctionExpression(arrow)) => arrow.return_type.as_deref(),
+            Some(Expression::FunctionExpression(function)) => function.return_type.as_deref(),
+            _ => None,
+        };
+        let Some(return_type) = return_type else {
+            return;
+        };
+        if let Some(element) = return_type_element_name(&return_type.type_annotation) {
+            self.local_function_return_types
+                .entry(id.name.to_string())
+                .or_insert(element);
+        }
+    }
+
+    /// Infer the element class of `await Promise.all(<expr>.map(cb))` where `cb`
+    /// returns a call to a same-module function whose declared return type is
+    /// `Promise<T>` / `T` for a non-builtin class `T`. `Promise.allSettled` /
+    /// `any` / `race` are excluded (only `all` yields the resolved element
+    /// array). Requires the `local_function_return_types` pre-pass. See #1793.
+    fn promise_all_map_element_type(&self, init: &Expression<'_>) -> Option<String> {
+        let Expression::CallExpression(call) = unwrap_await_paren_expr(init) else {
+            return None;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return None;
+        };
+        let Expression::Identifier(object) = &member.object else {
+            return None;
+        };
+        if object.name != "Promise" || member.property.name != "all" || call.arguments.len() != 1 {
+            return None;
+        }
+        let map_expr = call.arguments.first()?.as_expression()?;
+        let Expression::CallExpression(map_call) = unwrap_await_paren_expr(map_expr) else {
+            return None;
+        };
+        let Expression::StaticMemberExpression(map_member) = &map_call.callee else {
+            return None;
+        };
+        if map_member.property.name != "map" {
+            return None;
+        }
+        let callee_name = map_callback_returned_call_name(map_call.arguments.first()?)?;
+        self.local_function_return_types.get(&callee_name).cloned()
+    }
+
     /// Record a named import specifier (`import { fork } from ...`), tracking the
     /// `child_process.fork` and `node:url` `fileURLToPath` provenance bindings.
     fn handle_import_specifier(
@@ -1466,6 +1573,7 @@ impl<'a> ModuleInfoExtractor {
         if let BindingPattern::BindingIdentifier(id) = &declarator.id
             && let Some(element) =
                 infer_array_binding_element_type(declarator.type_annotation.as_deref(), Some(init))
+                    .or_else(|| self.promise_all_map_element_type(init))
         {
             let binding = id.name.to_string();
             self.record_vue_ref_value_array_binding_type(&binding, init, &element);
@@ -1827,6 +1935,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
         self.record_program_prologue(program);
         self.record_program_sanitizer_functions(program);
+        self.record_local_function_return_types(program);
         walk::walk_program(self, program);
     }
 
@@ -2916,6 +3025,58 @@ fn new_expression_class_name(expr: &Expression<'_>) -> Option<String> {
         return None;
     }
     Some(callee.name.to_string())
+}
+
+/// The callee identifier name of the (optionally awaited) call an iteration map
+/// callback returns: `async (n) => createDb(n)`, `(n) => await createDb(n)`, or
+/// a single-`return` block body. Member-expression callees and multi-statement
+/// bodies (including conditional early returns) yield `None`, keeping the
+/// Promise.all element inference conservative. See issue #1793.
+fn map_callback_returned_call_name(arg: &Argument<'_>) -> Option<String> {
+    let returned = match arg {
+        Argument::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                let Statement::ExpressionStatement(stmt) = arrow.body.statements.first()? else {
+                    return None;
+                };
+                &stmt.expression
+            } else {
+                single_return_expr(&arrow.body)?
+            }
+        }
+        Argument::FunctionExpression(function) => single_return_expr(function.body.as_deref()?)?,
+        _ => return None,
+    };
+    let Expression::CallExpression(call) = unwrap_await_paren_expr(returned) else {
+        return None;
+    };
+    match &call.callee {
+        Expression::Identifier(id) => Some(id.name.to_string()),
+        _ => None,
+    }
+}
+
+/// The single returned expression of a `{ return <expr>; }` block body. Any
+/// other statement count yields `None`, so a multi-statement or conditional
+/// callback body does not credit an element class. See issue #1793.
+fn single_return_expr<'a, 'b>(body: &'b FunctionBody<'a>) -> Option<&'b Expression<'a>> {
+    if body.statements.len() != 1 {
+        return None;
+    }
+    let Statement::ReturnStatement(ret) = body.statements.first()? else {
+        return None;
+    };
+    ret.argument.as_ref()
+}
+
+/// Recursively unwrap `await` and parenthesized wrappers to the inner
+/// expression. Used by the Promise.all element inference. See issue #1793.
+fn unwrap_await_paren_expr<'a, 'b>(expr: &'b Expression<'a>) -> &'b Expression<'a> {
+    match expr {
+        Expression::AwaitExpression(await_expr) => unwrap_await_paren_expr(&await_expr.argument),
+        Expression::ParenthesizedExpression(paren) => unwrap_await_paren_expr(&paren.expression),
+        other => other,
+    }
 }
 
 /// Recursively unwrap parenthesized expressions to reach the inner expression.

--- a/crates/extract/src/visitor/visit_impl_scope_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_scope_bindings.rs
@@ -6,6 +6,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::extract::{SanitizerScope, SinkLiteralValue};
 
+use super::super::helpers::array_element_type_from_type;
 use super::super::{ModuleInfoExtractor, SecurityPathSinkBinding};
 use super::{sink_literal_value, static_sink_literal_to_string, unwrap_static_expr};
 
@@ -243,6 +244,14 @@ impl ModuleInfoExtractor {
         }
 
         let mut scope = FxHashSet::default();
+        // Array-typed parameters (`items: Item[]`) mapped to their element class,
+        // so a `for...of` loop or `.map`/`.forEach` callback over the parameter in
+        // the function body credits the item's member accesses onto the class.
+        // Recorded here (before the body walk) rather than in
+        // `visit_formal_parameter`: at param-visit time the function-body scoped
+        // frame is not yet pushed, so a top-level function's array params would be
+        // silently dropped. See issue #1793.
+        let mut array_element_scope: FxHashMap<String, String> = FxHashMap::default();
         for param in &params.items {
             scope.extend(
                 param
@@ -251,6 +260,13 @@ impl ModuleInfoExtractor {
                     .into_iter()
                     .map(|id| id.name.to_string()),
             );
+            if let BindingPattern::BindingIdentifier(id) = &param.pattern
+                && let Some(type_annotation) = param.type_annotation.as_deref()
+                && let Some(element) =
+                    array_element_type_from_type(&type_annotation.type_annotation)
+            {
+                array_element_scope.insert(id.name.to_string(), element);
+            }
         }
         let sanitizer_scope = scope
             .iter()
@@ -273,6 +289,8 @@ impl ModuleInfoExtractor {
             .map(|name| (name.clone(), None))
             .collect::<FxHashMap<_, _>>();
         self.nested_declaration_stack.push(scope);
+        self.scoped_array_binding_element_types
+            .push(array_element_scope);
         self.sanitizer_binding_stack.push(sanitizer_scope);
         self.literal_allowlist_binding_stack.push(allowlist_scope);
         self.risky_regex_binding_stack.push(risky_regex_scope);
@@ -283,6 +301,7 @@ impl ModuleInfoExtractor {
     pub(super) fn pop_function_declaration_scope(&mut self) {
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.pop();
+            self.scoped_array_binding_element_types.pop();
             self.sanitizer_binding_stack.pop();
             self.literal_allowlist_binding_stack.pop();
             self.risky_regex_binding_stack.pop();

--- a/tests/fixtures/issue-1793-entry-script-iteration/package.json
+++ b/tests/fixtures/issue-1793-entry-script-iteration/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "issue-1793-entry-script-iteration",
+  "private": true,
+  "type": "module",
+  "main": "src/main.ts"
+}

--- a/tests/fixtures/issue-1793-entry-script-iteration/src/main.ts
+++ b/tests/fixtures/issue-1793-entry-script-iteration/src/main.ts
@@ -1,0 +1,60 @@
+import { SyntheticSchemaService } from "./service";
+import { SyntheticSchemaWriter } from "./schema-writer";
+
+type CreatedDb = {
+  name: string;
+  writer: SyntheticSchemaWriter;
+  close: () => Promise<void>;
+};
+
+enum WriteMode {
+  Golden = "golden",
+  Typed = "typed",
+}
+
+export async function generate(mode: WriteMode): Promise<void> {
+  // Part 2 (Promise.all inference): `createDb` (declared AFTER this consumer)
+  // returns Promise<CreatedDb>, so `dbsFromCreate` is CreatedDb[]. The map
+  // callback param `dbMapped` (name distinct from the for-of variable below)
+  // credits writeSchemaData / writeGraphDiagram / writeSchemaTyped.
+  const dbsFromCreate = await Promise.all(["alpha", "beta"].map(async (schemaName) => createDb(schemaName)));
+
+  if (mode === WriteMode.Golden) {
+    await resetSchemas(dbsFromCreate);
+  }
+
+  await Promise.all(
+    dbsFromCreate.map(async (dbMapped) => {
+      try {
+        if (mode === WriteMode.Golden) {
+          await dbMapped.writer.writeSchemaData("Golden");
+          await dbMapped.writer.writeGraphDiagram();
+        } else {
+          await dbMapped.writer.writeSchemaTyped();
+        }
+      } finally {
+        await dbMapped.close();
+      }
+    }),
+  );
+}
+
+async function createDb(name: string): Promise<CreatedDb> {
+  const service = new SyntheticSchemaService(name);
+  const writer = new SyntheticSchemaWriter(service);
+
+  return {
+    name,
+    writer,
+    close: async () => Promise.resolve(),
+  };
+}
+
+// Part 1 (array-typed formal parameter): the `dbsForReset: CreatedDb[]` param
+// plus the `for...of` loop bind `dbReset` (name distinct from the map callback
+// param above), so `dbReset.writer.resetSchema` credits resetSchema.
+async function resetSchemas(dbsForReset: CreatedDb[]): Promise<void> {
+  for (const dbReset of dbsForReset) {
+    await dbReset.writer.resetSchema("Golden");
+  }
+}

--- a/tests/fixtures/issue-1793-entry-script-iteration/src/schema-writer.ts
+++ b/tests/fixtures/issue-1793-entry-script-iteration/src/schema-writer.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+
+import { ExportFlavor, SyntheticSchemaService } from "./service";
+
+export class SyntheticSchemaWriter {
+  constructor(private readonly _schemaService: SyntheticSchemaService) {}
+
+  async resetSchema(exportFlavor: ExportFlavor): Promise<void> {
+    if (exportFlavor === "Golden") {
+      await this._schemaService.initialize();
+    }
+    await this._schemaService.resetSchema(exportFlavor);
+  }
+
+  async writeSchemaData(exportFlavor: ExportFlavor): Promise<void> {
+    if (exportFlavor === "Golden") {
+      await this._schemaService.initialize();
+    }
+    await this._schemaService.writeSchemaData(exportFlavor);
+  }
+
+  async writeGraphDiagram(): Promise<void> {
+    await this._schemaService.initialize();
+    await this._schemaService.writeGraphDiagram();
+  }
+
+  async writeSchemaTyped(): Promise<void> {
+    await this._schemaService.initialize();
+    const typeDeclarations = await this._schemaService.createTypedSchema();
+    await fs.promises.writeFile("./synthetic-typed-schema.ts", typeDeclarations, { encoding: "utf-8" });
+  }
+
+  // FN guard: never called anywhere. Must still report unused-class-member.
+  async deadMethod(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/tests/fixtures/issue-1793-entry-script-iteration/src/service.ts
+++ b/tests/fixtures/issue-1793-entry-script-iteration/src/service.ts
@@ -1,0 +1,27 @@
+export type ExportFlavor = "Golden" | "Typed";
+
+export class SyntheticSchemaService {
+  constructor(private readonly _name: string) {}
+
+  async initialize(): Promise<void> {
+    if (!this._name) {
+      throw new Error("Missing name");
+    }
+  }
+
+  async resetSchema(_exportFlavor: ExportFlavor): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async writeSchemaData(_exportFlavor: ExportFlavor): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async writeGraphDiagram(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async createTypedSchema(): Promise<string> {
+    return Promise.resolve("export type SyntheticRow = { id: string };");
+  }
+}

--- a/tests/fixtures/issue-1793-entry-script-iteration/tsconfig.json
+++ b/tests/fixtures/issue-1793-entry-script-iteration/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": { "target": "ESNext", "module": "ESNext", "moduleResolution": "Bundler", "strict": true },
+  "include": ["src"]
+}


### PR DESCRIPTION
Two extraction gaps kept the #1707 iteration-binding machinery from typing loop and callback variables, so member accesses through them never credited the class: an array-typed formal parameter (`createdDbs: CreatedDb[]`) recorded nothing into the scoped array-element map, and a `const xs = await Promise.all(arr.map(async n => createDb(n)))` declarator inferred no element type.

Part 1 records array-typed identifier params into a function-scoped element frame via `push_function_declaration_scope` / `pop_function_declaration_scope` (recording at param-visit time would silently drop the entry for top-level functions because the scoped stack is pushed later, in `visit_function_body`; a top-level-function unit test pins this). Part 2 unwraps `await` in element inference and recognizes `Promise.all(<expr>.map(cb))` where the callback returns a call to a module-local function with a declared `Promise<T>` or `T[]` return type, resolved through a `visit_program` pre-pass so declaration order does not matter. `Promise.allSettled`/`any`/`race`, imported callees, and multi-statement conditional-return callbacks are excluded. Additive-credit only. CACHE_VERSION 232 -> 233.

Fixes #1793

Tests: extract unit tests per shape plus negatives, and an integration fixture mirroring the reported entry-script repro with distinct for-of and map-callback binding names (each part individually load-bearing) and a dead control method asserted to stay flagged. Indexed access (`items[0].widget.m()`) is a separate compound-receiver gap, left out of scope.