### PR TITLE
fix: close config-extraction and dependency-crediting gaps

### DIFF
--- a/crates/core/src/plugins/config_parser.rs
+++ b/crates/core/src/plugins/config_parser.rs
@@ -1091,6 +1091,11 @@ fn find_config_object<'a>(program: &'a Program) -> Option<&'a ObjectExpression<'
                     _ => decl.declaration.as_expression(),
                 };
                 if let Some(expr) = expr {
+                    if let Some(obj) =
+                        resolve_call_config_object(program, expr, MAX_CONFIG_WRAPPER_DEPTH)
+                    {
+                        return Some(obj);
+                    }
                     if let Some(obj) = extract_object_from_expression(expr) {
                         return Some(obj);
                     }
@@ -1106,6 +1111,11 @@ fn find_config_object<'a>(program: &'a Program) -> Option<&'a ObjectExpression<'
                 if let Expression::AssignmentExpression(assign) = &expr_stmt.expression
                     && is_module_exports_target(&assign.left)
                 {
+                    if let Some(obj) =
+                        resolve_call_config_object(program, &assign.right, MAX_CONFIG_WRAPPER_DEPTH)
+                    {
+                        return Some(obj);
+                    }
                     if let Some(obj) = extract_object_from_expression(&assign.right) {
                         return Some(obj);
                     }
@@ -1205,15 +1215,81 @@ fn extract_object_from_function<'a>(func: &'a Function<'a>) -> Option<&'a Object
 fn extract_object_from_function_body<'a>(
     body: &'a FunctionBody<'a>,
 ) -> Option<&'a ObjectExpression<'a>> {
-    for stmt in &body.statements {
-        if let Statement::ReturnStatement(ret) = stmt
-            && let Some(argument) = &ret.argument
-            && let Some(obj) = extract_object_from_expression(argument)
-        {
-            return Some(obj);
+    find_returned_object(&body.statements, MAX_CONFIG_BRANCH_DEPTH)
+}
+
+/// Maximum control-flow nesting searched for a config `return`.
+const MAX_CONFIG_BRANCH_DEPTH: u8 = 4;
+
+/// Find the first returned object literal in `statements`, descending into
+/// control flow.
+///
+/// A config callback routinely branches on the build mode
+/// (`if (command === "serve") { return { ... } } return { ... }`), so looking at
+/// top-level statements only means the whole config extracts nothing. Nested
+/// function and arrow bodies are deliberately not searched: their returns belong
+/// to the inner function, not to the config callback.
+///
+/// The first return in source order wins. A config whose branches declare
+/// different values therefore contributes only the first branch's.
+fn find_returned_object<'a>(
+    statements: &'a [Statement<'a>],
+    depth: u8,
+) -> Option<&'a ObjectExpression<'a>> {
+    if depth == 0 {
+        return None;
+    }
+    for stmt in statements {
+        let found = match stmt {
+            Statement::ReturnStatement(ret) => ret
+                .argument
+                .as_ref()
+                .and_then(|argument| extract_object_from_expression(argument)),
+            Statement::BlockStatement(block) => find_returned_object(&block.body, depth - 1),
+            Statement::IfStatement(if_stmt) => {
+                find_returned_object_in_statement(&if_stmt.consequent, depth - 1).or_else(|| {
+                    if_stmt
+                        .alternate
+                        .as_ref()
+                        .and_then(|alt| find_returned_object_in_statement(alt, depth - 1))
+                })
+            }
+            Statement::TryStatement(try_stmt) => {
+                find_returned_object(&try_stmt.block.body, depth - 1)
+                    .or_else(|| {
+                        try_stmt
+                            .handler
+                            .as_ref()
+                            .and_then(|handler| find_returned_object(&handler.body.body, depth - 1))
+                    })
+                    .or_else(|| {
+                        try_stmt
+                            .finalizer
+                            .as_ref()
+                            .and_then(|finalizer| find_returned_object(&finalizer.body, depth - 1))
+                    })
+            }
+            Statement::SwitchStatement(switch) => switch
+                .cases
+                .iter()
+                .find_map(|case| find_returned_object(&case.consequent, depth - 1)),
+            _ => None,
+        };
+        if found.is_some() {
+            return found;
         }
     }
     None
+}
+
+fn find_returned_object_in_statement<'a>(
+    stmt: &'a Statement<'a>,
+    depth: u8,
+) -> Option<&'a ObjectExpression<'a>> {
+    match stmt {
+        Statement::BlockStatement(block) => find_returned_object(&block.body, depth),
+        other => find_returned_object(std::slice::from_ref(other), depth),
+    }
 }
 
 /// Check if an assignment target is `module.exports`.
