### PR TITLE
fix: harden imported input boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
               - '.clippy.toml'
               - 'rust-toolchain.toml'
             windows-rust:
+              - 'crates/core/src/discover/walk.rs'
+              - 'crates/core/src/plugins/manifest_entries.rs'
+              - 'crates/core/tests/integration_test.rs'
+              - 'crates/core/tests/integration_test/symlink_root_containment.rs'
               - 'crates/engine/src/changed_files.rs'
               - 'crates/engine/src/churn.rs'
               - 'crates/engine/Cargo.toml'
@@ -326,12 +330,14 @@ jobs:
         run: cargo test -p fallow-engine changed_files::tests
       - name: Test churn path handling
         run: cargo test -p fallow-engine churn::tests
+      - name: Test source and manifest symlink containment
+        run: cargo test -p fallow-core symlink
       - name: Test LSP diagnostic URI handling
         run: cargo test -p fallow-lsp windows_initialization_publishes_uri_safe_diagnostics
       - name: Test MCP subprocess cleanup
         run: cargo test -p fallow-mcp completed_success_cleans_descendant_process_tree
       - name: Clippy platform-specific paths
-        run: cargo clippy -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings
+        run: cargo clippy -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings
 
   skills-vendor:
     name: Skills vendor drift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a remote ref, refuses to move an existing tag, and leaves multi-root
   workspaces unchanged until per-root baseline semantics exist.
 
+### Fixed
+
+- **Imported churn history is bounded and validated before analysis.** Churn
+  files now enforce a serialized size limit, reject paths outside the project,
+  and report line-total overflow as an input error instead of panicking or
+  wrapping.
+
+- **Unified diffs read from stdin enforce the same size cap as diff files.**
+  Oversized or invalid stdin now disables line filtering and reports all
+  findings instead of allocating an unbounded buffer or parsing a truncated
+  diff.
+
+- **Source and plugin-manifest symlinks stay inside the project root.** Broken
+  links, directory targets, and links to outside files are skipped before
+  content is read, while links to regular files inside the project remain
+  supported under their visible paths.
+
 ## [3.6.0] - 2026-07-15
 
 ### Changed

--- a/crates/cli/src/report/ci/diff_filter.rs
+++ b/crates/cli/src/report/ci/diff_filter.rs
@@ -180,32 +180,8 @@ pub fn load_diff_index_for_findings(source: &DiffSource, quiet: bool) -> Option<
 
 /// Drain stdin once and parse it into a `LoadedDiff`, warning on failure / empty index.
 fn load_diff_index_from_stdin(quiet: bool) -> Option<LoadedDiff> {
-    let mut buf = String::new();
-    match std::io::stdin().read_to_string(&mut buf) {
-        Ok(_) => {
-            let index = DiffIndex::from_unified_diff(&buf);
-            if !quiet && index.added_line_count() == 0 {
-                eprintln!(
-                    "fallow: warning [diff-file]: --diff-stdin parsed \
-                     0 added lines; no findings will pass the diff filter. \
-                     Did you pipe a non-unified diff or an empty stream? \
-                     (Pure-rename, binary-only, and deletion-only diffs \
-                     also produce empty indices.)"
-                );
-            }
-            Some(LoadedDiff { index, raw: buf })
-        }
-        Err(err) => {
-            if !quiet {
-                eprintln!(
-                    "fallow: warning [diff-file]: could not read stdin: {err} \
-                     (line-level filtering disabled; rerun with \
-                     --diff-file PATH to point at a file on disk)"
-                );
-            }
-            None
-        }
-    }
+    let stdin = std::io::stdin();
+    load_diff_index_from_reader(stdin.lock(), "--diff-stdin", MAX_DIFF_BYTES, quiet)
 }
 
 /// Read a diff file (respecting the size cap) and parse it into a `LoadedDiff`.
@@ -222,20 +198,8 @@ fn load_diff_index_from_file(path: &Path, label: &str, quiet: bool) -> Option<Lo
         }
         return None;
     }
