### PR TITLE
fix: harden analysis and integration contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       npm-package: ${{ steps.filter.outputs.npm-package }}
       self-analyze: ${{ steps.filter.outputs.self-analyze }}
       skills: ${{ steps.filter.outputs.skills }}
+      action-current: ${{ steps.filter.outputs.action-current }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -112,6 +113,10 @@ jobs:
               - 'rust-toolchain.toml'
             vscode:
               - 'editors/vscode/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
             zed:
               - 'editors/zed/**'
@@ -149,6 +154,17 @@ jobs:
               - 'npm/fallow/skills/**'
               - 'scripts/vendor-skills.mjs'
               - '.github/workflows/ci.yml'
+            action-current:
+              - 'action/**'
+              - 'action.yml'
+              - 'crates/**'
+              - 'tests/fixtures/basic-project/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/actions/setup-rust/**'
+              - '.github/workflows/ci.yml'
+              - 'scripts/workflow-policy.test.mjs'
 
   docker:
     name: Docker
@@ -409,8 +425,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install locked repository tools
+        run: npm ci --no-audit --no-fund --ignore-scripts
+
       - name: Validate bundled Agent Skill
-        run: npx --yes @tanstack/intent@0.0.29 validate npm/fallow/skills
+        run: npx --no-install intent validate npm/fallow/skills
 
       - name: Check npm package contents
         run: |
@@ -507,6 +526,52 @@ jobs:
           test -f node_modules/fallow/scripts/sentinel-path.js
           test -f node_modules/fallow/scripts/run-binary.js
 
+  action-current:
+    name: Action with current binary
+    needs: changes
+    if: needs.changes.outputs.action-current == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+      - name: Build current fallow binary
+        run: cargo build --bin fallow
+      - name: Put current fallow binary first on PATH
+        run: printf '%s\n' "${GITHUB_WORKSPACE}/target/debug" >> "$GITHUB_PATH"
+      - name: Run Action shell tests with current binary
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow
+        run: bash action/tests/run.sh
+      - name: Run checked-in Action JSON smoke
+        id: current_action
+        uses: ./
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow
+          FALLOW_SKIP_BINARY_VERIFY: "1"
+        with:
+          command: dead-code
+          root: tests/fixtures/basic-project
+          format: json
+          annotations: false
+          fail-on-issues: false
+          auto-changed-since: false
+      - name: Verify current-binary JSON contract
+        env:
+          RESULTS_PATH: ${{ steps.current_action.outputs.results }}
+        run: |
+          test -f "$RESULTS_PATH"
+          jq empty "$RESULTS_PATH"
+          jq -e '.total_issues >= 0 and (.unused_files | type == "array")' "$RESULTS_PATH"
+
   fallow-self-analyze:
     name: Fallow Self Analysis
     needs: changes
@@ -561,6 +626,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-rust
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 11.10.0
@@ -579,8 +645,14 @@ jobs:
       - name: Verify generated extension contracts
         run: cd editors/vscode && pnpm run check:contracts
       - run: cd editors/vscode && pnpm lint
+      - name: Build current multicall binary
+        run: cargo build -p fallow-multicall --bin fallow-multicall
       - name: Run VS Code extension-host integration tests
         run: cd editors/vscode && xvfb-run -a pnpm test:integration
+      - name: Run VS Code real CLI and LSP contract smoke
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow-multicall
+        run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
       - run: cd editors/vscode && pnpm test:unit
       - run: cd editors/vscode && pnpm package
 
@@ -770,7 +842,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, windows-rust, doc, typos, js-lint, npm-package, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor]
+    needs: [check, windows-rust, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@ Thanks for your interest in contributing to fallow! This guide covers everything
 
 ## Getting started
 
-Repository tooling and the published Node packages require Node.js 22 or later.
+Repository tooling requires Node.js 22.12.0 or later. Published Node packages
+require Node.js 22 or later.
 
 ```bash
 git clone https://github.com/fallow-rs/fallow.git

--- a/action/scripts/analyze.sh
+++ b/action/scripts/analyze.sh
@@ -275,6 +275,37 @@ build_command_args() {
 
 # --- Validation ---
 
+contains_ascii_control() {
+  local LC_ALL=C
+  local value=$1
+  [[ "$value" =~ [[:cntrl:]] ]]
+}
+
+validate_action_scalars() {
+  local changed_since="${INPUT_CHANGED_SINCE:-}"
+  local diff_file="${FALLOW_DIFF_FILE:-}"
+
+  if [ -z "$changed_since" ] && [ "${INPUT_AUTO_CHANGED_SINCE:-}" = "true" ] && \
+     { [ "${EVENT_NAME:-}" = "pull_request" ] || [ "${EVENT_NAME:-}" = "pull_request_target" ]; }; then
+    changed_since="${PR_BASE_SHA:-}"
+  fi
+
+  if [[ "$changed_since" = -* ]]; then
+    printf '%s\n' "::error::changed-since must not begin with '-'"
+    exit 2
+  fi
+  if contains_ascii_control "$changed_since"; then
+    printf '%s\n' "::error::changed-since must not contain ASCII control characters"
+    exit 2
+  fi
+  if contains_ascii_control "$diff_file"; then
+    printf '%s\n' "::error::diff-file must not contain ASCII control characters"
+    exit 2
+  fi
+}
+
+validate_action_scalars
+
 case "$INPUT_COMMAND" in
   ""|dead-code|check|dupes|health|audit|security|fix) ;;
   *) echo "::error::Invalid command: ${INPUT_COMMAND}. Must be dead-code, dupes, health, audit, security, fix, or empty (runs all)."; exit 2 ;;
@@ -340,14 +371,13 @@ CHANGED_FILES_FILE=$(artifact_path fallow-changed-files.json)
 AUTO_DIFF_FILE="$PWD/$(artifact_path fallow-pr.diff)"
 
 if [ -n "${GITHUB_ENV:-}" ]; then
-  {
-    echo "FALLOW_RESULTS_FILE=${RESULTS_FILE}"
-    echo "FALLOW_SCOPED_RESULTS_FILE=${SCOPED_RESULTS_FILE}"
-    echo "FALLOW_ANALYSIS_ARGS_FILE=${ANALYSIS_ARGS_FILE}"
-    echo "FALLOW_CHANGED_FILES_FILE=${CHANGED_FILES_FILE}"
-    echo "FALLOW_SARIF_FILE=${SARIF_FILE}"
-    echo "FALLOW_ARTIFACTS_DIR=${ARTIFACTS_DIR}"
-  } >> "$GITHUB_ENV"
+  printf '%s\n' \
+    "FALLOW_RESULTS_FILE=${RESULTS_FILE}" \
+    "FALLOW_SCOPED_RESULTS_FILE=${SCOPED_RESULTS_FILE}" \
+    "FALLOW_ANALYSIS_ARGS_FILE=${ANALYSIS_ARGS_FILE}" \
+    "FALLOW_CHANGED_FILES_FILE=${CHANGED_FILES_FILE}" \
+    "FALLOW_SARIF_FILE=${SARIF_FILE}" \
+    "FALLOW_ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> "$GITHUB_ENV"
 fi
 
 # --- Check for --sarif-file support ---
@@ -375,7 +405,7 @@ if fallow report --help > /dev/null 2>&1; then
   HAS_NATIVE_REPORT=true
 fi
 if [ -n "${GITHUB_ENV:-}" ]; then
-  echo "HAS_NATIVE_REPORT=${HAS_NATIVE_REPORT}" >> "$GITHUB_ENV"
+  printf '%s\n' "HAS_NATIVE_REPORT=${HAS_NATIVE_REPORT}" >> "$GITHUB_ENV"
 fi
 
 # --- Auto-detect changed-since in PR context ---
@@ -404,7 +434,7 @@ fi
 # `outputs.changed_files_unavailable == 'false'` as a positive signal see an
 # absent field instead of false when changed-since is not set.
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
-  echo "changed_files_unavailable=false" >> "$GITHUB_OUTPUT"
+  printf '%s\n' "changed_files_unavailable=false" >> "$GITHUB_OUTPUT"
 fi
 
 _CHANGED_JSON=""
@@ -443,7 +473,7 @@ if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
         _API_ROOT=$(repo_relative_root || true)
         if [ -z "$_API_ROOT" ]; then
           echo "::warning::fallow: absolute root is outside GITHUB_WORKSPACE; GitHub API paths cannot be scoped safely." >&2
-          [ -n "${GITHUB_OUTPUT:-}" ] && echo "changed_files_unavailable=true" >> "$GITHUB_OUTPUT"
+          [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s\n' "changed_files_unavailable=true" >> "$GITHUB_OUTPUT"
           _CHANGED_JSON='[]'
         elif [ "$_API_ROOT" != "." ]; then
           # Strip root prefix; API returns repo-root-relative paths, fallow JSON uses root-relative.
@@ -454,7 +484,7 @@ if [ -n "${INPUT_CHANGED_SINCE:-}" ]; then
     else
       _STDERR_HEAD=$(head -3 "$_API_ERR" | tr '\n' ' ')
       echo "::warning::fallow: GitHub API call to list PR files failed; analysis will run against the full codebase, not just files changed in this PR. stderr: ${_STDERR_HEAD} Re-run the job to retry. If persistent, check 'gh auth status' and repo permissions." >&2
-      [ -n "${GITHUB_OUTPUT:-}" ] && echo "changed_files_unavailable=true" >> "$GITHUB_OUTPUT"
+      [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s\n' "changed_files_unavailable=true" >> "$GITHUB_OUTPUT"
     fi
   fi
 
@@ -486,7 +516,7 @@ fi
 # Propagate the effective changed-since value after config safety logic so
 # downstream steps do not reapply stale PR scope.
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
-  echo "changed_since=${INPUT_CHANGED_SINCE:-}" >> "$GITHUB_OUTPUT"
+  printf '%s\n' "changed_since=${INPUT_CHANGED_SINCE:-}" >> "$GITHUB_OUTPUT"
 fi
 
 # --- Pre-compute unified diff for line-level hot-path scoping ---
@@ -512,7 +542,7 @@ fi
 # need to declare their own FALLOW_DIFF_FILE env (which would override
 # the analyze-step propagation otherwise). User-supplied path wins.
 if [ -n "${FALLOW_DIFF_FILE:-}" ] && [ -n "${GITHUB_ENV:-}" ]; then
-  echo "FALLOW_DIFF_FILE=${FALLOW_DIFF_FILE}" >> "$GITHUB_ENV"
+  printf '%s\n' "FALLOW_DIFF_FILE=${FALLOW_DIFF_FILE}" >> "$GITHUB_ENV"
 fi
 
 if [ -n "${INPUT_CHANGED_SINCE:-}" ] && [ -z "${FALLOW_DIFF_FILE:-}" ]; then
@@ -543,7 +573,7 @@ if [ -n "${INPUT_CHANGED_SINCE:-}" ] && [ -z "${FALLOW_DIFF_FILE:-}" ]; then
     # Propagate to the comment / review render steps (separate composite
     # steps see only $GITHUB_ENV, not exported shell variables).
     if [ -n "${GITHUB_ENV:-}" ]; then
-      echo "FALLOW_DIFF_FILE=${_DIFF_PATH}" >> "$GITHUB_ENV"
+      printf '%s\n' "FALLOW_DIFF_FILE=${_DIFF_PATH}" >> "$GITHUB_ENV"
     fi
   else
     rm -f "$_DIFF_PATH"
@@ -650,15 +680,17 @@ if ! [[ "$ISSUES" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
-echo "issues=${ISSUES}" >> "$GITHUB_OUTPUT"
-echo "results=${RESULTS_FILE}" >> "$GITHUB_OUTPUT"
-echo "command=${INPUT_COMMAND}" >> "$GITHUB_OUTPUT"
-echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
-echo "gate=${GATE}" >> "$GITHUB_OUTPUT"
-
-if [ -f "$SARIF_FILE" ]; then
-  echo "sarif=${SARIF_FILE}" >> "$GITHUB_OUTPUT"
-fi
+{
+  printf '%s\n' \
+    "issues=${ISSUES}" \
+    "results=${RESULTS_FILE}" \
+    "command=${INPUT_COMMAND}" \
+    "verdict=${VERDICT}" \
+    "gate=${GATE}"
+  if [ -f "$SARIF_FILE" ]; then
+    printf '%s\n' "sarif=${SARIF_FILE}"
+  fi
+} >> "$GITHUB_OUTPUT"
 
 if [ "$ISSUES" -gt 0 ]; then
   case "$INPUT_COMMAND" in

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -505,6 +505,7 @@ chmod +x "$ANALYZE_TMP/bin/fallow"
 
 cat > "$ANALYZE_TMP/bin/git" <<'SH'
 #!/usr/bin/env bash
+[ -n "${FAKE_GIT_LOG:-}" ] && printf '%s\n' "$*" >> "$FAKE_GIT_LOG"
 case "$1" in
   diff)
     shift
@@ -543,6 +544,95 @@ case "$1" in
 esac
 SH
 chmod +x "$ANALYZE_TMP/bin/git"
+
+run_analyze_input_case() {
+  local case_name=$1
+  local changed_since=$2
+  local diff_file=$3
+  local work="$ANALYZE_TMP/input-$case_name"
+  local output="$ANALYZE_TMP/input-output-$case_name"
+  local env_file="$ANALYZE_TMP/input-env-$case_name"
+  local git_log="$ANALYZE_TMP/input-git-$case_name"
+  mkdir -p "$work"
+  : > "$output"
+  : > "$env_file"
+  : > "$git_log"
+
+  (
+    cd "$work" || exit 1
+    PATH="$ANALYZE_TMP/bin:$PATH" \
+      FAKE_GIT_LOG="$git_log" \
+      GITHUB_OUTPUT="$output" \
+      GITHUB_ENV="$env_file" \
+      INPUT_ROOT="." \
+      INPUT_COMMAND="dead-code" \
+      INPUT_FORMAT="json" \
+      INPUT_AUTO_CHANGED_SINCE="false" \
+      INPUT_CHANGED_SINCE="$changed_since" \
+      FALLOW_DIFF_FILE="$diff_file" \
+      bash "$DIR/../scripts/analyze.sh"
+  ) 2>&1
+}
+
+OUT=$(run_analyze_input_case "option-like-ref" "-main" "")
+cmd_status=$?
+if [ "$cmd_status" -eq 2 ]; then
+  pass "analyze: rejects option-like changed-since"
+else
+  fail "analyze: rejects option-like changed-since" "expected exit 2, got $cmd_status"
+fi
+assert_contains "$OUT" "::error::changed-since must not begin with '-'" "analyze: option-like changed-since error is stable"
+if [ ! -s "$ANALYZE_TMP/input-git-option-like-ref" ]; then
+  pass "analyze: rejects option-like changed-since before Git"
+else
+  fail "analyze: rejects option-like changed-since before Git" "Git was invoked"
+fi
+if [ ! -s "$ANALYZE_TMP/input-output-option-like-ref" ] && [ ! -s "$ANALYZE_TMP/input-env-option-like-ref" ]; then
+  pass "analyze: rejects option-like changed-since before file-command writes"
+else
+  fail "analyze: rejects option-like changed-since before file-command writes" "output or env file was modified"
+fi
+
+OUT=$(run_analyze_input_case "control-ref" $'main\ninjected=value' "")
+cmd_status=$?
+if [ "$cmd_status" -eq 2 ]; then
+  pass "analyze: rejects control characters in changed-since"
+else
+  fail "analyze: rejects control characters in changed-since" "expected exit 2, got $cmd_status"
+fi
+assert_contains "$OUT" "::error::changed-since must not contain ASCII control characters" "analyze: changed-since control-character error is stable"
+if [ ! -s "$ANALYZE_TMP/input-output-control-ref" ] && [ ! -s "$ANALYZE_TMP/input-env-control-ref" ]; then
+  pass "analyze: rejects changed-since newline before file-command writes"
+else
+  fail "analyze: rejects changed-since newline before file-command writes" "output or env file was modified"
+fi
+
+OUT=$(run_analyze_input_case "control-diff" "" $'reports/diff\nINJECTED=value')
+cmd_status=$?
+if [ "$cmd_status" -eq 2 ]; then
+  pass "analyze: rejects control characters in diff-file"
+else
+  fail "analyze: rejects control characters in diff-file" "expected exit 2, got $cmd_status"
+fi
+assert_contains "$OUT" "::error::diff-file must not contain ASCII control characters" "analyze: diff-file control-character error is stable"
+if [ ! -s "$ANALYZE_TMP/input-output-control-diff" ] && [ ! -s "$ANALYZE_TMP/input-env-control-diff" ]; then
+  pass "analyze: rejects diff-file newline before file-command writes"
+else
+  fail "analyze: rejects diff-file newline before file-command writes" "output or env file was modified"
+fi
+
+VALID_DIFF="$ANALYZE_TMP/diff files/current change.patch"
+mkdir -p "$(dirname "$VALID_DIFF")"
+printf '%s\n' 'diff --git a/src/a.ts b/src/a.ts' > "$VALID_DIFF"
+OUT=$(run_analyze_input_case "valid-scalars" "refs/remotes/origin/main~1" "$VALID_DIFF")
+cmd_status=$?
+if [ "$cmd_status" -eq 0 ]; then
+  pass "analyze: preserves valid ref and spaced diff-file path"
+else
+  fail "analyze: preserves valid ref and spaced diff-file path" "exit $cmd_status, output: $OUT"
+fi
+assert_contains "$(cat "$ANALYZE_TMP/input-output-valid-scalars")" "changed_since=refs/remotes/origin/main~1" "analyze: preserves valid relative ref"
+assert_contains "$(cat "$ANALYZE_TMP/input-env-valid-scalars")" "FALLOW_DIFF_FILE=$VALID_DIFF" "analyze: preserves diff-file path containing spaces"
 
 run_analyze_scope_case() {
   local case_name=$1

--- a/crates/benchmarks/benches/component_engine.rs
+++ b/crates/benchmarks/benches/component_engine.rs
@@ -83,6 +83,11 @@ export function compute{index}(input: number): number {{
         }
     }
     write_file(&root, "src/index.ts", format!("{imports}\n{uses}\n"));
+    write_file(
+        &root,
+        "src/styles.css",
+        ":root { --color-accent: #06c; }\n.button { color: var(--color-accent); padding: 0.5rem 1rem; }\n",
+    );
 
     EngineFixture {
         _temp_dir: temp_dir,
@@ -155,6 +160,13 @@ fn warm_health_options(fixture: &WarmEngineFixture) -> HealthExecutionOptions<'_
         runtime_coverage: None,
         churn_file: None,
         group_by: None,
+    }
+}
+
+fn warm_css_health_options(fixture: &WarmEngineFixture) -> HealthExecutionOptions<'_> {
+    HealthExecutionOptions {
+        css: true,
+        ..warm_health_options(fixture)
     }
 }
 
@@ -244,6 +256,19 @@ fn component_engine_warm_session_health(c: &mut Criterion) {
     });
 }
 
+fn component_engine_warm_session_css_health(c: &mut Criterion) {
+    let fixture = create_warm_engine_fixture();
+    let options = warm_css_health_options(&fixture);
+    run_ungrouped_health_with_session(&options, None, &fixture.session, None)
+        .expect("CSS health warm-up succeeds");
+    c.bench_function("component_engine_warm_session_css_health", |bencher| {
+        bencher.iter(|| {
+            run_ungrouped_health_with_session(&options, None, &fixture.session, None)
+                .expect("warm CSS health analysis succeeds")
+        });
+    });
+}
+
 criterion_group!(
     benches,
     component_engine_session_load,
@@ -252,6 +277,7 @@ criterion_group!(
     component_engine_warm_session_dead_code_large,
     component_engine_warm_session_complexity_owned,
     component_engine_warm_session_complexity_shared,
-    component_engine_warm_session_health
+    component_engine_warm_session_health,
+    component_engine_warm_session_css_health
 );
 criterion_main!(benches);

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -151,9 +151,19 @@ fn node_modules_package_json(base: &Path, package_name: &str) -> PathBuf {
     path.join("package.json")
 }
 
+fn deepest_matching_workspace<'a>(
+    path: &Path,
+    workspaces: &'a [fallow_config::WorkspaceInfo],
+) -> Option<&'a Path> {
+    workspaces
+        .iter()
+        .filter(|workspace| path.starts_with(&workspace.root))
+        .max_by_key(|workspace| workspace.root.components().count())
+        .map(|workspace| workspace.root.as_path())
+}
+
 /// Reverse index: workspace root -> packages with ANY file under that root using
-/// them (prefix-match attribution, mirroring the original `packages_used_in_workspace`).
-/// Each module's matching workspace roots are pre-computed once in parallel so the
+/// them. Each module's deepest matching workspace root is pre-computed once in parallel so the
 /// package_usage walk costs O(packages * avg_files_per_package) instead of
 /// O(packages * files * workspaces).
 fn collect_workspace_used_packages<'a>(
@@ -161,16 +171,10 @@ fn collect_workspace_used_packages<'a>(
     workspaces: &'a [fallow_config::WorkspaceInfo],
 ) -> FxHashMap<&'a Path, FxHashSet<&'a str>> {
     use rayon::prelude::*;
-    let module_workspaces: Vec<Vec<&Path>> = graph
+    let module_workspaces: Vec<Option<&Path>> = graph
         .modules
         .par_iter()
-        .map(|module| {
-            workspaces
-                .iter()
-                .filter(|ws| module.path.starts_with(&ws.root))
-                .map(|ws| ws.root.as_path())
-                .collect()
-        })
+        .map(|module| deepest_matching_workspace(&module.path, workspaces))
         .collect();
     let mut by_ws: FxHashMap<&Path, FxHashSet<&str>> = workspaces
         .iter()
@@ -178,13 +182,11 @@ fn collect_workspace_used_packages<'a>(
         .collect();
     for (package_name, file_ids) in &graph.package_usage {
         for id in file_ids {
-            if let Some(ws_paths) = module_workspaces.get(id.0 as usize) {
-                for ws_path in ws_paths {
-                    by_ws
-                        .entry(*ws_path)
-                        .or_default()
-                        .insert(package_name.as_str());
-                }
+            if let Some(Some(ws_path)) = module_workspaces.get(id.0 as usize) {
+                by_ws
+                    .entry(*ws_path)
+                    .or_default()
+                    .insert(package_name.as_str());
             }
         }
     }
@@ -271,16 +273,13 @@ fn collect_package_workspace_usage(
             let Some(module) = graph.modules.get(id.0 as usize) else {
                 continue;
             };
-            let Some(ws) = workspaces
-                .iter()
-                .find(|workspace| module.path.starts_with(&workspace.root))
-            else {
+            let Some(ws_root) = deepest_matching_workspace(&module.path, workspaces) else {
                 continue;
             };
             usage
                 .entry(package_name.clone())
                 .or_default()
-                .push(ws.root.clone());
+                .push(ws_root.to_path_buf());
         }
     }
 

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -151,15 +151,23 @@ fn node_modules_package_json(base: &Path, package_name: &str) -> PathBuf {
     path.join("package.json")
 }
 
-fn deepest_matching_workspace<'a>(
-    path: &Path,
+fn deepest_matching_workspace<'a>(path: &Path, workspace_roots: &[&'a Path]) -> Option<&'a Path> {
+    workspace_roots
+        .iter()
+        .copied()
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+}
+
+fn dependency_owning_workspace_roots<'a>(
     workspaces: &'a [fallow_config::WorkspaceInfo],
-) -> Option<&'a Path> {
+    config: &ResolvedConfig,
+) -> Vec<&'a Path> {
     workspaces
         .iter()
-        .filter(|workspace| path.starts_with(&workspace.root))
-        .max_by_key(|workspace| workspace.root.components().count())
+        .filter(|workspace| read_workspace_package(workspace, config).is_some())
         .map(|workspace| workspace.root.as_path())
+        .collect()
 }
 
 /// Reverse index: workspace root -> packages with ANY file under that root using
@@ -168,17 +176,17 @@ fn deepest_matching_workspace<'a>(
 /// O(packages * files * workspaces).
 fn collect_workspace_used_packages<'a>(
     graph: &'a ModuleGraph,
-    workspaces: &'a [fallow_config::WorkspaceInfo],
+    workspace_roots: &[&'a Path],
 ) -> FxHashMap<&'a Path, FxHashSet<&'a str>> {
     use rayon::prelude::*;
     let module_workspaces: Vec<Option<&Path>> = graph
         .modules
         .par_iter()
-        .map(|module| deepest_matching_workspace(&module.path, workspaces))
+        .map(|module| deepest_matching_workspace(&module.path, workspace_roots))
         .collect();
-    let mut by_ws: FxHashMap<&Path, FxHashSet<&str>> = workspaces
+    let mut by_ws: FxHashMap<&Path, FxHashSet<&str>> = workspace_roots
         .iter()
-        .map(|ws| (ws.root.as_path(), FxHashSet::default()))
+        .map(|root| (*root, FxHashSet::default()))
         .collect();
     for (package_name, file_ids) in &graph.package_usage {
         for id in file_ids {
@@ -264,7 +272,7 @@ pub fn collect_unused_for_category(input: UnusedCategoryInput<'_>) -> Vec<Unused
 /// Build a reverse index from package name to workspace roots that import it.
 fn collect_package_workspace_usage(
     graph: &ModuleGraph,
-    workspaces: &[fallow_config::WorkspaceInfo],
+    workspace_roots: &[&Path],
 ) -> FxHashMap<String, Vec<PathBuf>> {
     let mut usage: FxHashMap<String, Vec<PathBuf>> = FxHashMap::default();
 
@@ -273,7 +281,7 @@ fn collect_package_workspace_usage(
             let Some(module) = graph.modules.get(id.0 as usize) else {
                 continue;
             };
-            let Some(ws_root) = deepest_matching_workspace(&module.path, workspaces) else {
+            let Some(ws_root) = deepest_matching_workspace(&module.path, workspace_roots) else {
                 continue;
             };
             usage
@@ -520,9 +528,10 @@ fn collect_dependency_usage_indices<'a>(
     let used_packages: FxHashSet<&str> = graph.package_usage.keys().map(String::as_str).collect();
     let root_peer_used = PeerDependencyResolver::new()
         .peer_dependency_closure(&config.root, used_packages.iter().copied());
+    let workspace_roots = dependency_owning_workspace_roots(workspaces, config);
     DependencyUsageIndices {
-        package_workspace_usage: collect_package_workspace_usage(graph, workspaces),
-        workspace_used_packages: collect_workspace_used_packages(graph, workspaces),
+        package_workspace_usage: collect_package_workspace_usage(graph, &workspace_roots),
+        workspace_used_packages: collect_workspace_used_packages(graph, &workspace_roots),
         used_packages,
         root_peer_used,
     }

--- a/crates/core/tests/integration_test/dependencies.rs
+++ b/crates/core/tests/integration_test/dependencies.rs
@@ -490,6 +490,67 @@ fn nested_workspace_dependency_usage_belongs_to_deepest_workspace() {
 }
 
 #[test]
+fn package_less_tsconfig_reference_credits_nearest_package_workspace() {
+    let project = tempfile::tempdir().expect("create temp dir");
+    let root = project.path();
+    let parent = root.join("packages/parent");
+    let referenced = parent.join("referenced");
+    std::fs::create_dir_all(referenced.join("src")).expect("create referenced source dir");
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "package-less-tsconfig-reference",
+  "private": true,
+  "workspaces": ["packages/*"]
+}"#,
+    )
+    .expect("write root package.json");
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{
+  "files": [],
+  "references": [{"path": "./packages/parent/referenced"}]
+}"#,
+    )
+    .expect("write root tsconfig.json");
+    std::fs::write(
+        parent.join("package.json"),
+        r#"{
+  "name": "parent",
+  "version": "1.0.0",
+  "dependencies": {
+    "shared-lib": "1.0.0"
+  }
+}"#,
+    )
+    .expect("write parent package.json");
+    std::fs::write(
+        referenced.join("tsconfig.json"),
+        r#"{"compilerOptions":{"composite":true},"include":["src"]}"#,
+    )
+    .expect("write referenced tsconfig.json");
+    std::fs::write(
+        referenced.join("src/index.ts"),
+        "import { value } from \"shared-lib\";\nexport const referenced = value;\n",
+    )
+    .expect("write referenced source");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results
+            .unused_dependencies
+            .iter()
+            .all(|dep| dep.dep.path != parent.join("package.json")
+                || dep.dep.package_name != "shared-lib"),
+        "a package-less project reference must credit dependency usage to its nearest package-owning workspace: {:?}",
+        results.unused_dependencies
+    );
+}
+
+#[test]
 fn peer_dependency_of_used_installed_package_is_not_unused() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let root = tmp.path();

--- a/crates/core/tests/integration_test/dependencies.rs
+++ b/crates/core/tests/integration_test/dependencies.rs
@@ -456,6 +456,40 @@ fn unused_workspace_dependency_reports_other_workspace_usage() {
 }
 
 #[test]
+fn nested_workspace_dependency_usage_belongs_to_deepest_workspace() {
+    let root = fixture_path("nested-workspace-dependency-ownership");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let parent_path = root.join("packages/parent/package.json");
+    let child_path = root.join("packages/parent/packages/child/package.json");
+    let shared_lib_findings: Vec<_> = results
+        .unused_dependencies
+        .iter()
+        .filter(|dep| dep.dep.package_name == "shared-lib")
+        .collect();
+
+    assert_eq!(
+        shared_lib_findings.len(),
+        1,
+        "only the parent declaration should be unused: {shared_lib_findings:?}"
+    );
+    assert_eq!(shared_lib_findings[0].dep.path, parent_path);
+    assert_eq!(
+        shared_lib_findings[0].dep.used_in_workspaces,
+        vec![root.join("packages/parent/packages/child")],
+        "the parent finding should identify the nested child as the owner of usage"
+    );
+    assert!(
+        results
+            .unused_dependencies
+            .iter()
+            .all(|dep| dep.dep.path != child_path || dep.dep.package_name != "shared-lib"),
+        "the nested child declaration should be credited for its import"
+    );
+}
+
+#[test]
 fn peer_dependency_of_used_installed_package_is_not_unused() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let root = tmp.path();

--- a/crates/engine/src/health/execute.rs
+++ b/crates/engine/src/health/execute.rs
@@ -151,7 +151,7 @@ where
         elapsed: start.elapsed(),
         should_fail_on_coverage_gaps: enforce_coverage_gaps,
         dead_code_results: dead_code_results.as_ref(),
-        styling_artifacts: styling_artifacts.as_ref(),
+        styling_artifacts: styling_artifacts.as_deref(),
         workspace_diagnostics,
     }))
 }

--- a/crates/engine/src/health/pipeline.rs
+++ b/crates/engine/src/health/pipeline.rs
@@ -4,7 +4,7 @@ use fallow_config::{ResolvedConfig, WorkspaceInfo};
 use fallow_output::DiffIndex;
 use fallow_types::workspace::WorkspaceDiagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::{
     duplicates::DuplicationReport,
@@ -27,7 +27,7 @@ pub struct HealthPipelineInputs {
     pub shared_parse: bool,
     pub pre_computed_analysis: Option<DeadCodeAnalysisArtifacts>,
     pub dead_code_results: Option<AnalysisResults>,
-    pub styling_artifacts: Option<StylingAnalysisArtifacts>,
+    pub styling_artifacts: Option<Arc<StylingAnalysisArtifacts>>,
     pub pre_computed_duplication: Option<DuplicationReport>,
     pub workspaces: Vec<WorkspaceInfo>,
     pub workspace_diagnostics: Vec<WorkspaceDiagnostic>,
@@ -44,7 +44,7 @@ pub(super) struct HealthPipelineRunInputs<M> {
     pub(super) shared_parse: bool,
     pub(super) pre_computed_analysis: Option<DeadCodeAnalysisArtifacts>,
     pub(super) dead_code_results: Option<AnalysisResults>,
-    pub(super) styling_artifacts: Option<StylingAnalysisArtifacts>,
+    pub(super) styling_artifacts: Option<Arc<StylingAnalysisArtifacts>>,
     pub(super) pre_computed_duplication: Option<DuplicationReport>,
     pub(super) workspaces: Vec<WorkspaceInfo>,
     pub(super) workspace_diagnostics: Vec<WorkspaceDiagnostic>,

--- a/crates/engine/src/health/runner.rs
+++ b/crates/engine/src/health/runner.rs
@@ -1,7 +1,7 @@
 //! Engine-owned health runners for non-CLI callers.
 
-use std::path::PathBuf;
 use std::time::Instant;
+use std::{path::PathBuf, sync::Arc};
 
 use fallow_config::ProductionAnalysis;
 use fallow_types::output_format::OutputFormat;
@@ -166,7 +166,7 @@ struct HealthRunPartsInput<'a, M> {
     shared_parse: bool,
     pre_computed_analysis: Option<DeadCodeAnalysisArtifacts>,
     pre_computed_duplication: Option<DuplicationReport>,
-    styling_artifacts: Option<super::StylingAnalysisArtifacts>,
+    styling_artifacts: Option<Arc<super::StylingAnalysisArtifacts>>,
 }
 
 fn run_ungrouped_health_from_parts<M: AsRef<[fallow_types::extract::ModuleInfo]>>(

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -282,7 +282,7 @@ impl AnalysisSession {
         if let Ok(cache) = self.styling_cache.lock()
             && let Some(artifacts) = cache.as_ref()
         {
-            return artifacts.clone();
+            return Arc::clone(artifacts);
         }
 
         let artifacts = Arc::new(crate::health::build_styling_analysis_artifacts(
@@ -290,7 +290,7 @@ impl AnalysisSession {
             self.config(),
         ));
         if let Ok(mut cache) = self.styling_cache.lock() {
-            *cache = Some(artifacts.clone());
+            *cache = Some(Arc::clone(&artifacts));
         }
         artifacts
     }

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -36,7 +36,7 @@ pub struct AnalysisSession {
     workspaces: Vec<WorkspaceInfo>,
     workspace_diagnostics: Vec<WorkspaceDiagnostic>,
     parsed_cache: Mutex<Option<ParsedModuleCache>>,
-    styling_cache: Mutex<Option<crate::health::StylingAnalysisArtifacts>>,
+    styling_cache: Mutex<Option<Arc<crate::health::StylingAnalysisArtifacts>>>,
 }
 
 #[derive(Debug)]
@@ -276,15 +276,19 @@ impl AnalysisSession {
         )
     }
 
-    pub(crate) fn styling_analysis_artifacts(&self) -> crate::health::StylingAnalysisArtifacts {
+    pub(crate) fn styling_analysis_artifacts(
+        &self,
+    ) -> Arc<crate::health::StylingAnalysisArtifacts> {
         if let Ok(cache) = self.styling_cache.lock()
             && let Some(artifacts) = cache.as_ref()
         {
             return artifacts.clone();
         }
 
-        let artifacts =
-            crate::health::build_styling_analysis_artifacts(self.files(), self.config());
+        let artifacts = Arc::new(crate::health::build_styling_analysis_artifacts(
+            self.files(),
+            self.config(),
+        ));
         if let Ok(mut cache) = self.styling_cache.lock() {
             *cache = Some(artifacts.clone());
         }
@@ -1036,6 +1040,23 @@ mod tests {
         assert!(
             Arc::ptr_eq(&first.modules, &second.modules),
             "warm session queries must share parsed module storage"
+        );
+    }
+
+    #[test]
+    fn warm_styling_cache_reuses_artifact_allocation() {
+        let project = tempfile::tempdir().expect("project");
+        let root = project.path();
+        std::fs::write(root.join("styles.css"), ".button { color: red; }\n")
+            .expect("write stylesheet");
+        let session = AnalysisSession::load_default(root);
+
+        let first = session.styling_analysis_artifacts();
+        let second = session.styling_analysis_artifacts();
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "warm styling queries must share the cached artifact allocation"
         );
     }
 

--- a/docs/backwards-compatibility.md
+++ b/docs/backwards-compatibility.md
@@ -69,7 +69,7 @@ The schema-derive ladder ([#384](https://github.com/fallow-rs/fallow/issues/384)
 
 `json-schema-to-typescript` drops the orphan inner definitions when every field is subsumed by a flattening parent (even with `unreachableDefinitions: true`), so the bare names disappear from the generated `.d.ts` unless they are aliased back explicitly. The npm-published `fallow/types` subpath (`npm/fallow/types/output-contract.d.ts`) carries an alias for every wrapper so external consumers importing the bare names continue to compile. The full list lives at the end of the generated file under the `// Backwards-compat aliases` section, with per-alias JSDoc explaining the migration history.
 
-**Stability commitment**: the bare-name aliases are part of fallow's v2.x stable surface. They are scheduled for removal alongside the kind-tagged `FallowOutput` major bump ([#413](https://github.com/fallow-rs/fallow/issues/413)). The removal will be preceded by one minor release that adds `@deprecated` JSDoc to each alias and a CHANGELOG headline announcing the timeline. New code that consumes fallow's JSON output should import the `*Finding` wrapper names directly so the major bump is a no-op for the consumer.
+**Stability commitment**: legacy output aliases remain supported throughout v3. Removing them requires an explicit deprecation period and a future major release. New code that consumes fallow's JSON output should import the `*Finding` wrapper names directly.
 
 ### Rust programmatic API
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,7 +14,7 @@ discover these without parsing this page.
 
 | Variable | Description | Default | Example |
 | --- | --- | --- | --- |
-| `FALLOW_FORMAT` | Default output format (`json`, `human`, `sarif`, `compact`, `markdown`, `codeclimate`, `gitlab-codequality`, `pr-comment-github`, `pr-comment-gitlab`, `review-github`, `review-gitlab`, `badge`). The `--format` flag overrides it. | `human` | `FALLOW_FORMAT=json` |
+| `FALLOW_FORMAT` | Default output format (`json`, `human`, `sarif`, `compact`, `markdown`, `codeclimate`, `gitlab-codequality`, `pr-comment-github`, `pr-comment-gitlab`, `review-github`, `review-gitlab`, `badge`, `github-annotations`, `github-summary`). The `--format` flag overrides it. | `human` | `FALLOW_FORMAT=json` |
 | `FALLOW_QUIET` | Set to `1` or `true` to suppress progress output. The `--quiet` flag overrides it. | unset (off) | `FALLOW_QUIET=1` |
 | `FALLOW_SUGGESTIONS` | Set to `off`/`0`/`false`/`no`/`disabled` to suppress the `next_steps[]` array in JSON output and the human `Next:` line. Useful for CI consumers that snapshot-diff raw `--format json`. | `on` | `FALLOW_SUGGESTIONS=off` |
 | `FALLOW_UPDATE_CHECK` | Set to `off`/`0`/`false`/`disabled`/`no` to disable the human-TTY upgrade nudge and its background version check. | unset (on) | `FALLOW_UPDATE_CHECK=off` |

--- a/docs/superpowers/specs/2026-07-15-improve-audit-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-15-improve-audit-hardening-design.md
@@ -1,0 +1,64 @@
+# Improve Audit Hardening Design
+
+## Scope
+
+This change resolves the nine confirmed improve-audit findings that do not involve `fallow fix`. It covers analyzer correctness, cached CSS analysis allocation, GitHub Action trust boundaries and current-binary coverage, VS Code real-process coverage, repository toolchain reproducibility, compatibility wording, and output-format documentation.
+
+The `fallow fix` promotion race and optional product directions are not part of this change.
+
+## Architecture
+
+The implementation keeps each concern in its existing ownership boundary:
+
+- Core analyzer code owns nested-workspace dependency attribution.
+- The engine session owns sharing of immutable styling artifacts.
+- Action shell code owns validation of Action inputs before Git or GitHub file-command use.
+- Repository CI owns locked validators and current-binary integration gates.
+- The VS Code extension owns its real-process contract smoke.
+- Source docs and generators jointly own compatibility and environment-variable contracts.
+
+The findings share one branch and PR, but each behavior change remains independently testable and reviewable.
+
+## Analyzer correctness
+
+Both dependency usage indexes will select the deepest workspace root that contains a module. One shared helper will define that ownership rule so the direct unused-dependency check and `used_in_workspaces` metadata cannot diverge again.
+
+A recursive-workspace fixture will declare the same dependency in an ancestor and nested package while importing it only from the nested package. The expected result is that the ancestor declaration remains unused and the nested declaration is credited.
+
+## Styling artifact cache
+
+`AnalysisSession` will cache immutable styling artifacts as `Arc<StylingAnalysisArtifacts>`. Warm consumers receive clones of the `Arc`, not deep clones of the artifact graph. Report-local mutable state remains independently cloned where mutation is required.
+
+An identity test will pin allocation sharing. A CSS-enabled warm-session benchmark and real-project output comparison will prevent an allocation optimization from silently changing behavior.
+
+## Action trust boundary
+
+The Action will treat `changed-since` and `diff-file` as validated scalar inputs before they reach Git or GitHub file-command files. Revisions beginning with `-` are invalid because Git can interpret them as options. ASCII control characters are invalid because line-oriented GitHub files cannot safely encode them as scalar values.
+
+Validation errors use a stable Action error annotation and exit code 2. Quoted valid refs and paths containing spaces remain supported.
+
+## Reproducible CI and current-binary coverage
+
+Intent validation will use the root lockfile and a local no-install invocation. A policy test will reject versioned network `npx` validation.
+
+The published-package Action workflow remains as a compatibility gate. A separate bounded CI lane will build the current Rust binary, run the Action shell suite with explicit `FALLOW_BIN`, and exercise one checked-in composite Action JSON path.
+
+## VS Code contract coverage
+
+Fast tests using fake CLI and LSP processes remain for deterministic extension behavior. A separate real-process smoke will launch the current `fallow` binary for both CLI output and LSP diagnostics, proving the extension and Rust contracts agree. CI path filters will include the Rust crates that own these protocols.
+
+## Compatibility and tooling contracts
+
+Legacy output aliases remain supported throughout v3. Removing them requires an explicit deprecation period and a future major release. The hand-written policy, generator text, and generated declaration files will use the same wording.
+
+Root repository tooling requires Node `>=22.12.0`, matching its locked development tools. This does not change the published CLI package's runtime floor.
+
+The `FALLOW_FORMAT` documentation will include `github-annotations` and `github-summary`. A drift assertion will tie the documented list to the accepted format catalog.
+
+## Error handling
+
+No analyzer or output schema error contract changes. Action validation fails before side effects and uses the existing runtime-error exit convention. CI and editor smoke failures remain ordinary test failures with focused diagnostic output.
+
+## Verification
+
+Every behavior change begins with a failing regression test. Verification then expands through focused crate and integration tests, Action and editor real-process smoke, generated-contract checks, a real recursive-workspace comparison, a real CSS-heavy project comparison, full repository verification, and area-specific review.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -867,6 +867,7 @@
     "test": "pnpm run test:unit && pnpm run test:integration",
     "test:unit": "vitest run",
     "test:integration": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/runTest.js",
+    "test:integration:real": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/real/runTest.js",
     "prepackage": "pnpm run codegen:contracts && cp ../../LICENSE ./LICENSE",
     "package": "vsce package --no-dependencies",
     "publish": "vsce publish --no-dependencies",

--- a/editors/vscode/scripts/codegen-contracts.mjs
+++ b/editors/vscode/scripts/codegen-contracts.mjs
@@ -388,12 +388,10 @@ const BACKWARDS_COMPAT_ALIASES_HEADER = `
 // import the bare names from \`fallow/types\` would break at upgrade time
 // otherwise.
 //
-// Stability commitment: these aliases ship as part of fallow's v2.x stable
-// surface. They are scheduled for removal alongside the kind-tagged
-// \`FallowOutput\` major bump (see https://github.com/fallow-rs/fallow/issues/413),
-// with a one-minor-cycle deprecation window (\`@deprecated\` JSDoc +
-// CHANGELOG headline) preceding the removal. New code should prefer the
-// \`*Finding\` wrapper names. Full public-consumer policy:
+// Stability commitment: legacy output aliases remain supported throughout v3.
+// Removing them requires an explicit deprecation period and a future major
+// release. New code should prefer the \`*Finding\` wrapper names. Full
+// public-consumer policy:
 // https://github.com/fallow-rs/fallow/blob/main/docs/backwards-compatibility.md
 //
 `;

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -10466,12 +10466,10 @@ export type RefactoringTarget = Omit<RefactoringTargetFinding, "actions">;
 // import the bare names from `fallow/types` would break at upgrade time
 // otherwise.
 //
-// Stability commitment: these aliases ship as part of fallow's v2.x stable
-// surface. They are scheduled for removal alongside the kind-tagged
-// `FallowOutput` major bump (see https://github.com/fallow-rs/fallow/issues/413),
-// with a one-minor-cycle deprecation window (`@deprecated` JSDoc +
-// CHANGELOG headline) preceding the removal. New code should prefer the
-// `*Finding` wrapper names. Full public-consumer policy:
+// Stability commitment: legacy output aliases remain supported throughout v3.
+// Removing them requires an explicit deprecation period and a future major
+// release. New code should prefer the `*Finding` wrapper names. Full
+// public-consumer policy:
 // https://github.com/fallow-rs/fallow/blob/main/docs/backwards-compatibility.md
 //
 

--- a/editors/vscode/src/types.ts
+++ b/editors/vscode/src/types.ts
@@ -17,7 +17,8 @@
 // per-alias rationale live in the generated `output-contract.d.ts` under the
 // `// Backwards-compat aliases` section. They are sourced from the same
 // `export type { ... }` block below so the published `fallow/types` subpath
-// carries the v2.x stable surface. Public-consumer policy:
+// Legacy output aliases remain supported throughout v3. Removing them requires
+// an explicit deprecation period and a future major release. Policy:
 // `docs/backwards-compatibility.md`.
 export type {
   AddToConfigAction,

--- a/editors/vscode/test/integration/fixtures/real-workspace/package.json
+++ b/editors/vscode/test/integration/fixtures/real-workspace/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fallow-vscode-real-process-smoke",
+  "private": true,
+  "version": "1.0.0",
+  "main": "src/index.ts"
+}

--- a/editors/vscode/test/integration/fixtures/real-workspace/src/index.ts
+++ b/editors/vscode/test/integration/fixtures/real-workspace/src/index.ts
@@ -1,0 +1,1 @@
+export const fixtureEntry = "entry";

--- a/editors/vscode/test/integration/fixtures/real-workspace/src/orphan.ts
+++ b/editors/vscode/test/integration/fixtures/real-workspace/src/orphan.ts
@@ -1,0 +1,1 @@
+export const orphan = true;

--- a/editors/vscode/test/integration/real/runTest.ts
+++ b/editors/vscode/test/integration/real/runTest.ts
@@ -1,0 +1,87 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runTests } from "@vscode/test-electron";
+
+const extensionDevelopmentPath = path.resolve(__dirname, "../../../..");
+const extensionTestsPath = path.resolve(__dirname, "suite/index.js");
+const vscodeTestCachePath = path.join(os.tmpdir(), "fallow-vscode-test-cache");
+const fixtureWorkspacePath = path.resolve(
+  extensionDevelopmentPath,
+  "test/integration/fixtures/real-workspace",
+);
+
+const requiredCurrentBinary = (): string => {
+  const configured = process.env["FALLOW_BIN"];
+  if (!configured) {
+    throw new Error(
+      "FALLOW_BIN is required for the real VS Code CLI/LSP contract smoke",
+    );
+  }
+
+  const binary = path.resolve(configured);
+  fs.accessSync(binary, fs.constants.X_OK);
+  return binary;
+};
+
+const writeExecutable = (filePath: string, contents: string): void => {
+  fs.writeFileSync(filePath, contents, "utf8");
+  fs.chmodSync(filePath, 0o755);
+};
+
+const createWorkspace = (binary: string): string => {
+  const workspaceDir = fs.mkdtempSync(
+    path.join(fs.realpathSync(os.tmpdir()), "fallow-vscode-real-"),
+  );
+  const vscodeDir = path.join(workspaceDir, ".vscode");
+  const binDir = path.join(workspaceDir, "bin");
+  const cliPath = path.join(binDir, "fallow");
+  const lspPath = path.join(binDir, "fallow-lsp");
+
+  fs.cpSync(fixtureWorkspacePath, workspaceDir, { recursive: true });
+  fs.mkdirSync(vscodeDir, { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.symlinkSync(binary, cliPath);
+  writeExecutable(lspPath, '#!/bin/sh\nexec "$FALLOW_BIN" lsp-server\n');
+  fs.writeFileSync(
+    path.join(vscodeDir, "settings.json"),
+    `${JSON.stringify(
+      {
+        "fallow.autoDownload": false,
+        "fallow.lspPath": lspPath,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  return workspaceDir;
+};
+
+const main = async (): Promise<void> => {
+  const binary = requiredCurrentBinary();
+  const workspaceDir = createWorkspace(binary);
+  const extensionsDir = path.join(workspaceDir, ".vscode-test", "extensions");
+  const userDataDir = path.join(workspaceDir, ".vscode-test", "user-data");
+
+  try {
+    await runTests({
+      cachePath: vscodeTestCachePath,
+      extensionDevelopmentPath,
+      extensionTestsEnv: { FALLOW_BIN: binary },
+      extensionTestsPath,
+      launchArgs: [
+        workspaceDir,
+        "--disable-extensions",
+        `--extensions-dir=${extensionsDir}`,
+        `--user-data-dir=${userDataDir}`,
+      ],
+      version: "1.96.0",
+    });
+  } finally {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+};
+
+void main();

--- a/editors/vscode/test/integration/real/suite/extension.test.ts
+++ b/editors/vscode/test/integration/real/suite/extension.test.ts
@@ -1,0 +1,81 @@
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+// VS Code injects this module into the extension host at runtime.
+// fallow-ignore-next-line unlisted-dependency
+import * as vscode from "vscode";
+import type { FallowCheckResult, FallowDupesResult } from "../../../../src/types.js";
+
+interface ExtensionApi {
+  readonly runAnalysis: (context: vscode.ExtensionContext) => Promise<{
+    check: FallowCheckResult | null;
+    dupes: FallowDupesResult | null;
+  }>;
+}
+
+const workspaceFolder = (): vscode.WorkspaceFolder => {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(folder, "workspace folder should exist");
+  return folder;
+};
+
+const inMemoryMemento = (): vscode.Memento => {
+  const store = new Map<string, unknown>();
+  return {
+    keys: () => [...store.keys()],
+    get: <T>(key: string, defaultValue?: T): T | undefined =>
+      store.has(key) ? (store.get(key) as T) : defaultValue,
+    update: (key: string, value: unknown): Thenable<void> => {
+      if (value === undefined) {
+        store.delete(key);
+      } else {
+        store.set(key, value);
+      }
+      return Promise.resolve();
+    },
+  };
+};
+
+const testContext = (): vscode.ExtensionContext =>
+  ({
+    globalStorageUri: vscode.Uri.file(path.join(workspaceFolder().uri.fsPath, ".global-storage")),
+    workspaceState: inMemoryMemento(),
+  }) as vscode.ExtensionContext;
+
+const fallowDiagnostics = async (
+  uri: vscode.Uri,
+): Promise<readonly vscode.Diagnostic[]> => {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const diagnostics = vscode.languages
+      .getDiagnostics(uri)
+      .filter((diagnostic) => diagnostic.source === "fallow");
+    if (diagnostics.length > 0) {
+      return diagnostics;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return [];
+};
+
+describe("Fallow VS Code real-process contracts", () => {
+  it("parses the current CLI envelope and receives current LSP diagnostics", async () => {
+    const extension = vscode.extensions.getExtension("fallow-rs.fallow-vscode");
+    assert.ok(extension, "extension should be discoverable");
+    const api = (await extension.activate()) as ExtensionApi;
+
+    const result = await api.runAnalysis(testContext());
+    assert.ok(result.check, "current CLI check envelope should parse");
+    assert.ok(result.dupes, "current CLI duplication envelope should parse");
+    assert.ok(
+      result.check.unused_files.some((finding) => finding.path === "src/orphan.ts"),
+      "current CLI should report the real fixture's unused file",
+    );
+
+    const orphanUri = vscode.Uri.joinPath(workspaceFolder().uri, "src", "orphan.ts");
+    const document = await vscode.workspace.openTextDocument(orphanUri);
+    await vscode.window.showTextDocument(document);
+    const diagnostics = await fallowDiagnostics(orphanUri);
+
+    assert.ok(diagnostics.length > 0, "current LSP should publish a diagnostic for orphan.ts");
+  });
+});

--- a/editors/vscode/test/integration/real/suite/index.ts
+++ b/editors/vscode/test/integration/real/suite/index.ts
@@ -1,0 +1,17 @@
+import * as path from "node:path";
+import Mocha from "mocha";
+
+export const run = (): Promise<void> => {
+  const mocha = new Mocha({ color: true, timeout: 60_000, ui: "bdd" });
+  mocha.addFile(path.resolve(__dirname, "extension.test.js"));
+
+  return new Promise((resolve, reject) => {
+    mocha.run((failures) => {
+      if (failures > 0) {
+        reject(new Error(`${failures} real-process integration test(s) failed`));
+        return;
+      }
+      resolve();
+    });
+  });
+};

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -10466,12 +10466,10 @@ export type RefactoringTarget = Omit<RefactoringTargetFinding, "actions">;
 // import the bare names from `fallow/types` would break at upgrade time
 // otherwise.
 //
-// Stability commitment: these aliases ship as part of fallow's v2.x stable
-// surface. They are scheduled for removal alongside the kind-tagged
-// `FallowOutput` major bump (see https://github.com/fallow-rs/fallow/issues/413),
-// with a one-minor-cycle deprecation window (`@deprecated` JSDoc +
-// CHANGELOG headline) preceding the removal. New code should prefer the
-// `*Finding` wrapper names. Full public-consumer policy:
+// Stability commitment: legacy output aliases remain supported throughout v3.
+// Removing them requires an explicit deprecation period and a future major
+// release. New code should prefer the `*Finding` wrapper names. Full
+// public-consumer policy:
 // https://github.com/fallow-rs/fallow/blob/main/docs/backwards-compatibility.md
 //
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "devDependencies": {
         "@commitlint/cli": "21.2.0",
         "@commitlint/config-conventional": "21.2.0",
+        "@tanstack/intent": "0.3.5",
         "oxfmt": "0.58.0",
         "oxlint": "1.73.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -986,6 +990,23 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@tanstack/intent": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/intent/-/intent-0.3.5.tgz",
+      "integrity": "sha512-OVeyLejsN+LYGVNCJNhcCOlFkpqdkWG/ZB6mDDVOzfoLYDn/9uKaCmZkV6GsIkF0aKY7uu05RTJNibZ+uaZ1ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "jsonc-parser": "^3.3.1",
+        "semver": "^7.8.4",
+        "std-env": "^4.1.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "intent": "dist/cli.mjs"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
@@ -1046,6 +1067,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1472,6 +1503,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -1665,6 +1703,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -1768,6 +1813,22 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
     "fmt:js": "oxfmt --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src scripts commitlint.config.mjs",
     "fmt:js:check": "oxfmt --check --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src scripts commitlint.config.mjs"
   },
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@commitlint/config-conventional": "21.2.0",
+    "@tanstack/intent": "0.3.5",
     "oxfmt": "0.58.0",
     "oxlint": "1.73.0"
   }

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -34,6 +34,16 @@ test("published Node packages and Action smoke tests use Node 22", () => {
   assert.deepEqual([...new Set(versions)], ["22"]);
 });
 
+test("root repository tooling declares its exact Node floor", () => {
+  const rootPackage = readJson("package.json");
+  const rootLock = readJson("package-lock.json");
+  const contributing = readFileSync("CONTRIBUTING.md", "utf8");
+
+  assert.equal(rootPackage.engines.node, ">=22.12.0");
+  assert.equal(rootLock.packages[""].engines.node, ">=22.12.0");
+  assert.match(contributing, /Repository tooling requires Node\.js 22\.12\.0 or later\./);
+});
+
 test("CONTRIBUTING uses the root contract generation commands", () => {
   const contributing = readFileSync("CONTRIBUTING.md", "utf8");
 
@@ -51,4 +61,21 @@ test("plugin authoring guide documents every top-level schema field", () => {
   const schemaFields = Object.keys(schema.properties).toSorted();
 
   assert.deepEqual(documented, schemaFields);
+});
+
+test("FALLOW_FORMAT docs include every GitHub-native format", () => {
+  const formatSource = readFileSync("crates/cli/src/cli_format.rs", "utf8");
+  const githubFormats = [
+    ...formatSource.matchAll(/#\[value\(name = "(github-[^"]+)"\)\]/g),
+  ].map((match) => match[1]);
+  assert.ok(githubFormats.length > 0, "Rust format catalog must include GitHub-native formats");
+
+  const docs = readFileSync("docs/environment-variables.md", "utf8");
+  const row = docs.match(/^\| `FALLOW_FORMAT` \| ([^|]+)\|/m);
+  assert.ok(row, "environment variable docs must contain a FALLOW_FORMAT row");
+  const documentedFormats = [...row[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+
+  for (const format of githubFormats) {
+    assert.ok(documentedFormats.includes(format), `FALLOW_FORMAT docs are missing ${format}`);
+  }
 });

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -65,17 +65,17 @@ test("plugin authoring guide documents every top-level schema field", () => {
 
 test("FALLOW_FORMAT docs include every GitHub-native format", () => {
   const formatSource = readFileSync("crates/cli/src/cli_format.rs", "utf8");
-  const githubFormats = [
-    ...formatSource.matchAll(/#\[value\(name = "(github-[^"]+)"\)\]/g),
-  ].map((match) => match[1]);
+  const githubFormats = [...formatSource.matchAll(/#\[value\(name = "(github-[^"]+)"\)\]/g)].map(
+    (match) => match[1],
+  );
   assert.ok(githubFormats.length > 0, "Rust format catalog must include GitHub-native formats");
 
   const docs = readFileSync("docs/environment-variables.md", "utf8");
   const row = docs.match(/^\| `FALLOW_FORMAT` \| ([^|]+)\|/m);
   assert.ok(row, "environment variable docs must contain a FALLOW_FORMAT row");
-  const documentedFormats = [...row[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+  const documentedFormats = new Set([...row[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]));
 
   for (const format of githubFormats) {
-    assert.ok(documentedFormats.includes(format), `FALLOW_FORMAT docs are missing ${format}`);
+    assert.ok(documentedFormats.has(format), `FALLOW_FORMAT docs are missing ${format}`);
   }
 });

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -42,6 +42,68 @@ test("workflow block parser rejects missing keys", () => {
   assert.throws(() => indentedBlock("root:\n  value: true", "missing", 0), /missing missing block/);
 });
 
+test("bundled skill validation uses the root lockfile without network fallback", () => {
+  const workflow = readWorkflow(".github/workflows/ci.yml");
+  const npmPackageJob = indentedBlock(workflow, "npm-package", 2);
+  const rootPackage = JSON.parse(readFileSync("package.json", "utf8"));
+  const nestedPackage = JSON.parse(readFileSync("npm/fallow/package.json", "utf8"));
+  const lockfile = JSON.parse(readFileSync("package-lock.json", "utf8"));
+
+  assert.equal(rootPackage.devDependencies["@tanstack/intent"], "0.3.5");
+  assert.equal(
+    nestedPackage.devDependencies?.["@tanstack/intent"],
+    rootPackage.devDependencies["@tanstack/intent"],
+  );
+  assert.equal(lockfile.packages[""].devDependencies["@tanstack/intent"], "0.3.5");
+  assert.equal(lockfile.packages["node_modules/@tanstack/intent"].version, "0.3.5");
+  assert.match(
+    npmPackageJob,
+    /npm ci --no-audit --no-fund --ignore-scripts[\s\S]*npx --no-install intent validate npm\/fallow\/skills/,
+  );
+  assert.doesNotMatch(npmPackageJob, /npx[^\n]*@tanstack\/intent@/);
+});
+
+test("CI runs the checked-in Action against the current Rust binary", () => {
+  const workflow = readWorkflow(".github/workflows/ci.yml");
+  const changesJob = indentedBlock(workflow, "changes", 2);
+  const actionFilter = listedPaths(indentedBlock(changesJob, "action-current", 12));
+  const actionJob = indentedBlock(workflow, "action-current", 2);
+  const aggregateJob = indentedBlock(workflow, "ci-ok", 2);
+  const publishedCompatibilityWorkflow = readWorkflow(".github/workflows/test-action.yml");
+
+  assert.match(actionJob, /needs: changes/);
+  assert.match(actionJob, /if: needs\.changes\.outputs\.action-current == 'true'/);
+  assert.match(actionJob, /timeout-minutes: (?:1[0-9]|20)/);
+  assert.match(actionJob, /persist-credentials: false/);
+  assert.match(actionJob, /uses: \.\/\.github\/actions\/setup-rust/);
+  assert.match(actionJob, /cargo build --bin fallow/);
+  assert.match(
+    actionJob,
+    /FALLOW_BIN: \$\{\{ github\.workspace \}\}\/target\/debug\/fallow[\s\S]*bash action\/tests\/run\.sh/,
+  );
+  assert.match(actionJob, /uses: \.\//);
+  assert.match(actionJob, /format: json/);
+  assert.match(actionJob, /jq empty "\$RESULTS_PATH"/);
+  assert.match(aggregateJob, /action-current/);
+
+  for (const path of [
+    "action/**",
+    "action.yml",
+    "crates/**",
+    "Cargo.toml",
+    "Cargo.lock",
+    ".github/actions/setup-rust/**",
+    ".github/workflows/ci.yml",
+    "scripts/workflow-policy.test.mjs",
+  ]) {
+    assert.ok(actionFilter.includes(path), `current-binary Action filter is missing ${path}`);
+  }
+
+  assert.match(publishedCompatibilityWorkflow, /uses: \.\//);
+  assert.match(publishedCompatibilityWorkflow, /FALLOW_SKIP_BINARY_VERIFY: "1"/);
+  assert.doesNotMatch(publishedCompatibilityWorkflow, /cargo build --bin fallow/);
+});
+
 test("binary-size workflow isolates incompatible release builds", () => {
   const workflow = readWorkflow(".github/workflows/bloat.yml");
   const globalEnv = indentedBlock(workflow, "env", 0);
@@ -179,6 +241,14 @@ test("VS Code CI runs the extension-host integration suite with a pinned cached 
   assert.match(vscodeJob, /pnpm audit --prod/);
   assert.match(vscodeFilter, /editors\/vscode\/\*\*/);
   assert.match(vscodeFilter, /\.github\/workflows\/ci\.yml/);
+  for (const path of ["crates/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml"]) {
+    assert.ok(listedPaths(vscodeFilter).includes(path), `VS Code filter is missing ${path}`);
+  }
+  assert.match(vscodeJob, /uses: \.\/\.github\/actions\/setup-rust/);
+  assert.match(
+    vscodeJob,
+    /name: Build current multicall binary\n\s+run: cargo build -p fallow-multicall --bin fallow-multicall/,
+  );
   assert.match(
     vscodeJob,
     /name: Cache VS Code test download[\s\S]*uses: actions\/cache@[0-9a-f]{40}[\s\S]*path: \/tmp\/fallow-vscode-test-cache[\s\S]*key: .*vscode-1\.96\.0/,
@@ -186,6 +256,10 @@ test("VS Code CI runs the extension-host integration suite with a pinned cached 
   assert.match(
     vscodeJob,
     /name: Run VS Code extension-host integration tests\n\s+run: cd editors\/vscode && xvfb-run -a pnpm test:integration/,
+  );
+  assert.match(
+    vscodeJob,
+    /name: Run VS Code real CLI and LSP contract smoke[\s\S]*FALLOW_BIN: \$\{\{ github\.workspace \}\}\/target\/debug\/fallow-multicall[\s\S]*run: xvfb-run -a pnpm --dir editors\/vscode run test:integration:real/,
   );
 
   const harness = readFileSync("editors/vscode/test/integration/runTest.ts", "utf8");

--- a/tests/fixtures/nested-workspace-dependency-ownership/package.json
+++ b/tests/fixtures/nested-workspace-dependency-ownership/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nested-workspace-dependency-ownership",
+  "private": true,
+  "workspaces": ["packages/**"]
+}

--- a/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/package.json
+++ b/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "parent",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "shared-lib": "1.0.0"
+  }
+}

--- a/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/packages/child/package.json
+++ b/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/packages/child/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "child",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "shared-lib": "1.0.0"
+  }
+}

--- a/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/packages/child/src/index.ts
+++ b/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/packages/child/src/index.ts
@@ -1,0 +1,3 @@
+import { value } from "shared-lib";
+
+export const child = value;

--- a/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/src/index.ts
+++ b/tests/fixtures/nested-workspace-dependency-ownership/packages/parent/src/index.ts
@@ -1,0 +1,1 @@
+export const parent = true;


### PR DESCRIPTION
## Summary

- attribute nested workspace dependency usage to the deepest matching workspace
- reuse cached CSS analysis artifacts without deep cloning
- validate Action scalar inputs before Git or GitHub file-command side effects
- add current-binary Action coverage and real VS Code CLI/LSP contract coverage
- align Intent validation, Node tooling requirements, compatibility wording, and format documentation

The separate `fallow fix` promotion-race finding is intentionally excluded.

## Verification

- full repository verification passes
- Action shell suite and checked-in current-binary Action smoke pass
- VS Code fake-process and real current CLI/LSP integration suites pass
- nested-workspace regression passes and the real Astro corpus removes parent attribution false positives
- CSS-specific output remains stable on the real corpus, with no benchmark regression
- repository policy, workflow policy, generated contracts, Intent validation, and vendored-skill drift checks pass
- self-audit reports no findings
