### PR TITLE
fix(ci): restore VS Code dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
-          version: 10.33.0
+          version: 11.10.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Fallow",
   "description": "Codebase intelligence for TypeScript and JavaScript. Real-time diagnostics for unused code, duplication, complexity hotspots, architecture drift, and design-system styling, with optional runtime evidence via Fallow Runtime.",
   "version": "2.48.1",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.10.0",
   "publisher": "fallow-rs",
   "license": "MIT",
   "repository": {

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -169,6 +169,8 @@ test("VS Code CI runs the extension-host integration suite with a pinned cached 
   assert.match(workflow, /^  pull_request:$/m, "CI must run for pull requests");
   assert.match(vscodeJob, /needs\.changes\.outputs\.vscode == 'true'/);
   assert.match(vscodeJob, /persist-credentials: false/);
+  assert.match(vscodeJob, /version: 11\.10\.0/);
+  assert.match(vscodeJob, /pnpm audit --prod/);
   assert.match(vscodeFilter, /editors\/vscode\/\*\*/);
   assert.match(vscodeFilter, /\.github\/workflows\/ci\.yml/);
   assert.match(
@@ -181,6 +183,8 @@ test("VS Code CI runs the extension-host integration suite with a pinned cached 
   );
 
   const harness = readFileSync("editors/vscode/test/integration/runTest.ts", "utf8");
+  const packageJson = readFileSync("editors/vscode/package.json", "utf8");
+  assert.match(packageJson, /"packageManager": "pnpm@11\.10\.0"/);
   assert.match(harness, /version: "1\.96\.0"/);
 });
 


### PR DESCRIPTION
## Summary

- upgrade the VS Code CI job to pnpm 11.10.0
- keep the extension packageManager pin aligned with CI
- protect the audit command and package-manager version with workflow policy assertions

## Why

npm retired the legacy audit endpoints used by pnpm 10. pnpm 11 uses the supported bulk advisory endpoint, so the production dependency audit remains fail-closed instead of failing on HTTP 410.

## Verification

- pnpm 11 frozen-lockfile install
- production dependency audit
- generated contract check, lint, unit tests, packaging, and extension-host integration
- fast repository verification
