### PR TITLE
test(cli): isolate orphan-sweep fixtures from the shared temp dir

### DIFF
--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -916,7 +916,7 @@ use crate::base_worktree::{
     is_fallow_audit_worktree_path, is_reusable_audit_worktree_path, list_audit_worktrees,
     materialize_base_dependency_context, parse_worktree_list, paths_equal, process_is_alive,
     remove_audit_worktree, reusable_audit_worktree_path, reusable_worktree_last_used_path,
-    reusable_worktree_lock_path, reusable_worktree_sha_path, sweep_orphan_audit_worktrees,
+    reusable_worktree_lock_path, reusable_worktree_sha_path, sweep_orphan_audit_worktrees_in,
     touch_last_used, unregister_worktree,
 };
 

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -378,7 +378,10 @@ fn audit_orphan_sweep_removes_dead_pid_worktree() {
     let tmp = tempfile::TempDir::new().expect("temp dir should be created");
     let repo = init_throwaway_repo(tmp.path(), "repo");
 
-    let worktree_path = std::env::temp_dir().join(format!(
+    // Under tmp.path(), NOT std::env::temp_dir(): a fabricated dead-pid dir in
+    // the shared temp dir is legitimate prey for any concurrent sweep (a
+    // parallel test or a spawned fallow binary), which races the asserts below.
+    let worktree_path = tmp.path().join(format!(
         "fallow-audit-base-{}-{}",
         DEAD_PID,
         std::time::SystemTime::now()
@@ -400,7 +403,7 @@ fn audit_orphan_sweep_removes_dead_pid_worktree() {
     assert!(worktree_path.is_dir());
     assert!(worktree_is_registered_with_git(&repo, &worktree_path));
 
-    sweep_orphan_audit_worktrees(&repo);
+    sweep_orphan_audit_worktrees_in(&repo, tmp.path());
 
     assert!(
         !worktree_path.exists(),
@@ -420,7 +423,7 @@ fn audit_orphan_sweep_keeps_live_pid_worktree() {
     let tmp = tempfile::TempDir::new().expect("temp dir should be created");
     let repo = init_throwaway_repo(tmp.path(), "repo");
 
-    let worktree_path = std::env::temp_dir().join(format!(
+    let worktree_path = tmp.path().join(format!(
         "fallow-audit-base-{}-{}",
         live_pid,
         std::time::SystemTime::now()
@@ -440,7 +443,7 @@ fn audit_orphan_sweep_keeps_live_pid_worktree() {
         ],
     );
 
-    sweep_orphan_audit_worktrees(&repo);
+    sweep_orphan_audit_worktrees_in(&repo, tmp.path());
 
     assert!(
         worktree_path.is_dir(),
@@ -1082,7 +1085,7 @@ fn orphan_sweep_removes_unregistered_dead_pid_dir() {
     assert!(!process_is_alive(DEAD_PID));
     let tmp = tempfile::TempDir::new().expect("temp dir should be created");
     let repo = init_throwaway_repo(tmp.path(), "repo-unreg-orphan");
-    let dir = std::env::temp_dir().join(format!(
+    let dir = tmp.path().join(format!(
         "fallow-audit-base-{DEAD_PID}-{}-0",
         SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1092,7 +1095,7 @@ fn orphan_sweep_removes_unregistered_dead_pid_dir() {
     fs::create_dir_all(&dir).expect("orphan dir should be created");
     fs::write(dir.join(".git"), "gitdir: fallow-audit-unregistered\n").expect("stub should write");
 
-    sweep_orphan_audit_worktrees(&repo);
+    sweep_orphan_audit_worktrees_in(&repo, tmp.path());
 
     assert!(
         !dir.exists(),

--- a/crates/cli/src/base_worktree.rs
+++ b/crates/cli/src/base_worktree.rs
@@ -856,6 +856,15 @@ pub fn remove_audit_worktree(repo_root: &Path, path: &Path) {
 }
 
 pub fn sweep_orphan_audit_worktrees(repo_root: &Path) {
+    sweep_orphan_audit_worktrees_in(repo_root, &std::env::temp_dir());
+}
+
+/// `temp_root` is the directory scanned for unregistered dead-pid worktree
+/// directories. Production always passes `std::env::temp_dir()`; tests pass a
+/// private root because a fabricated dead-pid fixture in the SHARED temp dir
+/// is legitimate prey for any concurrent sweep (a parallel test or a spawned
+/// fallow binary), which races the fixture's own assertions.
+pub fn sweep_orphan_audit_worktrees_in(repo_root: &Path, temp_root: &Path) {
     // Legacy pass: deregister dead-pid non-reusable worktrees left REGISTERED
     // by pre-#1815 fallow (or by a crash in the transient registration
     // window). The `--expire=now` prune, retained only here, also sweeps any
@@ -872,7 +881,7 @@ pub fn sweep_orphan_audit_worktrees(repo_root: &Path) {
     // Primary pass: remove unregistered dead-pid worktree DIRECTORIES via a
     // temp-dir prefix scan. A dead PID means the owning process is gone
     // regardless of repo, so this scan is global (not repo-scoped).
-    for path in scan_non_reusable_orphan_paths() {
+    for path in scan_non_reusable_orphan_paths(temp_root) {
         let _ = std::fs::remove_dir_all(&path);
     }
 }
@@ -900,9 +909,8 @@ fn deregister_legacy_orphan_worktrees(repo_root: &Path) -> bool {
 
 /// Enumerate unregistered non-reusable worktree DIRECTORY paths owned by a
 /// dead PID. Reusable caches yield no parseable PID and are skipped.
-fn scan_non_reusable_orphan_paths() -> Vec<PathBuf> {
-    let temp = std::env::temp_dir();
-    let Ok(entries) = std::fs::read_dir(&temp) else {
+fn scan_non_reusable_orphan_paths(temp: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(temp) else {
         return Vec::new();
     };
     let mut paths = Vec::new();


### PR DESCRIPTION
Follow-up to #1825. The orphan sweep scans `std::env::temp_dir()` globally for dead-pid worktree directories, so a test fixture fabricated there with a fake dead PID is legitimate prey for any concurrent sweep (a parallel test or a spawned fallow binary). Under full-suite parallelism this raced the fixture's own assertions: the fixture dir vanished between `git worktree add` and the registration precondition check (caught once in a local `cargo test --workspace --all-targets` run; passes in isolation).

The scanned temp root is now injectable (`sweep_orphan_audit_worktrees_in`), and the three orphan-sweep tests point at their own `TempDir`. Production behavior is unchanged: the public wrapper still scans the real temp dir.

Validated with the full fallow-cli lib suite twice consecutively, plus clippy and fmt.