### PR TITLE
fix(ci): scope bloat debug profile to CLI

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -27,15 +27,17 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
-  # Keep debug info for cargo-bloat function name resolution
-  CARGO_PROFILE_RELEASE_STRIP: "none"
-  CARGO_PROFILE_RELEASE_DEBUG: "2"
 
 jobs:
   cli-bloat:
     name: CLI size analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Keep debug info only for cargo-bloat function name resolution. The
+    # shipped-binary job uses the stripped production release profile.
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: "none"
+      CARGO_PROFILE_RELEASE_DEBUG: "2"
     permissions:
       contents: read
     outputs:

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -44,12 +44,16 @@ test("workflow block parser rejects missing keys", () => {
 
 test("binary-size workflow isolates incompatible release builds", () => {
   const workflow = readWorkflow(".github/workflows/bloat.yml");
+  const globalEnv = indentedBlock(workflow, "env", 0);
   const cliJob = indentedBlock(workflow, "cli-bloat", 2);
   const shippedJob = indentedBlock(workflow, "shipped-binaries", 2);
   const aggregateJob = indentedBlock(workflow, "bloat", 2);
 
   assert.match(cliJob, /cargo bloat --release -p fallow-cli/);
+  assert.match(cliJob, /CARGO_PROFILE_RELEASE_STRIP: "none"/);
+  assert.match(cliJob, /CARGO_PROFILE_RELEASE_DEBUG: "2"/);
   assert.doesNotMatch(cliJob, /fallow-lsp|fallow-mcp|fallow-multicall/);
+  assert.doesNotMatch(globalEnv, /CARGO_PROFILE_RELEASE_(STRIP|DEBUG)/);
   assert.match(shippedJob, /cargo build --release -p fallow-lsp -p fallow-mcp -p fallow-multicall/);
   assert.doesNotMatch(shippedJob, /cargo bloat/);
   assert.match(aggregateJob, /needs:\n\s+- cli-bloat\n\s+- shipped-binaries/);


### PR DESCRIPTION
Scopes the cargo-bloat debug profile to CLI analysis so the LSP, MCP, and multicall job uses the repository's stripped production release profile. The split workflow proved its failure propagation correctly, but the normal multicall link still received exit 143 while inheriting unnecessary full debug symbols.

This also makes the shipped-binary metrics representative of production artifacts. A workflow policy test prevents the debug overrides from leaking back into the global environment.

Validation:
- Full repository verifier
- Workflow policy regression test
- Actionlint and YAML parse
- GitHub Action permission and required-check review