### PR TITLE
fix: preserve cloud never-called confidence

### DIFF
--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -12,8 +12,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::coverage::RunContext;
 use crate::coverage::cloud_client::{
-    CloudError, CloudRequest, CloudRuntimeContext, CloudRuntimeFunction, CloudRuntimeProvenance,
-    CloudRuntimeWarning, CloudTrackingState, fetch_runtime_context,
+    CloudError, CloudNeverCalledSource, CloudRequest, CloudRuntimeContext, CloudRuntimeFunction,
+    CloudRuntimeProvenance, CloudRuntimeWarning, CloudTrackingState, fetch_runtime_context,
 };
 use crate::error::emit_error;
 use crate::health::HealthOptions;
@@ -998,15 +998,22 @@ fn cloud_finding_decision(
     Option<u64>,
 ) {
     match function.tracking_state {
-        CloudTrackingState::NeverCalled => (
-            if local.static_used {
-                RuntimeCoverageVerdict::ReviewRequired
-            } else {
-                RuntimeCoverageVerdict::SafeToDelete
-            },
-            RuntimeCoverageConfidence::High,
-            Some(0),
-        ),
+        CloudTrackingState::NeverCalled => match function.never_called_source {
+            CloudNeverCalledSource::RuntimeObserved => (
+                if local.static_used {
+                    RuntimeCoverageVerdict::ReviewRequired
+                } else {
+                    RuntimeCoverageVerdict::SafeToDelete
+                },
+                RuntimeCoverageConfidence::High,
+                Some(0),
+            ),
+            CloudNeverCalledSource::InventoryBackfill | CloudNeverCalledSource::Unknown => (
+                RuntimeCoverageVerdict::ReviewRequired,
+                RuntimeCoverageConfidence::Low,
+                Some(0),
+            ),
+        },
         CloudTrackingState::Untracked => (
             RuntimeCoverageVerdict::CoverageUnavailable,
             RuntimeCoverageConfidence::None,
@@ -1799,7 +1806,9 @@ mod tests {
         let mut unused = used.clone();
         unused.static_used = false;
 
-        let never_called = cloud_function("src/api.ts", "handler", Some(10), Some(10), Some(20));
+        let mut never_called =
+            cloud_function("src/api.ts", "handler", Some(10), Some(10), Some(20));
+        never_called.never_called_source = CloudNeverCalledSource::RuntimeObserved;
         assert_eq!(
             cloud_finding_decision(&never_called, &used),
             (
@@ -1813,6 +1822,28 @@ mod tests {
             (
                 RuntimeCoverageVerdict::SafeToDelete,
                 RuntimeCoverageConfidence::High,
+                Some(0)
+            )
+        );
+
+        let mut inventory_backfill = never_called.clone();
+        inventory_backfill.never_called_source = CloudNeverCalledSource::InventoryBackfill;
+        assert_eq!(
+            cloud_finding_decision(&inventory_backfill, &unused),
+            (
+                RuntimeCoverageVerdict::ReviewRequired,
+                RuntimeCoverageConfidence::Low,
+                Some(0)
+            )
+        );
+
+        let mut legacy = never_called.clone();
+        legacy.never_called_source = CloudNeverCalledSource::Unknown;
+        assert_eq!(
+            cloud_finding_decision(&legacy, &unused),
+            (
+                RuntimeCoverageVerdict::ReviewRequired,
+                RuntimeCoverageConfidence::Low,
                 Some(0)
             )
         );
@@ -2225,6 +2256,7 @@ mod tests {
             end_line,
             hit_count: Some(0),
             tracking_state: CloudTrackingState::NeverCalled,
+            never_called_source: CloudNeverCalledSource::Unknown,
             deployments_observed: 1,
             untracked_reason: None,
         }

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -1660,6 +1660,7 @@ mod tests {
         snapshot.summary.coverage_percent = 0.0;
         snapshot.summary.last_received_at = Some("2026-04-30T10:00:00.000Z".to_owned());
         let mut matched = cloud_function("src/a.ts", "oldFlow", Some(10), Some(10), Some(20));
+        matched.never_called_source = CloudNeverCalledSource::RuntimeObserved;
         matched.deployments_observed = 2;
         let mut unmatched =
             cloud_function("src/missing.ts", "missingInAst", Some(1), Some(1), Some(3));

--- a/crates/cli/src/coverage/cloud_client.rs
+++ b/crates/cli/src/coverage/cloud_client.rs
@@ -177,6 +177,7 @@ pub enum CloudNeverCalledSource {
     RuntimeObserved,
     InventoryBackfill,
     #[default]
+    #[serde(other)]
     Unknown,
 }
 
@@ -584,6 +585,12 @@ mod tests {
         )
         .expect("legacy cloud responses must remain deserializable");
         assert_eq!(legacy.never_called_source, CloudNeverCalledSource::Unknown);
+
+        let future: CloudRuntimeFunction = serde_json::from_str(
+            r#"{"file_path":"src/a.ts","function_name":"a","tracking_state":"never_called","never_called_source":"future_source"}"#,
+        )
+        .expect("future provenance values must remain deserializable");
+        assert_eq!(future.never_called_source, CloudNeverCalledSource::Unknown);
     }
 
     #[test]

--- a/crates/cli/src/coverage/cloud_client.rs
+++ b/crates/cli/src/coverage/cloud_client.rs
@@ -171,6 +171,15 @@ pub struct CloudRuntimeSummary {
     pub last_received_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudNeverCalledSource {
+    RuntimeObserved,
+    InventoryBackfill,
+    #[default]
+    Unknown,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct CloudRuntimeFunction {
     pub file_path: String,
@@ -192,6 +201,8 @@ pub struct CloudRuntimeFunction {
     pub hit_count: Option<u64>,
     #[serde(default)]
     pub tracking_state: CloudTrackingState,
+    #[serde(default)]
+    pub never_called_source: CloudNeverCalledSource,
     #[serde(default)]
     pub deployments_observed: u32,
     #[serde(default)]
@@ -546,6 +557,33 @@ mod tests {
         .expect("absent importance metrics must deserialize");
         assert_eq!(absent.cyclomatic, None);
         assert_eq!(absent.owner_count, None);
+    }
+
+    #[test]
+    fn runtime_function_preserves_never_called_source_conservatively() {
+        let runtime_observed: CloudRuntimeFunction = serde_json::from_str(
+            r#"{"file_path":"src/a.ts","function_name":"a","tracking_state":"never_called","never_called_source":"runtime_observed"}"#,
+        )
+        .expect("runtime-observed provenance must deserialize");
+        assert_eq!(
+            runtime_observed.never_called_source,
+            CloudNeverCalledSource::RuntimeObserved
+        );
+
+        let inventory_backfill: CloudRuntimeFunction = serde_json::from_str(
+            r#"{"file_path":"src/a.ts","function_name":"a","tracking_state":"never_called","never_called_source":"inventory_backfill"}"#,
+        )
+        .expect("inventory-backfill provenance must deserialize");
+        assert_eq!(
+            inventory_backfill.never_called_source,
+            CloudNeverCalledSource::InventoryBackfill
+        );
+
+        let legacy: CloudRuntimeFunction = serde_json::from_str(
+            r#"{"file_path":"src/a.ts","function_name":"a","tracking_state":"never_called"}"#,
+        )
+        .expect("legacy cloud responses must remain deserializable");
+        assert_eq!(legacy.never_called_source, CloudNeverCalledSource::Unknown);
     }
 
     #[test]

--- a/crates/cli/tests/coverage_analyze_tests.rs
+++ b/crates/cli/tests/coverage_analyze_tests.rs
@@ -60,6 +60,7 @@ fn cloud_body() -> &'static str {
           "end_line": 3,
           "hit_count": 0,
           "tracking_state": "never_called",
+          "never_called_source": "runtime_observed",
           "deployments_observed": 2
         }],
         "warnings": []
@@ -119,6 +120,11 @@ fn coverage_analyze_cloud_fetches_percent_encoded_runtime_context() {
         Some("tracked")
     );
     assert_eq!(
+        json.pointer("/runtime_coverage/findings/0/confidence")
+            .and_then(serde_json::Value::as_str),
+        Some("high")
+    );
+    assert_eq!(
         json.pointer("/runtime_coverage/summary/data_source")
             .and_then(serde_json::Value::as_str),
         Some("cloud")
@@ -146,6 +152,86 @@ fn coverage_analyze_cloud_fetches_percent_encoded_runtime_context() {
     assert!(
         !lower.contains("accept-encoding: gzip"),
         "request must not advertise gzip without ureq's gzip feature: {request}"
+    );
+}
+
+#[test]
+fn coverage_analyze_cloud_keeps_inventory_backfill_candidates_conservative() {
+    let body = r#"{
+      "data": {
+        "repo": "acme/web",
+        "window": { "period_days": 30 },
+        "summary": {
+          "trace_count": 100,
+          "deployments_seen": 2,
+          "functions_tracked": 1,
+          "functions_hit": 0,
+          "functions_unhit": 1,
+          "functions_untracked": 0,
+          "coverage_percent": 0
+        },
+        "functions": [{
+          "file_path": "src/covered.ts",
+          "function_name": "indirectlyCovered",
+          "line_number": 5,
+          "start_line": 5,
+          "end_line": 7,
+          "hit_count": 0,
+          "tracking_state": "never_called",
+          "never_called_source": "inventory_backfill",
+          "deployments_observed": 2
+        }],
+        "warnings": []
+      }
+    }"#;
+    let (endpoint, _request, handle) = serve_once(body);
+    let output = std::process::Command::new(fallow_bin())
+        .args([
+            "coverage",
+            "analyze",
+            "--cloud",
+            "--repo",
+            "acme/web",
+            "--api-endpoint",
+            &endpoint,
+            "--format",
+            "json",
+            "--root",
+        ])
+        .arg(fixture_path("coverage-gaps"))
+        .env("NO_COLOR", "1")
+        .env("RUST_LOG", "")
+        .env("FALLOW_API_KEY", "fallow_live_test")
+        .env_remove("FALLOW_RUNTIME_COVERAGE_SOURCE")
+        .output()
+        .expect("run fallow");
+    handle.join().expect("server joins");
+    let command_output = common::CommandOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        code: output.status.code().unwrap_or(-1),
+    };
+    assert_eq!(command_output.code, 0, "stderr={}", command_output.stderr);
+    let json = parse_json(&command_output);
+    assert_eq!(
+        json.pointer("/runtime_coverage/findings/0/function")
+            .and_then(serde_json::Value::as_str),
+        Some("indirectlyCovered")
+    );
+    assert_eq!(
+        json.pointer("/runtime_coverage/findings/0/verdict")
+            .and_then(serde_json::Value::as_str),
+        Some("review_required")
+    );
+    assert_eq!(
+        json.pointer("/runtime_coverage/findings/0/confidence")
+            .and_then(serde_json::Value::as_str),
+        Some("low")
+    );
+    assert_eq!(
+        json.pointer("/runtime_coverage/findings/0/actions/0/type")
+            .and_then(serde_json::Value::as_str),
+        Some("review-runtime")
     );
 }
 


### PR DESCRIPTION
## Summary

- preserve Cloud never-called provenance in the CLI
- avoid deletion advice when evidence only comes from inventory backfill
- keep older Cloud responses conservative

## Verification

- [x] focused deserialization, decision, and CLI regression tests
- [x] full workspace tests
- [x] check, strict Clippy, formatting, typos, and documentation gates
- [x] real-project smoke against the fallow-cloud checkout
- [x] native review

Inventory-backfilled and unknown never-called evidence now produces
`review_required` with low confidence. Only runtime-observed evidence can
produce the existing high-confidence deletion recommendation.
