### PR TITLE
feat(output): model the --format json error envelope + close plan-028 contract follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The structured `--format json` error envelope is now part of the published
+  output schema.** When a command fails under `--format json`, fallow emits
+  `{"error": true, "message": ..., "exit_code": ...}` on stdout. This shape was
+  documented in prose but had no schema definition, so agents validating fallow
+  output against `docs/output-schema.json` could not validate error responses.
+  It is now a typed `ErrorOutput` document-root branch (alongside the
+  `kind`-tagged success envelopes and the bare-array Code Climate output),
+  exported from `fallow/types`. The wire output is unchanged.
+
 ### Changed
 
 - **The bundled GitHub Action renders inline annotations and the job summary

--- a/crates/api/tests/schema_conformance.rs
+++ b/crates/api/tests/schema_conformance.rs
@@ -329,11 +329,14 @@ fn boundary_violations_document_conforms_as_dead_code() {
 
 /// The programmatic trace serializers are a separate, un-enveloped contract:
 /// they emit no `kind` and are not a `FallowOutput` oneOf branch, so they are
-/// out of the published-envelope schema by design (plan-028 ruling). This guard
-/// fails loudly if a trace serializer ever grows a root `kind`, which would
-/// force a deliberate schema decision (schematize the trace shapes, or keep them
-/// programmatic-only). Follow-up: decide whether to add trace shapes to the
-/// envelope schema.
+/// out of the published-envelope schema by design. This is distinct from the
+/// CLI `fallow trace <file:symbol>` surface, which IS a published
+/// `kind: "trace"` envelope (`SymbolChainTrace`, validated end-to-end in
+/// `crates/cli/tests/schema_conformance.rs`). Decision (plan-028 follow-up,
+/// resolved): keep the api programmatic trace shapes programmatic-only; do NOT
+/// give them a root `kind` (that would be a wire change breaking the MCP trace
+/// tools). This guard fails loudly if a serializer ever grows a root `kind`, so
+/// the distinction cannot erode silently.
 #[test]
 fn trace_family_is_not_a_published_envelope() {
     let project = small_project();

--- a/crates/cli/src/bin/schema_emit.rs
+++ b/crates/cli/src/bin/schema_emit.rs
@@ -882,6 +882,8 @@ fn register_per_command_envelope_definitions(generator: &mut schemars::SchemaGen
     let _ = generator.subschema_for::<fallow_types::trace_chain::ChainHop>();
     let _ = generator.subschema_for::<fallow_types::trace_chain::UnresolvedCallee>();
     let _ = generator.subschema_for::<fallow_types::trace_chain::UnresolvedReason>();
+    // Structured error envelope (`--format json` failure path, no `kind`).
+    let _ = generator.subschema_for::<fallow_output::ErrorOutput>();
     let _ = generator.subschema_for::<CodeClimateOutput>();
     let _ = generator.subschema_for::<CodeClimateIssue>();
     let _ = generator.subschema_for::<CodeClimateIssueKind>();
@@ -967,7 +969,9 @@ fn merge_with_committed(derived: &Map<String, Value>) -> Result<Value, String> {
 }
 
 /// Hand-maintained root envelopes that still need top-level `oneOf` entries.
-const HAND_MAINTAINED_ROOT_ENVELOPES: &[&str] = &[];
+/// `ErrorOutput` is the `--format json` failure document: it carries no `kind`,
+/// so it is a document-root branch discriminated by the `error: true` field.
+const HAND_MAINTAINED_ROOT_ENVELOPES: &[&str] = &["ErrorOutput"];
 const FALLOW_OUTPUT_VARIANTS: &[(&str, &[&str], &str)] = &[
     (
         "audit",
@@ -1182,7 +1186,10 @@ fn rewrite_document_root_one_of(document: &mut Value) -> Result<(), String> {
              branch on `kind` instead of probing for unique field presence. \
              `CodeClimateOutput` is a bare JSON array (per the Code Climate / \
              GitLab Code Quality spec) and stays a sibling root branch \
-             discriminated by checking whether the document root is an array.",
+             discriminated by checking whether the document root is an array. \
+             `ErrorOutput` is the `--format json` failure document, emitted on \
+             stdout with a non-zero exit; it carries no `kind` and is \
+             discriminated by the `error: true` field.",
             fallow_output_kind_list()
         )),
     );

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -11,11 +11,7 @@ use fallow_config::OutputFormat;
 )]
 pub fn emit_error(message: &str, exit_code: u8, output: OutputFormat) -> ExitCode {
     if matches!(output, OutputFormat::Json) {
-        let error_obj = serde_json::json!({
-            "error": true,
-            "message": message,
-            "exit_code": exit_code,
-        });
+        let error_obj = fallow_output::ErrorOutput::new(message, exit_code);
         if let Ok(json) = serde_json::to_string_pretty(&error_obj) {
             println!("{json}");
         }

--- a/crates/cli/tests/schema_conformance.rs
+++ b/crates/cli/tests/schema_conformance.rs
@@ -206,4 +206,54 @@ fn cli_json_documents_conform_to_output_schema() {
         &["decision-surface", "--base", "HEAD"],
         "decision-surface",
     );
+
+    // Symbol-level call-chain trace: the CLI `fallow trace` surface IS a
+    // published `kind: "trace"` envelope (unlike the un-enveloped api
+    // programmatic trace serializers, which are guarded out of the contract by
+    // `trace_family_is_not_a_published_envelope` in the api crate).
+    run_and_validate(
+        &schema,
+        root,
+        &["trace", "src/lib.ts:used", "--callers"],
+        "trace",
+    );
+}
+
+/// The structured error envelope (`--format json` failure path) has no `kind`,
+/// so it is a document-root branch (`ErrorOutput`) rather than a `FallowOutput`
+/// variant. Validate a real emitted error document against the whole schema so
+/// the root `oneOf` selects the error branch, and confirm a success document
+/// still validates (the new branch did not break the union).
+#[test]
+fn error_envelope_conforms_to_output_schema() {
+    let schema = load_schema_root();
+    let validator = jsonschema::draft7::new(&schema).expect("compile output schema root");
+
+    // A non-existent root is a validation error (exit 2), emitted as the JSON
+    // error envelope on stdout.
+    let output = Command::new(fallow_bin())
+        .args(["dead-code", "--root", "/nonexistent-fallow-path-xyz"])
+        .args(["--format", "json", "--quiet", "--no-cache"])
+        .env("RUST_LOG", "")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run fallow binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("error stdout is not JSON: {err}\nstdout:\n{stdout}"));
+
+    assert_eq!(value.get("error").and_then(Value::as_bool), Some(true));
+    assert!(
+        value.get("kind").is_none(),
+        "error envelope carries no kind"
+    );
+    let errors: Vec<String> = validator
+        .iter_errors(&value)
+        .map(|err| format!("  at {} : {err}", err.instance_path()))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "error envelope does not conform to docs/output-schema.json:\n{}",
+        errors.join("\n"),
+    );
 }

