### PR TITLE
fix: harden analysis boundaries and verification

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -3,16 +3,13 @@ disallowed-types = [
     { path = "std::collections::HashSet", reason = "Use rustc_hash::FxHashSet for better performance" },
 ]
 
-# Process spawning is banned by default (level set to allow in the workspace
-# Cargo.toml, then re-denied per-crate). fallow's analysis crates (fallow-core,
-# fallow-extract, fallow-graph) re-enable this deny at their crate root so the
-# "static analysis never executes the analyzed project's code, only `git`"
-# invariant is machine-checkable: every git spawn there routes through
-# `fallow_core::spawn::git`, the one allowed call site. The CLI / MCP crates
-# legitimately spawn git worktrees, the coverage sidecar, and subprocesses, and
-# are off the analysis path, so they keep the workspace-level allow.
+# Process spawning is allowed at workspace level, then re-denied by the core,
+# extract, graph, and engine crates. Core, extract, and graph never spawn
+# processes. Engine permits only narrowly expected, engine-owned Git wrappers.
+# CLI and MCP legitimately spawn worktrees, sidecars, and subprocesses outside
+# the analysis core, so they keep the workspace-level allow.
 disallowed-methods = [
-    { path = "std::process::Command::new", reason = "On the analysis path, route process spawning through fallow_core::spawn (only `git` is permitted); the deny is scoped to fallow-core/extract/graph via crate-root attributes" },
+    { path = "std::process::Command::new", reason = "Analysis crates forbid process spawning except narrowly expected engine-owned Git wrappers; the deny is scoped by crate-root attributes" },
 ]
 
 # Maximum nesting depth before clippy::excessive_nesting fires.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      windows-rust: ${{ steps.filter.outputs.windows-rust }}
       vscode: ${{ steps.filter.outputs.vscode }}
       zed: ${{ steps.filter.outputs.zed }}
       npm: ${{ steps.filter.outputs.npm }}
@@ -55,10 +56,10 @@ jobs:
             # keeping the filter at `crates/**` (rather than a narrower
             # per-crate list) ensures edits to ANY of the following subtrees
             # trigger the gate:
-            #   - crates/types/src/                       (finding structs)
-            #   - crates/core/src/duplicates/types.rs     (CloneFamily, CloneGroup, AttributedCloneGroup)
-            #   - crates/cli/src/health_types/            (ComplexityViolation, HealthFinding, hotspots, refactoring, coverage)
-            #   - crates/cli/src/output_envelope.rs       (FallowOutput enum + per-command envelopes)
+            #   - crates/types/src/                       (analysis and base payload types)
+            #   - crates/output/src/                      (health, action, and envelope wire shapes)
+            #   - crates/api/src/                         (programmatic and attribution wrappers)
+            #   - crates/cli/src/bin/schema_emit.rs       (derived definition registry and schema assembly)
             #   - crates/config/src/config/              (FallowConfig + RulesConfig + presets, source of schema.json)
             # Both `docs/output-schema.json` and `schema.json` are included so
             # PR edits that ONLY touch a committed schema (without a matching
@@ -91,6 +92,20 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'deny.toml'
+              - '.clippy.toml'
+              - 'rust-toolchain.toml'
+            windows-rust:
+              - 'crates/engine/src/changed_files.rs'
+              - 'crates/engine/src/churn.rs'
+              - 'crates/engine/Cargo.toml'
+              - 'crates/mcp/src/tools/code_mode_subprocess.rs'
+              - 'crates/mcp/src/tools/process_tree.rs'
+              - 'crates/mcp/Cargo.toml'
+              - '.github/actions/setup-rust/**'
+              - '.github/workflows/ci.yml'
+              - 'scripts/workflow-policy.test.mjs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
               - '.clippy.toml'
               - 'rust-toolchain.toml'
             vscode:
@@ -272,6 +287,31 @@ jobs:
 
       - name: Check for uncommitted changes
         run: git diff --exit-code
+
+  windows-rust:
+    name: Windows path and subprocess handling
+    needs: changes
+    if: needs.changes.outputs.windows-rust == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy
+          cache-key: pr-windows-rust
+      - name: Test changed-file path handling
+        run: cargo test -p fallow-engine changed_files::tests
+      - name: Test churn path handling
+        run: cargo test -p fallow-engine churn::tests
+      - name: Test MCP subprocess cleanup
+        run: cargo test -p fallow-mcp completed_success_cleans_descendant_process_tree
+      - name: Clippy platform-specific paths
+        run: cargo clippy -p fallow-engine -p fallow-mcp --all-targets -- -D warnings
 
   skills-vendor:
     name: Skills vendor drift
