### PR TITLE
fix(report): singular noun for a single fix in the github-summary headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `--format github-summary` auto-fix headline uses the singular noun for a
+  single fix.** It read "would apply **1 fixes**" for one fix; it now reads
+  "1 fix". Same wording via `fallow fix --format github-summary` and
+  `fallow report --from`.
+
 - **Dead-code analysis no longer repeats quadratic allocation work across deep
   `export *` barrel chains.** Star re-export propagation now builds its
   named-import origin index once per graph and batches reference deduplication

--- a/crates/cli/src/report/github_summary.rs
+++ b/crates/cli/src/report/github_summary.rs
@@ -2165,7 +2165,8 @@ pub fn render_fix_summary(env: &Value) -> String {
     } else {
         "Applied"
     });
-    let _ = write!(out, " **{fix_attempts} fixes**");
+    let fix_noun = if fix_attempts == 1 { "fix" } else { "fixes" };
+    let _ = write!(out, " **{fix_attempts} {fix_noun}**");
     if !dry_run {
         let _ = write!(out, " ({} succeeded)", num(env, "total_fixed"));
     }

--- a/crates/cli/tests/github_format_tests.rs
+++ b/crates/cli/tests/github_format_tests.rs
@@ -705,6 +705,32 @@ fn render_summary_fix_mirrors_render_fix_summary() {
     );
 }
 
+/// A single fix uses the singular noun in the headline (`1 fix`, not
+/// `1 fixes`). One fix is the common PR case.
+#[test]
+fn fix_summary_single_fix_uses_singular_noun() {
+    let env = json!({
+        "dry_run": true,
+        "total_fixed": 0,
+        "skipped": 0,
+        "skipped_content_changed": 0,
+        "skipped_mixed_line_endings": 0,
+        "skipped_low_confidence_exports": 0,
+        "fixes": [
+            { "type": "remove_export", "path": "src/lib.ts", "line": 2, "name": "dead", "applied": false }
+        ]
+    });
+    let rendered = fallow_cli::report::github_summary::render_fix_summary(&env);
+    assert!(
+        rendered.contains("would apply **1 fix**"),
+        "single fix should read '1 fix', got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("1 fixes"),
+        "must not use the plural noun for one fix: {rendered}"
+    );
+}
+
 /// The bundled action no-ops annotations for the fix command, so the native
 /// `EnvelopeKind::Fix` annotation renderer must emit nothing.
 #[test]


### PR DESCRIPTION
The `--format github-summary` auto-fix headline read "would apply **1 fixes**" for a single fix. It now branches on the count and reads "1 fix", matching the other github-summary and github-annotations count strings. One fix is the common PR case. The wording is shared by the live `fallow fix --format github-summary` and `fallow report --from` paths (both render via `render_fix_summary`), so both are corrected in one place.

Adds a singular-case test; the existing plural snapshot (count 3) is unchanged. clippy `-D warnings` and fmt clean.