### PR TITLE
chore: upgrade trigger-tree to v1.23.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,7 @@
       "source": {
         "source": "github",
         "repo": "Hedde/trigger_tree",
-        "ref": "v1.22.0"
+        "ref": "v1.23.1"
       }
     }
   }

--- a/.trigger-tree/README.md
+++ b/.trigger-tree/README.md
@@ -7,34 +7,36 @@ shared project configuration.
 
 ## Pinned source
 
-Both clients use trigger-tree v1.22.0 from tag commit
-`3a1efb7d29e655424bacb98dad2ff7f87efa5274`.
+Both clients use trigger-tree v1.23.1 from tag commit
+`b4d839f681d8c038d46d6d1f0f1914838ada6162`.
 
-Version 1.22.0 supports Python 3.10 through 3.14. The project status line
+Version 1.23.1 supports Python 3.10 through 3.14. The project status line
 prefers `python3.13`, then falls back to `python3` and `python`.
 
 Claude Code declares the tagged marketplace and enabled plugin in
 `.claude/settings.json`.
 
-Codex currently installs plugins for the user rather than one project. Its
-local marketplace lives at
-`~/.codex/local-marketplaces/trigger-tree-v1.22.0-off`. That snapshot differs
-from upstream only to keep installation deterministic and privacy-safe:
-
-- Both fallback `TT_LOG_PROMPTS` values are `off`.
-- The marketplace resolves the plugin from the local tagged snapshot instead
-  of the floating upstream `main` branch.
+Codex installs the official plugin source for the user from a local v1.23.1
+tag snapshot at
+`~/.codex/local-marketplaces/trigger-tree-v1.23.1-pinned`. Only the marketplace
+entry is changed to resolve that local snapshot because Codex CLI 0.144.6
+otherwise follows its floating `main` plugin source even when the marketplace
+checkout is pinned. The user-wide `~/.trigger-tree/config.sh` sets
+`TT_LOG_PROMPTS='off'`, so repositories without their own configuration store
+prompt markers only. Configuration precedence is bundled default, user
+default, then project override.
 
 Codex reviews plugin hooks by hash. After installing or updating trigger-tree,
 start Codex interactively and choose `Trust all and continue` for its four
 hooks. Non-interactive sessions skip untrusted hooks without recording events.
-Version 1.22.0 reports persisted Codex hook trust in `tt doctor`; an upgrade
+Version 1.23.1 reports persisted Codex hook trust in `tt doctor`; an upgrade
 that changes a hook still requires another interactive review.
 
-Repositories without a project configuration therefore store prompt markers
-only. Fallow overrides that fallback with `TT_LOG_PROMPTS='hash'`. A hash still
+Fallow overrides the user default with `TT_LOG_PROMPTS='hash'`. A hash still
 allows prompts to be correlated and may be vulnerable to guessing when the
-input space is small. Use `off` when that linkability is undesirable.
+input space is small. Use `off` when that linkability is undesirable. Version
+1.23.1 makes `tt doctor` report the effective mode and which configuration
+layer selected it.
 
 ## Local data
 
@@ -42,7 +44,7 @@ Runtime files such as `history.jsonl`, rotated histories, session state,
 reports, and badges are ignored. They are never required for a clean checkout
 or CI.
 
-Version 1.22.0 scans the Git-visible documentation set, includes `.agents/`
+Version 1.23.1 scans the Git-visible documentation set, includes `.agents/`
 and `.codex/`, and records the originating client on new events. Existing
 v1.19.1 events remain valid and appear with client `unknown`.
 
@@ -56,7 +58,8 @@ Before upgrading:
 1. Verify the new tag and resolved commit.
 2. Review the upstream prompt default and privacy policy.
 3. Review both hook manifests for new events or tool access.
-4. Reapply the Codex `off` fallback to a fresh tagged local marketplace.
+4. Verify the local Codex marketplace still resolves the exact tag and the
+   user-wide `off` default still applies before project overrides.
 5. Review and trust the four updated Codex hooks interactively.
 6. Run one real Codex session and one real Claude Code session in this
    checkout.
@@ -70,8 +73,8 @@ Do not update either marketplace to a floating branch.
 Remove the client integrations:
 
 ```sh
-codex plugin remove trigger-tree@trigger-tree-private
-codex plugin marketplace remove trigger-tree-private
+codex plugin remove trigger-tree@trigger-tree-pinned
+codex plugin marketplace remove trigger-tree-pinned
 claude plugin uninstall trigger-tree@trigger-tree --scope project
 claude plugin marketplace remove trigger-tree --scope project
 ```


### PR DESCRIPTION
## Summary
- Upgrade Claude and Codex Trigger Tree integrations to v1.23.1.
- Replace the privacy-patched Codex marketplace with a tag-exact plugin snapshot.
- Use the new user-wide configuration layer for the marker-only Codex fallback.

## Upstream
- Implements [Hedde/trigger_tree#13](https://github.com/Hedde/trigger_tree/issues/13).
- Adds bundled, user-wide, and project configuration precedence.
- Adds a graceful Codex Desktop fallback when no GUI session is available.
- Hardens assignment parsing and expands CI examples.

## Verification
- [x] Trigger Tree v1.23.1 tests, doctor, and static gate
- [x] User-wide `off` and project `hash` precedence
- [x] GitLab Code Quality artifact validation
- [x] Fresh Claude and Codex telemetry with client attribution
- [x] Prompt privacy probe across current and rotated histories
- [x] Fallow repository verification
