### PR TITLE
feat(action): render annotations and job summary via the native GitHub formats

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -139,6 +139,69 @@ jobs:
           fi
           echo "Issues match: $ISSUES"
 
+  test-native-annotations:
+    name: Test native annotation fastpath
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Run action with annotations enabled
+        id: fallow
+        uses: ./
+        env:
+          FALLOW_SKIP_BINARY_VERIFY: "1"
+        with:
+          command: dead-code
+          root: tests/fixtures/basic-project
+          format: json
+          annotations: true
+          fail-on-issues: false
+
+      - name: Verify native annotation fastpath ran
+        env:
+          RESULTS_PATH: ${{ steps.fallow.outputs.results }}
+          ISSUES: ${{ steps.fallow.outputs.issues }}
+        run: |
+          if [ ! -f "$RESULTS_PATH" ]; then
+            echo "::error::Results output file not found"
+            exit 1
+          fi
+          if [ -z "$ISSUES" ] || [ "$ISSUES" -eq 0 ]; then
+            echo "::error::Expected issues > 0 for basic-project fixture, got: $ISSUES"
+            exit 1
+          fi
+
+          # The composite already emitted annotations via the native path, but a
+          # later step cannot capture that step's log. Re-run annotate.sh with
+          # the installed binary against the saved envelope to assert the native
+          # renderer ran. HAS_NATIVE_REPORT mirrors what analyze.sh exports for a
+          # report-capable (3.4.2+) binary.
+          OUT=$(HAS_NATIVE_REPORT=true \
+            FALLOW_COMMAND=dead-code \
+            MAX_ANNOTATIONS=50 \
+            ACTION_JQ_DIR="${GITHUB_WORKSPACE}/action/jq" \
+            FALLOW_RESULTS_FILE="$RESULTS_PATH" \
+            bash "${GITHUB_WORKSPACE}/action/scripts/annotate.sh" 2>&1)
+          printf '%s\n' "$OUT"
+
+          if ! printf '%s\n' "$OUT" | grep -q 'annotations rendered via native github-annotations'; then
+            echo "::error::annotate.sh did not take the native path"
+            exit 1
+          fi
+          if ! printf '%s\n' "$OUT" | grep -qE '^::(warning|error) '; then
+            echo "::error::native annotation stream emitted no ::warning or ::error lines"
+            exit 1
+          fi
+          echo "Native annotation fastpath verified ($ISSUES issues)"
+
   test-zero-issues:
     name: Test clean project (zero issues)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The bundled GitHub Action renders inline annotations and the job summary
+  natively when the installed fallow supports it.** The annotate and summary
+  steps previously rendered both surfaces through the action's bundled jq. On
+  fallow >= 3.4.2 they now call `fallow report --from <results> --format
+  github-annotations|github-summary`, re-rendering the same saved analysis JSON
+  the run already produced (no extra analysis cost) and making the binary the
+  single source of truth for GitHub presentation. Older binaries without
+  `fallow report` stay on the jq renderers automatically via a capability probe
+  (there is no version floor), so nothing changes for them, and `version:
+  latest` users flip to the native path silently. A step log line names which
+  renderer ran. Two behavior deltas on the native path: the annotation stream
+  ends with a `fallow emitted N annotation(s)` budget notice that counts toward
+  `max-annotations`, and the job summary uses fallow's purpose-built
+  step-summary rendering instead of the comment-shaped body. The `fix` command
+  keeps the jq summary (there is no native fix rendering yet), and the jq
+  renderers remain in place as the fallback.
+
 ## [3.4.2] - 2026-07-13
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ inputs:
     required: false
     default: 'https://api.fallow.cloud'
   annotations:
-    description: 'Emit findings as inline PR annotations via workflow commands (no Advanced Security required)'
+    description: 'Emit findings as inline PR annotations via workflow commands (no Advanced Security required). On fallow >= 3.4.2 the action renders these natively via `fallow report --format github-annotations`; older binaries fall back to the bundled jq renderers, and version: latest users flip to the native path silently. The step log line "fallow: annotations rendered via native github-annotations" (or "via jq fallback") tells you which renderer ran.'
     required: false
     default: 'true'
   review-comments:
@@ -100,7 +100,7 @@ inputs:
     required: false
     default: 'false'
   max-annotations:
