### PR TITLE
chore: upgrade trigger-tree to v1.22.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,7 @@
       "source": {
         "source": "github",
         "repo": "Hedde/trigger_tree",
-        "ref": "v1.21.3"
+        "ref": "v1.22.0"
       }
     }
   }

--- a/.trigger-tree/README.md
+++ b/.trigger-tree/README.md
@@ -7,10 +7,10 @@ shared project configuration.
 
 ## Pinned source
 
-Both clients use trigger-tree v1.21.3 from tag commit
-`8b6489402c24e415e205ba00277b7fa53890c403`.
+Both clients use trigger-tree v1.22.0 from tag commit
+`3a1efb7d29e655424bacb98dad2ff7f87efa5274`.
 
-Version 1.21.3 supports Python 3.10 through 3.14. The project status line
+Version 1.22.0 supports Python 3.10 through 3.14. The project status line
 prefers `python3.13`, then falls back to `python3` and `python`.
 
 Claude Code declares the tagged marketplace and enabled plugin in
@@ -18,7 +18,7 @@ Claude Code declares the tagged marketplace and enabled plugin in
 
 Codex currently installs plugins for the user rather than one project. Its
 local marketplace lives at
-`~/.codex/local-marketplaces/trigger-tree-v1.21.3-off`. That snapshot differs
+`~/.codex/local-marketplaces/trigger-tree-v1.22.0-off`. That snapshot differs
 from upstream only to keep installation deterministic and privacy-safe:
 
 - Both fallback `TT_LOG_PROMPTS` values are `off`.
@@ -28,7 +28,7 @@ from upstream only to keep installation deterministic and privacy-safe:
 Codex reviews plugin hooks by hash. After installing or updating trigger-tree,
 start Codex interactively and choose `Trust all and continue` for its four
 hooks. Non-interactive sessions skip untrusted hooks without recording events.
-Version 1.21.3 reports persisted Codex hook trust in `tt doctor`; an upgrade
+Version 1.22.0 reports persisted Codex hook trust in `tt doctor`; an upgrade
 that changes a hook still requires another interactive review.
 
 Repositories without a project configuration therefore store prompt markers
@@ -42,9 +42,12 @@ Runtime files such as `history.jsonl`, rotated histories, session state,
 reports, and badges are ignored. They are never required for a clean checkout
 or CI.
 
-Version 1.21.3 scans the Git-visible documentation set, includes `.agents/`
+Version 1.22.0 scans the Git-visible documentation set, includes `.agents/`
 and `.codex/`, and records the originating client on new events. Existing
 v1.19.1 events remain valid and appear with client `unknown`.
+
+The static gate can also write a deterministic GitLab Code Quality artifact
+with `tt gate --code-quality <path>`.
 
 ## Updating
 


### PR DESCRIPTION
## Summary
- Upgrade the Claude and Codex Trigger Tree integrations to v1.22.0.
- Pin both clients to the exact tagged commit and preserve Fallow's project hash mode.
- Keep the user-wide Codex fallback at `off`.

## Upstream
- Adds deterministic GitLab Code Quality output to `tt gate`.
- Hook manifests, telemetry collection, and privacy defaults are unchanged from v1.21.3.
- Upstream CI passes on the tagged release commit.

## Verification
- [x] Trigger Tree v1.22.0 tests, doctor, and static gate
- [x] GitLab Code Quality artifact validation
- [x] Fresh Claude and Codex telemetry with client attribution
- [x] Prompt privacy probe across current and rotated histories
- [x] Fallow repository verification
