### PR TITLE
fix(cli): expect unsafe_code on the Windows source-map canonicalizer

### DIFF
--- a/crates/cli/src/coverage/upload_source_maps.rs
+++ b/crates/cli/src/coverage/upload_source_maps.rs
@@ -597,6 +597,10 @@ fn securely_open_source_map(candidate: &SourceMapCandidate) -> std::io::Result<s
 }
 
 #[cfg(windows)]
+#[expect(
+    unsafe_code,
+    reason = "final-path canonicalization requires Win32 FFI calls"
+)]
 fn securely_open_source_map(candidate: &SourceMapCandidate) -> std::io::Result<std::fs::File> {
     use std::os::windows::ffi::OsStrExt as _;
     use std::os::windows::io::AsRawHandle as _;


### PR DESCRIPTION
The re-dispatched release validation surfaced a second latent Windows-only clippy failure in `upload_source_maps.rs` (the box fix in #1844 cleared the first). The cfg(windows) `securely_open_source_map` makes three Win32 FFI calls (`GetFinalPathNameByHandleW`, `CompareStringOrdinal`) whose `unsafe` blocks trip `-D unsafe_code`; that lint only runs on the release Windows clippy leg, so it was latent on main. Annotated at the function level with a reason, matching the existing Win32-FFI pattern in `crates/mcp/src/tools/process_tree.rs`.