### PR TITLE
test: agent-surface contract tests (instance validation + cross-surface parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ name = "fallow-node"
 version = "3.4.2"
 dependencies = [
  "fallow-api",
+ "fallow-types",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -90,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -101,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -286,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +469,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -936,6 +943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -979,6 +995,7 @@ dependencies = [
  "fallow-output",
  "fallow-types",
  "globset",
+ "jsonschema",
  "rayon",
  "rustc-hash 2.1.2",
  "schemars",
@@ -1031,6 +1048,7 @@ dependencies = [
  "ignore",
  "insta",
  "jsonc-parser",
+ "jsonschema",
  "miette",
  "notify",
  "oxc_coverage_instrument",
@@ -1329,6 +1347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-glob"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1439,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1537,9 +1576,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1938,6 +1979,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2151,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "miette"
@@ -2256,7 +2339,21 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2266,6 +2363,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2281,6 +2393,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3152,6 +3285,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.0",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,7 +3464,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3818,7 +3968,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3828,7 +3978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4129,6 +4279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,6 +4398,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "valuable"
@@ -4377,7 +4543,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ notify = "8"
 criterion2 = { version = "3.0.3", default-features = false }
 dhat = "0.3"
 insta = { version = "1", features = ["yaml"] }
+jsonschema = { version = "0.47", default-features = false }
 proptest = "1"
 tempfile = "3"
 libc = "0.2"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -33,6 +33,7 @@ xxhash-rust = { workspace = true }
 schema = ["dep:schemars", "fallow-engine/schema", "fallow-output/schema", "fallow-types/schema"]
 
 [dev-dependencies]
+jsonschema = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/api/tests/capability_parity.rs
+++ b/crates/api/tests/capability_parity.rs
@@ -1,0 +1,77 @@
+//! api-side drift guard for the cross-surface capability parity table
+//! (`fallow_types::mcp_manifest::CAPABILITY_PARITY`).
+//!
+//! Source-scans this crate's public `run_*` re-exports and asserts they match
+//! the table's `api_runner` column in both directions: every runner named in
+//! the table exists, and every public runner appears in the table. A new
+//! `run_*` entry point that is not recorded in the parity table fails here.
+
+#![expect(
+    clippy::unwrap_used,
+    reason = "tests use unwrap to keep the source scan concise"
+)]
+
+use std::collections::BTreeSet;
+
+/// Extract the public `run_*` identifiers re-exported from `lib.rs`.
+///
+/// Scans the non-`#[cfg(test)]` portion, skipping comment lines, for tokens
+/// that begin with `run_` at an identifier boundary. This mirrors the
+/// include_str source-scan the schemars-alias guards use, and matches the 17
+/// `pub use runtime::{...}` / `pub use list_runtime::{...}` runner re-exports
+/// without hard-coding their names.
+fn public_run_fns(source: &str) -> BTreeSet<String> {
+    let head = source.split("#[cfg(test)]").next().unwrap_or(source);
+    let mut found = BTreeSet::new();
+    for line in head.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+            continue;
+        }
+        let bytes = line.as_bytes();
+        let mut cursor = 0;
+        while let Some(pos) = line[cursor..].find("run_") {
+            let start = cursor + pos;
+            let boundary = start == 0
+                || !matches!(bytes[start - 1], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_');
+            if boundary {
+                let mut end = start + "run_".len();
+                while end < bytes.len() && matches!(bytes[end], b'a'..=b'z' | b'_') {
+                    end += 1;
+                }
+                found.insert(line[start..end].to_string());
+            }
+            cursor = start + "run_".len();
+        }
+    }
+    found
+}
+
+#[test]
+fn api_run_fns_match_capability_parity_table() {
+    let scanned = public_run_fns(include_str!("../src/lib.rs"));
+    assert!(
+        scanned.len() >= 7,
+        "source scan found too few run_* re-exports ({}); the scan pattern likely broke",
+        scanned.len()
+    );
+
+    let table: BTreeSet<String> = fallow_types::mcp_manifest::CAPABILITY_PARITY
+        .iter()
+        .filter_map(|row| row.api_runner)
+        .map(str::to_string)
+        .collect();
+
+    for runner in &table {
+        assert!(
+            scanned.contains(runner),
+            "capability-parity api_runner {runner:?} is not a public run_* re-export of fallow-api"
+        );
+    }
+    for runner in &scanned {
+        assert!(
+            table.contains(runner),
+            "public run_* {runner:?} is missing from the CAPABILITY_PARITY table; add a row for it"
+        );
+    }
+}

--- a/crates/api/tests/capability_parity.rs
+++ b/crates/api/tests/capability_parity.rs
@@ -6,11 +6,6 @@
 //! the table exists, and every public runner appears in the table. A new
 //! `run_*` entry point that is not recorded in the parity table fails here.
 
-#![expect(
-    clippy::unwrap_used,
-    reason = "tests use unwrap to keep the source scan concise"
-)]
-
 use std::collections::BTreeSet;
 
 /// Extract the public `run_*` identifiers re-exported from `lib.rs`.

