### PR TITLE
chore: prevent narrator-style comments

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "**/*.rs"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.mjs"
+  - "**/*.cjs"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.py"
+  - "**/*.sh"
+  - "**/*.yml"
+  - "**/*.yaml"
+  - "**/*.toml"
+  - "**/*.css"
+  - "**/*.scss"
+  - "**/*.vue"
+  - "**/*.svelte"
+  - "**/*.astro"
+---
+
+# Code comments
+
+- Do not add inline comments that narrate routine steps, label standard control flow, or restate adjacent code.
+- Inline comments should preserve non-obvious rationale, invariants, safety constraints, protocol behavior, performance tradeoffs, compatibility workarounds, or issue context.
+- Rustdoc and JSDoc are API documentation. They may describe public behavior, contracts, examples, errors, and safety requirements.
+- Before finishing, inspect every added or changed comment. Remove narration and generic scaffolding.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); node \"$root/scripts/check-comment-quality.mjs\" --working-tree --claude-hook",
+            "statusMessage": "Checking added comments for routine narration..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,6 +20,11 @@ if command -v python3 &> /dev/null; then
   python3 scripts/scan-hidden-unicode.py --mode committed --staged
 fi
 
+if command -v node &> /dev/null; then
+  echo "Running narrator-comment check..."
+  node scripts/check-comment-quality.mjs --staged
+fi
+
 # Run oxlint + oxfmt --check only when this commit touches a JS/TS file
 # inside one of the lintable scopes. Keeps pure-Rust commits fast.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,8 @@ jobs:
         run: npm run lint:js
       - name: oxfmt --check
         run: npm run fmt:js:check
