### PR TITLE
fix(ci): hold incompatible React Vite plugin major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,9 +84,11 @@ updates:
     cooldown:
       default-days: 7
     ignore:
-      # electron-vite 5 supports Vite through version 7. Remove this when its
-      # peer dependency range includes Vite 8.
+      # electron-vite 5 supports Vite through version 7, while plugin-react 6
+      # requires Vite 8. Remove both guards when electron-vite supports Vite 8.
       - dependency-name: vite
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
         update-types: ["version-update:semver-major"]
       # Electron 43 embeds Node 24. Keep the type surface aligned with the
       # runtime and raise this together with Electron.

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -73,6 +73,10 @@ test("review Electron holds majors that exceed its wrapper and runtime", () => {
   );
   assert.match(
     update,
+    /- dependency-name: "@vitejs\/plugin-react"\s+update-types: \["version-update:semver-major"\]/u,
+  );
+  assert.match(
+    update,
     /- dependency-name: "@types\/node"\s+update-types: \["version-update:semver-major"\]/u,
   );
 });


### PR DESCRIPTION
Keeps `@vitejs/plugin-react` on its Vite 7-compatible major while `electron-vite` 5 prevents the review app from moving to Vite 8. A clean install of the proposed plugin major fails its peer dependency resolution.

Extends the repository policy test so Dependabot cannot reopen that incompatible major independently.

Validation:
- incompatible update reproduced with a clean install
- YAML configuration parses
- repository policy, formatting, linting, workspace build, and tests pass