--- a/crates/api/tests/schema_conformance.rs
+++ b/crates/api/tests/schema_conformance.rs
@@ -1,0 +1,353 @@
+//! Instance-level conformance: REAL serializer output validated against the
+//! published `docs/output-schema.json` (JSON Schema draft-07).
+//!
+//! This complements, and does not duplicate, the existing gates:
+//!
+//! - `crates/cli/src/bin/schema_emit.rs` + the CI "schema drift gate" prove the
+//!   committed schema still matches the schemars-derived Rust types. That is a
+//!   type <-> schema check; it never runs a real document through a validator.
+//! - This test proves a REAL runtime document (built by the same `run_*` +
+//!   `serialize_*_programmatic_json` path the MCP tools and the napi addon use)
+//!   validates against that schema. It catches divergence a type-derivation
+//!   gate cannot: post-pass injection (`attach_telemetry_meta`), envelope
+//!   wrapping, and any hand-tuned serializer that drifts from its derived type.
+//!   (The plan-028 Step 0 probe found exactly one such bug: feature-flags
+//!   `_meta.telemetry`, fixed in `fix(output): conform feature-flags _meta`.)
+//!
+//! The schema is loaded from disk per-path (NOT `include_str!`) so the test
+//! always reads the currently committed `docs/output-schema.json` without a
+//! rebuild.
+//!
+//! Scope note (deliberate, see plan 028):
+//! - Git-/pipeline-dependent envelopes (`audit`, `audit-brief`,
+//!   `decision-surface`) are instance-validated end-to-end at the process level
+//!   in `crates/cli/tests/schema_conformance.rs`, where they are actually
+//!   assembled, rather than reconstructed in-process here.
+//! - The programmatic trace family (`serialize_trace_*_programmatic_json`) is
+//!   intentionally OUT of the published-envelope contract: it emits
+//!   un-discriminated JSON with no `kind`, so it is not a `FallowOutput` oneOf
+//!   branch. `trace_family_is_not_a_published_envelope` guards that boundary and
+//!   records the follow-up (schematize the programmatic trace shapes, or keep
+//!   them a separate programmatic-only contract).
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "tests use unwrap/expect/panic to keep fixture setup and schema lookups concise"
+)]
+
+use std::path::{Path, PathBuf};
+
+use fallow_api::{
+    AnalysisOptions, CombinedOptions, ComplexityOptions, DeadCodeFilters, DeadCodeOptions,
+    DuplicationOptions, FeatureFlagsOptions, TraceExportOptions, run_boundary_violations,
+    run_circular_dependencies, run_combined, run_dead_code, run_duplication, run_feature_flags,
+    run_health, run_trace_export, serialize_boundary_violations_programmatic_json,
+    serialize_circular_dependencies_programmatic_json, serialize_combined_programmatic_json,
+    serialize_dead_code_programmatic_json, serialize_duplication_programmatic_json,
+    serialize_feature_flags_programmatic_json, serialize_health_programmatic_json,
+    serialize_trace_export_programmatic_json,
+};
+use serde_json::Value;
+
+/// Path to the committed schema, resolved from this crate's manifest dir so the
+/// test tracks the real `docs/output-schema.json` without a rebuild.
+fn schema_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/output-schema.json")
+}
+
+/// Loads `docs/output-schema.json` and compiles a per-`kind` draft-07 validator
+/// on demand from the matching `FallowOutput` oneOf branch.
+///
+/// Validating against the single branch (not the whole 26-way oneOf) yields
+/// readable, scoped error paths and makes a vacuous pass impossible: the branch
+/// carries the `kind` const, so a document with the wrong `kind` cannot satisfy
+/// it.
+struct EnvelopeSchema {
+    root: Value,
+}
+
+impl EnvelopeSchema {
+    fn load() -> Self {
+        let text = std::fs::read_to_string(schema_path()).expect("read output-schema.json");
+        let root = serde_json::from_str(&text).expect("parse output-schema.json");
+        Self { root }
+    }
+
+    fn definitions(&self) -> &Value {
+        self.root
+            .get("definitions")
+            .expect("schema has a definitions object")
+    }
+
+    /// Build a self-contained draft-07 schema for a single `FallowOutput`
+    /// branch: the branch's `allOf` plus the full `definitions` map so internal
+    /// `#/definitions/...` refs resolve.
+    fn branch_schema(&self, kind: &str) -> Value {
+        let branches = self
+            .definitions()
+            .get("FallowOutput")
+            .and_then(|f| f.get("oneOf"))
+            .and_then(Value::as_array)
+            .expect("FallowOutput.oneOf is an array");
+
+        let branch = branches
+            .iter()
+            .find(|branch| branch_matches_kind(branch, kind))
+            .unwrap_or_else(|| panic!("no FallowOutput oneOf branch declares kind {kind:?}"));
+
+        serde_json::json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "allOf": branch.get("allOf").expect("branch has an allOf"),
+            "definitions": self.definitions(),
+        })
+    }
+
+    /// Assert `value` conforms to the schema branch for `kind`, and that its own
+    /// `kind` discriminator matches (belt-and-suspenders against a vacuous pass).
+    fn assert_conforms(&self, kind: &str, value: &Value) {
+        assert_eq!(
+            value.get("kind").and_then(Value::as_str),
+            Some(kind),
+            "document kind must be {kind:?}, got {:?}",
+            value.get("kind"),
+        );
+
+        let schema = self.branch_schema(kind);
+        let validator = jsonschema::draft7::new(&schema)
+            .unwrap_or_else(|err| panic!("compile draft-07 branch for {kind:?}: {err}"));
+
+        let errors: Vec<String> = validator
+            .iter_errors(value)
+            .map(|err| format!("  at {} : {err}", err.instance_path()))
+            .collect();
+
+        assert!(
+            errors.is_empty(),
+            "'{kind}' document does not conform to docs/output-schema.json:\n{}",
+            errors.join("\n"),
+        );
+    }
+}
+
+/// Does this oneOf branch pin `kind` to `const == kind`?
+fn branch_matches_kind(branch: &Value, kind: &str) -> bool {
+    branch
+        .get("allOf")
+        .and_then(Value::as_array)
+        .is_some_and(|parts| {
+            parts.iter().any(|part| {
+                part.get("properties")
+                    .and_then(|p| p.get("kind"))
+                    .and_then(|k| k.get("const"))
+                    .and_then(Value::as_str)
+                    == Some(kind)
+            })
+        })
+}
+
+fn analysis_at(root: &Path) -> AnalysisOptions {
+    AnalysisOptions {
+        root: Some(root.to_path_buf()),
+        no_cache: true,
+        ..AnalysisOptions::default()
+    }
+}
+
+/// A tiny project with one entry, two dead exports, and one import edge: enough
+/// to exercise the dead-code, duplication, health, and combined serializers.
+fn small_project() -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temp dir");
+    let root = project.path();
+    std::fs::create_dir(root.join("src")).expect("src dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"conformance-fixture","main":"src/index.ts"}"#,
+    )
+    .expect("package.json");
+    std::fs::write(
+        root.join("src/index.ts"),
+        "import './lib';\nexport const entry = 1;\nconsole.log(entry);\n",
+    )
+    .expect("entry");
+    std::fs::write(
+        root.join("src/lib.ts"),
+        "export const used = 1;\nexport const deadA = 2;\nexport const deadB = 3;\n",
+    )
+    .expect("lib");
+    project
+}
+
+#[test]
+fn dead_code_document_conforms() {
+    let project = small_project();
+    let run = run_dead_code(&DeadCodeOptions {
+        analysis: analysis_at(project.path()),
+        filters: DeadCodeFilters {
+            unused_exports: true,
+            ..DeadCodeFilters::default()
+        },
+        ..DeadCodeOptions::default()
+    })
+    .expect("dead-code runs");
+    let json = serialize_dead_code_programmatic_json(run).expect("serialize dead-code");
+    EnvelopeSchema::load().assert_conforms("dead-code", &json);
+}
+
+#[test]
+fn duplication_document_conforms() {
+    let project = small_project();
+    let run = run_duplication(&DuplicationOptions {
+        analysis: analysis_at(project.path()),
+        ..DuplicationOptions::default()
+    })
+    .expect("duplication runs");
+    let json = serialize_duplication_programmatic_json(run).expect("serialize duplication");
+    EnvelopeSchema::load().assert_conforms("dupes", &json);
+}
+
+#[test]
+fn feature_flags_document_conforms() {
+    let project = tempfile::tempdir().expect("temp dir");
+    let root = project.path();
+    std::fs::create_dir(root.join("src")).expect("src dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"flags-fixture","main":"src/index.ts"}"#,
+    )
+    .expect("package.json");
+    std::fs::write(
+        root.join("src/index.ts"),
+        "if (process.env.FEATURE_ALPHA) {\n  console.log('on');\n}\n",
+    )
+    .expect("entry");
+
+    // Default path (no --explain): _meta carries only telemetry. This is the
+    // exact shape that failed before the FeatureFlagsMeta schema fix.
+    let run = run_feature_flags(&FeatureFlagsOptions {
+        analysis: analysis_at(root),
+        top: None,
+    })
+    .expect("feature-flags runs");
+    let json = serialize_feature_flags_programmatic_json(run).expect("serialize feature-flags");
+    EnvelopeSchema::load().assert_conforms("feature-flags", &json);
+}
+
+#[test]
+fn feature_flags_explain_document_conforms() {
+    let project = tempfile::tempdir().expect("temp dir");
+    let root = project.path();
+    std::fs::create_dir(root.join("src")).expect("src dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"flags-explain-fixture","main":"src/index.ts"}"#,
+    )
+    .expect("package.json");
+    std::fs::write(
+        root.join("src/index.ts"),
+        "if (process.env.FEATURE_ALPHA) {\n  console.log('on');\n}\n",
+    )
+    .expect("entry");
+
+    // --explain path: _meta carries both feature_flags AND telemetry.
+    let run = run_feature_flags(&FeatureFlagsOptions {
+        analysis: AnalysisOptions {
+            explain: true,
+            ..analysis_at(root)
+        },
+        top: None,
+    })
+    .expect("feature-flags --explain runs");
+    let json = serialize_feature_flags_programmatic_json(run).expect("serialize feature-flags");
+    assert!(
+        json["_meta"]["feature_flags"].is_object(),
+        "--explain must populate _meta.feature_flags"
+    );
+    EnvelopeSchema::load().assert_conforms("feature-flags", &json);
+}
+
+#[test]
+fn health_document_conforms() {
+    let project = small_project();
+    let run = run_health(&ComplexityOptions {
+        analysis: analysis_at(project.path()),
+        complexity: true,
+        score: true,
+        ..ComplexityOptions::default()
+    })
+    .expect("health runs");
+    let json = serialize_health_programmatic_json(run).expect("serialize health");
+    EnvelopeSchema::load().assert_conforms("health", &json);
+}
+
+#[test]
+fn combined_document_conforms() {
+    let project = small_project();
+    let run = run_combined(&CombinedOptions {
+        analysis: analysis_at(project.path()),
+        health_options: ComplexityOptions {
+            complexity: true,
+            score: true,
+            ..ComplexityOptions::default()
+        },
+        ..CombinedOptions::default()
+    })
+    .expect("combined runs");
+    let json = serialize_combined_programmatic_json(run).expect("serialize combined");
+    EnvelopeSchema::load().assert_conforms("combined", &json);
+}
+
+#[test]
+fn circular_dependencies_document_conforms_as_dead_code() {
+    // run_circular_dependencies serializes a filtered CheckOutput; the wire
+    // discriminator is `dead-code`, not a distinct kind (the "circular" string
+    // is only an error context). Validate against the dead-code branch.
+    let project = small_project();
+    let run = run_circular_dependencies(&DeadCodeOptions {
+        analysis: analysis_at(project.path()),
+        ..DeadCodeOptions::default()
+    })
+    .expect("circular-dependencies runs");
+    let json =
+        serialize_circular_dependencies_programmatic_json(run).expect("serialize circular deps");
+    EnvelopeSchema::load().assert_conforms("dead-code", &json);
+}
+
+#[test]
+fn boundary_violations_document_conforms_as_dead_code() {
+    let project = small_project();
+    let run = run_boundary_violations(&DeadCodeOptions {
+        analysis: analysis_at(project.path()),
+        ..DeadCodeOptions::default()
+    })
+    .expect("boundary-violations runs");
+    let json =
+        serialize_boundary_violations_programmatic_json(run).expect("serialize boundary violations");
+    EnvelopeSchema::load().assert_conforms("dead-code", &json);
+}
+
+/// The programmatic trace serializers are a separate, un-enveloped contract:
+/// they emit no `kind` and are not a `FallowOutput` oneOf branch, so they are
+/// out of the published-envelope schema by design (plan-028 ruling). This guard
+/// fails loudly if a trace serializer ever grows a root `kind`, which would
+/// force a deliberate schema decision (schematize the trace shapes, or keep them
+/// programmatic-only). Follow-up: decide whether to add trace shapes to the
+/// envelope schema.
+#[test]
+fn trace_family_is_not_a_published_envelope() {
+    let project = small_project();
+    let out = run_trace_export(&TraceExportOptions {
+        analysis: analysis_at(project.path()),
+        file: "src/lib.ts".to_string(),
+        export_name: "deadA".to_string(),
+    })
+    .expect("trace export runs");
+    let json = serialize_trace_export_programmatic_json(out).expect("serialize trace export");
+
+    assert!(
+        json.get("kind").is_none(),
+        "programmatic trace output must stay un-enveloped (no root kind); if this \
+         changes, schematize the trace shapes in docs/output-schema.json first. Got: {json}"
+    );
+}

