### PR TITLE
test(npm): allow launcher tests without dependencies

### DIFF
--- a/npm/fallow/scripts/run-binary.test.js
+++ b/npm/fallow/scripts/run-binary.test.js
@@ -13,8 +13,13 @@ function currentPlatformPackage() {
   if (process.platform !== "linux") {
     return getPlatformPackage(process.platform, process.arch);
   }
-  const { familySync } = require("detect-libc");
-  return getPlatformPackage(process.platform, process.arch, familySync());
+  let libcFamily;
+  try {
+    libcFamily = require("detect-libc").familySync();
+  } catch {
+    libcFamily = undefined;
+  }
+  return getPlatformPackage(process.platform, process.arch, libcFamily);
 }
 
 function runLauncher(t, launcher, args) {


### PR DESCRIPTION
## Summary

- mirror the production Linux libc fallback in launcher tests
- keep the npm package CI job independent of an npm install step

## Verification

- launcher test from an isolated package copy without node_modules
- npm --prefix npm/fallow test
- npm run lint:js
- npm run fmt:js:check