@@ -713,7 +753,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, doc, typos, js-lint, npm-package, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor]
+    needs: [check, windows-rust, doc, typos, js-lint, npm-package, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ cargo build --release -p fallow-cli  # Release build (CLI only)
 ```bash
 npm run verify                        # Alias for the canonical fast checks
 npm run verify:fast                   # Formatting, linting, contracts, boundaries
-npm run verify:full                   # Fast checks plus tests, benches, docs, NAPI
+npm run verify:full                   # Fast checks plus script/Rust tests, benches, docs, NAPI
 cargo test -p fallow-core             # Focused single-crate test run
 ```
 
@@ -164,9 +164,9 @@ The schema covers two layers, with different ownership rules:
 
 ### Layer 1: types derived from Rust
 
-The per-finding structs in `crates/types/src/results.rs` and `crates/types/src/duplicates.rs`, the JSON-layer augmentation types in `crates/types/src/output.rs`, the per-finding action wrappers in `crates/types/src/output_health.rs`, the health output subtree in `crates/cli/src/health_types/`, the shared envelope and utility shapes in `crates/types/src/envelope.rs`, and the per-command envelope structs in `crates/cli/src/output_envelope.rs` all carry `#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]`. The full list of derived definitions is `derived_definition_names()` in `crates/cli/src/bin/schema_emit.rs`.
+Rust-owned schema types live across `crates/types/src/` (analysis and base payloads), `crates/output/src/` (health, action, utility, and envelope wire shapes), `crates/api/src/` (programmatic and attribution wrappers), and `crates/config/src/` (configuration inputs). The types, output, and API crates gate their `JsonSchema` derives behind a `schema` feature; config derives `JsonSchema` unconditionally because it also owns the configuration schema. The authoritative output-contract inventory is `derived_definition_names()` plus the corresponding registrations and imports in `crates/cli/src/bin/schema_emit.rs`.
 
-The health and envelope types live on `fallow-cli` (the binary crate) rather than `fallow-types`, so deriving `JsonSchema` on them required a sibling `schema` cargo feature on `fallow-cli`. The `schema-emit` feature now depends on `fallow-cli/schema` alongside `fallow-types/schema` + `fallow-core/schema`, so a single `cargo run -p fallow-cli --features schema-emit --bin fallow-schema-emit` covers the whole tree.
+The CLI's `schema-emit` feature enables the feature-gated derives through `fallow-cli/schema` and includes config's always-available schema types, so a single `cargo run -p fallow-cli --features schema-emit --bin fallow-schema-emit` covers the whole tree.
 
 A drift gate (`cargo test -p fallow-cli --features schema-emit --bin fallow-schema-emit`) compares the derived shape against the committed `docs/output-schema.json` and fails when:
 - a Rust struct gains a field that is missing from the schema,
@@ -192,9 +192,9 @@ The following surfaces of `docs/output-schema.json` stay hand-maintained today:
 
 The `committed_property_refs_match_derived_property_refs` drift test catches `$ref`-value drift between derived and committed property shapes (e.g. if a future change repoints `CombinedOutput.dupes` away from `DuplicationReport`); this is a check, not a hand-maintained section.
 
-The document-root `oneOf` is now derived from Rust as of #384 item 6: the typed `FallowOutput` enum (in `crates/cli/src/output_envelope.rs`) wraps every object-shaped envelope and emits the root union via the `rewrite_document_root_one_of` step in `crates/cli/src/bin/schema_emit.rs`. Editing the root `oneOf` by hand will be reverted on the next regeneration. The root union is `[FallowOutput, CodeClimateOutput, ...HAND_MAINTAINED_ROOT_ENVELOPES]`: `CodeClimateOutput` (a bare JSON array via `#[serde(transparent)]`) is a sibling branch because the planned future move to `#[serde(tag = "kind")]` requires every variant of `FallowOutput` to serialize as an object, which the Code Climate / GitLab Code Quality spec forbids for that one envelope.
+The document-root `oneOf` is now derived from Rust as of #384 item 6: the typed `FallowOutput` enum in `crates/output/src/root_envelopes.rs` wraps every object-shaped envelope and emits the root union via the `rewrite_document_root_one_of` step in `crates/cli/src/bin/schema_emit.rs`. Editing the root `oneOf` by hand will be reverted on the next regeneration. The root union is `[FallowOutput, CodeClimateOutput, ...HAND_MAINTAINED_ROOT_ENVELOPES]`: `CodeClimateOutput` (a bare JSON array via `#[serde(transparent)]`) is a sibling branch because the planned future move to `#[serde(tag = "kind")]` requires every variant of `FallowOutput` to serialize as an object, which the Code Climate / GitLab Code Quality spec forbids for that one envelope.
 
-If you add a new finding type or utility shape, derive `JsonSchema` on the matching Rust struct, register it in `derived_definition_names()`, and the drift gate forces the schema to follow. **Adding a new top-level envelope** also requires adding a new variant to `FallowOutput` in `crates/cli/src/output_envelope.rs` so the document root keeps documenting every wire shape.
+If you add a new finding type or utility shape, derive `JsonSchema` on the matching Rust struct, register it in `derived_definition_names()`, and the drift gate forces the schema to follow. **Adding a new top-level envelope** also requires adding a new variant to `FallowOutput` in `crates/output/src/root_envelopes.rs` so the document root keeps documenting every wire shape.
 
 ### After editing the schema
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,10 +161,9 @@ suspicious_operation_groupings = "warn" # Catch visually ambiguous arithmetic/bi
 unused_peekable = "warn"               # Catch Peekable iterators that never peek
 
 # Process-spawn ban (method list lives in .clippy.toml). Allowed workspace-wide
-# so the CLI / MCP crates can spawn git worktrees, the coverage sidecar, and
-# subprocesses off the analysis path; fallow-core/extract/graph re-deny it at
-# their crate root to enforce that the analysis path spawns only `git` via
-# fallow_core::spawn.
+# so CLI and MCP can spawn worktrees, sidecars, and subprocesses off the core
+# analysis path. Core, extract, graph, and engine re-deny it at their crate
+# roots; engine-owned Git wrappers carry narrow expectations at their call sites.
 disallowed_methods = "allow"
 
 # Allow common pedantic false positives

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Concrete work scoped to the next one or two minor releases.
 
 ### Richer MCP responses
 
-In progress: agents already query fallow via MCP, but the responses lack context agents need to make confident removal decisions: re-export chains, who imports this symbol, recent churn, duplicate siblings. The work expands existing tool responses before adding new tools, and is partially landed.
+The `inspect_target` tool already combines re-export chains, importers, duplicate siblings, and optional recent churn into one evidence bundle. The remaining work is to bring the same decision-ready context to broader MCP analysis flows where agents currently have to follow up with a separate inspection call.
 
 ### Coverage sidecar ergonomics
 
@@ -22,13 +22,11 @@ The coverage setup state machine works end to end, but the install handoff still
 
 `fallow fix` leaves Prettier, dprint, or Biome to clean up whitespace after removals. Invoke the project's configured formatter automatically when running in-place.
 
-### Baseline-adoption ergonomics
+### Baseline-adoption command
 
-Follow-ups to the `fallow.changedSince` setting shipped for issue #185. The setting works (Problems panel and sidebar scope to files changed since the configured ref) but a few UX polish items would close the loop for users adopting fallow on legacy codebases:
+The `fallow.changedSince` setting scopes the Problems panel and sidebar, while the status bar reports whether that scope was applied or dropped. One editor shortcut would still close the setup loop for legacy codebases:
 
 - **"Fallow: Set Baseline at HEAD" command** -- a palette command that runs `git tag fallow-baseline` and writes `fallow.changedSince` into `.vscode/settings.json` in one step, so users do not need to leave the editor or know the git tag command.
-- **Filter-dropped status surfacing** -- when the LSP cannot resolve the configured ref (typo, shallow clone, missing tag), it currently falls back to full scope and logs a `WARNING` to the Fallow output channel. Surface that state in the status bar (e.g. `Fallow: 118 issues (since fallow-baseline: scope dropped)`) so users notice immediately rather than after the next "wait, why am I seeing all these issues again?" question.
-- **Shallow-clone hint in CI templates** -- the runtime hint already explains the `fetch-depth: 0` fix; the GitHub Action template should default to a checkout depth that works with long-lived baseline tags, or document the requirement in the inline comments. The GitLab template ships `GIT_DEPTH: "0"` as a default since v2.54.0.
 
 ### Per-package `changedSince` overrides
 

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -73,28 +73,36 @@ normalize_config_path() {
 }
 
 find_changed_fallow_config() {
-  local changed_files=$1
+  local changed_files_json=$1
   local explicit_config=""
+  local matched=""
+  local root_prefix=""
 
   if [ -n "${INPUT_CONFIG:-}" ]; then
     explicit_config=$(normalize_config_path "$INPUT_CONFIG")
   fi
+  if [ -n "${INPUT_ROOT:-}" ] && [ "$INPUT_ROOT" != "." ]; then
+    root_prefix="${INPUT_ROOT#./}/"
+  fi
 
-  while IFS= read -r changed_file; do
-    [ -n "$changed_file" ] || continue
-    changed_file=$(normalize_changed_path "$changed_file")
-    case "$changed_file" in
-      .fallowrc.json|.fallowrc.jsonc|fallow.toml|.fallow.toml)
-        printf '%s\n' "$changed_file"
-        return 0
-        ;;
-    esac
+  matched=$(printf '%s' "$changed_files_json" | jq -r \
+    --arg explicit "$explicit_config" --arg root "$root_prefix" '
+    .[]
+    | sub("^\\./"; "")
+    | if ($root != "" and startswith($root)) then ltrimstr($root) else . end
+    | select(
+        . == ".fallowrc.json"
+        or . == ".fallowrc.jsonc"
+        or . == "fallow.toml"
+        or . == ".fallow.toml"
+        or ($explicit != "" and . == $explicit)
+      )
+  ' | head -1)
 
-    if [ -n "$explicit_config" ] && [ "$changed_file" = "$explicit_config" ]; then
-      printf '%s\n' "$changed_file"
-      return 0
-    fi
-  done <<< "$changed_files"
+  if [ -n "$matched" ]; then
+    printf '%s\n' "$matched"
+    return 0
+  fi
 
   return 1
 }
@@ -369,21 +377,21 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "changed_files_unavailable=false" >> "$GITHUB_OUTPUT"
 fi
 
-_CHANGED=""
+_CHANGED_JSON=""
 
 if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
   _ROOT="${INPUT_ROOT:-.}"
-  _CHANGED=""
+  _CHANGED_JSON=""
 
   # Try three-dot diff (precise: changes since merge-base, needs full history)
-  _CHANGED=$(cd "$_ROOT" && git diff --name-only --relative "${INPUT_CHANGED_SINCE}...HEAD" -- . 2>/dev/null || true)
+  _CHANGED_JSON=$(cd "$_ROOT" && git diff --name-only -z --relative "${INPUT_CHANGED_SINCE}...HEAD" -- . 2>/dev/null | jq -Rs 'split("\u0000") | map(select(length > 0))' || true)
 
   # Shallow clone fallback: fetch the base commit and try two-dot diff
-  if [ -z "$_CHANGED" ]; then
+  if ! printf '%s' "$_CHANGED_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
     if ! git cat-file -e "${INPUT_CHANGED_SINCE}^{commit}" 2>/dev/null; then
       git fetch --depth=1 origin "$INPUT_CHANGED_SINCE" 2>/dev/null || true
     fi
-    _CHANGED=$(cd "$_ROOT" && git diff --name-only --relative "${INPUT_CHANGED_SINCE}" HEAD -- . 2>/dev/null || true)
+    _CHANGED_JSON=$(cd "$_ROOT" && git diff --name-only -z --relative "${INPUT_CHANGED_SINCE}" HEAD -- . 2>/dev/null | jq -Rs 'split("\u0000") | map(select(length > 0))' || true)
   fi
 
   # Last resort: GitHub API (works regardless of clone depth).
@@ -393,19 +401,19 @@ if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
   # workflow steps can gate on the degraded state rather than silently
   # running unscoped analysis. The existing shallow-clone warning below
   # keeps its framing for the no-API-credentials case.
-  if [ -z "$_CHANGED" ] && [ -n "${GH_TOKEN:-}" ] && [ -n "${PR_NUMBER:-}" ] && [ -n "${GH_REPO:-}" ]; then
+  if ! printf '%s' "$_CHANGED_JSON" | jq -e 'length > 0' >/dev/null 2>&1 \
+      && [ -n "${GH_TOKEN:-}" ] && [ -n "${PR_NUMBER:-}" ] && [ -n "${GH_REPO:-}" ]; then
     _API_TMP=$(mktemp)
     _API_ERR=$(mktemp)
     trap 'rm -f "$_API_TMP" "$_API_ERR"' EXIT
-    if gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename' \
+    if gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename | @json' \
          > "$_API_TMP" 2> "$_API_ERR"; then
-      _API_FILES=$(cat "$_API_TMP")
-      if [ -n "$_API_FILES" ]; then
+      _CHANGED_JSON=$(jq -s '.' "$_API_TMP")
+      if printf '%s' "$_CHANGED_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
         if [ "$_ROOT" != "." ]; then
           # Strip root prefix; API returns repo-root-relative paths, fallow JSON uses root-relative.
-          _CHANGED=$(echo "$_API_FILES" | sed -n "s|^${_ROOT}/||p")
-        else
-          _CHANGED="$_API_FILES"
+          _CHANGED_JSON=$(printf '%s' "$_CHANGED_JSON" | jq -c --arg prefix "${_ROOT%/}/" \
+            'map(select(startswith($prefix)) | ltrimstr($prefix))')
         fi
       fi
     else
@@ -415,15 +423,16 @@ if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
     fi
   fi
 
-  if [ -n "$_CHANGED" ]; then
-    echo "$_CHANGED" | jq -R -s 'split("\n") | map(select(length > 0))' > "$CHANGED_FILES_FILE"
+  if printf '%s' "$_CHANGED_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
+    printf '%s\n' "$_CHANGED_JSON" > "$CHANGED_FILES_FILE"
   else
     echo "::warning::Could not determine changed files for --changed-since scoping. Use fetch-depth: 0 in actions/checkout for best results."
   fi
 fi
 
-if is_dead_code_baseline_command && [ -n "$_CHANGED" ]; then
-  CONFIG_SCOPE_TRIGGER=$(find_changed_fallow_config "$_CHANGED" || true)
+if is_dead_code_baseline_command \
+    && printf '%s' "$_CHANGED_JSON" | jq -e 'length > 0' >/dev/null 2>&1; then
+  CONFIG_SCOPE_TRIGGER=$(find_changed_fallow_config "$_CHANGED_JSON" || true)
   if [ -n "$CONFIG_SCOPE_TRIGGER" ]; then
     if [ "$AUTO_CHANGED_SINCE" = "true" ]; then
       if [ "$USER_DIFF_FILE" = "true" ]; then

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -508,12 +508,23 @@ cat > "$ANALYZE_TMP/bin/git" <<'SH'
 case "$1" in
   diff)
     shift
