### PR TITLE
fix(graph): preserve ignored TypeScript aliases

### DIFF
--- a/crates/core/tests/integration_test/common.rs
+++ b/crates/core/tests/integration_test/common.rs
@@ -56,6 +56,21 @@ pub fn create_config(root: PathBuf) -> fallow_config::ResolvedConfig {
     .resolve(root, OutputFormat::Human, 4, true, true, None)
 }
 
+/// A config with `ignorePatterns` set, resolved through the same path a user's
+/// `fallow.toml` takes. Building the `GlobSet` this way keeps the default ignore
+/// set (`node_modules`, build output) that overwriting `ResolvedConfig::ignore_patterns`
+/// after the fact would discard. Everything else defaults.
+pub fn create_config_with_ignore_patterns(
+    root: PathBuf,
+    ignore_patterns: &[&str],
+) -> fallow_config::ResolvedConfig {
+    FallowConfig {
+        ignore_patterns: ignore_patterns.iter().map(|p| (*p).to_string()).collect(),
+        ..Default::default()
+    }
+    .resolve(root, OutputFormat::Human, 4, true, true, None)
+}
+
 /// A config with `unusedComponentProps.ignorePattern` set, used to exercise the
 /// opt-in prop-exemption knob. Everything else defaults.
 pub fn create_config_with_unused_props_ignore(

--- a/crates/core/tests/integration_test/issue_1911_unlisted_alias.rs
+++ b/crates/core/tests/integration_test/issue_1911_unlisted_alias.rs
@@ -114,3 +114,49 @@ fn issue_1911_nested_paths_alias_activates_in_production_without_typescript_depe
 
     assert_alias_resolution(&results);
 }
+
+#[test]
+fn issue_1942_ignored_paths_alias_not_reported_as_unlisted_dependency() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    write(
+        &root.join("package.json"),
+        r#"{ "name": "fallow-ignored-alias-repro", "private": true }"#,
+    );
+    write(
+        &root.join("tsconfig.json"),
+        r#"{
+            "compilerOptions": {
+                "paths": { "@synthetic/*": ["./sparta/*"] }
+            },
+            "include": ["src/**/*.ts", "sparta/**/*.ts"]
+        }"#,
+    );
+    write(
+        &root.join("src/entry.ts"),
+        r#"import { localValue } from "@synthetic/api/local-module";
+           console.log(localValue);"#,
+    );
+    write(
+        &root.join("sparta/api/local-module.ts"),
+        r#"export const localValue = "resolved inside the workspace";"#,
+    );
+
+    let mut config = create_config(root.to_path_buf());
+    config.ignore_patterns = globset::GlobSetBuilder::new()
+        .add(globset::Glob::new("sparta/api/local-module.ts").expect("valid ignore glob"))
+        .build()
+        .expect("build ignore glob set");
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.unlisted_dependencies.is_empty(),
+        "ignored local alias target should not be an unlisted dependency: {:?}",
+        results.unlisted_dependencies
+    );
+    assert!(
+        results.unresolved_imports.is_empty(),
+        "ignored local alias target should still resolve: {:?}",
+        results.unresolved_imports
+    );
+}

--- a/crates/core/tests/integration_test/issue_1911_unlisted_alias.rs
+++ b/crates/core/tests/integration_test/issue_1911_unlisted_alias.rs
@@ -8,10 +8,17 @@
 //! `tsconfig.json` / `tsconfig.*.json` config file, so its `compilerOptions.paths`
 //! are registered project-wide, the valid alias imports resolve internally, and
 //! only a genuinely-broken alias target surfaces as `unresolved-import`.
+//!
+//! Also covers issue #1942, the same misreport reached from the other side: the
+//! alias target exists but `ignorePatterns` kept it out of the file index, so
+//! the bare-looking specifier fell through to npm-package classification. The
+//! resolver now keeps the concrete target for alias matches that land inside the
+//! analyzed root, while targets outside it stay npm packages so workspace
+//! install symlinks keep their dependency credit (#1008).
 
 use std::path::Path;
 