--- a/crates/output/src/error_envelope.rs
+++ b/crates/output/src/error_envelope.rs
@@ -1,0 +1,33 @@
+//! The structured error envelope emitted on stdout for `--format json`.
+
+use serde::Serialize;
+
+/// Structured JSON error emitted on stdout when `--format json` is active and a
+/// command fails. It carries no `kind` discriminator: it is distinguished from
+/// the kind-tagged success envelopes by the required `error: true` field, and is
+/// a document-root branch alongside `FallowOutput` and `CodeClimateOutput` in
+/// `docs/output-schema.json`. Agents that pass `--format json` and observe a
+/// non-zero exit code parse this shape from stdout.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ErrorOutput {
+    /// Always `true`. The discriminator that separates an error document from a
+    /// success envelope (which instead carries a `kind`).
+    pub error: bool,
+    /// Human-readable error message.
+    pub message: String,
+    /// The process exit code the CLI returns alongside this document.
+    pub exit_code: u8,
+}
+
+impl ErrorOutput {
+    /// Build an error envelope for the given message and exit code.
+    #[must_use]
+    pub fn new(message: impl Into<String>, exit_code: u8) -> Self {
+        Self {
+            error: true,
+            message: message.into(),
+            exit_code,
+        }
+    }
+}

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -29,6 +29,7 @@ mod coverage_envelopes;
 mod dead_code_sarif;
 mod diff;
 mod dupes;
+mod error_envelope;
 mod feature_flags;
 mod fix;
 mod health;
@@ -137,6 +138,7 @@ pub use dupes::{
     DUPES_SUPPRESS_COMMENT, DUPES_SUPPRESS_DESCRIPTION, DupesOutput, DupesOutputInput,
     build_dupes_output, clone_family_actions, clone_group_actions, serialize_dupes_json_output,
 };