-    match std::fs::read_to_string(path) {
-        Ok(text) => {
-            let index = DiffIndex::from_unified_diff(&text);
-            if !quiet && index.added_line_count() == 0 {
-                eprintln!(
-                    "fallow: warning [diff-file]: {label} parsed 0 added \
-                     lines; no findings will pass the diff filter. \
-                     Verify the file is a unified diff (look for \
-                     `+++ b/<path>` headers). Pure-rename, binary-only, \
-                     and deletion-only diffs also produce empty indices."
-                );
-            }
-            Some(LoadedDiff { index, raw: text })
-        }
+    match std::fs::File::open(path) {
+        Ok(file) => load_diff_index_from_reader(file, label, MAX_DIFF_BYTES, quiet),
         Err(err) => {
             if !quiet {
                 eprintln!(
@@ -246,6 +210,56 @@ fn load_diff_index_from_file(path: &Path, label: &str, quiet: bool) -> Option<Lo
             None
         }
     }
+}
+
+fn load_diff_index_from_reader(
+    reader: impl std::io::Read,
+    label: &str,
+    limit: u64,
+    quiet: bool,
+) -> Option<LoadedDiff> {
+    let mut bytes = Vec::new();
+    if let Err(err) = reader.take(limit + 1).read_to_end(&mut bytes) {
+        if !quiet {
+            eprintln!(
+                "fallow: warning [diff-file]: could not read {label}: {err} \
+                 (line-level filtering disabled)"
+            );
+        }
+        return None;
+    }
+    if bytes.len() as u64 > limit {
+        if !quiet {
+            eprintln!(
+                "fallow: warning [diff-file]: {label} is at least {} bytes (cap {limit}); \
+                 line-level filtering disabled, reporting all findings",
+                bytes.len()
+            );
+        }
+        return None;
+    }
+    let text = match String::from_utf8(bytes) {
+        Ok(text) => text,
+        Err(err) => {
+            if !quiet {
+                eprintln!(
+                    "fallow: warning [diff-file]: could not read {label} as UTF-8: {err} \
+                     (line-level filtering disabled)"
+                );
+            }
+            return None;
+        }
+    };
+    let index = DiffIndex::from_unified_diff(&text);
+    if !quiet && index.added_line_count() == 0 {
+        eprintln!(
+            "fallow: warning [diff-file]: {label} parsed 0 added lines; \
+             no findings will pass the diff filter. Verify the input is a unified diff \
+             (look for `+++ b/<path>` headers). Pure-rename, binary-only, and \
+             deletion-only diffs also produce empty indices."
+        );
+    }
+    Some(LoadedDiff { index, raw: text })
 }
 
 /// Process-wide cache for the diff index resolved at startup, so combined
@@ -602,10 +616,50 @@ fn diff_index_keeps_issue(
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write as _;
+    use std::io::{Cursor, Write as _};
 
     use super::*;
     use fallow_output::relative_to_diff_path;
+
+    #[test]
+    fn bounded_diff_reader_accepts_exact_limit() {
+        let loaded =
+            load_diff_index_from_reader(Cursor::new(b"12345678"), "test diff", 8, true).unwrap();
+        assert_eq!(loaded.raw, "12345678");
+    }
+
+    #[test]
+    fn bounded_diff_reader_rejects_limit_plus_one() {
+        assert!(
+            load_diff_index_from_reader(Cursor::new(b"123456789"), "test diff", 8, true).is_none()
+        );
+    }
+
+    #[test]
+    fn bounded_diff_reader_rejects_invalid_utf8() {
+        assert!(
+            load_diff_index_from_reader(Cursor::new([0xff, 0xfe]), "test diff", 8, true).is_none()
+        );
+    }
+
+    #[test]
+    fn bounded_diff_reader_parses_valid_unified_diff() {
+        let text = "diff --git a/src/a.ts b/src/a.ts\n\
+                    --- a/src/a.ts\n\
+                    +++ b/src/a.ts\n\
+                    @@ -0,0 +1,1 @@\n\
+                    +export const a = 1;\n";
+        let loaded =
+            load_diff_index_from_reader(Cursor::new(text), "test diff", 1024, true).unwrap();
+        assert_eq!(loaded.index.added_line_count(), 1);
+    }
+
+    #[test]
+    fn bounded_diff_reader_preserves_empty_index_behavior() {
+        let loaded =
+            load_diff_index_from_reader(Cursor::new(b"not a diff"), "test diff", 32, true).unwrap();
+        assert_eq!(loaded.index.added_line_count(), 0);
+    }
 
     #[test]
     fn filter_issues_from_path_skips_oversize_diff() {

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -2927,6 +2927,41 @@ fn health_churn_file_powers_hotspots_and_ownership_without_git() {
     );
     assert_eq!(parse_json(&bad)["error"].as_bool(), Some(true));
 
+    // Imported line totals that exceed the public u32 contract are rejected as
+    // one structured input error. The old aggregation path panicked in debug
+    // builds and wrapped in release builds.
+    write_file(
+        &dir.path().join("overflow.json"),
+        r#"{ "schema": "fallow-churn/v1", "events": [
+          { "path": "src/hot.ts", "timestamp": 1700000000, "added": 4294967295, "deleted": 0 },
+          { "path": "src/hot.ts", "timestamp": 1700000001, "added": 1, "deleted": 0 }
+        ] }"#,
+    );
+    let overflow = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &[
+            "--hotspots",
+            "--churn-file",
+            "overflow.json",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(
+        overflow.code, 2,
+        "overflowing churn file should exit 2: stdout={} stderr={}",
+        overflow.stdout, overflow.stderr
+    );
+    let overflow_json = parse_json(&overflow);
+    assert_eq!(overflow_json["error"].as_bool(), Some(true));
+    assert!(overflow_json.get("hotspots").is_none());
+    assert!(
+        !overflow.stderr.contains("panicked"),
+        "overflow must not panic: {}",
+        overflow.stderr
+    );
+
     // Inert: with no churn-consuming section (--score only), the same malformed
     // file is never validated, so it does not fail the run. The gate is
     // validate-iff-consume.

--- a/crates/core/src/discover/walk.rs
+++ b/crates/core/src/discover/walk.rs
@@ -336,6 +336,7 @@ impl HiddenDirScope {
 /// identical to the config-capture-disabled walk.
 struct FileVisitor<'a> {
     root: &'a Path,
+    canonical_root: Option<&'a Path>,
     ignore_patterns: &'a globset::GlobSet,
     production_excludes: &'a Option<globset::GlobSet>,
     shared: &'a Mutex<Vec<(std::path::PathBuf, u64)>>,
@@ -366,8 +367,21 @@ impl ignore::ParallelVisitor for FileVisitor<'_> {
         {
             return ignore::WalkState::Continue;
         }
+        let symlink_size = if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            let Some(size) = contained_symlink_file_size(entry.path(), self.canonical_root) else {
+                tracing::debug!(
+                    path = %entry.path().display(),
+                    "skipping source symlink with a broken, non-file, or outside-root target"
+                );
+                return ignore::WalkState::Continue;
+            };
+            Some(size)
+        } else {
+            None
+        };
         if has_source_extension(entry.path()) {
-            let size_bytes = entry.metadata().map_or(0, |m| m.len());
+            let size_bytes =
+                symlink_size.unwrap_or_else(|| entry.metadata().map_or(0, |m| m.len()));
             self.local.push((entry.into_path(), size_bytes));
         } else if self.config_shared.is_some() {
             // A non-source file admitted by the config-candidate type group. No
@@ -376,6 +390,16 @@ impl ignore::ParallelVisitor for FileVisitor<'_> {
         }
         ignore::WalkState::Continue
     }
+}
+
+fn contained_symlink_file_size(path: &Path, canonical_root: Option<&Path>) -> Option<u64> {
+    let root = canonical_root?;
+    let target = path.canonicalize().ok()?;
+    if !target.starts_with(root) {
+        return None;
+    }
+    let metadata = target.metadata().ok()?;
+    metadata.is_file().then_some(metadata.len())
 }
 
 impl Drop for FileVisitor<'_> {
@@ -404,6 +428,7 @@ impl Drop for FileVisitor<'_> {
 /// Builder that creates per-thread `FileVisitor` instances for the parallel walker.
 struct FileVisitorBuilder<'a> {
     root: &'a Path,
+    canonical_root: Option<&'a Path>,
     ignore_patterns: &'a globset::GlobSet,
     production_excludes: &'a Option<globset::GlobSet>,
     shared: &'a Mutex<Vec<(std::path::PathBuf, u64)>>,
@@ -414,6 +439,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for FileVisitorBuilder<'s> {
     fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
         Box::new(FileVisitor {
             root: self.root,
+            canonical_root: self.canonical_root,
             ignore_patterns: self.ignore_patterns,
             production_excludes: self.production_excludes,
             shared: self.shared,
@@ -650,11 +676,13 @@ pub fn discover_files_and_config_candidates(
     let walk_builder =
         build_source_walk_builder(config, additional_hidden_dir_scopes, capture_config);
     let production_excludes = build_production_excludes(config);
+    let canonical_root = config.root.canonicalize().ok();
 
     let collected: Mutex<Vec<(std::path::PathBuf, u64)>> = Mutex::new(Vec::new());
     let config_collected: Mutex<Vec<std::path::PathBuf>> = Mutex::new(Vec::new());
     let mut visitor_builder = FileVisitorBuilder {
         root: &config.root,
+        canonical_root: canonical_root.as_deref(),
         ignore_patterns: &config.ignore_patterns,
         production_excludes: &production_excludes,
         shared: &collected,
@@ -1094,6 +1122,63 @@ mod tests {
                         .replace('\\', "/")
                 })
                 .collect()
+        }
+
+        #[cfg(unix)]
+        fn symlink_file(target: &Path, link: &Path) {
+            std::os::unix::fs::symlink(target, link).expect("create file symlink");
+        }
+
+        #[cfg(windows)]
+        fn symlink_file(target: &Path, link: &Path) {
+            std::os::windows::fs::symlink_file(target, link).expect("create file symlink");
+        }
+
+        #[cfg(unix)]
+        fn symlink_dir(target: &Path, link: &Path) {
+            std::os::unix::fs::symlink(target, link).expect("create directory symlink");
+        }
+
+        #[cfg(windows)]
+        fn symlink_dir(target: &Path, link: &Path) {
+            std::os::windows::fs::symlink_dir(target, link).expect("create directory symlink");
+        }
+
+        #[test]
+        fn source_symlinks_must_target_regular_files_inside_root() {
+            let dir = tempfile::tempdir().expect("create project");
+            let outside = tempfile::tempdir().expect("create outside dir");
+            let src = dir.path().join("src");
+            std::fs::create_dir_all(&src).unwrap();
+            std::fs::write(src.join("regular.ts"), "export const regular = 1;").unwrap();
+            std::fs::write(src.join("inside-target.ts"), "export const inside = 1;").unwrap();
+            std::fs::write(
+                outside.path().join("outside-target.ts"),
+                "export const outside = 1;",
+            )
+            .unwrap();
+            std::fs::create_dir_all(src.join("directory-target")).unwrap();
+
+            symlink_file(&src.join("inside-target.ts"), &src.join("inside-link.ts"));
+            symlink_file(
+                &outside.path().join("outside-target.ts"),
+                &src.join("outside-link.ts"),
+            );
+            symlink_file(&src.join("missing-target.ts"), &src.join("broken-link.ts"));
+            symlink_dir(
+                &src.join("directory-target"),
+                &src.join("directory-link.ts"),
+            );
+
+            let config = make_config(dir.path().to_path_buf(), false);
+            let names = file_names(&discover_files(&config), dir.path());
+
+            assert!(names.contains(&"src/regular.ts".to_string()));
+            assert!(names.contains(&"src/inside-target.ts".to_string()));
+            assert!(names.contains(&"src/inside-link.ts".to_string()));
+            assert!(!names.contains(&"src/outside-link.ts".to_string()));
+            assert!(!names.contains(&"src/broken-link.ts".to_string()));
+            assert!(!names.contains(&"src/directory-link.ts".to_string()));
         }
 
         #[test]

--- a/crates/core/src/plugins/manifest_entries.rs
+++ b/crates/core/src/plugins/manifest_entries.rs
@@ -491,6 +491,7 @@ fn dotted_lookup<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
 /// to the manifest glob; runs only when an active plugin declares manifestEntries.
 fn discover_manifest_paths(root: &Path, matcher: &globset::GlobMatcher) -> Vec<PathBuf> {
     let mut out = Vec::new();
+    let canonical_root = root.canonicalize().ok();
     let walker = ignore::WalkBuilder::new(root)
         .hidden(false)
         .git_ignore(true)
@@ -499,12 +500,22 @@ fn discover_manifest_paths(root: &Path, matcher: &globset::GlobMatcher) -> Vec<P
         .filter_entry(|entry| entry.file_name() != "node_modules")
         .build();
     for entry in walker.flatten() {
-        // Skip directories; match everything else (regular files and any
-        // symlinked manifest) against the glob, reads fail gracefully.
-        if entry.file_type().is_none_or(|ft| ft.is_dir()) {
+        let Some(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
             continue;
         }
         let path = entry.path();
+        if file_type.is_symlink()
+            && !is_contained_regular_file_symlink(path, canonical_root.as_deref())
+        {
+            tracing::debug!(
+                path = %path.display(),
+                "skipping manifest symlink with a broken, non-file, or outside-root target"
+            );
+            continue;
+        }
         if let Some(rel) = root_relative_forward_slash(path, root)
             && matcher.is_match(Path::new(&rel))
         {
@@ -516,6 +527,16 @@ fn discover_manifest_paths(root: &Path, matcher: &globset::GlobMatcher) -> Vec<P
     // across machines and CI runners.
     out.sort();
     out
+}
+
+fn is_contained_regular_file_symlink(path: &Path, canonical_root: Option<&Path>) -> bool {
+    let Some(root) = canonical_root else {
+        return false;
+    };
+    let Ok(target) = path.canonicalize() else {
+        return false;
+    };
+    target.starts_with(root) && target.metadata().is_ok_and(|metadata| metadata.is_file())
 }
 
 /// Root-relative forward-slash string for a discovered (absolute) path, or
@@ -694,6 +715,53 @@ mod tests {
         let p = root.join(rel);
         std::fs::create_dir_all(p.parent().unwrap()).unwrap();
         std::fs::write(p, body).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(target: &Path, link: &Path) {
+        std::os::unix::fs::symlink(target, link).expect("create file symlink");
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(target: &Path, link: &Path) {
+        std::os::windows::fs::symlink_file(target, link).expect("create file symlink");
+    }
+
+    #[test]
+    fn manifest_symlinks_must_target_regular_files_inside_root() {
+        let dir = tempfile::tempdir().expect("create project");
+        let outside = tempfile::tempdir().expect("create outside dir");
+        let root = dir.path();
+        let targets = root.join("targets");
+        let plugins = root.join("plugins");
+        std::fs::create_dir_all(&targets).unwrap();
+        std::fs::create_dir_all(&plugins).unwrap();
+        std::fs::write(targets.join("inside.jsonc"), r#"{"type":"plugin"}"#).unwrap();
+        std::fs::write(outside.path().join("outside.jsonc"), r#"{"type":"plugin"}"#).unwrap();
+
+        symlink_file(
+            &targets.join("inside.jsonc"),
+            &plugins.join("inside-kibana.jsonc"),
+        );
+        symlink_file(
+            &outside.path().join("outside.jsonc"),
+            &plugins.join("outside-kibana.jsonc"),
+        );
+        symlink_file(
+            &targets.join("missing.jsonc"),
+            &plugins.join("broken-kibana.jsonc"),
+        );
+
+        let matcher = globset::Glob::new("**/*-kibana.jsonc")
+            .unwrap()
+            .compile_matcher();
+        let paths = discover_manifest_paths(root, &matcher);
+        let relative: Vec<String> = paths
+            .iter()
+            .filter_map(|path| root_relative_forward_slash(path, root))
+            .collect();
+
+        assert_eq!(relative, vec!["plugins/inside-kibana.jsonc"]);
     }
 
     fn kinds(reports: &[RuleReport]) -> Vec<WarningKind> {

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -105,6 +105,8 @@ mod safe_analysis;
 mod sfc_parsing;
 #[path = "integration_test/svelte_dead_event.rs"]
 mod svelte_dead_event;
+#[path = "integration_test/symlink_root_containment.rs"]
+mod symlink_root_containment;
 #[path = "integration_test/unreachable_exports.rs"]
 mod unreachable_exports;
 #[path = "integration_test/workspaces.rs"]

--- a/crates/core/tests/integration_test/symlink_root_containment.rs
+++ b/crates/core/tests/integration_test/symlink_root_containment.rs
@@ -1,0 +1,62 @@
+use super::common::create_config;
+use std::path::Path;
+
+#[cfg(unix)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).expect("create file symlink");
+}
+
+#[cfg(windows)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::windows::fs::symlink_file(target, link).expect("create file symlink");
+}
+
+#[test]
+fn symlink_root_containment() {
+    let project = tempfile::tempdir().expect("create project");
+    let outside = tempfile::tempdir().expect("create outside dir");
+    let root = project.path();
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("create src");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"symlink-containment","private":true,"main":"src/index.ts"}"#,
+    )
+    .expect("write package");
+    std::fs::write(
+        src.join("index.ts"),
+        "import { inside } from './inside-link';\nexport const value = inside;\n",
+    )
+    .expect("write entry");
+    std::fs::write(src.join("inside-target.ts"), "export const inside = 1;\n")
+        .expect("write inside target");
+    std::fs::write(
+        outside.path().join("outside-target.ts"),
+        "export const leaked = 1;\n",
+    )
+    .expect("write outside target");
+    symlink_file(&src.join("inside-target.ts"), &src.join("inside-link.ts"));
+    symlink_file(
+        &outside.path().join("outside-target.ts"),
+        &src.join("outside-link.ts"),
+    );
+
+    let results =
+        fallow_core::analyze(&create_config(root.to_path_buf())).expect("analysis should succeed");
+    assert!(
+        results.unresolved_imports.is_empty(),
+        "the in-root symlink must remain analyzable: {:?}",
+        results.unresolved_imports
+    );
+    assert!(
+        results.unused_files.iter().all(|finding| {
+            !finding
+                .file
+                .path
+                .to_string_lossy()
+                .contains("outside-link.ts")
+        }),
+        "outside symlink content must not enter analysis: {:?}",
+        results.unused_files
+    );
+}

--- a/crates/engine/src/churn.rs
+++ b/crates/engine/src/churn.rs
@@ -247,9 +247,10 @@ struct ChurnFileEvent {
 /// `root` is the project root that relative event paths are joined to (matching
 /// how the git path joins numstat paths), so the churn keys line up with the
 /// analyzed files. Returns a human-readable error (the CLI maps it to exit code
-/// 2) on a missing file, malformed JSON, wrong `schema`, an empty event path, a
-/// far-future timestamp, or an event count past `MAX_CHURN_EVENTS`. An empty
-/// `events` array is valid (no hotspots), not an error. Never runs `git`.
+/// 2) on an oversized or missing file, malformed JSON, wrong `schema`, an
+/// invalid repo-relative event path, a far-future timestamp, line totals above
+/// `u32::MAX`, or an event count past `MAX_CHURN_EVENTS`. An empty `events`
+/// array is valid (no hotspots), not an error. Never runs `git`.
 pub fn analyze_churn_from_file(path: &Path, root: &Path) -> Result<ChurnResult, String> {
     let raw = read_churn_file_with_limit(path, MAX_CHURN_FILE_BYTES)?;
     let doc: ChurnFileDoc = serde_json::from_str(&raw)
@@ -293,8 +294,9 @@ fn read_churn_file_with_limit(path: &Path, limit: usize) -> Result<String, Strin
 
 /// Validate and fold a parsed `fallow-churn/v1` document into event state.
 ///
-/// Rejects empty paths and far-future (likely millisecond) timestamps; interns
-/// authors into the pool exactly as the git-log path does.
+/// Rejects invalid paths, far-future (likely millisecond) timestamps, and line
+/// totals outside the public `u32` contract. Interns authors into the pool
+/// exactly as the git-log path does.
 fn churn_event_state_from_doc(
     doc: &ChurnFileDoc,
     path: &Path,

--- a/crates/engine/src/churn.rs
+++ b/crates/engine/src/churn.rs
@@ -4,7 +4,8 @@
 //! recency-weighted churn scores and trend indicators.
 
 use rustc_hash::FxHashMap;
-use std::path::{Path, PathBuf};
+use std::io::Read as _;
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::OnceLock;
 
@@ -64,6 +65,9 @@ const CHURN_FILE_SCHEMA: &str = "fallow-churn/v1";
 /// state from a single untrusted file. Mirrors the diff parser's
 /// `MAX_ADDED_LINES` guard in the CLI.
 const MAX_CHURN_EVENTS: usize = 5_000_000;
+
+/// Upper bound on the serialized churn import before JSON deserialization.
+const MAX_CHURN_FILE_BYTES: usize = 256 * 1024 * 1024;
 
 /// Reject an imported `timestamp` more than this many seconds in the future
 /// (one year). A unix-seconds commit time is never legitimately this far ahead
@@ -247,8 +251,7 @@ struct ChurnFileEvent {
 /// far-future timestamp, or an event count past `MAX_CHURN_EVENTS`. An empty
 /// `events` array is valid (no hotspots), not an error. Never runs `git`.
 pub fn analyze_churn_from_file(path: &Path, root: &Path) -> Result<ChurnResult, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read churn file {}: {e}", path.display()))?;
+    let raw = read_churn_file_with_limit(path, MAX_CHURN_FILE_BYTES)?;
     let doc: ChurnFileDoc = serde_json::from_str(&raw)
         .map_err(|e| format!("failed to parse churn file {}: {e}", path.display()))?;
     if doc.schema != CHURN_FILE_SCHEMA {
@@ -268,6 +271,24 @@ pub fn analyze_churn_from_file(path: &Path, root: &Path) -> Result<ChurnResult, 
 
     let state = churn_event_state_from_doc(&doc, path, root)?;
     Ok(build_churn_result(state, false))
+}
+
+fn read_churn_file_with_limit(path: &Path, limit: usize) -> Result<String, String> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("failed to read churn file {}: {e}", path.display()))?;
+    let mut bytes = Vec::new();
+    file.take(limit as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("failed to read churn file {}: {e}", path.display()))?;
+    if bytes.len() > limit {
+        return Err(format!(
+            "churn file {} is at least {} bytes, exceeding the {limit} byte limit",
+            path.display(),
+            bytes.len()
+        ));
+    }
+    String::from_utf8(bytes)
+        .map_err(|e| format!("failed to read churn file {} as UTF-8: {e}", path.display()))
 }
 
 /// Validate and fold a parsed `fallow-churn/v1` document into event state.
@@ -301,6 +322,7 @@ struct ChurnFileImportBuilder<'a> {
     root: &'a Path,
     future_limit: u64,
     files: FxHashMap<PathBuf, FileEvents>,
+    totals: FxHashMap<PathBuf, (u64, u64)>,
     author_pool: Vec<String>,
     author_index: FxHashMap<String, u32>,
 }
@@ -312,6 +334,7 @@ impl<'a> ChurnFileImportBuilder<'a> {
             root,
             future_limit,
             files: FxHashMap::default(),
+            totals: FxHashMap::default(),
             author_pool: Vec::new(),
             author_index: FxHashMap::default(),
         }
@@ -322,6 +345,18 @@ impl<'a> ChurnFileImportBuilder<'a> {
         validate_churn_event_timestamp(self.path, event.timestamp, self.future_limit, &rel)?;
 
         let abs_path = self.root.join(&rel);
+        let totals = self.totals.entry(abs_path.clone()).or_default();
+        totals.0 += u64::from(event.added);
+        totals.1 += u64::from(event.deleted);
+        if totals.0 > u64::from(u32::MAX) || totals.1 > u64::from(u32::MAX) {
+            return Err(format!(
+                "churn file {} has line totals for \"{rel}\" exceeding the u32 limit \
+                 (added {}, deleted {})",
+                self.path.display(),
+                totals.0,
+                totals.1
+            ));
+        }
         let author_idx = self.intern_author(event.author.as_deref());
         self.files
             .entry(abs_path)
@@ -357,6 +392,18 @@ fn normalize_churn_event_path(path: &Path, event_path: &str) -> Result<String, S
     if rel.is_empty() {
         return Err(format!(
             "churn file {} has an event with an empty path",
+            path.display()
+        ));
+    }
+    let bytes = rel.as_bytes();
+    let has_drive_prefix = bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+    let has_empty_component = rel.split('/').any(str::is_empty);
+    let components_are_normal = Path::new(rel)
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)));
+    if rel.starts_with('/') || has_drive_prefix || has_empty_component || !components_are_normal {
+        return Err(format!(
+            "churn file {} has an invalid repo-relative event path \"{event_path}\"",
             path.display()
         ));
     }
@@ -917,8 +964,8 @@ fn git_path_from_bytes(path: &[u8]) -> PathBuf {
 fn aggregate_file_churn(path: PathBuf, file: FileEvents, now_secs: u64) -> FileChurn {
     let mut timestamps = Vec::with_capacity(file.events.len());
     let mut weighted_commits = 0.0;
-    let mut lines_added = 0;
-    let mut lines_deleted = 0;
+    let mut lines_added = 0_u32;
+    let mut lines_deleted = 0_u32;
     let mut authors: FxHashMap<u32, AuthorContribution> = FxHashMap::default();
 
     for event in file.events {
@@ -926,8 +973,8 @@ fn aggregate_file_churn(path: PathBuf, file: FileEvents, now_secs: u64) -> FileC
         let age_days = (now_secs.saturating_sub(event.timestamp)) as f64 / SECS_PER_DAY;
         let weight = 0.5_f64.powf(age_days / HALF_LIFE_DAYS);
         weighted_commits += weight;
-        lines_added += event.lines_added;
-        lines_deleted += event.lines_deleted;
+        lines_added = lines_added.saturating_add(event.lines_added);
+        lines_deleted = lines_deleted.saturating_add(event.lines_deleted);
         accumulate_author(&mut authors, event.author_idx, weight, event.timestamp);
     }
 
@@ -1963,6 +2010,22 @@ mod tests {
     }
 
     #[test]
+    fn churn_file_reader_accepts_exact_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_churn_file(dir.path(), "12345678");
+        assert_eq!(read_churn_file_with_limit(&path, 8).unwrap(), "12345678");
+    }
+
+    #[test]
+    fn churn_file_reader_rejects_limit_plus_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_churn_file(dir.path(), "123456789");
+        let err = read_churn_file_with_limit(&path, 8).unwrap_err();
+        assert!(err.contains("at least 9 bytes"), "{err}");
+        assert!(err.contains("8 byte limit"), "{err}");
+    }
+
+    #[test]
     fn churn_file_empty_path_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_churn_file(
@@ -1971,6 +2034,43 @@ mod tests {
         );
         let err = analyze_churn_from_file(&path, Path::new("/project")).unwrap_err();
         assert!(err.contains("empty path"), "{err}");
+    }
+
+    #[test]
+    fn churn_file_rejects_non_relative_paths() {
+        let invalid = [
+            "/tmp/a.ts",
+            r"C:\tmp\a.ts",
+            "../a.ts",
+            "src/../../a.ts",
+            "./src/a.ts",
+            "//server/share/a.ts",
+        ];
+        for event_path in invalid {
+            let dir = tempfile::tempdir().unwrap();
+            let body = format!(
+                r#"{{ "schema": "fallow-churn/v1", "events": [ {{ "path": {event_path:?}, "timestamp": 1700000000, "added": 1, "deleted": 0 }} ] }}"#
+            );
+            let path = write_churn_file(dir.path(), &body);
+            let err = analyze_churn_from_file(&path, Path::new("/project")).unwrap_err();
+            assert!(err.contains(event_path), "{event_path}: {err}");
+            assert!(err.contains("repo-relative"), "{event_path}: {err}");
+        }
+    }
+
+    #[test]
+    fn churn_file_accepts_unicode_and_spaces_in_path_components() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_churn_file(
+            dir.path(),
+            r#"{ "schema": "fallow-churn/v1", "events": [ { "path": "src/ruimte map/naïef.ts", "timestamp": 1700000000, "added": 1, "deleted": 0 } ] }"#,
+        );
+        let result = analyze_churn_from_file(&path, Path::new("/project")).unwrap();
+        assert!(
+            result
+                .files
+                .contains_key(&PathBuf::from("/project/src/ruimte map/naïef.ts"))
+        );
     }
 
     #[test]
@@ -2036,5 +2136,36 @@ mod tests {
                 .files
                 .contains_key(&PathBuf::from("/project/src/a.ts"))
         );
+    }
+
+    #[test]
+    fn churn_file_rejects_line_totals_above_u32() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_churn_file(
+            dir.path(),
+            r#"{ "schema": "fallow-churn/v1", "events": [
+                { "path": "src/a.ts", "timestamp": 1700000000, "added": 4294967295, "deleted": 0 },
+                { "path": "src/a.ts", "timestamp": 1700000001, "added": 1, "deleted": 0 }
+            ] }"#,
+        );
+        let err = analyze_churn_from_file(&path, Path::new("/project")).unwrap_err();
+        assert!(err.contains("exceeding the u32 limit"), "{err}");
+        assert!(err.contains("src/a.ts"), "{err}");
+    }
+
+    #[test]
+    fn churn_file_accepts_line_totals_at_u32_max() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_churn_file(
+            dir.path(),
+            r#"{ "schema": "fallow-churn/v1", "events": [
+                { "path": "src/a.ts", "timestamp": 1700000000, "added": 4294967294, "deleted": 4294967295 },
+                { "path": "src/a.ts", "timestamp": 1700000001, "added": 1, "deleted": 0 }
+            ] }"#,
+        );
+        let result = analyze_churn_from_file(&path, Path::new("/project")).unwrap();
+        let churn = &result.files[&PathBuf::from("/project/src/a.ts")];
+        assert_eq!(churn.lines_added, u32::MAX);
+        assert_eq!(churn.lines_deleted, u32::MAX);
     }
 }

