### PR TITLE
fix(lsp): normalize Windows diagnostic paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
               - 'crates/engine/src/changed_files.rs'
               - 'crates/engine/src/churn.rs'
               - 'crates/engine/Cargo.toml'
+              - 'crates/lsp/**'
               - 'crates/mcp/src/tools/code_mode_subprocess.rs'
               - 'crates/mcp/src/tools/mod.rs'
               - 'crates/mcp/src/tools/process_tree.rs'
@@ -309,10 +310,12 @@ jobs:
         run: cargo test -p fallow-engine changed_files::tests
       - name: Test churn path handling
         run: cargo test -p fallow-engine churn::tests
+      - name: Test LSP diagnostic URI handling
+        run: cargo test -p fallow-lsp windows_initialization_publishes_uri_safe_diagnostics
       - name: Test MCP subprocess cleanup
         run: cargo test -p fallow-mcp completed_success_cleans_descendant_process_tree
       - name: Clippy platform-specific paths
-        run: cargo clippy -p fallow-engine -p fallow-mcp --all-targets -- -D warnings
+        run: cargo clippy -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings
 
   skills-vendor:
     name: Skills vendor drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Reusable audit base snapshots are root-owned and safe to clean while audits run.** Each requested project root now has one base-worktree cache that is rebuilt in place when the full resolved base SHA changes. The reuse lock stays held for the audit lifetime, old SHA-keyed caches remain reclaimable, and `fallow audit-cache remove --root <PATH>` provides explicit preview and confirmation controls. Temporary source snapshots are private on Unix, predictable sidecars reject symlinks, and Git administration cleanup is restricted to the current repository's verified worktree entry.
 
+### Fixed
+
+- **Windows editor diagnostics use valid file URIs.** LSP paths no longer retain
+  the Windows verbatim path prefix that prevented diagnostics from rendering.
+  (Closes [#1899](https://github.com/fallow-rs/fallow/issues/1899))
+
 ## [3.5.1] - 2026-07-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
 name = "fallow-lsp"
 version = "3.5.1"
 dependencies = [
+ "dunce",
  "fallow-api",
  "fallow-config",
  "fallow-types",

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -16,6 +16,7 @@ name = "fallow-lsp"
 path = "src/main.rs"
 
 [dependencies]
+dunce = { workspace = true }
 fallow-api = { workspace = true }
 fallow-config = { workspace = true }
 fallow-types = { workspace = true }

--- a/crates/lsp/src/initialization.rs
+++ b/crates/lsp/src/initialization.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use fallow_config::{DetectionMode, DuplicatesConfig};
 use serde::Deserialize;
 
+use crate::path_utils::canonicalize_for_lsp;
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LspHealthOptions {
@@ -79,7 +81,7 @@ fn resolve_config_path(raw: Option<&str>, root: Option<&Path>) -> Option<PathBuf
         path
     };
 
-    Some(path.canonicalize().unwrap_or(path))
+    Some(canonicalize_for_lsp(&path))
 }
 
 pub fn initialization_config_path(

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -16,6 +16,7 @@ mod document_state;
 mod hover;
 mod initialization;
 mod markdown;
+mod path_utils;
 mod position;
 mod protocol;
 mod server_capabilities;
@@ -64,6 +65,7 @@ use initialization::{
     LspInitializationOptions, initialization_duplication_options,
     initialization_inline_complexity_enabled, initialization_production_override,
 };
+use path_utils::canonicalize_for_lsp;
 #[cfg(test)]
 use protocol::analysis_complete_params_for_test;
 #[cfg(test)]
@@ -171,7 +173,7 @@ impl LanguageServer for FallowLspServer {
                     .root_uri
                     .and_then(|u| u.to_file_path().map(|path| path.into_owned()))
             });
-        let canonical_root = root.map(|path| path.canonicalize().unwrap_or(path));
+        let canonical_root = root.map(|path| canonicalize_for_lsp(&path));
         if let Some(path) = &canonical_root {
             *self.root.write().await = Some(path.clone());
         }
@@ -903,9 +905,7 @@ async fn serve_stdio() {
 /// in agreement with the CLI. A `Vec` is returned (always length one) so the
 /// caller's accumulate-then-publish structure stays uniform.
 fn find_project_roots(workspace_root: &std::path::Path) -> Vec<std::path::PathBuf> {
-    let root = workspace_root
-        .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
+    let root = canonicalize_for_lsp(workspace_root);
     vec![root]
 }
 

--- a/crates/lsp/src/path_utils.rs
+++ b/crates/lsp/src/path_utils.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-#[allow(
+#[expect(
     clippy::redundant_pub_crate,
     reason = "shared by sibling LSP modules through the private path_utils module"
 )]

--- a/crates/lsp/src/path_utils.rs
+++ b/crates/lsp/src/path_utils.rs
@@ -1,0 +1,9 @@
+use std::path::{Path, PathBuf};
+
+#[allow(
+    clippy::redundant_pub_crate,
+    reason = "shared by sibling LSP modules through the private path_utils module"
+)]
+pub(crate) fn canonicalize_for_lsp(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}