-use super::common::create_config;
+use super::common::{create_config, create_config_with_ignore_patterns};
 
 fn write(path: &Path, contents: &str) {
     if let Some(parent) = path.parent() {
@@ -132,31 +139,115 @@ fn issue_1942_ignored_paths_alias_not_reported_as_unlisted_dependency() {
             "include": ["src/**/*.ts", "sparta/**/*.ts"]
         }"#,
     );
+    // The second import is the positive control: a specifier that matches no
+    // alias and is installed nowhere must still be reported, so a regression
+    // that suppresses every unlisted dependency cannot make this test pass.
     write(
         &root.join("src/entry.ts"),
         r#"import { localValue } from "@synthetic/api/local-module";
-           console.log(localValue);"#,
+           import { helper } from "definitely-not-installed";
+           console.log(localValue, helper);"#,
     );
     write(
         &root.join("sparta/api/local-module.ts"),
         r#"export const localValue = "resolved inside the workspace";"#,
     );
 
-    let mut config = create_config(root.to_path_buf());
-    config.ignore_patterns = globset::GlobSetBuilder::new()
-        .add(globset::Glob::new("sparta/api/local-module.ts").expect("valid ignore glob"))
-        .build()
-        .expect("build ignore glob set");
+    let config =
+        create_config_with_ignore_patterns(root.to_path_buf(), &["sparta/api/local-module.ts"]);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
 
+    let unlisted: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
     assert!(
-        results.unlisted_dependencies.is_empty(),
-        "ignored local alias target should not be an unlisted dependency: {:?}",
-        results.unlisted_dependencies
+        !unlisted.contains(&"@synthetic/api"),
+        "ignored local alias target should not be an unlisted dependency, got {unlisted:?}"
     );
     assert!(
-        results.unresolved_imports.is_empty(),
-        "ignored local alias target should still resolve: {:?}",
-        results.unresolved_imports
+        unlisted.contains(&"definitely-not-installed"),
+        "a genuinely unlisted dependency must still be reported, got {unlisted:?}"
+    );
+
+    let unresolved: Vec<&str> = results
+        .unresolved_imports
+        .iter()
+        .map(|finding| finding.import.specifier.as_str())
+        .collect();
+    assert!(
+        !unresolved.contains(&"@synthetic/api/local-module"),
+        "ignored local alias target should still resolve, got {unresolved:?}"
+    );
+}
+
+/// The alias guard added for #1942 must not swallow npm-package accounting for
+/// a workspace dependency whose install symlink resolves outside the analyzed
+/// root, which is the case `package_usage_name_for_external_bare_specifier`
+/// exists to serve (#1008). The specifier shape alone is ambiguous: `@acme/ui`
+/// pattern-matches the `@acme/*` alias key, so only the resolved target's
+/// location distinguishes the two.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_1942_guard_still_credits_workspace_package_resolved_outside_root() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let repo = dir.path();
+    let app = repo.join("apps/web");
+
+    write(
+        &repo.join("packages/ui/package.json"),
+        r#"{ "name": "@acme/ui", "version": "1.0.0", "main": "src/index.ts" }"#,
+    );
+    write(
+        &repo.join("packages/ui/src/index.ts"),
+        r#"export const Button = "button";"#,
+    );
+
+    write(
+        &app.join("package.json"),
+        r#"{
+            "name": "web",
+            "private": true,
+            "dependencies": { "@acme/ui": "workspace:*" }
+        }"#,
+    );
+    // A `paths` key whose prefix matches the workspace scope, which is what makes
+    // the specifier indistinguishable from an aliased project file by shape.
+    write(
+        &app.join("tsconfig.json"),
+        r#"{
+            "compilerOptions": { "paths": { "@acme/*": ["../../packages/*/src"] } },
+            "include": ["src/**/*.ts"]
+        }"#,
+    );
+    write(
+        &app.join("src/main.ts"),
+        r#"import { Button } from "@acme/ui";
+           console.log(Button);"#,
+    );
+
+    let link = app.join("node_modules/@acme/ui");
+    std::fs::create_dir_all(link.parent().expect("link parent")).expect("create node_modules dir");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(repo.join("packages/ui"), &link).expect("symlink workspace package");
+    #[cfg(windows)]
+    if std::os::windows::fs::symlink_dir(repo.join("packages/ui"), &link).is_err() {
+        // Windows needs developer mode or elevation for symlinks; without the
+        // link there is nothing to regress, so skip rather than fail spuriously.
+        return;
+    }
+
+    let config = create_config(app);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unused.contains(&"@acme/ui"),
+        "imported workspace package must stay credited as used, got {unused:?}"
     );
 }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -24,7 +24,13 @@ pub use store::GraphCacheStore;
 /// graph types that derive serde for the cache, the manifest types, or the
 /// store envelope) changes, so a stale `graph-cache.bin` written by an older
 /// binary is rejected rather than deserialized into the wrong shape.
