### PR TITLE
fix(mcp): prevent stale process-group cleanup

### DIFF
--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -54,6 +54,13 @@ fn process_exists(pid: u32) -> bool {
 #[cfg(windows)]
 struct ProcessCleanup(Vec<u32>);
 
+#[cfg(any(unix, windows))]
+impl ProcessCleanup {
+    fn disarm(&mut self, pid: u32) {
+        self.0.retain(|candidate| *candidate != pid);
+    }
+}
+
 #[cfg(windows)]
 #[expect(
     unsafe_code,
@@ -126,6 +133,38 @@ async fn wait_for_process_exit(pid: u32) -> bool {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     false
+}
+
+#[cfg(unix)]
+#[test]
+fn process_cleanup_disarm_does_not_signal_reused_pid() {
+    let mut replacement = std::process::Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("replacement process");
+    let replacement_pid = replacement.id();
+    let mut cleanup = ProcessCleanup(vec![replacement_pid]);
+
+    cleanup.disarm(replacement_pid);
+    drop(cleanup);
+
+    let mut replacement_status = None;
+    for _ in 0..20 {
+        replacement_status = replacement.try_wait().expect("replacement status");
+        if replacement_status.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    if replacement_status.is_none() {
+        replacement.kill().expect("terminate replacement process");
+        replacement.wait().expect("reap replacement process");
+    }
+
+    assert!(
+        replacement_status.is_none(),
+        "disarmed cleanup signaled a reused PID"
+    );
 }
 
 #[tokio::test]
@@ -229,7 +268,8 @@ async fn run_fallow_exit_code_2_with_stderr_returns_structured_json_error() {
         parsed["message"]
             .as_str()
             .unwrap()
-            .contains("invalid config")
+            .contains("invalid config"),
+        "unexpected subprocess error body: {text}"
     );
 }
 
@@ -444,7 +484,10 @@ async fn run_fallow_unicode_in_stderr_error() {
     let text = extract_text(&result);
     let parsed: serde_json::Value = serde_json::from_str(text).expect("error should be valid JSON");
     let msg = parsed["message"].as_str().unwrap();
-    assert!(msg.contains("ungültige Konfiguration"));
+    assert!(
+        msg.contains("ungültige Konfiguration"),
+        "unexpected subprocess error body: {text}"
+    );
 }
 
 #[cfg(unix)]
@@ -491,7 +534,12 @@ async fn run_fallow_stdout_preserves_content() {
     )
     .await
     .unwrap();
-    assert_eq!(result.is_error, Some(false));
+    assert_eq!(
+        result.is_error,
+        Some(false),
+        "unexpected subprocess result: {}",
+        extract_text(&result)
+    );
     let text = extract_text(&result);
     assert!(text.contains(r#""key": "value""#));
 }
@@ -547,9 +595,13 @@ async fn run_fallow_completed_child_cleans_descendant_process_tree() {
 
     assert_eq!(result.is_error, Some(false));
     let descendant_pid = read_pid(&descendant_pid_path).await;
-    let _cleanup = ProcessCleanup(vec![descendant_pid]);
+    let mut cleanup = ProcessCleanup(vec![descendant_pid]);
+    let descendant_exited = wait_for_process_exit(descendant_pid).await;
+    if descendant_exited {
+        cleanup.disarm(descendant_pid);
+    }
     assert!(
-        wait_for_process_exit(descendant_pid).await,
+        descendant_exited,
         "completed subprocess descendant {descendant_pid} survived"
     );
 }
@@ -576,13 +628,17 @@ async fn run_fallow_completed_child_cleanup_closes_inherited_pipes_without_timeo
     .expect("completed subprocess should stay a tool result");
 
     let descendant_pid = read_pid(&descendant_pid_path).await;
-    let _cleanup = ProcessCleanup(vec![descendant_pid]);
+    let mut cleanup = ProcessCleanup(vec![descendant_pid]);
+    let descendant_exited = wait_for_process_exit(descendant_pid).await;
+    if descendant_exited {
+        cleanup.disarm(descendant_pid);
+    }
     assert_eq!(result.is_error, Some(false));
     assert!(
         started.elapsed() < Duration::from_secs(1),
         "completed child waited for the timeout before cleaning inherited pipes"
     );
-    assert!(wait_for_process_exit(descendant_pid).await);
+    assert!(descendant_exited);
 }
 
 #[cfg(windows)]
@@ -618,9 +674,13 @@ Write-Output '{}'
 
     assert_eq!(result.is_error, Some(false));
     let descendant_pid = read_pid(&descendant_pid_path).await;
-    let _cleanup = ProcessCleanup(vec![descendant_pid]);
+    let mut cleanup = ProcessCleanup(vec![descendant_pid]);
+    let descendant_exited = wait_for_process_exit(descendant_pid).await;
+    if descendant_exited {
+        cleanup.disarm(descendant_pid);
+    }
     assert!(
-        wait_for_process_exit(descendant_pid).await,
+        descendant_exited,
         "completed Windows job descendant {descendant_pid} survived"
     );
 }