--- a/crates/engine/src/discover_walk.rs
+++ b/crates/engine/src/discover_walk.rs
@@ -332,6 +332,7 @@ impl HiddenDirScope {
 /// identical to the config-capture-disabled walk.
 struct FileVisitor<'a> {
     root: &'a Path,
+    canonical_root: Option<&'a Path>,
     ignore_patterns: &'a globset::GlobSet,
     production_excludes: &'a Option<globset::GlobSet>,
     shared: &'a Mutex<Vec<(std::path::PathBuf, u64)>>,
@@ -362,8 +363,21 @@ impl ignore::ParallelVisitor for FileVisitor<'_> {
         {
             return ignore::WalkState::Continue;
         }
+        let symlink_size = if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            let Some(size) = contained_symlink_file_size(entry.path(), self.canonical_root) else {
+                tracing::debug!(
+                    path = %entry.path().display(),
+                    "skipping source symlink with a broken, non-file, or outside-root target"
+                );
+                return ignore::WalkState::Continue;
+            };
+            Some(size)
+        } else {
+            None
+        };
         if has_source_extension(entry.path()) {
-            let size_bytes = entry.metadata().map_or(0, |m| m.len());
+            let size_bytes =
+                symlink_size.unwrap_or_else(|| entry.metadata().map_or(0, |m| m.len()));
             self.local.push((entry.into_path(), size_bytes));
         } else if self.config_shared.is_some() {
             // A non-source file admitted by the config-candidate type group. No
@@ -372,6 +386,16 @@ impl ignore::ParallelVisitor for FileVisitor<'_> {
         }
         ignore::WalkState::Continue
     }
