### PR TITLE
fix(vscode): update brace expansion

### DIFF
--- a/editors/vscode/pnpm-lock.yaml
+++ b/editors/vscode/pnpm-lock.yaml
@@ -839,8 +839,8 @@ packages:
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3042,7 +3042,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3750,7 +3750,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:


### PR DESCRIPTION
Updates the locked VS Code extension dependency graph from brace-expansion 5.0.7 to the patched 5.0.8 release for GHSA-mh99-v99m-4gvg. The existing minimatch range accepts the patch, so no package range, override, or compatibility layer is added.\n\nVerification: frozen install, production audit, generated contracts, TypeScript lint, 648 unit tests, extension build and packaging, and npm run verify:fast.