### PR TITLE
fix: resolve two unused-dependency false positives

### DIFF
--- a/crates/core/src/plugins/config_parser.rs
+++ b/crates/core/src/plugins/config_parser.rs
@@ -1146,13 +1146,20 @@ fn extract_object_from_expression<'a>(
             for arg in &call.arguments {
                 match arg {
                     Argument::ObjectExpression(obj) => return Some(obj),
+                    // Both arrow forms reach here: the concise
+                    // `defineConfig(() => ({ ... }))` and the block body
+                    // `defineConfig(({ mode }) => { ...; return { ... }; })`.
+                    // The block form is the common shape for configs that
+                    // branch on the mode, and handling only the concise one
+                    // made every such config invisible to extraction.
                     Argument::ArrowFunctionExpression(arrow) => {
-                        if arrow.expression
-                            && !arrow.body.statements.is_empty()
-                            && let Statement::ExpressionStatement(expr_stmt) =
-                                &arrow.body.statements[0]
-                        {
-                            return extract_object_from_expression(&expr_stmt.expression);
+                        if let Some(obj) = extract_object_from_arrow_function(arrow) {
+                            return Some(obj);
+                        }
+                    }
+                    Argument::FunctionExpression(func) => {
+                        if let Some(obj) = extract_object_from_function(func) {
+                            return Some(obj);
                         }
                     }
                     _ => {}
@@ -3186,6 +3193,48 @@ mod tests {
         "#;
         let include = extract_config_string_array(source, &ts_path(), &["test", "include"]);
         assert_eq!(include, vec!["**/*.test.ts"]);
+    }
+
+    /// A block-bodied callback is the common shape for configs that branch on
+    /// the build mode. Only the concise arrow used to be traversed, so every
+    /// such config extracted nothing at all (issue #2005).
+    #[test]
+    fn extract_define_config_block_body_arrow_function() {
+        let source = r#"
+            import { defineConfig } from 'vite';
+            export default defineConfig(({ mode }) => {
+                const isProduction = mode === 'production';
+                return {
+                    test: {
+                        environment: "jsdom",
+                        setupFiles: "./tests/setup.ts"
+                    },
+                    base: isProduction ? '/app/' : '/'
+                };
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
+        );
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "setupFiles"]).as_deref(),
+            Some("./tests/setup.ts")
+        );
+    }
+
+    #[test]
+    fn extract_define_config_function_expression() {
+        let source = r#"
+            import { defineConfig } from 'vite';
+            export default defineConfig(function () {
+                return { test: { environment: "happy-dom" } };
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("happy-dom")
+        );
     }
 
     #[test]

--- a/crates/core/src/plugins/jest.rs
+++ b/crates/core/src/plugins/jest.rs
@@ -286,7 +286,9 @@ fn credit_inline_project_runner_fields(
     }
 
     for value in read("testEnvironment") {
-        if !matches!(value.as_str(), "node" | "jsdom") {
+        if matches!(value.as_str(), "node" | "jsdom") {
+            super::credit_environment_optional_peers(&value, result);
+        } else {
             result
                 .referenced_dependencies
                 .push(crate::resolve::extract_package_name(&value));
@@ -578,12 +580,15 @@ fn extract_jest_scalar_dependencies(
 ) {
     if let Some(env) =
         config_parser::extract_config_string(parse_source, parse_path, &["testEnvironment"])
-        && !matches!(env.as_str(), "node" | "jsdom")
     {
-        result
-            .referenced_dependencies
-            .push(format!("jest-environment-{env}"));
-        result.referenced_dependencies.push(env);
+        if matches!(env.as_str(), "node" | "jsdom") {
+            super::credit_environment_optional_peers(&env, result);
+        } else {
+            result
+                .referenced_dependencies
+                .push(format!("jest-environment-{env}"));
+            result.referenced_dependencies.push(env);
+        }
     }
 
     if let Some(resolver) =

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -1155,6 +1155,23 @@ fn add_import_referenced_dependencies(result: &mut PluginResult, source: &str, c
     }
 }
 
+/// Credit the optional peer dependencies a test environment loads at runtime.
+///
+/// `jsdom` declares `canvas` as an optional peer and requires it lazily when it
+/// is installed, so a project that installs `canvas` to give jsdom real canvas
+/// support has no import of it anywhere in its own source. Without this credit
+/// the dependency is reported as unused and removing it silently breaks every
+/// canvas-backed test (issue #2005).
+///
+/// `happy-dom` ships its own canvas stub and takes no such peer, so it gets no
+/// credit here. Only names already declared in the manifest can be credited, so
+/// this never invents an unlisted dependency.
+fn credit_environment_optional_peers(environment: &str, result: &mut PluginResult) {
+    if environment == "jsdom" {
+        result.referenced_dependencies.push("canvas".to_string());
+    }
+}
+
 mod adonis;
 mod angular;
 mod astro;

--- a/crates/core/src/plugins/vitest.rs
+++ b/crates/core/src/plugins/vitest.rs
@@ -24,6 +24,10 @@ const ENTRY_PATTERNS: &[&str] = &[
 const CONFIG_PATTERNS: &[&str] = &[
     "**/vitest.config.{ts,js,mts,mjs}",
     "vitest.workspace.{ts,js}",
+    // A vite config carrying a `test` block IS the vitest config for that
+    // project; vitest reads it directly. Every extraction below is keyed under
+    // `test`, so a vite config without one contributes nothing.
+    "**/vite.config.{ts,js,mts,mjs}",
 ];
 
 const ALWAYS_USED: &[&str] = &[
@@ -228,14 +232,24 @@ fn add_vitest_setup_files(
 }
 
 fn add_vitest_environment_dependency(result: &mut PluginResult, source: &str, config_path: &Path) {
-    if let Some(env) =
+    let Some(env) =
         config_parser::extract_config_string(source, config_path, &["test", "environment"])
-        && !matches!(env.as_str(), "node" | "jsdom" | "happy-dom")
-    {
-        result
-            .referenced_dependencies
-            .push(format!("vitest-environment-{env}"));
-        result.referenced_dependencies.push(env);
+    else {
+        return;
+    };
+
+    match env.as_str() {
+        "node" => {}
+        "jsdom" | "happy-dom" => {
+            result.referenced_dependencies.push(env.clone());
+            super::credit_environment_optional_peers(&env, result);
+        }
+        _ => {
+            result
+                .referenced_dependencies
+                .push(format!("vitest-environment-{env}"));
+            result.referenced_dependencies.push(env);
+        }
     }
 }
 

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -156,6 +156,9 @@ pub struct ScriptCommand {
     pub config_args: Vec<String>,
     /// File path arguments (positional args that look like file paths).
     pub file_args: Vec<String>,
+    /// Packages this command names through a flag value rather than by
+    /// importing them or invoking them as the binary.
+    pub flag_packages: Vec<String>,
 }
 
 /// Filter scripts to only production-relevant ones (start, build, and their pre/post hooks).
@@ -373,6 +376,7 @@ fn accumulate_parsed_commands(
             }
         }
 
+        result.used_packages.extend(cmd.flag_packages);
         result.config_files.extend(cmd.config_args);
         result.entry_files.extend(cmd.file_args);
     }
@@ -542,17 +546,74 @@ fn parse_command_segment(
             binary,
             config_args: Vec::new(),
             file_args: Vec::new(),
+            flag_packages: Vec::new(),
         });
     }
 
     let is_node_runner = NODE_RUNNERS.contains(&binary.as_str());
     let (file_args, config_args) = extract_args_for_binary(&tokens, idx + 1, is_node_runner);
+    let flag_packages = flag_referenced_packages(&binary, &tokens[idx + 1..]);
 
     Some(ScriptCommand {
         binary,
         config_args,
         file_args,
+        flag_packages,
     })
+}
+
+/// Built-in eslint formatters, which ship inside eslint itself and resolve to no
+/// separate package.
+const ESLINT_BUILTIN_FORMATTERS: &[&str] = &["stylish", "json", "json-with-metadata", "html"];
+
+/// Packages a CLI names through a flag value rather than a positional argument.
+///
+/// eslint expands `--format gha` to the `eslint-formatter-gha` package using a
+/// documented shorthand, so a formatter invoked only from a CI command has no
+/// import, no config entry, and no binary invocation anywhere in the project and
+/// is reported as an unused dependency (issue #2006).
+///
+/// The synthesized name only ever exempts an already-declared dependency from
+/// the unused scan; it is not consulted by unlisted-dependency detection, so an
+/// undeclared formatter cannot turn into a new finding.
+fn flag_referenced_packages(binary: &str, args: &[&str]) -> Vec<String> {
+    if binary != "eslint" {
+        return Vec::new();
+    }
+
+    let mut packages = Vec::new();
+    let mut idx = 0;
+    while idx < args.len() {
+        let token = args[idx];
+        let value = if let Some(value) = token
+            .strip_prefix("--format=")
+            .or_else(|| token.strip_prefix("-f="))
+        {
+            idx += 1;
+            value
+        } else if matches!(token, "--format" | "-f") {
+            idx += 2;
+            let Some(value) = args.get(idx - 1) else {
+                break;
+            };
+            value
+        } else {
+            idx += 1;
+            continue;
+        };
+
+        let value = strip_surrounding_quotes(value);
+        // A path or a scoped/namespaced package is passed through as written by
+        // eslint, so only the bare shorthand expands.
+        if value.is_empty()
+            || value.contains(['/', '\\', '.'])
+            || ESLINT_BUILTIN_FORMATTERS.contains(&value)
+        {
+            continue;
+        }
+        packages.push(format!("eslint-formatter-{value}"));
+    }
+    packages
 }
 
 /// Extract a config file path from a `--config` or `-c` flag.

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -235,6 +235,8 @@ mod issue_1910_generic_inherited_property;
 mod issue_1911_unlisted_alias;
 #[path = "integration_test/issue_2005_jsdom_optional_peer_canvas.rs"]
 mod issue_2005_jsdom_optional_peer_canvas;
+#[path = "integration_test/issue_2006_cli_flag_value_dependency.rs"]
+mod issue_2006_cli_flag_value_dependency;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -233,6 +233,8 @@ mod issue_1863_interface_property_dispatch;
 mod issue_1910_generic_inherited_property;
 #[path = "integration_test/issue_1911_unlisted_alias.rs"]
 mod issue_1911_unlisted_alias;
+#[path = "integration_test/issue_2005_jsdom_optional_peer_canvas.rs"]
+mod issue_2005_jsdom_optional_peer_canvas;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_2005_jsdom_optional_peer_canvas.rs
+++ b/crates/core/tests/integration_test/issue_2005_jsdom_optional_peer_canvas.rs
@@ -1,0 +1,100 @@
+//! Regression tests for issue #2005: `canvas` reported as an unused
+//! devDependency in a vitest + jsdom project.
+//!
+//! `canvas` is an optional peer of `jsdom`, loaded lazily at runtime when it is
+//! installed, so a project that installs it to give jsdom real canvas support
+//! has no import of it anywhere in its own source. The reporter acted on the
+//! finding shape that `fallow fix` automates, which would have removed the
+//! dependency and broken every canvas-backed test.
+
+use std::path::Path;
+
+use super::common::create_config;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, contents).expect("write file");
+}
+
+/// The reporter's shape: `canvas` and an unrelated unused package are both
+/// declared, and the vitest config selects the jsdom environment.
+fn create_project(root: &Path, environment: &str) {
+    write(
+        &root.join("package.json"),
+        r#"{
+            "name": "jsdom-canvas-repro",
+            "private": true,
+            "devDependencies": {
+                "vitest": "^4.1.5",
+                "jsdom": "^29.1.1",
+                "canvas": "^3.2.3",
+                "left-pad": "^1.3.0"
+            }
+        }"#,
+    );
+    write(
+        &root.join("vite.config.ts"),
+        &format!(
+            r#"export default {{
+                test: {{ environment: "{environment}" }},
+            }};"#
+        ),
+    );
+    write(
+        &root.join("src/index.ts"),
+        r"export const render = (): string => 'ok';",
+    );
+    write(
+        &root.join("tests/render.test.ts"),
+        r#"import { render } from "../src/index";
+           it("renders", () => { render(); });"#,
+    );
+}
+
+fn unused_dev_dependencies(results: &fallow_types::results::AnalysisResults) -> Vec<&str> {
+    results
+        .unused_dev_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect()
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2005_jsdom_environment_credits_optional_canvas_peer() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    create_project(dir.path(), "jsdom");
+
+    let config = create_config(dir.path().to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused = unused_dev_dependencies(&results);
+    assert!(
+        !unused.contains(&"canvas"),
+        "canvas is an optional jsdom peer loaded at runtime, got {unused:?}"
+    );
+    assert!(
+        unused.contains(&"left-pad"),
+        "an unrelated unused devDependency must still be reported, got {unused:?}"
+    );
+}
+
+/// happy-dom ships its own canvas implementation and declares no `canvas` peer,
+/// so selecting it must not silently exempt a genuinely unused `canvas`.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2005_happy_dom_environment_does_not_credit_canvas() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    create_project(dir.path(), "happy-dom");
+
+    let config = create_config(dir.path().to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused = unused_dev_dependencies(&results);
+    assert!(
+        unused.contains(&"canvas"),
+        "happy-dom takes no canvas peer, so canvas stays unused, got {unused:?}"
+    );
+}

--- a/crates/core/tests/integration_test/issue_2006_cli_flag_value_dependency.rs
+++ b/crates/core/tests/integration_test/issue_2006_cli_flag_value_dependency.rs
@@ -1,0 +1,112 @@
+//! Regression tests for issue #2006: `eslint-formatter-gha` reported as an
+//! unused devDependency while it is used via `npx eslint --format gha` in a
+//! GitHub Actions workflow.
+//!
+//! CI `run:` commands are already scanned and their binaries credited, but flag
+//! values were discarded, so a package named only as a flag argument had no
+//! reference anywhere. eslint expands `--format gha` to `eslint-formatter-gha`
+//! through a documented shorthand.
+
+use std::path::Path;
+
+use super::common::create_config;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, contents).expect("write file");
+}
+
+fn create_project(root: &Path, run_command: &str) {
+    write(
+        &root.join("package.json"),
+        r#"{
+            "name": "eslint-formatter-repro",
+            "private": true,
+            "main": "src/index.ts",
+            "devDependencies": {
+                "eslint": "^9.0.0",
+                "eslint-formatter-gha": "^2.0.1",
+                "left-pad": "^1.3.0"
+            }
+        }"#,
+    );
+    write(&root.join("src/index.ts"), r"export const value = 1;");
+    write(
+        &root.join(".github/workflows/ci.yml"),
+        &format!(
+            r"name: CI
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: {run_command}
+"
+        ),
+    );
+}
+
+fn unused_dev_dependencies(results: &fallow_types::results::AnalysisResults) -> Vec<&str> {
+    results
+        .unused_dev_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect()
+}
+
+fn analyze(root: &Path) -> fallow_types::results::AnalysisResults {
+    let config = create_config(root.to_path_buf());
+    fallow_core::analyze(&config).expect("analysis should succeed")
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2006_eslint_formatter_flag_value_credits_the_package() {
+    for command in [
+        "npx eslint --format gha",
+        "npx eslint --format=gha",
+        "npx eslint -f gha",
+    ] {
+        let dir = tempfile::tempdir().expect("temp dir");
+        create_project(dir.path(), command);
+        let results = analyze(dir.path());
+
+        let unused = unused_dev_dependencies(&results);
+        assert!(
+            !unused.contains(&"eslint-formatter-gha"),
+            "`{command}` should credit the formatter package, got {unused:?}"
+        );
+        assert!(
+            unused.contains(&"left-pad"),
+            "an unrelated unused devDependency must still be reported for `{command}`, got {unused:?}"
+        );
+    }
+}
+
+/// Built-in formatters ship inside eslint, so they must not synthesize a package
+/// name, and a synthesized name must never become an unlisted dependency.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2006_builtin_formatter_credits_nothing_and_invents_no_dependency() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    create_project(dir.path(), "npx eslint --format stylish");
+    let results = analyze(dir.path());
+
+    let unused = unused_dev_dependencies(&results);
+    assert!(
+        unused.contains(&"eslint-formatter-gha"),
+        "a formatter that no command names stays unused, got {unused:?}"
+    );
+
+    let unlisted: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    assert!(
+        unlisted.is_empty(),
+        "flag-value credit must never create an unlisted dependency, got {unlisted:?}"
+    );
+}


