### PR TITLE
style(cli): wrap is_file_level_only matches! arm over rustfmt width

### DIFF
--- a/crates/cli/src/report/human/mod.rs
+++ b/crates/cli/src/report/human/mod.rs
@@ -289,7 +289,10 @@ fn section_suppress_rule(title: &str) -> Option<&'static str> {
 
 /// Rules that only support file-level suppression (not next-line).
 fn is_file_level_only(rule: &str) -> bool {
-    matches!(rule, "circular-dependencies" | "boundary-violation" | "unused-file")
+    matches!(
+        rule,
+        "circular-dependencies" | "boundary-violation" | "unused-file"
+    )
 }
 
 /// Rules whose findings live in YAML files (so the suppression comment must


### PR DESCRIPTION
Immediate follow-up to #1820: the added `"unused-file"` token pushed the `matches!` line over the rustfmt width and the fork disallows maintainer edits, so main's Format check is red on dddfbc801. This is the `cargo fmt --all` output, nothing else.