+      - name: Narrator comment guard
+        run: node scripts/check-comment-quality.mjs --all
       - name: Script tests
         run: node --test scripts/*.test.mjs
 

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -8982,7 +8982,6 @@ fn binding_pattern_array_destructure_second_element_name_is_extracted() {
     // skips the hole and names `pkg` via `binding_pattern_value_name` for
     // ArrayPattern. The for-of binding is only used when the variable flows
     // into a `require.resolve(pkg + '/package.json')` inside the loop body.
-    // Here we just verify the loop body and the require call are parsed.
     let info = parse(
         r"
         const pkgTable = { react: 'react', lodash: 'lodash' }

--- a/scripts/check-comment-quality.mjs
+++ b/scripts/check-comment-quality.mjs
@@ -49,8 +49,114 @@ const TOOL_DIRECTIVE =
   /\b(?:fallow-ignore|eslint|oxlint|prettier|rustfmt|clippy|ts-expect-error|ts-ignore|istanbul ignore|c8 ignore)\b/iu;
 const EXPLANATION_SIGNAL =
   /\b(?:because|since|so that|otherwise|avoid|prevent|workaround|compatib\w*|invariant|safety|performance|protocol)\b/iu;
+const JAVASCRIPT_EXTENSIONS = new Set([
+  ".astro",
+  ".cjs",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".svelte",
+  ".ts",
+  ".tsx",
+  ".vue",
+]);
 
 const isSourcePath = (path) => SOURCE_EXTENSIONS.has(extname(path).toLowerCase());
+
+const multilineOpener = (path, line, start) => {
+  const extension = extname(path).toLowerCase();
+  const candidates = [];
+
+  if (JAVASCRIPT_EXTENSIONS.has(extension)) {
+    const index = line.indexOf("`", start);
+    if (index !== -1) {
+      candidates.push({ index, length: 1, delimiter: "`", escaped: true });
+    }
+  }
+
+  if (extension === ".py") {
+    for (const delimiter of ['"""', "'''"]) {
+      const index = line.indexOf(delimiter, start);
+      if (index !== -1) {
+        candidates.push({ index, length: delimiter.length, delimiter, escaped: false });
+      }
+    }
+  }
+
+  if (extension === ".rs") {
+    const rawString = /(?:br|r)(#*)"/gu;
+    rawString.lastIndex = start;
+    for (const match of line.matchAll(rawString)) {
+      if (match.index > 0 && /[A-Za-z0-9_]/u.test(line[match.index - 1])) {
+        continue;
+      }
+      candidates.push({
+        index: match.index,
+        length: match[0].length,
+        delimiter: `"${match[1]}`,
+        escaped: false,
+      });
+      break;
+    }
+  }
+
+  return candidates.toSorted((left, right) => left.index - right.index)[0] ?? null;
+};
+
+const closingDelimiterIndex = (line, delimiter, start, escaped) => {
+  let index = line.indexOf(delimiter, start);
+  if (!escaped) {
+    return index;
+  }
+
+  while (index !== -1) {
+    let backslashes = 0;
+    for (let cursor = index - 1; cursor >= 0 && line[cursor] === "\\"; cursor -= 1) {
+      backslashes += 1;
+    }
+    if (backslashes % 2 === 0) {
+      return index;
+    }
+    index = line.indexOf(delimiter, index + delimiter.length);
+  }
+  return index;
+};
+
+const maskMultilineStrings = (path, line, initialState) => {
+  const masked = [...line];
+  let state = initialState;
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    if (state === null) {
+      const opener = multilineOpener(path, line, cursor);
+      if (opener === null) {
+        break;
+      }
+      const contentStart = opener.index + opener.length;
+      const close = closingDelimiterIndex(line, opener.delimiter, contentStart, opener.escaped);
+      const end = close === -1 ? line.length : close + opener.delimiter.length;
+      masked.fill(" ", opener.index, end);
+      if (close === -1) {
+        state = { delimiter: opener.delimiter, escaped: opener.escaped };
+        break;
+      }
+      cursor = end;
+      continue;
+    }
+
+    const close = closingDelimiterIndex(line, state.delimiter, cursor, state.escaped);
+    const end = close === -1 ? line.length : close + state.delimiter.length;
+    masked.fill(" ", cursor, end);
+    if (close === -1) {
+      break;
+    }
+    state = null;
+    cursor = end;
+  }
+
+  return { line: masked.join(""), state };
+};
 
 const hasClosingQuote = (line, start, quote) => {
   for (let index = start + 1; index < line.length; index += 1) {
@@ -140,8 +246,11 @@ export const scanSourceText = (path, source) => {
   }
 
   const findings = [];
+  let multilineState = null;
   for (const [index, line] of source.split(/\r?\n/u).entries()) {
-    if (isNarratorComment(line)) {
+    const masked = maskMultilineStrings(path, line, multilineState);
+    multilineState = masked.state;
+    if (isNarratorComment(masked.line)) {
       findings.push({ path, line: index + 1, text: line.trim() });
     }
   }
@@ -204,7 +313,20 @@ const scanUntrackedFiles = () => {
   );
 };
 
-const scanDiff = (args) => scanUnifiedDiff(git(["diff", "--no-ext-diff", "--unified=0", ...args]));
+const scanDiff = (args, readSource) => {
+  const candidates = scanUnifiedDiff(git(["diff", "--no-ext-diff", "--unified=0", ...args]));
+  const findingLines = new Map();
+
+  return candidates.filter((candidate) => {
+    if (!findingLines.has(candidate.path)) {
+      findingLines.set(
+        candidate.path,
+        new Set(scanSourceText(candidate.path, readSource(candidate.path)).map(({ line }) => line)),
+      );
+    }
+    return findingLines.get(candidate.path).has(candidate.line);
+  });
+};
 
 const usage = () => {
   console.error(
@@ -241,9 +363,12 @@ const run = () => {
   if (modes[0] === "--all") {
     findings = scanTrackedFiles();
   } else if (modes[0] === "--staged") {
-    findings = scanDiff(["--cached", "--diff-filter=ACMR"]);
+    findings = scanDiff(["--cached", "--diff-filter=ACMR"], (path) => git(["show", `:${path}`]));
   } else {
-    findings = [...scanDiff(["HEAD", "--diff-filter=ACMR"]), ...scanUntrackedFiles()];
+    findings = [
+      ...scanDiff(["HEAD", "--diff-filter=ACMR"], (path) => readFileSync(path, "utf8")),
+      ...scanUntrackedFiles(),
+    ];
   }
 
   if (findings.length === 0) {

--- a/scripts/check-comment-quality.mjs
+++ b/scripts/check-comment-quality.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const SOURCE_EXTENSIONS = new Set([
+  ".astro",
+  ".bash",
+  ".c",
+  ".cc",
+  ".cjs",
+  ".cpp",
+  ".css",
+  ".cs",
+  ".go",
+  ".h",
+  ".hpp",
+  ".htm",
+  ".html",
+  ".js",
+  ".jsx",
+  ".java",
+  ".kt",
+  ".kts",
+  ".mjs",
+  ".php",
+  ".py",
+  ".rb",
+  ".rs",
+  ".scss",
+  ".sh",
+  ".svelte",
+  ".swift",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".vue",
+  ".yaml",
+  ".yml",
+  ".zig",
+]);
+
+const NARRATOR_START = /^(?:here we|now we|let's|next we|finally we|first we)\b/iu;
+const STEP_START = /^step\s+\d+\b/iu;
+const KEEPER_KEYWORD = /\b(?:TODO|FIXME|HACK|NOTE|SAFETY|WARN(?:ING)?|BUG|XXX|PERF)\b/u;
+const TOOL_DIRECTIVE =
+  /\b(?:fallow-ignore|eslint|oxlint|prettier|rustfmt|clippy|ts-expect-error|ts-ignore|istanbul ignore|c8 ignore)\b/iu;
+const EXPLANATION_SIGNAL =
+  /\b(?:because|since|so that|otherwise|avoid|prevent|workaround|compatib\w*|invariant|safety|performance|protocol)\b/iu;
+
+const isSourcePath = (path) => SOURCE_EXTENSIONS.has(extname(path).toLowerCase());
+
+const commentBody = (line) => {
+  const trimmed = line.trimStart();
+  if (
+    trimmed.startsWith("///") ||
+    trimmed.startsWith("//!") ||
+    trimmed.startsWith("/**") ||
+    trimmed.startsWith("/*!") ||
+    trimmed.startsWith("*")
+  ) {
+    return null;
+  }
+
+  const match = trimmed.match(/^(?:\/\/|#|\/\*+|<!--)\s*(.*?)(?:\s*\*\/|\s*-->)?$/u);
+  return match?.[1]?.trim() ?? null;
+};
+
+const isNarratorComment = (line) => {
+  const body = commentBody(line);
+  if (body === null || (!NARRATOR_START.test(body) && !STEP_START.test(body))) {
+    return false;
+  }
+
+  return !KEEPER_KEYWORD.test(body) && !TOOL_DIRECTIVE.test(body) && !EXPLANATION_SIGNAL.test(body);
+};
+
+export const scanSourceText = (path, source) => {
+  if (!isSourcePath(path)) {
+    return [];
+  }
+
+  const findings = [];
+  for (const [index, line] of source.split(/\r?\n/u).entries()) {
+    if (isNarratorComment(line)) {
+      findings.push({ path, line: index + 1, text: line.trim() });
+    }
+  }
+  return findings;
+};
+
+export const scanUnifiedDiff = (diff) => {
+  const findings = [];
+  let path = null;
+  let newLine = 0;
+
+  for (const line of diff.split(/\r?\n/u)) {
+    if (line.startsWith("+++ ")) {
+      const candidate = line.slice(4);
+      path = candidate === "/dev/null" ? null : candidate.replace(/^b\//u, "");
+      continue;
+    }
+
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/u);
+    if (hunk !== null) {
+      newLine = Number.parseInt(hunk[1], 10);
+      continue;
+    }
+
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      if (path !== null && isNarratorComment(line.slice(1)) && isSourcePath(path)) {
+        findings.push({ path, line: newLine, text: line.slice(1).trim() });
+      }
+      newLine += 1;
+      continue;
+    }
+
+    if (!line.startsWith("-") && !line.startsWith("\\")) {
+      newLine += 1;
+    }
+  }
+
+  return findings;
+};
+
+const git = (args) =>
+  execFileSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+const scanTrackedFiles = () => {
+  const paths = git(["ls-files", "-z"]).split("\0").filter(Boolean);
+  return paths.flatMap((path) =>
+    isSourcePath(path) ? scanSourceText(path, readFileSync(path, "utf8")) : [],
+  );
+};
+
+const scanUntrackedFiles = () => {
+  const paths = git(["ls-files", "--others", "--exclude-standard", "-z"])
+    .split("\0")
+    .filter(Boolean);
+  return paths.flatMap((path) =>
+    isSourcePath(path) ? scanSourceText(path, readFileSync(path, "utf8")) : [],
+  );
+};
+
+const scanDiff = (args) => scanUnifiedDiff(git(["diff", "--no-ext-diff", "--unified=0", ...args]));
+
+const usage = () => {
+  console.error(
+    "Usage: node scripts/check-comment-quality.mjs (--all | --staged | --working-tree) [--claude-hook]",
+  );
+};
+
+const run = () => {
+  const args = new Set(process.argv.slice(2));
+  const modes = ["--all", "--staged", "--working-tree"].filter((mode) => args.has(mode));
+  const allowed = new Set([...modes, "--claude-hook"]);
+  const unknown = [...args].filter((arg) => !allowed.has(arg));
+
+  if (modes.length !== 1 || unknown.length > 0) {
+    usage();
+    process.exitCode = 2;
+    return;
+  }
+
+  let findings;
+  if (modes[0] === "--all") {
+    findings = scanTrackedFiles();
+  } else if (modes[0] === "--staged") {
+    findings = scanDiff(["--cached", "--diff-filter=ACMR"]);
+  } else {
+    findings = [...scanDiff(["HEAD", "--diff-filter=ACMR"]), ...scanUntrackedFiles()];
+  }
+
+  if (findings.length === 0) {
+    return;
+  }
+
+  console.error("Narrator-style comments found:");
+  for (const finding of findings) {
+    console.error(`  ${finding.path}:${finding.line}: ${finding.text}`);
+  }
+  console.error("Remove routine narration or replace it with non-obvious rationale.");
+  process.exitCode = args.has("--claude-hook") ? 2 : 1;
+};
+
+const invokedPath =
+  process.argv[1] === undefined ? null : pathToFileURL(resolve(process.argv[1])).href;
+if (invokedPath === import.meta.url) {
+  run();
+}

--- a/scripts/check-comment-quality.mjs
+++ b/scripts/check-comment-quality.mjs
@@ -52,30 +52,87 @@ const EXPLANATION_SIGNAL =
 
 const isSourcePath = (path) => SOURCE_EXTENSIONS.has(extname(path).toLowerCase());
 
-const commentBody = (line) => {
-  const trimmed = line.trimStart();
-  if (
-    trimmed.startsWith("///") ||
-    trimmed.startsWith("//!") ||
-    trimmed.startsWith("/**") ||
-    trimmed.startsWith("/*!") ||
-    trimmed.startsWith("*")
-  ) {
-    return null;
+const hasClosingQuote = (line, start, quote) => {
+  for (let index = start + 1; index < line.length; index += 1) {
+    if (line[index] === "\\") {
+      index += 1;
+    } else if (line[index] === quote) {
+      return true;
+    }
   }
-
-  const match = trimmed.match(/^(?:\/\/|#|\/\*+|<!--)\s*(.*?)(?:\s*\*\/|\s*-->)?$/u);
-  return match?.[1]?.trim() ?? null;
+  return false;
 };
 
-const isNarratorComment = (line) => {
-  const body = commentBody(line);
-  if (body === null || (!NARRATOR_START.test(body) && !STEP_START.test(body))) {
+const isRustLifetime = (line, index) => {
+  if (line[index] !== "'") {
+    return false;
+  }
+
+  const name = line.slice(index + 1).match(/^[A-Za-z_][A-Za-z0-9_]*/u)?.[0];
+  if (name === undefined || line[index + name.length + 1] === "'") {
+    return false;
+  }
+
+  const previous = line[index - 1];
+  return previous === "&" || previous === "<" || previous === ",";
+};
+
+const lineCommentBodies = (line) => {
+  const bodies = [];
+  let quote = null;
+
+  for (let index = 0; index < line.length - 1; index += 1) {
+    const character = line[index];
+    if (quote !== null) {
+      if (character === "\\") {
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (
+      (character === '"' || character === "'" || character === "`") &&
+      !isRustLifetime(line, index) &&
+      hasClosingQuote(line, index, character)
+    ) {
+      quote = character;
+      continue;
+    }
+
+    if (character === "/" && line[index + 1] === "/") {
+      const directComment = line.slice(0, index).trim().length === 0;
+      if (directComment && (line.startsWith("///", index) || line.startsWith("//!", index))) {
+        return [];
+      }
+      bodies.push(line.slice(index + 2).trim());
+      index += 1;
+    }
+  }
+
+  return bodies;
+};
+
+const commentBodies = (line) => {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("/**") || trimmed.startsWith("/*!") || trimmed.startsWith("*")) {
+    return [];
+  }
+
+  const direct = trimmed.match(/^(?:#|\/\*+|<!--)\s*(.*?)(?:\s*\*\/|\s*-->)?$/u);
+  return [...(direct === null ? [] : [direct[1].trim()]), ...lineCommentBodies(line)];
+};
+
+const isNarratorBody = (body) => {
+  if (!NARRATOR_START.test(body) && !STEP_START.test(body)) {
     return false;
   }
 
   return !KEEPER_KEYWORD.test(body) && !TOOL_DIRECTIVE.test(body) && !EXPLANATION_SIGNAL.test(body);
 };
+
+const isNarratorComment = (line) => commentBodies(line).some(isNarratorBody);
 
 export const scanSourceText = (path, source) => {
   if (!isSourcePath(path)) {
@@ -155,6 +212,15 @@ const usage = () => {
   );
 };
 
+const repeatedClaudeStop = () => {
+  try {
+    const input = readFileSync(0, "utf8").trim();
+    return input.length > 0 && JSON.parse(input).stop_hook_active === true;
+  } catch {
+    return false;
+  }
+};
+
 const run = () => {
   const args = new Set(process.argv.slice(2));
   const modes = ["--all", "--staged", "--working-tree"].filter((mode) => args.has(mode));
@@ -164,6 +230,10 @@ const run = () => {
   if (modes.length !== 1 || unknown.length > 0) {
     usage();
     process.exitCode = 2;
+    return;
+  }
+
+  if (args.has("--claude-hook") && repeatedClaudeStop()) {
     return;
   }
 

--- a/scripts/check-comment-quality.test.mjs
+++ b/scripts/check-comment-quality.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { scanSourceText, scanUnifiedDiff } from "./check-comment-quality.mjs";
+
+const SCRIPT_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "check-comment-quality.mjs");
+
+test("source scan finds high-signal narrator comments", () => {
+  const findings = [
+    ...scanSourceText("src/main.rs", "// Here we parse the input.\nlet value = parse();\n"),
+    ...scanSourceText("scripts/build.py", "# Step 2: build the package\nbuild()\n"),
+    ...scanSourceText("src/view.ts", "/* Next we render the result. */\nrender();\n"),
+  ];
+
+  assert.deepEqual(
+    findings.map(({ path, line }) => [path, line]),
+    [
+      ["src/main.rs", 1],
+      ["scripts/build.py", 1],
+      ["src/view.ts", 1],
+    ],
+  );
+});
+
+test("source scan preserves documentation and explanatory comments", () => {
+  const source = [
+    "/// Here we document public behavior.",
+    "//! Now we describe the module contract.",
+    "/** Next we document the JavaScript API. */",
+    "// Here we keep the branch because Windows reports a different error.",
+    "// Step 1 is retained to prevent a protocol downgrade.",
+    "// Here we NOTE the compatibility constraint.",
+    "// Step 2: fallow-ignore the generated binding.",
+    "const text = '// Finally we render';",
+  ].join("\n");
+
+  assert.deepEqual(scanSourceText("src/lib.rs", source), []);
+});
+
+test("source scan ignores unsupported and non-comment files", () => {
+  assert.deepEqual(scanSourceText("docs/guide.md", "// Here we explain the guide.\n"), []);
+  assert.deepEqual(scanSourceText("assets/message.txt", "# First we prepare.\n"), []);
+});
+
+test("diff scan reports added line numbers and ignores removed narration", () => {
+  const diff = [
+    "diff --git a/src/main.rs b/src/main.rs",
+    "--- a/src/main.rs",
+    "+++ b/src/main.rs",
+    "@@ -8,2 +8,3 @@",
+    "-// Now we remove the legacy branch.",
+    "+// The branch preserves the old wire contract.",
+    "+// Finally we return the result.",
+    " return result;",
+    "diff --git a/docs/guide.md b/docs/guide.md",
+    "--- a/docs/guide.md",
+    "+++ b/docs/guide.md",
+    "@@ -0,0 +1 @@",
+    "+// Here we document the workflow.",
+  ].join("\n");
+
+  assert.deepEqual(scanUnifiedDiff(diff), [
+    {
+      path: "src/main.rs",
+      line: 9,
+      text: "// Finally we return the result.",
+    },
+  ]);
+});
+
+test("diff scan handles new files and multiple hunks", () => {
+  const diff = [
+    "diff --git a/scripts/task.sh b/scripts/task.sh",
+    "new file mode 100755",
+    "--- /dev/null",
+    "+++ b/scripts/task.sh",
+    "@@ -0,0 +1,2 @@",
+    "+#!/usr/bin/env bash",
+    "+# Let's prepare the release.",
+    "@@ -0,0 +20 @@",
+    "+# Step 3: publish",
+  ].join("\n");
+
+  assert.deepEqual(
+    scanUnifiedDiff(diff).map(({ line }) => line),
+    [2, 20],
+  );
+});
+
+test("CLI modes enforce staged and working-tree additions", () => {
+  const root = mkdtempSync(join(tmpdir(), "fallow-comment-quality-"));
+  const git = (...args) => execFileSync("git", args, { cwd: root, stdio: "ignore" });
+  const run = (...args) =>
+    spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+  try {
+    git("init", "--quiet");
+    writeFileSync(join(root, "main.rs"), "fn main() {}\n");
+    git("add", "main.rs");
+    git(
+      "-c",
+      "user.name=Comment Guard Test",
+      "-c",
+      "user.email=comment-guard@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--quiet",
+      "--no-verify",
+      "-m",
+      "initial",
+    );
+
+    writeFileSync(join(root, "main.rs"), "// Here we start the program.\nfn main() {}\n");
+    git("add", "main.rs");
+
+    const staged = run("--staged");
+    assert.equal(staged.status, 1, staged.stderr);
+    assert.match(staged.stderr, /main\.rs:1/u);
+
+    writeFileSync(join(root, "task.py"), "# Step 2: process the result\n");
+    const workingTree = run("--working-tree", "--claude-hook");
+    assert.equal(workingTree.status, 2, workingTree.stderr);
+    assert.match(workingTree.stderr, /task\.py:1/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-comment-quality.test.mjs
+++ b/scripts/check-comment-quality.test.mjs
@@ -46,6 +46,23 @@ test("source scan preserves documentation and explanatory comments", () => {
   assert.deepEqual(scanSourceText("src/lib.rs", source), []);
 });
 
+test("source scan ignores narrator-shaped text inside multiline strings", () => {
+  const template = [
+    "const example = `",
+    "// Now we show the example.",
+    "`;",
+    "// Finally we run the example.",
+  ].join("\n");
+  const rustRaw = ['let example = r#"', "// Now we show the example.", '"#;', ""].join("\n");
+  const pythonTriple = ['example = """', "# Step 2: show the example", '"""', ""].join("\n");
+
+  assert.deepEqual(scanSourceText("src/example.ts", template), [
+    { path: "src/example.ts", line: 4, text: "// Finally we run the example." },
+  ]);
+  assert.deepEqual(scanSourceText("src/example.rs", rustRaw), []);
+  assert.deepEqual(scanSourceText("scripts/example.py", pythonTriple), []);
+});
+
 test("source scan ignores unsupported and non-comment files", () => {
   assert.deepEqual(scanSourceText("docs/guide.md", "// Here we explain the guide.\n"), []);
   assert.deepEqual(scanSourceText("assets/message.txt", "# First we prepare.\n"), []);
@@ -109,7 +126,8 @@ test("CLI modes enforce staged and working-tree additions", () => {
   try {
     git("init", "--quiet");
     writeFileSync(join(root, "main.rs"), "fn main() {}\n");
-    git("add", "main.rs");
+    writeFileSync(join(root, "example.ts"), "const example = `\nold value\n`;\n");
+    git("add", "main.rs", "example.ts");
     git(
       "-c",
       "user.name=Comment Guard Test",
@@ -125,11 +143,13 @@ test("CLI modes enforce staged and working-tree additions", () => {
     );
 
     writeFileSync(join(root, "main.rs"), "// Here we start the program.\nfn main() {}\n");
-    git("add", "main.rs");
+    writeFileSync(join(root, "example.ts"), "const example = `\n// Now we show the example.\n`;\n");
+    git("add", "main.rs", "example.ts");
 
     const staged = run(["--staged"]);
     assert.equal(staged.status, 1, staged.stderr);
     assert.match(staged.stderr, /main\.rs:1/u);
+    assert.doesNotMatch(staged.stderr, /example\.ts/u);
 
     writeFileSync(join(root, "task.py"), "# Step 2: process the result\n");
     const workingTree = run(

--- a/scripts/check-comment-quality.test.mjs
+++ b/scripts/check-comment-quality.test.mjs
@@ -14,6 +14,8 @@ test("source scan finds high-signal narrator comments", () => {
     ...scanSourceText("src/main.rs", "// Here we parse the input.\nlet value = parse();\n"),
     ...scanSourceText("scripts/build.py", "# Step 2: build the package\nbuild()\n"),
     ...scanSourceText("src/view.ts", "/* Next we render the result. */\nrender();\n"),
+    ...scanSourceText("src/check.ts", "validate(); // Now we report the result.\n"),
+    ...scanSourceText("src/lib.rs", "let value: &'a str = input; // Let's return it.\n"),
   ];
 
   assert.deepEqual(
@@ -22,6 +24,8 @@ test("source scan finds high-signal narrator comments", () => {
       ["src/main.rs", 1],
       ["scripts/build.py", 1],
       ["src/view.ts", 1],
+      ["src/check.ts", 1],
+      ["src/lib.rs", 1],
     ],
   );
 });
@@ -36,6 +40,7 @@ test("source scan preserves documentation and explanatory comments", () => {
     "// Here we NOTE the compatibility constraint.",
     "// Step 2: fallow-ignore the generated binding.",
     "const text = '// Finally we render';",
+    'const text = "prefix // Now we render";',
   ].join("\n");
 
   assert.deepEqual(scanSourceText("src/lib.rs", source), []);
@@ -94,10 +99,11 @@ test("diff scan handles new files and multiple hunks", () => {
 test("CLI modes enforce staged and working-tree additions", () => {
   const root = mkdtempSync(join(tmpdir(), "fallow-comment-quality-"));
   const git = (...args) => execFileSync("git", args, { cwd: root, stdio: "ignore" });
-  const run = (...args) =>
+  const run = (args, input = "") =>
     spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
       cwd: root,
       encoding: "utf8",
+      input,
     });
 
   try {
@@ -121,14 +127,24 @@ test("CLI modes enforce staged and working-tree additions", () => {
     writeFileSync(join(root, "main.rs"), "// Here we start the program.\nfn main() {}\n");
     git("add", "main.rs");
 
-    const staged = run("--staged");
+    const staged = run(["--staged"]);
     assert.equal(staged.status, 1, staged.stderr);
     assert.match(staged.stderr, /main\.rs:1/u);
 
     writeFileSync(join(root, "task.py"), "# Step 2: process the result\n");
-    const workingTree = run("--working-tree", "--claude-hook");
+    const workingTree = run(
+      ["--working-tree", "--claude-hook"],
+      JSON.stringify({ stop_hook_active: false }),
+    );
     assert.equal(workingTree.status, 2, workingTree.stderr);
     assert.match(workingTree.stderr, /task\.py:1/u);
+
+    const repeatedStop = run(
+      ["--working-tree", "--claude-hook"],
+      JSON.stringify({ stop_hook_active: true }),
+    );
+    assert.equal(repeatedStop.status, 0, repeatedStop.stderr);
+    assert.equal(repeatedStop.stderr, "");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -120,3 +120,13 @@ test("FALLOW_FORMAT docs include every GitHub-native format", () => {
     assert.ok(documentedFormats.has(format), `FALLOW_FORMAT docs are missing ${format}`);
   }
 });
+
+test("narrator comment guard runs for commits, Claude, and CI", () => {
+  const preCommit = readFileSync(".githooks/pre-commit", "utf8");
+  const claudeSettings = readFileSync(".claude/settings.json", "utf8");
+  const ci = readFileSync(".github/workflows/ci.yml", "utf8");
+
+  assert.match(preCommit, /check-comment-quality\.mjs --staged/u);
+  assert.match(claudeSettings, /check-comment-quality\.mjs.*--working-tree.*--claude-hook/u);
+  assert.match(ci, /node scripts\/check-comment-quality\.mjs --all/u);
+});


### PR DESCRIPTION
## Summary
- add shared comment guidance that preserves Rustdoc, JSDoc, and non-obvious rationale
- reject high-signal narrator comments in staged changes, Claude Stop hooks, and CI
- cover diff parsing, exemptions, hook wiring, and real git staging behavior

## Verification
- [x] `node --test scripts/*.test.mjs`
- [x] `node scripts/check-comment-quality.mjs --all`
- [x] `npm run lint:js`
- [x] `npm run fmt:js:check`
- [x] `typos`
- [x] `cargo test -p fallow-extract binding_pattern_array_destructure_second_element_name_is_extracted`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