+pub use error_envelope::ErrorOutput;
 pub use fallow_types::envelope;
 pub use fallow_types::output;
 pub use fallow_types::output_dead_code;

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -1,13 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Fallow JSON Output Schemas",
-  "description": "Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator. Current kind values: `audit`, `explain`, `inspect_target`, `trace`, `review-envelope`, `review-reconcile`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `list-workspaces`, `health`, `dupes`, `dead-code-grouped`, `impact`, `impact-cross-repo`, `security`, `security-survivors`, `security-blind-spots`, `dead-code`, `combined`, `feature-flags`, `audit-brief`, `decision-surface`, `review-walkthrough-guide`, `review-walkthrough-validation`, `suppression-inventory`. Consumers should branch on `kind` instead of probing for unique field presence. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.",
+  "description": "Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator. Current kind values: `audit`, `explain`, `inspect_target`, `trace`, `review-envelope`, `review-reconcile`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `list-workspaces`, `health`, `dupes`, `dead-code-grouped`, `impact`, `impact-cross-repo`, `security`, `security-survivors`, `security-blind-spots`, `dead-code`, `combined`, `feature-flags`, `audit-brief`, `decision-surface`, `review-walkthrough-guide`, `review-walkthrough-validation`, `suppression-inventory`. Consumers should branch on `kind` instead of probing for unique field presence. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array. `ErrorOutput` is the `--format json` failure document, emitted on stdout with a non-zero exit; it carries no `kind` and is discriminated by the `error: true` field.",
   "oneOf": [
     {
       "$ref": "#/definitions/FallowOutput"
     },
     {
       "$ref": "#/definitions/CodeClimateOutput"
+    },
+    {
+      "$ref": "#/definitions/ErrorOutput"
     }
   ],
   "definitions": {
@@ -18705,6 +18708,29 @@
       ],
       "title": "fallow audit --brief --format json",
       "description": "Complete `fallow audit --brief --format json` wire envelope.\n\nThis is distinct from [`ReviewBriefOutput`], which is the reusable review\ndigest embedded in walkthrough output. The wire envelope also carries audit\nmetadata, optional telemetry, and the subtract-style analysis subreports."
+    },
+    "ErrorOutput": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "description": "Always `true`. The discriminator that separates an error document from a\nsuccess envelope (which instead carries a `kind`)."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message."
+        },
+        "exit_code": {
+          "type": "integer",
+          "description": "The process exit code the CLI returns alongside this document."
+        }
+      },
+      "required": [
+        "error",
+        "message",
+        "exit_code"
+      ],
+      "description": "Structured JSON error emitted on stdout when `--format json` is active and a\ncommand fails. It carries no `kind` discriminator: it is distinguished from\nthe kind-tagged success envelopes by the required `error: true` field, and is\na document-root branch alongside `FallowOutput` and `CodeClimateOutput` in\n`docs/output-schema.json`. Agents that pass `--format json` and observe a\nnon-zero exit code parse this shape from stdout."
     }
   }
 }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -24,9 +24,9 @@
 
 
 /**
- * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator. Current kind values: `audit`, `explain`, `inspect_target`, `trace`, `review-envelope`, `review-reconcile`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `list-workspaces`, `health`, `dupes`, `dead-code-grouped`, `impact`, `impact-cross-repo`, `security`, `security-survivors`, `security-blind-spots`, `dead-code`, `combined`, `feature-flags`, `audit-brief`, `decision-surface`, `review-walkthrough-guide`, `review-walkthrough-validation`, `suppression-inventory`. Consumers should branch on `kind` instead of probing for unique field presence. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.
+ * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator. Current kind values: `audit`, `explain`, `inspect_target`, `trace`, `review-envelope`, `review-reconcile`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `list-workspaces`, `health`, `dupes`, `dead-code-grouped`, `impact`, `impact-cross-repo`, `security`, `security-survivors`, `security-blind-spots`, `dead-code`, `combined`, `feature-flags`, `audit-brief`, `decision-surface`, `review-walkthrough-guide`, `review-walkthrough-validation`, `suppression-inventory`. Consumers should branch on `kind` instead of probing for unique field presence. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array. `ErrorOutput` is the `--format json` failure document, emitted on stdout with a non-zero exit; it carries no `kind` and is discriminated by the `error: true` field.
  */
-export type FallowJsonOutput = (FallowOutput | CodeClimateOutput)
+export type FallowJsonOutput = (FallowOutput | CodeClimateOutput | ErrorOutput)
 /**
  * Typed root of every fallow JSON envelope shape that serializes as a JSON
  * object and participates in the documented `FallowOutput` contract. The
@@ -10385,6 +10385,29 @@ export interface CodeClimateLines {
  * 1-based start line.
  */
 begin: number
