### PR TITLE
docs(cli): drop intra-doc link to the cfg(test)-only UNSET snapshot

### DIFF
--- a/crates/cli/src/telemetry.rs
+++ b/crates/cli/src/telemetry.rs
@@ -1336,7 +1336,7 @@ fn inspect(example: bool, output: OutputFormat) -> ExitCode {
 
 /// Point-in-time copy of every per-run accumulator `build_workflow_event`
 /// consumes. Production snapshots the process globals once per event; tests
-/// pass [`RunAccumulatorSnapshot::UNSET`] so the assertion is deterministic
+/// pass the test-only `RunAccumulatorSnapshot::UNSET` so the assertion is deterministic
 /// even while a PARALLEL test drives a real command path (e.g.
 /// `load_config_for_analysis` -> `note_config_shape`) that mutates the
 /// globals mid-test. A reset-before-read guard cannot close that race.


### PR DESCRIPTION
The Documentation job on main (4cb65794e) failed with an unresolved intra-doc link: `RunAccumulatorSnapshot::UNSET` is `#[cfg(test)]`, so it does not exist in the non-test rustdoc build that runs under `-D warnings`. The doc comment now uses a plain code span.

Validated with `RUSTDOCFLAGS="-D warnings" cargo doc -p fallow-cli --no-deps --document-private-items`.