@@ -674,9 +734,15 @@ async fn run_fallow_timeout_terminates_and_reaps_process_tree() {
     assert_eq!(result.is_error, Some(true));
     let direct_pid = read_pid(&direct_pid_path).await;
     let descendant_pid = read_pid(&descendant_pid_path).await;
-    let _cleanup = ProcessCleanup(vec![direct_pid, descendant_pid]);
+    let mut cleanup = ProcessCleanup(vec![direct_pid, descendant_pid]);
     let direct_exited = wait_for_process_exit(direct_pid).await;
     let descendant_exited = wait_for_process_exit(descendant_pid).await;
+    if direct_exited {
+        cleanup.disarm(direct_pid);
+    }
+    if descendant_exited {
+        cleanup.disarm(descendant_pid);
+    }
 
     assert!(
         direct_exited && descendant_exited,
@@ -761,9 +827,15 @@ Start-Sleep -Seconds 30
     assert_eq!(result.is_error, Some(true));
     let direct_pid = read_pid(&direct_pid_path).await;
     let descendant_pid = read_pid(&descendant_pid_path).await;
-    let _cleanup = ProcessCleanup(vec![direct_pid, descendant_pid]);
+    let mut cleanup = ProcessCleanup(vec![direct_pid, descendant_pid]);
     let direct_exited = wait_for_process_exit(direct_pid).await;
     let descendant_exited = wait_for_process_exit(descendant_pid).await;
+    if direct_exited {
+        cleanup.disarm(direct_pid);
+    }
+    if descendant_exited {
+        cleanup.disarm(descendant_pid);
+    }
 
     assert!(
         direct_exited && descendant_exited,
@@ -827,6 +899,9 @@ async fn run_fallow_exit_code_2_prefers_json_stdout_over_stderr() {
     assert_eq!(result.is_error, Some(true));
     let text = extract_text(&result);
     let parsed: serde_json::Value = serde_json::from_str(text).expect("should be valid JSON");
-    assert_eq!(parsed["message"], "structured error");
+    assert_eq!(
+        parsed["message"], "structured error",
+        "unexpected subprocess error body: {text}"
+    );
     assert!(!text.contains("raw stderr msg"));
 }

--- a/crates/mcp/src/tools/code_mode_subprocess.rs
+++ b/crates/mcp/src/tools/code_mode_subprocess.rs
@@ -36,18 +36,36 @@ pub(super) fn run_fallow_sync(
     let (mut child, process_tree) = spawn_managed_child(command, binary)?;
 
     loop {
-        let status = match child.try_wait() {
-            Ok(status) => status,
+        #[cfg(unix)]
+        let (completed, status) = match process_tree.has_exited_without_reaping() {
+            Ok(completed) => (completed, None),
             Err(error) => {
-                let cleanup_errors = cleanup_std_child(Some(&process_tree), &mut child);
+                let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
                 return Err(with_cleanup_errors(
                     format!("failed to wait for fallow subprocess: {error}"),
-                    &cleanup_errors,
+                    &cleanup.errors,
                 ));
             }
         };
-        if let Some(status) = status {
-            let cleanup_errors = cleanup_std_child(Some(&process_tree), &mut child);
+        #[cfg(not(unix))]
+        let (completed, status) = match child.try_wait() {
+            Ok(status) => (status.is_some(), status),
+            Err(error) => {
+                let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
+                return Err(with_cleanup_errors(
+                    format!("failed to wait for fallow subprocess: {error}"),
+                    &cleanup.errors,
+                ));
+            }
+        };
+        if completed {
+            let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
+            let status = status.or(cleanup.status).ok_or_else(|| {
+                with_cleanup_errors(
+                    "completed fallow subprocess status unavailable".to_string(),
+                    &cleanup.errors,
+                )
+            })?;
             let result = (|| {
                 let stdout_len = file_len(stdout_file.as_file())?;
                 if stdout_len > max_output_bytes as u64 {
@@ -60,28 +78,28 @@ pub(super) fn run_fallow_sync(
                 let stderr = read_limited_file(stderr_file.as_file_mut(), STDERR_LIMIT_BYTES)?;
                 normalize_output(status.code().unwrap_or(-1), &stdout, &stderr)
             })();
-            return with_completed_cleanup(result, &cleanup_errors);
+            return with_completed_cleanup(result, &cleanup.errors);
         }
 
         if Instant::now() >= deadline {
-            let cleanup_errors = cleanup_std_child(Some(&process_tree), &mut child);
+            let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
             return Err(with_cleanup_errors(
                 "code mode execution timed out while running fallow".to_string(),
-                &cleanup_errors,
+                &cleanup.errors,
             ));
         }
         let stdout_len = match file_len(stdout_file.as_file()) {
             Ok(stdout_len) => stdout_len,
             Err(error) => {
-                let cleanup_errors = cleanup_std_child(Some(&process_tree), &mut child);
-                return Err(with_cleanup_errors(error, &cleanup_errors));
+                let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
+                return Err(with_cleanup_errors(error, &cleanup.errors));
             }
         };
         if stdout_len > max_output_bytes as u64 {
-            let cleanup_errors = cleanup_std_child(Some(&process_tree), &mut child);
+            let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
             return Err(with_cleanup_errors(
                 format!("code mode host output exceeded {max_output_bytes} bytes"),
-                &cleanup_errors,
+                &cleanup.errors,
             ));
         }
 
@@ -102,10 +120,10 @@ fn spawn_managed_child(
     let process_tree = match ProcessTree::for_std_child(&child) {
         Ok(process_tree) => process_tree,
         Err(error) => {
-            let cleanup_errors = cleanup_std_child(None, &mut child);
+            let cleanup = cleanup_std_child(None, &mut child);
             return Err(with_cleanup_errors(
                 format!("failed to configure fallow subprocess tree: {error}"),
-                &cleanup_errors,
+                &cleanup.errors,
             ));
         }
     };

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -258,28 +258,28 @@ async fn spawn_fallow(
     let process_tree = match ProcessTree::for_tokio_child(&child) {
         Ok(process_tree) => process_tree,
         Err(error) => {
-            let cleanup_errors = cleanup_tokio_child(None, &mut child).await;
+            let cleanup = cleanup_tokio_child(None, &mut child).await;
             return Err(subprocess_error_with_cleanup(
                 binary,
                 error,
-                &cleanup_errors,
+                &cleanup.errors,
             ));
         }
     };
     let Some(stdout) = child.stdout.take() else {
-        let cleanup_errors = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+        let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
         return Err(subprocess_error_with_cleanup(
             binary,
             io::Error::other("stdout pipe unavailable"),
-            &cleanup_errors,
+            &cleanup.errors,
         ));
     };
     let Some(stderr) = child.stderr.take() else {
-        let cleanup_errors = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+        let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
         return Err(subprocess_error_with_cleanup(
             binary,
             io::Error::other("stderr pipe unavailable"),
-            &cleanup_errors,
+            &cleanup.errors,
         ));
     };
     let stdout_task = tokio::spawn(drain_pipe(stdout, max_output_bytes));
@@ -314,25 +314,60 @@ async fn complete_fallow_process(
     } = process;
     let deadline = tokio::time::Instant::now() + timeout;
 
-    let status = match tokio::time::timeout_at(deadline, child.wait()).await {
-        Ok(Ok(status)) => status,
+    #[cfg(unix)]
+    let (status, cleanup_errors) =
+        match tokio::time::timeout_at(deadline, process_tree.wait_for_exit_without_reaping()).await
+        {
+            Ok(Ok(())) => {
+                let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+                let Some(status) = cleanup.status else {
+                    abort_drain_tasks(&stdout_task, &stderr_task);
+                    return Err(subprocess_error_with_cleanup(
+                        binary,
+                        io::Error::other("completed subprocess status unavailable"),
+                        &cleanup.errors,
+                    ));
+                };
+                (status, cleanup.errors)
+            }
+            Ok(Err(error)) => {
+                let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+                abort_drain_tasks(&stdout_task, &stderr_task);
+                return Err(subprocess_error_with_cleanup(
+                    binary,
+                    error,
+                    &cleanup.errors,
+                ));
+            }
+            Err(_) => {
+                let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+                abort_drain_tasks(&stdout_task, &stderr_task);
+                return Ok(timeout_result(timeout, &cleanup.errors));
+            }
+        };
+
+    #[cfg(not(unix))]
+    let (status, cleanup_errors) = match tokio::time::timeout_at(deadline, child.wait()).await {
+        Ok(Ok(status)) => {
+            let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+            (status, cleanup.errors)
+        }
         Ok(Err(error)) => {
-            let cleanup_errors = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+            let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
             abort_drain_tasks(&stdout_task, &stderr_task);
             return Err(subprocess_error_with_cleanup(
                 binary,
                 error,
-                &cleanup_errors,
+                &cleanup.errors,
             ));
         }
         Err(_) => {
-            let cleanup_errors = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+            let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
             abort_drain_tasks(&stdout_task, &stderr_task);
-            return Ok(timeout_result(timeout, &cleanup_errors));
+            return Ok(timeout_result(timeout, &cleanup.errors));
         }
     };
 
-    let cleanup_errors = cleanup_tokio_child(Some(&process_tree), &mut child).await;
     let drain_output = async {
         let stdout = (&mut stdout_task).await.map_err(io::Error::other)??;
         let stderr = (&mut stderr_task).await.map_err(io::Error::other)??;

--- a/crates/mcp/src/tools/process_tree.rs
+++ b/crates/mcp/src/tools/process_tree.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::process::ExitStatus;
 use std::time::{Duration, Instant};
 
 const CLEANUP_GRACE: Duration = Duration::from_secs(1);
@@ -100,6 +101,8 @@ impl Drop for WindowsJobGuard {
 pub(super) struct ProcessTree {
     #[cfg(unix)]
     process_group_id: i32,
+    #[cfg(unix)]
+    leader_exit_observed: std::sync::atomic::AtomicBool,
     #[cfg(windows)]
     job: WindowsHandle,
 }
@@ -150,7 +153,10 @@ impl ProcessTree {
     fn for_pid(pid: u32) -> io::Result<Self> {
         let process_group_id = i32::try_from(pid)
             .map_err(|_| io::Error::other(format!("invalid fallow subprocess PID {pid}")))?;
-        Ok(Self { process_group_id })
+        Ok(Self {
+            process_group_id,
+            leader_exit_observed: std::sync::atomic::AtomicBool::new(false),
+        })
     }
 
     #[cfg(windows)]
@@ -194,7 +200,58 @@ impl ProcessTree {
         if error.raw_os_error() == Some(libc::ESRCH) {
             return Ok(());
         }
+        #[cfg(target_vendor = "apple")]
+        // macOS returns EPERM when the reserved process group contains only
+        // the observed zombie leader, so there are no live members to signal.
+        if error.raw_os_error() == Some(libc::EPERM)
+            && self
+                .leader_exit_observed
+                .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Ok(());
+        }
         Err(error)
+    }
+
+    #[cfg(unix)]
+    pub(super) async fn wait_for_exit_without_reaping(&self) -> io::Result<()> {
+        loop {
+            if self.has_exited_without_reaping()? {
+                return Ok(());
+            }
+            tokio::time::sleep(CLEANUP_POLL_INTERVAL).await;
+        }
+    }
+
+    #[cfg(unix)]
+    #[expect(
+        unsafe_code,
+        reason = "non-reaping POSIX child observation requires waitid"
+    )]
+    pub(super) fn has_exited_without_reaping(&self) -> io::Result<bool> {
+        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+        // SAFETY: `info` points to writable storage for a siginfo_t. WNOWAIT
+        // observes the dedicated child without releasing its PID or PGID.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                self.process_group_id as libc::id_t,
+                info.as_mut_ptr(),
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: waitid initialized the siginfo_t on success. A zero si_pid
+        // means WNOHANG observed no state change yet.
+        let exited = unsafe { info.assume_init().si_pid() } != 0;
+        if exited {
+            self.leader_exit_observed
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(exited)
     }
 
     #[cfg(windows)]
@@ -221,10 +278,15 @@ impl ProcessTree {
     }
 }
 
+pub(super) struct ChildCleanup {
+    pub(super) status: Option<ExitStatus>,
+    pub(super) errors: Vec<String>,
+}
+
 pub(super) async fn cleanup_tokio_child(
     process_tree: Option<&ProcessTree>,
     child: &mut tokio::process::Child,
-) -> Vec<String> {
+) -> ChildCleanup {
     let mut errors = Vec::new();
     if !request_tree_termination(process_tree, &mut errors)
         && let Err(error) = child.start_kill()
@@ -232,40 +294,55 @@ pub(super) async fn cleanup_tokio_child(
         errors.push(format!("failed to kill direct subprocess: {error}"));
     }
 
-    match tokio::time::timeout(CLEANUP_GRACE, child.wait()).await {
-        Ok(Ok(_)) => return errors,
+    let status = match tokio::time::timeout(CLEANUP_GRACE, child.wait()).await {
+        Ok(Ok(status)) => {
+            return ChildCleanup {
+                status: Some(status),
+                errors,
+            };
+        }
         Ok(Err(error)) => {
             errors.push(format!("failed to reap direct subprocess: {error}"));
-            return errors;
+            return ChildCleanup {
+                status: None,
+                errors,
+            };
         }
-        Err(_) => errors.push(format!(
-            "direct subprocess did not exit within {}ms cleanup grace",
-            CLEANUP_GRACE.as_millis()
-        )),
-    }
+        Err(_) => {
+            errors.push(format!(
+                "direct subprocess did not exit within {}ms cleanup grace",
+                CLEANUP_GRACE.as_millis()
+            ));
+            None
+        }
+    };
 
     if let Err(error) = child.start_kill() {
         errors.push(format!("failed to retry direct subprocess kill: {error}"));
     }
-    match tokio::time::timeout(REAP_RETRY_GRACE, child.wait()).await {
-        Ok(Ok(_)) => {}
+    let status = match tokio::time::timeout(REAP_RETRY_GRACE, child.wait()).await {
+        Ok(Ok(status)) => Some(status),
         Ok(Err(error)) => {
             errors.push(format!(
                 "failed to reap direct subprocess after retry: {error}"
             ));
+            status
         }
-        Err(_) => errors.push(format!(
-            "direct subprocess still did not exit after {}ms kill retry",
-            REAP_RETRY_GRACE.as_millis()
-        )),
-    }
-    errors
+        Err(_) => {
+            errors.push(format!(
+                "direct subprocess still did not exit after {}ms kill retry",
+                REAP_RETRY_GRACE.as_millis()
+            ));
+            status
+        }
+    };
+    ChildCleanup { status, errors }
 }
 
 pub(super) fn cleanup_std_child(
     process_tree: Option<&ProcessTree>,
     child: &mut std::process::Child,
-) -> Vec<String> {
+) -> ChildCleanup {
     let mut errors = Vec::new();
     if !request_tree_termination(process_tree, &mut errors)
         && let Err(error) = child.kill()
@@ -273,32 +350,49 @@ pub(super) fn cleanup_std_child(
         errors.push(format!("failed to kill direct subprocess: {error}"));
     }
 
-    match poll_std_child(child, CLEANUP_GRACE) {
-        Ok(true) => return errors,
-        Ok(false) => errors.push(format!(
-            "direct subprocess did not exit within {}ms cleanup grace",
-            CLEANUP_GRACE.as_millis()
-        )),
+    let status = match poll_std_child(child, CLEANUP_GRACE) {
+        Ok(Some(status)) => {
+            return ChildCleanup {
+                status: Some(status),
+                errors,
+            };
+        }
+        Ok(None) => {
+            errors.push(format!(
+                "direct subprocess did not exit within {}ms cleanup grace",
+                CLEANUP_GRACE.as_millis()
+            ));
+            None
+        }
         Err(error) => {
             errors.push(format!("failed to reap direct subprocess: {error}"));
-            return errors;
+            return ChildCleanup {
+                status: None,
+                errors,
+            };
         }
-    }
+    };
 
     if let Err(error) = child.kill() {
         errors.push(format!("failed to retry direct subprocess kill: {error}"));
     }
-    match poll_std_child(child, REAP_RETRY_GRACE) {
-        Ok(true) => {}
-        Ok(false) => errors.push(format!(
-            "direct subprocess still did not exit after {}ms kill retry",
-            REAP_RETRY_GRACE.as_millis()
-        )),
-        Err(error) => errors.push(format!(
-            "failed to reap direct subprocess after retry: {error}"
-        )),
-    }
-    errors
+    let status = match poll_std_child(child, REAP_RETRY_GRACE) {
+        Ok(Some(status)) => Some(status),
+        Ok(None) => {
+            errors.push(format!(
+                "direct subprocess still did not exit after {}ms kill retry",
+                REAP_RETRY_GRACE.as_millis()
+            ));
+            status
+        }
+        Err(error) => {
+            errors.push(format!(
+                "failed to reap direct subprocess after retry: {error}"
+            ));
+            status
+        }
+    };
+    ChildCleanup { status, errors }
 }
 
 fn request_tree_termination(process_tree: Option<&ProcessTree>, errors: &mut Vec<String>) -> bool {
@@ -314,18 +408,55 @@ fn request_tree_termination(process_tree: Option<&ProcessTree>, errors: &mut Vec
     }
 }
 
-fn poll_std_child(child: &mut std::process::Child, grace: Duration) -> io::Result<bool> {
+fn poll_std_child(
+    child: &mut std::process::Child,
+    grace: Duration,
+) -> io::Result<Option<ExitStatus>> {
     let deadline = Instant::now() + grace;
     loop {
-        if child.try_wait()?.is_some() {
-            return Ok(true);
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
         }
 
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
-            return Ok(false);
+            return Ok(None);
         }
         std::thread::sleep(CLEANUP_POLL_INTERVAL.min(remaining));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[expect(
+        unsafe_code,
+        reason = "the regression test verifies that the observed PID remains reserved"
+    )]
+    async fn non_reaping_exit_observation_reserves_process_group_identity() {
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.args(["-c", "exit 0"]);
+        configure_tokio_command(&mut command);
+        let mut child = command.spawn().expect("test subprocess");
+        let pid = child.id().expect("test subprocess PID");
+        let process_tree = ProcessTree::for_tokio_child(&child).expect("test process tree");
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            process_tree.wait_for_exit_without_reaping(),
+        )
+        .await
+        .expect("test subprocess exit")
+        .expect("non-reaping exit observation");
+        // SAFETY: Signal zero only checks whether the captured PID still exists.
+        let leader_is_reserved = unsafe { libc::kill(pid as libc::pid_t, 0) } == 0;
+        let cleanup = cleanup_tokio_child(Some(&process_tree), &mut child).await;
+
+        assert!(leader_is_reserved, "subprocess leader was reaped too early");
+        assert!(cleanup.errors.is_empty(), "{:?}", cleanup.errors);
+        assert!(cleanup.status.is_some_and(|status| status.success()));
     }
 }
 


### PR DESCRIPTION
## Summary

- Keep the Unix child leader unreaped until its dedicated process group has been cleaned, preventing stale process-group reuse.
- Apply the same lifecycle protection to MCP CLI subprocesses and Code Mode.
- Disarm test cleanup guards once a PID is confirmed dead, and preserve actionable subprocess diagnostics.

## Verification

- Focused MCP lifecycle and Code Mode regressions
- Repeated high-concurrency subprocess stress
- Full repository verification
- Real stdio MCP `project_info` call against this repository
- Workspace Clippy, benchmark compilation, and Rust docs