### PR TITLE
fix: repair post-dependabot validation gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -884,7 +884,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, windows-rust, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor, viz-frontend]
+    needs: [check, windows-rust, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, zed, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor, viz-frontend]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/apps/review-electron/README.md
+++ b/apps/review-electron/README.md
@@ -17,6 +17,7 @@ npm run build      # build main + preload + renderer into out/
 npm run package    # build + electron-builder (unsigned macOS .app, dir target)
 npm test           # vitest unit tests
 npm run test:e2e   # Playwright-electron e2e
+npm run test:shots # capture Playwright screenshots for design QA
 npm run typecheck  # tsc --noEmit
 ```
 

--- a/apps/review-electron/e2e/app.e2e.ts
+++ b/apps/review-electron/e2e/app.e2e.ts
@@ -5,6 +5,9 @@ import {
   type ElectronApplication,
   type Page,
 } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { appendFileSync, cpSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { ensureReviewStarted } from "./review";
 
@@ -12,24 +15,70 @@ const appDir = resolve(__dirname, "..");
 const worktreeRoot = resolve(appDir, "..", "..");
 
 let app: ElectronApplication | undefined;
+let temporaryReviewRoot: string | undefined;
 
 test.afterEach(async () => {
-  await app?.close();
-  app = undefined;
+  try {
+    await app?.close();
+    app = undefined;
+  } finally {
+    if (temporaryReviewRoot !== undefined) {
+      rmSync(temporaryReviewRoot, { recursive: true, force: true });
+      temporaryReviewRoot = undefined;
+    }
+  }
 });
 
-const launch = async (): Promise<ElectronApplication> =>
+const resolveFallowBin = (): string => {
+  const explicit = process.env["FALLOW_BIN"]?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  for (const profile of ["release", "debug"] as const) {
+    const candidate = resolve(worktreeRoot, "target", profile, "fallow");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return "fallow";
+};
+
+const createReviewRoot = (dirty = false): string => {
+  const temporaryRoot = mkdtempSync(resolve(tmpdir(), "fallow-review-e2e-"));
+  temporaryReviewRoot = temporaryRoot;
+  const reviewRoot = resolve(temporaryRoot, "project");
+  cpSync(resolve(appDir, "fixtures", "sample-app"), reviewRoot, { recursive: true });
+
+  const git = (args: string[]): void => {
+    execFileSync("git", args, { cwd: reviewRoot, stdio: "ignore" });
+  };
+  git(["init", "-b", "main"]);
+  git(["config", "user.email", "test@example.com"]);
+  git(["config", "user.name", "Fallow E2E"]);
+  git(["add", "."]);
+  git(["commit", "-m", "baseline"]);
+
+  if (dirty) {
+    appendFileSync(resolve(reviewRoot, "src", "App.tsx"), "\nexport const e2eDiffMarker = true;\n");
+  }
+  return reviewRoot;
+};
+
+const launch = async (reviewRoot?: string): Promise<ElectronApplication> =>
   electron.launch({
     args: [resolve(appDir, "out", "main", "index.js")],
     cwd: worktreeRoot,
     env: {
       ...process.env,
-      FALLOW_BIN: process.env["FALLOW_BIN"] ?? resolve(worktreeRoot, "target", "release", "fallow"),
+      FALLOW_BIN: resolveFallowBin(),
+      ...(reviewRoot === undefined ? {} : { FALLOW_REVIEW_ROOT: reviewRoot }),
     } as Record<string, string>,
   });
 
-const launchLoadedReview = async (): Promise<Page> => {
-  app = await launch();
+const launchLoadedReview = async (reviewRoot = createReviewRoot()): Promise<Page> => {
+  app = await launch(reviewRoot);
   const win = await app.firstWindow();
   await ensureReviewStarted(win);
   await expect(win.getByTestId("review-loaded")).toBeVisible({ timeout: 150_000 });
@@ -37,7 +86,7 @@ const launchLoadedReview = async (): Promise<Page> => {
 };
 
 test("boots and renders the review shell", async () => {
-  app = await launch();
+  app = await launch(createReviewRoot());
   const win = await app.firstWindow();
   await expect(win.getByRole("heading", { name: "Fallow Review" })).toBeVisible();
   await ensureReviewStarted(win);
@@ -45,14 +94,15 @@ test("boots and renders the review shell", async () => {
 });
 
 test("loads a grounded walkthrough from the real engine", async () => {
-  // `fallow review` runs on the worktree; wait for the focus headline to render.
+  // `fallow review` runs on a real fixture project; wait for the focus headline to render.
   await launchLoadedReview();
 });
 
 test("opens a file diff from the walkthrough", async () => {
-  const win = await launchLoadedReview();
-  await win.getByTestId("file-open").first().click();
-  await expect(win.getByText(/@@|no textual diff/).first()).toBeVisible({ timeout: 20_000 });
+  const reviewRoot = createReviewRoot(true);
+  const win = await launchLoadedReview(reviewRoot);
+  await win.getByRole("button", { name: "open App.tsx" }).click();
+  await expect(win.getByText(/@@/).first()).toBeVisible({ timeout: 20_000 });
 });
 
 test("inspector bridge pushes a grounded card to the UI", async () => {
@@ -63,14 +113,14 @@ test("inspector bridge pushes a grounded card to the UI", async () => {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      file: "apps/review-electron/src/main/index.ts",
+      file: "src/App.tsx",
       line: 1,
-      component: "main",
+      component: "App",
     }),
   });
   expect(res.ok).toBe(true);
 
   const inspector = win.getByTestId("inspector-card");
   await expect(inspector).toBeVisible({ timeout: 30_000 });
-  await expect(inspector).toContainText("src/main/index.ts:1");
+  await expect(inspector).toContainText("src/App.tsx:1");
 });

--- a/apps/review-electron/e2e/shots.e2e.ts
+++ b/apps/review-electron/e2e/shots.e2e.ts
@@ -1,11 +1,27 @@
 import { test, _electron as electron, type ElectronApplication } from "@playwright/test";
-import { chmodSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { ensureReviewStarted } from "./review";
 
 const appDir = resolve(__dirname, "..");
 const worktreeRoot = resolve(appDir, "..", "..");
 const shots = process.env["FALLOW_REVIEW_SHOTS_DIR"] ?? "/tmp/fallow-review-qa";
+
+const resolveFallowBin = (): string => {
+  const explicit = process.env["FALLOW_BIN"]?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  for (const profile of ["release", "debug"] as const) {
+    const candidate = resolve(worktreeRoot, "target", profile, "fallow");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return "fallow";
+};
 
 const safe = async (fn: () => Promise<void>): Promise<void> => {
   try {
@@ -23,7 +39,7 @@ test("capture screens for design QA", async () => {
     cwd: worktreeRoot,
     env: {
       ...process.env,
-      FALLOW_BIN: process.env["FALLOW_BIN"] ?? resolve(worktreeRoot, "target", "release", "fallow"),
+      FALLOW_BIN: resolveFallowBin(),
     } as Record<string, string>,
   });
   const win = await app.firstWindow();

--- a/apps/review-electron/package.json
+++ b/apps/review-electron/package.json
@@ -13,7 +13,8 @@
     "lint": "oxlint",
     "format": "oxfmt",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test app.e2e.ts",
+    "test:shots": "playwright test shots.e2e.ts"
   },
   "dependencies": {
     "@electron-toolkit/utils": "^4.0.0",

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -184,6 +184,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
     /missing windows-audit-smoke block/,
   );
   assert.match(aggregateJob, /windows-rust/);
+  assert.match(aggregateJob, /needs: \[[^\n]*\bzed\b[^\n]*\]/);
   assert.doesNotMatch(aggregateJob, /windows-audit-smoke|windows-arm64/);
 });
 


### PR DESCRIPTION
## Summary

- make the Zed job part of the required aggregate CI gate and preserve that requirement with a policy test
- make Electron review E2E runs deterministic with isolated Git fixtures and release, debug, or `PATH` binary resolution
- keep screenshot capture as a separate design QA command

The Zed manifest repair landed independently in #1986 while this PR was running CI. This PR keeps the CI aggregation fix that prevents the same failure from being ignored again.

## Verification

- [x] Zed tests, WASI build, and formatting
- [x] Workflow policy tests, actionlint, and zizmor
- [x] Electron typecheck, lint, unit tests, production build, and E2E without an explicit `FALLOW_BIN`
- [x] Full repository verification, including workspace tests, benchmark compilation, documentation, and NAPI
- [x] Native pre-ship review
