### PR TITLE
chore: integrate trigger-tree agent telemetry

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,16 +45,16 @@
     "command": "python3.13 \"$CLAUDE_PROJECT_DIR\"/.claude/tt-statusline.py 2>/dev/null || python3 \"$CLAUDE_PROJECT_DIR\"/.claude/tt-statusline.py 2>/dev/null || python \"$CLAUDE_PROJECT_DIR\"/.claude/tt-statusline.py",
     "refreshInterval": 5
   },
+  "enabledPlugins": {
+    "trigger-tree@trigger-tree": true
+  },
   "extraKnownMarketplaces": {
     "trigger-tree": {
       "source": {
         "source": "github",
         "repo": "Hedde/trigger_tree",
-        "ref": "v1.19.1"
+        "ref": "v1.21.0"
       }
     }
-  },
-  "enabledPlugins": {
-    "trigger-tree@trigger-tree": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,5 +39,22 @@
         ]
       }
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "python3.13 \"$CLAUDE_PROJECT_DIR\"/.claude/tt-statusline.py 2>/dev/null || python3 \"$CLAUDE_PROJECT_DIR\"/.claude/tt-statusline.py 2>/dev/null || python \"$CLAUDE_PROJECT_DIR\"/.claude/tt-statusline.py",
+    "refreshInterval": 5
+  },
+  "extraKnownMarketplaces": {
+    "trigger-tree": {
+      "source": {
+        "source": "github",
+        "repo": "Hedde/trigger_tree",
+        "ref": "v1.19.1"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "trigger-tree@trigger-tree": true
   }
 }

--- a/.claude/tt-statusline.py
+++ b/.claude/tt-statusline.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""trigger-tree statusline: live doc-discovery stats for the current session.
+
+Portable (macOS/Linux), stdlib only. The dot pulses with the age of the last read or scan:
+● bright green < 90s, ◐ amber < 10min, ○ dim otherwise.
+Register in project or user settings under "statusLine" with a refreshInterval.
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import unicodedata
+from datetime import datetime, timezone
+
+ROOT = os.environ.get("TT_PROJECT_DIR") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+HIST = os.path.join(ROOT, ".trigger-tree", "history.jsonl")
+BADGE = os.path.join(ROOT, ".trigger-tree", "badge.json")
+
+RESET = "\033[0m"
+FRESH = "\033[1;38;5;114m"  # bright green
+WARM = "\033[38;5;178m"  # amber
+COLD = "\033[38;5;245m"  # dim
+
+
+def terminal_safe(value):
+    """Strip terminal controls and invisible direction overrides from untrusted text."""
+    bidi_controls = "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+    text = re.sub(r"(?:\x1b\]|\x9d).*?(?:\x07|\x1b\\|\x9c)", "", str(value), flags=re.S)
+    text = re.sub(r"(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]", "", text)
+    text = re.sub(r"\x1b[@-_]", "", text)
+    return "".join(
+        ch
+        for ch in text
+        if unicodedata.category(ch) not in ("Cc", "Cs") and ch not in bidi_controls
+    )
+
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # emoji-safe on Windows consoles
+except AttributeError:  # pragma: no cover, exotic stdout replacement
+    pass
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        data = {}
+    session = data.get("session_id")
+    if not session:
+        print("🌳 tt: no data")
+        return
+
+    files, scans, last, last_time = {}, 0, None, None
+    state_name = hashlib.sha256(str(session).encode("utf-8")).hexdigest()[:32] + ".json"
+    state_path = os.path.join(ROOT, ".trigger-tree", "sessions", state_name)
+    try:
+        state = json.loads(open(state_path, encoding="utf-8").read())
+    except (OSError, ValueError):
+        state = None
+    if state is not None:
+        files = {path: True for path in state.get("files", [])}
+        scans = int(state.get("scans", 0))
+        last = state.get("last")
+        try:
+            last_time = datetime.strptime(last["ts"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except (KeyError, TypeError, ValueError):
+            last_time = None
+    elif not os.path.isfile(HIST):
+        print("🌳 tt: no data")
+        return
+    else:
+        fh = open(HIST, encoding="utf-8")
+        try:
+            scans, last, last_time = _collect_history(fh, session, files)
+        finally:
+            fh.close()
+
+    if not files and not scans:
+        print("🌳 tt: 0 docs consulted")
+        return
+
+    dirs = {os.path.dirname(p) for p in files}
+    depth = max((p.count("/") for p in files), default=0)
+    grade = mature_grade()
+    stats = f"{grade} · " if grade else ""
+    stats += f"{len(files)} files · {scans} searches · {len(dirs)} folders · depth {depth}"
+
+    age = 10**9
+    if last_time is not None:
+        age = time.time() - last_time.timestamp()
+
+    if age < 90:
+        dot, color = "●", FRESH
+    elif age < 600:
+        dot, color = "◐", WARM
+    else:
+        dot, color = "○", COLD
+
+    path = terminal_safe(last["path"]) + ("/" if last.get("t") == "scan" else "")
+    print(f"🌳 {stats} {color}{dot} {path}{RESET}")
+
+
+def mature_grade():
+    """Read the optional public-safe badge cache; measuring badges have no grade."""
+    try:
+        payload = json.loads(open(BADGE, encoding="utf-8").read())
+    except (OSError, ValueError):
+        return None
+    message = payload.get("message")
+    match = re.fullmatch(r"([A-F]) \(\d{1,3}\)", message) if isinstance(message, str) else None
+    return match.group(1) if match else None
+
+
+def _collect_history(fh, session, files):
+    scans, last, last_time = 0, None, None
+    for line in fh:
+        if f'"session":"{session}"' not in line and f'"session": "{session}"' not in line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        typ = event.get("t")
+        if typ == "read":
+            files[event["path"]] = True
+        elif typ == "scan":
+            scans += 1
+        else:
+            continue
+        try:
+            event_time = datetime.strptime(event["ts"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except (KeyError, ValueError):
+            event_time = None
+        if last is None or (
+            event_time is not None and (last_time is None or event_time >= last_time)
+        ):
+            last, last_time = event, event_time
+    return scans, last, last_time
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        print("🌳 tt")
+    sys.exit(0)

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ editors/vscode/LICENSE
 !.claude/skills/
 !.claude/rules/
 !.claude/agents/
+!.claude/tt-statusline.py
 
 # Codex
 .codex/
@@ -118,3 +119,8 @@ decisions/
 # Runtime scratch the review app writes (human notes feed, captured framing).
 # App-subtree .gitignore already ignores it; this keeps a root `git add -A` safe.
 .fallow-review/
+
+# trigger-tree keeps telemetry local while sharing its project configuration.
+.trigger-tree/*
+!.trigger-tree/config.sh
+!.trigger-tree/README.md

--- a/.trigger-tree/README.md
+++ b/.trigger-tree/README.md
@@ -1,0 +1,79 @@
+# trigger-tree integration
+
+Fallow uses [trigger-tree](https://github.com/Hedde/trigger_tree) to measure
+which maintainer documentation Codex and Claude Code discover. Telemetry stays
+in this directory and is ignored by Git, except for this documentation and the
+shared project configuration.
+
+## Pinned source
+
+Both clients use trigger-tree v1.19.1 from tag commit
+`f860090defde3d11a743bf559d304947f1f825af`.
+
+The locally installed hook manifests on this Mac prefer `python3.13`, the
+newest interpreter supported by v1.19.1. The project status line falls back to
+`python3` and then `python` for other environments.
+
+Claude Code declares the tagged marketplace and enabled plugin in
+`.claude/settings.json`.
+
+Codex currently installs plugins for the user rather than one project. Its
+local marketplace lives at
+`~/.codex/local-marketplaces/trigger-tree-v1.19.1-off`. That snapshot differs
+from upstream only to keep installation deterministic, privacy-safe, and
+compatible with this Mac:
+
+- Both fallback `TT_LOG_PROMPTS` values are `off`.
+- The marketplace resolves the plugin from the local tagged snapshot instead
+  of the floating upstream `main` branch.
+- The hook launcher prefers `python3.13` before the newer system `python3`.
+
+Repositories without a project configuration therefore store prompt markers
+only. Fallow overrides that fallback with `TT_LOG_PROMPTS='hash'`. A hash still
+allows prompts to be correlated and may be vulnerable to guessing when the
+input space is small. Use `off` when that linkability is undesirable.
+
+## Local data
+
+Runtime files such as `history.jsonl`, rotated histories, session state,
+reports, and badges are ignored. They are never required for a clean checkout
+or CI.
+
+The long-lived maintainer checkout contains large ignored scratch trees.
+trigger-tree v1.19.1 caps its filesystem inventory before applying watch
+patterns, so doctor can report an optional low-coverage warning here even when
+the configured tracked paths match. The integration verifies the watch, scan,
+and always-loaded expressions with explicit positive and negative path cases.
+
+## Updating
+
+Before upgrading:
+
+1. Verify the new tag and resolved commit.
+2. Review the upstream prompt default and privacy policy.
+3. Review both hook manifests for new events or tool access.
+4. Reapply the Codex `off` fallback to a fresh tagged local marketplace.
+5. If the system `python3` remains unsupported, reapply the `python3.13`
+   preference to both locally installed hook manifests.
+6. Run one real Codex session and one real Claude Code session in this
+   checkout.
+7. Confirm prompt probes remain absent from current and rotated histories.
+8. Run trigger-tree doctor and the static gate.
+
+Do not update either marketplace to a floating branch.
+
+## Removal
+
+Remove the client integrations:
+
+```sh
+codex plugin remove trigger-tree@trigger-tree-private
+codex plugin marketplace remove trigger-tree-private
+claude plugin uninstall trigger-tree@trigger-tree --scope project
+claude plugin marketplace remove trigger-tree --scope project
+```
+
+The upstream trigger-tree uninstall command removes its Claude status line and
+copied script, but intentionally preserves telemetry, project configuration,
+and ignore rules. Delete `.trigger-tree/` separately only when its local
+history is no longer wanted.

--- a/.trigger-tree/README.md
+++ b/.trigger-tree/README.md
@@ -7,26 +7,27 @@ shared project configuration.
 
 ## Pinned source
 
-Both clients use trigger-tree v1.19.1 from tag commit
-`f860090defde3d11a743bf559d304947f1f825af`.
+Both clients use trigger-tree v1.21.0 from tag commit
+`84e478d550de752a9a8eabfa9a6323fa4257543c`.
 
-The locally installed hook manifests on this Mac prefer `python3.13`, the
-newest interpreter supported by v1.19.1. The project status line falls back to
-`python3` and then `python` for other environments.
+Version 1.21.0 supports Python 3.10 through 3.14. The project status line
+prefers `python3.13`, then falls back to `python3` and `python`.
 
 Claude Code declares the tagged marketplace and enabled plugin in
 `.claude/settings.json`.
 
 Codex currently installs plugins for the user rather than one project. Its
 local marketplace lives at
-`~/.codex/local-marketplaces/trigger-tree-v1.19.1-off`. That snapshot differs
-from upstream only to keep installation deterministic, privacy-safe, and
-compatible with this Mac:
+`~/.codex/local-marketplaces/trigger-tree-v1.21.0-off`. That snapshot differs
+from upstream only to keep installation deterministic and privacy-safe:
 
 - Both fallback `TT_LOG_PROMPTS` values are `off`.
 - The marketplace resolves the plugin from the local tagged snapshot instead
   of the floating upstream `main` branch.
-- The hook launcher prefers `python3.13` before the newer system `python3`.
+
+Codex reviews plugin hooks by hash. After installing or updating trigger-tree,
+start Codex interactively and choose `Trust all and continue` for its four
+hooks. Non-interactive sessions skip untrusted hooks without recording events.
 
 Repositories without a project configuration therefore store prompt markers
 only. Fallow overrides that fallback with `TT_LOG_PROMPTS='hash'`. A hash still
@@ -39,11 +40,9 @@ Runtime files such as `history.jsonl`, rotated histories, session state,
 reports, and badges are ignored. They are never required for a clean checkout
 or CI.
 
-The long-lived maintainer checkout contains large ignored scratch trees.
-trigger-tree v1.19.1 caps its filesystem inventory before applying watch
-patterns, so doctor can report an optional low-coverage warning here even when
-the configured tracked paths match. The integration verifies the watch, scan,
-and always-loaded expressions with explicit positive and negative path cases.
+Version 1.21.0 scans the Git-visible documentation set, includes `.agents/`
+and `.codex/`, and records the originating client on new events. Existing
+v1.19.1 events remain valid and appear with client `unknown`.
 
 ## Updating
 
@@ -53,8 +52,7 @@ Before upgrading:
 2. Review the upstream prompt default and privacy policy.
 3. Review both hook manifests for new events or tool access.
 4. Reapply the Codex `off` fallback to a fresh tagged local marketplace.
-5. If the system `python3` remains unsupported, reapply the `python3.13`
-   preference to both locally installed hook manifests.
+5. Review and trust the four updated Codex hooks interactively.
 6. Run one real Codex session and one real Claude Code session in this
    checkout.
 7. Confirm prompt probes remain absent from current and rotated histories.

--- a/.trigger-tree/config.sh
+++ b/.trigger-tree/config.sh
@@ -16,6 +16,9 @@ TT_ALWAYS_LOADED_REGEX='(^|/)(?:CLAUDE|AGENTS|GEMINI)\.md$|(^|/)CLAUDE\.local\.m
 # Example project override additions for other instruction systems:
 # TT_ALWAYS_LOADED_REGEX='...|^\.github/copilot-instructions\.md$|^\.cursor/rules/'
 
+# Markdown that is intentionally human-facing or generated per platform.
+TT_SCOPE_IGNORE='.github/*,CHANGELOG.md,CODE_OF_CONDUCT.md,npm/darwin-*/README.md,npm/linux-*/README.md,npm/win32-*/README.md'
+
 # Comma-separated globs for rare-but-critical documentation that must be reviewed,
 # never treated as an archive candidate. Safety paths are protected regardless.
 TT_CRITICAL_GLOB='AGENTS.md,CLAUDE.md,.claude/rules/workflow.md,.claude/rules/release-workflow.md,.claude/rules/detection.md,.codex/references/quality-gates.md,.codex/references/review-routing.md'

--- a/.trigger-tree/config.sh
+++ b/.trigger-tree/config.sh
@@ -1,0 +1,31 @@
+# trigger-tree project configuration.
+# Override per project: create $PROJECT/.trigger-tree/config.sh with the same variables.
+# Paths are relative to the project root.
+
+# A Read of a file matching this regex counts as a documentation read.
+TT_WATCH_REGEX='^docs/.*\.(?:md|markdown)$|^\.claude/(?:rules|agents|skills)/.*\.md$|^\.codex/(?:references|agents|skills)/.*\.(?:md|toml)$|^\.agents/(?:rules|agents|skills)/.*\.md$|^\.agents/README\.md$|(^|/)(?:CLAUDE|AGENTS|GEMINI)\.md$|^(?:CONTEXT|CONTRIBUTING|README|BENCHMARKS|SECURITY|ROADMAP)\.md$'
+
+# A Glob/Grep whose explicit target dir matches this regex counts as search activity.
+# The event records that a search happened, not why it happened or whether routing failed.
+TT_SCAN_REGEX='^(?:docs|\.claude/(?:rules|agents|skills)|\.codex/(?:references|agents|skills)|\.agents/(?:rules|agents|skills))(/|$)'
+
+# Files matching this regex are loaded automatically (system-prompt injection, nested
+# CLAUDE.md on-demand loading, Skill tool) and therefore cannot be judged through
+# Read telemetry; they are excluded from untouched review-candidate analysis.
+TT_ALWAYS_LOADED_REGEX='(^|/)(?:CLAUDE|AGENTS|GEMINI)\.md$|(^|/)CLAUDE\.local\.md$|^\.claude/(?:rules|agents|skills)/|^\.codex/(?:agents|skills)/|^\.agents/(?:agents|rules|skills)/'
+# Example project override additions for other instruction systems:
+# TT_ALWAYS_LOADED_REGEX='...|^\.github/copilot-instructions\.md$|^\.cursor/rules/'
+
+# Comma-separated globs for rare-but-critical documentation that must be reviewed,
+# never treated as an archive candidate. Safety paths are protected regardless.
+TT_CRITICAL_GLOB='AGENTS.md,CLAUDE.md,.claude/rules/workflow.md,.claude/rules/release-workflow.md,.claude/rules/detection.md,.codex/references/quality-gates.md,.codex/references/review-routing.md'
+
+# Store only a stable prompt fingerprint. Use `off` for markers without linkability.
+TT_LOG_PROMPTS='hash'
+
+# Rotate history.jsonl to history-<timestamp>.jsonl when it exceeds this many bytes.
+TT_ROTATE_BYTES='5242880'
+
+# Experimental, correlational view joining reads with local session outcomes.
+# Values: off (default) or on. This never makes causal claims or sends data anywhere.
+TT_EXPERIMENTAL_OUTCOMES='off'


### PR DESCRIPTION
## Summary
- Integrate trigger-tree v1.21.0 for Codex and Claude Code.
- Keep prompt telemetry hash-only in Fallow and fully off by default in unconfigured Codex repositories.
- Preserve the existing Fallow hooks and keep runtime telemetry out of Git.

## Details
- Claude Code uses a project-scoped marketplace pinned to the v1.21.0 release commit.
- Codex uses a user-wide local marketplace pinned to the same commit, with privacy-safe fallback defaults.
- Codex hook trust is reviewed and persisted after installation.
- The shared configuration covers Fallow's documentation, agent rules, skills, routers, and critical guidance.
- Removal and update procedures are documented in `.trigger-tree/README.md`.

## Verification
- [x] Both plugin sources resolve to trigger-tree v1.21.0 at the pinned release commit.
- [x] Existing Claude and Codex hooks remain intact.
- [x] Fresh Codex and Claude host sessions emit client-attributed session, prompt, read, and outcome events.
- [x] Prompt probe text is absent from current and rotated telemetry; prompt events contain hashes only.
- [x] Both client doctors pass without warnings.
- [x] The advisory trigger-tree gate passes.
- [x] Trigger-tree setup is content-idempotent.
- [x] Fallow audit passes for the branch diff.
- [x] Workspace build, tests, formatter, clippy, typos, and hidden Unicode checks pass.

## Upstream follow-ups
- [Codex installation and version pinning](https://github.com/Hedde/trigger_tree/issues/6)
- [User-wide Codex prompt privacy](https://github.com/Hedde/trigger_tree/issues/7)
- [Doctor coverage scan accuracy](https://github.com/Hedde/trigger_tree/issues/8)
- [Client attribution in shared telemetry](https://github.com/Hedde/trigger_tree/issues/9)
- [Python interpreter support](https://github.com/Hedde/trigger_tree/issues/10)
- [Codex hook trust documentation](https://github.com/Hedde/trigger_tree/issues/11)