-    description: 'Maximum number of inline annotations to emit (default: 50)'
+    description: 'Maximum number of inline annotations to emit (default: 50). On the native path the action applies this cap to the rendered stream (GitHub itself displays at most 10 annotations per type per step).'
     required: false
     default: '50'
   max-comments:

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -324,6 +324,22 @@ if { [ "$INPUT_COMMAND" = "dead-code" ] || [ "$INPUT_COMMAND" = "check" ] || [ -
   rm -f "$HELP_TMP"
 fi
 
+# --- Check for native `fallow report` support ---
+# `fallow report --from <results.json> --format github-annotations|github-summary`
+# lets the annotate / summary steps re-render the saved envelope instead of the
+# bundled jq. One probe covers both formats (they shipped together). The
+# annotate / summary steps run in separate step processes, so the result flows
+# through $GITHUB_ENV like the other analyze outputs above; unset on older
+# binaries keeps those steps on the jq fallback.
+
+HAS_NATIVE_REPORT=false
+if fallow report --help > /dev/null 2>&1; then
+  HAS_NATIVE_REPORT=true
+fi
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "HAS_NATIVE_REPORT=${HAS_NATIVE_REPORT}" >> "$GITHUB_ENV"
+fi
+
 # --- Auto-detect changed-since in PR context ---
 
 AUTO_CHANGED_SINCE=false

--- a/action/scripts/annotate.sh
+++ b/action/scripts/annotate.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Emit inline PR annotations via workflow commands
+# Emit inline PR annotations via workflow commands.
+#
+# Render precedence (fail-open, most preferred first):
+#   1. native - `fallow report --from <results> --format github-annotations`
+#               when the analyze step probed HAS_NATIVE_REPORT=true and the
+#               command carries a report kind (i.e. not fix)
+#   2. typed  - the pr-comment decision JSON, present only when the comment
+#               step ran; strict escaping the native format is byte-compatible with
+#   3. jq     - the bundled annotations-*.jq renderers (older binaries)
+#
 # Required env: FALLOW_COMMAND, MAX_ANNOTATIONS, ACTION_JQ_DIR
 # Optional env: CHANGED_SINCE, INPUT_ROOT, FALLOW_RESULTS_FILE,
 #   FALLOW_SCOPED_RESULTS_FILE, FALLOW_CHANGED_FILES_FILE,
-#   FALLOW_PR_DECISION_FILE
+#   FALLOW_PR_DECISION_FILE, HAS_NATIVE_REPORT, FALLOW_BIN
 
 MAX="${MAX_ANNOTATIONS:-50}"
 if ! [[ "$MAX" =~ ^[0-9]+$ ]]; then
@@ -13,6 +22,74 @@ if ! [[ "$MAX" =~ ^[0-9]+$ ]]; then
   MAX=50
 fi
 
+_FALLOW_TMPS=()
+trap 'rm -f "${_FALLOW_TMPS[@]:-}"' EXIT
+
+# Resolve the results file the render paths consume, scoping it to the changed
+# files when --changed-since is active. Native and jq select the same input.
+resolve_results_file() {
+  local results_file="${FALLOW_RESULTS_FILE:-fallow-results.json}"
+  local scoped_file="${FALLOW_SCOPED_RESULTS_FILE:-fallow-results-scoped.json}"
+  local changed_files_file="${FALLOW_CHANGED_FILES_FILE:-fallow-changed-files.json}"
+  if [ -n "${CHANGED_SINCE:-}" ]; then
+    local changed_json=""
+
+    # Prefer pre-computed list from analyze step (handles shallow clones via API fallback)
+    if [ -f "$changed_files_file" ]; then
+      changed_json=$(cat "$changed_files_file")
+    else
+      # Fallback: compute locally (for standalone usage outside the action)
+      local root="${INPUT_ROOT:-.}"
+      local changed_files
+      changed_files=$(cd "$root" && git diff --name-only --relative "${CHANGED_SINCE}...HEAD" -- . 2>/dev/null || true)
+      if [ -n "$changed_files" ]; then
+        changed_json=$(echo "$changed_files" | jq -R -s 'split("\n") | map(select(length > 0))')
+      fi
+    fi
+
+    if [ -n "$changed_json" ] && [ "$changed_json" != "[]" ]; then
+      if jq --argjson changed "$changed_json" -f "${ACTION_JQ_DIR}/filter-changed.jq" "$results_file" > "$scoped_file" 2>/dev/null; then
+        results_file="$scoped_file"
+      fi
+    fi
+  fi
+  printf '%s\n' "$results_file"
+}
+
+# 1. Native renderer. The action adds only the MAX cap and its truncation
+# notice on top of the native stream, so the emitted annotations stay
+# byte-identical to `fallow report --from ... | head -n MAX`.
+emit_native_annotations_if_available() {
+  [ "${HAS_NATIVE_REPORT:-false}" = "true" ] || return 1
+  # fix has no report kind; the step gate already excludes it, belt and braces.
+  [ "$FALLOW_COMMAND" = "fix" ] && return 1
+
+  local input_file
+  input_file=$(resolve_results_file)
+
+  local native_file
+  native_file=$(mktemp)
+  _FALLOW_TMPS+=("$native_file")
+
+  if ! "${FALLOW_BIN:-fallow}" report --from "$input_file" --format github-annotations > "$native_file" 2>/dev/null; then
+    echo "::warning::fallow native annotation render failed; falling back to jq"
+    return 1
+  fi
+
+  local total
+  total=$(wc -l < "$native_file" | tr -d ' ')
+  if [ "$total" -gt 0 ]; then
+    head -n "$MAX" "$native_file"
+    if [ "$total" -gt "$MAX" ]; then
+      echo "::notice::Showing ${MAX} of ${total} annotations. Increase max-annotations to see more."
+    fi
+  fi
+  echo "fallow: annotations rendered via native github-annotations" >&2
+  return 0
+}
+
+# 2. Typed renderer: the pr-comment decision JSON, present only when the
+# comment step produced it. Same strict escaping as the native format.
 emit_typed_annotations_if_available() {
   local decision_file="${FALLOW_PR_DECISION_FILE:-}"
   if [ -z "$decision_file" ] || [ ! -f "$decision_file" ]; then
@@ -57,12 +134,15 @@ emit_typed_annotations_if_available() {
   return 0
 }
 
-_FALLOW_TMPS=()
-trap 'rm -f "${_FALLOW_TMPS[@]:-}"' EXIT
+if emit_native_annotations_if_available; then
+  exit 0
+fi
 
 if emit_typed_annotations_if_available; then
   exit 0
 fi
+
+# 3. jq fallback for binaries without `fallow report`.
 
 # Detect package manager from lock files
 PKG_MANAGER="npm"
@@ -74,31 +154,7 @@ elif [ -f "${ROOT}/yarn.lock" ] || [ -f "yarn.lock" ]; then
 fi
 export PKG_MANAGER
 
-# Scope results to changed files when --changed-since is active
-RESULTS_FILE="${FALLOW_RESULTS_FILE:-fallow-results.json}"
-SCOPED_RESULTS_FILE="${FALLOW_SCOPED_RESULTS_FILE:-fallow-results-scoped.json}"
-CHANGED_FILES_FILE="${FALLOW_CHANGED_FILES_FILE:-fallow-changed-files.json}"
-if [ -n "${CHANGED_SINCE:-}" ]; then
-  CHANGED_JSON=""
-
-  # Prefer pre-computed list from analyze step (handles shallow clones via API fallback)
-  if [ -f "$CHANGED_FILES_FILE" ]; then
-    CHANGED_JSON=$(cat "$CHANGED_FILES_FILE")
-  else
-    # Fallback: compute locally (for standalone usage outside the action)
-    _ROOT="${INPUT_ROOT:-.}"
-    CHANGED_FILES=$(cd "$_ROOT" && git diff --name-only --relative "${CHANGED_SINCE}...HEAD" -- . 2>/dev/null || true)
-    if [ -n "$CHANGED_FILES" ]; then
-      CHANGED_JSON=$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')
-    fi
-  fi
-
-  if [ -n "$CHANGED_JSON" ] && [ "$CHANGED_JSON" != "[]" ]; then
-    if jq --argjson changed "$CHANGED_JSON" -f "${ACTION_JQ_DIR}/filter-changed.jq" "$RESULTS_FILE" > "$SCOPED_RESULTS_FILE" 2>/dev/null; then
-      RESULTS_FILE="$SCOPED_RESULTS_FILE"
-    fi
-  fi
-fi
+RESULTS_FILE=$(resolve_results_file)
 
 ANNOTATIONS_FILE=$(mktemp)
 _FALLOW_TMPS+=("$ANNOTATIONS_FILE")
@@ -133,3 +189,4 @@ if [ "$TOTAL" -gt 0 ]; then
     echo "::notice::Showing ${MAX} of ${TOTAL} annotations. Increase max-annotations to see more."
   fi
 fi
+echo "fallow: annotations rendered via jq fallback" >&2

--- a/action/scripts/summary.sh
+++ b/action/scripts/summary.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Write job summary. Prefer the typed PR/MR comment envelope produced by the
-# Rust renderer, then fall back to the jq job-summary renderers for standalone
-# runs that do not post a PR comment.
+# Write the job summary.
+#
+# Render precedence (fail-open, most preferred first):
+#   1. native - `fallow report --from <results> --format github-summary` when
+#               the analyze step probed HAS_NATIVE_REPORT=true and the command
+#               carries a report kind (i.e. not fix). The purpose-built
+#               step-summary rendering, so it wins over the comment-shaped
+#               typed body below.
+#   2. typed  - the pr-comment envelope's .body, present only when the comment
+#               step produced it
+#   3. jq     - the bundled summary-*.jq renderers (older binaries)
+#
 # Required env: FALLOW_COMMAND, ACTION_JQ_DIR
 # Optional env: CHANGED_SINCE, INPUT_ROOT, FALLOW_RESULTS_FILE,
 #   FALLOW_SCOPED_RESULTS_FILE, FALLOW_CHANGED_FILES_FILE,
-#   FALLOW_PR_COMMENT_ENVELOPE_FILE
+#   FALLOW_PR_COMMENT_ENVELOPE_FILE, HAS_NATIVE_REPORT, FALLOW_BIN
 
 select_summary_script() {
   case "$FALLOW_COMMAND" in
@@ -22,6 +31,74 @@ select_summary_script() {
   esac
 }
 
+# Resolve the results file the render paths consume, scoping it to the changed
+# files when --changed-since is active. Native and jq select the same input.
+resolve_results_file() {
+  local results_file="${FALLOW_RESULTS_FILE:-fallow-results.json}"
+  local scoped_file="${FALLOW_SCOPED_RESULTS_FILE:-fallow-results-scoped.json}"
+  local changed_files_file="${FALLOW_CHANGED_FILES_FILE:-fallow-changed-files.json}"
+  if [ -n "${CHANGED_SINCE:-}" ]; then
+    local changed_json=""
+
+    # Prefer pre-computed list from analyze step (handles shallow clones via API fallback)
+    if [ -f "$changed_files_file" ]; then
+      changed_json=$(cat "$changed_files_file")
+    else
+      # Fallback: compute locally (for standalone usage outside the action)
+      local root="${INPUT_ROOT:-.}"
+      local changed_files
+      changed_files=$(cd "$root" && git diff --name-only --relative "${CHANGED_SINCE}...HEAD" -- . 2>/dev/null || true)
+      if [ -n "$changed_files" ]; then
+        changed_json=$(echo "$changed_files" | jq -R -s 'split("\n") | map(select(length > 0))')
+      fi
+    fi
+
+    if [ -n "$changed_json" ] && [ "$changed_json" != "[]" ]; then
+      if jq --argjson changed "$changed_json" -f "${ACTION_JQ_DIR}/filter-changed.jq" "$results_file" > "$scoped_file" 2>/dev/null; then
+        results_file="$scoped_file"
+      fi
+    fi
+  fi
+  printf '%s\n' "$results_file"
+}
+
+# The changed-files disclaimer appended when results were scoped to a diff.
+scoping_footnote() {
+  local commit_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/commit/${CHANGED_SINCE}"
+  printf '%s' "*Issue counts scoped to files changed since [\`${CHANGED_SINCE:0:7}\`](${commit_url}) · health metrics reflect the full codebase*"
+}
+
+# 1. Native renderer: the purpose-built step-summary rendering, source of truth.
+emit_native_summary_if_available() {
+  [ "${HAS_NATIVE_REPORT:-false}" = "true" ] || return 1
+  # fix has no report kind: summary-fix.jq stays on the jq path below.
+  [ "$FALLOW_COMMAND" = "fix" ] && return 1
+
+  local input_file
+  input_file=$(resolve_results_file)
+
+  local rendered
+  if ! rendered=$("${FALLOW_BIN:-fallow}" report --from "$input_file" --format github-summary 2>/dev/null); then
+    echo "::warning::fallow native summary render failed; falling back to jq"
+    return 1
+  fi
+  # Empty render: the binary succeeded but had nothing to say. Keep the jq
+  # summary rather than writing a blank section.
+  [ -n "$rendered" ] || return 1
+
+  # Match the jq path's changed-files disclaimer when results were scoped.
+  local scoped_file="${FALLOW_SCOPED_RESULTS_FILE:-fallow-results-scoped.json}"
+  if [ "$input_file" = "$scoped_file" ]; then
+    rendered="${rendered}"$'\n\n'"$(scoping_footnote)"
+  fi
+
+  echo "$rendered" >> "$GITHUB_STEP_SUMMARY"
+  echo "fallow: summary rendered via native github-summary" >&2
+  return 0
+}
+
+# 2. Typed renderer: the pr-comment envelope body, present only when the
+# comment step produced it.
 append_typed_summary_if_available() {
   local envelope_file="${FALLOW_PR_COMMENT_ENVELOPE_FILE:-}"
   if [ -z "$envelope_file" ] || [ ! -f "$envelope_file" ]; then
@@ -41,41 +118,23 @@ append_typed_summary_if_available() {
   return 0
 }
 
+if emit_native_summary_if_available; then
+  exit 0
+fi
+
 if append_typed_summary_if_available; then
   exit 0
 fi
 
+# 3. jq fallback for binaries without `fallow report`.
 JQ_FILE=$(select_summary_script)
 if [ ! -f "$JQ_FILE" ]; then
   echo "::warning::Summary script not found: ${JQ_FILE}"
   exit 0
 fi
 
-# Scope results to changed files when --changed-since is active
-RESULTS_FILE="${FALLOW_RESULTS_FILE:-fallow-results.json}"
+RESULTS_FILE=$(resolve_results_file)
 SCOPED_RESULTS_FILE="${FALLOW_SCOPED_RESULTS_FILE:-fallow-results-scoped.json}"
-CHANGED_FILES_FILE="${FALLOW_CHANGED_FILES_FILE:-fallow-changed-files.json}"
-if [ -n "${CHANGED_SINCE:-}" ]; then
-  CHANGED_JSON=""
-
-  # Prefer pre-computed list from analyze step (handles shallow clones via API fallback)
-  if [ -f "$CHANGED_FILES_FILE" ]; then
-    CHANGED_JSON=$(cat "$CHANGED_FILES_FILE")
-  else
-    # Fallback: compute locally (for standalone usage outside the action)
-    ROOT="${INPUT_ROOT:-.}"
-    CHANGED_FILES=$(cd "$ROOT" && git diff --name-only --relative "${CHANGED_SINCE}...HEAD" -- . 2>/dev/null || true)
-    if [ -n "$CHANGED_FILES" ]; then
-      CHANGED_JSON=$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')
-    fi
-  fi
-
-  if [ -n "$CHANGED_JSON" ] && [ "$CHANGED_JSON" != "[]" ]; then
-    if jq --argjson changed "$CHANGED_JSON" -f "${ACTION_JQ_DIR}/filter-changed.jq" "$RESULTS_FILE" > "$SCOPED_RESULTS_FILE" 2>/dev/null; then
-      RESULTS_FILE="$SCOPED_RESULTS_FILE"
-    fi
-  fi
-fi
 
 if ! BODY=$(jq -r -f "$JQ_FILE" "$RESULTS_FILE"); then
   echo "::warning::Failed to generate job summary"
@@ -84,8 +143,8 @@ fi
 
 # Add scoping indicator when results were filtered to changed files
 if [ "$RESULTS_FILE" = "$SCOPED_RESULTS_FILE" ]; then
-  COMMIT_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/commit/${CHANGED_SINCE}"
-  BODY="${BODY}"$'\n\n'"*Issue counts scoped to files changed since [\`${CHANGED_SINCE:0:7}\`](${COMMIT_URL}) · health metrics reflect the full codebase*"
+  BODY="${BODY}"$'\n\n'"$(scoping_footnote)"
 fi
 
 echo "$BODY" >> "$GITHUB_STEP_SUMMARY"
+echo "fallow: summary rendered via jq fallback" >&2

--- a/action/tests/fixtures/dead-code-envelope.json
+++ b/action/tests/fixtures/dead-code-envelope.json
@@ -1,0 +1,261 @@
+{
+  "kind": "dead-code",
+  "schema_version": 7,
+  "version": "3.4.2",
+  "elapsed_ms": 18,
+  "total_issues": 7,
+  "entry_points": {
+    "total": 1,
+    "sources": {
+      "package.json": 1
+    }
+  },
+  "summary": {
+    "total_issues": 7,
+    "unused_files": 1,
+    "unused_exports": 2,
+    "unused_types": 2,
+    "private_type_leaks": 0,
+    "unused_dependencies": 2,
+    "unused_enum_members": 0,
+    "unused_class_members": 0,
+    "unused_store_members": 0,
+    "unprovided_injects": 0,
+    "unrendered_components": 0,
+    "unused_component_props": 0,
+    "unused_component_emits": 0,
+    "unused_component_inputs": 0,
+    "unused_component_outputs": 0,
+    "unused_svelte_events": 0,
+    "unused_server_actions": 0,
+    "unused_load_data_keys": 0,
+    "unresolved_imports": 0,
+    "unlisted_dependencies": 0,
+    "duplicate_exports": 0,
+    "type_only_dependencies": 0,
+    "test_only_dependencies": 0,
+    "dev_dependencies_in_production": 0,
+    "circular_dependencies": 0,
+    "re_export_cycles": 0,
+    "boundary_violations": 0,
+    "boundary_coverage_violations": 0,
+    "boundary_call_violations": 0,
+    "policy_violations": 0,
+    "stale_suppressions": 0,
+    "unused_catalog_entries": 0,
+    "empty_catalog_groups": 0,
+    "unresolved_catalog_references": 0,
+    "unused_dependency_overrides": 0,
+    "misconfigured_dependency_overrides": 0,
+    "invalid_client_exports": 0,
+    "mixed_client_server_barrels": 0,
+    "misplaced_directives": 0,
+    "route_collisions": 0,
+    "dynamic_segment_name_conflicts": 0
+  },
+  "unused_files": [
+    {
+      "path": "src/orphan.ts",
+      "actions": [
+        {
+          "type": "delete-file",
+          "auto_fixable": false,
+          "description": "Delete this file",
+          "note": "File deletion may remove runtime functionality not visible to static analysis"
+        },
+        {
+          "type": "suppress-file",
+          "auto_fixable": false,
+          "description": "Suppress with a file-level comment at the top of the file",
+          "comment": "// fallow-ignore-file unused-file"
+        }
+      ]
+    }
+  ],
+  "unused_exports": [
+    {
+      "path": "src/utils.ts",
+      "export_name": "unusedFunction",
+      "is_type_only": false,
+      "line": 3,
+      "col": 13,
+      "span_start": 65,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    },
+    {
+      "path": "src/utils.ts",
+      "export_name": "anotherUnused",
+      "is_type_only": false,
+      "line": 5,
+      "col": 16,
+      "span_start": 126,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the unused export from the public API"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-export"
+        }
+      ]
+    }
+  ],
+  "unused_types": [
+    {
+      "path": "src/types.ts",
+      "export_name": "UnusedType",
+      "is_type_only": true,
+      "line": 3,
+      "col": 12,
+      "span_start": 55,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    },
+    {
+      "path": "src/types.ts",
+      "export_name": "UnusedInterface",
+      "is_type_only": true,
+      "line": 5,
+      "col": 17,
+      "span_start": 104,
+      "is_re_export": false,
+      "actions": [
+        {
+          "type": "remove-export",
+          "auto_fixable": true,
+          "description": "Remove the `export` (or `export type`) keyword from the type declaration"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the line",
+          "comment": "// fallow-ignore-next-line unused-type"
+        }
+      ]
+    }
+  ],
+  "private_type_leaks": [],
+  "unused_dependencies": [
+    {
+      "package_name": "react",
+      "location": "dependencies",
+      "path": "package.json",
+      "line": 5,
+      "actions": [
+        {
+          "type": "remove-dependency",
+          "auto_fixable": true,
+          "description": "Remove from dependencies in package.json"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"react\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "react",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    },
+    {
+      "package_name": "unused-dep",
+      "location": "dependencies",
+      "path": "package.json",
+      "line": 6,
+      "actions": [
+        {
+          "type": "remove-dependency",
+          "auto_fixable": true,
+          "description": "Remove from dependencies in package.json"
+        },
+        {
+          "type": "add-to-config",
+          "auto_fixable": false,
+          "description": "Add \"unused-dep\" to ignoreDependencies in fallow config",
+          "config_key": "ignoreDependencies",
+          "value": "unused-dep",
+          "value_schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json#/properties/ignoreDependencies/items"
+        }
+      ]
+    }
+  ],
+  "unused_dev_dependencies": [],
+  "unused_optional_dependencies": [],
+  "unused_enum_members": [],
+  "unused_class_members": [],
+  "unresolved_imports": [],
+  "unlisted_dependencies": [],
+  "duplicate_exports": [],
+  "type_only_dependencies": [],
+  "test_only_dependencies": [],
+  "dev_dependencies_in_production": [],
+  "circular_dependencies": [],
+  "re_export_cycles": [],
+  "boundary_violations": [],
+  "boundary_coverage_violations": [],
+  "boundary_call_violations": [],
+  "policy_violations": [],
+  "stale_suppressions": [],
+  "unused_catalog_entries": [],
+  "empty_catalog_groups": [],
+  "unresolved_catalog_references": [],
+  "unused_dependency_overrides": [],
+  "misconfigured_dependency_overrides": [],
+  "invalid_client_exports": [],
+  "mixed_client_server_barrels": [],
+  "misplaced_directives": [],
+  "route_collisions": [],
+  "dynamic_segment_name_conflicts": [],
+  "next_steps": [
+    {
+      "id": "impact-report",
+      "command": "fallow impact",
+      "reason": "local value report: 4608 findings resolved; share the non-zero numbers with the user"
+    },
+    {
+      "id": "trace-unused-export",
+      "command": "fallow dead-code --trace src/utils.ts:anotherUnused",
+      "reason": "verify an export is truly unused before deleting"
+    },
+    {
+      "id": "audit-changed",
+      "command": "fallow audit",
+      "reason": "gate only the files your branch changed (auto-detects the base)"
+    }
+  ],
+  "_meta": {
+    "telemetry": {
+      "analysis_run_id": "run_bf68ef8e76af8b80"
+    }
+  }
+}

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -2149,6 +2149,107 @@ assert_contains "$OUT" "::" "annotate.sh: custom artifacts path emits annotation
 
 rm -rf "$WORK_DIR"
 
+# --- Native report fastpath (annotate.sh / summary.sh) ---
+# Exercise the native github-annotations / github-summary fastpath. These need a
+# report-capable fallow binary (on PATH or at $FALLOW_BIN); without one the whole
+# section skips, and older binaries keep the jq path covered by the tests above.
+
+echo ""
+echo "=== Native report fastpath ==="
+
+FASTPATH_SCRIPTS="$DIR/../scripts"
+FASTPATH_ENVELOPE="$FIXTURES/dead-code-envelope.json"
+
+# Resolve a report-capable binary the same way issuekind-drift-guard.sh does:
+# explicit $FALLOW_BIN, else a locally built target/{release,debug}/fallow, else
+# a PATH lookup. Absolute so the check survives the cwd changes above.
+FASTPATH_REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+FASTPATH_BIN="${FALLOW_BIN:-}"
+if [ -z "$FASTPATH_BIN" ]; then
+  for FASTPATH_CAND in "$FASTPATH_REPO_ROOT/target/release/fallow" "$FASTPATH_REPO_ROOT/target/debug/fallow"; do
+    if [ -x "$FASTPATH_CAND" ]; then FASTPATH_BIN="$FASTPATH_CAND"; break; fi
+  done
+fi
+[ -n "$FASTPATH_BIN" ] || FASTPATH_BIN="fallow"
+
+if ! command -v "$FASTPATH_BIN" > /dev/null 2>&1 || ! "$FASTPATH_BIN" report --help > /dev/null 2>&1; then
+  echo "  (skipped: no fallow binary with 'report' support on PATH or at \$FALLOW_BIN)"
+else
+  FASTPATH_WORK=$(mktemp -d)
+
+  # (a) byte-equality: the action layers only the cap on the native stream.
+  FASTPATH_EXPECTED=$("$FASTPATH_BIN" report --from "$FASTPATH_ENVELOPE" --format github-annotations | head -n 999)
+  FASTPATH_ACTUAL=$(
+    HAS_NATIVE_REPORT=true \
+      FALLOW_BIN="$FASTPATH_BIN" \
+      FALLOW_COMMAND="dead-code" \
+      MAX_ANNOTATIONS="999" \
+      ACTION_JQ_DIR="$JQ_DIR" \
+      FALLOW_RESULTS_FILE="$FASTPATH_ENVELOPE" \
+      bash "$FASTPATH_SCRIPTS/annotate.sh" 2>/dev/null
+  )
+  if [ "$FASTPATH_ACTUAL" = "$FASTPATH_EXPECTED" ]; then
+    pass "annotate.sh native fastpath is byte-identical to report --from | head"
+  else
+    fail "annotate.sh native fastpath is byte-identical to report --from | head" "diverged from the native render"
+  fi
+
+  # (b) truncation notice fires with a small cap.
+  FASTPATH_TRUNC=$(
+    HAS_NATIVE_REPORT=true \
+      FALLOW_BIN="$FASTPATH_BIN" \
+      FALLOW_COMMAND="dead-code" \
+      MAX_ANNOTATIONS="2" \
+      ACTION_JQ_DIR="$JQ_DIR" \
+      FALLOW_RESULTS_FILE="$FASTPATH_ENVELOPE" \
+      bash "$FASTPATH_SCRIPTS/annotate.sh" 2>/dev/null
+  )
+  assert_contains "$FASTPATH_TRUNC" "Showing 2 of " "annotate.sh native fastpath honors max-annotations"
+
+  # (c) summary fastpath writes the native heading.
+  FASTPATH_SUMMARY="$FASTPATH_WORK/summary.md"
+  HAS_NATIVE_REPORT=true \
+    FALLOW_BIN="$FASTPATH_BIN" \
+    FALLOW_COMMAND="dead-code" \
+    ACTION_JQ_DIR="$JQ_DIR" \
+    GITHUB_STEP_SUMMARY="$FASTPATH_SUMMARY" \
+    FALLOW_RESULTS_FILE="$FASTPATH_ENVELOPE" \
+    bash "$FASTPATH_SCRIPTS/summary.sh" > /dev/null 2>&1
+  assert_contains "$(cat "$FASTPATH_SUMMARY")" "# Fallow Analysis" "summary.sh native fastpath writes the native heading"
+
+  # (d) fix has no report kind: the fastpath is bypassed for the jq summary.
+  FASTPATH_FIX_SUMMARY="$FASTPATH_WORK/fix-summary.md"
+  FASTPATH_FIX_LOG=$(
+    HAS_NATIVE_REPORT=true \
+      FALLOW_BIN="$FASTPATH_BIN" \
+      FALLOW_COMMAND="fix" \
+      ACTION_JQ_DIR="$JQ_DIR" \
+      GITHUB_STEP_SUMMARY="$FASTPATH_FIX_SUMMARY" \
+      FALLOW_RESULTS_FILE="$FIXTURES/fix.json" \
+      bash "$FASTPATH_SCRIPTS/summary.sh" 2>&1
+  )
+  assert_contains "$FASTPATH_FIX_LOG" "summary rendered via jq fallback" "summary.sh routes fix to jq even with native support"
+  assert_not_contains "$FASTPATH_FIX_LOG" "rendered via native" "summary.sh never renders fix natively"
+
+  # (e) probe-false pins the exact jq behavior for older binaries.
+  FASTPATH_PROBE_FALSE=$(
+    HAS_NATIVE_REPORT=false \
+      FALLOW_COMMAND="dead-code" \
+      MAX_ANNOTATIONS="50" \
+      ACTION_JQ_DIR="$JQ_DIR" \
+      FALLOW_RESULTS_FILE="$FIXTURES/check.json" \
+      bash "$FASTPATH_SCRIPTS/annotate.sh" 2>/dev/null
+  )
+  FASTPATH_JQ_ONLY=$(jq -r -f "$JQ_DIR/annotations-check.jq" "$FIXTURES/check.json" 2>/dev/null | head -n 50)
+  if [ "$FASTPATH_PROBE_FALSE" = "$FASTPATH_JQ_ONLY" ]; then
+    pass "annotate.sh probe-false keeps the exact jq annotation output"
+  else
+    fail "annotate.sh probe-false keeps the exact jq annotation output" "diverged from the jq render"
+  fi
+
+  rm -rf "$FASTPATH_WORK"
+fi
+
 # --- Code Scanning availability gate (check-code-scanning.sh) ---
 
 echo ""


### PR DESCRIPTION
The action's annotate and summary steps rendered through ~90KB of bundled jq that duplicated what the binary renders natively since v3.4.2. They now call `fallow report --from <results.json> --format github-annotations|github-summary`, re-rendering the same saved analysis JSON the run already produced (no extra analysis cost) behind a capability probe (`fallow report --help`, exported as `HAS_NATIVE_REPORT` via `$GITHUB_ENV`). Older binaries fall back to the jq renderers automatically; there is no version floor, and a step log line names which renderer ran.

Render precedence is native > typed decision/envelope > jq, fail-open at each step (a native render failure logs a `::warning` and falls through; verified including the structured-error-envelope case). The action keeps applying its `max-annotations` cap plus truncation notice on the native stream, so that input keeps its contract. `fix` stays on the jq summary (`report --from` has no fix kind yet). No jq file is modified or deleted; the eventual jq retirement is a separate follow-up.

Tests: a new run.sh fastpath section (byte-equality vs the raw native render, truncation, fix bypass, probe-false byte-pinning the legacy jq output; skips cleanly without a report-capable binary: 421 vs 414 assertions, both green) plus a dogfood job in test-action.yml asserting the native path ran end-to-end (SHA-pinned steps, contents: read).

Closes #1816.