### PR TITLE
ci: keep Dockerfile FALLOW_VERSION and checksums in lockstep with releases

### DIFF
--- a/.github/scripts/update-dockerfile-pins.mjs
+++ b/.github/scripts/update-dockerfile-pins.mjs
@@ -1,0 +1,159 @@
+// Post-release automation: rewrite the Dockerfile's `ARG FALLOW_VERSION` line
+// and its two per-arch sha256 pins (`fallow-linux-x64-musl`,
+// `fallow-linux-arm64-musl`) to match a just-published release. The pins were
+// hand-maintained starting at 2.94.0 (commit 1a8e7ac8d), drifted through 13
+// releases, and were fixed manually by #1805. This script is the release.yml
+// `docker-lockstep` job's rewrite step. Refs #1817.
+//
+// Every guard below fails loud (non-zero exit, file left untouched) instead
+// of silently no-oping, so a future Dockerfile refactor (renamed ARG,
+// reordered case arms, a third architecture) breaks the release job visibly
+// instead of quietly leaving the pins stale again.
+//
+// Usage:
+//   node update-dockerfile-pins.mjs <version> <amd64-sha256> <arm64-sha256> [dockerfile]
+//
+// <version> is the bare release version (no leading "v"), matching
+// GITHUB_REF_NAME with the tag prefix stripped. Exits 0 and rewrites the file
+// in place when the pins actually change; exits 1 (file untouched) otherwise.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_DOCKERFILE = "Dockerfile";
+
+// Keyed by the literal `asset="..."` value inside each Dockerfile case arm, so
+// replacement is correct even if the case arms are reordered (arm64 before
+// amd64, say). An asset value that appears in the Dockerfile but not here (or
+// vice versa) trips the "unexpected asset" / "does not declare asset" guards.
+const KNOWN_ASSETS = ["fallow-linux-x64-musl", "fallow-linux-arm64-musl"];
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
+const ARG_LINE_PATTERN = /^ARG FALLOW_VERSION=.*$/;
+const ASSET_LINE_PATTERN = /^(\s*)asset="([^"]+)";(.*)$/;
+const SHA_LINE_PATTERN = /^(\s*)sha256="([^"]*)";(.*)$/;
+
+function assertValidVersion(version) {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error(`invalid version "${version}": expected bare X.Y.Z (no leading "v")`);
+  }
+}
+
+function assertValidSha(label, sha) {
+  if (!SHA256_PATTERN.test(sha)) {
+    throw new Error(`invalid ${label} sha256 "${sha}": expected 64 hex characters`);
+  }
+}
+
+// Rewrites `source` to match { version, amd64Sha, arm64Sha }. Pure: throws
+// instead of touching disk. Also throws (rather than returning the input
+// unchanged) when the rewrite would be a no-op, since an unmatched rewrite is
+// the most likely symptom of a Dockerfile structure the guards below did not
+// anticipate.
+export function computeUpdatedDockerfile(source, { version, amd64Sha, arm64Sha }) {
+  assertValidVersion(version);
+  assertValidSha("amd64", amd64Sha);
+  assertValidSha("arm64", arm64Sha);
+
+  const shaByAsset = {
+    "fallow-linux-x64-musl": amd64Sha.toLowerCase(),
+    "fallow-linux-arm64-musl": arm64Sha.toLowerCase(),
+  };
+
+  const argMatches = source.match(new RegExp(ARG_LINE_PATTERN.source, "gm")) ?? [];
+  if (argMatches.length !== 1) {
+    throw new Error(`expected exactly 1 "ARG FALLOW_VERSION=" line, found ${argMatches.length}`);
+  }
+
+  const seenAssets = new Set();
+  const resolvedAssets = new Set();
+  let pendingAsset = null;
+
+  const rewritten = source.split("\n").map((line) => {
+    if (ARG_LINE_PATTERN.test(line)) {
+      return `ARG FALLOW_VERSION=${version}`;
+    }
+
+    const assetMatch = line.match(ASSET_LINE_PATTERN);
+    if (assetMatch) {
+      const [, , assetName] = assetMatch;
+      if (!KNOWN_ASSETS.includes(assetName)) {
+        throw new Error(`unexpected asset "${assetName}" in Dockerfile case arm`);
+      }
+      if (seenAssets.has(assetName)) {
+        throw new Error(`duplicate asset entry "${assetName}"`);
+      }
+      seenAssets.add(assetName);
+      pendingAsset = assetName;
+      return line;
+    }
+
+    const shaMatch = line.match(SHA_LINE_PATTERN);
+    if (shaMatch) {
+      if (pendingAsset === null) {
+        throw new Error(`sha256 pin ${JSON.stringify(line.trim())} has no preceding asset= line`);
+      }
+      const [, indent, , trailer] = shaMatch;
+      const replaced = `${indent}sha256="${shaByAsset[pendingAsset]}";${trailer}`;
+      resolvedAssets.add(pendingAsset);
+      pendingAsset = null;
+      return replaced;
+    }
+
+    return line;
+  });
+
+  for (const assetName of KNOWN_ASSETS) {
+    if (!seenAssets.has(assetName)) {
+      throw new Error(`Dockerfile does not declare asset "${assetName}"`);
+    }
+    if (!resolvedAssets.has(assetName)) {
+      throw new Error(`asset "${assetName}" has no sha256 pin`);
+    }
+  }
+
+  const updated = rewritten.join("\n");
+  if (updated === source) {
+    throw new Error("rewrite produced no changes; refusing a silent no-op");
+  }
+  return updated;
+}
+
+function main(argv) {
+  const [version, amd64Sha, arm64Sha, dockerfilePath = DEFAULT_DOCKERFILE] = argv.slice(2);
+  if (!version || !amd64Sha || !arm64Sha) {
+    console.error(
+      "usage: update-dockerfile-pins.mjs <version> <amd64-sha256> <arm64-sha256> [dockerfile]",
+    );
+    return 2;
+  }
+
+  let source;
+  try {
+    source = readFileSync(dockerfilePath, "utf8");
+  } catch (err) {
+    console.error(`::error::cannot read ${dockerfilePath}: ${err.message}`);
+    return 1;
+  }
+
+  let updated;
+  try {
+    updated = computeUpdatedDockerfile(source, { version, amd64Sha, arm64Sha });
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    return 1;
+  }
+
+  writeFileSync(dockerfilePath, updated);
+  console.log(`OK: ${dockerfilePath} pinned to FALLOW_VERSION=${version}`);
+  return 0;
+}
+
+// Run as a CLI only when invoked directly, so the test file can import
+// computeUpdatedDockerfile without triggering the argv loop. pathToFileURL
+// handles percent-encoding so a checkout path with spaces or non-ASCII
+// characters does not silently turn this into a no-op import.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main(process.argv));
+}

