### PR TITLE
perf(analysis): harden super-linear paths found by the #1843 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   taint recording is now capped, so these repos analyze in normal time and
   memory. (#1843)
 
+- **Analysis is more robust on large, generated, and minified codebases.** A
+  follow-up hardening pass to the taint-memory fix bounds or linearizes several
+  other paths that could grow super-linearly on adversarial input: duplicate
+  export and class heritage grouping, star re-export propagation, object-binding
+  and factory-return candidate resolution, JSDoc import scanning, template and
+  CSS-in-JS expression scanning (now depth-guarded against stack overflow on
+  pathologically nested input), and the health-time line-number and mask
+  scanners. Analysis output is unchanged on ordinary code. (#1843)
+
 ## [3.6.0] - 2026-07-15
 
 ### Changed

--- a/crates/core/src/analyze/members/heritage.rs
+++ b/crates/core/src/analyze/members/heritage.rs
@@ -356,6 +356,10 @@ pub(super) fn build_parent_to_children(
     indexes: &MemberPassIndexes<'_>,
 ) -> FxHashMap<ExportKey, Vec<ExportKey>> {
     let mut parent_to_children: FxHashMap<ExportKey, Vec<ExportKey>> = FxHashMap::default();
+    // O(1) dedup across the whole build: a `contains` scan of the growing child
+    // Vec is O(children^2) for a widely-extended base (issue #1843 follow-up).
+    // Keyed on (parent key, child key); the Vec insertion order is unchanged.
+    let mut seen_pairs: FxHashSet<(ExportKey, ExportKey)> = FxHashSet::default();
 
     for resolved in resolved_modules {
         let local_to_export_keys = indexes.local_keys(resolved.file_id);
@@ -369,9 +373,11 @@ pub(super) fn build_parent_to_children(
 
                 for parent_key in parent_keys {
                     for resolved_parent_key in export_key_with_origins(graph, parent_key) {
-                        let children = parent_to_children.entry(resolved_parent_key).or_default();
-                        if !children.contains(&child_key) {
-                            children.push(child_key.clone());
+                        if seen_pairs.insert((resolved_parent_key.clone(), child_key.clone())) {
+                            parent_to_children
+                                .entry(resolved_parent_key)
+                                .or_default()
+                                .push(child_key.clone());
                         }
                     }
                 }
@@ -477,6 +483,11 @@ pub(super) fn build_interface_to_implementers(
     indexes: &MemberPassIndexes<'_>,
 ) -> FxHashMap<ExportKey, Vec<ExportKey>> {
     let mut interface_to_implementers: FxHashMap<ExportKey, Vec<ExportKey>> = FxHashMap::default();
+    // O(1) dedup across the whole build: a `contains` scan of the growing
+    // implementer Vec is O(implementers^2) for a widely-implemented interface
+    // (issue #1843 follow-up). Keyed on (interface key, implementer key); the Vec
+    // insertion order is unchanged.
+    let mut seen_pairs: FxHashSet<(ExportKey, ExportKey)> = FxHashSet::default();
     for resolved in resolved_modules {
         let Some(class_heritage) = class_heritage_by_file.get(&resolved.file_id) else {
             continue;
@@ -498,11 +509,13 @@ pub(super) fn build_interface_to_implementers(
                 };
                 for interface_key in interface_keys {
                     for resolved_interface_key in export_key_with_origins(graph, interface_key) {
-                        let implementers = interface_to_implementers
-                            .entry(resolved_interface_key)
-                            .or_default();
-                        if !implementers.contains(&implementer_key) {
-                            implementers.push(implementer_key.clone());
+                        if seen_pairs
+                            .insert((resolved_interface_key.clone(), implementer_key.clone()))
+                        {
+                            interface_to_implementers
+                                .entry(resolved_interface_key)
+                                .or_default()
+                                .push(implementer_key.clone());
                         }
                     }
                 }

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -919,17 +919,21 @@ fn partition_by_common_importer(entries: &[ExportEntry], graph: &ModuleGraph) ->
     }
 
     // Also union entries where one directly imports the other (i.e. the importer
-    // itself is a member of the duplicate set).
-    let entry_file_ids: FxHashSet<FileId> = entries.iter().map(|e| e.file_id).collect();
+    // itself is a member of the duplicate set). Build a `file_id -> first index`
+    // map once (first index wins, mirroring `position()`), so the importer lookup
+    // is O(1) instead of a linear `position()` scan over the growing entries vec
+    // nested inside the per-entry x per-importer loops (issue #1843 follow-up).
+    let mut entry_index_by_file_id: FxHashMap<FileId, usize> = FxHashMap::default();
+    for (i, entry) in entries.iter().enumerate() {
+        entry_index_by_file_id.entry(entry.file_id).or_insert(i);
+    }
     for (i, entry) in entries.iter().enumerate() {
         let idx = entry.file_id.0 as usize;
         if idx >= graph.reverse_deps.len() {
             continue;
         }
         for &importer in &graph.reverse_deps[idx] {
-            if entry_file_ids.contains(&importer)
-                && let Some(j) = entries.iter().position(|e| e.file_id == importer)
-            {
+            if let Some(&j) = entry_index_by_file_id.get(&importer) {
                 union_find.union(i, j);
             }
         }
@@ -3226,5 +3230,103 @@ mod tests {
             "entry export should be flagged when include_entry_exports is true"
         );
         assert_eq!(exports_on[0].export_name, "main");
+    }
+
+    fn make_export_entry(module_idx: usize, file_id: u32) -> ExportEntry {
+        ExportEntry {
+            module_idx,
+            path: PathBuf::from(format!("f{file_id}.ts")),
+            file_id: FileId(file_id),
+            span_start: 0,
+            is_type_only: false,
+        }
+    }
+
+    /// Reference implementation of the direct-import union path using the
+    /// original O(n^2) `entries.iter().position(...)` linear scan, so the
+    /// O(1) `file_id -> first index` map in `partition_by_common_importer`
+    /// (issue #1843 follow-up) can be proven to produce identical grouping.
+    fn reference_partition(entries: &[ExportEntry], graph: &ModuleGraph) -> Vec<Vec<usize>> {
+        let mut union_find = UnionFind::new(entries.len());
+
+        let mut importer_to_entries: FxHashMap<FileId, Vec<usize>> = FxHashMap::default();
+        for (i, entry) in entries.iter().enumerate() {
+            let idx = entry.file_id.0 as usize;
+            if idx >= graph.reverse_deps.len() {
+                continue;
+            }
+            for &importer in &graph.reverse_deps[idx] {
+                importer_to_entries.entry(importer).or_default().push(i);
+            }
+        }
+        for members in importer_to_entries.values() {
+            if let Some((&first, rest)) = members.split_first() {
+                for &other in rest {
+                    union_find.union(first, other);
+                }
+            }
+        }
+
+        let entry_file_ids: FxHashSet<FileId> = entries.iter().map(|e| e.file_id).collect();
+        for (i, entry) in entries.iter().enumerate() {
+            let idx = entry.file_id.0 as usize;
+            if idx >= graph.reverse_deps.len() {
+                continue;
+            }
+            for &importer in &graph.reverse_deps[idx] {
+                if entry_file_ids.contains(&importer)
+                    && let Some(j) = entries.iter().position(|e| e.file_id == importer)
+                {
+                    union_find.union(i, j);
+                }
+            }
+        }
+
+        union_find.components()
+    }
+
+    fn normalize_components(mut components: Vec<Vec<usize>>) -> Vec<Vec<usize>> {
+        for comp in &mut components {
+            comp.sort_unstable();
+        }
+        components.sort_unstable();
+        components
+    }
+
+    #[test]
+    fn partition_direct_import_index_matches_position_scan() {
+        // Four real files (FileIds 0..=3), all also duplicate-export entry files.
+        let mut graph = build_graph(&[
+            ("f0.ts", false),
+            ("f1.ts", false),
+            ("f2.ts", false),
+            ("f3.ts", false),
+        ]);
+
+        // file0 imported by file1 and file3; file2 imported by file1.
+        graph.reverse_deps[0] = vec![FileId(1), FileId(3)];
+        graph.reverse_deps[2] = vec![FileId(1)];
+
+        // Five entries with a DUPLICATE file_id (indices 1 and 2 both in file1),
+        // exercising the first-index-wins semantics the map must preserve.
+        let entries = vec![
+            make_export_entry(0, 0),
+            make_export_entry(1, 1),
+            make_export_entry(2, 1),
+            make_export_entry(3, 2),
+            make_export_entry(4, 3),
+        ];
+
+        let actual = normalize_components(partition_by_common_importer(&entries, &graph));
+        let reference = normalize_components(reference_partition(&entries, &graph));
+        assert_eq!(
+            actual, reference,
+            "map-based partition must match the position()-scan reference"
+        );
+
+        // Hand-computed grouping: {0,1,3,4} merged via the shared/direct-import
+        // unions; the duplicate-file_id entry at index 2 stays a singleton
+        // because position()/the first-index map never resolve to it.
+        assert_eq!(actual, vec![vec![0, 1, 3, 4], vec![2]]);
     }
 }

--- a/crates/extract/src/astro.rs
+++ b/crates/extract/src/astro.rs
@@ -73,6 +73,58 @@ static TEMPLATE_TAG_RE: LazyLock<regex::Regex> =
 static DEFINE_VARS_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| crate::static_regex(r"define:vars\s*="));
 
+/// Build the disjoint, ascending list of byte ranges to mask when scanning the
+/// Astro template: `<script>` / `<style>` block bodies and HTML comments. The
+/// three `find_iter` passes are concatenated (not globally sorted, and their
+/// ranges overlap when e.g. an HTML comment wraps a `<script>`), then sorted by
+/// start and merged into a non-overlapping ascending list so membership can be
+/// tested by binary search (`pos_in_masked_ranges`) instead of a linear scan
+/// over every range per position. The merged union covers exactly the same byte
+/// positions as the raw ranges, so masking decisions are byte-identical.
+fn build_masked_ranges(template: &str) -> Vec<(usize, usize)> {
+    let mut masked: Vec<(usize, usize)> = Vec::new();
+    masked.extend(
+        SCRIPT_BLOCK_RE
+            .find_iter(template)
+            .map(|m| (m.start(), m.end())),
+    );
+    masked.extend(
+        STYLE_BLOCK_RE
+            .find_iter(template)
+            .map(|m| (m.start(), m.end())),
+    );
+    masked.extend(
+        HTML_COMMENT_RE
+            .find_iter(template)
+            .map(|m| (m.start(), m.end())),
+    );
+    masked.sort_unstable_by_key(|&(start, _)| start);
+    // Merge overlapping / touching ranges so the result is disjoint and ascending,
+    // the invariant `pos_in_masked_ranges`'s binary search relies on.
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(masked.len());
+    for (start, end) in masked {
+        if let Some(last) = merged.last_mut()
+            && start <= last.1
+        {
+            last.1 = last.1.max(end);
+        } else {
+            merged.push((start, end));
+        }
+    }
+    merged
+}
+
+/// Test whether `pos` falls inside any masked range. `ranges` must be the disjoint
+/// ascending list produced by `build_masked_ranges`; membership is a binary search
+/// (`partition_point`) rather than a linear `.any()` scan, keeping the per-position
+/// cost logarithmic when a template carries many masked regions. Because the list
+/// is disjoint and ascending, only the last range with `start <= pos` can contain
+/// it, so a single bounds check on that candidate decides membership.
+fn pos_in_masked_ranges(ranges: &[(usize, usize)], pos: usize) -> bool {
+    let idx = ranges.partition_point(|&(start, _)| start <= pos);
+    idx > 0 && pos < ranges[idx - 1].1
+}
+
 /// Collect the set of identifier names that appear USED in the Astro template
 /// markup, so the frontmatter semantic pass does not mark a template-only-used
 /// import (a rendered `<Header/>` component, or a `{fmt(x)}` expression binding)
@@ -93,23 +145,8 @@ fn collect_astro_template_used_names(template: &str) -> FxHashSet<String> {
     // Byte ranges of `<script>` / `<style>` bodies and HTML comments. Positions
     // inside any of these are skipped rather than mutating the source (mutation
     // would corrupt multibyte UTF-8 inside a masked range).
-    let mut masked: Vec<(usize, usize)> = Vec::new();
-    masked.extend(
-        SCRIPT_BLOCK_RE
-            .find_iter(template)
-            .map(|m| (m.start(), m.end())),
-    );
-    masked.extend(
-        STYLE_BLOCK_RE
-            .find_iter(template)
-            .map(|m| (m.start(), m.end())),
-    );
-    masked.extend(
-        HTML_COMMENT_RE
-            .find_iter(template)
-            .map(|m| (m.start(), m.end())),
-    );
-    let is_masked = |pos: usize| masked.iter().any(|&(s, e)| pos >= s && pos < e);
+    let masked = build_masked_ranges(template);
+    let is_masked = |pos: usize| pos_in_masked_ranges(&masked, pos);
 
     // Component tag roots.
     for cap in TEMPLATE_TAG_RE.captures_iter(template) {
@@ -231,23 +268,8 @@ fn collect_template_expression_regions(template: &str) -> Vec<String> {
     if template.is_empty() {
         return regions;
     }
-    let mut masked: Vec<(usize, usize)> = Vec::new();
-    masked.extend(
-        SCRIPT_BLOCK_RE
-            .find_iter(template)
-            .map(|m| (m.start(), m.end())),
-    );
-    masked.extend(
-        STYLE_BLOCK_RE
-            .find_iter(template)
-            .map(|m| (m.start(), m.end())),
-    );
-    masked.extend(
-        HTML_COMMENT_RE
-            .find_iter(template)
-            .map(|m| (m.start(), m.end())),
-    );
-    let is_masked = |pos: usize| masked.iter().any(|&(s, e)| pos >= s && pos < e);
+    let masked = build_masked_ranges(template);
+    let is_masked = |pos: usize| pos_in_masked_ranges(&masked, pos);
 
     let bytes = template.as_bytes();
     let len = bytes.len();
@@ -1174,5 +1196,81 @@ mod tests {
             "an untyped receiver must not credit any Util member, found: {:?}",
             info.member_accesses
         );
+    }
+
+    /// Template that is roughly half HTML comments (masked) and half `{expr}`
+    /// braces / tags (credited), with an overlapping masked range (a comment that
+    /// wraps a `<script>`). The merged binary-search masking must decide every
+    /// byte position identically to the old linear `.any()` over the raw,
+    /// unsorted, overlapping ranges. Regression for the masking-cost change
+    /// (issue #1843 follow-up): behavior must stay byte-identical.
+    const MASKED_MIX_TEMPLATE: &str = concat!(
+        "<!-- <Widget/> and {Sidebar} -->\n",
+        "<Header title={fmt(x)} />\n",
+        "<!-- <script>{Buried}</script> -->\n",
+        "<script><Hidden/>{Ghost}</script>\n",
+        "<style>a { color: {red}; }</style>\n",
+        "<Footer>{items.map((i) => i.label)}</Footer>\n",
+    );
+
+    #[test]
+    fn astro_masked_ranges_match_linear_reference() {
+        let template = MASKED_MIX_TEMPLATE;
+
+        // Old masking: a linear scan over the three raw (unsorted, overlapping)
+        // `find_iter` passes.
+        let mut raw: Vec<(usize, usize)> = Vec::new();
+        raw.extend(
+            SCRIPT_BLOCK_RE
+                .find_iter(template)
+                .map(|m| (m.start(), m.end())),
+        );
+        raw.extend(
+            STYLE_BLOCK_RE
+                .find_iter(template)
+                .map(|m| (m.start(), m.end())),
+        );
+        raw.extend(
+            HTML_COMMENT_RE
+                .find_iter(template)
+                .map(|m| (m.start(), m.end())),
+        );
+        let linear = |pos: usize| raw.iter().any(|&(s, e)| pos >= s && pos < e);
+
+        let merged = build_masked_ranges(template);
+        // The overlapping comment+script pair must collapse during the merge.
+        assert!(
+            merged.len() < raw.len(),
+            "expected overlapping ranges to merge, raw={raw:?} merged={merged:?}"
+        );
+        for pos in 0..template.len() {
+            assert_eq!(
+                pos_in_masked_ranges(&merged, pos),
+                linear(pos),
+                "masking decision differs at byte {pos}"
+            );
+        }
+    }
+
+    #[test]
+    fn astro_template_used_names_masks_comments_credits_braces() {
+        let used = collect_astro_template_used_names(MASKED_MIX_TEMPLATE);
+
+        // Credited: tag roots + brace-expression identifiers outside masked regions.
+        for name in ["Header", "Footer", "fmt", "x", "items", "map", "i", "label"] {
+            assert!(
+                used.contains(name),
+                "expected {name} to be credited, got {used:?}"
+            );
+        }
+
+        // Masked: identifiers only reachable inside comments / `<script>` / `<style>`
+        // (each would be a tag root or brace ident if the range were not masked).
+        for name in ["Widget", "Sidebar", "Buried", "Hidden", "Ghost", "red"] {
+            assert!(
+                !used.contains(name),
+                "expected {name} to stay masked, got {used:?}"
+            );
+        }
     }
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -813,7 +813,15 @@ use crate::MemberKind;
 /// super-linear memory blowup on dense minified bundles. A file that previously
 /// recorded more than the cap now persists a truncated `tainted_bindings`
 /// vector, so warm 235 caches can carry over-cap entries; invalidate them.
-pub(super) const CACHE_VERSION: u32 = 236;
+///
+/// Bumped to 237 (issue #1843 follow-up): object-binding and factory-return
+/// candidate recording now cap the per-module set at
+/// `MAX_OBJECT_BINDING_CANDIDATES` / `MAX_FACTORY_RETURN_CANDIDATES` (4096),
+/// bounding the object-binding resolution fixed-point the same way the taint cap
+/// bounds its accumulator. A file exceeding a cap now persists fewer candidates,
+/// so its resolved `member_accesses` can change; warm 236 caches can carry
+/// over-cap entries; invalidate them.
+pub(super) const CACHE_VERSION: u32 = 237;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/css.rs
+++ b/crates/extract/src/css.rs
@@ -383,6 +383,13 @@ pub fn extract_css_var_reads_located(source: &str) -> Vec<(String, u32)> {
     }
     let in_theme = |offset: usize| theme_bodies.iter().any(|&(s, e)| offset >= s && offset < e);
     let mut out = Vec::new();
+    // Incremental line counter: `captures_iter` yields matches in source order, so
+    // advance from the previous read's offset instead of rescanning the whole
+    // prefix per read (issue #1843 follow-up). Masking preserves byte offsets 1:1,
+    // but newlines are counted over `source` (comment masking blanks newlines in
+    // `masked`), matching the original `line_at_offset(source, ..)`.
+    let mut last_pos = 0usize;
+    let mut last_line = 1u32;
     for cap in CSS_VAR_REF_RE.captures_iter(&masked) {
         let (Some(whole), Some(name)) = (cap.get(0), cap.get(1)) else {
             continue;
@@ -390,10 +397,10 @@ pub fn extract_css_var_reads_located(source: &str) -> Vec<(String, u32)> {
         if in_theme(whole.start()) {
             continue;
         }
-        out.push((
-            name.as_str().to_owned(),
-            line_at_offset(source, whole.start()),
-        ));
+        let offset = whole.start();
+        last_line = last_line.saturating_add(newlines_between(source, last_pos, offset));
+        last_pos = offset;
+        out.push((name.as_str().to_owned(), last_line));
     }
     out
 }
@@ -435,6 +442,12 @@ fn collect_theme_var_reads(
     let Some(body) = masked.get(body_start..body_end) else {
         return;
     };
+    // Incremental line counter: matches arrive in source order, so advance from
+    // the previous read's offset instead of rescanning the whole prefix per read
+    // (issue #1843 follow-up). Starting from offset 0 keeps the first read's line
+    // identical to `line_at_offset(source, offset)`.
+    let mut last_pos = 0usize;
+    let mut last_line = 1u32;
     for cap in CSS_VAR_REF_RE.captures_iter(body) {
         let (Some(whole), Some(name)) = (cap.get(0), cap.get(1)) else {
             continue;
@@ -442,7 +455,9 @@ fn collect_theme_var_reads(
         // Absolute byte offset of the `var(` token start in the original source
         // (masking preserves byte offsets 1:1).
         let offset = body_start + whole.start();
-        out.push((name.as_str().to_owned(), line_at_offset(source, offset)));
+        last_line = last_line.saturating_add(newlines_between(source, last_pos, offset));
+        last_pos = offset;
+        out.push((name.as_str().to_owned(), last_line));
     }
 }
 
@@ -453,6 +468,18 @@ fn line_at_offset(source: &str, offset: usize) -> u32 {
         .get(..offset)
         .map_or(0, |s| s.bytes().filter(|&b| b == b'\n').count());
     u32::try_from(1 + count).unwrap_or(u32::MAX)
+}
+
+/// Count the `\n` bytes in `source[from..to]`, returning 0 for a reversed or
+/// out-of-range span. Feeds an incremental 1-based line counter across regex
+/// matches that arrive in source order, replacing the O(matches * n) per-match
+/// `source[..offset]` prefix rescan (issue #1843 follow-up: worst on a single
+/// long line with no newlines).
+fn newlines_between(source: &str, from: usize, to: usize) -> u32 {
+    let count = source
+        .get(from..to)
+        .map_or(0, |s| s.bytes().filter(|&b| b == b'\n').count());
+    u32::try_from(count).unwrap_or(u32::MAX)
 }
 
 /// Walk a masked `@theme` body collecting top-level `--ident: value` declarations
@@ -1844,6 +1871,41 @@ mod tests {
                 .is_empty(),
             "a @theme-interior-only var() read is not a css-var consumer"
         );
+    }
+
+    #[test]
+    fn css_var_reads_line_match_naive_reference_on_dense_line() {
+        // Many `var()` reads packed onto a single long line (the pathological
+        // zero-newline prefix) plus one trailing read on the next line: the
+        // incremental line counter must agree byte-for-byte with the naive
+        // per-match prefix rescan. No `@theme`, comments, strings, or `url()`,
+        // so masking is identity and every read is a css-var read.
+        use std::fmt::Write as _;
+        let mut src = String::from(".x {");
+        for i in 0..500 {
+            let _ = write!(src, " color: var(--t{i});");
+        }
+        src.push_str(" }\n.y { color: var(--tail); }\n");
+
+        let got = extract_css_var_reads_located(&src);
+
+        // Reference: recompute each read's line via a full prefix rescan.
+        let want: Vec<(String, u32)> = CSS_VAR_REF_RE
+            .captures_iter(&src)
+            .filter_map(|cap| cap.get(0).zip(cap.get(1)))
+            .map(|(whole, name)| {
+                (
+                    name.as_str().to_owned(),
+                    line_at_offset(&src, whole.start()),
+                )
+            })
+            .collect();
+
+        assert_eq!(got, want);
+        assert!(got.len() > 500, "expected the dense line plus the trailer");
+        // The trailer sits on line 2; the packed reads all sit on line 1.
+        assert_eq!(got.last().map(|(_, l)| *l), Some(2));
+        assert!(got[..got.len() - 1].iter().all(|(_, l)| *l == 1));
     }
 
     #[test]

--- a/crates/extract/src/css_classes.rs
+++ b/crates/extract/src/css_classes.rs
@@ -92,6 +92,13 @@ pub fn scan_markup_class_tokens(source: &str) -> MarkupClassScan {
     let mut static_tokens = Vec::new();
     let mut any_interpolated = false;
 
+    // Incremental line counter: `captures_iter` yields matches in source order, so
+    // count only the newlines between the previous match and this one instead of
+    // rescanning the whole prefix per match (issue #1843 follow-up: the naive
+    // `source[..m.start()]` rescan is O(matches * source_len), worst on a single
+    // long line with no newlines).
+    let mut last_pos = 0usize;
+    let mut last_line = 1usize;
     for caps in STATIC_CLASS_ATTR_RE.captures_iter(source) {
         let Some(m) = caps.get(0) else { continue };
         let value = caps
@@ -102,8 +109,11 @@ pub fn scan_markup_class_tokens(source: &str) -> MarkupClassScan {
             any_interpolated = true;
             continue;
         }
-        let line = 1 + source[..m.start()].bytes().filter(|&b| b == b'\n').count();
-        let line = u32::try_from(line).unwrap_or(u32::MAX);
+        last_line += source
+            .get(last_pos..m.start())
+            .map_or(0, |s| s.bytes().filter(|&b| b == b'\n').count());
+        last_pos = m.start();
+        let line = u32::try_from(last_line).unwrap_or(u32::MAX);
         for token in value.split_whitespace() {
             if is_plausible_class_token(token) {
                 static_tokens.push(MarkupClassToken {
@@ -331,5 +341,52 @@ mod tests {
         assert!(!is_typo_edit("button", "buttons"));
         assert!(!is_typo_edit("buttons", "button"));
         assert!(!is_typo_edit("card", "cards"));
+    }
+
+    #[test]
+    fn class_token_lines_match_naive_reference_on_dense_line() {
+        // Many static class attributes packed onto a single long line (the
+        // pathological zero-newline prefix) plus one on the next line: the
+        // incremental line counter must agree byte-for-byte with the naive
+        // per-match prefix rescan.
+        use std::fmt::Write as _;
+        let mut src = String::from("<div>");
+        for i in 0..500 {
+            let _ = write!(src, "<i class=\"c{i}\"></i>");
+        }
+        src.push_str("</div>\n<span class=\"tail\"></span>");
+
+        let got: Vec<(String, u32)> = scan_markup_class_tokens(&src)
+            .static_tokens
+            .into_iter()
+            .map(|t| (t.value, t.line))
+            .collect();
+
+        // Reference: recompute each attribute's line via a full prefix rescan,
+        // tokenizing the captured value exactly as the scanner does.
+        let mut want: Vec<(String, u32)> = Vec::new();
+        for caps in STATIC_CLASS_ATTR_RE.captures_iter(&src) {
+            let Some(m) = caps.get(0) else { continue };
+            let value = caps
+                .get(1)
+                .or_else(|| caps.get(2))
+                .map_or("", |g| g.as_str());
+            if value_is_interpolated(value) {
+                continue;
+            }
+            let line = u32::try_from(1 + src[..m.start()].bytes().filter(|&b| b == b'\n').count())
+                .unwrap_or(u32::MAX);
+            for token in value.split_whitespace() {
+                if is_plausible_class_token(token) {
+                    want.push((token.to_owned(), line));
+                }
+            }
+        }
+
+        assert_eq!(got, want);
+        assert!(got.len() > 500, "expected the dense line plus the trailer");
+        // The trailer sits on line 2; the packed tokens all sit on line 1.
+        assert_eq!(got.last().map(|(_, l)| *l), Some(2));
+        assert!(got[..got.len() - 1].iter().all(|(_, l)| *l == 1));
     }
 }

--- a/crates/extract/src/css_in_js/template.rs
+++ b/crates/extract/src/css_in_js/template.rs
@@ -36,6 +36,17 @@ use super::shared::{WRAPPER, count_newlines};
 /// dropped by its `error_recovery: true` parse.
 const INTERP_PLACEHOLDER: &str = "fallowinterp";
 
+/// Maximum template-literal nesting depth the body scanner will descend before
+/// bailing (issue #1843 follow-up). `scan_template_body` and `scan_interpolation`
+/// are mutually recursive (a nested `` ${`...`} `` re-enters `scan_template_body`
+/// one level deeper), so an adversarial `` ${`${`${...}`}`} `` overflows the stack
+/// (SIGABRT under `panic = "abort"`). Past the cap the scan returns `None`
+/// (unterminated-equivalent) and the lift is dropped gracefully. Real
+/// styled-components / emotion / linaria CSS nests only a handful of levels, so
+/// output is byte-identical for any genuine input. Deliberately a constant, not a
+/// config knob, mirroring `MAX_TAINT_BINDING_HOPS` / `MAX_BINDING_PATH_DEPTH`.
+const MAX_CSS_IN_JS_TEMPLATE_DEPTH: usize = 64;
+
 /// Matches the opening of a CSS-in-JS tagged template: a recognized tag
 /// (`styled.div`, `styled(Component)`, bare `css` / `keyframes` /
 /// `createGlobalStyle` / `injectGlobal`) immediately followed by a backtick. The
@@ -67,11 +78,20 @@ pub fn css_in_js_virtual_stylesheet(source: &str) -> Option<String> {
     let mut current_line: usize = 1;
     let mut found = false;
     let mut search_from = 0;
+    // Incremental source-line cursor (issue #1843 follow-up). `body_start`
+    // advances monotonically across matches (the regex is scanned left-to-right
+    // and `search_from` only moves forward), so the block line is the running
+    // count plus the newline delta since the last block, instead of rescanning
+    // `source[..body_start]` from the start every iteration (the old
+    // O(matches * source-len) cost). Byte-identical: `last_line` always equals
+    // `1 + count_newlines(&source[..last_offset])`.
+    let mut last_offset: usize = 0;
+    let mut last_line: usize = 1;
 
     while let Some(m) = CSS_IN_JS_TAG_RE.find_at(source, search_from) {
         // The regex match ends at the opening backtick (its last byte).
         let backtick = m.end() - 1;
-        let Some((body, after)) = scan_template_body(bytes, backtick) else {
+        let Some((body, after)) = scan_template_body(bytes, backtick, 0) else {
             // Unterminated template; stop scanning (the rest is malformed).
             break;
         };
@@ -79,7 +99,9 @@ pub fn css_in_js_virtual_stylesheet(source: &str) -> Option<String> {
         // Blank-line-pad to the template body's real start line, so a metric on
         // line N of the lifted sheet maps to line N of the source.
         let body_start = backtick + 1;
-        let block_line = 1 + count_newlines(&source[..body_start]);
+        last_line += count_newlines(&source[last_offset..body_start]);
+        last_offset = body_start;
+        let block_line = last_line;
         while current_line < block_line {
             out.push('\n');
             current_line += 1;
@@ -107,7 +129,13 @@ pub fn css_in_js_virtual_stylesheet(source: &str) -> Option<String> {
 /// text with every top-level `${...}` interpolation replaced by the placeholder
 /// (newline count preserved), plus the index immediately after the closing
 /// backtick. Returns `None` if the template is unterminated.
-fn scan_template_body(bytes: &[u8], open: usize) -> Option<(String, usize)> {
+fn scan_template_body(bytes: &[u8], open: usize, depth: usize) -> Option<(String, usize)> {
+    // Bounded-work depth cap (issue #1843 follow-up): a template nested past
+    // `MAX_CSS_IN_JS_TEMPLATE_DEPTH` levels bails as if unterminated rather than
+    // recursing further and overflowing the stack. Byte work stays linear.
+    if depth > MAX_CSS_IN_JS_TEMPLATE_DEPTH {
+        return None;
+    }
     // The body is accumulated as raw bytes and converted to a `String` at the end.
     // Every static byte (including the continuation bytes of a multi-byte UTF-8
     // char) is copied verbatim and contiguously, and only ASCII bytes (the
@@ -135,7 +163,7 @@ fn scan_template_body(bytes: &[u8], open: usize) -> Option<(String, usize)> {
             }
             b'`' => return Some((String::from_utf8(out).unwrap_or_default(), i + 1)),
             b'$' if i + 1 < bytes.len() && bytes[i + 1] == b'{' => {
-                let interp_end = scan_interpolation(bytes, i + 2)?;
+                let interp_end = scan_interpolation(bytes, i + 2, depth)?;
                 // The span is bounded by ASCII `$` and the byte after `}`, so the
                 // sub-slice is always valid UTF-8. Count via the str helper to
                 // preserve newlines that lived inside nested templates/strings too.
@@ -158,26 +186,27 @@ fn scan_template_body(bytes: &[u8], open: usize) -> Option<(String, usize)> {
 /// Returns the index immediately after the matching `}`. Handles nested braces,
 /// nested template literals (which may carry their own `${}`), and string
 /// literals so a `}` inside a string or nested template does not close early.
-fn scan_interpolation(bytes: &[u8], start: usize) -> Option<usize> {
-    let mut depth: usize = 1;
+fn scan_interpolation(bytes: &[u8], start: usize, template_depth: usize) -> Option<usize> {
+    let mut brace_depth: usize = 1;
     let mut i = start;
     while i < bytes.len() {
         match bytes[i] {
             b'{' => {
-                depth += 1;
+                brace_depth += 1;
                 i += 1;
             }
             b'}' => {
-                depth -= 1;
+                brace_depth -= 1;
                 i += 1;
-                if depth == 0 {
+                if brace_depth == 0 {
                     return Some(i);
                 }
             }
             b'`' => {
                 // Nested template literal: skip it wholesale (recurses for its
-                // own interpolations).
-                let (_, after) = scan_template_body(bytes, i)?;
+                // own interpolations) one template level deeper so the shared
+                // depth cap in `scan_template_body` bounds the mutual recursion.
+                let (_, after) = scan_template_body(bytes, i, template_depth + 1)?;
                 i = after;
             }
             b'\'' | b'"' => {
@@ -335,5 +364,56 @@ mod tests {
             vcss.contains("border"),
             "outer template extent must include the post-interpolation decl: {vcss:?}"
         );
+    }
+
+    #[test]
+    fn deeply_nested_template_does_not_overflow_stack() {
+        // Issue #1843 follow-up (FIX A): scan_template_body <-> scan_interpolation
+        // are mutually recursive, so a pathologically nested `${`${`...`}`}` must
+        // hit MAX_CSS_IN_JS_TEMPLATE_DEPTH and bail (unterminated-equivalent)
+        // rather than recursing per input level and overflowing the stack
+        // (SIGABRT under panic=abort). Far past the cap; without it this recursion
+        // depth would blow the stack.
+        let levels = 50_000;
+        let mut src = String::from("const T = styled.div`");
+        for _ in 0..levels {
+            src.push_str("${`");
+        }
+        src.push_str("color: red;");
+        for _ in 0..levels {
+            src.push_str("`}");
+        }
+        src.push_str("`;\n");
+        // Past-cap bail drops the whole lift gracefully (no panic, no overflow).
+        assert!(css_in_js_virtual_stylesheet(&src).is_none());
+    }
+
+    #[test]
+    fn multi_template_block_lines_map_back_to_source() {
+        // Issue #1843 follow-up (FIX B): the incremental line cursor must yield
+        // the SAME block line numbers as a from-scratch newline count for EVERY
+        // template in a multi-template file, not just the first.
+        let src = "import styled from 'styled-components';\n\
+                   \n\
+                   const A = styled.div`\n\
+                   color: red;\n\
+                   `;\n\
+                   \n\
+                   const B = styled.span`\n\
+                   margin: 0;\n\
+                   `;\n\
+                   \n\
+                   const C = styled.p`\n\
+                   padding: 4px;\n\
+                   `;\n";
+        let vcss = css_in_js_virtual_stylesheet(src).expect("has templates");
+        for needle in ["color: red", "margin: 0", "padding: 4px"] {
+            let decl = needle.split(':').next().unwrap();
+            let vcss_pos = vcss.find(decl).expect("decl present in vcss");
+            let vcss_line = 1 + vcss[..vcss_pos].bytes().filter(|&b| b == b'\n').count();
+            let src_pos = src.find(needle).unwrap();
+            let src_line = 1 + src[..src_pos].bytes().filter(|&b| b == b'\n').count();
+            assert_eq!(vcss_line, src_line, "decl {needle:?} vcss={vcss:?}");
+        }
     }
 }

--- a/crates/extract/src/css_in_js/tokens.rs
+++ b/crates/extract/src/css_in_js/tokens.rs
@@ -220,7 +220,7 @@ pub fn css_in_js_theme_token_defs(source: &str, path: &Path) -> Vec<CssInJsToken
     let ret = Parser::new(&allocator, source, source_type).parse();
 
     let mut collector = ThemeDefCollector {
-        source,
+        lines: LineCounter::new(source),
         defs: Vec::new(),
     };
     collector.visit_program(&ret.program);
@@ -322,7 +322,7 @@ fn run_consumer_query<'a>(
                 return;
             }
             let mut collector = ConsumerCollector {
-                source,
+                lines: LineCounter::new(source),
                 alias,
                 leaf_paths,
                 hits: Vec::new(),
@@ -335,7 +335,7 @@ fn run_consumer_query<'a>(
                 return;
             }
             let mut collector = PandaTokenCallCollector {
-                source,
+                lines: LineCounter::new(source),
                 alias,
                 leaf_paths,
                 hits: Vec::new(),
@@ -351,7 +351,7 @@ fn run_consumer_query<'a>(
                 return;
             }
             let mut collector = PandaStyleValueCollector {
-                source,
+                lines: LineCounter::new(source),
                 aliases,
                 leaf_paths,
                 hits: Vec::new(),
@@ -364,7 +364,7 @@ fn run_consumer_query<'a>(
                 return;
             }
             let mut collector = ThemeConsumerCollector {
-                source,
+                lines: LineCounter::new(source),
                 leaf_paths,
                 hits: Vec::new(),
             };
@@ -376,7 +376,7 @@ fn run_consumer_query<'a>(
 
 /// Walks a consuming program for member accesses on a token binding alias.
 struct ConsumerCollector<'a, 'b> {
-    source: &'a str,
+    lines: LineCounter<'a>,
     alias: &'b str,
     leaf_paths: &'b FxHashSet<String>,
     hits: Vec<TokenConsumerHit>,
@@ -394,10 +394,8 @@ impl<'a> ConsumerCollector<'a, '_> {
         {
             let token_path = segments.join(".");
             if self.leaf_paths.contains(&token_path) {
-                self.hits.push(TokenConsumerHit {
-                    token_path,
-                    line: line_at(self.source, span_start),
-                });
+                let line = self.lines.line_at(span_start);
+                self.hits.push(TokenConsumerHit { token_path, line });
             }
         }
     }
@@ -433,7 +431,7 @@ impl<'a> Visit<'a> for ConsumerCollector<'a, '_> {
 }
 
 struct PandaTokenCallCollector<'a, 'b> {
-    source: &'a str,
+    lines: LineCounter<'a>,
     alias: &'b str,
     leaf_paths: &'b FxHashSet<String>,
     hits: Vec<TokenConsumerHit>,
@@ -450,9 +448,10 @@ impl<'a> Visit<'a> for PandaTokenCallCollector<'a, '_> {
         {
             let token_path = lit.value.as_str();
             if self.leaf_paths.contains(token_path) {
+                let line = self.lines.line_at(call.span().start);
                 self.hits.push(TokenConsumerHit {
                     token_path: token_path.to_owned(),
-                    line: line_at(self.source, call.span().start),
+                    line,
                 });
             }
         }
@@ -461,7 +460,7 @@ impl<'a> Visit<'a> for PandaTokenCallCollector<'a, '_> {
 }
 
 struct PandaStyleValueCollector<'a, 'b> {
-    source: &'a str,
+    lines: LineCounter<'a>,
     aliases: &'b FxHashSet<String>,
     leaf_paths: &'b FxHashSet<String>,
     hits: Vec<TokenConsumerHit>,
@@ -482,9 +481,10 @@ impl<'a> PandaStyleValueCollector<'a, '_> {
             Expression::StringLiteral(lit) => {
                 let token_path = lit.value.as_str();
                 if self.leaf_paths.contains(token_path) {
+                    let line = self.lines.line_at(lit.span().start);
                     self.hits.push(TokenConsumerHit {
                         token_path: token_path.to_owned(),
-                        line: line_at(self.source, lit.span().start),
+                        line,
                     });
                 }
             }
@@ -512,7 +512,7 @@ impl<'a> Visit<'a> for PandaStyleValueCollector<'a, '_> {
 }
 
 struct ThemeDefCollector<'a> {
-    source: &'a str,
+    lines: LineCounter<'a>,
     defs: Vec<CssInJsTokenDef>,
 }
 
@@ -529,7 +529,13 @@ impl<'a> ThemeDefCollector<'a> {
             return;
         };
         let mut tokens = Vec::new();
-        collect_token_leaves(self.source, obj, "", CssInJsTokenOrigin::Theme, &mut tokens);
+        collect_token_leaves(
+            &mut self.lines,
+            obj,
+            "",
+            CssInJsTokenOrigin::Theme,
+            &mut tokens,
+        );
         if tokens.is_empty() {
             return;
         }
@@ -549,7 +555,7 @@ impl<'a> Visit<'a> for ThemeDefCollector<'a> {
 }
 
 struct ThemeConsumerCollector<'a, 'b> {
-    source: &'a str,
+    lines: LineCounter<'a>,
     leaf_paths: &'b FxHashSet<String>,
     hits: Vec<TokenConsumerHit>,
 }
@@ -569,10 +575,8 @@ impl<'a> ThemeConsumerCollector<'a, '_> {
         }
         let token_path = token_segments.join(".");
         if self.leaf_paths.contains(&token_path) {
-            self.hits.push(TokenConsumerHit {
-                token_path,
-                line: line_at(self.source, span_start),
-            });
+            let line = self.lines.line_at(span_start);
+            self.hits.push(TokenConsumerHit { token_path, line });
         }
     }
 }
@@ -652,7 +656,7 @@ struct Recognized {
 
 /// Collects token-definition sites, gated on import provenance.
 struct TokenDefCollector<'a> {
-    source: &'a str,
+    lines: LineCounter<'a>,
     /// local-binding name -> (library, canonical role). Mirrors the
     /// `css_in_js_object` provenance map but for token-definition roles.
     imports: FxHashMap<&'a str, (Lib, &'a str)>,
@@ -662,7 +666,7 @@ struct TokenDefCollector<'a> {
 impl<'a> TokenDefCollector<'a> {
     fn new(source: &'a str) -> Self {
         Self {
-            source,
+            lines: LineCounter::new(source),
             imports: FxHashMap::default(),
             defs: Vec::new(),
         }
@@ -800,7 +804,7 @@ impl<'a> TokenDefCollector<'a> {
             return;
         };
         let mut tokens = Vec::new();
-        collect_token_leaves(self.source, obj, "", recognized.origin, &mut tokens);
+        collect_token_leaves(&mut self.lines, obj, "", recognized.origin, &mut tokens);
         if tokens.is_empty() {
             return;
         }
@@ -819,7 +823,7 @@ impl<'a> TokenDefCollector<'a> {
             return true;
         };
         let mut tokens = Vec::new();
-        collect_panda_config_token_leaves(self.source, obj, &mut tokens);
+        collect_panda_config_token_leaves(&mut self.lines, obj, &mut tokens);
         if !tokens.is_empty() {
             self.defs.push(CssInJsTokenDef {
                 binding: PANDA_CONFIG_BINDING.to_string(),
@@ -841,7 +845,7 @@ impl<'a> TokenDefCollector<'a> {
 /// credit every `vars.palette.<x>` access to it). Spreads and computed keys are
 /// skipped because they cannot be resolved statically.
 fn collect_token_leaves(
-    source: &str,
+    lines: &mut LineCounter<'_>,
     obj: &ObjectExpression<'_>,
     prefix: &str,
     origin: CssInJsTokenOrigin,
@@ -867,12 +871,12 @@ fn collect_token_leaves(
             {
                 out.push(CssInJsToken {
                     path,
-                    def_line: line_at(source, prop.key.span().start),
+                    def_line: lines.line_at(prop.key.span().start),
                     value: object_static_property_value(nested, "value"),
                 });
             }
             Expression::ObjectExpression(nested) => {
-                collect_token_leaves(source, nested, &path, origin, out);
+                collect_token_leaves(lines, nested, &path, origin, out);
             }
             // A bare identifier is an unresolvable reference, usually an imported
             // token group; do not record it as a leaf.
@@ -880,7 +884,7 @@ fn collect_token_leaves(
             _ => out.push(CssInJsToken {
                 value: static_token_value(&prop.value),
                 path,
-                def_line: line_at(source, prop.key.span().start),
+                def_line: lines.line_at(prop.key.span().start),
             }),
         }
     }
@@ -956,7 +960,7 @@ fn object_static_property_object<'a>(
 }
 
 fn collect_panda_config_token_leaves(
-    source: &str,
+    lines: &mut LineCounter<'_>,
     obj: &ObjectExpression<'_>,
     out: &mut Vec<CssInJsToken>,
 ) {
@@ -965,7 +969,7 @@ fn collect_panda_config_token_leaves(
     };
     for key in ["tokens", "semanticTokens"] {
         if let Some(tokens) = object_static_property_object(theme, key) {
-            collect_token_leaves(source, tokens, "", CssInJsTokenOrigin::Panda, out);
+            collect_token_leaves(lines, tokens, "", CssInJsTokenOrigin::Panda, out);
         }
     }
 }
@@ -987,15 +991,60 @@ impl<'a> Visit<'a> for TokenDefCollector<'a> {
     }
 }
 
-/// 1-based line number of a byte offset in `source`. Uses `.get(..end)` so an
-/// out-of-range or non-char-boundary offset clamps to line 1 rather than
-/// panicking (matches `css::line_at_offset`).
-fn line_at(source: &str, offset: u32) -> u32 {
-    let end = (offset as usize).min(source.len());
-    let count = source
-        .get(..end)
-        .map_or(0, |s| s.bytes().filter(|&b| b == b'\n').count());
-    u32::try_from(1 + count).unwrap_or(u32::MAX)
+/// Count `\n` bytes in `s` as a saturating `u32`.
+fn count_newlines_u32(s: &str) -> u32 {
+    u32::try_from(s.bytes().filter(|&b| b == b'\n').count()).unwrap_or(u32::MAX)
+}
+
+/// Incremental 1-based line-number counter over a fixed `source` (issue #1843
+/// follow-up). The old free `line_at` counted the newlines in `source[..offset]`
+/// from the start on every call, so a token file with M definitions cost
+/// O(M * source-len). Definitions and consumer hits are visited in source order,
+/// so this advances a cursor by only the newline delta since the previous query
+/// (`source[last_offset..offset]`), making a whole walk O(source-len). A
+/// non-monotonic query rewinds by the reverse delta, and an out-of-range or
+/// non-char-boundary offset clamps to line 1 exactly as the previous `line_at`
+/// did (matching `css::line_at_offset`), so the result is byte-identical to a
+/// from-scratch count regardless of query order. Deliberately a plain cursor,
+/// mirroring the `MAX_BINDING_PATH_DEPTH` bounded-work companions.
+struct LineCounter<'a> {
+    source: &'a str,
+    /// Byte offset of the last query whose line was computed. Always a valid
+    /// char boundary (only ever assigned a boundary-checked `end`).
+    last_offset: usize,
+    /// `1 + count_newlines(&source[..last_offset])`, the invariant maintained
+    /// across queries.
+    last_line: u32,
+}
+
+impl<'a> LineCounter<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            last_offset: 0,
+            last_line: 1,
+        }
+    }
+
+    /// 1-based line number of `offset`, byte-identical to the previous
+    /// `line_at(source, offset)`.
+    fn line_at(&mut self, offset: u32) -> u32 {
+        let end = (offset as usize).min(self.source.len());
+        // Preserve the previous `.get(..end)` contract: a non-char-boundary
+        // offset clamps to line 1 rather than panicking on the slice below.
+        if !self.source.is_char_boundary(end) {
+            return 1;
+        }
+        if end >= self.last_offset {
+            let delta = count_newlines_u32(&self.source[self.last_offset..end]);
+            self.last_line = self.last_line.saturating_add(delta);
+        } else {
+            let delta = count_newlines_u32(&self.source[end..self.last_offset]);
+            self.last_line = self.last_line.saturating_sub(delta);
+        }
+        self.last_offset = end;
+        self.last_line
+    }
 }
 
 #[cfg(all(test, not(miri)))]
@@ -1027,6 +1076,36 @@ mod tests {
 
     fn theme_defs(source: &str) -> Vec<CssInJsTokenDef> {
         css_in_js_theme_token_defs(source, Path::new("theme.ts"))
+    }
+
+    #[test]
+    fn incremental_def_lines_match_source_order() {
+        // Issue #1843 follow-up (FIX B): the incremental LineCounter must yield
+        // the same def_line as a from-scratch newline count for every token,
+        // across MULTIPLE definitions on multiple lines (the source-order cursor
+        // must advance correctly between separate `defineVars` calls, not just
+        // within one).
+        let src = "import { defineVars } from '@stylexjs/stylex';\n\
+export const colors = defineVars({\n\
+primary: '#000',\n\
+secondary: '#fff',\n\
+});\n\
+export const space = defineVars({\n\
+sm: '4px',\n\
+lg: '16px',\n\
+});\n";
+        let d = defs(src);
+        let line_of = |binding: &str, path: &str| {
+            d.iter()
+                .find(|def| def.binding == binding)
+                .and_then(|def| def.tokens.iter().find(|t| t.path == path))
+                .unwrap_or_else(|| panic!("token {binding}.{path} present"))
+                .def_line
+        };
+        assert_eq!(line_of("colors", "primary"), 3);
+        assert_eq!(line_of("colors", "secondary"), 4);
+        assert_eq!(line_of("space", "sm"), 7);
+        assert_eq!(line_of("space", "lg"), 8);
     }
 
     #[test]

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -780,9 +780,18 @@ fn extract_jsdoc_import_types(imports: &mut Vec<ImportInfo>, comments: &[Comment
 fn scan_jsdoc_imports_in(body: &str, imports: &mut Vec<ImportInfo>) {
     let bytes = body.as_bytes();
     let mut cursor = 0;
+    // Brace-nesting stack (byte offsets of currently-open `{`) maintained
+    // incrementally as the cursor advances, so each `import(` occurrence reuses
+    // the enclosing-brace position instead of rescanning the whole prefix from
+    // offset 0. issue #1843 follow-up: turns the per-occurrence O(prefix) rescan
+    // in the old `enclosing_jsdoc_brace_start` into a single O(body) forward
+    // pass over the comment while staying byte-identical.
+    let mut brace_stack: Vec<usize> = Vec::new();
+    let mut scanned = 0;
     while let Some(rel) = body[cursor..].find("import(") {
         let import_pos = cursor + rel;
-        if !is_inside_jsdoc_type_brace_group(bytes, import_pos) {
+        advance_jsdoc_brace_stack(bytes, &mut brace_stack, &mut scanned, import_pos);
+        if !is_inside_jsdoc_type_brace_group(bytes, import_pos, brace_stack.last().copied()) {
             cursor = import_pos + "import(".len();
             continue;
         }
@@ -907,9 +916,11 @@ fn jsdoc_type_import(
 
 /// Returns true when byte index `pos` falls inside a JSDoc type-expression
 /// brace group. Prose examples can contain ordinary JavaScript braces, so the
-/// enclosing brace must be tied to a JSDoc type tag.
-fn is_inside_jsdoc_type_brace_group(body: &[u8], pos: usize) -> bool {
-    let Some(open_brace) = enclosing_jsdoc_brace_start(body, pos) else {
+/// enclosing brace must be tied to a JSDoc type tag. `open_brace` is the
+/// innermost enclosing `{` offset (or `None` when `pos` is at brace depth zero),
+/// supplied by the caller's incrementally-maintained brace stack.
+fn is_inside_jsdoc_type_brace_group(body: &[u8], pos: usize, open_brace: Option<usize>) -> bool {
+    let Some(open_brace) = open_brace else {
         return false;
     };
 
@@ -923,19 +934,32 @@ fn is_inside_jsdoc_type_brace_group(body: &[u8], pos: usize) -> bool {
         && has_only_jsdoc_spacing_between(body, open_brace + 1, pos)
 }
 
-fn enclosing_jsdoc_brace_start(body: &[u8], pos: usize) -> Option<usize> {
-    let mut stack = Vec::new();
-    let limit = pos.min(body.len());
-    for (idx, &b) in body[..limit].iter().enumerate() {
-        match b {
-            b'{' => stack.push(idx),
+/// Advance the incrementally-maintained JSDoc brace stack from `*scanned` up to
+/// (but not including) `up_to`, pushing the offset of every `{` and popping on
+/// every `}`. Afterwards `stack.last()` is the innermost enclosing brace of
+/// `up_to`, identical to a fresh scan of `body[..up_to]` but amortized across
+/// every `import(` occurrence in the comment instead of rescanning each prefix
+/// from offset zero (issue #1843 follow-up).
+///
+/// `up_to` must not regress (the caller's `import(` cursor only moves forward);
+/// a non-advancing call is a no-op.
+fn advance_jsdoc_brace_stack(
+    body: &[u8],
+    stack: &mut Vec<usize>,
+    scanned: &mut usize,
+    up_to: usize,
+) {
+    let up_to = up_to.min(body.len());
+    while *scanned < up_to {
+        match body[*scanned] {
+            b'{' => stack.push(*scanned),
             b'}' => {
                 stack.pop();
             }
             _ => {}
         }
+        *scanned += 1;
     }
-    stack.pop()
 }
 
 fn line_prefix_before(body: &[u8], pos: usize) -> &str {
@@ -1182,8 +1206,8 @@ pub fn compute_import_binding_usage(
 #[cfg(test)]
 mod tests {
     use super::{
-        has_alpha_tag, has_beta_tag, has_internal_tag, has_public_tag, parse_source_to_module,
-        scan_jsdoc_imports_in,
+        advance_jsdoc_brace_stack, has_alpha_tag, has_beta_tag, has_internal_tag, has_public_tag,
+        parse_source_to_module, scan_jsdoc_imports_in,
     };
     use fallow_types::discover::FileId;
     use fallow_types::extract::{ImportInfo, ImportedName};
@@ -1621,5 +1645,79 @@ mod tests {
     fn scan_jsdoc_empty_member_name_is_skipped() {
         let imports = scan(" * @type {import('./x').}");
         assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn scan_jsdoc_many_imports_incremental_brace_stack_is_identical() {
+        // Regression for the issue #1843 follow-up: the enclosing-brace lookup
+        // is maintained incrementally across the whole comment rather than
+        // rescanning every prefix. A comment packed with many `import(...)` type
+        // refs must still extract exactly one import per `{...}` type group, in
+        // order, with the same paths and member names as before.
+        use std::fmt::Write as _;
+        let mut body = String::from("/**\n");
+        for i in 0..200 {
+            let _ = writeln!(body, " * @param a{i} {{import('./m{i}').T{i}}} description");
+        }
+        // A prose `import(` outside any type brace group and a nested brace
+        // must not add spurious imports or shift the enclosing-brace tracking.
+        body.push_str(" * @remarks import('./ignored') appears in prose here\n");
+        body.push_str(" * @typedef {{ nested: { deep: import('./deep').D } }} Obj\n");
+        body.push_str(" */\n");
+
+        let imports = scan(&body);
+        assert_eq!(imports.len(), 201, "got: {imports:?}");
+        for (i, import) in imports.iter().take(200).enumerate() {
+            assert_eq!(import.source, format!("./m{i}"));
+            assert_eq!(import.imported_name, ImportedName::Named(format!("T{i}")));
+            assert!(import.is_type_only);
+            assert!(import.local_name.is_empty());
+        }
+        // The nested-brace occurrence still resolves against its enclosing group.
+        assert_eq!(imports[200].source, "./deep");
+        assert_eq!(
+            imports[200].imported_name,
+            ImportedName::Named("D".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_jsdoc_brace_stack_matches_offset_zero_rescan() {
+        // Cross-checks the incremental brace stack against an independent
+        // offset-zero rescan over the full prefix, on inputs where the
+        // `import(` cursor skips over intervening braces (issue #1843 follow-up).
+        let cases = [
+            " * @type {import('./a').A} and {plain} then {import('./b').B}",
+            " * @remarks { import('./skip') } @param x {import('./c').C}",
+            " * text } stray close { import('./d').D } trailing",
+            " * @type {{ a: import('./e').E, b: { c: import('./f').F } }}",
+        ];
+        for body in cases {
+            let bytes = body.as_bytes();
+            let mut cursor = 0;
+            while let Some(rel) = body[cursor..].find("import(") {
+                let import_pos = cursor + rel;
+                // Independent offset-zero rescan reproducing the old helper.
+                let mut fresh = Vec::new();
+                for (idx, &b) in bytes[..import_pos].iter().enumerate() {
+                    match b {
+                        b'{' => fresh.push(idx),
+                        b'}' => {
+                            fresh.pop();
+                        }
+                        _ => {}
+                    }
+                }
+                let mut stack = Vec::new();
+                let mut scanned = 0;
+                advance_jsdoc_brace_stack(bytes, &mut stack, &mut scanned, import_pos);
+                assert_eq!(
+                    stack.last().copied(),
+                    fresh.last().copied(),
+                    "enclosing brace mismatch at {import_pos} in {body:?}"
+                );
+                cursor = import_pos + "import(".len();
+            }
+        }
     }
 }

--- a/crates/extract/src/tailwind.rs
+++ b/crates/extract/src/tailwind.rs
@@ -39,14 +39,24 @@ pub struct TailwindArbitraryUse {
 #[must_use]
 pub fn scan_tailwind_arbitrary_values(source: &str) -> Vec<TailwindArbitraryUse> {
     let mut out = Vec::new();
+    // Incremental line counter: `find_iter` yields matches in source order, so
+    // count only the newlines between the previous match and this one instead of
+    // rescanning the whole prefix per match (issue #1843 follow-up: the naive
+    // `source[..m.start()]` rescan is O(matches * source_len), worst on a single
+    // long line with no newlines).
+    let mut last_pos = 0usize;
+    let mut last_line = 1usize;
     for m in ARBITRARY_VALUE_RE.find_iter(source) {
         if is_arbitrary_variant_match(source.as_bytes(), m.end()) {
             continue;
         }
-        let line = 1 + source[..m.start()].bytes().filter(|&b| b == b'\n').count();
+        last_line += source
+            .get(last_pos..m.start())
+            .map_or(0, |s| s.bytes().filter(|&b| b == b'\n').count());
+        last_pos = m.start();
         out.push(TailwindArbitraryUse {
             value: m.as_str().to_owned(),
-            line: u32::try_from(line).unwrap_or(u32::MAX),
+            line: u32::try_from(last_line).unwrap_or(u32::MAX),
         });
     }
     out
@@ -130,5 +140,42 @@ mod tests {
     fn keeps_arbitrary_value_modifiers() {
         let v = values(r#"<div class="bg-[#fff]/50 ring-[3px]">x</div>"#);
         assert_eq!(v, vec!["bg-[#fff]", "ring-[3px]"]);
+    }
+
+    #[test]
+    fn line_numbers_match_naive_reference_on_dense_line() {
+        // Many arbitrary-value tokens packed onto a single long line (the
+        // pathological zero-newline prefix): the incremental line counter must
+        // agree byte-for-byte with the naive per-match prefix rescan.
+        use std::fmt::Write as _;
+        let mut src = String::from("<div class=\"");
+        for i in 0..500 {
+            let _ = write!(src, "w-[{i}px] ");
+        }
+        src.push_str("\">x</div>\n<span class=\"h-[3px]\"></span>");
+
+        let got: Vec<(String, u32)> = scan_tailwind_arbitrary_values(&src)
+            .into_iter()
+            .map(|u| (u.value, u.line))
+            .collect();
+
+        // Reference: recompute each match's line via a full prefix rescan.
+        let want: Vec<(String, u32)> = ARBITRARY_VALUE_RE
+            .find_iter(&src)
+            .filter(|m| !is_arbitrary_variant_match(src.as_bytes(), m.end()))
+            .map(|m| {
+                let line = 1 + src[..m.start()].bytes().filter(|&b| b == b'\n').count();
+                (
+                    m.as_str().to_owned(),
+                    u32::try_from(line).unwrap_or(u32::MAX),
+                )
+            })
+            .collect();
+
+        assert_eq!(got, want);
+        assert!(got.len() > 500, "expected the dense line plus the trailer");
+        // The trailer sits on line 2; the packed tokens all sit on line 1.
+        assert_eq!(got.last().map(|(_, l)| *l), Some(2));
+        assert!(got[..got.len() - 1].iter().all(|(_, l)| *l == 1));
     }
 }

--- a/crates/extract/src/template_complexity/engine.rs
+++ b/crates/extract/src/template_complexity/engine.rs
@@ -56,7 +56,7 @@ impl TemplateComplexity {
             return Ok(());
         };
         self.first_offset.get_or_insert(offset + trim_start);
-        let metrics = compute_expression_metrics(&source[trim_start..], nesting)?;
+        let metrics = compute_expression_metrics(&source[trim_start..], nesting, 0)?;
         self.cyclomatic = self.cyclomatic.saturating_add(metrics.cyclomatic);
         self.cognitive = self.cognitive.saturating_add(metrics.cognitive);
         Ok(())
@@ -120,27 +120,49 @@ impl ExpressionMetrics {
     }
 }
 
-fn compute_expression_metrics(source: &str, nesting: u16) -> Result<ExpressionMetrics, ScanError> {
+/// Maximum bracket/ternary recursion depth for template-expression metric
+/// scoring. Real template expressions nest only 3-5 levels deep, so this cap is
+/// generous; past it a pathological input like `((((...))))` is treated as
+/// malformed and its synthetic finding is dropped (via [`ScanError`]) rather
+/// than recursing until the stack overflows (SIGABRT under release
+/// `panic = "abort"`). Mirrors the `MAX_TAINT_BINDING_HOPS` /
+/// `MAX_BINDING_PATH_DEPTH` bounded-work style. Issue #1843 follow-up.
+const MAX_TEMPLATE_EXPR_DEPTH: u16 = 64;
+
+fn compute_expression_metrics(
+    source: &str,
+    nesting: u16,
+    depth: u16,
+) -> Result<ExpressionMetrics, ScanError> {
+    if depth > MAX_TEMPLATE_EXPR_DEPTH {
+        return Err(ScanError);
+    }
     let source = source.trim();
     if source.is_empty() {
         return Ok(ExpressionMetrics::default());
     }
     if let Some((question, colon)) = find_top_level_ternary(source)? {
         let mut metrics = ExpressionMetrics::default();
-        metrics.add(compute_expression_metrics(&source[..question], nesting)?);
+        metrics.add(compute_expression_metrics(
+            &source[..question],
+            nesting,
+            depth + 1,
+        )?);
         metrics.cyclomatic = metrics.cyclomatic.saturating_add(1);
         metrics.cognitive = metrics.cognitive.saturating_add(1 + nesting);
         metrics.add(compute_expression_metrics(
             &source[question + 1..colon],
             nesting.saturating_add(1),
+            depth + 1,
         )?);
         metrics.add(compute_expression_metrics(
             &source[colon + 1..],
             nesting.saturating_add(1),
+            depth + 1,
         )?);
         return Ok(metrics);
     }
-    scan_expression_without_ternary(source, nesting)
+    scan_expression_without_ternary(source, nesting, depth)
 }
 
 /// Mutable scanning state shared across the [`scan_expression_without_ternary`]
@@ -154,6 +176,7 @@ struct ScanState {
 fn scan_expression_without_ternary(
     source: &str,
     nesting: u16,
+    depth: u16,
 ) -> Result<ExpressionMetrics, ScanError> {
     let mut state = ScanState {
         metrics: ExpressionMetrics::default(),
@@ -169,7 +192,9 @@ fn scan_expression_without_ternary(
                 offset = skip_quoted(source, offset)?;
                 state.needs_rhs = false;
             }
-            b'(' | b'[' | b'{' => offset = scan_bracket_group(source, offset, nesting, &mut state)?,
+            b'(' | b'[' | b'{' => {
+                offset = scan_bracket_group(source, offset, nesting, depth, &mut state)?;
+            }
             b')' | b']' | b'}' => return Err(ScanError),
             _ if source[offset..].starts_with("?.") => {
                 state.metrics.cyclomatic = state.metrics.cyclomatic.saturating_add(1);
@@ -217,6 +242,7 @@ fn scan_bracket_group(
     source: &str,
     offset: usize,
     nesting: u16,
+    depth: u16,
     state: &mut ScanState,
 ) -> Result<usize, ScanError> {
     let close = matching_close_byte(source.as_bytes()[offset]).ok_or(ScanError)?;
@@ -224,6 +250,7 @@ fn scan_bracket_group(
     state.metrics.add(compute_expression_metrics(
         &source[offset + 1..end],
         nesting,
+        depth + 1,
     )?);
     state.last_logical_operator = None;
     state.needs_rhs = false;
@@ -398,4 +425,47 @@ fn is_identifier_start(byte: u8) -> bool {
 
 fn is_identifier_continue(byte: u8) -> bool {
     is_identifier_start(byte) || byte.is_ascii_digit()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shallow_expression_metrics_are_stable() {
+        // A normal 2-3 level nested expression scores by logical-operator and
+        // ternary count; the depth guard never fires for it.
+        let ternary = compute_expression_metrics("(a && b) ? c : (d || e)", 0, 0).unwrap();
+        assert_eq!(ternary.cyclomatic, 3);
+        assert_eq!(ternary.cognitive, 3);
+
+        let bracketed = compute_expression_metrics("(a && b)", 0, 0).unwrap();
+        assert_eq!(bracketed.cyclomatic, 1);
+        assert_eq!(bracketed.cognitive, 1);
+    }
+
+    #[test]
+    fn moderate_nesting_below_cap_scores_identically() {
+        // Ten bracket levels is far below MAX_TEMPLATE_EXPR_DEPTH, so wrapping
+        // `a && b` in redundant parens yields the same metrics as the bare
+        // expression.
+        let source = format!("{}a && b{}", "(".repeat(10), ")".repeat(10));
+        let metrics = compute_expression_metrics(&source, 0, 0).unwrap();
+        assert_eq!(metrics.cyclomatic, 1);
+        assert_eq!(metrics.cognitive, 1);
+    }
+
+    #[test]
+    fn pathologically_deep_nesting_is_dropped_without_crashing() {
+        // ~5000 nested parens previously recursed until the stack overflowed
+        // (SIGABRT under release panic = "abort"). The depth guard now bails
+        // past MAX_TEMPLATE_EXPR_DEPTH and the synthetic finding is dropped.
+        let depth = 5000;
+        let source = format!("{}a{}", "(".repeat(depth), ")".repeat(depth));
+        assert!(compute_expression_metrics(&source, 0, 0).is_err());
+
+        // The public entry point surfaces the same drop as a ScanError.
+        let mut complexity = TemplateComplexity::default();
+        assert!(complexity.add_expression(&source, 0, 0).is_err());
+    }
 }

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -116,6 +116,19 @@ const ITERABLE_ELEMENT_CALLBACK_METHODS: &[&str] = &[
 const ROUTE_LOADER_DATA_SOURCES: &[&str] =
     &["react-router", "react-router-dom", "@remix-run/react"];
 
+/// Per-module breadth cap on recorded factory-return candidates (issue #1843
+/// follow-up): the companion to `MAX_TAINTED_BINDINGS_PER_MODULE` for the
+/// `const local = callee(...)` factory-return channel. `factory_return_candidates`
+/// grows once per bare-callee assignment in the module and is resolved by an
+/// O(n) finalize pass, so a dense machine-generated bundle that emits tens of
+/// thousands of such assignments drove the working set (and the finalize scan)
+/// super-linearly. Past the cap no NEW candidate is recorded, degrading an
+/// over-cap file to the pre-existing module-level reachability instead of an
+/// arg-level factory-return claim, matching the false-negative-preferring
+/// direction of the depth/breadth taint caps. Deliberately a constant, not a
+/// config knob: real hand-written modules stay far below it.
+const MAX_FACTORY_RETURN_CANDIDATES: usize = 4096;
+
 fn is_css_module_import_source(source: &str) -> bool {
     let path = source.split(['?', '#']).next().unwrap_or(source);
     let Some(file_name) = path.rsplit('/').next() else {
@@ -243,7 +256,13 @@ impl ModuleInfoExtractor {
         };
 
         match &declarator.id {
-            BindingPattern::BindingIdentifier(id) => {
+            // Per-module breadth cap (issue #1843 follow-up): the guard stops
+            // recording once at capacity so a pathological bundle cannot grow the
+            // candidate set (and its finalize scan) without bound. At capacity the
+            // arm falls through to the no-op `_ =>` arm, identical to skipping.
+            BindingPattern::BindingIdentifier(id)
+                if self.factory_return_candidates.len() < MAX_FACTORY_RETURN_CANDIDATES =>
+            {
                 self.factory_return_candidates
                     .push(super::FactoryReturnCandidate {
                         local_name: id.name.to_string(),

--- a/crates/extract/src/visitor/visit_impl_object_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_object_bindings.rs
@@ -6,6 +6,20 @@ use oxc_ast::ast::*;
 
 use super::super::{BindingTarget, ModuleInfoExtractor, ObjectBindingCandidate};
 
+/// Per-module breadth cap on recorded object-binding candidates (issue #1843
+/// follow-up): the companion to `MAX_TAINTED_BINDINGS_PER_MODULE` for the
+/// `const obj = { key: ident }` object-binding channel. `object_binding_candidates`
+/// grows once per identifier-valued property (recursively through nested object
+/// literals) and is resolved by a fixpoint pass whose iteration bound is the
+/// candidate count, so an O(n^2) worst case. A dense machine-generated bundle
+/// with a huge object literal drove the working set (and that fixpoint) super-
+/// linearly. Past the cap no NEW candidate is recorded, degrading an over-cap
+/// file to module-level reachability instead of an object-binding member-access
+/// claim, matching the false-negative-preferring direction of the taint caps.
+/// Deliberately a constant, not a config knob: real hand-written modules stay
+/// far below it.
+const MAX_OBJECT_BINDING_CANDIDATES: usize = 4096;
+
 impl ModuleInfoExtractor {
     pub(super) fn extract_angular_inject_target(
         &self,
@@ -24,6 +38,11 @@ impl ModuleInfoExtractor {
         source_binding: &str,
         target_binding: &str,
     ) -> bool {
+        // Nothing to copy from an empty map: skip the two `format!` allocations
+        // and the no-op scan/collect below.
+        if self.binding_target_names.is_empty() {
+            return false;
+        }
         let source_prefix = format!("{source_binding}.");
         let target_prefix = format!("{target_binding}.");
         let copied: Vec<(String, BindingTarget)> = self
@@ -98,7 +117,14 @@ impl ModuleInfoExtractor {
 
             let binding_path = format!("{object_path}.{key_name}");
             match &prop.value {
-                Expression::Identifier(ident) => {
+                // Per-module breadth cap (issue #1843 follow-up): the guard stops
+                // recording once at capacity so a pathological object literal
+                // cannot grow the candidate set (and its O(n^2) fixpoint resolver)
+                // without bound. At capacity the arm falls through to the no-op
+                // `_ =>` arm, identical to skipping the push.
+                Expression::Identifier(ident)
+                    if self.object_binding_candidates.len() < MAX_OBJECT_BINDING_CANDIDATES =>
+                {
                     self.object_binding_candidates.push(ObjectBindingCandidate {
                         binding_path,
                         source_name: ident.name.to_string(),
@@ -110,5 +136,53 @@ impl ModuleInfoExtractor {
                 _ => {}
             }
         }
+    }
+}
+
+#[cfg(all(test, not(miri)))]
+mod tests {
+    use super::MAX_OBJECT_BINDING_CANDIDATES;
+    use crate::visitor::ModuleInfoExtractor;
+    use oxc_allocator::Allocator;
+    use oxc_ast_visit::Visit;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    /// A single object literal with far more identifier-valued properties than
+    /// the per-module cap must not grow `object_binding_candidates` past the cap.
+    /// Mirrors `tainted_binding_recording_is_bounded_on_dense_source`: the
+    /// object-binding channel has the same super-linear failure mode (an O(n^2)
+    /// fixpoint resolver over an unbounded candidate set) on dense machine-
+    /// generated source, and the cap degrades over-cap files to module-level
+    /// reachability rather than OOMing. See issue #1843 follow-up.
+    #[test]
+    fn object_binding_candidate_recording_is_bounded_on_dense_source() {
+        use std::fmt::Write as _;
+
+        let over_cap = MAX_OBJECT_BINDING_CANDIDATES + 1000;
+        let mut props = String::new();
+        for k in 0..over_cap {
+            // Each identifier-valued property seeds one object-binding candidate.
+            let _ = write!(props, "k{k}: v{k}, ");
+        }
+        let source = format!("const big = {{ {props} }};");
+
+        let allocator = Allocator::default();
+        let parser_return = Parser::new(&allocator, &source, SourceType::ts()).parse();
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.visit_program(&parser_return.program);
+
+        // The cap must engage (input deterministically exceeds it) but never
+        // zero out recording.
+        assert!(
+            !extractor.object_binding_candidates.is_empty(),
+            "the cap must not zero out object-binding recording"
+        );
+        assert!(
+            extractor.object_binding_candidates.len() <= MAX_OBJECT_BINDING_CANDIDATES,
+            "object-binding candidate recording must stay bounded at the \
+             per-module cap on dense source (got {})",
+            extractor.object_binding_candidates.len()
+        );
     }
 }

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -96,14 +96,20 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
         .iter()
         .any(|re| re.exported_name == "*");
 
+    let matching_exports_by_name = build_named_export_index(&modules[source_idx]);
+
     let mut changed = false;
     let mut existing_files: FxHashSet<FileId> = FxHashSet::default();
     let source = &mut modules[source_idx];
     for (name, refs) in &refs_by_name {
+        let matching_exports: &[usize] = matching_exports_by_name
+            .get(name.as_str())
+            .map_or(&[], Vec::as_slice);
         changed |= apply_star_refs_to_source(ApplyStarRefs {
             source: &mut *source,
             name,
             refs,
+            matching_exports,
             source_id,
             module_by_id,
             triggering_is_type_only,
@@ -113,6 +119,27 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
         });
     }
     changed
+}
+
+/// Index the source module's named exports by name so the per-re-exported-name
+/// star propagation can look up matching exports in O(1) instead of rescanning
+/// `source.exports` once per name.
+///
+/// Issue #1843 follow-up: the removed per-name scan was O(names x source_exports)
+/// and re-ran on every fixpoint visit, dominating wide-barrel re-export
+/// resolution. The map is built once over the module's pre-existing exports;
+/// synthetic exports appended during propagation are always named after the name
+/// currently being processed (each name is visited exactly once), so they never
+/// need to appear in a later name's lookup. The result is therefore byte-identical
+/// to the exact-`ExportName::Named`-match, ascending-index scan it replaces.
+fn build_named_export_index(source: &ModuleNode) -> FxHashMap<String, Vec<usize>> {
+    let mut index: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    for (idx, export) in source.exports.iter().enumerate() {
+        if let ExportName::Named(name) = &export.name {
+            index.entry(name.clone()).or_default().push(idx);
+        }
+    }
+    index
 }
 
 /// Collect the per-name references that must propagate through a star
@@ -292,6 +319,9 @@ struct ApplyStarRefs<'a> {
     source: &'a mut ModuleNode,
     name: &'a str,
     refs: &'a [StarReference],
+    /// Indices into `source.exports` whose name exactly matches `name`, prebuilt
+    /// once per source module by `build_named_export_index` (issue #1843 follow-up).
+    matching_exports: &'a [usize],
     source_id: FileId,
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
@@ -308,6 +338,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
         source,
         name,
         refs,
+        matching_exports,
         source_id,
         module_by_id,
         triggering_is_type_only,
@@ -320,15 +351,6 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
         return false;
     }
 
-    let export_name = ExportName::Named(name.to_string());
-
-    let matching_exports: Vec<usize> = source
-        .exports
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, export)| (export.name == export_name).then_some(idx))
-        .collect();
-
     if !matching_exports.is_empty() {
         apply_star_refs_to_matching_exports(ApplyMatchingStarRefs {
             source,
@@ -338,7 +360,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
             module_by_id,
             triggering_is_type_only,
             source_has_star_re_exports,
-            matching_exports: &matching_exports,
+            matching_exports,
             existing_files,
             synthetic_stubs,
         })
@@ -346,7 +368,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
         create_synthetic_exports_for_refs(CreateSyntheticExports {
             source,
             name,
-            export_name,
+            export_name: ExportName::Named(name.to_string()),
             refs,
             source_id,
             module_by_id,
@@ -935,4 +957,82 @@ fn propagate_entry_point_named(
         }
     }
     changed
+}
+
+#[cfg(test)]
+mod star_index_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn named(name: &str) -> ExportSymbol {
+        export_symbol(ExportName::Named(name.to_string()))
+    }
+
+    fn export_symbol(name: ExportName) -> ExportSymbol {
+        ExportSymbol {
+            name,
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: oxc_span::Span::new(0, 0),
+            references: Vec::new(),
+            members: Vec::new(),
+        }
+    }
+
+    fn module_with(exports: Vec<ExportSymbol>) -> ModuleNode {
+        ModuleNode {
+            file_id: FileId(0),
+            path: PathBuf::from("/project/source.ts"),
+            edge_range: 0..0,
+            exports,
+            re_exports: Vec::new(),
+            flags: 0,
+        }
+    }
+
+    /// The prebuilt name -> indices map must reproduce, byte-for-byte, the indices
+    /// the removed per-name `source.exports` scan produced: exact
+    /// `ExportName::Named` matching, ascending index order, `Default` excluded.
+    /// This pins the behavior-preserving contract for a wide-barrel source module.
+    #[test]
+    fn named_export_index_matches_reference_scan() {
+        // A wide barrel source: many named exports, a duplicate name, and a
+        // Default export interleaved to prove index alignment survives it.
+        let module = module_with(vec![
+            named("a"),
+            named("b"),
+            export_symbol(ExportName::Default),
+            named("c"),
+            named("b"), // duplicate name at a later index
+            named("d"),
+        ]);
+
+        let index = build_named_export_index(&module);
+
+        // Reference computation mirrors the old inline scan for each candidate name.
+        let reference = |name: &str| -> Vec<usize> {
+            let export_name = ExportName::Named(name.to_string());
+            module
+                .exports
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, export)| (export.name == export_name).then_some(idx))
+                .collect()
+        };
+
+        for name in ["a", "b", "c", "d"] {
+            let looked_up = index.get(name).cloned().unwrap_or_default();
+            assert_eq!(looked_up, reference(name), "index mismatch for `{name}`");
+        }
+
+        // A repeated name keeps both indices in ascending order (the `Default`
+        // export at index 2 is skipped, so the second `b` lands at index 4).
+        assert_eq!(index.get("b").map(Vec::as_slice), Some(&[1usize, 4][..]));
+
+        // Default is never keyed as a named export, and an absent name is empty.
+        assert!(!index.contains_key("default"));
+        assert!(!index.contains_key("missing"));
+    }
 }


### PR DESCRIPTION
Follow-up to the #1843 taint-memory fix. An audit for the same accumulator/scan pathology (unbounded per-module accumulator + super-linear scan, reachable on large/generated/minified input) found eight more paths; this fixes all eight.

- **core**: duplicate-export common-importer partition uses a `FileId`->index map instead of a linear `position()` scan in a loop; class-heritage grouping dedups via an `FxHashSet` instead of `Vec::contains`.
- **graph**: star re-export propagation builds a name->exports index once per source module instead of rescanning per name.
- **extract**: object-binding and factory-return candidate sets get per-module breadth caps (4096, mirroring `MAX_TAINTED_BINDINGS_PER_MODULE`); JSDoc import scanning tracks brace depth incrementally; template-complexity and CSS-in-JS template scanners are depth-guarded (64) against stack overflow on pathological nesting; the health-time line-number scanners and the astro mask-membership test are linearized.

All eight were implemented in isolated worktrees and adversarially verified, then re-reviewed pre-ship (SHIP, zero findings). Output is behavior-preserving on ordinary code: verified **byte-identical** old-vs-new across the fixture corpus (dead-code, `health --css`, `health --complexity`, astro; zero diffs). `CACHE_VERSION` 236 to 237 for the candidate caps only.

Follow-up to #1843.