--- a/crates/api/tests/schema_conformance.rs
+++ b/crates/api/tests/schema_conformance.rs
@@ -30,7 +30,7 @@
 //!   records the follow-up (schematize the programmatic trace shapes, or keep
 //!   them a separate programmatic-only contract).
 
-#![expect(
+#![allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::panic,
@@ -322,8 +322,8 @@ fn boundary_violations_document_conforms_as_dead_code() {
         ..DeadCodeOptions::default()
     })
     .expect("boundary-violations runs");
-    let json =
-        serialize_boundary_violations_programmatic_json(run).expect("serialize boundary violations");
+    let json = serialize_boundary_violations_programmatic_json(run)
+        .expect("serialize boundary violations");
     EnvelopeSchema::load().assert_conforms("dead-code", &json);
 }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -111,6 +111,7 @@ doctest = false
 
 [dev-dependencies]
 insta = { workspace = true }
+jsonschema = { workspace = true }
 fallow-types = { workspace = true }
 proptest = { workspace = true }
 proc-macro2 = { version = "1", features = ["span-locations"] }

--- a/crates/cli/tests/schema_conformance.rs
+++ b/crates/cli/tests/schema_conformance.rs
@@ -1,0 +1,209 @@
+//! Process-level instance conformance: real `fallow ... --format json` stdout
+//! documents validated against the published `docs/output-schema.json`
+//! (draft-07).
+//!
+//! The api-crate sibling (`crates/api/tests/schema_conformance.rs`) validates
+//! the serializers in-process. This test drives the actual binary, so it also
+//! covers the process-boundary work the api layer never sees: root-envelope
+//! injection, telemetry `_meta`, `next_steps`, and post-pass path stripping. It
+//! is the faithful home for the git-/pipeline-dependent envelopes (`audit`,
+//! `audit-brief`, `decision-surface`), which are assembled from a full audit
+//! run rather than a single serializer call.
+//!
+//! The schema is read from disk per invocation so the test tracks the committed
+//! `docs/output-schema.json` without a rebuild.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "tests use unwrap/expect/panic to keep fixture setup and schema lookups concise"
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use common::fallow_bin;
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Path to the committed schema, resolved from this crate's manifest dir.
+fn schema_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/output-schema.json")
+}
+
+fn load_schema_root() -> Value {
+    let text = std::fs::read_to_string(schema_path()).expect("read output-schema.json");
+    serde_json::from_str(&text).expect("parse output-schema.json")
+}
+
+/// Build a self-contained draft-07 validator for the `FallowOutput` oneOf
+/// branch pinned to `kind`, then assert `value` conforms and that its own
+/// `kind` matches (so a document cannot pass against the wrong branch).
+fn assert_conforms(root: &Value, kind: &str, value: &Value) {
+    assert_eq!(
+        value.get("kind").and_then(Value::as_str),
+        Some(kind),
+        "document kind must be {kind:?}, got {:?}",
+        value.get("kind"),
+    );
+
+    let definitions = root
+        .get("definitions")
+        .expect("schema has a definitions object");
+    let branches = definitions
+        .get("FallowOutput")
+        .and_then(|f| f.get("oneOf"))
+        .and_then(Value::as_array)
+        .expect("FallowOutput.oneOf is an array");
+    let branch = branches
+        .iter()
+        .find(|branch| {
+            branch
+                .get("allOf")
+                .and_then(Value::as_array)
+                .is_some_and(|parts| {
+                    parts.iter().any(|part| {
+                        part.get("properties")
+                            .and_then(|p| p.get("kind"))
+                            .and_then(|k| k.get("const"))
+                            .and_then(Value::as_str)
+                            == Some(kind)
+                    })
+                })
+        })
+        .unwrap_or_else(|| panic!("no FallowOutput oneOf branch declares kind {kind:?}"));
+
+    let branch_schema = serde_json::json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": branch.get("allOf").expect("branch has an allOf"),
+        "definitions": definitions,
+    });
+    let validator = jsonschema::draft7::new(&branch_schema)
+        .unwrap_or_else(|err| panic!("compile draft-07 branch for {kind:?}: {err}"));
+
+    let errors: Vec<String> = validator
+        .iter_errors(value)
+        .map(|err| format!("  at {} : {err}", err.instance_path()))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "'{kind}' stdout document does not conform to docs/output-schema.json:\n{}",
+        errors.join("\n"),
+    );
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.invalid")
+        .output()
+        .expect("git command failed");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// A small git-backed project: one entry, a dead export, a suppression marker,
+/// and a feature-flag reference. Committed so `audit`/`decision-surface` have a
+/// base ref; the working tree matches HEAD so those envelopes serialize their
+/// empty-but-valid shape.
+fn git_fixture() -> TempDir {
+    let tmp = TempDir::new().expect("temp dir");
+    let dir = tmp.path();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"cli-conformance","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/index.ts"),
+        "import { used } from './lib';\n\
+         if (process.env.FEATURE_ALPHA) {\n  used();\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/lib.ts"),
+        "export const used = () => 42;\n\
+         // fallow-ignore-next-line unused-export\n\
+         export const suppressed = () => 0;\n\
+         export const dead = () => 1;\n",
+    )
+    .unwrap();
+
+    git(dir, &["init", "-b", "main"]);
+    git(dir, &["add", "."]);
+    git(dir, &["-c", "commit.gpgsign=false", "commit", "-m", "base"]);
+    tmp
+}
+
+/// Run `fallow <args> --root <root> --format json --quiet --no-cache`, parse
+/// stdout, and validate it against the schema branch for `expected_kind`.
+fn run_and_validate(schema: &Value, root: &Path, args: &[&str], expected_kind: &str) {
+    let mut cmd = Command::new(fallow_bin());
+    cmd.env("RUST_LOG", "").env("NO_COLOR", "1");
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.arg("--root")
+        .arg(root)
+        .arg("--format")
+        .arg("json")
+        .arg("--quiet")
+        .arg("--no-cache");
+    let output = cmd.output().expect("run fallow binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout).unwrap_or_else(|err| {
+        panic!(
+            "{expected_kind}: stdout is not JSON: {err}\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr),
+        )
+    });
+    assert_conforms(schema, expected_kind, &value);
+}
+
+#[test]
+fn cli_json_documents_conform_to_output_schema() {
+    let fixture = git_fixture();
+    let root = fixture.path();
+    let schema = load_schema_root();
+
+    // Core commands (the plan's five) plus feature-flags, whose default-path
+    // _meta.telemetry shape is exactly what the process boundary must emit
+    // conformantly.
+    run_and_validate(&schema, root, &["dead-code"], "dead-code");
+    run_and_validate(&schema, root, &["health"], "health");
+    run_and_validate(&schema, root, &["dupes"], "dupes");
+    run_and_validate(&schema, root, &[], "combined");
+    run_and_validate(&schema, root, &["suppressions"], "suppression-inventory");
+    run_and_validate(&schema, root, &["flags"], "feature-flags");
+
+    // Git-/pipeline-dependent envelopes assembled from a full audit run.
+    run_and_validate(&schema, root, &["audit", "--base", "HEAD"], "audit");
+    run_and_validate(
+        &schema,
+        root,
+        &["audit", "--brief", "--base", "HEAD"],
+        "audit-brief",
+    );
+    run_and_validate(
+        &schema,
+        root,
+        &["decision-surface", "--base", "HEAD"],
+        "decision-surface",
+    );
+}

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { workspace = true }
 napi-build = "2"
 
 [dev-dependencies]
