### PR TITLE
fix(ci): allow multi-binary size checks to finish

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -35,7 +35,7 @@ jobs:
   bloat:
     name: Binary size tracking
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -42,6 +42,15 @@ test("workflow block parser rejects missing keys", () => {
   assert.throws(() => indentedBlock("root:\n  value: true", "missing", 0), /missing missing block/);
 });
 
+test("binary-size workflow budgets time for every shipped binary", () => {
+  const workflow = readWorkflow(".github/workflows/bloat.yml");
+  const job = indentedBlock(workflow, "bloat", 2);
+  const timeout = Number(job.match(/timeout-minutes: (\d+)/)?.[1]);
+
+  assert.match(job, /cargo build --release -p fallow-lsp -p fallow-mcp -p fallow-multicall/);
+  assert.ok(timeout >= 30, `multi-binary size tracking needs at least 30 minutes, got ${timeout}`);
+});
+
 test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const checkJob = indentedBlock(workflow, "check", 2);


### PR DESCRIPTION
Raises the binary-size job timeout after the new LSP, MCP, and multicall release builds reproduced exit 143 on consecutive main and pull request runs. Adds a workflow policy test that preserves enough budget for every tracked binary.

Validation:
- Full repository verifier
- Workflow policy regression test
- JavaScript formatting and YAML parse