+}
+/**
+ * Structured JSON error emitted on stdout when `--format json` is active and a
+ * command fails. It carries no `kind` discriminator: it is distinguished from
+ * the kind-tagged success envelopes by the required `error: true` field, and is
+ * a document-root branch alongside `FallowOutput` and `CodeClimateOutput` in
+ * `docs/output-schema.json`. Agents that pass `--format json` and observe a
+ * non-zero exit code parse this shape from stdout.
+ */
+export interface ErrorOutput {
+/**
+ * Always `true`. The discriminator that separates an error document from a
+ * success envelope (which instead carries a `kind`).
+ */
+error: boolean
+/**
+ * Human-readable error message.
+ */
+message: string
+/**
+ * The process exit code the CLI returns alongside this document.
+ */
+exit_code: number
 }
 
 /**

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -24,9 +24,9 @@
 
 
 /**
- * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator. Current kind values: `audit`, `explain`, `inspect_target`, `trace`, `review-envelope`, `review-reconcile`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `list-workspaces`, `health`, `dupes`, `dead-code-grouped`, `impact`, `impact-cross-repo`, `security`, `security-survivors`, `security-blind-spots`, `dead-code`, `combined`, `feature-flags`, `audit-brief`, `decision-surface`, `review-walkthrough-guide`, `review-walkthrough-validation`, `suppression-inventory`. Consumers should branch on `kind` instead of probing for unique field presence. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array.
+ * Schemas for the JSON output of fallow commands. Object-shaped envelopes covered by the `FallowOutput` contract carry a top-level `kind` discriminator. Current kind values: `audit`, `explain`, `inspect_target`, `trace`, `review-envelope`, `review-reconcile`, `coverage-setup`, `coverage-analyze`, `list-boundaries`, `list-workspaces`, `health`, `dupes`, `dead-code-grouped`, `impact`, `impact-cross-repo`, `security`, `security-survivors`, `security-blind-spots`, `dead-code`, `combined`, `feature-flags`, `audit-brief`, `decision-surface`, `review-walkthrough-guide`, `review-walkthrough-validation`, `suppression-inventory`. Consumers should branch on `kind` instead of probing for unique field presence. `CodeClimateOutput` is a bare JSON array (per the Code Climate / GitLab Code Quality spec) and stays a sibling root branch discriminated by checking whether the document root is an array. `ErrorOutput` is the `--format json` failure document, emitted on stdout with a non-zero exit; it carries no `kind` and is discriminated by the `error: true` field.
  */
-export type FallowJsonOutput = (FallowOutput | CodeClimateOutput)
+export type FallowJsonOutput = (FallowOutput | CodeClimateOutput | ErrorOutput)
 /**
  * Typed root of every fallow JSON envelope shape that serializes as a JSON
  * object and participates in the documented `FallowOutput` contract. The
@@ -10385,6 +10385,29 @@ export interface CodeClimateLines {
  * 1-based start line.
  */
 begin: number
+}
+/**
+ * Structured JSON error emitted on stdout when `--format json` is active and a
+ * command fails. It carries no `kind` discriminator: it is distinguished from
+ * the kind-tagged success envelopes by the required `error: true` field, and is
+ * a document-root branch alongside `FallowOutput` and `CodeClimateOutput` in
+ * `docs/output-schema.json`. Agents that pass `--format json` and observe a
+ * non-zero exit code parse this shape from stdout.
+ */
+export interface ErrorOutput {
+/**
+ * Always `true`. The discriminator that separates an error document from a
+ * success envelope (which instead carries a `kind`).
+ */
+error: boolean
+/**
+ * Human-readable error message.
+ */
+message: string
+/**
+ * The process exit code the CLI returns alongside this document.
+ */
+exit_code: number
 }
 
 /**


### PR DESCRIPTION
Closes the three plan-028 (F5) contract follow-ups the agent-surface instance-validation probe surfaced.

**Error envelope now in the published schema.** The structured `--format json` failure document (`{"error": true, "message": ..., "exit_code": ...}`) was documented in prose but had no schema definition, so agents validating fallow output against `docs/output-schema.json` could not validate error responses. It is now a typed `ErrorOutput` document-root branch (discriminated by `error: true`, no `kind`), alongside the kind-tagged success envelopes and the bare-array Code Climate output, exported from `fallow/types`. `emit_error` builds and serializes the typed struct (byte-identical output, no wire change), so the type is the wire.

**Trace follow-ups resolved.** The CLI `fallow trace <file:symbol>` surface IS a published `kind: "trace"` envelope (`SymbolChainTrace`), confirmed NOT orphaned and now validated end-to-end in the CLI conformance test. The api programmatic trace serializers stay deliberately un-enveloped (a root `kind` would be a wire change breaking the MCP trace tools); the guard test doc records that resolved decision.

Verified: error, trace, and success documents all validate against the regenerated schema; schema drift gate + contract drift check green; workspace clippy -D warnings, fmt, output/api/cli conformance tests all green. No existing test asserted the error shape (byte-identity confirmed).