### PR TITLE
docs(npm): rewrite the npm package README in the root-README style

### DIFF
--- a/npm/fallow/README.md
+++ b/npm/fallow/README.md
@@ -2,98 +2,60 @@
 
 **Codebase intelligence for TypeScript and JavaScript.**
 
-Free static analysis of code and styles, optional paid runtime intelligence (Fallow Runtime). Quality, risk, architecture, dependencies, duplication, and design-system drift, for humans, CI, and the agents writing your code.
+One binary finds unused code, circular dependencies, duplication, complexity hotspots, boundary violations, and design-system styling drift. An optional paid layer, Fallow Runtime, adds production execution evidence. No AI inside the analyzer, and no TypeScript compiler or Node.js runtime needed for static analysis: runs are deterministic, with typed output contracts and traceable explanations.
 
 [![CI](https://github.com/fallow-rs/fallow/actions/workflows/ci.yml/badge.svg)](https://github.com/fallow-rs/fallow/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/fallow.svg)](https://www.npmjs.com/package/fallow)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fallow-rs/fallow/blob/main/LICENSE)
 
-Fallow turns a frontend repository into a trusted quality report: health score, changed-code risk, hotspots, duplication, architecture issues, dependency hygiene, styling consistency, and cleanup opportunities.
-
-It helps you answer: what changed, what got riskier, what should be reviewed, what should be refactored, and what can be safely removed. No AI inside the analyzer. Fallow produces deterministic findings, typed output contracts, and traceable explanations that downstream tools can trust.
-
-Static analysis is open source. An optional runtime layer adds production execution evidence. Rust-native, sub-second, 123 framework plugins, no Node.js runtime dependency for analysis. fallow's edge is doing more in one pass: dead code, duplication, dependencies, complexity, architecture, styling consistency, and security candidates in a single tool. For head-to-head timings against [knip](https://knip.dev) and [jscpd](https://github.com/kucherenko/jscpd), see the [benchmarks](https://github.com/fallow-rs/fallow/tree/main/benchmarks): fallow is faster than knip on smaller projects, knip is faster on several larger repos, and jscpd's Rust rewrite is faster for raw duplication scanning.
-
-## Installation
+## Install
 
 ```bash
-npm install --save-dev fallow   # or: pnpm add -D fallow / yarn add -D fallow / bun add -d fallow
+npm install --save-dev fallow   # or: pnpm add -D fallow / yarn add -D fallow
 ```
 
-Installs the `fallow` CLI in your project, along with the `fallow-lsp` and `fallow-mcp` launchers that start the LSP and MCP servers from the same binary.
+This installs the `fallow` CLI plus the `fallow-lsp` and `fallow-mcp` launchers, so editor and agent integrations resolve the project-local binary instead of whatever happens to be on `PATH`. For one-off use, run `npx fallow` without installing. Other channels (cargo, Docker, prebuilt binaries) are covered in the [installation guide](https://docs.fallow.tools/installation).
 
-The package also ships a version-matched Agent Skill under `skills/fallow`.
-For tools that need CLI and issue-surface metadata without spawning the binary,
-`fallow/capabilities.json` mirrors `fallow schema` for the installed version.
-TanStack Intent discovers it from `node_modules` automatically:
+## Quick start
 
 ```bash
-npx @tanstack/intent list
-npx @tanstack/intent load fallow#fallow
+npx fallow                       # Full pipeline: dead code + duplication + health
+npx fallow audit                 # Gate only what a PR changed: verdict pass/warn/fail
+npx fallow health --score        # 0 to 100 health score with a letter grade
+npx fallow dupes                 # Duplication; modes strict, mild (default), weak, semantic
+npx fallow fix --dry-run         # Preview automatic cleanup
 ```
 
-For one-off CLI use without project-local skill discovery, run `npx fallow`.
+## Output and exit codes
 
-Parsing fallow's JSON output in TypeScript? Import the typed shapes:
+Add `--format json --quiet` to any command for one typed JSON document on stdout. Exit code 1 means findings, not failure; 0 is clean (or an audit pass or warn verdict); 2 is a validation or runtime error, reported as a JSON error envelope rather than a stack trace.
+
+Parsing the output in TypeScript? Import the typed shapes, version-pinned to the CLI you install:
 
 ```ts
 import type { CheckOutput, FallowJsonOutput } from "fallow/types";
 ```
 
-The types are generated from the same schema as the VS Code extension and pin to the CLI version you install. See [docs.fallow.tools](https://docs.fallow.tools) for the full output contract.
+Every issue carries an `actions[]` array with an `auto_fixable` flag, so scripts and agents know which findings they can hand to `fallow fix`. The full contract lives at [docs.fallow.tools](https://docs.fallow.tools).
 
-## Quick start
+## What fallow reports
 
-```bash
-npx fallow audit                 # PR-style audit: verdict pass / warn / fail
-npx fallow audit --format json   # Machine-readable audit (for CI and agents)
-npx fallow health --score        # Quality score and grade
-npx fallow                       # Full codebase analysis: health + duplication + cleanup
-npx fallow dead-code             # Cleanup-specific findings
-npx fallow fix --dry-run         # Preview automatic cleanup
-```
+- Unused files, exports, types, enum and class members, and dependencies
+- Circular dependencies and re-export cycles
+- Code duplication as clone families, across four detection modes
+- Complexity hotspots and a 0 to 100 health score
+- Architecture boundary violations, with zero-config presets
+- Design-system styling drift for CSS and CSS-in-JS (Sass/Less, CSS Modules, Tailwind, styled-components, Emotion, and more)
+- A changed-file PR gate with per-finding attribution (`fallow audit`)
+- Optional runtime intelligence: hot paths, cold code, runtime-weighted health, stale flags (licensed Fallow Runtime; a single local coverage capture is free)
 
-## What Fallow reports
-
-- **Quality score** -- compact health score with grade and trend delta when snapshot history is enabled
-- **PR risk** -- changed-code analysis with pass / warn / fail verdict and per-finding attribution
-- **Hotspots** -- functions, files, and packages combining complexity, churn, size, and coupling
-- **Duplication** -- clone families across four detection modes (strict, mild, weak, semantic)
-- **Design-system styling** -- CSS, Sass/Less, CSS Modules, Tailwind/shadcn/CVA, StyleX/PandaCSS, vanilla-extract, styled-components, and Emotion consistency signals
-- **Architecture** -- circular dependencies, boundary violations, re-export chains
-- **Dependency hygiene** -- unused, unlisted, unresolved, duplicate, and type-only deps; pnpm catalog and overrides
-- **Cleanup opportunities** -- unused files, exports, types, enum members, class members, stale suppressions
-- **Runtime intelligence (optional)** -- hot paths, cold code, runtime-weighted health, stale flags
-
-Cleanup opportunities are findings that look safe to review for removal because no graph evidence supports keeping them. Dead code is one category of cleanup, not the product identity.
-
-## Code duplication
-
-```bash
-fallow dupes                       # Default: mild mode
-fallow dupes --mode semantic       # Catch clones with renamed variables
-fallow dupes --threshold 5         # Fail CI if duplication exceeds 5%
-fallow dupes --save-baseline       # Save current duplication as baseline
-```
-
-Four detection modes (strict, mild, weak, semantic), clone family grouping with refactoring suggestions, baseline tracking, and cross-language TS/JS matching.
+For head-to-head timings against [knip](https://knip.dev) and [jscpd](https://github.com/kucherenko/jscpd), see [BENCHMARKS.md](https://github.com/fallow-rs/fallow/blob/main/BENCHMARKS.md): fallow is faster than knip on smaller projects, knip is faster on several larger repos, and jscpd's Rust rewrite is faster at raw duplication scanning.
 
 ## Built for agents
 
-Fallow gives AI agents structured repo truth instead of forcing them to infer everything from grep. Agents call the CLI or the MCP server to answer:
+Agents get structured repo truth instead of inferring everything from grep: who imports a symbol, why an export counts as used, what a PR changed, which cleanup action is safest.
 
-- Who imports this symbol?
-- Why is this export considered used or unused?
-- What changed in this PR?
-- Which files are risky to touch?
-- What duplicate siblings exist?
-- What cleanup action is safest?
-
-Every issue in `--format json` carries a machine-actionable `actions` array with an `auto_fixable` flag so agents can self-correct.
-
-### MCP server
-
-Agents that speak MCP can launch the bundled `fallow-mcp` server. Installed as a devDependency, the binary lives in `node_modules/.bin/` and is not on your `PATH`, so launch it through your package manager's runner:
+The bundled `fallow-mcp` server lives in `node_modules/.bin/` when installed as a devDependency, so launch it through your package manager's runner:
 
 ```json
 {
@@ -106,15 +68,22 @@ Agents that speak MCP can launch the bundled `fallow-mcp` server. Installed as a
 }
 ```
 
-Swap `npx` for `pnpm exec` / `yarn` / `bunx` to match your package manager. If `fallow-mcp` is installed globally (on your `PATH`), `"command": "fallow-mcp"` works directly. See the [MCP integration guide](https://docs.fallow.tools/integrations/mcp).
+Swap `npx` for `pnpm exec` or `yarn` to match your package manager; a globally installed `fallow-mcp` works as `"command": "fallow-mcp"` directly. See the [MCP integration guide](https://docs.fallow.tools/integrations/mcp).
+
+The package also ships a version-matched agent skill under `skills/fallow`, and `fallow/capabilities.json` mirrors `fallow schema` for tools that need CLI and issue-surface metadata without spawning the binary. TanStack Intent discovers both from `node_modules`:
+
+```bash
+npx @tanstack/intent list
+npx @tanstack/intent load fallow#fallow
+```
 
 ## Framework support
 
-123 built-in plugins covering Next.js, Nuxt, Remix, Qwik, SvelteKit, Gatsby, Astro, Angular, NestJS, AdonisJS, Ember, Expo Router, Vite, Webpack, Vitest, Jest, Playwright, Cypress, Storybook, ESLint, TypeScript, Tailwind, UnoCSS, Prisma, Drizzle, Convex, Turborepo, Hardhat, and many more. Auto-detected from your `package.json`.
+Over 100 built-in framework plugins covering Next.js, Nuxt, Remix, Qwik, SvelteKit, Gatsby, Astro, Angular, NestJS, AdonisJS, Ember, Expo Router, Vite, Webpack, Vitest, Jest, Playwright, Cypress, Storybook, ESLint, TypeScript, Tailwind, UnoCSS, Prisma, Drizzle, Convex, Turborepo, Hardhat, and more. Entry points are auto-detected from `package.json`, so the first run needs no configuration.
 
 ## Configuration
 
-Create a config file in your project root, or run `fallow init`:
+Works out of the box. To customize, run `fallow init` or create a config file in your project root:
 
 ```jsonc
 // .fallowrc.json
@@ -130,23 +99,13 @@ Create a config file in your project root, or run `fallow init`:
 }
 ```
 
-`$schema` gives editors autocomplete and validation and has no effect on
-analysis. As an npm package, `fallow` always ships a version-aligned schema at
-`./node_modules/fallow/schema.json`, which `fallow init` and
-`fallow recommend` point at by default: offline, no editor trust prompt. If
-you install fallow another way (cargo, homebrew, a bare binary) with no
-`node_modules/fallow` to point at, use the remote fallback instead:
-`https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json`. Some
-editors, including VS Code, refuse to load a remote schema URL until you
-explicitly trust the domain.
-
-Also supports TOML (`fallow init --toml` creates `fallow.toml`).
+`$schema` gives editors autocomplete and validation and has no effect on analysis. The npm package ships a version-aligned schema at `./node_modules/fallow/schema.json`, so validation works offline with no editor trust prompt. TOML works too: `fallow init --toml` creates `fallow.toml`. Full reference: [configuration overview](https://docs.fallow.tools/configuration/overview).
 
 ## Documentation
 
-- [Full documentation](https://docs.fallow.tools)
+- [docs.fallow.tools](https://docs.fallow.tools)
 - [GitHub repository](https://github.com/fallow-rs/fallow)
-- [Plugin Authoring Guide](https://github.com/fallow-rs/fallow/blob/main/docs/plugin-authoring.md)
+- [Plugin authoring guide](https://github.com/fallow-rs/fallow/blob/main/docs/plugin-authoring.md)
 
 ## License
 


### PR DESCRIPTION
Same treatment as the root README rewrite (#1886): count-free plugin phrasing (stable "over 100"), current masthead positioning covering the five analysis areas plus styling drift, and a new output-and-exit-codes section aimed at agents that read the package README from node_modules. Cleans up the double-hyphen bullet separators, drops bun from the install line to match the documented install channels, and keeps every link absolute because npm renders the README without repo context.