+    name_only=false
+    nul_delimited=false
     for arg in "$@"; do
       if [ "$arg" = "--name-only" ]; then
-        printf '%s\n' "${FAKE_CHANGED_FILES:-src/a.ts}"
-        exit 0
+        name_only=true
+      elif [ "$arg" = "-z" ]; then
+        nul_delimited=true
       fi
     done
+    if [ "$name_only" = "true" ]; then
+      if [ "$nul_delimited" = "true" ]; then
+        printf '%s\0' "${FAKE_CHANGED_FILES:-src/a.ts}"
+      else
+        printf '%s\n' "${FAKE_CHANGED_FILES:-src/a.ts}"
+      fi
+      exit 0
+    fi
     printf '%s\n' 'diff --git a/src/a.ts b/src/a.ts'
     printf '%s\n' '--- a/src/a.ts'
     printf '%s\n' '+++ b/src/a.ts'
@@ -620,6 +631,14 @@ else
 fi
 assert_contains "$ENV_OUT" "FALLOW_DIFF_FILE=$EXPLICIT_DIFF" "analyze: explicit diff file is preserved"
 assert_contains "$OUT" "explicit diff file remains active" "analyze: explicit diff warns about remaining scope"
+
+OUT=$(run_analyze_scope_case "newline-filename" $'src/line\nbreak.ts' "" "" "")
+CHANGED_FILE="$ANALYZE_TMP/scope-newline-filename/fallow-changed-files.json"
+if jq -e 'length == 1 and .[0] == "src/line\nbreak.ts"' "$CHANGED_FILE" >/dev/null; then
+  pass "analyze: changed-file JSON preserves newline-bearing filename"
+else
+  fail "analyze: changed-file JSON preserves newline-bearing filename" "got: $(cat "$CHANGED_FILE")"
+fi
 
 # Audit verdict + gate are emitted to GITHUB_OUTPUT for the Check threshold step.
 # Without this, the threshold step gates on raw introduced count, re-introducing
@@ -1647,6 +1666,10 @@ SCRIPTS_DIR="$DIR/../scripts"
 cat > "$API_FAIL_BIN/gh" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = "api" ]; then
+  case " $* " in
+    *" --paginate "*) ;;
+    *) echo "missing --paginate" >&2; exit 2 ;;
+  esac
   echo "gh: HTTP 500: Internal Server Error (api.github.com/repos/owner/repo/pulls/123/files)" >&2
   exit 1
 fi
@@ -1682,7 +1705,15 @@ assert_contains "$API_FAIL_STDERR" "gh auth status" \
 cat > "$API_FAIL_BIN/gh" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = "api" ]; then
-  printf 'src/a.ts\nsrc/b.ts\n'
+  case " $* " in
+    *" --paginate "*) ;;
+    *) echo "missing --paginate" >&2; exit 2 ;;
+  esac
+  printf '%s\n' \
+    '"src/a.ts"' \
+    '"src/line\nbreak.ts"' \
+    '"src/quote\"file.ts"' \
+    '"src/back\\slash.ts"'
   exit 0
 fi
 exit 0
@@ -1710,6 +1741,19 @@ if grep -q '^changed_files_unavailable=false$' "$API_FAIL_OUTPUT" \
 else
   fail "analyze: emits changed_files_unavailable=false on gh api success" \
     "expected only =false, got: $(grep changed_files_unavailable "$API_FAIL_OUTPUT" || echo 'absent')"
+fi
+API_CHANGED_FILE="$API_FAIL_WORK/fallow-changed-files.json"
+if jq -e '
+  length == 4
+  and .[0] == "src/a.ts"
+  and .[1] == "src/line\nbreak.ts"
+  and .[2] == "src/quote\"file.ts"
+  and .[3] == "src/back\\slash.ts"
+' "$API_CHANGED_FILE" >/dev/null; then
+  pass "analyze: API fallback preserves JSON-escaped filenames"
+else
+  fail "analyze: API fallback preserves JSON-escaped filenames" \
+    "got: $(cat "$API_CHANGED_FILE" 2>/dev/null || echo absent)"
 fi
 
 # --- Test 2b: analyze.sh emits changed_files_unavailable=false even without INPUT_CHANGED_SINCE ---

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,12 +34,10 @@ default = []
 # enabled in release builds; a compile_error! at
 # crates/cli/src/health/coverage.rs guards against that.
 test-sidecar-key = []
-# Library feature that toggles `JsonSchema` derives on the health output types
-# defined in `crates/cli/src/health_types/`. Mirrors the `schema` feature on
-# `fallow-types` so the schema-emit binary can derive a single `JsonSchema`
-# document covering health alongside the rest of the output contract. Strictly
-# additive: non-schema builds pay zero compile cost because every derive is
-# gated behind `#[cfg_attr(feature = "schema", ...)]`.
+# Library feature that enables `JsonSchema` derives across the API, output, and
+# base type crates so the schema-emit binary can derive one document covering
+# the complete output contract. Non-schema builds pay zero compile cost because
+# every derive is gated behind `#[cfg_attr(feature = "schema", ...)]`.
 schema = ["dep:schemars", "fallow-api/schema", "fallow-output/schema", "fallow-types/schema"]
 # Build-only feature that enables the `fallow-schema-emit` binary, which
 # regenerates `docs/output-schema.json` from the Rust source of truth. Pulls in

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -1,3 +1,4 @@
+use std::net::Ipv6Addr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -305,13 +306,12 @@ fn normalize_url_for_dedup(url: &str) -> String {
     let rest = rest.split_once('#').map_or(rest, |(value, _)| value);
     let authority_end = rest.find(['/', '?']).unwrap_or(rest.len());
     let (authority, tail) = rest.split_at(authority_end);
-    let authority = authority.to_ascii_lowercase();
-    let authority = authority.strip_suffix(":443").unwrap_or(&authority);
+    let authority = normalize_url_authority(authority, &scheme);
 
     let tail = if tail == "/" {
         ""
-    } else if tail.ends_with('/') && !tail.contains('?') {
-        tail.strip_suffix('/').unwrap_or(tail)
+    } else if tail.starts_with("/?") {
+        &tail[1..]
     } else {
         tail
     };
@@ -320,6 +320,49 @@ fn normalize_url_for_dedup(url: &str) -> String {
         format!("{scheme}://{authority}")
     } else {
         format!("{scheme}://{authority}{tail}")
+    }
+}
+
+/// Normalize only the case-insensitive parts of a URL authority and its default port.
+fn normalize_url_authority(authority: &str, scheme: &str) -> String {
+    let (userinfo, host_port) = authority
+        .rsplit_once('@')
+        .map_or((None, authority), |(userinfo, host_port)| {
+            (Some(userinfo), host_port)
+        });
+
+    let (host, port) = if host_port.starts_with('[') {
+        host_port.find("]:").map_or((host_port, None), |separator| {
+            let (host, port) = host_port.split_at(separator + 1);
+            (host, port.strip_prefix(':'))
+        })
+    } else {
+        host_port
+            .rsplit_once(':')
+            .map_or((host_port, None), |(host, port)| (host, Some(port)))
+    };
+
+    let port = port.map(|value| {
+        value
+            .parse::<u16>()
+            .map_or_else(|_| value.to_string(), |number| number.to_string())
+    });
+    let port =
+        port.filter(|port| !matches!((scheme, port.as_str()), ("http", "80") | ("https", "443")));
+    let host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .and_then(|value| value.parse::<Ipv6Addr>().ok())
+        .map_or_else(
+            || host.to_ascii_lowercase(),
+            |address| format!("[{address}]"),
+        );
+
+    match (userinfo, port.as_deref()) {
+        (Some(userinfo), Some(port)) => format!("{userinfo}@{host}:{port}"),
+        (Some(userinfo), None) => format!("{userinfo}@{host}"),
+        (None, Some(port)) => format!("{host}:{port}"),
+        (None, None) => host,
     }
 }
 
@@ -341,12 +384,23 @@ fn remote_config_display(location: &str) -> String {
 }
 
 /// Format a fetch error without trusting the HTTP client's URL rendering.