+fallow-types = { workspace = true }
 tempfile = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -1301,4 +1301,42 @@ mod tests {
             })
             .collect()
     }
+
+    /// Drift guard: the addon's `#[napi(js_name = ...)]` exports must match the
+    /// `napi_export` column of the cross-surface capability parity table
+    /// (`fallow_types::mcp_manifest::CAPABILITY_PARITY`). A new export that is
+    /// not recorded in the table, or a stale table entry, fails here. Mirrors
+    /// the include_str source-scan the schemars-alias guards use.
+    #[test]
+    fn napi_exports_match_capability_parity_table() {
+        use std::collections::BTreeSet;
+
+        let source = include_str!("lib.rs");
+        let mut scanned: BTreeSet<String> = BTreeSet::new();
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            if let Some(rest) = trimmed.strip_prefix("#[napi(js_name = \"") {
+                let name = rest.split('"').next().expect("js_name literal is closed");
+                scanned.insert(name.to_string());
+            }
+        }
+        assert_eq!(
+            scanned.len(),
+            7,
+            "expected seven #[napi(js_name = ...)] exports, scanned {scanned:?}"
+        );
+
+        let table: BTreeSet<String> = fallow_types::mcp_manifest::CAPABILITY_PARITY
+            .iter()
+            .filter_map(|row| row.napi_export)
+            .map(str::to_string)
+            .collect();
+
+        assert_eq!(
+            scanned, table,
+            "the #[napi(js_name = ...)] exports must equal the CAPABILITY_PARITY napi_export \
+             column exactly (missing => a new export is not in the table; extra => a stale \
+             table entry)"
+        );
+    }
 }