+}
+
+fn contained_symlink_file_size(path: &Path, canonical_root: Option<&Path>) -> Option<u64> {
+    let root = canonical_root?;
+    let target = path.canonicalize().ok()?;
+    if !target.starts_with(root) {
+        return None;
+    }
+    let metadata = target.metadata().ok()?;
+    metadata.is_file().then_some(metadata.len())
 }
 
 impl Drop for FileVisitor<'_> {
@@ -400,6 +424,7 @@ impl Drop for FileVisitor<'_> {
 /// Builder that creates per-thread `FileVisitor` instances for the parallel walker.
 struct FileVisitorBuilder<'a> {
     root: &'a Path,
+    canonical_root: Option<&'a Path>,
     ignore_patterns: &'a globset::GlobSet,
     production_excludes: &'a Option<globset::GlobSet>,
     shared: &'a Mutex<Vec<(std::path::PathBuf, u64)>>,
@@ -410,6 +435,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for FileVisitorBuilder<'s> {
     fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
         Box::new(FileVisitor {
             root: self.root,
+            canonical_root: self.canonical_root,
             ignore_patterns: self.ignore_patterns,
             production_excludes: self.production_excludes,
             shared: self.shared,
@@ -734,11 +760,13 @@ pub fn discover_files_and_config_candidates(
     let walk_builder =
         build_source_walk_builder(config, additional_hidden_dir_scopes, capture_config);
     let production_excludes = build_production_excludes(config);
+    let canonical_root = config.root.canonicalize().ok();
 
     let collected: Mutex<Vec<(std::path::PathBuf, u64)>> = Mutex::new(Vec::new());
     let config_collected: Mutex<Vec<std::path::PathBuf>> = Mutex::new(Vec::new());
     let mut visitor_builder = FileVisitorBuilder {
         root: &config.root,
+        canonical_root: canonical_root.as_deref(),
         ignore_patterns: &config.ignore_patterns,
         production_excludes: &production_excludes,
         shared: &collected,
@@ -1190,6 +1218,63 @@ mod tests {
                         .replace('\\', "/")
                 })
                 .collect()
+        }
+
+        #[cfg(unix)]
+        fn symlink_file(target: &Path, link: &Path) {
+            std::os::unix::fs::symlink(target, link).expect("create file symlink");
+        }
+
+        #[cfg(windows)]
+        fn symlink_file(target: &Path, link: &Path) {
+            std::os::windows::fs::symlink_file(target, link).expect("create file symlink");
+        }
+
+        #[cfg(unix)]
+        fn symlink_dir(target: &Path, link: &Path) {
+            std::os::unix::fs::symlink(target, link).expect("create directory symlink");
+        }
+
+        #[cfg(windows)]
+        fn symlink_dir(target: &Path, link: &Path) {
+            std::os::windows::fs::symlink_dir(target, link).expect("create directory symlink");
+        }
+
+        #[test]
+        fn source_symlinks_must_target_regular_files_inside_root() {
+            let dir = tempfile::tempdir().expect("create project");
+            let outside = tempfile::tempdir().expect("create outside dir");
+            let src = dir.path().join("src");
+            std::fs::create_dir_all(&src).unwrap();
+            std::fs::write(src.join("regular.ts"), "export const regular = 1;").unwrap();
+            std::fs::write(src.join("inside-target.ts"), "export const inside = 1;").unwrap();
+            std::fs::write(
+                outside.path().join("outside-target.ts"),
+                "export const outside = 1;",
+            )
+            .unwrap();
+            std::fs::create_dir_all(src.join("directory-target")).unwrap();
+
+            symlink_file(&src.join("inside-target.ts"), &src.join("inside-link.ts"));
+            symlink_file(
+                &outside.path().join("outside-target.ts"),
+                &src.join("outside-link.ts"),
+            );
+            symlink_file(&src.join("missing-target.ts"), &src.join("broken-link.ts"));
+            symlink_dir(
+                &src.join("directory-target"),
+                &src.join("directory-link.ts"),
+            );
+
+            let config = make_config(dir.path().to_path_buf(), false);
+            let names = file_names(&discover_files(&config), dir.path());
+
+            assert!(names.contains(&"src/regular.ts".to_string()));
+            assert!(names.contains(&"src/inside-target.ts".to_string()));
+            assert!(names.contains(&"src/inside-link.ts".to_string()));
+            assert!(!names.contains(&"src/outside-link.ts".to_string()));
+            assert!(!names.contains(&"src/broken-link.ts".to_string()));
+            assert!(!names.contains(&"src/directory-link.ts".to_string()));
         }
 
         #[test]

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -153,9 +153,15 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.match(windowsRustJob, /needs: changes/);
   assert.match(windowsRustJob, /if: needs\.changes\.outputs\.windows-rust == 'true'/);
   assert.match(windowsRustJob, /runs-on: windows-latest/);
+  assert.ok(windowsRustPaths.includes("crates/core/src/discover/walk.rs"));
+  assert.ok(windowsRustPaths.includes("crates/core/src/plugins/manifest_entries.rs"));
+  assert.ok(
+    windowsRustPaths.includes("crates/core/tests/integration_test/symlink_root_containment.rs"),
+  );
   assert.ok(windowsRustPaths.includes("crates/lsp/**"));
   assert.match(windowsRustJob, /cargo test -p fallow-engine changed_files::tests/);
   assert.match(windowsRustJob, /cargo test -p fallow-engine churn::tests/);
+  assert.match(windowsRustJob, /cargo test -p fallow-core symlink/);
   assert.match(
     windowsRustJob,
     /^[ \t]+run: cargo test -p fallow-lsp windows_initialization_publishes_uri_safe_diagnostics$/m,
@@ -166,7 +172,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   );
   assert.match(
     windowsRustJob,
-    /^[ \t]+run: cargo clippy -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings$/m,
+    /^[ \t]+run: cargo clippy -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings$/m,
   );
   assert.match(zedJob, /runs-on: ubuntu-latest/);
   assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);


### PR DESCRIPTION
## Summary
- bound churn imports before deserialization, reject unsafe paths and aggregate overflow
- enforce the unified-diff byte cap for both file and stdin inputs with fail-open reporting
- keep source and plugin-manifest symlinks inside the configured project root

## Verification
- [x] Focused engine, core, CLI, manifest, and symlink regression tests
- [x] Full normal Rust test matrix and benchmark compilation
- [x] Real-repository oversized stdin, outside-root symlink, and churn-import probes
- [x] Windows core symlink regression and all-target Clippy
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Rustdoc, repository policy, script, and npm wrapper gates
- [x] `fallow audit --format json --quiet`