@@ -1271,8 +1347,8 @@ fn find_variable_init_object<'a>(
 /// `pageExtensions` / plugin config is extracted instead of silently dropped.
 ///
 /// Returns the first argument (scanning nested wrapper calls) that resolves to a
-/// local `const NAME = { ... }`. An inline object argument is already handled by
-/// [`extract_object_from_expression`], which the caller tries first.
+/// local `const NAME = { ... }`. Inline object and callback arguments are handled
+/// by [`resolve_call_config_object`], which the caller tries first.
 fn resolve_wrapped_config_object<'a>(
     program: &'a Program,
     expr: &'a Expression<'a>,
@@ -1304,6 +1380,75 @@ fn resolve_wrapped_config_object<'a>(
         }
     }
     None
+}
+
+/// Maximum wrapper nesting resolved by [`resolve_call_config_object`].
+///
+/// Covers the shapes seen in the wild (`defineConfig(mergeConfig(base, defineConfig({..})))`)
+/// while keeping a hand-written config from driving unbounded recursion.
+const MAX_CONFIG_WRAPPER_DEPTH: u8 = 3;
+
+/// Resolve the config object carried by a wrapper call, giving each argument the
+/// full resolution chain in source order.
+///
+/// Config wrappers take the config first and their own options after it, as in
+/// `withSentryConfig(nextConfig, { org, project })` or
+/// `mergeConfig(viteConfig, defineConfig({ test }))`. Scanning the whole argument
+/// list for the first object literal therefore picks up the wrapper's options
+/// object whenever the config itself arrives as an identifier or a nested call,
+/// silently reading the wrong object. Resolving argument by argument, chain-first,
+/// keeps the config's own position winning.
+fn resolve_call_config_object<'a>(
+    program: &'a Program,
+    expr: &'a Expression<'a>,
+    depth: u8,
+) -> Option<&'a ObjectExpression<'a>> {
+    if depth == 0 {
+        return None;
+    }
+    let call = match expr {
+        Expression::CallExpression(call) => call,
+        Expression::ParenthesizedExpression(paren) => {
+            return resolve_call_config_object(program, &paren.expression, depth);
+        }
+        Expression::TSSatisfiesExpression(ts_sat) => {
+            return resolve_call_config_object(program, &ts_sat.expression, depth);
+        }
+        Expression::TSAsExpression(ts_as) => {
+            return resolve_call_config_object(program, &ts_as.expression, depth);
+        }
+        _ => return None,
+    };
+
+    call.arguments
+        .iter()
+        .filter_map(oxc_ast::ast::Argument::as_expression)
+        .find_map(|arg| resolve_config_argument(program, arg, depth))
+}
+
+/// Resolve one wrapper argument to the object it stands for.
+fn resolve_config_argument<'a>(
+    program: &'a Program,
+    expr: &'a Expression<'a>,
+    depth: u8,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expr {
+        Expression::ObjectExpression(obj) => Some(obj),
+        Expression::ArrowFunctionExpression(arrow) => extract_object_from_arrow_function(arrow),
+        Expression::FunctionExpression(func) => extract_object_from_function(func),
+        Expression::ParenthesizedExpression(paren) => {
+            resolve_config_argument(program, &paren.expression, depth)
+        }
+        Expression::TSSatisfiesExpression(ts_sat) => {
+            resolve_config_argument(program, &ts_sat.expression, depth)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            resolve_config_argument(program, &ts_as.expression, depth)
+        }
+        Expression::CallExpression(_) => resolve_call_config_object(program, expr, depth - 1),
+        _ => unwrap_to_identifier_name(expr)
+            .and_then(|name| find_variable_init_object(program, name)),
+    }
 }
 
 /// Find a named property in an object expression.