### PR DESCRIPTION
Fixes two unused-dependency false positives reported by @VariableVince, both reproduced against the repository he was testing on.

## #2005 — `canvas`

Three defects stacked up here:

1. The config parser only traversed the concise arrow inside a config call, so `defineConfig(({ mode }) => { ...; return { ... }; })` extracted nothing at all. That block-bodied form is the common shape for configs that branch on the build mode, so every key under it was invisible.
2. The vitest plugin listed `vite.config.*` for activation only, never for parsing, so a `test` block living in a vite config was never read.
3. `canvas` is an optional peer of `jsdom`, required lazily when installed, so a project that installs it to give jsdom real canvas support has no import of it anywhere. It is now credited from the jsdom environment in both the vitest and jest plugins. happy-dom ships its own canvas and takes no such peer, so it gets no credit.

## #2006 — `eslint-formatter-gha`

CI `run:` commands already have their binaries credited, but argument parsing skipped every flag together with its value, so a package named only as a flag argument had no reference anywhere. eslint expands `--format gha` to `eslint-formatter-gha` through a documented shorthand; that expansion is now recorded for `--format`/`-f` in its separate, `=`-joined, and quoted forms.

Built-in formatters expand to nothing, as do values carrying a path or namespace separator. The synthesized name only exempts an already-declared dependency from the unused scan and is never consulted by unlisted-dependency detection, so it cannot create a finding for a package that is not installed.

## Measured impact

On the reporter's project, `total_issues` goes 756 to 753. Every delta is a removed false positive and nothing new is reported:

- `canvas` no longer an unused devDependency
- `eslint-formatter-gha` no longer an unused devDependency
- the setup file reached through `setupFiles` no longer an unused file, which fell out of the parser fix

## Tests

Integration coverage for both issues, each with a negative control (an unrelated unused dependency that must still be reported, happy-dom not crediting canvas, a built-in formatter crediting nothing, and no unlisted dependency invented). Parser unit tests for the block-body arrow and function-expression config forms.
