### PR TITLE
fix(cli): honor JSON style for schema commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`--format json` now emits compact JSON by default.** Machine consumers get
   the same schema and values with less output. Use the global `--pretty` flag
   when indented JSON is useful for manual inspection. JSON success and error
-  documents still end with exactly one line feed. SARIF, Code Climate, schema
-  commands, saved baselines, snapshots, caches, and other persisted JSON keep
-  their existing presentation. (Closes [#1861](https://github.com/fallow-rs/fallow/issues/1861))
+  documents still end with exactly one line feed. Schema commands follow the
+  same compact-by-default behavior, while generated schema artifacts remain
+  indented. SARIF, Code Climate, saved baselines, snapshots, caches, and other
+  persisted JSON keep their existing presentation. (Closes
+  [#1861](https://github.com/fallow-rs/fallow/issues/1861))
 
 - **Reusable audit base snapshots are root-owned and safe to clean while audits run.** Each requested project root now has one base-worktree cache that is rebuilt in place when the full resolved base SHA changes. The reuse lock stays held for the audit lifetime, old SHA-keyed caches remain reclaimable, and `fallow audit-cache remove --root <PATH>` provides explicit preview and confirmation controls. Temporary source snapshots are private on Unix, predictable sidecars reject symlinks, and Git administration cleanup is restricted to the current repository's verified worktree entry.
 

--- a/crates/cli/src/init.rs
+++ b/crates/cli/src/init.rs
@@ -1078,9 +1078,9 @@ fn write_hook(path: &Path, content: &str) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn run_config_schema() -> ExitCode {
+pub fn run_config_schema(json_style: crate::json_style::JsonStyle) -> ExitCode {
     let schema = FallowConfig::json_schema();
-    match serde_json::to_string_pretty(&schema) {
+    match json_style.serialize(&schema) {
         Ok(json) => {
             println!("{json}");
             ExitCode::SUCCESS
@@ -1092,9 +1092,9 @@ pub fn run_config_schema() -> ExitCode {
     }
 }
 
-pub fn run_plugin_schema() -> ExitCode {
+pub fn run_plugin_schema(json_style: crate::json_style::JsonStyle) -> ExitCode {
     let schema = ExternalPluginDef::json_schema();
-    match serde_json::to_string_pretty(&schema) {
+    match json_style.serialize(&schema) {
         Ok(json) => {
             println!("{json}");
             ExitCode::SUCCESS
@@ -1106,9 +1106,9 @@ pub fn run_plugin_schema() -> ExitCode {
     }
 }
 
-pub fn run_rule_pack_schema() -> ExitCode {
+pub fn run_rule_pack_schema(json_style: crate::json_style::JsonStyle) -> ExitCode {
     let schema = fallow_config::RulePackDef::json_schema();
-    match serde_json::to_string_pretty(&schema) {
+    match json_style.serialize(&schema) {
         Ok(json) => {
             println!("{json}");
             ExitCode::SUCCESS

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2609,7 +2609,7 @@ pub fn run() -> ExitCode {
         return ExitCode::from(2);
     }
 
-    if let Some(code) = run_schema_command_if_requested(&cli) {
+    if let Some(code) = run_schema_command_if_requested(&cli, fmt.json_style) {
         return code;
     }
 
@@ -2714,12 +2714,15 @@ fn run_telemetry_command_if_requested(
     None
 }
 
-fn run_schema_command_if_requested(cli: &Cli) -> Option<ExitCode> {
+fn run_schema_command_if_requested(
+    cli: &Cli,
+    json_style: json_style::JsonStyle,
+) -> Option<ExitCode> {
     match cli.command {
-        Some(Command::Schema) => Some(schema::run_schema()),
-        Some(Command::ConfigSchema) => Some(init::run_config_schema()),
-        Some(Command::PluginSchema) => Some(init::run_plugin_schema()),
-        Some(Command::RulePackSchema) => Some(init::run_rule_pack_schema()),
+        Some(Command::Schema) => Some(schema::run_schema(json_style)),
+        Some(Command::ConfigSchema) => Some(init::run_config_schema(json_style)),
+        Some(Command::PluginSchema) => Some(init::run_plugin_schema(json_style)),
+        Some(Command::RulePackSchema) => Some(init::run_rule_pack_schema(json_style)),
         _ => None,
     }
 }
@@ -2866,10 +2869,10 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
         Command::Ci { subcommand } => {
             ci::run(map_ci_subcommand(subcommand), output, dispatch.json_style)
         }
-        Command::ConfigSchema => init::run_config_schema(),
-        Command::PluginSchema => init::run_plugin_schema(),
+        Command::ConfigSchema => init::run_config_schema(dispatch.json_style),
+        Command::PluginSchema => init::run_plugin_schema(dispatch.json_style),
         Command::PluginCheck => plugin_check::run_plugin_check(root, output, dispatch.json_style),
-        Command::RulePackSchema => init::run_rule_pack_schema(),
+        Command::RulePackSchema => init::run_rule_pack_schema(dispatch.json_style),
         Command::RulePack { subcommand } => dispatch_rule_pack_command(dispatch, subcommand),
         Command::Guard { files } => dispatch_guard_command(dispatch, &files),
         Command::CiTemplate { subcommand } => dispatch_ci_template_command(subcommand),

--- a/crates/cli/src/rule_pack/mod.rs
+++ b/crates/cli/src/rule_pack/mod.rs
@@ -79,7 +79,7 @@ pub enum RulePackSubcommand {
 
 pub fn run(subcommand: &RulePackSubcommand, ctx: &RulePackContext<'_>) -> ExitCode {
     match subcommand {
-        RulePackSubcommand::Schema => crate::init::run_rule_pack_schema(),
+        RulePackSubcommand::Schema => crate::init::run_rule_pack_schema(ctx.json_style),
         RulePackSubcommand::Init(args) => init::run(args, ctx),
         RulePackSubcommand::List => list::run(ctx),
         RulePackSubcommand::Test(args) => test::run(args, ctx),

--- a/crates/cli/src/schema.rs
+++ b/crates/cli/src/schema.rs
@@ -13,10 +13,10 @@ use crate::explain::{
     CHECK_RULES, DUPES_RULES, FLAGS_RULES, HEALTH_RULES, RuleDef, SECURITY_RULES, rule_docs_url,
 };
 
-pub fn run_schema() -> ExitCode {
+pub fn run_schema(json_style: crate::json_style::JsonStyle) -> ExitCode {
     let cmd = Cli::command();
     let schema = build_cli_schema(&cmd);
-    match serde_json::to_string_pretty(&schema) {
+    match json_style.serialize(&schema) {
         Ok(json) => {
             println!("{json}");
             ExitCode::SUCCESS

--- a/crates/cli/tests/json_format_tests.rs
+++ b/crates/cli/tests/json_format_tests.rs
@@ -415,8 +415,62 @@ fn config_path_rejects_pretty_because_it_is_not_json() {
 }
 
 #[test]
+fn schema_commands_use_the_selected_presentation_style() {
+    let commands: &[(&str, &[&str], &[&str])] = &[
+        ("schema", &["schema"], &["schema", "--pretty"]),
+        (
+            "config-schema",
+            &["config-schema"],
+            &["config-schema", "--pretty"],
+        ),
+        (
+            "plugin-schema",
+            &["plugin-schema"],
+            &["plugin-schema", "--pretty"],
+        ),
+        (
+            "rule-pack-schema",
+            &["rule-pack-schema"],
+            &["rule-pack-schema", "--pretty"],
+        ),
+        (
+            "rule-pack schema",
+            &["rule-pack", "schema"],
+            &["rule-pack", "schema", "--pretty"],
+        ),
+    ];
+
+    for (name, compact_args, pretty_args) in commands {
+        let compact = run_fallow_raw(compact_args);
+        let pretty = run_fallow_raw(pretty_args);
+
+        assert_eq!(compact.code, 0, "{name} should succeed");
+        assert_eq!(
+            pretty.code, compact.code,
+            "presentation must not change exit code"
+        );
+        assert_eq!(
+            compact.stdout.lines().count(),
+            1,
+            "{name} JSON should be compact by default"
+        );
+        assert!(
+            pretty.stdout.lines().count() > 1,
+            "--pretty should indent {name} JSON"
+        );
+        let compact_value = serde_json::from_str::<serde_json::Value>(&compact.stdout)
+            .expect("compact schema output should be valid JSON");
+        let pretty_value = serde_json::from_str::<serde_json::Value>(&pretty.stdout)
+            .expect("pretty schema output should be valid JSON");
+        assert_eq!(
+            compact_value, pretty_value,
+            "presentation must not change values"
+        );
+    }
+}
+
+#[test]
 fn always_json_commands_accept_pretty_without_a_format_override() {
-    let schema = run_fallow_raw(&["schema", "--pretty"]);
     let root = fixture_path("basic-project");
     let coverage = run_fallow_raw(&[
         "coverage",
@@ -427,10 +481,7 @@ fn always_json_commands_accept_pretty_without_a_format_override() {
         root.to_str().expect("fixture path should be UTF-8"),
     ]);
 
-    assert_eq!(schema.code, 0, "schema --pretty should succeed");
     assert_eq!(coverage.code, 0, "coverage setup JSON should succeed");
-    serde_json::from_str::<serde_json::Value>(&schema.stdout)
-        .expect("schema should remain valid JSON");
     serde_json::from_str::<serde_json::Value>(&coverage.stdout)
         .expect("coverage setup should remain valid JSON");
     assert!(coverage.stdout.lines().count() > 1);

--- a/scripts/generate-all.mjs
+++ b/scripts/generate-all.mjs
@@ -36,8 +36,18 @@ const run = (cmd, args, options = {}) =>
     stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
   });
 
-const cargoFallow = (subcommand) =>
-  run("cargo", ["run", "--quiet", "-p", "fallow-cli", "--bin", "fallow", "--", subcommand]);
+const cargoFallow = (subcommand, ...args) =>
+  run("cargo", [
+    "run",
+    "--quiet",
+    "-p",
+    "fallow-cli",
+    "--bin",
+    "fallow",
+    "--",
+    subcommand,
+    ...args,
+  ]);
 
 const outputSchema = () =>
   run("cargo", [
@@ -84,10 +94,10 @@ const issueRegistry = (capabilitySchema) => {
 };
 
 const generateSchemaFiles = (stagingRoot) => {
-  const configSchema = ensureTrailingNewline(cargoFallow("config-schema"));
-  const pluginSchema = ensureTrailingNewline(cargoFallow("plugin-schema"));
-  const rulePackSchema = ensureTrailingNewline(cargoFallow("rule-pack-schema"));
-  const capabilitySchema = ensureTrailingNewline(cargoFallow("schema"));
+  const configSchema = ensureTrailingNewline(cargoFallow("config-schema", "--pretty"));
+  const pluginSchema = ensureTrailingNewline(cargoFallow("plugin-schema", "--pretty"));
+  const rulePackSchema = ensureTrailingNewline(cargoFallow("rule-pack-schema", "--pretty"));
+  const capabilitySchema = ensureTrailingNewline(cargoFallow("schema", "--pretty"));
   const registry = issueRegistry(capabilitySchema);
   const output = ensureTrailingNewline(outputSchema());
 


### PR DESCRIPTION
## Summary

- make schema command JSON compact by default
- make global `--pretty` indent every schema command consistently
- keep committed generated schema artifacts pretty by requesting `--pretty` in codegen

## Context

Follow-up to #1861. This changes JSON whitespace only. Schema values, ordering, exit codes, and generated artifact contents remain unchanged.

## Verification

- [x] targeted schema JSON presentation tests
- [x] existing JSON style tests
- [x] generated contract drift check
- [x] public Zod project smoke
- [x] full repository verification