--- a/.github/scripts/update-dockerfile-pins.test.mjs
+++ b/.github/scripts/update-dockerfile-pins.test.mjs
@@ -1,0 +1,196 @@
+// Tests for update-dockerfile-pins.mjs, the release-time rewrite step that
+// keeps the Dockerfile's ARG FALLOW_VERSION and its two per-arch sha256 pins
+// in lockstep with a just-published release. Regression coverage for #1817
+// (the pins previously drifted for 13 releases before a manual fix in #1805).
+//
+// Run: node --test .github/scripts/update-dockerfile-pins.test.mjs
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { computeUpdatedDockerfile } from "./update-dockerfile-pins.mjs";
+
+const SCRIPT_PATH = fileURLToPath(new URL("./update-dockerfile-pins.mjs", import.meta.url));
+
+const CURRENT_AMD64_SHA = "e0af720a13a1758f982e5dda590e57f633c6c4d2ba79de9b1bc5a952a7dd6766";
+const CURRENT_ARM64_SHA = "f615c1ba69073ba8025ac03a6729ad8b8a0334c0c9059b7657cb5c05ee0b0c96";
+const NEW_AMD64_SHA = "1".repeat(64);
+const NEW_ARM64_SHA = "2".repeat(64);
+
+// Mirrors the real Dockerfile's download stage: one ARG line, a case block
+// keyed on TARGETARCH with an asset= line immediately followed by a sha256=
+// line per arch. `order` lets tests exercise the case arms in either sequence
+// since replacement must be asset-keyed, not position-keyed.
+function makeFixture({ order = ["amd64", "arm64"] } = {}) {
+  const arms = {
+    amd64: [
+      "    amd64) \\",
+      '      asset="fallow-linux-x64-musl"; \\',
+      `      sha256="${CURRENT_AMD64_SHA}"; \\`,
+      "      ;; \\",
+    ],
+    arm64: [
+      "    arm64) \\",
+      '      asset="fallow-linux-arm64-musl"; \\',
+      `      sha256="${CURRENT_ARM64_SHA}"; \\`,
+      "      ;; \\",
+    ],
+  };
+
+  return [
+    "FROM debian:bookworm-slim AS download",
+    "",
+    "ARG FALLOW_VERSION=3.3.0",
+    "ARG TARGETARCH",
+    "",
+    "# The sha256 pins below are bound to FALLOW_VERSION above; bump both together.",
+    "RUN set -eux; \\",
+    '  case "${TARGETARCH}" in \\',
+    ...order.flatMap((arch) => arms[arch]),
+    "    *) \\",
+    '      echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; \\',
+    "      exit 1; \\",
+    "      ;; \\",
+    "  esac; \\",
+    '  curl -fsSL "https://example.invalid/${asset}" -o /usr/local/bin/fallow; \\',
+    '  echo "${sha256}  /usr/local/bin/fallow" | sha256sum -c -; \\',
+    "  chmod +x /usr/local/bin/fallow",
+    "",
+  ].join("\n");
+}
+
+const NEW_PINS = { version: "3.4.0", amd64Sha: NEW_AMD64_SHA, arm64Sha: NEW_ARM64_SHA };
+
+test("rewrites the ARG line and both sha256 pins", () => {
+  const updated = computeUpdatedDockerfile(makeFixture(), NEW_PINS);
+  assert.match(updated, /^ARG FALLOW_VERSION=3\.4\.0$/m);
+  assert.match(
+    updated,
+    new RegExp(`asset="fallow-linux-x64-musl";[\\s\\S]*?sha256="${NEW_AMD64_SHA}"`),
+  );
+  assert.match(
+    updated,
+    new RegExp(`asset="fallow-linux-arm64-musl";[\\s\\S]*?sha256="${NEW_ARM64_SHA}"`),
+  );
+});
+
+test("is asset-keyed: survives swapped case-arm order", () => {
+  const swapped = makeFixture({ order: ["arm64", "amd64"] });
+  const updated = computeUpdatedDockerfile(swapped, NEW_PINS);
+  assert.match(
+    updated,
+    new RegExp(`asset="fallow-linux-x64-musl";[\\s\\S]*?sha256="${NEW_AMD64_SHA}"`),
+  );
+  assert.match(
+    updated,
+    new RegExp(`asset="fallow-linux-arm64-musl";[\\s\\S]*?sha256="${NEW_ARM64_SHA}"`),
+  );
+});
+
+test("rejects a Dockerfile with no ARG FALLOW_VERSION line", () => {
+  const noArg = makeFixture().replace(/^ARG FALLOW_VERSION=.*$\n/m, "");
+  assert.throws(() => computeUpdatedDockerfile(noArg, NEW_PINS), /found 0/);
+});
+
+test("rejects a Dockerfile with a duplicate ARG FALLOW_VERSION line", () => {
+  const duped = makeFixture().replace(
+    "ARG FALLOW_VERSION=3.3.0",
+    "ARG FALLOW_VERSION=3.3.0\nARG FALLOW_VERSION=3.3.0",
+  );
+  assert.throws(() => computeUpdatedDockerfile(duped, NEW_PINS), /found 2/);
+});
+
+test("rejects an asset block missing its sha256 pin", () => {
+  const missingSha = makeFixture().replace(`      sha256="${CURRENT_AMD64_SHA}"; \\\n`, "");
+  assert.throws(
+    () => computeUpdatedDockerfile(missingSha, NEW_PINS),
+    /fallow-linux-x64-musl.*no sha256 pin/,
+  );
+});
+
+test("rejects a sha256 pin with no preceding asset= line", () => {
+  const orphanSha = makeFixture().replace('      asset="fallow-linux-x64-musl"; \\\n', "");
+  assert.throws(() => computeUpdatedDockerfile(orphanSha, NEW_PINS), /no preceding asset= line/);
+});
+
+test("rejects an unexpected asset name", () => {
+  const renamed = makeFixture().replace(
+    'asset="fallow-linux-x64-musl";',
+    'asset="fallow-linux-riscv64-musl";',
+  );
+  assert.throws(() => computeUpdatedDockerfile(renamed, NEW_PINS), /unexpected asset/);
+});
+
+test("rejects a duplicate asset entry", () => {
+  const doubled = makeFixture().replace(
+    'asset="fallow-linux-arm64-musl";',
+    'asset="fallow-linux-x64-musl";',
+  );
+  assert.throws(() => computeUpdatedDockerfile(doubled, NEW_PINS), /duplicate asset entry/);
+});
+
+test("rejects an invalid version argument", () => {
+  assert.throws(
+    () => computeUpdatedDockerfile(makeFixture(), { ...NEW_PINS, version: "v3.4.0" }),
+    /invalid version/,
+  );
+});
+
+test("rejects an invalid sha256 argument", () => {
+  assert.throws(
+    () => computeUpdatedDockerfile(makeFixture(), { ...NEW_PINS, amd64Sha: "deadbeef" }),
+    /invalid amd64 sha256/,
+  );
+});
+
+test("rejects a no-op rewrite", () => {
+  assert.throws(
+    () =>
+      computeUpdatedDockerfile(makeFixture(), {
+        version: "3.3.0",
+        amd64Sha: CURRENT_AMD64_SHA,
+        arm64Sha: CURRENT_ARM64_SHA,
+      }),
+    /no changes/,
+  );
+});
+
+// CLI-level coverage: the exported function is pure, so these confirm the
+// file-touching contract the plan requires (rewrite in place on success,
+// untouched on failure) actually holds at the process boundary.
+function withTempDockerfile(fn) {
+  const work = mkdtempSync(join(tmpdir(), "dockerfile-pins-"));
+  const path = join(work, "Dockerfile");
+  writeFileSync(path, makeFixture());
+  try {
+    return fn(path);
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+test("CLI: rewrites the file in place on success", () => {
+  withTempDockerfile((path) => {
+    execFileSync("node", [SCRIPT_PATH, "3.4.0", NEW_AMD64_SHA, NEW_ARM64_SHA, path]);
+    const updated = readFileSync(path, "utf8");
+    assert.match(updated, /^ARG FALLOW_VERSION=3\.4\.0$/m);
+    assert.match(updated, new RegExp(NEW_AMD64_SHA));
+  });
+});
+
+test("CLI: leaves the file untouched and exits non-zero on a guard failure", () => {
+  withTempDockerfile((path) => {
+    const before = readFileSync(path, "utf8");
+    assert.throws(() =>
+      execFileSync("node", [SCRIPT_PATH, "v3.4.0", NEW_AMD64_SHA, NEW_ARM64_SHA, path], {
+        stdio: "pipe",
+      }),
+    );
+    assert.equal(readFileSync(path, "utf8"), before);
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,18 @@ jobs:
       - name: Build image
         run: docker build -t fallow:ci .
       - name: Run version
-        run: docker run --rm fallow:ci --version
+        # Asserts the image reports the version pinned in the Dockerfile's own
+        # ARG default, not just that the binary runs. This is what makes this
+        # required check a real end-to-end proof for a docker-lockstep PR
+        # (release.yml): the new pins download, checksum-verify, and report
+        # the just-released version instead of merely not crashing.
+        shell: bash
+        run: |
+          set -euo pipefail
+          PINNED_VERSION="$(grep -m1 '^ARG FALLOW_VERSION=' Dockerfile | cut -d '=' -f2)"
+          OUTPUT="$(docker run --rm fallow:ci --version)"
+          echo "${OUTPUT}"
+          echo "${OUTPUT}" | grep -qF "${PINNED_VERSION}"
       - name: Check exit code propagation
         shell: bash
         run: |
@@ -388,7 +399,7 @@ jobs:
           NODE
 
       - name: Test release packaging gate
-        run: node --test .github/scripts/verify-pack-contents.test.mjs
+        run: node --test .github/scripts/verify-pack-contents.test.mjs .github/scripts/update-dockerfile-pins.test.mjs
 
       - name: Run npm wrapper unit tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,6 +540,90 @@ jobs:
           git tag -f v1 "${GITHUB_SHA}"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" refs/tags/v1 --force
 
+  # The Dockerfile pins ARG FALLOW_VERSION plus two per-arch sha256 digests by
+  # hand. Nothing kept them in sync with releases: the pin sat on 2.94.0 for
+  # 13 releases until #1805 fixed it manually. This job closes that gap by
+  # rewriting the pins from the assets `release` just published and opening a
+  # PR, every release, automatically. Refs #1817.
+  #
+  # The digests cannot be produced earlier (e.g. as part of the release
+  # commit itself): they depend on the musl binaries the `build` matrix job
+  # compiles and `release` uploads, both of which only exist after the tag
+  # push that triggers this whole workflow. A follow-up job is the only sound
+  # design.
+  #
+  # No other job `needs` this one, intentionally: a Dockerfile refactor that
+  # trips one of update-dockerfile-pins.mjs's guards (see that file) must
+  # never block npm/VS Code publishing.
+  docker-lockstep:
+    name: Docker lockstep
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      # contents: write pushes the docker-lockstep/vX.Y.Z branch (via an
+      # explicit token URL below, not persisted checkout credentials).
+      # pull-requests: write opens the PR against it.
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Compute release version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Download published assets and rewrite Dockerfile pins
+        env:
+          # Hashes the exact bytes users' `docker build` fetches from the
+          # release, catching upload corruption as well as a stale pin.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" \
+            --pattern fallow-linux-x64-musl --pattern fallow-linux-arm64-musl \
+            --dir /tmp/docker-lockstep-assets
+          X64_SHA="$(sha256sum /tmp/docker-lockstep-assets/fallow-linux-x64-musl | cut -d ' ' -f1)"
+          ARM64_SHA="$(sha256sum /tmp/docker-lockstep-assets/fallow-linux-arm64-musl | cut -d ' ' -f1)"
+          node .github/scripts/update-dockerfile-pins.mjs "${VERSION}" "${X64_SHA}" "${ARM64_SHA}"
+
+      - name: Sanity-build the amd64 image
+        # arm64 digest correctness is already proven by hashing the published
+        # asset above; this also re-runs the Dockerfile's own `sha256sum -c`,
+        # so a corrupted pin fails the build here rather than shipping.
+        run: |
+          docker build -t fallow:docker-lockstep-check .
+          docker run --rm fallow:docker-lockstep-check --version | grep -qF "${VERSION}"
+
+      - name: Open pull request with the refreshed pins
+        env:
+          # A PR opened with the default GITHUB_TOKEN triggers no
+          # `pull_request` workflows (a GitHub restriction), so it needs a
+          # manual close/reopen, a label, or admin squash-merge to satisfy
+          # fallow-rs's required checks. Configuring a fine-grained PAT or
+          # GitHub App token in LOCKSTEP_PR_TOKEN makes the PR trigger CI
+          # like any other; this is a maintainer config decision, not a code
+          # change.
+          GH_TOKEN: ${{ secrets.LOCKSTEP_PR_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="docker-lockstep/v${VERSION}"
+          git checkout -b "${BRANCH}"
+          git add Dockerfile
+          git commit -m "chore(docker): pin FALLOW_VERSION ${VERSION} with refreshed checksums"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" \
+            "HEAD:refs/heads/${BRANCH}" --force
+
+          BODY="Automated Dockerfile lockstep for the v${VERSION} release: refreshes ARG FALLOW_VERSION and both per-arch sha256 pins from the just-published release assets. Refs #1817."
+          if ! gh pr create --repo "${GITHUB_REPOSITORY}" --base main --head "${BRANCH}" \
+            --title "chore(docker): pin FALLOW_VERSION ${VERSION} with refreshed checksums" \
+            --body "${BODY}"; then
+            echo "a pull request for ${BRANCH} may already exist; verifying" >&2
+            gh pr view "${BRANCH}" --repo "${GITHUB_REPOSITORY}"
+          fi
+
   # Belt-and-suspenders generated contract drift check before either privileged
   # publish job runs. PR CI runs `npm run generate:contracts:check` on every relevant
   # contract change, but a release tag could in theory be cut on a commit where

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # The sha256 pins below are bound to FALLOW_VERSION above; bump both together.
+# release.yml's docker-lockstep job keeps them in sync automatically after
+# every release by opening a PR here; a manual edit only needs to preserve
+# the lockstep rule for local review.
 RUN set -eux; \
   case "${TARGETARCH}" in \
     amd64) \


### PR DESCRIPTION
The Dockerfile's `ARG FALLOW_VERSION` and per-arch sha256 pins were hand-maintained and drifted 13 releases (2.94.0 through 3.3.0) before #1805 caught them up manually. A new `docker-lockstep` job in release.yml now closes the gap after every release: it downloads the two published musl assets, hashes the exact bytes users' `docker build` fetches, rewrites the pins via a guarded script (`.github/scripts/update-dockerfile-pins.mjs`, loud non-zero failure on any unexpected Dockerfile shape, never a silent no-op), sanity-builds the amd64 image including the Dockerfile's own `sha256sum -c`, and opens a PR.

The job carries no `needs` edge from the publish jobs, so a tripped guard can never block npm or VS Code publishing. PRs opened with the default `GITHUB_TOKEN` trigger no `pull_request` workflows; configuring `LOCKSTEP_PR_TOKEN` (fine-grained PAT or App token) makes them trigger CI normally, documented in the job.

The Docker required check in ci.yml now asserts the image reports the version pinned in the Dockerfile's own ARG default, making it a real end-to-end proof for lockstep PRs.

Fixes #1817

Tests: node --test coverage for the rewrite script (happy path, reordered case arms, every guard, idempotency refusal), actionlint and zizmor clean (no new findings), shellcheck-clean bash blocks, live dry-run against the checked-in Dockerfile verified byte-identical restore.