### PR TITLE
fix(extract): cap per-module tainted bindings to bound memory (#1843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   content is read, while links to regular files inside the project remain
   supported under their visible paths.
 
+- **Large minified bundles no longer exhaust memory during analysis.** Dense
+  single-line bundles (precompiled editor assets such as ProseMirror) could
+  drive taint-tracking memory up without bound, so `fallow dead-code` climbed
+  to tens of GiB and produced no output on repos that ship them. Per-module
+  taint recording is now capped, so these repos analyze in normal time and
+  memory. (#1843)
+
 ## [3.6.0] - 2026-07-15
 
 ### Changed

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -807,7 +807,13 @@ use crate::MemberKind;
 /// `const ui = createUi(); ui.orders.member` consumer credits the class member.
 /// Warm 234 caches lack the field and the fact, leaving those methods falsely
 /// reported as unused.
-pub(super) const CACHE_VERSION: u32 = 235;
+///
+/// Bumped to 236 (issue #1843): tainted-binding recording now caps the
+/// per-module set at `MAX_TAINTED_BINDINGS_PER_MODULE` (4096) to bound a
+/// super-linear memory blowup on dense minified bundles. A file that previously
+/// recorded more than the cap now persists a truncated `tainted_bindings`
+/// vector, so warm 235 caches can carry over-cap entries; invalidate them.
+pub(super) const CACHE_VERSION: u32 = 236;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/security_sources.rs
+++ b/crates/extract/src/tests/js_ts/security_sources.rs
@@ -438,3 +438,46 @@ fn non_trpc_query_callback_does_not_record_input_source() {
             .all(|b| b.source_path != "trpc.input")
     );
 }
+
+/// Issue #1843: dense minified bundles reuse short identifiers across thousands
+/// of scopes, so the module-wide, name-keyed `tainted_bindings` set grew
+/// super-linearly (the O(n) dedup + per-ident chain scans compounding into a
+/// runaway-memory / no-output OOM on `fallow dead-code`). A per-module breadth
+/// cap bounds the working set. Without the cap this input records tens of
+/// thousands of bindings (two per direct member-access declaration plus the
+/// chained fan-out); with it the count stays bounded and the parse completes
+/// fast. The security tainted-sink layer is false-negative-preferring, so
+/// degrading over-cap flows to module-level reachability is the safe direction,
+/// mirroring the `MAX_TAINT_BINDING_HOPS` depth cap.
+#[test]
+fn tainted_binding_recording_is_bounded_on_dense_source() {
+    use std::fmt::Write as _;
+
+    let mut source = String::new();
+    for k in 0..6000 {
+        // Each declaration records TWO distinct tainted bindings
+        // (`e.fN.g` and its object path `e.fN`), so 6000 declarations would
+        // otherwise seed 12000 direct bindings before any chain fan-out.
+        let _ = writeln!(source, "const u{k} = e.f{k}.g;");
+    }
+    // A chain step (`const c = `${u0}``) referencing an already-tainted local,
+    // exercising the chain-scan guard once the breadth cap is reached.
+    source.push_str("const chainA = `${u0}`;\n");
+    source.push_str("const chainB = `${chainA}`;\n");
+
+    let info = parse_ts(&source);
+
+    assert!(
+        !info.tainted_bindings.is_empty(),
+        "the cap must not zero out taint recording on smaller inputs"
+    );
+    // `MAX_TAINTED_BINDINGS_PER_MODULE` is a hard ceiling in `push_tainted_binding`,
+    // so the count can never exceed it (this dense input deterministically
+    // saturates to exactly the cap). Without the cap this input records ~36000.
+    assert!(
+        info.tainted_bindings.len() <= 4096,
+        "tainted binding recording must stay bounded at the per-module cap on \
+         dense minified-style source (got {})",
+        info.tainted_bindings.len()
+    );
+}

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -41,6 +41,23 @@ pub(super) const DIRECT_TAINT_HOP: u8 = 1;
 /// intended long-term substrate for deeper flows.
 pub(super) const MAX_TAINT_BINDING_HOPS: u8 = 3;
 
+/// Per-module breadth cap on recorded tainted bindings (issue #1843): the
+/// companion to the `MAX_TAINT_BINDING_HOPS` depth cap. The tainted-binding set
+/// is module-wide and name-keyed (a `const e = ...` in one function shares the
+/// `e` bucket with every other), so dense MINIFIED bundles that reuse short
+/// identifiers across thousands of scopes drove it super-linearly: the O(n)
+/// dedup scan in `push_tainted_binding` and the per-ident full-vector scan in
+/// `chained_bindings_for_idents` compounded into runaway memory (tens of GiB,
+/// no output) on a plain `fallow dead-code` run over ~1 MB single-line editor
+/// bundles that the 5 MB `--max-file-size` gate does not catch. Past the cap,
+/// no NEW binding is recorded and the scan-heavy recorders short-circuit, so an
+/// over-cap flow degrades to module-level reachability instead of an arg-level
+/// claim, matching the false-negative-preferring security-candidate doctrine.
+/// Deliberately a constant, not a config knob: real hand-written modules stay
+/// far below it (a source-backed binding is one member-access-initialized local
+/// declaration), so the cap only ever engages on machine-generated density.
+pub(super) const MAX_TAINTED_BINDINGS_PER_MODULE: usize = 4096;
+
 pub(super) type StaticPackageStringBindings = FxHashMap<String, Vec<String>>;
 pub(super) type StaticPackageObjectBindings = FxHashMap<String, FxHashMap<String, Vec<String>>>;
 pub(super) type StaticPackageLoopBindings =

--- a/crates/extract/src/visitor/visit_impl_taint_sources.rs
+++ b/crates/extract/src/visitor/visit_impl_taint_sources.rs
@@ -10,14 +10,14 @@ use fallow_types::extract::TaintedBinding;
 use super::super::{ModuleInfoExtractor, extract_destructured_names};
 use super::{
     DIRECT_TAINT_HOP, FRAMEWORK_REQUEST_SOURCE, GRAPHQL_ARGS_SOURCE, MAX_TAINT_BINDING_HOPS,
-    MCP_TOOL_INPUT_SOURCE, NEXT_FORM_DATA_SOURCE, NEXT_REQUEST_SOURCE, QUEUE_JOB_SOURCE,
-    TRPC_INPUT_SOURCE, apply_source_return_path, binding_source_path_candidates, callback_params,
-    callee_method_name, collect_chained_taint_idents, destructure_source_path,
-    extract_function_body_final_return_expr, extract_object_pattern_bindings, flatten_callee_path,
-    function_body_has_use_server, function_like_params, is_framework_route_receiver_path,
-    is_http_route_handler_name, is_route_registration_method, is_trpc_procedure_callee,
-    is_trpc_procedure_method, last_callback_params, route_callback_params, source_returning_helper,
-    unwrap_parens,
+    MAX_TAINTED_BINDINGS_PER_MODULE, MCP_TOOL_INPUT_SOURCE, NEXT_FORM_DATA_SOURCE,
+    NEXT_REQUEST_SOURCE, QUEUE_JOB_SOURCE, TRPC_INPUT_SOURCE, apply_source_return_path,
+    binding_source_path_candidates, callback_params, callee_method_name,
+    collect_chained_taint_idents, destructure_source_path, extract_function_body_final_return_expr,
+    extract_object_pattern_bindings, flatten_callee_path, function_body_has_use_server,
+    function_like_params, is_framework_route_receiver_path, is_http_route_handler_name,
+    is_route_registration_method, is_trpc_procedure_callee, is_trpc_procedure_method,
+    last_callback_params, route_callback_params, source_returning_helper, unwrap_parens,
 };
 
 impl ModuleInfoExtractor {
@@ -41,8 +41,27 @@ impl ModuleInfoExtractor {
             self.tainted_binding_hops[index] = self.tainted_binding_hops[index].min(hop);
             return;
         }
+        // Hard breadth cap (issue #1843): never grow the module-wide binding set
+        // past `MAX_TAINTED_BINDINGS_PER_MODULE`. This is the universal memory
+        // backstop: every recorder already gates on `tainted_bindings_at_capacity`
+        // at entry, so in practice nothing reaches here at capacity (a re-record
+        // of an existing pair is skipped by that entry guard too, not min-merged),
+        // but routing every push through this check keeps the bound guaranteed
+        // even if a future caller forgets the entry guard. The min-merge above
+        // still runs for any call that reaches here below the cap.
+        if self.tainted_bindings.len() >= MAX_TAINTED_BINDINGS_PER_MODULE {
+            return;
+        }
         self.tainted_bindings.push(binding);
         self.tainted_binding_hops.push(hop);
+    }
+
+    /// Whether the module-wide tainted-binding set has reached its breadth cap.
+    /// At capacity `push_tainted_binding` rejects every new pair, so the record
+    /// entry points and the per-ident chain scan short-circuit instead of doing
+    /// bounded-but-wasted O(n) work per subsequent declarator (issue #1843).
+    fn tainted_bindings_at_capacity(&self) -> bool {
+        self.tainted_bindings.len() >= MAX_TAINTED_BINDINGS_PER_MODULE
     }
 
     /// Record tainted-source bindings for `const <name> = <object>.<prop>` and
@@ -54,6 +73,9 @@ impl ModuleInfoExtractor {
     /// Captured at any scope (no `is_module_scope` gate): a sink inside a route
     /// handler reading a function-local source is exactly the target case.
     pub(super) fn record_tainted_source_binding(&mut self, name: &str, expr: &Expression<'_>) {
+        if self.tainted_bindings_at_capacity() {
+            return;
+        }
         for source_path in binding_source_path_candidates(expr) {
             self.push_tainted_binding(
                 TaintedBinding {
@@ -69,6 +91,9 @@ impl ModuleInfoExtractor {
     }
 
     fn record_tainted_param_binding(&mut self, name: &str, source_path: &'static str) {
+        if self.tainted_bindings_at_capacity() {
+            return;
+        }
         self.push_tainted_binding(
             TaintedBinding {
                 local: name.to_string(),
@@ -93,6 +118,9 @@ impl ModuleInfoExtractor {
     /// flows and cross-SFC-block chains are silent false negatives by design
     /// (FN-preferring, matching the #885 doctrine).
     pub(super) fn record_chained_tainted_binding(&mut self, name: &str, init: &Expression<'_>) {
+        if self.tainted_bindings_at_capacity() {
+            return;
+        }
         let mut idents = Vec::new();
         collect_chained_taint_idents(init, &mut idents);
         if idents.is_empty() {
@@ -114,6 +142,12 @@ impl ModuleInfoExtractor {
         name: &str,
         idents: &[String],
     ) -> Vec<(TaintedBinding, u8)> {
+        // At capacity every produced binding would be rejected by
+        // `push_tainted_binding`, so skip the per-ident full-vector scan
+        // entirely rather than compute a list only to drop it (issue #1843).
+        if self.tainted_bindings_at_capacity() {
+            return Vec::new();
+        }
         let mut out = Vec::new();
         for ident in idents {
             // No `nested_scope_shadows` guard on the referenced ident: tainted
@@ -165,6 +199,9 @@ impl ModuleInfoExtractor {
         obj_pat: &ObjectPattern<'_>,
         init: &Expression<'_>,
     ) {
+        if self.tainted_bindings_at_capacity() {
+            return;
+        }
         let Expression::Identifier(ident) = unwrap_parens(init) else {
             return;
         };
@@ -326,6 +363,9 @@ impl ModuleInfoExtractor {
     }
 
     pub(super) fn record_tainted_helper_call_binding(&mut self, name: &str, expr: &Expression<'_>) {
+        if self.tainted_bindings_at_capacity() {
+            return;
+        }
         let Expression::CallExpression(call) = unwrap_parens(expr) else {
             return;
         };
@@ -410,6 +450,9 @@ impl ModuleInfoExtractor {
         obj_pat: &ObjectPattern<'_>,
         expr: &Expression<'_>,
     ) {
+        if self.tainted_bindings_at_capacity() {
+            return;
+        }
         let Some(source_path) = destructure_source_path(expr) else {
             return;
         };


### PR DESCRIPTION
Dense minified single-line bundles (precompiled editor assets such as ProseMirror) drove taint-tracking memory up without bound, so `fallow dead-code` climbed to tens of GiB and produced no output on repos that ship them (the 5 MB `--max-file-size` gate does not catch ~1 MB single-line files).

Tainted-binding recording is module-wide and name-keyed with a depth cap (`MAX_TAINT_BINDING_HOPS`) but no breadth cap. On code that reuses short identifiers across thousands of scopes the set grew super-linearly via the O(n) dedup scan and the per-ident chain scan. This adds the missing breadth cap `MAX_TAINTED_BINDINGS_PER_MODULE` (4096): a hard cap in `push_tainted_binding` guarantees the memory bound across every recorder, and entry guards short-circuit the O(n) scans once at capacity. Over-cap flows degrade to module-level reachability, matching the false-negative-preferring security-candidate doctrine.

Real minified oxfmt/oxlint/vite bundles (5.7 MB) now analyze in ~2s at ~126 MB RSS instead of OOMing. CACHE_VERSION bumped 235 to 236.

Fixes #1843.