@@ -3234,6 +3379,150 @@ mod tests {
         assert_eq!(
             extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
             Some("happy-dom")
+        );
+    }
+
+    /// A wrapper takes the config first and its own options after it. Scanning
+    /// the argument list for the first object literal read the options object
+    /// instead, which is the exact shape the @sentry/nextjs wizard emits.
+    #[test]
+    fn wrapper_options_object_does_not_shadow_named_config_arg() {
+        let source = r#"
+            const nextConfig = { pageExtensions: ["page.tsx"] };
+            module.exports = withSentryConfig(nextConfig, { org: "o", project: "p", silent: true });
+        "#;
+        assert_eq!(
+            extract_config_string_array(source, &js_path(), &["pageExtensions"]),
+            vec!["page.tsx"]
+        );
+    }
+
+    #[test]
+    fn wrapper_options_object_does_not_shadow_named_config_arg_esm() {
+        let source = r#"
+            const nextConfig = { pageExtensions: ["page.tsx"] };
+            export default withSentryConfig(nextConfig, { org: "o", project: "p" });
+        "#;
+        assert_eq!(
+            extract_config_string_array(source, &ts_path(), &["pageExtensions"]),
+            vec!["page.tsx"]
+        );
+    }
+
+    /// Vitest's documented way to share a Vite config with the test runner.
+    #[test]
+    fn merge_config_extracts_nested_define_config_object() {
+        let source = r#"
+            import { defineConfig, mergeConfig } from 'vitest/config';
+            import viteConfig from './vite.config';
+            export default mergeConfig(viteConfig, defineConfig({
+                test: { environment: "jsdom" }
+            }));
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
+        );
+    }
+
+    #[test]
+    fn define_config_wrapping_merge_config_extracts_object() {
+        let source = r#"
+            import { defineConfig, mergeConfig } from 'vitest/config';
+            import base from './base';
+            export default defineConfig(mergeConfig(base, { test: { environment: "jsdom" } }));
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
+        );
+    }
+
+    /// Guards against "prefer an identifier-resolved const over any object
+    /// literal", which would change which object every plain config reads.
+    #[test]
+    fn inline_object_at_argument_zero_still_wins() {
+        let source = r#"
+            const unrelated = { pageExtensions: ["wrong.tsx"] };
+            module.exports = withSentryConfig({ pageExtensions: ["right.tsx"] }, { org: "o" });
+        "#;
+        assert_eq!(
+            extract_config_string_array(source, &js_path(), &["pageExtensions"]),
+            vec!["right.tsx"]
+        );
+    }
+
+    /// Vite's documented mode-branching config shape.
+    #[test]
+    fn conditional_config_callback_extracts_branch_return() {
+        let source = r#"
+            import { defineConfig } from 'vite';
+            export default defineConfig(({ command }) => {
+                if (command === "serve") {
+                    return { test: { environment: "jsdom" } };
+                }
+                return { test: { environment: "node" } };
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
+        );
+    }
+
+    #[test]
+    fn try_block_return_is_extracted() {
+        let source = r#"
+            export default (() => {
+                try {
+                    return { test: { environment: "jsdom" } };
+                } catch (e) {
+                    return { test: { environment: "node" } };
+                }
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
+        );
+    }
+
+    #[test]
+    fn switch_case_return_is_extracted() {
+        let source = r#"
+            import { defineConfig } from 'vite';
+            export default defineConfig(({ mode }) => {
+                switch (mode) {
+                    case "test":
+                        return { test: { environment: "jsdom" } };
+                    default:
+                        return { test: { environment: "node" } };
+                }
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
+        );
+    }
+
+    /// A guard clause followed by the real return must still resolve to the
+    /// trailing return, which is what worked before branch descent existed.
+    #[test]
+    fn guard_clause_then_top_level_return_is_unchanged() {
+        let source = r#"
+            import { defineConfig } from 'vite';
+            export default defineConfig(({ mode }) => {
+                if (!mode) {
+                    return {};
+                }
+                return { test: { environment: "jsdom" } };
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            None,
+            "the first return in source order wins, even when it is a guard clause"
         );
     }
 

--- a/crates/core/src/plugins/jest.rs
+++ b/crates/core/src/plugins/jest.rs
@@ -286,9 +286,11 @@ fn credit_inline_project_runner_fields(
     }
 
     for value in read("testEnvironment") {
-        if matches!(value.as_str(), "node" | "jsdom") {
-            super::credit_environment_optional_peers(&value, result);
-        } else {
+        super::credit_environment_optional_peers(&value, result);
+        // The bare built-in names resolve inside jest and name no package; every
+        // other value, including the fully qualified `jest-environment-jsdom`,
+        // is a package the project has to declare.
+        if !matches!(value.as_str(), "node" | "jsdom") {
             result
                 .referenced_dependencies
                 .push(crate::resolve::extract_package_name(&value));
@@ -581,12 +583,15 @@ fn extract_jest_scalar_dependencies(
     if let Some(env) =
         config_parser::extract_config_string(parse_source, parse_path, &["testEnvironment"])
     {
-        if matches!(env.as_str(), "node" | "jsdom") {
-            super::credit_environment_optional_peers(&env, result);
-        } else {
-            result
-                .referenced_dependencies
-                .push(format!("jest-environment-{env}"));
+        super::credit_environment_optional_peers(&env, result);
+        // The bare built-in names resolve inside jest and name no package. Every
+        // other value is a package the project declares, and the unprefixed form
+        // additionally resolves through jest's `jest-environment-` shorthand.
+        if !matches!(env.as_str(), "node" | "jsdom") {
+            result.referenced_dependencies.push(format!(
+                "jest-environment-{}",
+                super::canonical_test_environment(&env)
+            ));
             result.referenced_dependencies.push(env);
         }
     }

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -1167,9 +1167,23 @@ fn add_import_referenced_dependencies(result: &mut PluginResult, source: &str, c
 /// credit here. Only names already declared in the manifest can be credited, so
 /// this never invents an unlisted dependency.
 fn credit_environment_optional_peers(environment: &str, result: &mut PluginResult) {
-    if environment == "jsdom" {
+    if canonical_test_environment(environment) == "jsdom" {
         result.referenced_dependencies.push("canvas".to_string());
     }
+}
+
+/// Strip the runner prefix from a test environment specifier.
+///
+/// Both runners accept the bare name and the package it resolves to, so
+/// `testEnvironment: "jest-environment-jsdom"` and `environment: "jsdom"` select
+/// the same environment. Matching the literal short name only meant the fully
+/// qualified form, which the Jest docs use and projects copy, was treated as a
+/// third-party environment and missed its optional-peer credit.
+fn canonical_test_environment(environment: &str) -> &str {
+    environment
+        .strip_prefix("jest-environment-")
+        .or_else(|| environment.strip_prefix("vitest-environment-"))
+        .unwrap_or(environment)
 }
 
 mod adonis;

--- a/crates/core/src/plugins/vitest.rs
+++ b/crates/core/src/plugins/vitest.rs
@@ -22,16 +22,16 @@ const ENTRY_PATTERNS: &[&str] = &[
 ];
 
 const CONFIG_PATTERNS: &[&str] = &[
-    "**/vitest.config.{ts,js,mts,mjs}",
-    "vitest.workspace.{ts,js}",
+    "**/vitest.config.{ts,js,mts,mjs,cts,cjs}",
+    "**/vitest.workspace.{ts,js}",
     // A vite config carrying a `test` block IS the vitest config for that
     // project; vitest reads it directly. Every extraction below is keyed under
     // `test`, so a vite config without one contributes nothing.
-    "**/vite.config.{ts,js,mts,mjs}",
+    "**/vite.config.{ts,js,mts,mjs,cts,cjs}",
 ];
 
 const ALWAYS_USED: &[&str] = &[
-    "vitest.config.{ts,js,mts,mjs}",
+    "vitest.config.{ts,js,mts,mjs,cts,cjs}",
     "vitest.setup.{ts,js}",
     "vitest.workspace.{ts,js}",
     "**/src/setupTests.{ts,tsx,js,jsx}",
@@ -78,10 +78,14 @@ const VITEST_CONFIG_FILES: &[&str] = &[
     "vitest.config.js",
     "vitest.config.mts",
     "vitest.config.mjs",
+    "vitest.config.cts",
+    "vitest.config.cjs",
     "vite.config.ts",
     "vite.config.js",
     "vite.config.mts",
     "vite.config.mjs",
+    "vite.config.cts",
+    "vite.config.cjs",
 ];
 
 impl Plugin for VitestPlugin {
@@ -122,7 +126,7 @@ impl Plugin for VitestPlugin {
 
     fn used_exports(&self) -> Vec<(&'static str, &'static [&'static str])> {
         vec![
-            ("vitest.config.{ts,js,mts,mjs}", CONFIG_EXPORTS),
+            ("vitest.config.{ts,js,mts,mjs,cts,cjs}", CONFIG_EXPORTS),
             ("vitest.workspace.{ts,js}", CONFIG_EXPORTS),
         ]
     }
@@ -243,6 +247,15 @@ fn add_vitest_environment_dependency(result: &mut PluginResult, source: &str, co
         "jsdom" | "happy-dom" => {
             result.referenced_dependencies.push(env.clone());
             super::credit_environment_optional_peers(&env, result);
+        }
+        // A built-in vitest environment backed by an optional peer. There is no
+        // `vitest-environment-edge-runtime` package, and `edge-runtime` is an
+        // unrelated CLI package, so crediting either name exempted the wrong
+        // dependency while leaving the one vitest actually loads unreported.
+        "edge-runtime" => {
+            result
+                .referenced_dependencies
+                .push("@edge-runtime/vm".to_string());
         }
         _ => {
             result
@@ -484,6 +497,31 @@ mod tests {
         let source = r#"
             export default {
                 test: {
+                    environment: "custom-env"
+                }
+            };
+        "#;
+        let result = resolve(source);
+        assert!(
+            result
+                .referenced_dependencies
+                .contains(&"vitest-environment-custom-env".to_string())
+        );
+        assert!(
+            result
+                .referenced_dependencies
+                .contains(&"custom-env".to_string())
+        );
+    }
+
+    /// `edge-runtime` is a built-in vitest environment backed by the optional
+    /// peer `@edge-runtime/vm`. Crediting the shorthand names instead exempted an
+    /// unrelated CLI package and left the real dependency reported as unused.
+    #[test]
+    fn builtin_edge_runtime_environment_credits_vm_package() {
+        let source = r#"
+            export default {
+                test: {
                     environment: "edge-runtime"
                 }
             };
@@ -492,12 +530,21 @@ mod tests {
         assert!(
             result
                 .referenced_dependencies
-                .contains(&"vitest-environment-edge-runtime".to_string())
+                .contains(&"@edge-runtime/vm".to_string()),
+            "expected @edge-runtime/vm, got {:?}",
+            result.referenced_dependencies
         );
         assert!(
-            result
+            !result
                 .referenced_dependencies
-                .contains(&"edge-runtime".to_string())
+                .contains(&"vitest-environment-edge-runtime".to_string()),
+            "no such package exists"
+        );
+        assert!(
+            !result
+                .referenced_dependencies
+                .contains(&"edge-runtime".to_string()),
+            "the bare name is an unrelated package and must not be exempted"
         );
     }
 

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -562,10 +562,6 @@ fn parse_command_segment(
     })
 }
 
-/// Built-in eslint formatters, which ship inside eslint itself and resolve to no
-/// separate package.
-const ESLINT_BUILTIN_FORMATTERS: &[&str] = &["stylish", "json", "json-with-metadata", "html"];
-
 /// Packages a CLI names through a flag value rather than a positional argument.
 ///
 /// eslint expands `--format gha` to the `eslint-formatter-gha` package using a
@@ -575,7 +571,10 @@ const ESLINT_BUILTIN_FORMATTERS: &[&str] = &["stylish", "json", "json-with-metad
 ///
 /// The synthesized name only ever exempts an already-declared dependency from
 /// the unused scan; it is not consulted by unlisted-dependency detection, so an
-/// undeclared formatter cannot turn into a new finding.
+/// undeclared formatter cannot turn into a new finding. That is also why the
+/// bundled formatter names are not filtered out: eslint resolves the npm package
+/// before falling back to its bundled one, so a declared `eslint-formatter-json`
+/// really is loaded, and an undeclared one credits nothing either way.
 fn flag_referenced_packages(binary: &str, args: &[&str]) -> Vec<String> {
     if binary != "eslint" {
         return Vec::new();
@@ -585,6 +584,10 @@ fn flag_referenced_packages(binary: &str, args: &[&str]) -> Vec<String> {
     let mut idx = 0;
     while idx < args.len() {
         let token = args[idx];
+        // Everything past `--` belongs to another program.
+        if token == "--" {
+            break;
+        }
         let value = if let Some(value) = token
             .strip_prefix("--format=")
             .or_else(|| token.strip_prefix("-f="))
@@ -602,18 +605,41 @@ fn flag_referenced_packages(binary: &str, args: &[&str]) -> Vec<String> {
             continue;
         };
 
-        let value = strip_surrounding_quotes(value);
-        // A path or a scoped/namespaced package is passed through as written by
-        // eslint, so only the bare shorthand expands.
-        if value.is_empty()
-            || value.contains(['/', '\\', '.'])
-            || ESLINT_BUILTIN_FORMATTERS.contains(&value)
-        {
-            continue;
+        if let Some(package) = eslint_formatter_package(strip_surrounding_quotes(value)) {
+            packages.push(package);
         }
-        packages.push(format!("eslint-formatter-{value}"));
     }
     packages
+}
+
+/// Resolve an eslint `--format` value to the package eslint would load.
+///
+/// Mirrors eslint's own `normalizePackageName(name, "eslint-formatter")`: a value
+/// starting with `@` is always a package, never a path, so `@scope/sarif` becomes
+/// `@scope/eslint-formatter-sarif` and an already-qualified name passes through.
+/// Only an unscoped value carrying a path separator or extension is a file path.
+fn eslint_formatter_package(value: &str) -> Option<String> {
+    if value.is_empty() || value.starts_with('-') {
+        return None;
+    }
+
+    if let Some(scoped) = value.strip_prefix('@') {
+        let mut parts = scoped.splitn(2, '/');
+        let scope = parts.next().filter(|s| !s.is_empty())?;
+        return Some(match parts.next().filter(|s| !s.is_empty()) {
+            None => format!("@{scope}/eslint-formatter"),
+            Some(name) if name.starts_with("eslint-formatter") => format!("@{scope}/{name}"),
+            Some(name) => format!("@{scope}/eslint-formatter-{name}"),
+        });
+    }
+
+    if value.contains(['/', '\\', '.']) {
+        return None;
+    }
+    if value.starts_with("eslint-formatter-") {
+        return Some(value.to_string());
+    }
+    Some(format!("eslint-formatter-{value}"))
 }
 
 /// Extract a config file path from a `--config` or `-c` flag.
@@ -744,6 +770,74 @@ mod tests {
 
     fn package_set(packages: &[&str]) -> FxHashSet<String> {
         packages.iter().map(|pkg| (*pkg).to_string()).collect()
+    }
+
+    fn formatter_packages(command: &str) -> Vec<String> {
+        let tokens: Vec<&str> = command.split_whitespace().collect();
+        flag_referenced_packages("eslint", &tokens)
+    }
+
+    #[test]
+    fn bare_formatter_shorthand_expands() {
+        assert_eq!(
+            formatter_packages("--format gha"),
+            vec!["eslint-formatter-gha"]
+        );
+        assert_eq!(formatter_packages("-f gha"), vec!["eslint-formatter-gha"]);
+        assert_eq!(
+            formatter_packages("--format=gha"),
+            vec!["eslint-formatter-gha"]
+        );
+    }
+
+    /// GitHub's own code-scanning starter workflow passes exactly this value.
+    #[test]
+    fn scoped_formatter_is_credited_verbatim() {
+        assert_eq!(
+            formatter_packages("--format @microsoft/eslint-formatter-sarif"),
+            vec!["@microsoft/eslint-formatter-sarif"]
+        );
+    }
+
+    #[test]
+    fn scoped_shorthand_formatter_expands() {
+        assert_eq!(
+            formatter_packages("--format @microsoft/sarif"),
+            vec!["@microsoft/eslint-formatter-sarif"]
+        );
+        assert_eq!(
+            formatter_packages("--format @scope"),
+            vec!["@scope/eslint-formatter"]
+        );
+    }
+
+    #[test]
+    fn already_prefixed_formatter_is_not_double_prefixed() {
+        assert_eq!(
+            formatter_packages("--format eslint-formatter-gha"),
+            vec!["eslint-formatter-gha"]
+        );
+    }
+
+    #[test]
+    fn unscoped_path_formatter_is_skipped() {
+        assert!(formatter_packages("--format ./tools/fmt.js").is_empty());
+        assert!(formatter_packages("--format node_modules/x/index.js").is_empty());
+    }
+
+    #[test]
+    fn tokens_after_double_dash_are_not_scanned() {
+        assert!(formatter_packages("--fix -- --format gha").is_empty());
+    }
+
+    #[test]
+    fn flag_value_starting_with_dash_credits_nothing() {
+        assert!(formatter_packages("--format --fix").is_empty());
+    }
+
+    #[test]
+    fn non_eslint_binary_credits_nothing() {
+        assert!(flag_referenced_packages("prettier", &["--format", "gha"]).is_empty());
     }
 
     #[test]

--- a/crates/core/tests/integration_test/issue_2005_jsdom_optional_peer_canvas.rs
+++ b/crates/core/tests/integration_test/issue_2005_jsdom_optional_peer_canvas.rs
@@ -81,6 +81,99 @@ fn issue_2005_jsdom_environment_credits_optional_canvas_peer() {
     );
 }
 
+/// A jest project selecting jsdom hits the same optional peer. Both the fully
+/// qualified package name and the bare shorthand select the same environment,
+/// and the inline `projects[]` form is a separate code path from the scalar one.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2005_jest_jsdom_environment_credits_optional_canvas_peer() {
+    for config in [
+        r#"module.exports = { testEnvironment: "jsdom" };"#,
+        r#"module.exports = { testEnvironment: "jest-environment-jsdom" };"#,
+        r#"module.exports = { projects: [{ testEnvironment: "jest-environment-jsdom" }] };"#,
+    ] {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = dir.path();
+        write(
+            &root.join("package.json"),
+            r#"{
+                "name": "jest-jsdom-canvas-repro",
+                "private": true,
+                "devDependencies": {
+                    "jest": "^29.0.0",
+                    "jest-environment-jsdom": "^29.0.0",
+                    "canvas": "^3.2.3",
+                    "left-pad": "^1.3.0"
+                }
+            }"#,
+        );
+        write(&root.join("jest.config.js"), config);
+        write(
+            &root.join("src/index.ts"),
+            r"export const render = (): string => 'ok';",
+        );
+        write(
+            &root.join("tests/render.test.ts"),
+            r#"import { render } from "../src/index";
+               it("renders", () => { render(); });"#,
+        );
+
+        let results = fallow_core::analyze(&create_config(root.to_path_buf()))
+            .expect("analysis should succeed");
+        let unused = unused_dev_dependencies(&results);
+        assert!(
+            !unused.contains(&"canvas"),
+            "`{config}` should credit the optional jsdom peer, got {unused:?}"
+        );
+        assert!(
+            !unused.contains(&"jest-environment-jsdom"),
+            "the declared environment package must stay credited for `{config}`, got {unused:?}"
+        );
+        assert!(
+            unused.contains(&"left-pad"),
+            "an unrelated unused devDependency must still be reported for `{config}`, got {unused:?}"
+        );
+    }
+}
+
+/// The node environment takes no canvas peer, so canonicalization must not have
+/// widened the built-in arm into crediting canvas everywhere.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2005_jest_node_environment_does_not_credit_canvas() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    write(
+        &root.join("package.json"),
+        r#"{
+            "name": "jest-node-canvas-repro",
+            "private": true,
+            "devDependencies": { "jest": "^29.0.0", "canvas": "^3.2.3" }
+        }"#,
+    );
+    write(
+        &root.join("jest.config.js"),
+        r#"module.exports = { testEnvironment: "node" };"#,
+    );
+    write(
+        &root.join("src/index.ts"),
+        r"export const render = (): string => 'ok';",
+    );
+    write(
+        &root.join("tests/render.test.ts"),
+        r#"import { render } from "../src/index";
+           it("renders", () => { render(); });"#,
+    );
+
+    let results =
+        fallow_core::analyze(&create_config(root.to_path_buf())).expect("analysis should succeed");
+    let unused = unused_dev_dependencies(&results);
+    assert!(
+        unused.contains(&"canvas"),
+        "the node environment takes no canvas peer, got {unused:?}"
+    );
+}
+
 /// happy-dom ships its own canvas implementation and declares no `canvas` peer,
 /// so selecting it must not silently exempt a genuinely unused `canvas`.
 #[test]

--- a/crates/core/tests/integration_test/issue_2006_cli_flag_value_dependency.rs
+++ b/crates/core/tests/integration_test/issue_2006_cli_flag_value_dependency.rs
@@ -85,11 +85,55 @@ fn issue_2006_eslint_formatter_flag_value_credits_the_package() {
     }
 }
 
-/// Built-in formatters ship inside eslint, so they must not synthesize a package
-/// name, and a synthesized name must never become an unlisted dependency.
+/// GitHub's code-scanning starter workflow passes a scoped formatter, which
+/// eslint resolves as a package rather than a path.
 #[test]
 #[cfg_attr(miri, ignore)]
-fn issue_2006_builtin_formatter_credits_nothing_and_invents_no_dependency() {
+fn issue_2006_scoped_formatter_flag_value_credits_the_package() {
+    for command in [
+        "npx eslint --format @microsoft/eslint-formatter-sarif",
+        "npx eslint --format @microsoft/sarif",
+    ] {
+        let dir = tempfile::tempdir().expect("temp dir");
+        write(
+            &dir.path().join("package.json"),
+            r#"{
+                "name": "scoped-formatter-repro",
+                "private": true,
+                "main": "src/index.ts",
+                "devDependencies": {
+                    "eslint": "^9.0.0",
+                    "@microsoft/eslint-formatter-sarif": "^3.1.0",
+                    "left-pad": "^1.3.0"
+                }
+            }"#,
+        );
+        write(&dir.path().join("src/index.ts"), r"export const value = 1;");
+        write(
+            &dir.path().join(".github/workflows/ci.yml"),
+            &format!(
+                "name: CI\non: [push]\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: {command}\n"
+            ),
+        );
+        let results = analyze(dir.path());
+
+        let unused = unused_dev_dependencies(&results);
+        assert!(
+            !unused.contains(&"@microsoft/eslint-formatter-sarif"),
+            "`{command}` should credit the scoped formatter, got {unused:?}"
+        );
+        assert!(
+            unused.contains(&"left-pad"),
+            "an unrelated unused devDependency must still be reported for `{command}`, got {unused:?}"
+        );
+    }
+}
+
+/// A formatter that no command names stays unused, and a synthesized name must
+/// never become an unlisted dependency.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2006_unnamed_formatter_stays_unused_and_invents_no_dependency() {
     let dir = tempfile::tempdir().expect("temp dir");
     create_project(dir.path(), "npx eslint --format stylish");
     let results = analyze(dir.path());

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -29,8 +29,9 @@ pub use store::GraphCacheStore;
 /// changes. The manifest compares this constant, the cache mode, and per-file
 /// fingerprints, and carries no binary version, so a cache written before a
 /// classification change replays the old classification verbatim on an
-/// unmodified tree and silently hides the new behaviour.
-pub const GRAPH_CACHE_VERSION: u32 = 4;
+/// unmodified tree and silently hides the new behaviour. The same applies to
+/// plugin config extraction, which seeds entry points and path aliases.
+pub const GRAPH_CACHE_VERSION: u32 = 5;
 
 /// Cached form of a resolved target.
 ///


### PR DESCRIPTION
Follow-up to the false-positive work that landed earlier today. A multi-agent audit of the surrounding code found several extraction gaps of the same class; each finding below was reproduced on a fixture before and after, and every behavioural change is measured against a real project.

## Config extraction

**Wrapper argument shadowing.** Wrapper calls were scanned for the first object literal at *any* argument position, so a wrapper's own options object shadowed the real config whenever the config arrived as an identifier or a nested call:

```js
const nextConfig = { pageExtensions: ["page.tsx"] };
module.exports = withSentryConfig(nextConfig, { org: "o", project: "p", silent: true });
```

That is the literal output of the `@sentry/nextjs` wizard. `pageExtensions` was invisible, so every `*.page.tsx` file was reported as unused. Each argument now gets the full resolution chain in source order, and nested calls are followed, which also fixes Vitest's documented `mergeConfig(viteConfig, defineConfig({ test }))` shape.

**Branch returns.** Config callbacks were searched for a `return` only among top-level statements, so the mode-branching shape Vite documents extracted nothing at all. The walk now descends into blocks, `if/else`, `try/catch` and `switch`. It deliberately does not enter nested function bodies, and the first return in source order wins.

**Config extensions.** Vite and Vitest both load `.cts` and `.cjs`; only the four other extensions were enumerated. `vitest.workspace` also lacked the `**/` prefix its neighbours have.

## Dependency crediting

**Jest environments.** `testEnvironment: "jest-environment-jsdom"` selects the same environment as the bare `jsdom`, but only the short form matched, so the fully qualified form the Jest docs use missed its optional-peer credit. Both jest paths are covered now, including the inline `projects[]` entry.

**`edge-runtime`.** A built-in Vitest environment backed by the optional peer `@edge-runtime/vm`. It was credited as `vitest-environment-edge-runtime`, which does not exist, plus the bare `edge-runtime`, which is an unrelated package that was therefore silently exempted. This one is a net *reduction* in crediting.

**Scoped eslint formatters.** eslint resolves `--format` through `normalizePackageName`, where a leading `@` always means a package and never a path. Rejecting every value containing a slash dropped `@microsoft/eslint-formatter-sarif`, the formatter in GitHub's own code-scanning starter workflow. Scanning now also stops at `--`, and a value that is itself a flag credits nothing.

## Measured impact

No-regression probe on a real Vite project: `total_issues` 752 before and after, with all seven genuine unused dependencies still reported. The fixes are demonstrated on dedicated fixtures instead:

| Shape | Before | After |
|---|---|---|
| `withSentryConfig(nextConfig, {...})` | `app/page.page.tsx` unused | credited; unrelated `lib/dead.ts` still reported |
| `mergeConfig(base, defineConfig({...}))` | `canvas` + `src/setup.ts` unused | credited; unrelated `left-pad` still reported |
| `defineConfig(({ mode }) => { if … return })` | `canvas` + `src/setup.ts` unused | credited; unrelated `left-pad` still reported |

## Over-crediting guards

Every change is paired with a negative case, because a fix that trades a false positive for a false negative is worse than the symptom:

- `inline_object_at_argument_zero_still_wins` pins that argument-0 priority did not become "prefer a named const over any object literal", which would change which object every plain config reads.
- `guard_clause_then_top_level_return_is_unchanged` pins the first-return-wins semantics.
- `issue_2005_jest_node_environment_does_not_credit_canvas` and the happy-dom case pin that canonicalization did not widen the built-in arm.
- `builtin_edge_runtime_environment_credits_vm_package` asserts the two previously-invented names are *not* credited.
- `unscoped_path_formatter_is_skipped`, `tokens_after_double_dash_are_not_scanned`, `flag_value_starting_with_dash_credits_nothing`.

Bumps `GRAPH_CACHE_VERSION`: plugin config extraction seeds entry points and path aliases, so a warm cache would replay the old result and hide the fix on upgrade.