-fn remote_fetch_error_display(error: &str, url: &str) -> String {
-    if remote_config_display(url) == url {
-        error.to_string()
-    } else {
-        "request failed".to_string()
+fn remote_fetch_error_display(error: &ureq::Error, _url: &str) -> String {
+    match error {
+        ureq::Error::RequireHttpsOnly(redirect_target) => format!(
+            "configured for https only: {}",
+            remote_config_display(redirect_target)
+        ),
+        ureq::Error::StatusCode(code) => format!("http status {code}"),
+        ureq::Error::HostNotFound => "host not found".to_string(),
+        ureq::Error::Timeout(_) => "request timed out".to_string(),
+        _ => "request failed".to_string(),
     }
+}
+
+fn starts_with_url_prefix(value: &str, prefix: &str) -> bool {
+    value
+        .get(..prefix.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
 }
 
 /// Read the `FALLOW_EXTENDS_TIMEOUT_SECS` env var, falling back to [`DEFAULT_URL_TIMEOUT_SECS`].
@@ -380,7 +434,7 @@ fn fetch_url_config(url: &str, source: &str) -> Result<serde_json::Value, miette
         .new_agent();
 
     let mut response = agent.get(url).call().map_err(|e| {
-        let error_display = remote_fetch_error_display(&e.to_string(), url);
+        let error_display = remote_fetch_error_display(&e, url);
         miette::miette!(
             "Failed to fetch remote config from {url_display} \
              (referenced from {source_display}): {error_display}. \
@@ -536,11 +590,11 @@ impl<'a, Fetcher: RemoteConfigFetcher> ExtendsResolver<'a, Fetcher> {
             sealed_dir_canonical,
             depth,
         } = input;
-        if entry.starts_with(HTTPS_PREFIX) {
+        if starts_with_url_prefix(entry, HTTPS_PREFIX) {
             reject_sealed_remote_extends(path, entry, sealed, "URL")?;
             return self.resolve_remote(entry, depth + 1);
         }
-        if entry.starts_with(HTTP_PREFIX) {
+        if starts_with_url_prefix(entry, HTTP_PREFIX) {
             let entry_display = remote_config_display(entry);
             return Err(miette::miette!(
                 "URL extends must use https://, got http:// URL '{}' (in {}). \
@@ -626,9 +680,9 @@ impl<'a, Fetcher: RemoteConfigFetcher> ExtendsResolver<'a, Fetcher> {
         let url_display = remote_config_display(url);
         let mut merged = serde_json::Value::Object(serde_json::Map::new());
         for entry in &extends {
-            let base = if entry.starts_with(HTTPS_PREFIX) {
+            let base = if starts_with_url_prefix(entry, HTTPS_PREFIX) {
                 self.resolve_remote(entry, depth + 1)?
-            } else if entry.starts_with(HTTP_PREFIX) {
+            } else if starts_with_url_prefix(entry, HTTP_PREFIX) {
                 let entry_display = remote_config_display(entry);
                 return Err(miette::miette!(
                     "URL extends must use https://, got http:// URL '{}' (in remote config {}). \
@@ -2098,18 +2152,69 @@ unknown_field = true
     #[test]
     fn remote_fetch_error_detail_does_not_trust_normalized_urls() {
         let url = "https://request-user:request-password@config.example/config.json?token=request-token#request-fragment";
-        let normalized_error = "bad uri: https://request-user:request-password@config.example/config.json?token=request-token";
+        let normalized_error = ureq::Error::BadUri(
+            "https://request-user:request-password@config.example/config.json?token=request-token"
+                .to_string(),
+        );
 
         assert!(
-            remote_fetch_error_display(normalized_error, url) == "request failed",
+            remote_fetch_error_display(&normalized_error, url) == "request failed",
             "normalized network errors must not bypass URL redaction"
         );
+    }
+
+    #[test]
+    fn remote_fetch_error_detail_does_not_trust_redirect_like_payloads() {
+        let original = "https://config.example/config.json";
+        let error = ureq::Error::BadUri(
+            "http://redirect-user:redirect-password@example.com/next.json?token=secret#anchor"
+                .to_string(),
+        );
+
+        let display = remote_fetch_error_display(&error, original);
+        assert_eq!(display, "request failed");
+        for secret in [
+            "redirect-user",
+            "redirect-password",
+            "token=secret",
+            "anchor",
+        ] {
+            assert!(
+                !display.contains(secret),
+                "untrusted error detail must be hidden"
+            );
+        }
     }
 
     #[test]
     fn remote_extends_dispatch_when_explicitly_allowed() {
         let dir = test_dir("remote-explicitly-allowed");
         let url = "https://config.example/base.json";
+        std::fs::write(
+            dir.path().join(".fallowrc.json"),
+            format!(r#"{{"extends": "{url}"}}"#),
+        )
+        .unwrap();
+        let mut fetcher = MockRemoteFetcher::default()
+            .with_response(url, serde_json::json!({"rules": {"unused-files": "warn"}}));
+
+        let config = load_with_fetcher(
+            &dir.path().join(".fallowrc.json"),
+            ConfigLoadOptions {
+                allow_remote_extends: true,
+            },
+            &mut fetcher,
+        )
+        .unwrap();
+
+        assert_eq!(config.rules.unused_files, Severity::Warn);
+        assert_eq!(fetcher.requests, vec![url]);
+    }
+
+    #[test]
+    fn uppercase_https_remote_extends_dispatch_when_allowed() {
+        let dir = test_dir("remote-uppercase-scheme");
+        let url = "HTTPS://config.example/base.json";
         std::fs::write(
             dir.path().join(".fallowrc.json"),
             format!(r#"{{"extends": "{url}"}}"#),
@@ -4022,10 +4127,36 @@ thresholdOverrides = [
     }
 
     #[test]
-    fn normalize_url_trailing_slash() {
+    fn remote_fetch_error_redacts_require_https_only_redirect_target() {
+        let redirect_target =
+            "http://redirect-user:redirect-password@example.com/config.json?token=secret#anchor";
+        let dependency_error = ureq::Error::RequireHttpsOnly(redirect_target.to_string());
+
+        let display =
+            remote_fetch_error_display(&dependency_error, "https://config.example.com/config.json");
+
+        assert_eq!(
+            display,
+            "configured for https only: http://example.com/config.json"
+        );
+        for secret in [
+            "redirect-user",
+            "redirect-password",
+            "token=secret",
+            "anchor",
+        ] {
+            assert!(
+                !display.contains(secret),
+                "redirect secret must be redacted"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_url_preserves_non_root_trailing_slash() {
         assert_eq!(
             normalize_url_for_dedup("https://example.com/config/"),
-            "https://example.com/config"
+            "https://example.com/config/"
         );
     }
 
@@ -4058,6 +4189,16 @@ thresholdOverrides = [
     }
 
     #[test]
+    fn normalize_url_preserves_userinfo_case_and_normalizes_host() {
+        assert_eq!(
+            normalize_url_for_dedup(
+                "HTTPS://CaseSensitiveUser:CaseSensitivePassword@Example.COM/Config.json"
+            ),
+            "https://CaseSensitiveUser:CaseSensitivePassword@example.com/Config.json"
+        );
+    }
+
+    #[test]
     fn normalize_url_preserves_query_string() {
         assert_eq!(
             normalize_url_for_dedup("https://example.com/config.json?v=1"),
@@ -4082,6 +4223,18 @@ thresholdOverrides = [
     }
 
     #[test]
+    fn normalize_url_query_selects_resource_but_fragment_does_not() {
+        assert_ne!(
+            normalize_url_for_dedup("https://example.com/config.json?tenant=one"),
+            normalize_url_for_dedup("https://example.com/config.json?tenant=two")
+        );
+        assert_eq!(
+            normalize_url_for_dedup("https://example.com/config.json?tenant=one#first"),
+            normalize_url_for_dedup("https://example.com/config.json?tenant=one#second")
+        );
+    }
+
+    #[test]
     fn normalize_url_default_https_port() {
         assert_eq!(
             normalize_url_for_dedup("https://example.com:443/config.json"),
@@ -4090,6 +4243,42 @@ thresholdOverrides = [
         assert_eq!(
             normalize_url_for_dedup("https://example.com:8443/config.json"),
             "https://example.com:8443/config.json"
+        );
+    }
+
+    #[test]
+    fn normalize_url_only_strips_the_scheme_default_port() {
+        assert_eq!(
+            normalize_url_for_dedup("http://example.com:80/config.json"),
+            "http://example.com/config.json"
+        );
+        assert_eq!(
+            normalize_url_for_dedup("http://example.com:443/config.json"),
+            "http://example.com:443/config.json"
+        );
+        assert_eq!(
+            normalize_url_for_dedup("https://example.com:80/config.json"),
+            "https://example.com:80/config.json"
+        );
+    }
+
+    #[test]
+    fn normalize_url_canonicalizes_numeric_ports_and_root_query_path() {
+        assert_eq!(
+            normalize_url_for_dedup("https://example.com:0443/?profile=one"),
+            "https://example.com?profile=one"
+        );
+        assert_eq!(
+            normalize_url_for_dedup("https://example.com:080/config.json"),
+            "https://example.com:80/config.json"
+        );
+    }
+
+    #[test]
+    fn normalize_url_canonicalizes_equivalent_ipv6_hosts() {
+        assert_eq!(
+            normalize_url_for_dedup("https://[2001:0DB8:0:0:0:0:0:1]/config.json"),
+            "https://[2001:db8::1]/config.json"
         );
     }
 

--- a/crates/engine/src/changed_files.rs
+++ b/crates/engine/src/changed_files.rs
@@ -181,6 +181,7 @@ pub fn try_get_changed_files_with_toplevel(
         &[
             "diff",
             "--name-only",
+            "-z",
             "--end-of-options",
             &format!("{git_ref}...HEAD"),
         ],
@@ -188,12 +189,18 @@ pub fn try_get_changed_files_with_toplevel(
     files.extend(collect_git_paths(
         cwd,
         toplevel,
-        &["diff", "--name-only", "HEAD"],
+        &["diff", "--name-only", "-z", "HEAD"],
     )?);
     files.extend(collect_git_paths(
         cwd,
         toplevel,
-        &["ls-files", "--full-name", "--others", "--exclude-standard"],
+        &[
+            "ls-files",
+            "--full-name",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ],
     )?);
     Ok(files)
 }
@@ -249,7 +256,13 @@ fn append_untracked_diffs(
     let mut untracked: Vec<PathBuf> = collect_git_paths(
         root,
         toplevel,
-        &["ls-files", "--full-name", "--others", "--exclude-standard"],
+        &[
+            "ls-files",
+            "--full-name",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ],
     )?
     .into_iter()
     .filter_map(|path| {
@@ -343,18 +356,28 @@ fn collect_git_paths(
         });
     }
 
-    #[cfg(windows)]
-    let normalise_segment = |line: &str| line.replace('/', "\\");
-    #[cfg(not(windows))]
-    let normalise_segment = |line: &str| line.to_owned();
-
-    let files = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|line| !line.is_empty())
-        .map(|line| toplevel.join(normalise_segment(line)))
+    let files = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(git_path_from_bytes)
+        .map(|path| toplevel.join(path))
         .collect();
 
     Ok(files)
+}
+
+#[cfg(unix)]
+fn git_path_from_bytes(path: &[u8]) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    PathBuf::from(OsString::from_vec(path.to_vec()))
+}
+
+#[cfg(windows)]
+fn git_path_from_bytes(path: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(path).replace('/', "\\"))
 }
 
 #[expect(
@@ -816,6 +839,55 @@ mod tests {
         assert!(matches!(result, Err(ChangedFilesError::NotARepository)));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn changed_files_preserve_special_filenames() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        for args in [
+            &["init", "--quiet"][..],
+            &["config", "user.email", "test@example.com"][..],
+            &["config", "user.name", "Test User"][..],
+            &["config", "commit.gpgsign", "false"][..],
+        ] {
+            run_git(repo.path(), args);
+        }
+        std::fs::write(repo.path().join("initial.ts"), "initial\n").expect("initial fixture");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "--quiet", "-m", "initial"]);
+        run_git(repo.path(), &["tag", "base"]);
+
+        let canonical_root = repo.path().canonicalize().expect("canonical repo");
+        let special_files = [
+            "src/line\nbreak.ts",
+            "src/space name.ts",
+            "src/quote\"name.ts",
+            "src/back\\slash.ts",
+            "src/unicode-λ.ts",
+        ]
+        .map(|path| canonical_root.join(path));
+        std::fs::create_dir_all(canonical_root.join("src")).expect("source dir");
+        for special in &special_files {
+            std::fs::write(special, "changed\n").expect("special fixture");
+        }
+
+        let changed = try_get_changed_files(repo.path(), "base").expect("changed files");
+        for special in special_files {
+            assert!(
+                changed.contains(&special),
+                "missing {special:?}: {changed:?}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn git_path_bytes_use_windows_separators() {
+        assert_eq!(
+            git_path_from_bytes(b"src/nested/file.ts"),
+            PathBuf::from(r"src\nested\file.ts")
+        );
+    }
+
     #[test]
     fn changed_diff_covers_staged_unstaged_and_untracked_files() {
         let repo = tempfile::tempdir().expect("tempdir");
@@ -823,6 +895,7 @@ mod tests {
             &["init", "--quiet"][..],
             &["config", "user.email", "test@example.com"][..],
             &["config", "user.name", "Test User"][..],
+            &["config", "commit.gpgsign", "false"][..],
         ] {
             run_git(repo.path(), args);
         }

--- a/crates/engine/src/churn.rs
+++ b/crates/engine/src/churn.rs
@@ -412,9 +412,9 @@ pub fn is_git_repo(root: &Path) -> bool {
 const MAX_CHURN_CACHE_SIZE: usize = 64 * 1024 * 1024;
 
 /// Cache schema version. Bump when the on-disk shape of [`ChurnCache`]
-/// changes so older payloads are rejected on load. Bumped to 3 when the cache
-/// switched from aggregate rows to per-commit events for incremental updates.
-const CHURN_CACHE_VERSION: u8 = 3;
+/// changes so older payloads are rejected on load. Version 5 stores paths in
+/// their platform-native byte representation instead of lossy UTF-8 strings.
+const CHURN_CACHE_VERSION: u8 = 5;
 
 /// Serializable per-commit event for the disk cache.
 #[derive(Clone, bitcode::Encode, bitcode::Decode)]
@@ -428,7 +428,7 @@ struct CachedCommitEvent {
 /// Serializable per-file churn entry for the disk cache.
 #[derive(Clone, bitcode::Encode, bitcode::Decode)]
 struct CachedFileChurn {
-    path: String,
+    path: Vec<u8>,
     events: Vec<CachedCommitEvent>,
 }
 
@@ -504,7 +504,7 @@ fn save_churn_cache(
         .files
         .iter()
         .map(|f| CachedFileChurn {
-            path: f.0.to_string_lossy().to_string(),
+            path: path_to_cache_bytes(f.0),
             events: f.1.events.clone(),
         })
         .collect();
@@ -602,13 +602,15 @@ impl ChurnCache {
         let files = self
             .files
             .into_iter()
-            .map(|entry| {
-                (
-                    PathBuf::from(entry.path),
-                    FileEvents {
-                        events: entry.events,
-                    },
-                )
+            .filter_map(|entry| {
+                path_from_cache_bytes(&entry.path).map(|path| {
+                    (
+                        path,
+                        FileEvents {
+                            events: entry.events,
+                        },
+                    )
+                })
             })
             .collect();
         ChurnEventState {
@@ -616,6 +618,50 @@ impl ChurnCache {
             author_pool: self.author_pool,
         }
     }
+}
+
+#[cfg(unix)]
+fn path_to_cache_bytes(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(unix)]
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "Windows rejects truncated UTF-16 bytes through this shared fallible contract"
+)]
+fn path_from_cache_bytes(path: &[u8]) -> Option<PathBuf> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    Some(PathBuf::from(OsStr::from_bytes(path)))
+}
+
+#[cfg(windows)]
+fn path_to_cache_bytes(path: &Path) -> Vec<u8> {
+    use std::os::windows::ffi::OsStrExt;
+
+    path.as_os_str()
+        .encode_wide()
+        .flat_map(u16::to_le_bytes)
+        .collect()
+}
+
+#[cfg(windows)]
+fn path_from_cache_bytes(path: &[u8]) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    let chunks = path.chunks_exact(2);
+    if !chunks.remainder().is_empty() {
+        return None;
+    }
+    let wide: Vec<u16> = chunks
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect();
+    Some(PathBuf::from(OsString::from_wide(&wide)))
 }
 
 /// Run `git log --numstat` and return event-level churn state.
@@ -635,7 +681,8 @@ fn analyze_churn_events(
             "--no-merges",
             "--no-renames",
             "--use-mailmap",
-            "--format=format:%at|%ae",
+            "-z",
+            "--format=format:%at|%ae%x00",
             &format!("--after={}", since.git_after),
         ])
         .current_dir(root);
@@ -654,8 +701,7 @@ fn analyze_churn_events(
         return None;
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Some(parse_git_log_events(&stdout, root))
+    Some(parse_git_log_events_z(&output.stdout, root))
 }
 
 /// Merge new churn events into cached event state.
@@ -690,6 +736,7 @@ fn merge_churn_states(base: &mut ChurnEventState, delta: ChurnEventState) {
 }
 
 /// Parse `git log --numstat --format=format:%at|%ae` output into events.
+#[cfg(test)]
 fn parse_git_log_events(stdout: &str, root: &Path) -> ChurnEventState {
     let now_secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -702,6 +749,27 @@ fn parse_git_log_events(stdout: &str, root: &Path) -> ChurnEventState {
         parser.consume_line(line);
     }
 
+    parser.finish()
+}
+
+fn parse_git_log_events_z(stdout: &[u8], root: &Path) -> ChurnEventState {
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let mut parser = GitLogEventParser::new(root, now_secs);
+    for record in stdout.split(|byte| *byte == 0) {
+        let record = record.strip_prefix(b"\n").unwrap_or(record);
+        if record.is_empty() {
+            continue;
+        }
+        if record.contains(&b'\t') {
+            parser.record_numstat_bytes(record);
+        } else {
+            parser.consume_line(&String::from_utf8_lossy(record));
+        }
+    }
     parser.finish()
 }
 
@@ -775,6 +843,37 @@ impl<'a> GitLogEventParser<'a> {
             return;
         };
 
+        self.record_numstat_path(added, deleted, PathBuf::from(path));
+    }
+
+    fn record_numstat_bytes(&mut self, record: &[u8]) {
+        let Some(first_tab) = record.iter().position(|byte| *byte == b'\t') else {
+            return;
+        };
+        let Some(second_tab_offset) = record[first_tab + 1..]
+            .iter()
+            .position(|byte| *byte == b'\t')
+        else {
+            return;
+        };
+        let second_tab = first_tab + 1 + second_tab_offset;
+        let Some(added) = std::str::from_utf8(&record[..first_tab])
+            .ok()
+            .and_then(|value| value.parse().ok())
+        else {
+            return;
+        };
+        let Some(deleted) = std::str::from_utf8(&record[first_tab + 1..second_tab])
+            .ok()
+            .and_then(|value| value.parse().ok())
+        else {
+            return;
+        };
+        let path = git_path_from_bytes(&record[second_tab + 1..]);
+        self.record_numstat_path(added, deleted, path);
+    }
+
+    fn record_numstat_path(&mut self, added: u32, deleted: u32, path: PathBuf) {
         let ts = self.current_timestamp.unwrap_or(self.now_secs);
         self.files
             .entry(self.root.join(path))
@@ -794,6 +893,19 @@ impl<'a> GitLogEventParser<'a> {
             author_pool: self.author_pool,
         }
     }
+}
+
+#[cfg(unix)]
+fn git_path_from_bytes(path: &[u8]) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    PathBuf::from(OsString::from_vec(path.to_vec()))
+}
+
+#[cfg(windows)]
+fn git_path_from_bytes(path: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(path).replace('/', "\\"))
 }
 
 /// Aggregate one file's raw commit events into a [`FileChurn`], applying
@@ -1586,6 +1698,103 @@ mod tests {
         let path = root.join(path);
         std::fs::create_dir_all(path.parent().expect("test path has parent")).unwrap();
         std::fs::write(path, contents).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn churn_preserves_special_filenames() {
+        let repo = tempfile::tempdir().expect("create repo");
+        let root = repo.path();
+        git(root, &["init", "--quiet"]);
+        git(root, &["config", "user.email", "churn@example.test"]);
+        git(root, &["config", "user.name", "Churn Test"]);
+        git(root, &["config", "commit.gpgsign", "false"]);
+
+        let special_files = [
+            "src/line\nbreak.ts",
+            "src/space name.ts",
+            "src/quote\"name.ts",
+            "src/back\\slash.ts",
+            "src/unicode-λ.ts",
+        ]
+        .map(|path| root.join(path));
+        std::fs::create_dir_all(root.join("src")).expect("source dir");
+        for special in &special_files {
+            std::fs::write(special, "export const value = 1;\n").expect("special fixture");
+        }
+        git(root, &["add", "."]);
+        git(root, &["commit", "--quiet", "-m", "initial"]);
+
+        let since = parse_since("1y").expect("valid duration");
+        let churn = analyze_churn(root, &since).expect("churn result");
+        for special in special_files {
+            assert!(
+                churn.files.contains_key(&special),
+                "missing {special:?}: {:?}",
+                churn.files.keys()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn churn_cache_preserves_non_utf8_filenames() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let invalid_path = PathBuf::from(OsString::from_vec(b"src/non-utf8-\xff.ts".to_vec()));
+        let mut files = FxHashMap::default();
+        files.insert(
+            invalid_path.clone(),
+            FileEvents {
+                events: vec![CachedCommitEvent {
+                    timestamp: 1,
+                    lines_added: 2,
+                    lines_deleted: 1,
+                    author_idx: None,
+                }],
+            },
+        );
+        let state = ChurnEventState {
+            files,
+            author_pool: Vec::new(),
+        };
+        let cache_dir = tempfile::tempdir().expect("cache directory");
+        save_churn_cache(cache_dir.path(), "abc123", "1 year ago", &state, false);
+        let warm = load_churn_cache(cache_dir.path(), "1 year ago")
+            .expect("warm churn cache")
+            .into_event_state();
+
+        assert!(warm.files.contains_key(&invalid_path));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn git_path_bytes_use_windows_separators() {
+        assert_eq!(
+            git_path_from_bytes(b"src/nested/file.ts"),
+            PathBuf::from(r"src\nested\file.ts")
+        );
+    }
+
+    #[test]
+    fn churn_cache_rejects_pre_lossless_path_encoding_version() {
+        let cache_dir = tempfile::tempdir().expect("cache directory");
+        let cache = ChurnCache {
+            version: 4,
+            last_indexed_sha: "abc123".to_string(),
+            git_after: "1 year ago".to_string(),
+            files: vec![CachedFileChurn {
+                path: br#"/project/\"src/line\\nbreak.ts\""#.to_vec(),
+                events: Vec::new(),
+            }],
+            shallow_clone: false,
+            author_pool: Vec::new(),
+        };
+        std::fs::write(cache_dir.path().join("churn.bin"), bitcode::encode(&cache))
+            .expect("cache fixture");
+
+        assert!(load_churn_cache(cache_dir.path(), "1 year ago").is_none());
     }
 
     #[test]

--- a/crates/extract/src/cache/store.rs
+++ b/crates/extract/src/cache/store.rs
@@ -2,6 +2,9 @@
 
 use std::path::Path;
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use fallow_types::source_fingerprint::SourceFingerprint;
 use rustc_hash::FxHashMap;
 
@@ -11,6 +14,11 @@ use super::types::{
     CACHE_VERSION, CachedModule, DEFAULT_CACHE_MAX_SIZE, EVICTION_SIGNIFICANT_BPS,
     EVICTION_TARGET_BPS, EVICTION_TRIGGER_BPS,
 };
+
+#[cfg(test)]
+thread_local! {
+    static FULL_STORE_ENCODE_COUNT: Cell<usize> = const { Cell::new(0) };
+}
 
 /// Cached module information stored on disk.
 #[derive(Debug, Encode, Decode)]
@@ -86,13 +94,12 @@ impl CacheStore {
 
         self.config_hash = config_hash;
         let initial_entries = self.entries.len();
-        let mut encoded = bitcode::encode(self);
+        let mut encoded = self.encode();
 
         let trigger = (max_size_bytes / 10_000).saturating_mul(EVICTION_TRIGGER_BPS);
         if encoded.len() > trigger {
             let target = (max_size_bytes / 10_000).saturating_mul(EVICTION_TARGET_BPS);
-            self.evict_lru_to_target(target);
-            encoded = bitcode::encode(self);
+            encoded = self.evict_lru_to_target(target, encoded);
             let evicted = initial_entries.saturating_sub(self.entries.len());
             let final_size = encoded.len();
             let significant_evicted =
@@ -123,38 +130,104 @@ impl CacheStore {
 
     /// Evict LRU entries until the re-encoded size is under `target_bytes`
     /// or only one entry remains.
-    fn evict_lru_to_target(&mut self, target_bytes: usize) {
-        let mut order: Vec<(u64, String)> = self
+    fn evict_lru_to_target(&mut self, target_bytes: usize, mut encoded: Vec<u8>) -> Vec<u8> {
+        let mut order: Vec<(u64, String, usize)> = self
             .entries
             .iter()
-            .map(|(k, v)| (v.last_access_secs, k.clone()))
+            .map(|(key, entry)| {
+                (
+                    entry.last_access_secs,
+                    key.clone(),
+                    bitcode::encode(entry)
+                        .len()
+                        .saturating_add(key.len())
+                        .max(1),
+                )
+            })
             .collect();
         order.sort();
 
-        const BATCH: usize = 100;
+        const MAX_REFINEMENT_PASSES: usize = 2;
+        const ESTIMATE_SAFETY_BPS: usize = 9_800;
         let mut idx = 0;
-        while idx < order.len() {
-            let batch_end = (idx + BATCH).min(order.len());
-            for (_, key) in &order[idx..batch_end] {
-                if self.entries.len() <= 1 {
-                    break;
-                }
+        let mut estimated_remaining: usize = order
+            .iter()
+            .map(|(_, _, estimated_bytes)| estimated_bytes)
+            .sum();
+        for _ in 0..MAX_REFINEMENT_PASSES {
+            if encoded.len() <= target_bytes || self.entries.len() <= 1 {
+                break;
+            }
+
+            let estimated_budget = estimated_eviction_budget(
+                estimated_remaining,
+                target_bytes,
+                encoded.len(),
+                ESTIMATE_SAFETY_BPS,
+            );
+            let start_idx = idx;
+            while idx + 1 < order.len() && estimated_remaining > estimated_budget {
+                let (_, key, estimated_bytes) = &order[idx];
+                self.entries.remove(key);
+                estimated_remaining = estimated_remaining.saturating_sub(*estimated_bytes);
+                idx += 1;
+            }
+            if idx == start_idx && idx + 1 < order.len() {
+                let (_, key, estimated_bytes) = &order[idx];
+                self.entries.remove(key);
+                estimated_remaining = estimated_remaining.saturating_sub(*estimated_bytes);
+                idx += 1;
+            }
+            encoded = self.encode();
+        }
+
+        if encoded.len() > target_bytes && self.entries.len() > 1 {
+            let conservative_budget = target_bytes / 2;
+            while idx + 1 < order.len() && estimated_remaining > conservative_budget {
+                let (_, key, estimated_bytes) = &order[idx];
+                self.entries.remove(key);
+                estimated_remaining = estimated_remaining.saturating_sub(*estimated_bytes);
+                idx += 1;
+            }
+            encoded = self.encode();
+        }
+
+        // Per-entry encodings are deliberately conservative, but keep the
+        // configured cap exact if a future bitcode layout violates that
+        // estimate. This safety path runs only after byte-aware retention had
+        // three opportunities to preserve a recent suffix.
+        if encoded.len() > target_bytes && self.entries.len() > 1 {
+            let keep_newest_from = order.len().saturating_sub(1);
+            for (_, key, _) in &order[idx..keep_newest_from] {
                 self.entries.remove(key);
             }
-            idx = batch_end;
-
-            let encoded_size = bitcode::encode(self).len();
-            if encoded_size <= target_bytes || self.entries.len() <= 1 {
-                if encoded_size > target_bytes && self.entries.len() <= 1 {
-                    tracing::warn!(
-                        encoded_kb = encoded_size / 1024,
-                        target_kb = target_bytes / 1024,
-                        "Single cache entry exceeds configured max; cache will overshoot the cap"
-                    );
-                }
-                return;
-            }
+            encoded = self.encode();
         }
+
+        if encoded.len() > target_bytes && self.entries.len() == 1 {
+            tracing::warn!(
+                encoded_kb = encoded.len() / 1024,
+                target_kb = target_bytes / 1024,
+                "Single cache entry exceeds configured max; cache will overshoot the cap"
+            );
+        }
+        encoded
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        #[cfg(test)]
+        FULL_STORE_ENCODE_COUNT.with(|count| count.set(count.get() + 1));
+        bitcode::encode(self)
+    }
+
+    #[cfg(test)]
+    pub(super) fn reset_full_store_encode_count() {
+        FULL_STORE_ENCODE_COUNT.with(|count| count.set(0));
+    }
+
+    #[cfg(test)]
+    pub(super) fn full_store_encode_count() -> usize {
+        FULL_STORE_ENCODE_COUNT.with(Cell::get)
     }
 
     /// Look up a cached module by path and content hash.
@@ -224,6 +297,23 @@ impl CacheStore {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+pub(super) fn estimated_eviction_budget(
+    estimated_remaining: usize,
+    target_bytes: usize,
+    encoded_bytes: usize,
+    safety_bps: usize,
+) -> usize {
+    if encoded_bytes == 0 {
+        return 0;
+    }
+
+    const BASIS_POINTS: u128 = 10_000;
+    let scaled = estimated_remaining as u128 * target_bytes as u128 / encoded_bytes as u128;
+    let safety = (safety_bps as u128).min(BASIS_POINTS);
+    let budget = scaled / BASIS_POINTS * safety + scaled % BASIS_POINTS * safety / BASIS_POINTS;
+    budget.min(usize::MAX as u128) as usize
 }
 
 fn write_cache_gitignore(cache_dir: &Path) -> Result<(), String> {

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -3989,6 +3989,94 @@ fn cache_save_evicts_when_over_threshold() {
 }
 
 #[test]
+fn cache_eviction_bounds_full_store_encoding_work() {
+    let dir = test_cache_dir("bounded_eviction_encoding");
+    let mut store = CacheStore::new();
+    for i in 0..2_000u64 {
+        store.insert(Path::new(&format!("file{i}.ts")), synthetic_module(i, i, 1));
+    }
+    store
+        .save(&dir, 99, DEFAULT_CACHE_MAX_SIZE)
+        .expect("measure unbounded cache size");
+    let unbounded_size = std::fs::metadata(dir.join("cache.bin"))
+        .expect("cache metadata")
+        .len() as usize;
+
+    CacheStore::reset_full_store_encode_count();
+    store
+        .save(&dir, 99, unbounded_size)
+        .expect("save with eviction");
+    let encode_count = CacheStore::full_store_encode_count();
+
+    assert!(
+        encode_count <= 5,
+        "eviction encoded the full store {encode_count} times"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn cache_eviction_budget_avoids_intermediate_overflow() {
+    let large = usize::MAX / 2;
+    let expected = ((large as u128 * large as u128 / large as u128) * 9_800 / 10_000) as usize;
+
+    assert_eq!(
+        super::store::estimated_eviction_budget(large, large, large, 9_800),
+        expected
+    );
+}
+
+#[test]
+fn cache_eviction_preserves_recent_entries_with_skewed_sizes() {
+    let dir = test_cache_dir("skewed_eviction_sizes");
+    let mut store = CacheStore::new();
+    for i in 0..1_000u64 {
+        store.insert(
+            Path::new(&format!("small{i}.ts")),
+            synthetic_module(i, i, 1),
+        );
+    }
+    store.insert(Path::new("large.ts"), synthetic_module(10_000, 1_000, 512));
+    store
+        .save(&dir, 99, DEFAULT_CACHE_MAX_SIZE)
+        .expect("measure unbounded cache size");
+    let unbounded_size = std::fs::metadata(dir.join("cache.bin"))
+        .expect("cache metadata")
+        .len() as usize;
+    let cap = unbounded_size * 9 / 10;
+
+    CacheStore::reset_full_store_encode_count();
+    store.save(&dir, 99, cap).expect("save skewed cache");
+    let encode_count = CacheStore::full_store_encode_count();
+    let loaded = CacheStore::load(&dir, 99, DEFAULT_CACHE_MAX_SIZE).expect("load skewed cache");
+
+    assert!(
+        loaded.len() > 200,
+        "size skew should retain recent small entries, retained {}",
+        loaded.len()
+    );
+    assert!(
+        loaded.get(Path::new("large.ts"), 10_000).is_some(),
+        "newest large entry survives"
+    );
+    assert!(
+        loaded.get(Path::new("small0.ts"), 0).is_none(),
+        "oldest small entry is evicted"
+    );
+    assert!(
+        encode_count <= 5,
+        "full-store encode count was {encode_count}"
+    );
+    let on_disk = std::fs::metadata(dir.join("cache.bin"))
+        .expect("cache metadata")
+        .len() as usize;
+    assert!(on_disk <= cap * 60 / 100, "cache exceeds eviction target");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn cache_save_always_honors_cap_with_huge_entries() {
     let dir = test_cache_dir("huge_entry_overshoot");
     let mut store = CacheStore::new();

--- a/crates/mcp/src/tools/code_mode_subprocess.rs
+++ b/crates/mcp/src/tools/code_mode_subprocess.rs
@@ -47,16 +47,20 @@ pub(super) fn run_fallow_sync(
             }
         };
         if let Some(status) = status {
-            let stdout_len = file_len(stdout_file.as_file())?;
-            if stdout_len > max_output_bytes as u64 {
-                return Err(format!(
-                    "code mode host output exceeded {max_output_bytes} bytes"
-                ));
-            }
+            let cleanup_errors = cleanup_std_child(Some(&process_tree), &mut child);
+            let result = (|| {
+                let stdout_len = file_len(stdout_file.as_file())?;
+                if stdout_len > max_output_bytes as u64 {
+                    return Err(format!(
+                        "code mode host output exceeded {max_output_bytes} bytes"
+                    ));
+                }
 
-            let stdout = read_file(stdout_file.as_file_mut(), "stdout")?;
-            let stderr = read_limited_file(stderr_file.as_file_mut(), STDERR_LIMIT_BYTES)?;
-            return normalize_output(status.code().unwrap_or(-1), &stdout, &stderr);
+                let stdout = read_file(stdout_file.as_file_mut(), "stdout")?;
+                let stderr = read_limited_file(stderr_file.as_file_mut(), STDERR_LIMIT_BYTES)?;
+                normalize_output(status.code().unwrap_or(-1), &stdout, &stderr)
+            })();
+            return with_completed_cleanup(result, &cleanup_errors);
         }
 
         if Instant::now() >= deadline {
@@ -116,6 +120,35 @@ fn with_cleanup_errors(message: String, cleanup_errors: &[String]) -> String {
     }
 }
 
+fn with_completed_cleanup<T>(
+    result: Result<T, String>,
+    cleanup_errors: &[String],
+) -> Result<T, String> {
+    match result {
+        Ok(value) if cleanup_errors.is_empty() => Ok(value),
+        Ok(_) => Err(with_cleanup_errors(
+            "failed to clean completed fallow subprocess".to_string(),
+            cleanup_errors,
+        )),
+        Err(error) => Err(with_structured_cleanup_errors(error, cleanup_errors)),
+    }
+}
+
+fn with_structured_cleanup_errors(error: String, cleanup_errors: &[String]) -> String {
+    if cleanup_errors.is_empty() {
+        return error;
+    }
+
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&error) else {
+        return with_cleanup_errors(error, cleanup_errors);
+    };
+    let Some(object) = value.as_object_mut() else {
+        return with_cleanup_errors(error, cleanup_errors);
+    };
+    object.insert("cleanup_errors".to_string(), json!(cleanup_errors));
+    serde_json::to_string(&value).unwrap_or_else(|_| with_cleanup_errors(error, cleanup_errors))
+}
+
 fn file_len(file: &fs::File) -> Result<u64, String> {
     file.metadata()
         .map(|metadata| metadata.len())
@@ -166,5 +199,205 @@ pub(super) fn normalize_output(
             "exit_code": exit_code
         })
         .to_string()),
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    struct ProcessCleanup(u32);
+
+    impl Drop for ProcessCleanup {
+        fn drop(&mut self) {
+            drop(
+                Command::new("kill")
+                    .args(["-KILL", &self.0.to_string()])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status(),
+            );
+        }
+    }
+
+    fn process_exists(pid: u32) -> bool {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    fn wait_for_process_exit(pid: u32) -> bool {
+        for _ in 0..200 {
+            if !process_exists(pid) {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    fn run_completed_subprocess(
+        completion_script: &str,
+        max_output_bytes: usize,
+    ) -> Result<String, String> {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let descendant_pid_path = temp.path().join("descendant.pid");
+        let script = format!(r#"trap '' HUP; sleep 30 & echo $! > "$1"; {completion_script}"#);
+        let args = [
+            "-c".to_string(),
+            script,
+            "fallow-code-mode-completion-test".to_string(),
+            descendant_pid_path.to_string_lossy().into_owned(),
+        ];
+
+        let result = run_fallow_sync(
+            "/bin/sh",
+            "test",
+            &args,
+            Instant::now() + Duration::from_secs(5),
+            max_output_bytes,
+        );
+        let descendant_pid: u32 = fs::read_to_string(&descendant_pid_path)
+            .expect("descendant PID file")
+            .trim()
+            .parse()
+            .expect("descendant PID");
+        let _cleanup = ProcessCleanup(descendant_pid);
+        assert!(
+            wait_for_process_exit(descendant_pid),
+            "completed subprocess descendant {descendant_pid} survived"
+        );
+        result
+    }
+
+    #[test]
+    fn completed_success_cleans_descendant_process_tree() {
+        let output = run_completed_subprocess("printf '{}'", 1024)
+            .expect("completed subprocess should preserve successful output");
+        assert_eq!(output, "{}");
+    }
+
+    #[test]
+    fn completed_nonzero_cleans_descendant_and_preserves_json_error() {
+        let expected = r#"{"error":true,"message":"config error","exit_code":2}"#;
+        let error = run_completed_subprocess(&format!("printf '{expected}'; exit 2"), 1024)
+            .expect_err("nonzero subprocess should preserve JSON stdout as the error");
+        assert_eq!(error, expected);
+    }
+
+    #[test]
+    fn completed_output_overflow_cleans_descendant_and_preserves_error() {
+        let error = run_completed_subprocess(
+            r#"i=0; while [ "$i" -lt 32 ]; do printf x; i=$((i + 1)); done"#,
+            16,
+        )
+        .expect_err("completed subprocess should enforce the output limit");
+        assert_eq!(error, "code mode host output exceeded 16 bytes");
+    }
+
+    #[test]
+    fn completed_cleanup_error_preserves_structured_subprocess_error() {
+        let subprocess_error = r#"{"error":true,"message":"config error","exit_code":2}"#;
+        let error = with_completed_cleanup::<String>(
+            Err(subprocess_error.to_string()),
+            &["descendant survived".to_string()],
+        )
+        .expect_err("cleanup failure should remain an error");
+        let value: serde_json::Value = serde_json::from_str(&error)
+            .expect("cleanup diagnostics must preserve the JSON envelope");
+
+        assert_eq!(value["message"], "config error");
+        assert_eq!(value["cleanup_errors"][0], "descendant survived");
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    struct ProcessCleanup(u32);
+
+    impl Drop for ProcessCleanup {
+        fn drop(&mut self) {
+            drop(
+                Command::new("taskkill")
+                    .args(["/PID", &self.0.to_string(), "/T", "/F"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status(),
+            );
+        }
+    }
+
+    fn process_exists(pid: u32) -> bool {
+        let pid = pid.to_string();
+        Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+            .output()
+            .is_ok_and(|output| {
+                String::from_utf8_lossy(&output.stdout)
+                    .split_whitespace()
+                    .any(|field| field == pid)
+            })
+    }
+
+    fn wait_for_process_exit(pid: u32) -> bool {
+        for _ in 0..200 {
+            if !process_exists(pid) {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
+
+    #[test]
+    fn completed_success_cleans_descendant_process_tree() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let descendant_pid_path = temp.path().join("descendant.pid");
+        let script_path = temp.path().join("process-tree-fixture.ps1");
+        let script = r"
+param(
+    [Parameter(Mandatory = $true)][string]$DescendantPidPath
+)
+$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' -PassThru
+$child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
+[Console]::Out.Write('{}')
+";
+        fs::write(&script_path, script).expect("PowerShell fixture script");
+        let args = [
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-ExecutionPolicy".to_string(),
+            "Bypass".to_string(),
+            "-File".to_string(),
+            script_path.to_string_lossy().into_owned(),
+            "-DescendantPidPath".to_string(),
+            descendant_pid_path.to_string_lossy().into_owned(),
+        ];
+
+        let output = run_fallow_sync(
+            "powershell.exe",
+            "test",
+            &args,
+            Instant::now() + Duration::from_secs(5),
+            1024,
+        )
+        .expect("completed subprocess should preserve successful output");
+        let descendant_pid: u32 = fs::read_to_string(&descendant_pid_path)
+            .expect("descendant PID file")
+            .trim()
+            .parse()
+            .expect("descendant PID");
+        let _cleanup = ProcessCleanup(descendant_pid);
+
+        assert_eq!(output, "{}");
+        assert!(
+            wait_for_process_exit(descendant_pid),
+            "completed subprocess descendant {descendant_pid} survived"
+        );
     }
 }

--- a/editors/vscode/scripts/codegen-contracts.mjs
+++ b/editors/vscode/scripts/codegen-contracts.mjs
@@ -63,9 +63,9 @@ const BANNER = `/**
  * \`npm/fallow/types/output-contract.d.ts\` (published as \`fallow/types\`).
  *
  * To change a shape:
- *   1. Edit the Rust struct in \`crates/types/src/results.rs\` (or the
- *      duplicates crate at \`crates/core/src/duplicates/types.rs\`). The Rust
- *      side is the runtime source of truth for the JSON output.
+ *   1. Find the Rust owner through \`derived_definition_names()\` and its
+ *      imports in \`crates/cli/src/bin/schema_emit.rs\`, then edit that type.
+ *      Rust is the runtime source of truth for the JSON output.
  *   2. Regenerate \`docs/output-schema.json\` with
  *      \`cargo run -p fallow-cli --features schema-emit --bin fallow-schema-emit\`.
  *      The schema-emit drift tests compare the committed schema against the

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -7,9 +7,9 @@
  * `npm/fallow/types/output-contract.d.ts` (published as `fallow/types`).
  *
  * To change a shape:
- *   1. Edit the Rust struct in `crates/types/src/results.rs` (or the
- *      duplicates crate at `crates/core/src/duplicates/types.rs`). The Rust
- *      side is the runtime source of truth for the JSON output.
+ *   1. Find the Rust owner through `derived_definition_names()` and its
+ *      imports in `crates/cli/src/bin/schema_emit.rs`, then edit that type.
+ *      Rust is the runtime source of truth for the JSON output.
  *   2. Regenerate `docs/output-schema.json` with
  *      `cargo run -p fallow-cli --features schema-emit --bin fallow-schema-emit`.
  *      The schema-emit drift tests compare the committed schema against the

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -7,9 +7,9 @@
  * `npm/fallow/types/output-contract.d.ts` (published as `fallow/types`).
  *
  * To change a shape:
- *   1. Edit the Rust struct in `crates/types/src/results.rs` (or the
- *      duplicates crate at `crates/core/src/duplicates/types.rs`). The Rust
- *      side is the runtime source of truth for the JSON output.
+ *   1. Find the Rust owner through `derived_definition_names()` and its
+ *      imports in `crates/cli/src/bin/schema_emit.rs`, then edit that type.
+ *      Rust is the runtime source of truth for the JSON output.
  *   2. Regenerate `docs/output-schema.json` with
  *      `cargo run -p fallow-cli --features schema-emit --bin fallow-schema-emit`.
  *      The schema-emit drift tests compare the committed schema against the

--- a/scripts/verify-repo.mjs
+++ b/scripts/verify-repo.mjs
@@ -41,6 +41,11 @@ const FAST_COMMANDS = [
 
 const FULL_ONLY_COMMANDS = [
   {
+    label: "Repository script tests",
+    command: "node",
+    args: ["--test", "scripts/*.test.mjs"],
+  },
+  {
     label: "Workspace tests",
     command: "cargo",
     args: ["test", "--workspace", "--lib", "--bins", "--tests", "--examples"],
@@ -118,8 +123,8 @@ export const helpText = () => `Usage: node scripts/verify-repo.mjs [--fast | --f
 
 Canonical local repository verification:
   --fast  Formatting, linting, generated contracts, and crate boundaries (default)
-  --full  Fast checks plus workspace tests, benchmark compilation, rustdoc,
-          and the local NAPI build and tests
+  --full  Fast checks plus repository script tests, workspace tests, benchmark
+          compilation, rustdoc, and the local NAPI build and tests
 
 Prerequisites:
   - Node.js 22 or newer and root dependencies installed with npm install

--- a/scripts/verify-repo.test.mjs
+++ b/scripts/verify-repo.test.mjs
@@ -21,6 +21,7 @@ const FAST_COMMANDS = [
 ];
 
 const FULL_ONLY_COMMANDS = [
+  ["node", ["--test", "scripts/*.test.mjs"]],
   ["cargo", ["test", "--workspace", "--lib", "--bins", "--tests", "--examples"]],
   ["cargo", ["check", "--workspace", "--benches"]],
   ["cargo", ["doc", "--workspace", "--no-deps", "--document-private-items"]],

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -78,13 +78,28 @@ test("binary-size workflow isolates incompatible release builds", () => {
 test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const checkJob = indentedBlock(workflow, "check", 2);
+  const windowsRustJob = indentedBlock(workflow, "windows-rust", 2);
   const zedJob = indentedBlock(workflow, "zed", 2);
   const aggregateJob = indentedBlock(workflow, "ci-ok", 2);
+  const workflowWithoutWindowsRust = workflow.replace(windowsRustJob, "");
 
-  assert.doesNotMatch(workflow, /windows-latest|windows-11-arm|macos-latest/);
+  assert.doesNotMatch(workflowWithoutWindowsRust, /windows-latest|windows-11-arm|macos-latest/);
   assert.match(checkJob, /runs-on: ubuntu-latest/);
   assert.match(checkJob, /timeout-minutes: 20/);
   assert.doesNotMatch(checkJob, /matrix\.|windows-latest|macos-latest/);
+  assert.match(windowsRustJob, /needs: changes/);
+  assert.match(windowsRustJob, /if: needs\.changes\.outputs\.windows-rust == 'true'/);
+  assert.match(windowsRustJob, /runs-on: windows-latest/);
+  assert.match(windowsRustJob, /cargo test -p fallow-engine changed_files::tests/);
+  assert.match(windowsRustJob, /cargo test -p fallow-engine churn::tests/);
+  assert.match(
+    windowsRustJob,
+    /cargo test -p fallow-mcp completed_success_cleans_descendant_process_tree/,
+  );
+  assert.match(
+    windowsRustJob,
+    /cargo clippy -p fallow-engine -p fallow-mcp --all-targets -- -D warnings/,
+  );
   assert.match(zedJob, /runs-on: ubuntu-latest/);
   assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);
   assert.throws(() => indentedBlock(workflow, "windows-arm64", 2), /missing windows-arm64 block/);
@@ -92,6 +107,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
     () => indentedBlock(workflow, "windows-audit-smoke", 2),
     /missing windows-audit-smoke block/,
   );
+  assert.match(aggregateJob, /windows-rust/);
   assert.doesNotMatch(aggregateJob, /windows-audit-smoke|windows-arm64/);
 });
 


### PR DESCRIPTION
## Summary

- Preserve raw Git path identity in changed-file and churn analysis, including cached non-UTF-8 paths.
- Redact credentials and normalize remote configuration URLs before validation and cycle detection.
- Clean completed MCP subprocess trees on every return path and add focused Windows CI coverage.
- Bound extraction-cache eviction work and harden Action pagination, repository verification, generated contracts, and ownership guidance.

## Validation

- Rust formatting, checks, Clippy, documentation, workspace tests, and focused regressions pass.
- JavaScript formatting, repository policy tests, Action integration tests, VS Code checks, and generated-contract checks pass.
- Cold and warm analysis output is deterministic on representative real-world projects.
- The new Windows path and subprocess job must pass before merge.