### PR TITLE
perf(extract): bound the object-binding resolver on minified bundles (#1843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pathologically nested input), and the health-time line-number and mask
   scanners. Analysis output is unchanged on ordinary code. (#1843)
 
+- **A real minified vendor bundle no longer stalls analysis for minutes.** The
+  object-binding member-resolution pass could grow super-linearly on a large
+  minified bundle full of nested object maps (a 2 MB bundle stalled the parse
+  for over a minute). It is now bounded by a prefix index plus size and pass
+  caps, so such files analyze in a fraction of a second. Output is unchanged on
+  ordinary code. (#1843)
+
 ## [3.6.0] - 2026-07-15
 
 ### Changed

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -821,7 +821,15 @@ use crate::MemberKind;
 /// bounds its accumulator. A file exceeding a cap now persists fewer candidates,
 /// so its resolved `member_accesses` can change; warm 236 caches can carry
 /// over-cap entries; invalidate them.
-pub(super) const CACHE_VERSION: u32 = 237;
+///
+/// Bumped to 238 (issue #1843 follow-up): the object-binding resolution
+/// fixed-point is now additionally bounded by a `binding_target_names` size cap
+/// (8192) and a pass cap (8), because a real minified bundle full of nested
+/// object maps drove it to tens of seconds even under the candidate cap. A file
+/// that hits either bound now resolves fewer nested bindings, so its
+/// `member_accesses` can change; warm 237 caches can carry the fuller set;
+/// invalidate them.
+pub(super) const CACHE_VERSION: u32 = 238;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/security_sources.rs
+++ b/crates/extract/src/tests/js_ts/security_sources.rs
@@ -481,3 +481,37 @@ fn tainted_binding_recording_is_bounded_on_dense_source() {
         info.tainted_bindings.len()
     );
 }
+
+/// Issue #1843 follow-up: the object-binding fixed-point could blow up on a real
+/// minified bundle full of nested object maps (a 2.1 MB oxfmt bundle hung the
+/// parse for over 90s). The prefix index plus the per-module size and pass caps
+/// bound it. Without them, this input's fixed-point runs candidate-count passes
+/// over an unbounded, growing `binding_target_names` (tens of seconds); with
+/// them it completes near-instantly.
+#[test]
+fn object_binding_resolution_is_bounded_on_dense_source() {
+    use std::fmt::Write as _;
+    use std::time::Instant;
+    let mut src = String::from("class K {}\n");
+    // large binding_target_names seed
+    for i in 0..4000 {
+        let _ = writeln!(src, "declare const t{i}: K;");
+    }
+    // wide object literal + a deep rebinding chain (the fixed-point driver)
+    src.push_str("const a0 = { ");
+    for i in 0..200 {
+        let _ = write!(src, "p{i}: t{i}, ");
+    }
+    src.push_str("};\n");
+    for k in 1..4000 {
+        let _ = writeln!(src, "const a{k} = {{ p: a{} }};", k - 1);
+    }
+    let start = Instant::now();
+    let _ = parse_ts(&src);
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 20,
+        "object-binding resolution must stay bounded on dense source (took {elapsed:?}); \
+         without the caps this input runs for well over a minute"
+    );
+}

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -286,6 +286,14 @@ pub(crate) struct ModuleInfoExtractor {
     /// cached `ModuleInfo` field. See issue #1793.
     local_function_return_types: FxHashMap<String, String>,
     object_binding_candidates: Vec<ObjectBindingCandidate>,
+    /// Working state for the object-binding fixed-point (issue #1843 follow-up):
+    /// an ancestor-prefix index over `binding_target_names`, mapping every proper
+    /// dotted prefix `P` of a key to the keys that start with `P.`. Built once per
+    /// `resolve_object_binding_candidates` run and kept current as that pass
+    /// inserts. `copy_nested_binding_targets` uses it to enumerate keys under a
+    /// source prefix in O(matches) instead of scanning all of
+    /// `binding_target_names`. `None` outside the pass. NOT persisted.
+    binding_target_prefix_index: Option<FxHashMap<String, Vec<String>>>,
     local_declaration_names: FxHashSet<String>,
     pending_local_export_specifiers: Vec<PendingLocalExportSpecifier>,
     local_structural_functions: FxHashMap<String, LocalStructuralFunction>,
@@ -2264,8 +2272,37 @@ impl ModuleInfoExtractor {
             return;
         }
 
+        // Bound the fixed-point (issue #1843 follow-up). Two costs explode on a
+        // pathological minified bundle: per-pass copy work (bounded by the prefix
+        // index below plus the `MAX_BINDING_TARGET_NAMES` size cap in
+        // `insert_binding_target`) and the PASS COUNT. The loop otherwise runs up
+        // to `candidates.len()` passes to resolve a rebinding chain, but real
+        // chains are a few levels deep, so a small pass cap keeps every real case
+        // while turning the crafted / minified worst case into K passes. A chain
+        // deeper than the cap stops propagating (a false negative, matching the
+        // FN-preferring `MAX_BINDING_PATH_DEPTH` / `MAX_TAINT_BINDING_HOPS`
+        // doctrine).
+        const MAX_RESOLUTION_PASSES: usize = 8;
+
+        // Build the ancestor-prefix index once so `copy_nested_binding_targets`
+        // enumerates keys under a source prefix in O(matches) rather than scanning
+        // all of `binding_target_names`. Kept current by `insert_binding_target`.
+        let mut index: FxHashMap<String, Vec<String>> = FxHashMap::default();
+        for key in self.binding_target_names.keys() {
+            for (dot, _) in key.match_indices('.') {
+                index
+                    .entry(key[..dot].to_string())
+                    .or_default()
+                    .push(key.clone());
+            }
+        }
+        self.binding_target_prefix_index = Some(index);
+
         let candidates = self.object_binding_candidates.clone();
-        let max_iterations = candidates.len().saturating_add(1);
+        let max_iterations = candidates
+            .len()
+            .saturating_add(1)
+            .min(MAX_RESOLUTION_PASSES);
         for _ in 0..max_iterations {
             let mut changed = false;
             for candidate in &candidates {
@@ -2275,6 +2312,8 @@ impl ModuleInfoExtractor {
                 break;
             }
         }
+
+        self.binding_target_prefix_index = None;
     }
 
     fn collect_namespace_object_aliases(&self) -> Vec<fallow_types::extract::NamespaceObjectAlias> {

--- a/crates/extract/src/visitor/visit_impl_object_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_object_bindings.rs
@@ -45,15 +45,35 @@ impl ModuleInfoExtractor {
         }
         let source_prefix = format!("{source_binding}.");
         let target_prefix = format!("{target_binding}.");
-        let copied: Vec<(String, BindingTarget)> = self
-            .binding_target_names
-            .iter()
-            .filter_map(|(binding, target)| {
-                binding
-                    .strip_prefix(&source_prefix)
-                    .map(|suffix| (format!("{target_prefix}{suffix}"), target.clone()))
-            })
-            .collect();
+        // Prefix-index fast-path (issue #1843 follow-up): during the object-binding
+        // fixed-point, enumerate the keys under `source_binding.` in O(matches) via
+        // the index instead of scanning all of `binding_target_names`, which is
+        // what made a real minified bundle full of nested object maps take tens of
+        // seconds. Outside the pass (`None`) the map is small and the full scan is
+        // used. Both branches produce the same `(binding, target)` set.
+        let copied: Vec<(String, BindingTarget)> =
+            if let Some(index) = &self.binding_target_prefix_index {
+                index
+                    .get(source_binding)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|key| {
+                        self.binding_target_names.get(key).map(|target| {
+                            let suffix = &key[source_prefix.len()..];
+                            (format!("{target_prefix}{suffix}"), target.clone())
+                        })
+                    })
+                    .collect()
+            } else {
+                self.binding_target_names
+                    .iter()
+                    .filter_map(|(binding, target)| {
+                        binding
+                            .strip_prefix(&source_prefix)
+                            .map(|suffix| (format!("{target_prefix}{suffix}"), target.clone()))
+                    })
+                    .collect()
+            };
 
         let mut changed = false;
         for (binding, target) in copied {
@@ -65,6 +85,32 @@ impl ModuleInfoExtractor {
     fn insert_binding_target(&mut self, binding: String, target: BindingTarget) -> bool {
         if self.binding_target_names.get(&binding) == Some(&target) {
             return false;
+        }
+        // Hard size cap on the object-binding fixed-point's growth (issue #1843
+        // follow-up). A pathological minified bundle (huge object maps copied
+        // across many bindings) makes the fixed-point multiply
+        // `binding_target_names` without bound, taking tens of seconds. Once the
+        // map reaches the cap, stop recording NEW keys (an over-cap chain degrades
+        // to a false negative, matching the FN-preferring doctrine); updates to an
+        // already-present key still apply. Only reached via the fixed-point (the
+        // index is `Some`), so the walk-time member crediting is unaffected.
+        const MAX_BINDING_TARGET_NAMES: usize = 8192;
+        if self.binding_target_prefix_index.is_some()
+            && self.binding_target_names.len() >= MAX_BINDING_TARGET_NAMES
+            && !self.binding_target_names.contains_key(&binding)
+        {
+            return false;
+        }
+        // Keep the ancestor-prefix index current for inserts made during the
+        // fixed-point (issue #1843 follow-up), so a key added this pass is visible
+        // to a later `copy_nested_binding_targets` call under every prefix.
+        if let Some(index) = self.binding_target_prefix_index.as_mut() {
+            for (dot, _) in binding.match_indices('.') {
+                index
+                    .entry(binding[..dot].to_string())
+                    .or_default()
+                    .push(binding.clone());
+            }
         }
         self.binding_target_names.insert(binding, target);
         true


### PR DESCRIPTION
Follow-up to the #1843 hardening, found while investigating the residual object-binding cost. The object-binding member-resolution fixed-point blew up on a **real 2 MB minified vendor bundle** full of nested object maps (>90s parse), because `copy_nested_binding_targets` scanned all of `binding_target_names` per candidate per pass, `binding_target_names` grew without bound as maps were copied across bindings, and the loop ran candidate-count passes without converging. The earlier candidate breadth cap bounds C but not B or the pass count.

Bounded three ways: an **ancestor-prefix index** makes `copy_nested` O(matches) instead of O(binding_target_names); a **size cap** (8192) stops the fixed-point from multiplying `binding_target_names`; and a **pass cap** (8) stops the loop from running candidate-count passes when it does not converge.

Real object-binding chains are a few levels deep and real modules stay far below the caps, so ordinary output is **byte-identical** (verified across the fixture corpus); an over-cap file degrades member crediting to a false negative (FN-preferring). The 2 MB bundle now analyzes in **~0.2s** (5.7 MB real-mini corpus: >90s → 0.47s). `CACHE_VERSION` 237 → 238.

Follow-up to #1843.