### PR TITLE
chore(docker): pin FALLOW_VERSION 3.6.0 with refreshed checksums

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim AS download
 
-ARG FALLOW_VERSION=3.5.1
+ARG FALLOW_VERSION=3.6.0
 ARG TARGETARCH
 
 RUN apt-get update \
@@ -15,11 +15,11 @@ RUN set -eux; \
   case "${TARGETARCH}" in \
     amd64) \
       asset="fallow-linux-x64-musl"; \
-      sha256="423e47fab8dc7b6ad0be18320c887dd3b416c8629d46f20066db3bf663dc831d"; \
+      sha256="62c507e8facd576e650f04beb99e60eb30f3285d7da85da15e0a7d629968c39f"; \
       ;; \
     arm64) \
       asset="fallow-linux-arm64-musl"; \
-      sha256="a71473e27132306cdff4dfe3ab507268e6c980b6eb01d8c673f90272bf8abe83"; \
+      sha256="3fc04a863c610e343107edbb6377c0d8b02b5989faf990d82ec7803f5cf80043"; \
       ;; \
     *) \
       echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; \


### PR DESCRIPTION
Automated Dockerfile lockstep for the v3.6.0 release: refreshes ARG FALLOW_VERSION and both per-arch sha256 pins from the just-published release assets. Refs #1817.