### PR TITLE
fix(graph): reuse re-export import origin index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dead-code analysis no longer repeats quadratic allocation work across deep
+  `export *` barrel chains.** Star re-export propagation now builds its
+  named-import origin index once per graph and batches reference deduplication
+  per export instead of rebuilding a growing set for every incoming reference.
+  This bounds memory churn and materially reduces graph-build time on projects
+  with deep barrels and wide named-import fan-in. Thanks @zirodev23 for the
+  report in #1843.
+
 - **`fallow flags --format json` now conforms to the published output schema.**
   The default (no `--explain`) feature-flags document injects a
   `_meta.telemetry` block for run correlation, but the schema modeled

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -91,7 +91,12 @@ impl ModuleGraph {
 
         let entry_star_targets = self.collect_entry_star_targets();
         let edges_by_target = self.build_edges_by_target();
-        let named_import_origin_index = NamedImportOriginIndex::from_edges(&self.edges);
+        let named_import_origin_index =
+            if self.needs_named_import_origin_index(&re_export_info, &entry_star_targets) {
+                NamedImportOriginIndex::from_edges(&self.edges)
+            } else {
+                NamedImportOriginIndex::default()
+            };
 
         self.run_re_export_fixpoint(
             &re_export_info,
@@ -161,6 +166,22 @@ impl ModuleGraph {
             edges_by_target.entry(edge.target).or_default().push(idx);
         }
         edges_by_target
+    }
+
+    fn needs_named_import_origin_index(
+        &self,
+        re_export_info: &[ReExportTuple],
+        entry_star_targets: &FxHashSet<FileId>,
+    ) -> bool {
+        re_export_info.iter().any(|entry| {
+            if entry.exported_name != "*" || entry_star_targets.contains(&entry.barrel) {
+                return false;
+            }
+
+            self.modules
+                .get(entry.barrel.0 as usize)
+                .is_some_and(|barrel| !barrel.is_entry_point())
+        })
     }
 
     /// Run the monotone fixpoint that propagates references through every chain.

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -15,8 +15,8 @@ use crate::resolve::ResolvedModule;
 use super::ModuleGraph;
 
 use propagate::{
-    NamedReExportPropagation, StarReExportPropagation, propagate_named_re_export,
-    propagate_star_re_export,
+    NamedImportOriginIndex, NamedReExportPropagation, StarReExportPropagation,
+    propagate_named_re_export, propagate_star_re_export,
 };
 
 /// A re-export cycle or self-loop detected during Phase 4 chain resolution.
@@ -62,6 +62,7 @@ struct ReExportTuple {
 struct ReExportContext<'a> {
     entry_star_targets: &'a FxHashSet<FileId>,
     edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
+    named_import_origin_index: &'a NamedImportOriginIndex,
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     existing_refs: &'a mut FxHashSet<FileId>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
@@ -90,11 +91,13 @@ impl ModuleGraph {
 
         let entry_star_targets = self.collect_entry_star_targets();
         let edges_by_target = self.build_edges_by_target();
+        let named_import_origin_index = NamedImportOriginIndex::from_edges(&self.edges);
 
         self.run_re_export_fixpoint(
             &re_export_info,
             &entry_star_targets,
             &edges_by_target,
+            &named_import_origin_index,
             module_by_id,
         );
 
@@ -166,6 +169,7 @@ impl ModuleGraph {
         re_export_info: &[ReExportTuple],
         entry_star_targets: &FxHashSet<FileId>,
         edges_by_target: &FxHashMap<FileId, Vec<usize>>,
+        named_import_origin_index: &NamedImportOriginIndex,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     ) {
         let safety_cap = re_export_info.len().saturating_add(1);
@@ -181,6 +185,7 @@ impl ModuleGraph {
             let mut context = ReExportContext {
                 entry_star_targets,
                 edges_by_target,
+                named_import_origin_index,
                 module_by_id,
                 existing_refs: &mut existing_refs,
                 synthetic_stubs: &mut synthetic_stubs,
@@ -221,6 +226,7 @@ impl ModuleGraph {
                 modules: &mut self.modules,
                 edges: &self.edges,
                 edges_by_target: context.edges_by_target,
+                named_import_origin_index: context.named_import_origin_index,
                 module_by_id: context.module_by_id,
                 barrel_id: entry.barrel,
                 barrel_idx,

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -225,6 +225,7 @@ fn barrel_star_ref(
 
 type ReferenceSite = (FileId, u32, u32);
 
+#[derive(Default)]
 pub(in crate::graph) struct NamedImportOriginIndex(
     FxHashMap<ReferenceSite, FxHashMap<String, StarReferenceOrigin>>,
 );
@@ -689,11 +690,11 @@ fn attach_star_refs_to_exports(
     references: &[SymbolReference],
     existing_files: &mut FxHashSet<FileId>,
 ) -> bool {
-    #[cfg(test)]
-    STAR_REFERENCE_SET_REBUILDS.set(STAR_REFERENCE_SET_REBUILDS.get() + 1);
-
     let mut changed = false;
     for export_idx in export_indices {
+        #[cfg(test)]
+        STAR_REFERENCE_SET_REBUILDS.set(STAR_REFERENCE_SET_REBUILDS.get() + 1);
+
         existing_files.clear();
         existing_files.extend(
             source.exports[*export_idx]

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -5,12 +5,37 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use fallow_types::discover::FileId;
 use fallow_types::extract::{ExportName, VisibilityTag};
 
 use crate::graph::types::{ExportSymbol, ModuleNode, ReferenceKind, SymbolReference};
 use crate::graph::{Edge, ImportedName};
 use crate::resolve::ResolvedModule;
+
+#[cfg(test)]
+thread_local! {
+    static NAMED_IMPORT_ORIGIN_INDEX_BUILDS: Cell<usize> = const { Cell::new(0) };
+    static STAR_REFERENCE_SET_REBUILDS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(super) fn count_named_import_origin_index_builds<T>(run: impl FnOnce() -> T) -> (T, usize) {
+    NAMED_IMPORT_ORIGIN_INDEX_BUILDS.set(0);
+    let result = run();
+    let builds = NAMED_IMPORT_ORIGIN_INDEX_BUILDS.get();
+    (result, builds)
+}
+
+#[cfg(test)]
+pub(super) fn count_star_reference_set_rebuilds<T>(run: impl FnOnce() -> T) -> (T, usize) {
+    STAR_REFERENCE_SET_REBUILDS.set(0);
+    let result = run();
+    let rebuilds = STAR_REFERENCE_SET_REBUILDS.get();
+    (result, rebuilds)
+}
 
 /// Handle `export * from './source'`: propagate named imports through to the source module.
 ///
@@ -23,6 +48,7 @@ pub(in crate::graph) struct StarReExportPropagation<'a> {
     pub(in crate::graph) modules: &'a mut [ModuleNode],
     pub(in crate::graph) edges: &'a [Edge],
     pub(in crate::graph) edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
+    pub(in crate::graph) named_import_origin_index: &'a NamedImportOriginIndex,
     pub(in crate::graph) module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     pub(in crate::graph) barrel_id: FileId,
     pub(in crate::graph) barrel_idx: usize,
@@ -38,6 +64,7 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
         modules,
         edges,
         edges_by_target,
+        named_import_origin_index,
         module_by_id,
         barrel_id,
         barrel_idx,
@@ -55,8 +82,14 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
     }
 
     let barrel_file_id = modules[barrel_idx].file_id;
-    let refs_by_name =
-        collect_star_refs_by_name(modules, edges, edges_by_target, barrel_file_id, barrel_idx);
+    let refs_by_name = collect_star_refs_by_name(
+        modules,
+        edges,
+        edges_by_target,
+        named_import_origin_index,
+        barrel_file_id,
+        barrel_idx,
+    );
 
     let source_has_star_re_exports = modules[source_idx]
         .re_exports
@@ -89,12 +122,12 @@ fn collect_star_refs_by_name(
     modules: &[ModuleNode],
     edges: &[Edge],
     edges_by_target: &FxHashMap<FileId, Vec<usize>>,
+    named_import_origin_index: &NamedImportOriginIndex,
     barrel_file_id: FileId,
     barrel_idx: usize,
 ) -> FxHashMap<String, Vec<StarReference>> {
-    let named_import_origin_by_reference = named_import_origin_by_reference(edges);
     let named_refs = named_star_refs(edges, edges_by_target, barrel_file_id);
-    let barrel_refs = barrel_star_refs(&modules[barrel_idx], &named_import_origin_by_reference);
+    let barrel_refs = barrel_star_refs(&modules[barrel_idx], named_import_origin_index);
 
     let mut refs_by_name: FxHashMap<String, Vec<StarReference>> = FxHashMap::default();
     for (name, ref_item) in named_refs {
@@ -149,7 +182,7 @@ fn named_refs_for_edge(edge: &Edge) -> Vec<(String, StarReference)> {
 
 fn barrel_star_refs(
     module: &ModuleNode,
-    named_import_origin_by_reference: &FxHashMap<(FileId, u32, u32, String), StarReferenceOrigin>,
+    named_import_origin_index: &NamedImportOriginIndex,
 ) -> Vec<(String, Vec<StarReference>)> {
     module
         .exports
@@ -166,7 +199,7 @@ fn barrel_star_refs(
                         reference,
                         &name,
                         export.is_type_only,
-                        named_import_origin_by_reference,
+                        named_import_origin_index,
                     )
                 })
                 .collect();
@@ -179,47 +212,59 @@ fn barrel_star_ref(
     reference: SymbolReference,
     name: &str,
     is_type_only: bool,
-    named_import_origin_by_reference: &FxHashMap<(FileId, u32, u32, String), StarReferenceOrigin>,
+    named_import_origin_index: &NamedImportOriginIndex,
 ) -> StarReference {
     StarReference {
         reference,
-        origin: named_import_origin_by_reference
-            .get(&(
-                reference.from_file,
-                reference.import_span.start,
-                reference.import_span.end,
-                name.to_string(),
-            ))
+        origin: named_import_origin_index
+            .get(reference, name)
             .cloned()
             .unwrap_or(StarReferenceOrigin::BarrelExport { is_type_only }),
     }
 }
 
-fn named_import_origin_by_reference(
-    edges: &[Edge],
-) -> FxHashMap<(FileId, u32, u32, String), StarReferenceOrigin> {
-    edges
-        .iter()
-        .flat_map(|edge| {
-            edge.symbols.iter().filter_map(move |sym| {
+type ReferenceSite = (FileId, u32, u32);
+
+pub(in crate::graph) struct NamedImportOriginIndex(
+    FxHashMap<ReferenceSite, FxHashMap<String, StarReferenceOrigin>>,
+);
+
+impl NamedImportOriginIndex {
+    pub(in crate::graph) fn from_edges(edges: &[Edge]) -> Self {
+        #[cfg(test)]
+        NAMED_IMPORT_ORIGIN_INDEX_BUILDS.set(NAMED_IMPORT_ORIGIN_INDEX_BUILDS.get() + 1);
+
+        let mut index: FxHashMap<ReferenceSite, FxHashMap<String, StarReferenceOrigin>> =
+            FxHashMap::default();
+        for edge in edges {
+            for sym in &edge.symbols {
                 let ImportedName::Named(name) = &sym.imported_name else {
-                    return None;
+                    continue;
                 };
-                Some((
-                    (
-                        edge.source,
-                        sym.import_span.start,
-                        sym.import_span.end,
+                index
+                    .entry((edge.source, sym.import_span.start, sym.import_span.end))
+                    .or_default()
+                    .insert(
                         name.clone(),
-                    ),
-                    StarReferenceOrigin::NamedImport {
-                        local_name: sym.local_name.clone(),
-                        is_type_only: sym.is_type_only,
-                    },
-                ))
-            })
-        })
-        .collect()
+                        StarReferenceOrigin::NamedImport {
+                            local_name: sym.local_name.clone(),
+                            is_type_only: sym.is_type_only,
+                        },
+                    );
+            }
+        }
+        Self(index)
+    }
+
+    fn get(&self, reference: SymbolReference, name: &str) -> Option<&StarReferenceOrigin> {
+        self.0
+            .get(&(
+                reference.from_file,
+                reference.import_span.start,
+                reference.import_span.end,
+            ))
+            .and_then(|origins| origins.get(name))
+    }
 }
 
 #[derive(Clone)]
@@ -478,7 +523,8 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
         existing_files,
     } = input;
 
-    let mut changed = false;
+    let mut type_refs = Vec::new();
+    let mut value_refs = Vec::new();
     for star_ref in refs {
         let (attach_type_exports, attach_value_exports) = star_ref.attach_targets(
             module_by_id,
@@ -487,21 +533,25 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
             triggering_is_type_only,
         );
         if attach_type_exports {
-            changed |= attach_star_ref_to_exports(
-                source,
-                &exports.type_indices,
-                star_ref.reference,
-                existing_files,
-            );
+            type_refs.push(star_ref.reference);
         }
         if attach_value_exports {
-            changed |= attach_star_ref_to_exports(
-                source,
-                &exports.value_indices,
-                star_ref.reference,
-                existing_files,
-            );
+            value_refs.push(star_ref.reference);
         }
+    }
+
+    let mut changed = false;
+    if !type_refs.is_empty() {
+        changed |=
+            attach_star_refs_to_exports(source, &exports.type_indices, &type_refs, existing_files);
+    }
+    if !value_refs.is_empty() {
+        changed |= attach_star_refs_to_exports(
+            source,
+            &exports.value_indices,
+            &value_refs,
+            existing_files,
+        );
     }
     changed
 }
@@ -633,12 +683,15 @@ fn create_synthetic_export(input: CreateSyntheticExport<'_>) -> bool {
     true
 }
 
-fn attach_star_ref_to_exports(
+fn attach_star_refs_to_exports(
     source: &mut ModuleNode,
     export_indices: &[usize],
-    reference: SymbolReference,
+    references: &[SymbolReference],
     existing_files: &mut FxHashSet<FileId>,
 ) -> bool {
+    #[cfg(test)]
+    STAR_REFERENCE_SET_REBUILDS.set(STAR_REFERENCE_SET_REBUILDS.get() + 1);
+
     let mut changed = false;
     for export_idx in export_indices {
         existing_files.clear();
@@ -648,9 +701,11 @@ fn attach_star_ref_to_exports(
                 .iter()
                 .map(|r| r.from_file),
         );
-        if existing_files.insert(reference.from_file) {
-            source.exports[*export_idx].references.push(reference);
-            changed = true;
+        for reference in references {
+            if existing_files.insert(reference.from_file) {
+                source.exports[*export_idx].references.push(*reference);
+                changed = true;
+            }
         }
     }
     changed

--- a/crates/graph/src/graph/re_exports/tests.rs
+++ b/crates/graph/src/graph/re_exports/tests.rs
@@ -184,7 +184,14 @@ fn barrel_re_export_creates_export_symbol() {
         },
     ];
 
-    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    let (graph, origin_index_builds) = count_named_import_origin_index_builds(|| {
+        ModuleGraph::build(&resolved_modules, &entry_points, &files)
+    });
+
+    assert_eq!(
+        origin_index_builds, 0,
+        "named re-exports should not build the star-import origin index"
+    );
 
     let barrel = &graph.modules[1];
     let foo_export = barrel.exports.iter().find(|e| e.name.to_string() == "foo");
@@ -878,7 +885,14 @@ fn entry_point_star_re_export_propagates_to_source() {
         },
     ];
 
-    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    let (graph, origin_index_builds) = count_named_import_origin_index_builds(|| {
+        ModuleGraph::build(&resolved_modules, &entry_points, &files)
+    });
+
+    assert_eq!(
+        origin_index_builds, 0,
+        "entry-point star re-exports should use the fast path without an origin index"
+    );
 
     let utils_module = &graph.modules[1];
     let foo = utils_module
@@ -2218,9 +2232,9 @@ fn star_re_export_many_consumers_no_quadratic_blowup() {
         ModuleGraph::build(&resolved_modules, &entry_points, &files)
     });
 
-    assert_eq!(
-        reference_set_rebuilds, 2,
-        "the reference set should be built once per fixpoint iteration"
+    assert!(
+        (1..=2).contains(&reference_set_rebuilds),
+        "the reference set should be built at most once per fixpoint iteration"
     );
 
     let source = &graph.modules[source_id.0 as usize];

--- a/crates/graph/src/graph/re_exports/tests.rs
+++ b/crates/graph/src/graph/re_exports/tests.rs
@@ -1,5 +1,6 @@
 use rustc_hash::FxHashSet;
 
+use super::propagate::{count_named_import_origin_index_builds, count_star_reference_set_rebuilds};
 use crate::graph::ModuleGraph;
 use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport};
 use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
@@ -2213,7 +2214,14 @@ fn star_re_export_many_consumers_no_quadratic_blowup() {
         ..Default::default()
     });
 
-    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    let (graph, reference_set_rebuilds) = count_star_reference_set_rebuilds(|| {
+        ModuleGraph::build(&resolved_modules, &entry_points, &files)
+    });
+
+    assert_eq!(
+        reference_set_rebuilds, 2,
+        "the reference set should be built once per fixpoint iteration"
+    );
 
     let source = &graph.modules[source_id.0 as usize];
     let shared = source
@@ -3116,6 +3124,19 @@ fn star_re_export_duplicate_name_value_import_credits_value_export() {
         !value_export.references.is_empty(),
         "value use through a star barrel should credit the value export"
     );
+}
+
+#[test]
+fn star_re_export_origin_index_is_built_once_per_graph() {
+    let (_, builds) = count_named_import_origin_index_builds(|| {
+        graph_for_merged_star_chain_import(
+            vec![named_import("Merged", "Local", false)],
+            vec![],
+            vec!["Local"],
+        )
+    });
+
+    assert_eq!(builds, 1, "the whole-edge origin index must be shared");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Reuse the named-import origin index across star re-export propagation.
- Batch reference deduplication per export to remove quadratic allocation churn.
- Preserve named-import credit through merged namespace and value re-exports.

## Issue

Closes #1843

## Verification

- [x] Focused graph regression tests
- [x] Synthetic scaling repro
- [x] Real public-project smoke
- [x] Full repository gates
