### PR TITLE
perf: queue re-export propagation

### DIFF
--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -4,20 +4,58 @@ mod propagate;
 #[cfg(test)]
 mod tests;
 
+use std::collections::VecDeque;
 use std::path::PathBuf;
 
 use rustc_hash::{FxHashMap, FxHashSet};
+
+#[cfg(test)]
+use std::cell::{Cell, RefCell};
 
 use fallow_types::discover::FileId;
 
 use crate::resolve::ResolvedModule;
 
-use super::ModuleGraph;
+use super::{Edge, ModuleGraph};
 
 use propagate::{
     NamedImportOriginIndex, NamedReExportPropagation, StarReExportPropagation,
     propagate_named_re_export, propagate_star_re_export,
 };
+
+#[cfg(test)]
+thread_local! {
+    static PROPAGATION_VISITS: RefCell<Option<Vec<(FileId, FileId)>>> =
+        const { RefCell::new(None) };
+    static DIFFERENTIAL_CHECK_ENABLED: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+fn record_propagation_visit(entry: &ReExportTuple) {
+    PROPAGATION_VISITS.with(|visits| {
+        if let Some(visits) = visits.borrow_mut().as_mut() {
+            visits.push((entry.barrel, entry.source));
+        }
+    });
+}
+
+#[cfg(test)]
+fn capture_propagation_visits<T>(run: impl FnOnce() -> T) -> (T, Vec<(FileId, FileId)>) {
+    PROPAGATION_VISITS.with(|visits| *visits.borrow_mut() = Some(Vec::new()));
+    let result = run();
+    let visits = PROPAGATION_VISITS.with(|visits| visits.borrow_mut().take().unwrap_or_default());
+    (result, visits)
+}
+
+#[cfg(test)]
+fn with_re_export_differential_check<T>(run: impl FnOnce() -> T) -> T {
+    DIFFERENTIAL_CHECK_ENABLED.with(|enabled| {
+        let previous = enabled.replace(true);
+        let result = run();
+        enabled.set(previous);
+        result
+    })
+}
 
 /// A re-export cycle or self-loop detected during Phase 4 chain resolution.
 ///
@@ -66,6 +104,65 @@ struct ReExportContext<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     existing_refs: &'a mut FxHashSet<FileId>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
+}
+
+#[cfg(test)]
+struct LegacyReExportFullScan<'a> {
+    modules: &'a mut [super::types::ModuleNode],
+    edges: &'a [Edge],
+    re_export_info: &'a [ReExportTuple],
+    entry_star_targets: &'a FxHashSet<FileId>,
+    edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
+    named_import_origin_index: &'a NamedImportOriginIndex,
+    module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
+}
+
+/// Deterministic scheduler for monotone re-export propagation.
+///
+/// Each tuple reads export state from `barrel` and may add references or
+/// synthetic exports to `source`. When `source` changes, only tuples whose
+/// `barrel` is that module can observe the new state, so those tuple indices
+/// are re-enqueued in their original stable order.
+struct ReExportPropagationPlan {
+    observers_by_module: FxHashMap<FileId, Vec<usize>>,
+    queue: VecDeque<usize>,
+    enqueued: Vec<bool>,
+}
+
+impl ReExportPropagationPlan {
+    fn new(re_export_info: &[ReExportTuple]) -> Self {
+        let mut observers_by_module: FxHashMap<FileId, Vec<usize>> = FxHashMap::default();
+        for (idx, entry) in re_export_info.iter().enumerate() {
+            observers_by_module
+                .entry(entry.barrel)
+                .or_default()
+                .push(idx);
+        }
+
+        Self {
+            observers_by_module,
+            queue: (0..re_export_info.len()).collect(),
+            enqueued: vec![true; re_export_info.len()],
+        }
+    }
+
+    fn pop_front(&mut self) -> Option<usize> {
+        let idx = self.queue.pop_front()?;
+        self.enqueued[idx] = false;
+        Some(idx)
+    }
+
+    fn enqueue_observers(&mut self, changed_module: FileId) {
+        let Some(observers) = self.observers_by_module.get(&changed_module) else {
+            return;
+        };
+        for &idx in observers {
+            if !self.enqueued[idx] {
+                self.enqueued[idx] = true;
+                self.queue.push_back(idx);
+            }
+        }
+    }
 }
 
 impl ModuleGraph {
@@ -184,7 +281,7 @@ impl ModuleGraph {
         })
     }
 
