### PR TITLE
fix: validate Impact statusline flags

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2696,6 +2696,7 @@ fn is_impact_statusline(cli: &Cli) -> bool {
         cli.command.as_ref(),
         Some(Command::Impact {
             subcommand: Some(ImpactCli::Statusline),
+            all: false,
             ..
         })
     )
@@ -5149,6 +5150,10 @@ mod tests {
 
         let status = Cli::try_parse_from(["fallow", "impact", "status"]).expect("argv parses");
         assert!(!is_impact_statusline(&status));
+
+        let all_statusline =
+            Cli::try_parse_from(["fallow", "impact", "--all", "statusline"]).expect("argv parses");
+        assert!(!is_impact_statusline(&all_statusline));
     }
 
     #[test]

--- a/crates/cli/tests/telemetry_tests.rs
+++ b/crates/cli/tests/telemetry_tests.rs
@@ -161,6 +161,29 @@ fn impact_statusline_bypasses_telemetry_inspect_output() {
 }
 
 #[test]
+fn impact_statusline_rejects_cross_repo_flag() {
+    let home = tempfile::tempdir().expect("temp home");
+    let root = tempfile::tempdir().expect("temp project");
+    let output = Command::new(fallow_bin())
+        .env("FALLOW_TELEMETRY", "inspect")
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("APPDATA", home.path().join("AppData"))
+        .env("RUST_LOG", "")
+        .env("NO_COLOR", "1")
+        .args(["--root", &root.path().to_string_lossy()])
+        .args(["impact", "--all", "statusline"])
+        .output()
+        .expect("failed to run fallow binary");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("cannot be combined with a subcommand")
+    );
+}
+
+#[test]
 fn telemetry_inspect_reports_safe_followup_fields() {
     let mut cmd = Command::new(fallow_bin());
     let home = tempfile::tempdir().expect("temp home");


### PR DESCRIPTION
Fix `fallow impact --all statusline` so it follows the existing cross-repository argument validation instead of taking the epilogue-free statusline fast path.

Adds parser-level and CLI regression coverage for the invalid combination. The valid statusline remains a single path-free line with empty stderr.

Validation:
- `npm run verify:full`
- isolated valid and invalid CLI smoke tests
- real-project statusline smoke test