--- a/crates/types/src/mcp_manifest.rs
+++ b/crates/types/src/mcp_manifest.rs
@@ -413,6 +413,383 @@ pub const MCP_TOOLS: &[McpToolInfo] = &[
     },
 ];
 
+/// One row of the cross-surface capability parity table: how a single fallow
+/// capability is (or is deliberately not) exposed on the three agent execution
+/// surfaces.
+///
+/// The three surfaces:
+/// - `api_runner`: the `fallow_api::run_*` entry point (the in-process Rust API
+///   that both the napi addon and the MCP server's in-process path build on).
+/// - `napi_export`: the `#[napi(js_name = ...)]` function in `crates/napi` (the
+///   `@fallow/node` addon surface).
+/// - `mcp_tool`: a tool `name` in [`MCP_TOOLS`] (the MCP server surface).
+///
+/// `omission_note` is REQUIRED exactly when at least one surface is `None`; it
+/// states the intent behind the asymmetry (folded into another tool, CLI-only,
+/// no fix surface on the addon, and so on). Rows where all three surfaces are
+/// `Some` are the only capabilities exposed first-class on every surface, and
+/// carry no note.
+///
+/// This table is drift-tested from all three sides: [`MCP_TOOLS`] here (every
+/// tool appears in exactly one row), the `#[napi]` exports in `crates/napi`,
+/// and the public `run_*` re-exports in `crates/api`. It is a hand-authored
+/// statement of product intent, not a generated artifact: each note is a claim
+/// the maintainer endorses.
+#[derive(Debug, Clone, Copy)]
+pub struct CapabilityParityRow {
+    /// Human-readable capability name. Table key for readers; not a wire value.
+    pub capability: &'static str,
+    /// `fallow_api::run_*` entry point, when the capability is a programmatic
+    /// runner.
+    pub api_runner: Option<&'static str>,
+    /// `#[napi(js_name = ...)]` export, when the addon exposes the capability.
+    pub napi_export: Option<&'static str>,
+    /// [`MCP_TOOLS`] `name`, when the MCP server exposes a dedicated tool.
+    pub mcp_tool: Option<&'static str>,
+    /// Intent behind a surface omission. `Some` exactly when a surface above is
+    /// `None`.
+    pub omission_note: Option<&'static str>,
+}
+
+/// Cross-surface capability parity: which of the three agent execution surfaces
+/// (api runner / napi export / MCP tool) exposes each fallow capability, and why
+/// a surface is deliberately absent.
+///
+/// Only three capabilities are first-class on ALL three surfaces (dead-code,
+/// duplication, feature-flags: the aligned primitives). The napi addon ships a
+/// deliberately narrow set of seven whole-project analysis primitives and has NO
+/// fix, trace, impact, audit, or introspection surface; the MCP server is the
+/// broad agent surface and folds several api/napi primitives (circular deps,
+/// boundary violations, complexity, health-runner) into `analyze` / `check_health`
+/// rather than shipping dedicated tools.
+pub const CAPABILITY_PARITY: &[CapabilityParityRow] = &[
+    // -- Aligned primitives: first-class on all three surfaces (no note). --
+    CapabilityParityRow {
+        capability: "dead-code analysis",
+        api_runner: Some("run_dead_code"),
+        napi_export: Some("detectDeadCode"),
+        mcp_tool: Some("analyze"),
+        omission_note: None,
+    },
+    CapabilityParityRow {
+        capability: "code duplication",
+        api_runner: Some("run_duplication"),
+        napi_export: Some("detectDuplication"),
+        mcp_tool: Some("find_dupes"),
+        omission_note: None,
+    },
+    CapabilityParityRow {
+        capability: "feature-flag detection",
+        api_runner: Some("run_feature_flags"),
+        napi_export: Some("detectFeatureFlags"),
+        mcp_tool: Some("feature_flags"),
+        omission_note: None,
+    },
+    // -- api + napi, folded into a broader MCP tool (no dedicated MCP tool). --
+    CapabilityParityRow {
+        capability: "circular dependencies",
+        api_runner: Some("run_circular_dependencies"),
+        napi_export: Some("detectCircularDependencies"),
+        mcp_tool: None,
+        omission_note: Some(
+            "No dedicated MCP tool: circular dependencies ship inside the `analyze` dead-code result. Exposed standalone on the api and napi surfaces.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "boundary violations",
+        api_runner: Some("run_boundary_violations"),
+        napi_export: Some("detectBoundaryViolations"),
+        mcp_tool: None,
+        omission_note: Some(
+            "No dedicated MCP tool: boundary violations ship inside `analyze`; the MCP `guard` tool is the file-scoped architecture gate and shells out to the CLI rather than calling this runner. Exposed standalone on the api and napi surfaces.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "complexity",
+        api_runner: Some("run_complexity_with_runner"),
+        napi_export: Some("computeComplexity"),
+        mcp_tool: None,
+        omission_note: Some(
+            "No dedicated MCP tool: complexity ships inside `check_health`'s health report. Exposed standalone on the api (runner-injected) and napi (computeComplexity) surfaces.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "health (runner-injected entry point)",
+        api_runner: Some("run_health_with_runner"),
+        napi_export: Some("computeHealth"),
+        mcp_tool: None,
+        omission_note: Some(
+            "Runner-injected health entry point that napi's computeHealth binds. The MCP surface for health is `check_health`, which uses the run_health convenience wrapper; same capability, different entry point.",
+        ),
+    },
+    // -- MCP tool + api runner, no napi export (addon ships only the seven
+    //    whole-project primitives). --
+    CapabilityParityRow {
+        capability: "health / hotspots",
+        api_runner: Some("run_health"),
+        napi_export: None,
+        mcp_tool: Some("check_health"),
+        omission_note: Some(
+            "napi exposes health through computeHealth, which binds the runner-injected run_health_with_runner variant (its own row); this row is the MCP `check_health` tool plus the run_health convenience wrapper.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "changed-scope dead code",
+        api_runner: Some("run_dead_code"),
+        napi_export: None,
+        mcp_tool: Some("check_changed"),
+        omission_note: Some(
+            "Changed-scope dead code: reuses run_dead_code with a git ref. No napi export; the addon ships whole-project primitives, not git-scoped variants.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "changed-code review gate",
+        api_runner: Some("run_audit"),
+        napi_export: None,
+        mcp_tool: Some("audit"),
+        omission_note: Some(
+            "Changed-code review gate. No napi export; the audit pipeline (git base resolution, sub-analyses) is exposed on the CLI, MCP, and api surfaces only.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "decision surface",
+        api_runner: Some("run_decision_surface"),
+        napi_export: None,
+        mcp_tool: Some("decision_surface"),
+        omission_note: Some(
+            "Changed-code decision surface. No napi export; the changed-code pipeline is CLI, MCP, and api only.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "project info",
+        api_runner: Some("run_project_info"),
+        napi_export: None,
+        mcp_tool: Some("project_info"),
+        omission_note: Some(
+            "Project discovery (files, entry points, plugins). No napi export; introspection is CLI, MCP, and api only.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "boundary listing",
+        api_runner: Some("run_list_boundaries"),
+        napi_export: None,
+        mcp_tool: Some("list_boundaries"),
+        omission_note: Some(
+            "Architecture boundary listing. No napi export; introspection is CLI, MCP, and api only.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "export usage trace",
+        api_runner: Some("run_trace_export"),
+        napi_export: None,
+        mcp_tool: Some("trace_export"),
+        omission_note: Some(
+            "Export usage trace. No napi export; the trace family is CLI, MCP, and api only (and emits an un-enveloped programmatic shape, see the plan-028 schema-conformance note).",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "file edge trace",
+        api_runner: Some("run_trace_file"),
+        napi_export: None,
+        mcp_tool: Some("trace_file"),
+        omission_note: Some(
+            "File edge trace (imports, exports, importers). No napi export; the trace family is CLI, MCP, and api only.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "dependency usage trace",
+        api_runner: Some("run_trace_dependency"),
+        napi_export: None,
+        mcp_tool: Some("trace_dependency"),
+        omission_note: Some(
+            "Dependency usage trace. No napi export; the trace family is CLI, MCP, and api only.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "clone trace",
+        api_runner: Some("run_trace_clone"),
+        napi_export: None,
+        mcp_tool: Some("trace_clone"),
+        omission_note: Some(
+            "Duplicate-clone deep dive. No napi export; the trace family is CLI, MCP, and api only.",
+        ),
+    },
+    // -- api-only: no napi export and no dedicated MCP tool. --
+    CapabilityParityRow {
+        capability: "combined report",
+        api_runner: Some("run_combined"),
+        napi_export: None,
+        mcp_tool: None,
+        omission_note: Some(
+            "api-only: the bare `fallow` combined report (dead-code + dupes + health). No napi export and no MCP tool; agents compose the three primitives (analyze / find_dupes / check_health) instead.",
+        ),
+    },
+    // -- MCP-only tools that shell out to the CLI: no api runner, no napi
+    //    export. --
+    CapabilityParityRow {
+        capability: "Code Mode composition",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("code_execute"),
+        omission_note: Some(
+            "Code Mode composition meta-tool: runs a sandboxed JS snippet that composes other tools. MCP-only orchestration surface; no api runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "security candidates",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("security_candidates"),
+        omission_note: Some(
+            "Security candidate surfacing. MCP shells out to `fallow security`; no fallow_api run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "target inspection",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("inspect_target"),
+        omission_note: Some(
+            "Single-target evidence bundle. MCP shells out to `fallow inspect`; served by a bespoke serializer rather than a run_* runner, and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "architecture guard",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("guard"),
+        omission_note: Some(
+            "File-scoped architecture gate. MCP shells out to `fallow guard`; the programmatic boundary surface is run_boundary_violations / detectBoundaryViolations (the boundary-violations row), not this tool.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "runtime-coverage merge",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("check_runtime_coverage"),
+        omission_note: Some(
+            "Runtime-coverage merge into health. MCP shells out to `fallow health --runtime-coverage`; no dedicated run_* runner (run_health covers base health) and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "runtime-coverage hot paths",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("get_hot_paths"),
+        omission_note: Some(
+            "Runtime-coverage hot-path view. MCP shells out to `fallow health --runtime-coverage`; no dedicated run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "runtime-coverage blast radius",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("get_blast_radius"),
+        omission_note: Some(
+            "Runtime-coverage blast-radius view. MCP shells out to `fallow health --runtime-coverage`; no dedicated run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "runtime-coverage importance",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("get_importance"),
+        omission_note: Some(
+            "Runtime-coverage importance view. MCP shells out to `fallow health --runtime-coverage`; no dedicated run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "runtime-coverage cleanup candidates",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("get_cleanup_candidates"),
+        omission_note: Some(
+            "Runtime-coverage cleanup-candidate view. MCP shells out to `fallow health --runtime-coverage`; no dedicated run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "design-token blast radius",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("get_token_blast_radius"),
+        omission_note: Some(
+            "Design-token blast radius. MCP shells out to `fallow health --css`; no dedicated run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "issue-type explanation",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("fallow_explain"),
+        omission_note: Some(
+            "Static issue-type explanation. Served by serialize_explain_programmatic_json (a serializer, not a run_* runner) and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "auto-fix preview",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("fix_preview"),
+        omission_note: Some(
+            "Auto-fix dry run. MCP shells out to `fallow fix --dry-run`; no run_* runner and no napi export (the addon has no fix surface).",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "auto-fix apply",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("fix_apply"),
+        omission_note: Some(
+            "Auto-fix apply: the only mutating tool. MCP shells out to `fallow fix --yes`; no run_* runner and no napi export (the addon has no fix surface).",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "config recommendation",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("recommend"),
+        omission_note: Some(
+            "Project-tailored config recommendation. MCP shells out to `fallow recommend`; no run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "suppression inventory",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("list_suppressions"),
+        omission_note: Some(
+            "Active fallow-ignore inventory. MCP shells out to `fallow suppressions`; no run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "impact ledger",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("impact"),
+        omission_note: Some(
+            "Local impact ledger. MCP shells out to `fallow impact`; no run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "cross-repo impact ledger",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("impact_all"),
+        omission_note: Some(
+            "Cross-repo impact ledger. MCP shells out to `fallow impact --all`; no run_* runner and no napi export.",
+        ),
+    },
+    CapabilityParityRow {
+        capability: "reverse-dependency closure",
+        api_runner: None,
+        napi_export: None,
+        mcp_tool: Some("impact_closure"),
+        omission_note: Some(
+            "Reverse-dependency closure for a path. MCP shells out to `fallow dead-code --impact-closure`; no dedicated run_* runner and no napi export.",
+        ),
+    },
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -529,5 +906,82 @@ mod tests {
                 tool.name
             );
         }
+    }
+
+    #[test]
+    fn capability_parity_covers_every_mcp_tool_exactly_once() {
+        use std::collections::BTreeSet;
+
+        let table_tools: Vec<&str> = CAPABILITY_PARITY
+            .iter()
+            .filter_map(|row| row.mcp_tool)
+            .collect();
+
+        // No MCP tool is named in more than one row.
+        let unique: BTreeSet<&str> = table_tools.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            table_tools.len(),
+            "an MCP tool appears in more than one capability-parity row"
+        );
+
+        // The parity table's MCP column equals the live MCP_TOOLS set exactly:
+        // missing => a tool is absent from the table; extra => a phantom name.
+        let live: BTreeSet<&str> = MCP_TOOLS.iter().map(|tool| tool.name).collect();
+        assert_eq!(
+            unique, live,
+            "capability-parity mcp_tool column must equal the MCP_TOOLS name set exactly"
+        );
+    }
+
+    #[test]
+    fn capability_parity_notes_track_surface_absence() {
+        for row in CAPABILITY_PARITY {
+            let any_absent =
+                row.api_runner.is_none() || row.napi_export.is_none() || row.mcp_tool.is_none();
+            assert_eq!(
+                row.omission_note.is_some(),
+                any_absent,
+                "row {:?}: omission_note must be present exactly when a surface is absent",
+                row.capability
+            );
+        }
+    }
+
+    #[test]
+    fn capability_parity_napi_exports_are_unique_per_row() {
+        use std::collections::BTreeSet;
+
+        let exports: Vec<&str> = CAPABILITY_PARITY
+            .iter()
+            .filter_map(|row| row.napi_export)
+            .collect();
+        let unique: BTreeSet<&str> = exports.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            exports.len(),
+            "a napi export appears in more than one capability-parity row"
+        );
+    }
+
+    #[test]
+    fn only_aligned_primitives_span_all_three_surfaces() {
+        let full_parity: Vec<&str> = CAPABILITY_PARITY
+            .iter()
+            .filter(|row| {
+                row.api_runner.is_some() && row.napi_export.is_some() && row.mcp_tool.is_some()
+            })
+            .map(|row| row.capability)
+            .collect();
+        assert_eq!(
+            full_parity,
+            [
+                "dead-code analysis",
+                "code duplication",
+                "feature-flag detection"
+            ],
+            "the set of capabilities exposed on all three surfaces changed; update the parity \
+             narrative and confirm the new alignment is intended"
+        );
     }
 }


### PR DESCRIPTION
Held item F5: nothing validated real runtime JSON against the published `docs/output-schema.json`, and nothing asserted the three agent execution surfaces (api runners / napi exports / MCP tools) relate to each other on purpose. Every surface was drift-gated only against its own source of truth.

This adds:
- **Instance conformance** (`jsonschema` 0.47 dev-dep): real serializer output (crates/api) and real binary output (crates/cli) validated per-`kind` against `docs/output-schema.json`, loaded per-path so the tests track the committed schema without a rebuild. Covers dead-code, duplication, feature-flags (both forms), health, combined, circular/boundary (dead-code branch), suppression-inventory, audit, audit-brief, decision-surface.
- **Cross-surface parity table** (`CAPABILITY_PARITY` next to `MCP_TOOLS`): a hand-authored product-intent statement drift-tested from all three sides (31 MCP tools each in exactly one row, 7 napi exports set-equal to the `#[napi]` scan, 17 api `run_*` set-equal to the re-export scan), with an `omission_note` required exactly when a surface is deliberately absent.

**This effort already paid for itself**: the Step 0 probe found a real contract bug (`fallow flags --format json` emitted schema-invalid `_meta`), fixed and merged separately in #1845.

Recorded follow-ups (not addressed here): the api programmatic trace serializers are un-enveloped (no `kind`), so they are outside the published-envelope contract; the structured error envelope is unmodeled in the schema; and the schema's `trace` (`SymbolChainTrace`) kind may be orphaned (no CLI surface found emits it).

Verified: all new tests green on the rebased base, `cargo shear` / clippy `-D warnings` / fmt clean, neuter-checked (in-memory schema mutation fails all conformance tests; a removed parity row fails all three drift directions).