### PR TITLE
chore: integrate Hawk and upgrade Rust 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,6 +783,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      RUSTUP_TOOLCHAIN: 1.92.0
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/hawk.yml
+++ b/.github/workflows/hawk.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/hawk.yml
+++ b/.github/workflows/hawk.yml
@@ -1,0 +1,79 @@
+name: Hawk
+
+on:
+  schedule:
+    # Every Monday at 05:00 UTC
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hawk-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: '0'
+  CARGO_TERM_COLOR: always
+  HAWK_ARCHIVE: cargo-hawk-x86_64-unknown-linux-gnu.tar.gz
+  HAWK_SHA256: 027124444baddf7fa3597ce2d76d1eff48e95902be303beada2558e3687c1bff
+  HAWK_VERSION: 0.1.9
+
+jobs:
+  audit:
+    name: Workspace visibility audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: '1.97.1'
+          cache-key: hawk
+
+      - name: Install Hawk
+        shell: bash
+        run: |
+          archive_url="https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/${HAWK_ARCHIVE}"
+          install_root="${RUNNER_TEMP}/cargo-hawk"
+          mkdir -p "${install_root}"
+          curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            --output "${RUNNER_TEMP}/${HAWK_ARCHIVE}" \
+            "${archive_url}"
+          printf '%s *%s\n' "${HAWK_SHA256}" "${RUNNER_TEMP}/${HAWK_ARCHIVE}" \
+            | sha256sum --check --strict
+          tar --extract --gzip \
+            --file "${RUNNER_TEMP}/${HAWK_ARCHIVE}" \
+            --strip-components 1 \
+            --directory "${install_root}"
+          printf '%s\n' "${install_root}" >> "${GITHUB_PATH}"
+
+      - name: Run warning-only dead-public audit
+        shell: bash
+        run: |
+          set -o pipefail
+          ./scripts/check-hawk.sh dead-public 2>&1 | tee hawk.log
+
+      - name: Write summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo '## Hawk workspace visibility audit'
+            echo
+            echo 'This scheduled audit is informational. Review the attached log before changing visibility or deleting declarations.'
+            echo
+            echo 'A declaration is safe to delete only after its identity is absent from every relevant release target.'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload audit log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hawk-audit-log
+          path: hawk.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
             npm_dir: darwin-arm64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            container: rust:1.95-bullseye
+            container: rust:1.97.1-bullseye
             binary: fallow
             multicall_binary: fallow-multicall
             lsp_binary: fallow-lsp
