### PR TITLE
chore: upgrade trigger-tree to v1.23.2

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,7 @@
       "source": {
         "source": "github",
         "repo": "Hedde/trigger_tree",
-        "ref": "v1.23.1"
+        "ref": "v1.23.2"
       }
     }
   }

--- a/.trigger-tree/README.md
+++ b/.trigger-tree/README.md
@@ -7,21 +7,19 @@ shared project configuration.
 
 ## Pinned source
 
-Both clients use trigger-tree v1.23.1 from tag commit
-`b4d839f681d8c038d46d6d1f0f1914838ada6162`.
+Both clients use trigger-tree v1.23.2 from tag commit
+`78a801629f0b11f403737e0ae9e5c2bfa827a6bb`.
 
-Version 1.23.1 supports Python 3.10 through 3.14. The project status line
+Version 1.23.2 supports Python 3.10 through 3.14. The project status line
 prefers `python3.13`, then falls back to `python3` and `python`.
 
 Claude Code declares the tagged marketplace and enabled plugin in
 `.claude/settings.json`.
 
-Codex installs the official plugin source for the user from a local v1.23.1
-tag snapshot at
-`~/.codex/local-marketplaces/trigger-tree-v1.23.1-pinned`. Only the marketplace
-entry is changed to resolve that local snapshot because Codex CLI 0.144.6
-otherwise follows its floating `main` plugin source even when the marketplace
-checkout is pinned. The user-wide `~/.trigger-tree/config.sh` sets
+Codex installs the official plugin for the user from the pinned v1.23.2
+marketplace. This release resolves the plugin relative to the pinned
+marketplace checkout, so Codex installs the tagged bytes without a local
+wrapper. The user-wide `~/.trigger-tree/config.sh` sets
 `TT_LOG_PROMPTS='off'`, so repositories without their own configuration store
 prompt markers only. Configuration precedence is bundled default, user
 default, then project override.
@@ -29,13 +27,13 @@ default, then project override.
 Codex reviews plugin hooks by hash. After installing or updating trigger-tree,
 start Codex interactively and choose `Trust all and continue` for its four
 hooks. Non-interactive sessions skip untrusted hooks without recording events.
-Version 1.23.1 reports persisted Codex hook trust in `tt doctor`; an upgrade
+Version 1.23.2 reports persisted Codex hook trust in `tt doctor`; an upgrade
 that changes a hook still requires another interactive review.
 
 Fallow overrides the user default with `TT_LOG_PROMPTS='hash'`. A hash still
 allows prompts to be correlated and may be vulnerable to guessing when the
 input space is small. Use `off` when that linkability is undesirable. Version
-1.23.1 makes `tt doctor` report the effective mode and which configuration
+1.23.2 makes `tt doctor` report the effective mode and which configuration
 layer selected it.
 
 ## Local data
@@ -44,7 +42,7 @@ Runtime files such as `history.jsonl`, rotated histories, session state,
 reports, and badges are ignored. They are never required for a clean checkout
 or CI.
 
-Version 1.23.1 scans the Git-visible documentation set, includes `.agents/`
+Version 1.23.2 scans the Git-visible documentation set, includes `.agents/`
 and `.codex/`, and records the originating client on new events. Existing
 v1.19.1 events remain valid and appear with client `unknown`.
 
@@ -58,7 +56,7 @@ Before upgrading:
 1. Verify the new tag and resolved commit.
 2. Review the upstream prompt default and privacy policy.
 3. Review both hook manifests for new events or tool access.
-4. Verify the local Codex marketplace still resolves the exact tag and the
+4. Verify the official Codex marketplace resolves the exact tag and the
    user-wide `off` default still applies before project overrides.
 5. Review and trust the four updated Codex hooks interactively.
 6. Run one real Codex session and one real Claude Code session in this
@@ -73,8 +71,8 @@ Do not update either marketplace to a floating branch.
 Remove the client integrations:
 
 ```sh
-codex plugin remove trigger-tree@trigger-tree-pinned
-codex plugin marketplace remove trigger-tree-pinned
+codex plugin remove trigger-tree@trigger-tree
+codex plugin marketplace remove trigger-tree
 claude plugin uninstall trigger-tree@trigger-tree --scope project
 claude plugin marketplace remove trigger-tree --scope project
 ```


### PR DESCRIPTION
## Summary
- Upgrade Claude and Codex Trigger Tree integrations to v1.23.2.
- Use the official pinned Codex marketplace without a local wrapper.
- Preserve the user-wide marker-only default and Fallow's project hash override.

## Upstream
- Fixes deterministic Codex tag installation in [Hedde/trigger_tree#6](https://github.com/Hedde/trigger_tree/issues/6).
- Adds a release-integrity guard against floating plugin sources.

## Verification
- [x] Official Codex pin resolves exact v1.23.2 bytes
- [x] Trigger Tree tests, doctor, and static gate
- [x] User-wide `off` and project `hash` precedence
- [x] Fresh Claude and Codex telemetry with prompt privacy
- [x] Fallow repository verification