-    /// Run the monotone fixpoint that propagates references through every chain.
+    /// Run monotone propagation, revisiting only tuples affected by new state.
     fn run_re_export_fixpoint(
         &mut self,
         re_export_info: &[ReExportTuple],
@@ -193,15 +290,37 @@ impl ModuleGraph {
         named_import_origin_index: &NamedImportOriginIndex,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     ) {
-        let safety_cap = re_export_info.len().saturating_add(1);
-        let mut changed = true;
-        let mut iteration: usize = 0;
+        #[cfg(test)]
+        let mut legacy_modules: Option<Vec<super::types::ModuleNode>> = DIFFERENTIAL_CHECK_ENABLED
+            .with(|enabled| {
+                enabled.get().then(|| {
+                    serde_json::from_value(
+                        serde_json::to_value(&self.modules)
+                            .expect("module graph should serialize for differential testing"),
+                    )
+                    .expect("module graph should deserialize for differential testing")
+                })
+            });
+
+        let safety_cap = self.re_export_transition_safety_cap(re_export_info);
+        let mut processed = 0usize;
+        let mut plan = ReExportPropagationPlan::new(re_export_info);
         let mut existing_refs: FxHashSet<FileId> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
-        while changed && iteration < safety_cap {
-            changed = false;
-            iteration += 1;
+        while let Some(entry_idx) = plan.pop_front() {
+            if processed >= safety_cap {
+                tracing::error!(
+                    processed,
+                    safety_cap,
+                    re_export_edges = re_export_info.len(),
+                    "Re-export propagation exceeded its finite-state safety cap; \
+                     propagation may be non-monotonic. Please file a bug at \
+                     https://github.com/fallow-rs/fallow/issues with the repro."
+                );
+                break;
+            }
+            processed += 1;
 
             let mut context = ReExportContext {
                 entry_star_targets,
@@ -212,40 +331,88 @@ impl ModuleGraph {
                 synthetic_stubs: &mut synthetic_stubs,
             };
 
-            for entry in re_export_info {
-                changed |= self.propagate_re_export_entry(entry, &mut context);
+            let entry = &re_export_info[entry_idx];
+            #[cfg(test)]
+            record_propagation_visit(entry);
+            if Self::propagate_re_export_entry(&mut self.modules, &self.edges, entry, &mut context)
+            {
+                plan.enqueue_observers(entry.source);
             }
         }
 
-        if iteration >= safety_cap && changed {
-            tracing::error!(
-                iterations = iteration,
-                safety_cap,
-                re_export_edges = re_export_info.len(),
-                "Re-export chain fixpoint exceeded safety cap; \
-                 propagation may be non-monotonic. Please file a bug at \
-                 https://github.com/fallow-rs/fallow/issues with the repro."
+        #[cfg(test)]
+        if let Some(legacy_modules) = legacy_modules.as_mut() {
+            Self::run_re_export_full_scan(LegacyReExportFullScan {
+                modules: legacy_modules,
+                edges: &self.edges,
+                re_export_info,
+                entry_star_targets,
+                edges_by_target,
+                named_import_origin_index,
+                module_by_id,
+            });
+            assert_eq!(
+                serde_json::to_value(legacy_modules)
+                    .expect("legacy module graph should serialize for comparison"),
+                serde_json::to_value(&self.modules)
+                    .expect("queue module graph should serialize for comparison"),
+                "work-queue propagation must match the legacy full-scan fixpoint"
             );
         }
     }
 
+    /// Bound scheduler work by the finite set of exports, synthetic names, and
+    /// reference source modules that monotone propagation can add.
+    fn re_export_transition_safety_cap(&self, re_export_info: &[ReExportTuple]) -> usize {
+        let initial_exports = self
+            .modules
+            .iter()
+            .map(|module| module.exports.len())
+            .sum::<usize>();
+        let named_inputs = self
+            .edges
+            .iter()
+            .flat_map(|edge| &edge.symbols)
+            .filter(|symbol| {
+                matches!(
+                    &symbol.imported_name,
+                    fallow_types::extract::ImportedName::Named(_)
+                )
+            })
+            .count()
+            .saturating_add(initial_exports)
+            .saturating_add(re_export_info.len());
+
+        let module_count = self.modules.len();
+        let synthetic_exports = module_count.saturating_mul(named_inputs).saturating_mul(2);
+        let max_exports = initial_exports.saturating_add(synthetic_exports);
+        let reference_additions = max_exports.saturating_mul(module_count);
+        let state_changes = synthetic_exports.saturating_add(reference_additions);
+
+        re_export_info
+            .len()
+            .saturating_add(state_changes.saturating_mul(re_export_info.len()))
+            .max(re_export_info.len())
+    }
+
     /// Propagate references for one re-export edge, dispatching star vs named.
     fn propagate_re_export_entry(
-        &mut self,
+        modules: &mut [super::types::ModuleNode],
+        edges: &[Edge],
         entry: &ReExportTuple,
         context: &mut ReExportContext<'_>,
     ) -> bool {
         let barrel_idx = entry.barrel.0 as usize;
         let source_idx = entry.source.0 as usize;
 
-        if barrel_idx >= self.modules.len() || source_idx >= self.modules.len() {
+        if barrel_idx >= modules.len() || source_idx >= modules.len() {
             return false;
         }
 
         if entry.exported_name == "*" {
             propagate_star_re_export(StarReExportPropagation {
-                modules: &mut self.modules,
-                edges: &self.edges,
+                modules,
+                edges,
                 edges_by_target: context.edges_by_target,
                 named_import_origin_index: context.named_import_origin_index,
                 module_by_id: context.module_by_id,
@@ -259,7 +426,7 @@ impl ModuleGraph {
             })
         } else {
             propagate_named_re_export(NamedReExportPropagation {
-                modules: &mut self.modules,
+                modules,
                 barrel_id: entry.barrel,
                 barrel_idx,
                 source_idx,
@@ -267,6 +434,40 @@ impl ModuleGraph {
                 exported_name: &entry.exported_name,
                 existing_refs: context.existing_refs,
             })
+        }
+    }
+
+    #[cfg(test)]
+    fn run_re_export_full_scan(input: LegacyReExportFullScan<'_>) {
+        let LegacyReExportFullScan {
+            modules,
+            edges,
+            re_export_info,
+            entry_star_targets,
+            edges_by_target,
+            named_import_origin_index,
+            module_by_id,
+        } = input;
+        let max_iterations = re_export_info.len().saturating_add(1);
+        let mut existing_refs: FxHashSet<FileId> = FxHashSet::default();
+        let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
+
+        for _ in 0..max_iterations {
+            let mut changed = false;
+            for entry in re_export_info {
+                let mut context = ReExportContext {
+                    entry_star_targets,
+                    edges_by_target,
+                    named_import_origin_index,
+                    module_by_id,
+                    existing_refs: &mut existing_refs,
+                    synthetic_stubs: &mut synthetic_stubs,
+                };
+                changed |= Self::propagate_re_export_entry(modules, edges, entry, &mut context);
+            }
+            if !changed {
+                break;
+            }
         }
     }
 }

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -384,7 +384,19 @@ impl ModuleGraph {
             .saturating_add(re_export_info.len());
 
         let module_count = self.modules.len();
-        let synthetic_exports = module_count.saturating_mul(named_inputs).saturating_mul(2);
+        let synthetic_export_hosts = self
+            .modules
+            .iter()
+            .filter(|module| {
+                module
+                    .re_exports
+                    .iter()
+                    .any(|re_export| re_export.exported_name == "*")
+            })
+            .count();
+        let synthetic_exports = synthetic_export_hosts
+            .saturating_mul(named_inputs)
+            .saturating_mul(2);
         let max_exports = initial_exports.saturating_add(synthetic_exports);
         let reference_additions = max_exports.saturating_mul(module_count);
         let state_changes = synthetic_exports.saturating_add(reference_additions);

--- a/crates/graph/src/graph/re_exports/tests.rs
+++ b/crates/graph/src/graph/re_exports/tests.rs
@@ -1,6 +1,10 @@
 use rustc_hash::FxHashSet;
 
 use super::propagate::{count_named_import_origin_index_builds, count_star_reference_set_rebuilds};
+use super::{
+    ReExportPropagationPlan, ReExportTuple, capture_propagation_visits,
+    with_re_export_differential_check,
+};
 use crate::graph::ModuleGraph;
 use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport};
 use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
@@ -2371,6 +2375,372 @@ fn deep_named_re_export_chain_propagates_25_hops() {
     run_chain(25);
 }
 
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "fixture construction makes the scheduling assertion self-contained"
+)]
+fn work_queue_does_not_revisit_unrelated_settled_edge() {
+    const CHAIN_LENGTH: u32 = 6;
+    let unrelated_barrel_id = FileId(CHAIN_LENGTH + 2);
+    let unrelated_source_id = FileId(CHAIN_LENGTH + 3);
+    let unrelated_consumer_id = FileId(CHAIN_LENGTH + 4);
+
+    let mut files = Vec::new();
+    let mut resolved_modules = Vec::new();
+
+    files.push(discovered_file(0, "/project/leaf.ts"));
+    resolved_modules.push(ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/leaf.ts"),
+        exports: vec![merged_export(false)],
+        ..Default::default()
+    });
+
+    for idx in 1..=CHAIN_LENGTH {
+        let path = format!("/project/barrel_{idx}.ts");
+        files.push(discovered_file(idx, &path));
+        resolved_modules.push(ResolvedModule {
+            file_id: FileId(idx),
+            path: PathBuf::from(path),
+            re_exports: vec![ResolvedReExport {
+                info: fallow_types::extract::ReExportInfo {
+                    source: format!("./barrel_{}", idx - 1),
+                    imported_name: "Merged".to_string(),
+                    exported_name: "Merged".to_string(),
+                    is_type_only: false,
+                    span: oxc_span::Span::default(),
+                },
+                target: ResolveResult::InternalModule(FileId(idx - 1)),
+            }],
+            ..Default::default()
+        });
+    }
+
+    let chain_consumer_id = FileId(CHAIN_LENGTH + 1);
+    files.push(discovered_file(
+        chain_consumer_id.0,
+        "/project/chain_consumer.ts",
+    ));
+    resolved_modules.push(ResolvedModule {
+        file_id: chain_consumer_id,
+        path: PathBuf::from("/project/chain_consumer.ts"),
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: format!("./barrel_{CHAIN_LENGTH}"),
+                imported_name: ImportedName::Named("Merged".to_string()),
+                local_name: "Merged".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(0, 10),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(FileId(CHAIN_LENGTH)),
+        }],
+        ..Default::default()
+    });
+
+    files.push(discovered_file(
+        unrelated_barrel_id.0,
+        "/project/unrelated_barrel.ts",
+    ));
+    resolved_modules.push(ResolvedModule {
+        file_id: unrelated_barrel_id,
+        path: PathBuf::from("/project/unrelated_barrel.ts"),
+        re_exports: vec![ResolvedReExport {
+            info: fallow_types::extract::ReExportInfo {
+                source: "./unrelated_source".to_string(),
+                imported_name: "Merged".to_string(),
+                exported_name: "Merged".to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(unrelated_source_id),
+        }],
+        ..Default::default()
+    });
+
+    files.push(discovered_file(
+        unrelated_source_id.0,
+        "/project/unrelated_source.ts",
+    ));
+    resolved_modules.push(ResolvedModule {
+        file_id: unrelated_source_id,
+        path: PathBuf::from("/project/unrelated_source.ts"),
+        exports: vec![merged_export(false)],
+        ..Default::default()
+    });
+
+    files.push(discovered_file(
+        unrelated_consumer_id.0,
+        "/project/unrelated_consumer.ts",
+    ));
+    resolved_modules.push(ResolvedModule {
+        file_id: unrelated_consumer_id,
+        path: PathBuf::from("/project/unrelated_consumer.ts"),
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "./unrelated_barrel".to_string(),
+                imported_name: ImportedName::Named("Merged".to_string()),
+                local_name: "Merged".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(0, 10),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(unrelated_barrel_id),
+        }],
+        ..Default::default()
+    });
+
+    let entry_points = vec![
+        EntryPoint {
+            path: PathBuf::from("/project/chain_consumer.ts"),
+            source: EntryPointSource::PackageJsonMain,
+        },
+        EntryPoint {
+            path: PathBuf::from("/project/unrelated_consumer.ts"),
+            source: EntryPointSource::PackageJsonMain,
+        },
+    ];
+
+    let (_, visits) =
+        capture_propagation_visits(|| ModuleGraph::build(&resolved_modules, &entry_points, &files));
+    let unrelated_visits = visits
+        .iter()
+        .filter(|visit| **visit == (unrelated_barrel_id, unrelated_source_id))
+        .count();
+
+    assert_eq!(
+        unrelated_visits, 1,
+        "an unrelated settled edge should only run during the initial stable-order pass"
+    );
+}
+
+#[test]
+fn work_queue_matches_legacy_on_generated_small_graphs() {
+    with_re_export_differential_check(|| {
+        for barrel_count in 1..=8 {
+            let graph = graph_for_named_chain(barrel_count);
+            let leaf = &graph.modules[0];
+            assert!(
+                leaf.exports[0].references.iter().any(|reference| {
+                    reference.from_file == FileId(barrel_count.saturating_add(1))
+                }),
+                "generated {barrel_count}-barrel graph should reach the leaf"
+            );
+        }
+
+        graph_for_merged_star_import(
+            vec![
+                named_import("Merged", "MergedValue", false),
+                named_import("Merged", "MergedType", true),
+            ],
+            vec!["MergedType"],
+            vec!["MergedValue"],
+        );
+        graph_for_merged_star_chain_import(
+            vec![
+                named_import_with_span("Merged", "MergedType", false, 0, 10),
+                named_import_with_span("Merged", "MergedValue", false, 20, 30),
+            ],
+            vec!["MergedType"],
+            vec!["MergedValue"],
+        );
+    });
+}
+
+#[test]
+fn equivalent_re_export_declaration_orders_produce_identical_results() {
+    let forward = graph_for_parallel_named_re_exports(false);
+    let reversed = graph_for_parallel_named_re_exports(true);
+
+    assert_eq!(
+        serde_json::to_value(&forward.modules[2].exports).unwrap(),
+        serde_json::to_value(&reversed.modules[2].exports).unwrap(),
+    );
+    assert_eq!(
+        serde_json::to_value(&forward.modules[3].exports).unwrap(),
+        serde_json::to_value(&reversed.modules[3].exports).unwrap(),
+    );
+}
+
+#[test]
+fn propagation_plan_preserves_stable_fifo_order() {
+    let entries = [
+        re_export_tuple(2, 1),
+        re_export_tuple(1, 0),
+        re_export_tuple(4, 3),
+    ];
+    let mut plan = ReExportPropagationPlan::new(&entries);
+
+    assert_eq!(plan.pop_front(), Some(0));
+    assert_eq!(plan.pop_front(), Some(1));
+    assert_eq!(plan.pop_front(), Some(2));
+    assert_eq!(plan.pop_front(), None);
+}
+
+#[test]
+fn propagation_plan_requeues_only_affected_observers_once() {
+    let entries = [
+        re_export_tuple(2, 1),
+        re_export_tuple(1, 0),
+        re_export_tuple(2, 3),
+        re_export_tuple(4, 2),
+    ];
+    let mut plan = ReExportPropagationPlan::new(&entries);
+    while plan.pop_front().is_some() {}
+
+    plan.enqueue_observers(FileId(2));
+    plan.enqueue_observers(FileId(2));
+
+    assert_eq!(plan.pop_front(), Some(0));
+    assert_eq!(plan.pop_front(), Some(2));
+    assert_eq!(plan.pop_front(), None);
+}
+
+fn re_export_tuple(barrel: u32, source: u32) -> ReExportTuple {
+    ReExportTuple {
+        barrel: FileId(barrel),
+        source: FileId(source),
+        imported_name: "Merged".to_string(),
+        exported_name: "Merged".to_string(),
+        is_type_only: false,
+    }
+}
+
+fn graph_for_named_chain(barrel_count: u32) -> ModuleGraph {
+    let consumer_id = FileId(barrel_count + 1);
+    let mut files = vec![discovered_file(0, "/project/leaf.ts")];
+    let mut resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/leaf.ts"),
+        exports: vec![merged_export(false)],
+        ..Default::default()
+    }];
+
+    for idx in 1..=barrel_count {
+        let path = format!("/project/barrel_{idx}.ts");
+        files.push(discovered_file(idx, &path));
+        resolved_modules.push(ResolvedModule {
+            file_id: FileId(idx),
+            path: PathBuf::from(path),
+            re_exports: vec![ResolvedReExport {
+                info: fallow_types::extract::ReExportInfo {
+                    source: format!("./barrel_{}", idx - 1),
+                    imported_name: "Merged".to_string(),
+                    exported_name: "Merged".to_string(),
+                    is_type_only: false,
+                    span: oxc_span::Span::default(),
+                },
+                target: ResolveResult::InternalModule(FileId(idx - 1)),
+            }],
+            ..Default::default()
+        });
+    }
+
+    files.push(discovered_file(consumer_id.0, "/project/consumer.ts"));
+    resolved_modules.push(ResolvedModule {
+        file_id: consumer_id,
+        path: PathBuf::from("/project/consumer.ts"),
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: format!("./barrel_{barrel_count}"),
+                imported_name: ImportedName::Named("Merged".to_string()),
+                local_name: "Merged".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(0, 10),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(FileId(barrel_count)),
+        }],
+        ..Default::default()
+    });
+
+    let entry_points = vec![EntryPoint {
+        path: PathBuf::from("/project/consumer.ts"),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+    ModuleGraph::build(&resolved_modules, &entry_points, &files)
+}
+
+fn graph_for_parallel_named_re_exports(reverse: bool) -> ModuleGraph {
+    let files = vec![
+        discovered_file(0, "/project/consumer.ts"),
+        discovered_file(1, "/project/barrel.ts"),
+        discovered_file(2, "/project/a.ts"),
+        discovered_file(3, "/project/b.ts"),
+    ];
+    let entry_points = vec![EntryPoint {
+        path: PathBuf::from("/project/consumer.ts"),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+    let mut re_exports = vec![
+        ResolvedReExport {
+            info: fallow_types::extract::ReExportInfo {
+                source: "./a".to_string(),
+                imported_name: "A".to_string(),
+                exported_name: "A".to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(FileId(2)),
+        },
+        ResolvedReExport {
+            info: fallow_types::extract::ReExportInfo {
+                source: "./b".to_string(),
+                imported_name: "B".to_string(),
+                exported_name: "B".to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(FileId(3)),
+        },
+    ];
+    if reverse {
+        re_exports.reverse();
+    }
+
+    let resolved_modules = vec![
+        ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/project/consumer.ts"),
+            resolved_imports: vec![
+                ResolvedImport {
+                    info: named_import("A", "A", false).info,
+                    target: ResolveResult::InternalModule(FileId(1)),
+                },
+                ResolvedImport {
+                    info: named_import("B", "B", false).info,
+                    target: ResolveResult::InternalModule(FileId(1)),
+                },
+            ],
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(1),
+            path: PathBuf::from("/project/barrel.ts"),
+            re_exports,
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(2),
+            path: PathBuf::from("/project/a.ts"),
+            exports: vec![named_export("A", false)],
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(3),
+            path: PathBuf::from("/project/b.ts"),
+            exports: vec![named_export("B", false)],
+            ..Default::default()
+        },
+    ];
+
+    ModuleGraph::build(&resolved_modules, &entry_points, &files)
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "fixture construction dominates; assertions stay tight"
@@ -3393,9 +3763,13 @@ fn named_import_with_span(
 }
 
 fn merged_export(is_type_only: bool) -> fallow_types::extract::ExportInfo {
+    named_export("Merged", is_type_only)
+}
+
+fn named_export(name: &str, is_type_only: bool) -> fallow_types::extract::ExportInfo {
     fallow_types::extract::ExportInfo {
-        name: ExportName::Named("Merged".to_string()),
-        local_name: Some("Merged".to_string()),
+        name: ExportName::Named(name.to_string()),
+        local_name: Some(name.to_string()),
         is_type_only,
         visibility: VisibilityTag::None,
         expected_unused_reason: None,

--- a/crates/graph/src/graph/re_exports/tests.rs
+++ b/crates/graph/src/graph/re_exports/tests.rs
@@ -2599,6 +2599,28 @@ fn propagation_plan_requeues_only_affected_observers_once() {
     assert_eq!(plan.pop_front(), None);
 }
 
+#[test]
+fn named_only_chain_safety_cap_excludes_synthetic_export_states() {
+    let graph = graph_for_named_chain(256);
+    let re_export_info = graph.collect_re_export_tuples();
+    let initial_exports = graph
+        .modules
+        .iter()
+        .map(|module| module.exports.len())
+        .sum::<usize>();
+    let expected = re_export_info.len().saturating_add(
+        initial_exports
+            .saturating_mul(graph.modules.len())
+            .saturating_mul(re_export_info.len()),
+    );
+
+    assert_eq!(
+        graph.re_export_transition_safety_cap(&re_export_info),
+        expected,
+        "named-only chains cannot create synthetic exports"
+    );
+}
+
 fn re_export_tuple(barrel: u32, source: u32) -> ReExportTuple {
     ReExportTuple {
         barrel: FileId(barrel),


### PR DESCRIPTION
## Summary
- replace repeated full re-export scans with a deterministic affected-edge FIFO queue
- preserve legacy semantics through differential and declaration-order tests
- retain the existing export lookup because profiling did not justify a second optimization

## Verification
- [x] Differential graph correctness tests
- [x] Before and after re-export benchmarks
- [x] Exact normalized repository self-analysis parity
- [x] Graph re-export tests and core library tests
- [x] Graph and core all-target clippy with warnings denied
- [x] `cargo fmt --all -- --check`

Measured median benchmark improvements:

- 64-edge chain: `94.645 µs` to `25.446 µs`
- 256-edge chain: `2.3501 ms` to `100.60 µs`
