### PR TITLE
feat(vscode): set baseline at HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **VS Code can set a changed-code baseline at HEAD in one command.** The new
+  `Fallow: Set Baseline at HEAD` palette command creates the local lightweight
+  `fallow-baseline` tag, writes `fallow.changedSince` to a single-folder
+  workspace, and refreshes analysis. It confirms before mutation, never pushes
+  a remote ref, refuses to move an existing tag, and leaves multi-root
+  workspaces unchanged until per-root baseline semantics exist.
+
 ## [3.6.0] - 2026-07-15
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,12 +22,6 @@ The coverage setup state machine works end to end, but the install handoff still
 
 `fallow fix` leaves Prettier, dprint, or Biome to clean up whitespace after removals. Invoke the project's configured formatter automatically when running in-place.
 
-### Baseline-adoption command
-
-The `fallow.changedSince` setting scopes the Problems panel and sidebar, while the status bar reports whether that scope was applied or dropped. One editor shortcut would still close the setup loop for legacy codebases:
-
-- **"Fallow: Set Baseline at HEAD" command** -- a palette command that runs `git tag fallow-baseline` and writes `fallow.changedSince` into `.vscode/settings.json` in one step, so users do not need to leave the editor or know the git tag command.
-
 ### Per-package `changedSince` overrides
 
 Monorepos with packages on different release cadences want different baseline refs per package (e.g. `packages/web` tracks `main`, `packages/legacy` tracks `release/2024.10`). Today `fallow.changedSince` is workspace-wide. Extending this to per-package overrides requires config-schema work (a new `[overrides]` block keyed on workspace root, or `package.json` field), resolution semantics (which baseline wins for a file in package A imported from package B), and matching status-bar logic.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -39,6 +39,7 @@ code --install-extension fallow-rs.fallow-vscode
 | Command | Description |
 |---------|-------------|
 | `Fallow: Run Analysis` | Run full codebase analysis and update tree views. Clean runs show a scoped JS/TS summary and link to the Fallow output channel. |
+| `Fallow: Set Baseline at HEAD` | Create the local lightweight `fallow-baseline` Git tag at the current commit, set `fallow.changedSince` in the single-folder workspace, and refresh analysis. The command confirms before mutation, never pushes, and refuses to move an existing tag. |
 | `Fallow: Audit Changed Files` | Audit the current change set for a pass/warn/fail verdict, shown in the audit verdict status-bar item (or an information message when that item is disabled). Findings are static candidates to verify. |
 | `Fallow: Reload Health` | Re-run the Health view analysis (score, complexity, hotspot and refactoring candidates) |
 | `Fallow: Scan for Security Candidates` | Scan for local security candidates (`client-server-leak`, tainted-sink CWE findings) and populate the Security Candidates view. Requires `fallow.security.enabled`. Results are UNVERIFIED candidates to verify, never confirmed vulnerabilities. |
@@ -96,7 +97,7 @@ Mute state is stored in the workspace, so it survives reload but does not bleed 
 | `fallow.license.showStatusBar` | `true` | Show a Fallow license indicator in the status bar. Disable to remove the indicator and skip the license status probe on activation. |
 | `fallow.license.refreshOnStartup` | `false` | Probe license status once when the extension activates. Off by default so the editor never shells out to fallow on startup unless you opt in; the indicator otherwise updates only when you run a Fallow license command. |
 | `fallow.production` | `false` | Production mode: exclude test/dev files, only production scripts. |
