### PR TITLE
fix(cli): box the large MapOutcome::Ready variant (Windows clippy)

### DIFF
--- a/crates/cli/src/coverage/upload_source_maps.rs
+++ b/crates/cli/src/coverage/upload_source_maps.rs
@@ -521,10 +521,10 @@ fn prepare_source_map_with_open(
     }
 
     match serde_json::from_str::<serde_json::Value>(&content) {
-        Ok(source_map) => MapOutcome::Ready(PreparedSourceMap {
+        Ok(source_map) => MapOutcome::Ready(Box::new(PreparedSourceMap {
             candidate: candidate.clone(),
             source_map,
-        }),
+        })),
         Err(err) => MapOutcome::failed(
             candidate,
             FailureKind::Validation,
@@ -702,7 +702,7 @@ fn prepare_source_maps_for_upload(
     for candidate in maps {
         warn_large_source_map(candidate);
         match prepare_source_map(candidate) {
-            MapOutcome::Ready(prepared) => ready.push(prepared),
+            MapOutcome::Ready(prepared) => ready.push(*prepared),
             failed => {
                 outcomes.push(failed);
                 if args.fail_fast {
@@ -1037,7 +1037,7 @@ enum FailureKind {
 
 #[derive(Debug, Clone)]
 enum MapOutcome {
-    Ready(PreparedSourceMap),
+    Ready(Box<PreparedSourceMap>),
     Success,
     Failed {
         file_name: String,


### PR DESCRIPTION
The dispatchable release validation (first run on main) caught a latent Windows-only clippy failure: `large_enum_variant` on `MapOutcome::Ready`, whose `PreparedSourceMap` payload is 256 bytes on Windows (over the 200-byte threshold) but under it on macOS/Linux, so PR CI never saw it. The Windows clippy step only runs in the release Windows job, so this would have failed the next release. Boxing the variant makes it a pointer everywhere. Exactly the class of pre-tag failure the pre-flight exists to catch.