### PR TITLE
docs: classify the CI path-rebase as a behavior change, not a semver major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,17 +88,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every `ModuleInfo`. Existing owned APIs remain compatible, and detector facts
   are prepared before modules become immutable.
 
-- **BREAKING: CI-facing formats now emit repository-root-relative paths when
-  `--root` is a subdirectory.** `codeclimate`, `review-github`, and
-  `review-gitlab` addressed files relative to `--root`, while
-  `github-annotations` already rebased onto the git toplevel. CI platforms
-  address files from the repository root, so GitLab's Code Quality widget
-  matched nothing and every inline review discussion was rejected when the
-  analyzed project lived in a package subdirectory. All CI formats now share
-  one namespace, detected via the git toplevel. Consumers that post-process
-  these paths themselves (prepending the offset in a wrapper script) should
-  drop that step or pass `--report-path-prefix ''` to restore the old output.
-  Single-package repositories, where `--root` is the toplevel, are unaffected.
+- **Behavior change (subdirectory roots): CI-facing formats now emit
+  repository-root-relative paths when `--root` is a subdirectory.**
+  `codeclimate`, `review-github`, and `review-gitlab` addressed files
+  relative to `--root`, while `github-annotations` already rebased onto the
+  git toplevel. CI platforms address files from the repository root, so
+  GitLab's Code Quality widget matched nothing and every inline review
+  discussion was rejected when the analyzed project lived in a package
+  subdirectory. All CI formats now share one namespace, detected via the git
+  toplevel. Consumers that post-process these paths themselves (prepending
+  the offset in a wrapper script) should drop that step or pass
+  `--report-path-prefix ''` to restore the old output. Single-package
+  repositories, where `--root` is the toplevel, are unaffected. Classified
+  as a behavior-correcting fix rather than a semver major: for the affected
+  cohort the old paths were rejected by their only consumers, and one flag
+  restores the previous shape.
 
 - **`--annotations-path-prefix` is now `--report-path-prefix`.** It governs
   every CI-facing format rather than only the GitHub-native ones. The old name

--- a/docs/backwards-compatibility.md
+++ b/docs/backwards-compatibility.md
@@ -124,6 +124,12 @@ When a stable interface needs to change:
 2. The new behavior is available alongside the old one
 3. The old behavior is removed in the next major version
 
+## Notable behavior changes within v3
+
+These are documented for the rare CI script that depended on the old behavior. None require a config migration.
+
+- **CI-facing formats emit repository-root-relative paths when `--root` is a subdirectory** ([#1808](https://github.com/fallow-rs/fallow/pull/1808)). `codeclimate`, `review-github`, and `review-gitlab` used to address files relative to `--root`, which GitLab's Code Quality widget and the GitHub/GitLab review APIs rejected for package-subdirectory roots; they now rebase onto the git toplevel like `github-annotations`. Single-package repositories are unaffected. Wrapper scripts that prepended the offset themselves should drop that step, or pass `--report-path-prefix ''` to restore the old output. `--annotations-path-prefix` was renamed to `--report-path-prefix` with the old name kept as an alias.
+
 ## Notable behavior changes within v2
 
 These are documented for the rare CI script that depended on the old behavior. None require a config migration.


### PR DESCRIPTION
The #1808 CHANGELOG entry led with BREAKING, which would push the next release toward a major bump for a fix whose affected cohort (subdirectory `--root` runs) previously got output their only consumers rejected (GitLab Code Quality matched nothing, review APIs rejected the discussions), and which has a one-flag restore (`--report-path-prefix ''`).

Relabels the entry as "Behavior change (subdirectory roots)" with the classification rationale inline, and records it in the backwards-compatibility doc's notable-behavior-changes list (new v3 section), mirroring the `--coverage` resolution precedent. v4 stays reserved for the announced kind-tagged FallowOutput / alias-removal major (#413).