--- a/crates/lsp/src/tests.rs
+++ b/crates/lsp/src/tests.rs
@@ -642,6 +642,141 @@ async fn initialize_advertises_pull_diagnostics_for_refreshable_clients() {
     );
 }
 
+#[cfg(windows)]
+#[tokio::test(flavor = "current_thread")]
+async fn windows_initialization_publishes_uri_safe_diagnostics() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path().to_path_buf();
+    let source_dir = root.join("src");
+    let unused_file = source_dir.join("unused.ts");
+    std::fs::create_dir_all(&source_dir).expect("create source dir");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"windows-lsp-uri","private":true,"main":"src/index.ts"}"#,
+    )
+    .expect("write package");
+    std::fs::write(source_dir.join("index.ts"), "export const ready = 1;\n")
+        .expect("write entry point");
+    std::fs::write(&unused_file, "export const unused = 2;\n").expect("write unused file");
+
+    let workspace_uri = Uri::from_file_path(&root).expect("workspace file URI");
+    let (mut service, _) = LspService::build(FallowLspServer::new).finish();
+    let initialize = Request::build("initialize")
+        .params(json!({
+            "capabilities": {},
+            "workspaceFolders": [{
+                "uri": workspace_uri,
+                "name": "windows-lsp-uri"
+            }]
+        }))
+        .id(1)
+        .finish();
+    let response = service
+        .ready()
+        .await
+        .expect("service should be ready")
+        .call(initialize)
+        .await
+        .expect("initialize request should be handled")
+        .expect("initialize request should return a response");
+    assert!(
+        response.is_ok(),
+        "workspace-folder initialization must succeed"
+    );
+
+    let backend = service.inner();
+    let stored_root = backend
+        .root
+        .read()
+        .await
+        .clone()
+        .expect("workspace root should be stored");
+    assert!(
+        !stored_root.to_string_lossy().starts_with(r"\\?\"),
+        "workspace root must not use a Windows verbatim path: {}",
+        stored_root.display()
+    );
+
+    backend.run_analysis().await;
+    let cached = backend.cached_diagnostics.read().await;
+    let unused_uri = cached
+        .iter()
+        .find_map(|(uri, diagnostics)| {
+            diagnostics
+                .iter()
+                .any(|diagnostic| {
+                    matches!(
+                        diagnostic.code.as_ref(),
+                        Some(NumberOrString::String(code)) if code == "unused-file"
+                    )
+                })
+                .then_some(uri.clone())
+        })
+        .expect("analysis should cache an unused-file diagnostic");
+    drop(cached);
+
+    let uri_text = unused_uri.to_string();
+    let lowercase_uri = uri_text.to_ascii_lowercase();
+    assert!(
+        uri_text.starts_with("file:///"),
+        "unexpected file URI: {uri_text}"
+    );
+    assert!(
+        !uri_text.contains("file:////"),
+        "unexpected file URI: {uri_text}"
+    );
+    assert!(
+        !uri_text.contains(r"\\?\"),
+        "unexpected file URI: {uri_text}"
+    );
+    assert!(
+        !lowercase_uri.contains("%5c%5c%3f"),
+        "unexpected encoded verbatim marker in file URI: {uri_text}"
+    );
+    assert_eq!(
+        unused_uri
+            .to_file_path()
+            .expect("diagnostic URI should convert to a file path")
+            .into_owned(),
+        unused_file,
+        "diagnostic URI should round-trip to the unused file"
+    );
+
+    let legacy_uri = Uri::from_file_path(&root).expect("legacy root file URI");
+    let (mut legacy_service, _) = LspService::build(FallowLspServer::new).finish();
+    let initialize = Request::build("initialize")
+        .params(json!({
+            "capabilities": {},
+            "rootUri": legacy_uri
+        }))
+        .id(1)
+        .finish();
+    let response = legacy_service
+        .ready()
+        .await
+        .expect("legacy service should be ready")
+        .call(initialize)
+        .await
+        .expect("legacy initialize request should be handled")
+        .expect("legacy initialize request should return a response");
+    assert!(
+        response.is_ok(),
+        "legacy rootUri initialization must succeed"
+    );
+    let legacy_root = legacy_service
+        .inner()
+        .root
+        .read()
+        .await
+        .clone()
+        .expect("legacy root should be stored");
+    assert!(
+        !legacy_root.to_string_lossy().starts_with(r"\\?\"),
+        "legacy root must not use a Windows verbatim path: {}",
+        legacy_root.display()
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn fallow_issue_types_request_is_served() {
     let (mut service, _) = LspService::build(FallowLspServer::new)

--- a/crates/lsp/src/tests.rs
+++ b/crates/lsp/src/tests.rs
@@ -301,7 +301,7 @@ fn blocking_analysis_surfaces_project_analysis_errors() {
 #[tokio::test(flavor = "current_thread")]
 async fn failed_analysis_refresh_preserves_last_valid_snapshot_and_diagnostics() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let root = dir.path().canonicalize().expect("canonical root");
+    let root = canonicalize_for_lsp(dir.path());
     let orphan = write_analysis_failure_fixture(&root, "^__");
     let orphan_uri = Uri::from_file_path(&orphan).expect("orphan file URI");
 
@@ -378,7 +378,7 @@ async fn failed_analysis_refresh_preserves_last_valid_snapshot_and_diagnostics()
 #[tokio::test(flavor = "current_thread")]
 async fn explicit_config_failure_preserves_last_valid_snapshot_and_diagnostics() {
     let dir = tempfile::tempdir().expect("temp dir");
-    let root = dir.path().canonicalize().expect("canonical root");
+    let root = canonicalize_for_lsp(dir.path());
     let orphan = write_analysis_failure_fixture(&root, "^__");
     let orphan_uri = Uri::from_file_path(&orphan).expect("orphan file URI");
 
@@ -738,7 +738,7 @@ async fn windows_initialization_publishes_uri_safe_diagnostics() {
             .to_file_path()
             .expect("diagnostic URI should convert to a file path")
             .into_owned(),
-        unused_file,
+        canonicalize_for_lsp(&unused_file),
         "diagnostic URI should round-trip to the unused file"
     );
 

--- a/crates/lsp/src/tests.rs
+++ b/crates/lsp/src/tests.rs
@@ -1407,7 +1407,7 @@ fn find_project_roots_returns_only_workspace_root() {
 
     let roots = find_project_roots(root);
     assert_eq!(roots.len(), 1, "LSP analyzes exactly one root per run");
-    let expected = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let expected = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     assert_eq!(roots[0], expected, "the single root is the workspace root");
 }
 

--- a/crates/lsp/src/tests.rs
+++ b/crates/lsp/src/tests.rs
@@ -643,6 +643,10 @@ async fn initialize_advertises_pull_diagnostics_for_refreshable_clients() {
 }
 
 #[cfg(windows)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one protocol regression covers both supported LSP initialization shapes"
+)]
 #[tokio::test(flavor = "current_thread")]
 async fn windows_initialization_publishes_uri_safe_diagnostics() {
     let dir = tempfile::tempdir().expect("temp dir");

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -96,7 +96,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.match(windowsRustJob, /cargo test -p fallow-engine churn::tests/);
   assert.match(
     windowsRustJob,
-    /cargo test -p fallow-lsp windows_initialization_publishes_uri_safe_diagnostics/,
+    /^[ \t]+run: cargo test -p fallow-lsp windows_initialization_publishes_uri_safe_diagnostics$/m,
   );
   assert.match(
     windowsRustJob,
@@ -104,7 +104,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   );
   assert.match(
     windowsRustJob,
-    /cargo clippy -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings/,
+    /^[ \t]+run: cargo clippy -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings$/m,
   );
   assert.match(zedJob, /runs-on: ubuntu-latest/);
   assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -77,6 +77,7 @@ test("binary-size workflow isolates incompatible release builds", () => {
 
 test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
+  const windowsRustPaths = listedPaths(indentedBlock(workflow, "windows-rust", 12));
   const checkJob = indentedBlock(workflow, "check", 2);
   const windowsRustJob = indentedBlock(workflow, "windows-rust", 2);
   const zedJob = indentedBlock(workflow, "zed", 2);
@@ -90,15 +91,20 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.match(windowsRustJob, /needs: changes/);
   assert.match(windowsRustJob, /if: needs\.changes\.outputs\.windows-rust == 'true'/);
   assert.match(windowsRustJob, /runs-on: windows-latest/);
+  assert.ok(windowsRustPaths.includes("crates/lsp/**"));
   assert.match(windowsRustJob, /cargo test -p fallow-engine changed_files::tests/);
   assert.match(windowsRustJob, /cargo test -p fallow-engine churn::tests/);
+  assert.match(
+    windowsRustJob,
+    /cargo test -p fallow-lsp windows_initialization_publishes_uri_safe_diagnostics/,
+  );
   assert.match(
     windowsRustJob,
     /cargo test -p fallow-mcp completed_success_cleans_descendant_process_tree/,
   );
   assert.match(
     windowsRustJob,
-    /cargo clippy -p fallow-engine -p fallow-mcp --all-targets -- -D warnings/,
+    /cargo clippy -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings/,
   );
   assert.match(zedJob, /runs-on: ubuntu-latest/);
   assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);


### PR DESCRIPTION
## Summary
- Normalize LSP filesystem paths before they reach diagnostic URI construction on Windows.
- Cover workspace folder and legacy root initialization with a Windows protocol regression.
- Gate LSP path changes with focused Windows tests and strict Clippy.

## Issue
Closes #1899

## Verification
- [x] Windows LSP URI regression
- [x] `cargo check --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] Real-project LSP smoke
- [x] `fallow audit --format json --quiet`