-| `fallow.changedSince` | `""` | Git ref (tag, branch, or SHA) to scope the Problems panel and sidebar to files changed since that ref, mirroring the CLI's `--changed-since`. Tag your current commit (e.g. `fallow-baseline`) and set this to the tag to enforce "no new issues going forward" while ignoring pre-existing findings. |
+| `fallow.changedSince` | `""` | Git ref (tag, branch, or SHA) to scope the Problems panel and sidebar to files changed since that ref, mirroring the CLI's `--changed-since`. Run **Fallow: Set Baseline at HEAD** in a single-folder workspace to create and configure `fallow-baseline` safely. |
 | `fallow.audit.gate` | `"new-only"` | Which findings affect the audit verdict. `new-only` fails only on findings introduced by the current change set (runs an extra base-snapshot pass); `all` fails on every finding in changed files. Mirrors `fallow audit --gate`. |
 | `fallow.audit.statusBar.enabled` | `true` | Show the audit verdict (pass/warn/fail) for the current change set in the status bar. Toggling takes effect immediately, no window reload needed. |
 | `fallow.audit.runOnSave` | `false` | Re-run the audit verdict automatically when a JS/TS file is saved. Off by default to avoid added latency; the **Fallow: Audit Changed Files** command and the status-bar item run it on demand. |

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -94,6 +94,11 @@
         "icon": "$(inspect)"
       },
       {
+        "command": "fallow.setBaselineAtHead",
+        "title": "Fallow: Set Baseline at HEAD",
+        "icon": "$(git-commit)"
+      },
+      {
         "command": "fallow.selectWorkspace",
         "title": "Fallow: Select Workspace Scope...",
         "icon": "$(layers)"
@@ -487,7 +492,7 @@
         "fallow.changedSince": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Show only issues in files changed since the given git ref. Tag your current commit (`git tag fallow-baseline`) and set this to the tag name to keep existing issues hidden while flagging new ones in the Problems panel. Mirrors the CLI's `--changed-since`. Empty = full scope."
+          "markdownDescription": "Show only issues in files changed since the given git ref. Run **Fallow: Set Baseline at HEAD** to create the local `fallow-baseline` tag and configure this setting in one step. The command never pushes or moves an existing tag. Mirrors the CLI's `--changed-since`. Empty = full scope."
         },
         "fallow.health.enabled": {
           "type": "boolean",

--- a/editors/vscode/src/baselineCommand.ts
+++ b/editors/vscode/src/baselineCommand.ts
@@ -1,0 +1,311 @@
+import { execFile } from "node:child_process";
+import { registerChild, unregisterChild } from "./process-registry.js";
+
+export const BASELINE_TAG = "fallow-baseline";
+
+const BASELINE_REF = `refs/tags/${BASELINE_TAG}`;
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024;
+
+export interface GitCommandResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export type GitRunner = (args: ReadonlyArray<string>, cwd: string) => Promise<GitCommandResult>;
+
+export interface BaselineCommandHost {
+  readonly workspaceRoots: () => ReadonlyArray<string>;
+  readonly changedSince: () => string;
+  readonly confirm: (message: string) => Promise<boolean>;
+  readonly showWarning: (message: string, action?: string) => Promise<boolean>;
+  readonly showError: (message: string) => Promise<void>;
+  readonly showInformation: (message: string) => Promise<void>;
+  readonly openChangedSinceSetting: () => Promise<void>;
+  readonly updateChangedSince: (value: string) => Promise<void>;
+  readonly refreshAnalysis: () => Promise<void>;
+  readonly appendOutput: (line: string) => void;
+}
+
+export type BaselineCommandOutcome =
+  | "configured"
+  | "already-configured"
+  | "cancelled"
+  | "no-workspace"
+  | "multi-root"
+  | "not-repository"
+  | "unborn-head"
+  | "tag-conflict"
+  | "git-error"
+  | "settings-error"
+  | "refresh-error";
+
+type BaselineGitState =
+  | { readonly kind: "missing"; readonly head: string }
+  | { readonly kind: "at-head"; readonly head: string }
+  | { readonly kind: "elsewhere"; readonly head: string; readonly tagCommit: string }
+  | { readonly kind: "not-repository"; readonly detail: string }
+  | { readonly kind: "unborn-head"; readonly detail: string }
+  | { readonly kind: "error"; readonly detail: string };
+
+const commandDetail = (result: GitCommandResult): string =>
+  result.stderr.trim() || result.stdout.trim() || `git exited with code ${result.code}`;
+
+export const runGitCommand: GitRunner = (args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = execFile(
+      "git",
+      [...args],
+      {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      },
+      (error, stdout, stderr) => {
+        unregisterChild(child);
+        if (!error) {
+          resolve({ code: 0, stdout, stderr });
+          return;
+        }
+        if (typeof error.code === "number") {
+          resolve({ code: error.code, stdout, stderr });
+          return;
+        }
+        reject(error);
+      },
+    );
+    registerChild(child);
+  });
+
+const inspectBaselineGitState = async (
+  root: string,
+  runGit: GitRunner,
+): Promise<BaselineGitState> => {
+  try {
+    const repository = await runGit(["rev-parse", "--show-toplevel"], root);
+    if (repository.code !== 0) {
+      return { kind: "not-repository", detail: commandDetail(repository) };
+    }
+
+    const head = await runGit(["rev-parse", "--verify", "HEAD"], root);
+    if (head.code !== 0) {
+      return { kind: "unborn-head", detail: commandDetail(head) };
+    }
+    const headCommit = head.stdout.trim();
+
+    const tagExists = await runGit(["show-ref", "--verify", "--quiet", BASELINE_REF], root);
+    if (tagExists.code === 1) {
+      return { kind: "missing", head: headCommit };
+    }
+    if (tagExists.code !== 0) {
+      return { kind: "error", detail: commandDetail(tagExists) };
+    }
+
+    const tag = await runGit(["rev-parse", "--verify", `${BASELINE_REF}^{commit}`], root);
+    if (tag.code !== 0) {
+      return { kind: "error", detail: commandDetail(tag) };
+    }
+    const tagCommit = tag.stdout.trim();
+    return tagCommit === headCommit
+      ? { kind: "at-head", head: headCommit }
+      : { kind: "elsewhere", head: headCommit, tagCommit };
+  } catch (error) {
+    return {
+      kind: "error",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+};
+
+const confirmationMessage = (createTag: boolean, currentChangedSince: string): string => {
+  const actions = createTag
+    ? `Create the local lightweight Git tag \`${BASELINE_TAG}\` at HEAD and set \`fallow.changedSince\` to that tag?`
+    : `Set \`fallow.changedSince\` to the existing \`${BASELINE_TAG}\` tag at HEAD?`;
+  const replacement =
+    currentChangedSince && currentChangedSince !== BASELINE_TAG
+      ? ` This replaces the current effective value \`${currentChangedSince}\`.`
+      : "";
+  return `${actions}${replacement} This does not push anything to a remote.`;
+};
+
+const resolveWorkspaceRoot = async (
+  host: BaselineCommandHost,
+): Promise<string | "no-workspace" | "multi-root"> => {
+  const roots = host.workspaceRoots();
+  if (roots.length === 0) {
+    await host.showWarning("Fallow: open a workspace folder before setting a baseline.");
+    return "no-workspace";
+  }
+  if (roots.length > 1) {
+    await host.showWarning(
+      "Fallow: Set Baseline at HEAD currently supports single-folder workspaces only. `fallow.changedSince` is workspace-wide, so no Git ref or setting was changed.",
+    );
+    return "multi-root";
+  }
+  return roots[0];
+};
+
+const handleUnavailableState = async (
+  host: BaselineCommandHost,
+  state: Exclude<BaselineGitState, { readonly kind: "missing" | "at-head" }>,
+): Promise<BaselineCommandOutcome> => {
+  if (state.kind === "not-repository") {
+    host.appendOutput(`Set Baseline at HEAD: ${state.detail}`);
+    await host.showWarning("Fallow: the workspace folder is not inside a Git repository.");
+    return "not-repository";
+  }
+  if (state.kind === "unborn-head") {
+    host.appendOutput(`Set Baseline at HEAD: ${state.detail}`);
+    await host.showWarning(
+      "Fallow: the repository has no commit yet. Create the first commit before setting a baseline.",
+    );
+    return "unborn-head";
+  }
+  if (state.kind === "error") {
+    host.appendOutput(`Set Baseline at HEAD failed: ${state.detail}`);
+    await host.showError("Fallow: could not inspect the Git baseline. See the Fallow output.");
+    return "git-error";
+  }
+
+  host.appendOutput(
+    `Set Baseline at HEAD: ${BASELINE_TAG} points to ${state.tagCommit}, HEAD is ${state.head}.`,
+  );
+  const openSettings = await host.showWarning(
+    `Fallow: the local tag \`${BASELINE_TAG}\` already points to another commit. It was not moved.`,
+    "Open Setting",
+  );
+  if (openSettings) {
+    await host.openChangedSinceSetting();
+  }
+  return "tag-conflict";
+};
+
+const persistChangedSince = async (
+  host: BaselineCommandHost,
+  createTag: boolean,
+): Promise<"settings-error" | null> => {
+  try {
+    await host.updateChangedSince(BASELINE_TAG);
+    return null;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    host.appendOutput(`Set Baseline at HEAD setting update failed: ${detail}`);
+    const prefix = createTag
+      ? `The local tag \`${BASELINE_TAG}\` was created, but`
+      : `The local tag \`${BASELINE_TAG}\` already points to HEAD, but`;
+    await host.showError(
+      `Fallow: ${prefix} the workspace setting could not be updated. Set \`fallow.changedSince\` to \`${BASELINE_TAG}\` manually.`,
+    );
+    return "settings-error";
+  }
+};
+
+const refreshBaselineAnalysis = async (
+  host: BaselineCommandHost,
+): Promise<"refresh-error" | null> => {
+  try {
+    await host.refreshAnalysis();
+    return null;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    host.appendOutput(`Set Baseline at HEAD refresh failed: ${detail}`);
+    await host.showError(
+      `Fallow: the baseline is configured, but analysis could not refresh. Run "Fallow: Run Analysis" to apply it.`,
+    );
+    return "refresh-error";
+  }
+};
+
+const confirmBaselineChange = async (
+  host: BaselineCommandHost,
+  createTag: boolean,
+  settingChanges: boolean,
+  currentChangedSince: string,
+): Promise<boolean> => {
+  if (!createTag && !settingChanges) {
+    return true;
+  }
+  return host.confirm(confirmationMessage(createTag, currentChangedSince));
+};
+
+const createBaselineTag = async (
+  host: BaselineCommandHost,
+  runGit: GitRunner,
+  root: string,
+): Promise<"git-error" | null> => {
+  const created = await runGit(["tag", BASELINE_TAG, "HEAD"], root);
+  if (created.code === 0) {
+    return null;
+  }
+  host.appendOutput(`Set Baseline at HEAD failed: ${commandDetail(created)}`);
+  await host.showError("Fallow: could not create the baseline tag. See the Fallow output.");
+  return "git-error";
+};
+
+const reportBaselineSuccess = async (
+  host: BaselineCommandHost,
+  alreadyConfigured: boolean,
+): Promise<"configured" | "already-configured"> => {
+  await host.showInformation(
+    alreadyConfigured
+      ? `Fallow: \`${BASELINE_TAG}\` is already the active baseline at HEAD.`
+      : `Fallow: baseline set at HEAD. New findings are scoped from \`${BASELINE_TAG}\`.`,
+  );
+  return alreadyConfigured ? "already-configured" : "configured";
+};
+
+const configureBaseline = async (
+  host: BaselineCommandHost,
+  runGit: GitRunner,
+  root: string,
+  createTag: boolean,
+): Promise<BaselineCommandOutcome> => {
+  const currentChangedSince = host.changedSince().trim();
+  const settingChanges = currentChangedSince !== BASELINE_TAG;
+  const confirmed = await confirmBaselineChange(
+    host,
+    createTag,
+    settingChanges,
+    currentChangedSince,
+  );
+  if (!confirmed) {
+    return "cancelled";
+  }
+
+  if (createTag) {
+    const tagFailure = await createBaselineTag(host, runGit, root);
+    if (tagFailure) {
+      return tagFailure;
+    }
+  }
+
+  if (settingChanges) {
+    const persistenceFailure = await persistChangedSince(host, createTag);
+    if (persistenceFailure) {
+      return persistenceFailure;
+    }
+  }
+
+  const refreshFailure = await refreshBaselineAnalysis(host);
+  if (refreshFailure) {
+    return refreshFailure;
+  }
+
+  return reportBaselineSuccess(host, !createTag && !settingChanges);
+};
+
+export const runBaselineCommand = async (
+  host: BaselineCommandHost,
+  runGit: GitRunner = runGitCommand,
+): Promise<BaselineCommandOutcome> => {
+  const root = await resolveWorkspaceRoot(host);
+  if (root === "no-workspace" || root === "multi-root") {
+    return root;
+  }
+  const state = await inspectBaselineGitState(root, runGit);
+  if (state.kind !== "missing" && state.kind !== "at-head") {
+    return handleUnavailableState(host, state);
+  }
+
+  return configureBaseline(host, runGit, root, state.kind === "missing");
+};

--- a/editors/vscode/src/baselineCommand.ts
+++ b/editors/vscode/src/baselineCommand.ts
@@ -233,7 +233,7 @@ const createBaselineTag = async (
   runGit: GitRunner,
   root: string,
 ): Promise<"git-error" | null> => {
-  const created = await runGit(["tag", BASELINE_TAG, "HEAD"], root);
+  const created = await runGit(["tag", "--no-sign", BASELINE_TAG, "HEAD"], root);
   if (created.code === 0) {
     return null;
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -6,6 +6,7 @@ import {
   countCheckIssues,
   countDuplicationGroups,
 } from "./analysis-utils.js";
+import { runBaselineCommand } from "./baselineCommand.js";
 import { shouldAcceptLspAnalysisComplete } from "./analysisNotification.js";
 import { startClient, stopClient, restartClient } from "./client.js";
 import { createSingleFlight } from "./analysis-single-flight.js";
@@ -664,6 +665,49 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Extens
     cliAnalysisRan = await triggerCliAnalysis({ force: true });
   };
 
+  const runSetBaselineAtHeadCommand = async (): Promise<void> => {
+    await runBaselineCommand({
+      workspaceRoots: () =>
+        vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [],
+      changedSince: () =>
+        vscode.workspace.getConfiguration("fallow").get<string>("changedSince", ""),
+      confirm: async (message) =>
+        (await vscode.window.showWarningMessage(message, { modal: true }, "Set Baseline")) ===
+        "Set Baseline",
+      showWarning: async (message, action) => {
+        if (!action) {
+          await vscode.window.showWarningMessage(message);
+          return false;
+        }
+        return (await vscode.window.showWarningMessage(message, action)) === action;
+      },
+      showError: async (message) => {
+        await vscode.window.showErrorMessage(message);
+      },
+      showInformation: async (message) => {
+        await vscode.window.showInformationMessage(message);
+      },
+      openChangedSinceSetting: async () => {
+        await vscode.commands.executeCommand(
+          "workbench.action.openSettings",
+          "fallow.changedSince",
+        );
+      },
+      updateChangedSince: async (value) => {
+        await vscode.workspace
+          .getConfiguration("fallow")
+          .update("changedSince", value, vscode.ConfigurationTarget.Workspace);
+      },
+      refreshAnalysis: async () => {
+        cliAnalysisRan = await triggerCliAnalysis({ force: true });
+        if (!cliAnalysisRan) {
+          throw new Error("analysis did not complete");
+        }
+      },
+      appendOutput: (line) => outputChannel.appendLine(line),
+    });
+  };
+
   const runHealthAnalysisCommand = async (): Promise<void> => {
     healthAnalysisRan = await triggerHealthAnalysis();
   };
@@ -755,6 +799,9 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Extens
     vscode.commands.registerCommand("fallow.inspectActiveFile", () =>
       runInspectActiveFile(context, outputChannel),
     ),
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("fallow.setBaselineAtHead", runSetBaselineAtHeadCommand),
   );
 
   // Re-run the sidebar after a scope change so the tree views and status bar

--- a/editors/vscode/test/baselineCommand.test.ts
+++ b/editors/vscode/test/baselineCommand.test.ts
@@ -136,7 +136,7 @@ describe("runBaselineCommand", () => {
 
     await expect(runBaselineCommand(host, runGit)).resolves.toBe("configured");
 
-    expect(runGit).toHaveBeenLastCalledWith(["tag", BASELINE_TAG, "HEAD"], "/repo");
+    expect(runGit).toHaveBeenLastCalledWith(["tag", "--no-sign", BASELINE_TAG, "HEAD"], "/repo");
     expect(updateChangedSince).toHaveBeenCalledWith(BASELINE_TAG);
     expect(refreshAnalysis).toHaveBeenCalledOnce();
     expect(showInformation).toHaveBeenCalledWith(
@@ -252,6 +252,7 @@ describe("runGitCommand", () => {
     expect(
       (await runGitCommand(["-c", "commit.gpgsign=false", "commit", "-m", "initial"], root)).code,
     ).toBe(0);
+    expect((await runGitCommand(["config", "tag.gpgSign", "true"], root)).code).toBe(0);
   });
 
   afterEach(async () => {

--- a/editors/vscode/test/baselineCommand.test.ts
+++ b/editors/vscode/test/baselineCommand.test.ts
@@ -1,0 +1,279 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BASELINE_TAG,
+  runBaselineCommand,
+  runGitCommand,
+  type BaselineCommandHost,
+  type GitCommandResult,
+  type GitRunner,
+} from "../src/baselineCommand.js";
+
+interface MutableHost {
+  roots: string[];
+  currentChangedSince: string;
+  confirmResult: boolean;
+  warningActionResult: boolean;
+  updateError: Error | null;
+  refreshError: Error | null;
+}
+
+const hostState: MutableHost = {
+  roots: ["/repo"],
+  currentChangedSince: "",
+  confirmResult: true,
+  warningActionResult: false,
+  updateError: null,
+  refreshError: null,
+};
+
+const confirm = vi.fn(async () => hostState.confirmResult);
+const showWarning = vi.fn(async () => hostState.warningActionResult);
+const showError = vi.fn(async () => undefined);
+const showInformation = vi.fn(async () => undefined);
+const openChangedSinceSetting = vi.fn(async () => undefined);
+const updateChangedSince = vi.fn(async () => {
+  if (hostState.updateError) {
+    throw hostState.updateError;
+  }
+  hostState.currentChangedSince = BASELINE_TAG;
+});
+const refreshAnalysis = vi.fn(async () => {
+  if (hostState.refreshError) {
+    throw hostState.refreshError;
+  }
+});
+const appendOutput = vi.fn();
+
+const host: BaselineCommandHost = {
+  workspaceRoots: () => hostState.roots,
+  changedSince: () => hostState.currentChangedSince,
+  confirm,
+  showWarning,
+  showError,
+  showInformation,
+  openChangedSinceSetting,
+  updateChangedSince,
+  refreshAnalysis,
+  appendOutput,
+};
+
+const result = (code: number, stdout = "", stderr = ""): GitCommandResult => ({
+  code,
+  stdout,
+  stderr,
+});
+
+const gitRunner = (responses: ReadonlyArray<GitCommandResult>): GitRunner => {
+  let index = 0;
+  return vi.fn(async () => {
+    const response = responses[index];
+    index += 1;
+    if (!response) {
+      throw new Error(`unexpected git call ${index}`);
+    }
+    return response;
+  });
+};
+
+const missingTag = (): GitRunner =>
+  gitRunner([result(0, "/repo\n"), result(0, "head-sha\n"), result(1), result(0)]);
+
+const tagAtHead = (): GitRunner =>
+  gitRunner([result(0, "/repo\n"), result(0, "head-sha\n"), result(0), result(0, "head-sha\n")]);
+
+describe("runBaselineCommand", () => {
+  beforeEach(() => {
+    hostState.roots = ["/repo"];
+    hostState.currentChangedSince = "";
+    hostState.confirmResult = true;
+    hostState.warningActionResult = false;
+    hostState.updateError = null;
+    hostState.refreshError = null;
+    vi.clearAllMocks();
+  });
+
+  it("refuses to run without a workspace", async () => {
+    hostState.roots = [];
+
+    await expect(runBaselineCommand(host, gitRunner([]))).resolves.toBe("no-workspace");
+
+    expect(showWarning).toHaveBeenCalledWith(
+      "Fallow: open a workspace folder before setting a baseline.",
+    );
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("refuses multi-root workspaces without mutation", async () => {
+    hostState.roots = ["/repo-a", "/repo-b"];
+
+    await expect(runBaselineCommand(host, gitRunner([]))).resolves.toBe("multi-root");
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(updateChangedSince).not.toHaveBeenCalled();
+  });
+
+  it("reports a non-Git workspace", async () => {
+    const runGit = gitRunner([result(128, "", "not a git repository")]);
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("not-repository");
+
+    expect(appendOutput).toHaveBeenCalledWith("Set Baseline at HEAD: not a git repository");
+  });
+
+  it("reports a repository without a commit", async () => {
+    const runGit = gitRunner([result(0, "/repo\n"), result(128, "", "unknown revision")]);
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("unborn-head");
+
+    expect(updateChangedSince).not.toHaveBeenCalled();
+  });
+
+  it("creates the tag, persists the setting, and refreshes", async () => {
+    const runGit = missingTag();
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("configured");
+
+    expect(runGit).toHaveBeenLastCalledWith(["tag", BASELINE_TAG, "HEAD"], "/repo");
+    expect(updateChangedSince).toHaveBeenCalledWith(BASELINE_TAG);
+    expect(refreshAnalysis).toHaveBeenCalledOnce();
+    expect(showInformation).toHaveBeenCalledWith(
+      `Fallow: baseline set at HEAD. New findings are scoped from \`${BASELINE_TAG}\`.`,
+    );
+  });
+
+  it("does not mutate after cancellation", async () => {
+    hostState.confirmResult = false;
+    const runGit = missingTag();
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("cancelled");
+
+    expect(runGit).toHaveBeenCalledTimes(3);
+    expect(updateChangedSince).not.toHaveBeenCalled();
+  });
+
+  it("names the existing setting before replacing it", async () => {
+    hostState.currentChangedSince = "main";
+    const runGit = missingTag();
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("configured");
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.stringContaining("This replaces the current effective value `main`."),
+    );
+    expect(confirm).toHaveBeenCalledWith(
+      expect.stringContaining("This does not push anything to a remote."),
+    );
+  });
+
+  it("treats a tag already at HEAD as idempotent", async () => {
+    hostState.currentChangedSince = BASELINE_TAG;
+    const runGit = tagAtHead();
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("already-configured");
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(updateChangedSince).not.toHaveBeenCalled();
+    expect(refreshAnalysis).toHaveBeenCalledOnce();
+  });
+
+  it("updates only the setting when the tag already points to HEAD", async () => {
+    hostState.currentChangedSince = "main";
+    const runGit = tagAtHead();
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("configured");
+
+    expect(runGit).toHaveBeenCalledTimes(4);
+    expect(updateChangedSince).toHaveBeenCalledWith(BASELINE_TAG);
+  });
+
+  it("refuses to move an existing tag and can open the setting", async () => {
+    hostState.warningActionResult = true;
+    const runGit = gitRunner([
+      result(0, "/repo\n"),
+      result(0, "head-sha\n"),
+      result(0),
+      result(0, "other-sha\n"),
+    ]);
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("tag-conflict");
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(openChangedSinceSetting).toHaveBeenCalledOnce();
+    expect(updateChangedSince).not.toHaveBeenCalled();
+  });
+
+  it("reports Git failures without changing settings", async () => {
+    const runGit = gitRunner([
+      result(0, "/repo\n"),
+      result(0, "head-sha\n"),
+      result(2, "", "corrupt ref"),
+    ]);
+
+    await expect(runBaselineCommand(host, runGit)).resolves.toBe("git-error");
+
+    expect(showError).toHaveBeenCalled();
+    expect(updateChangedSince).not.toHaveBeenCalled();
+  });
+
+  it("reports partial state when settings persistence fails", async () => {
+    hostState.updateError = new Error("settings are read-only");
+
+    await expect(runBaselineCommand(host, missingTag())).resolves.toBe("settings-error");
+
+    expect(showError).toHaveBeenCalledWith(
+      expect.stringContaining(`The local tag \`${BASELINE_TAG}\` was created`),
+    );
+    expect(refreshAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("reports a refresh failure after configuring the baseline", async () => {
+    hostState.refreshError = new Error("analysis failed");
+
+    await expect(runBaselineCommand(host, missingTag())).resolves.toBe("refresh-error");
+
+    expect(updateChangedSince).toHaveBeenCalledWith(BASELINE_TAG);
+    expect(showError).toHaveBeenCalledWith(expect.stringContaining("baseline is configured"));
+  });
+});
+
+describe("runGitCommand", () => {
+  let root = "";
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "fallow-vscode-baseline-"));
+    expect((await runGitCommand(["init"], root)).code).toBe(0);
+    expect((await runGitCommand(["config", "user.email", "test@example.com"], root)).code).toBe(0);
+    expect((await runGitCommand(["config", "user.name", "Fallow Test"], root)).code).toBe(0);
+    await writeFile(join(root, "index.ts"), "export const value = 1;\n");
+    expect((await runGitCommand(["add", "index.ts"], root)).code).toBe(0);
+    expect(
+      (await runGitCommand(["-c", "commit.gpgsign=false", "commit", "-m", "initial"], root)).code,
+    ).toBe(0);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("runs the command end to end and creates a lightweight tag at HEAD", async () => {
+    const realHost: BaselineCommandHost = {
+      ...host,
+      workspaceRoots: () => [root],
+      changedSince: () => "",
+      confirm: async () => true,
+      updateChangedSince: async () => undefined,
+      refreshAnalysis: async () => undefined,
+    };
+
+    await expect(runBaselineCommand(realHost, runGitCommand)).resolves.toBe("configured");
+
+    const tag = await runGitCommand(["rev-parse", `refs/tags/${BASELINE_TAG}`], root);
+    const head = await runGitCommand(["rev-parse", "HEAD"], root);
+
+    expect(tag.code).toBe(0);
+    expect(tag.stdout.trim()).toBe(head.stdout.trim());
+  });
+});

--- a/editors/vscode/test/integration/suite/extension.test.ts
+++ b/editors/vscode/test/integration/suite/extension.test.ts
@@ -168,6 +168,7 @@ describe("Fallow VS Code extension", () => {
     assert.ok(commands.includes("fallow.reloadAnalysis"));
     assert.ok(commands.includes("fallow.health.reload"));
     assert.ok(commands.includes("fallow.audit"));
+    assert.ok(commands.includes("fallow.setBaselineAtHead"));
     assert.ok(commands.includes("fallow.fix"));
     assert.ok(commands.includes("fallow.fixDryRun"));
     assert.ok(commands.includes("fallow.restart"));
@@ -216,8 +217,7 @@ describe("Fallow VS Code extension", () => {
     // log. The awaited direct call is what we assert produced the expected argv.
     assert.ok(
       sidebarAnalysisCalls.some(
-        (entry) =>
-          entry.args.join(" ") === "--format json --quiet --skip health",
+        (entry) => entry.args.join(" ") === "--format json --quiet --skip health",
       ),
       "combined analysis should not pass package default duplication settings as overrides",
     );

--- a/editors/vscode/test/package-manifest.test.ts
+++ b/editors/vscode/test/package-manifest.test.ts
@@ -83,6 +83,15 @@ describe("package.json command contributions", () => {
       icon: "$(refresh)",
     });
   });
+
+  it("contributes and registers the baseline-at-HEAD command", () => {
+    expect(command("fallow.setBaselineAtHead")).toMatchObject({
+      title: "Fallow: Set Baseline at HEAD",
+      icon: "$(git-commit)",
+    });
+    expect(extensionSource).toContain('registerCommand("fallow.setBaselineAtHead"');
+    expect(commandPaletteEntry("fallow.setBaselineAtHead")).toBeUndefined();
+  });
 });
 
 describe("package.json view title menus", () => {


### PR DESCRIPTION
## Summary
- add a VS Code command that creates a local `fallow-baseline` tag at `HEAD` and configures changed-since analysis
- protect existing tags, multi-root workspaces, and existing effective baseline settings with explicit checks and confirmation
- document the local-only workflow and refresh analysis after configuration

## Verification
- [x] Focused command unit tests
- [x] Temporary Git repository smoke
- [x] VS Code unit and integration tests
- [x] VS Code type checking and codegen drift checks
- [x] JavaScript formatting
- [x] Fallow self-analysis, no introduced complexity or duplication

The self-analysis still reports unrelated existing dead-code findings in benchmark fixture package manifests.
