### PR TITLE
fix(zed): remove obsolete ed25519 feature

### DIFF
--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/fallow.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ed25519-dalek = { version = "3", default-features = false, features = ["std"] }
+ed25519-dalek = { version = "3", default-features = false }
 zed_extension_api = "0.7.0"
 
 [workspace]


### PR DESCRIPTION
## Summary

- Remove the obsolete `std` feature from the Zed extension's `ed25519-dalek` 3 dependency.
- Keep default features disabled while retaining signature verification support.
- Restore the Zed CI job broken by #1951.

## Verification

- [x] `cargo test --manifest-path editors/zed/Cargo.toml`
- [x] `cargo build --target wasm32-wasip2 --manifest-path editors/zed/Cargo.toml`
- [x] `cargo fmt --check --manifest-path editors/zed/Cargo.toml`