@@ -132,7 +132,7 @@ jobs:
             npm_dir: linux-x64-gnu
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            container: rust:1.95-bullseye
+            container: rust:1.97.1-bullseye
             binary: fallow
             multicall_binary: fallow-multicall
             lsp_binary: fallow-lsp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,9 @@ exclusions.
 
 [Hawk](https://github.com/astral-sh/hawk) audits Rust workspace visibility and
 dead public declarations across crate boundaries. The scheduled workflow uses
-Hawk 0.1.9 with Rust 1.97.1 and keeps the supported `fallow-api` facade plus its
-re-exported contract crates out of scope.
+Hawk 0.1.9 with Rust 1.97.1 and keeps the supported `fallow-api` facade, its
+re-exported contract crates, and the cross-repo `fallow-license` surface out of
+scope.
 
 Install the matching Hawk release, then run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,25 @@ release and publish jobs, and network or real-project smoke tests remain
 CI-only. Run `npm run verify:full -- --help` to review the exact local scope and
 exclusions.
 
+### Workspace visibility audit
+
+[Hawk](https://github.com/astral-sh/hawk) audits Rust workspace visibility and
+dead public declarations across crate boundaries. The scheduled workflow uses
+Hawk 0.1.9 with Rust 1.97.1 and keeps the supported `fallow-api` facade plus its
+re-exported contract crates out of scope.
+
+Install the matching Hawk release, then run:
+
+```bash
+./scripts/check-hawk.sh dead-public  # Report dead public declarations
+./scripts/check-hawk.sh all          # Include visibility reduction suggestions
+```
+
+Hawk is experimental, so its findings are review input rather than an automatic
+fix list. Before deleting a declaration or narrowing its visibility, confirm it
+is unused by every relevant feature profile and release target. The scheduled
+workflow stores its complete output as an artifact for review.
+
 ### Running locally
 
 ```bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rust:1.96-bookworm AS builder
+FROM rust:1.97.1-bookworm AS builder
 
 WORKDIR /src
 

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1981,7 +1981,7 @@ fn run_audit_dupes<'a>(
     changed_files: Option<&'a FxHashSet<PathBuf>>,
     pre_discovered: Option<Vec<fallow_types::discover::DiscoveredFile>>,
 ) -> Result<Option<DupesResult>, ExitCode> {
-    let dupes_cfg = match crate::load_config_for_analysis(
+    let dupes_cfg = crate::load_config_for_analysis(
         opts.root,
         opts.config_path,
         crate::ConfigLoadOptions {
@@ -1995,10 +1995,8 @@ fn run_audit_dupes<'a>(
             allow_remote_extends: opts.allow_remote_extends,
         },
         fallow_config::ProductionAnalysis::Dupes,
-    ) {
-        Ok(c) => c.duplicates,
-        Err(code) => return Err(code),
-    };
+    )?
+    .duplicates;
     let dupes_opts = build_audit_dupes_options(opts, changed_since, changed_files, &dupes_cfg);
     let dupes_run = if let Some(files) = pre_discovered {
         crate::dupes::execute_dupes_with_files(&dupes_opts, files)
@@ -2062,16 +2060,13 @@ fn run_audit_health<'a>(
     shared_parse: Option<fallow_engine::health::HealthSharedParseData>,
 ) -> Result<Option<HealthResult>, ExitCode> {
     let runtime_coverage = match opts.runtime_coverage {
-        Some(path) => match crate::health::coverage::prepare_options(
+        Some(path) => Some(crate::health::coverage::prepare_options(
             path,
             opts.min_invocations_hot,
             None,
             None,
             opts.output,
-        ) {
-            Ok(options) => Some(options),
-            Err(code) => return Err(code),
-        },
+        )?),
         None => None,
     };
 

--- a/crates/cli/src/migrate/knip.rs
+++ b/crates/cli/src/migrate/knip.rs
@@ -226,7 +226,7 @@ mod tests {
             &serde_json::json!(["lodash"])
         );
         assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].field == "ignoreDependencies");
+        assert_eq!(warnings[0].field, "ignoreDependencies");
     }
 
     #[test]

--- a/crates/cli/tests/runtime_coverage_tests.rs
+++ b/crates/cli/tests/runtime_coverage_tests.rs
@@ -180,7 +180,7 @@ mod gated {
         let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|err| {
             panic!(
                 "expected JSON output; err={err}; stdout head={}",
-                &stdout.chars().take(400).collect::<String>()
+                stdout.chars().take(400).collect::<String>()
             )
         });
         assert_eq!(
@@ -238,12 +238,12 @@ mod gated {
             code,
             0,
             "happy path must exit 0; stderr={stderr}; stdout head={}",
-            &stdout.chars().take(400).collect::<String>()
+            stdout.chars().take(400).collect::<String>()
         );
         let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|err| {
             panic!(
                 "expected JSON output; err={err}; stdout head={}",
-                &stdout.chars().take(400).collect::<String>()
+                stdout.chars().take(400).collect::<String>()
             )
         });
         assert!(
@@ -272,7 +272,7 @@ mod gated {
             code,
             0,
             "security runtime coverage must exit 0; stderr={stderr}; stdout head={}",
-            &stdout.chars().take(400).collect::<String>()
+            stdout.chars().take(400).collect::<String>()
         );
         let json: serde_json::Value =
             serde_json::from_str(&stdout).expect("security output should be JSON");

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -1187,14 +1187,14 @@ mod tests {
     fn split_respects_quotes() {
         let segments = shell::split_shell_operators("echo 'a && b' && jest");
         assert_eq!(segments.len(), 2);
-        assert!(segments[1].trim() == "jest");
+        assert_eq!(segments[1].trim(), "jest");
     }
 
     #[test]
     fn split_double_quotes() {
         let segments = shell::split_shell_operators("echo \"a || b\" || jest");
         assert_eq!(segments.len(), 2);
-        assert!(segments[1].trim() == "jest");
+        assert_eq!(segments[1].trim(), "jest");
     }
 
     #[test]

--- a/crates/engine/src/repo_refs.rs
+++ b/crates/engine/src/repo_refs.rs
@@ -966,7 +966,7 @@ impl BatchBlobReader {
         self.stdout
             .read_exact(&mut terminator)
             .map_err(|error| materialization_error(path, error))?;
-        if terminator != [b'\n'] {
+        if terminator != *b"\n" {
             return Err(EngineError::new(format!(
                 "Git object response for `{}` had no terminator",
                 path.display()

--- a/crates/graph/tests/cross_platform.rs
+++ b/crates/graph/tests/cross_platform.rs
@@ -221,7 +221,7 @@ fn very_long_filename_does_not_panic() {
     let filename = "a".repeat(200) + ".ts";
     let path = PathBuf::from(format!("/project/src/{filename}"));
     assert!(path.to_str().is_some());
-    assert!(path.extension().and_then(OsStr::to_str) == Some("ts"));
+    assert_eq!(path.extension().and_then(OsStr::to_str), Some("ts"));
 }
 
 #[test]

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,6 +1,6 @@
 # Hawk treats workspace libraries as internal unless excluded on the command
-# line. scripts/check-hawk.sh protects fallow's supported facade and the
-# contract crates whose types it re-exports.
+# line. scripts/check-hawk.sh protects fallow's supported facade, the contract
+# crates whose types it re-exports, and the license crate used by the sidecar.
 preserve-uniform-field-visibility = true
 
 [[production]]

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,31 @@
+# Hawk treats workspace libraries as internal unless excluded on the command
+# line. scripts/check-hawk.sh protects fallow's supported facade and the
+# contract crates whose types it re-exports.
+preserve-uniform-field-visibility = true
+
+[[production]]
+package = "fallow-cli"
+bin = "fallow"
+reason = "Primary CLI binary included in platform packages"
+
+[[production]]
+package = "fallow-lsp"
+bin = "fallow-lsp"
+reason = "Language server binary included in releases"
+
+[[production]]
+package = "fallow-mcp"
+bin = "fallow-mcp"
+reason = "MCP server binary included in releases"
+
+[[production]]
+package = "fallow-multicall"
+bin = "fallow-multicall"
+reason = "Combined binary included in platform packages"
+
+[[feature-profile]]
+name = "default"
+
+[[feature-profile]]
+name = "all"
+all-features = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Pinned to match CI (see .github/workflows/ci.yml). Bump in lockstep with CI
 # so `cargo clippy` / `cargo test` surface the same lints locally as in CI.
-channel = "1.95"
+channel = "1.97.1"
 components = ["clippy", "rustfmt"]

--- a/scripts/check-hawk.sh
+++ b/scripts/check-hawk.sh
@@ -20,6 +20,7 @@ hawk_args=(
   --exclude-crate fallow_types
   --exclude-crate fallow_output
   --exclude-crate fallow_config
+  --exclude-crate fallow_license
   --color never
 )
 

--- a/scripts/check-hawk.sh
+++ b/scripts/check-hawk.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_HAWK_VERSION="cargo hawk 0.1.9"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+readonly REPO_ROOT
+
+if [[ "$(cargo +1.97.1 hawk --version)" != "${EXPECTED_HAWK_VERSION}" ]]; then
+  printf 'error: expected %s\n' "${EXPECTED_HAWK_VERSION}" >&2
+  exit 2
+fi
+
+hawk_args=(
+  check
+  --manifest-path "${REPO_ROOT}/Cargo.toml"
+  --config "${REPO_ROOT}/hawk.toml"
+  --exclude-crate fallow_api
+  --exclude-crate fallow_types
+  --exclude-crate fallow_output
+  --exclude-crate fallow_config
+  --color never
+)
+
+if [[ "${1:-dead-public}" == "dead-public" ]]; then
+  hawk_args+=(
+    -A hawk::unnecessary_public
+    -A hawk::unnecessary_restricted_visibility
+  )
+elif [[ "${1:-}" != "all" ]]; then
+  printf 'usage: %s [dead-public|all]\n' "$0" >&2
+  exit 2
+fi
+
+if [[ -n "${FALLOW_HAWK_TARGET_DIR:-}" ]]; then
+  hawk_args+=(--target-dir "${FALLOW_HAWK_TARGET_DIR}")
+fi
+
+if [[ -n "${FALLOW_HAWK_GRAPH_DIR:-}" ]]; then
+  hawk_args+=(--graph-dir "${FALLOW_HAWK_GRAPH_DIR}")
+fi
+
+exec cargo +1.97.1 hawk "${hawk_args[@]}"

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -187,6 +187,15 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.doesNotMatch(aggregateJob, /windows-audit-smoke|windows-arm64/);
 });
 
+test("MSRV CI forces Rust 1.92 despite the repository toolchain override", () => {
+  const workflow = readWorkflow(".github/workflows/ci.yml");
+  const msrvJob = indentedBlock(workflow, "msrv", 2);
+
+  assert.match(msrvJob, /RUSTUP_TOOLCHAIN: 1\.92\.0/);
+  assert.match(msrvJob, /toolchain: '1\.92\.0'/);
+  assert.match(msrvJob, /run: cargo check --workspace/);
+});
+
 test("release runs Windows correctness and lifecycle verification without credentials", () => {
   const releaseWorkflow = readWorkflow(".github/workflows/release.yml");
   const validationWorkflow = readWorkflow(".github/workflows/release-validation.yml");


### PR DESCRIPTION
## Summary

- Upgrade the default, development container, and Linux release toolchains to Rust 1.97.1 while preserving the Rust 1.92 MSRV.
- Add a pinned Hawk 0.1.9 workspace audit for the four released binaries and both default and all-feature profiles.
- Protect the supported Rust facade, re-exported contract crates, and cross-repo license API from automated visibility changes.
- Run the dead-public audit weekly and on demand, with a verified release checksum and an uploaded log.

Hawk remains informational because it is experimental and its current release has no stable JSON identity for safe cross-target deletion. Visibility reductions can follow separately after Linux and Windows validation.

## Verification

- [x] `npm run verify:fast`
- [x] `cargo test --workspace`
- [x] `cargo doc --workspace --no-deps --document-private-items`
- [x] `cargo +1.92.0 check --workspace`
- [x] Hawk 0.1.9 clean-worktree audit
- [x] Workflow policy, actionlint, YAML parsing, shellcheck, and zizmor