-pub const GRAPH_CACHE_VERSION: u32 = 3;
+///
+/// Bump it for import-resolution semantics changes too, not only for wire-shape
+/// changes. The manifest compares this constant, the cache mode, and per-file
+/// fingerprints, and carries no binary version, so a cache written before a
+/// classification change replays the old classification verbatim on an
+/// unmodified tree and silently hides the new behaviour.
+pub const GRAPH_CACHE_VERSION: u32 = 4;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -1152,10 +1152,38 @@ fn resolve_style_canonical_path(
     {
         return ResolveResult::NpmPackage(pkg_name);
     }
+    if is_inside_project_root(ctx, &canonical)
+        && matches_nearest_tsconfig_path_alias(ctx, from_file, specifier)
+    {
+        return ResolveResult::ExternalFile(canonical);
+    }
     if let Some(pkg_name) = package_usage_name_for_external_bare_specifier(specifier) {
         return ResolveResult::NpmPackage(pkg_name);
     }
     ResolveResult::ExternalFile(canonical)
+}
+
+/// Whether `path` lives under the analyzed project root.
+///
+/// Containment is tested against both the configured root and its canonicalized
+/// form: the resolver returns realpaths (`ResolveOptions::symlinks` defaults to
+/// true) while the configured root may itself be reached through a symlink, as
+/// it is under `/tmp` on macOS.
+///
+/// This separates the two cases that reach the bare-specifier classification
+/// tail with no `node_modules` segment in the resolved path. A path-alias target
+/// inside the root is a project file the alias points at, which stays a concrete
+/// `ExternalFile` when `ignorePatterns` kept it out of the file index. A target
+/// outside the root is a workspace package reached through its install symlink,
+/// which must keep npm-package accounting so the declared dependency is credited
+/// (see `package_usage_name_for_external_bare_specifier`).
+fn is_inside_project_root(ctx: &ResolveContext<'_>, path: &Path) -> bool {
+    if path.starts_with(ctx.root) {
+        return true;
+    }
+    ctx.canonicalize_cache
+        .get(ctx.root)
+        .is_some_and(|canonical_root| path.starts_with(canonical_root))
 }
 
 /// Package-usage key for an import that resolved into `node_modules`.
@@ -1285,7 +1313,9 @@ impl ResolvedPathContext<'_, '_> {
         // A resolved path alias target can be absent from the project file index when
         // ignorePatterns excluded it. Keep the concrete target instead of reclassifying
         // the alias's bare-looking specifier as an npm package.
-        if matches_nearest_tsconfig_path_alias(self.ctx, self.from_file, self.specifier) {
+        if is_inside_project_root(self.ctx, path)
+            && matches_nearest_tsconfig_path_alias(self.ctx, self.from_file, self.specifier)
+        {
             return Some(ResolveResult::ExternalFile(path.to_path_buf()));
         }
 

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -1282,6 +1282,13 @@ impl ResolvedPathContext<'_, '_> {
             return Some(self.package_result_or_preserved_file(pkg_name, path));
         }
 
+        // A resolved path alias target can be absent from the project file index when
+        // ignorePatterns excluded it. Keep the concrete target instead of reclassifying
+        // the alias's bare-looking specifier as an npm package.
+        if matches_nearest_tsconfig_path_alias(self.ctx, self.from_file, self.specifier) {
+            return Some(ResolveResult::ExternalFile(path.to_path_buf()));
+        }
+
         package_usage_name_for_external_bare_specifier(self.specifier)
             .map(ResolveResult::NpmPackage)
     }


### PR DESCRIPTION
## What

Preserve resolved TypeScript path-alias targets as external files when `ignorePatterns` excludes them from discovery.

## Why

Without this guard, the resolved local alias falls through to bare-package classification and is reported as an unlisted dependency.

Fixes #1942

## Test plan

- `cargo test -p fallow-core --test integration_test issue_1942_ignored_paths_alias_not_reported_as_unlisted_dependency`
- `cargo test -p fallow-graph`
- `cargo test -p fallow-core --test integration_test -- --skip caching::warm_metadata_cache_reports_source_that_becomes_unreadable` (956 passed; the skipped permission test is root-incompatible)
- `npm run verify:fast`
- Issue reproduction smoke: zero unresolved imports and zero unlisted dependencies
