### PR TITLE
fix(plugins): let a callback's own return outrank a branch return

### DIFF
--- a/crates/core/src/plugins/config_parser.rs
+++ b/crates/core/src/plugins/config_parser.rs
@@ -1212,23 +1212,42 @@ fn extract_object_from_function<'a>(func: &'a Function<'a>) -> Option<&'a Object
         .and_then(|body| extract_object_from_function_body(body))
 }
 
+/// Resolve the object a config callback returns.
+///
+/// A return at the body's own level is the callback's main config and always
+/// wins, which keeps the overwhelmingly common `guard clause; return { ... }`
+/// shape resolving to the real config rather than to the guard's early return.
+/// Only a body with no top-level return falls back to searching branches, which
+/// is the shape Vite documents for switching config by command:
+/// `if (command === "serve") { return { ... } } else { return { ... } }`.
 fn extract_object_from_function_body<'a>(
     body: &'a FunctionBody<'a>,
 ) -> Option<&'a ObjectExpression<'a>> {
-    find_returned_object(&body.statements, MAX_CONFIG_BRANCH_DEPTH)
+    find_top_level_returned_object(&body.statements)
+        .or_else(|| find_returned_object(&body.statements, MAX_CONFIG_BRANCH_DEPTH))
 }
 
 /// Maximum control-flow nesting searched for a config `return`.
 const MAX_CONFIG_BRANCH_DEPTH: u8 = 4;
 
+/// Find the first object returned by a statement at this exact level.
+fn find_top_level_returned_object<'a>(
+    statements: &'a [Statement<'a>],
+) -> Option<&'a ObjectExpression<'a>> {
+    statements.iter().find_map(|stmt| match stmt {
+        Statement::ReturnStatement(ret) => ret
+            .argument
+            .as_ref()
+            .and_then(|argument| extract_object_from_expression(argument)),
+        _ => None,
+    })
+}
+
 /// Find the first returned object literal in `statements`, descending into
 /// control flow.
 ///
-/// A config callback routinely branches on the build mode
-/// (`if (command === "serve") { return { ... } } return { ... }`), so looking at
-/// top-level statements only means the whole config extracts nothing. Nested
-/// function and arrow bodies are deliberately not searched: their returns belong
-/// to the inner function, not to the config callback.
+/// Nested function and arrow bodies are deliberately not searched: their returns
+/// belong to the inner function, not to the config callback.
 ///
 /// The first return in source order wins. A config whose branches declare
 /// different values therefore contributes only the first branch's.
@@ -3452,7 +3471,9 @@ mod tests {
         );
     }
 
-    /// Vite's documented mode-branching config shape.
+    /// Vite's documented shape for switching config by command: every branch
+    /// returns and the callback has no return of its own, so extraction has to
+    /// descend to find anything at all.
     #[test]
     fn conditional_config_callback_extracts_branch_return() {
         let source = r#"
@@ -3460,13 +3481,15 @@ mod tests {
             export default defineConfig(({ command }) => {
                 if (command === "serve") {
                     return { test: { environment: "jsdom" } };
+                } else {
+                    return { test: { environment: "node" } };
                 }
-                return { test: { environment: "node" } };
             });
         "#;
         assert_eq!(
             extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
-            Some("jsdom")
+            Some("jsdom"),
+            "with no top-level return, the first branch in source order wins"
         );
     }
 
@@ -3506,10 +3529,11 @@ mod tests {
         );
     }
 
-    /// A guard clause followed by the real return must still resolve to the
-    /// trailing return, which is what worked before branch descent existed.
+    /// A guard clause followed by the real return must resolve to the trailing
+    /// return. Descending into branches before checking this level regressed it:
+    /// the guard's early return shadowed the actual config.
     #[test]
-    fn guard_clause_then_top_level_return_is_unchanged() {
+    fn guard_clause_does_not_shadow_the_top_level_return() {
         let source = r#"
             import { defineConfig } from 'vite';
             export default defineConfig(({ mode }) => {
@@ -3521,8 +3545,29 @@ mod tests {
         "#;
         assert_eq!(
             extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
-            None,
-            "the first return in source order wins, even when it is a guard clause"
+            Some("jsdom"),
+            "a return at the callback's own level is the main config"
+        );
+    }
+
+    /// The same precedence with an else-if chain, where every branch returns and
+    /// the trailing return is the default config.
+    #[test]
+    fn else_if_chain_does_not_shadow_the_top_level_return() {
+        let source = r#"
+            import { defineConfig } from 'vite';
+            export default defineConfig(({ mode }) => {
+                if (mode === "a") {
+                    return { base: "/a/" };
+                } else if (mode === "b") {
+                    return { base: "/b/" };
+                }
+                return { test: { environment: "jsdom" } };
+            });
+        "#;
+        assert_eq!(
+            extract_config_string(source, &ts_path(), &["test", "environment"]).as_deref(),
+            Some("jsdom")
         );
     }
 

--- a/tools/type-aware-sidecar/package-lock.json
+++ b/tools/type-aware-sidecar/package-lock.json
@@ -830,6 +830,7 @@
       "integrity": "sha512-REdMxUreK3VSUeWcLd5+ijUGNKFyHT8s1trKmYEE/tlYE6ggdOkFOlKba/vI/l1fIqh/NTEEr1Cyw4AwttOicA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }


### PR DESCRIPTION
Fixes a regression introduced by the branch-descent change in #2014, found while sweeping this session's work.

## The regression

Descending into control flow to find a config `return` searched branches at the same precedence as the callback's own statements, so the first return in source order won even when it was a guard clause:

```js
export default defineConfig(({ mode }) => {
  if (!mode) { return {}; }
  return { test: { environment: "jsdom" } };
});
```

This resolved to the guard's empty object, losing the real config. Before #2014 the walk only matched top-level `return` statements, so the `if` was skipped and the trailing return was found. That makes this a regression, not a missing feature, and the shape is far more common than the branch-only form the descent was added for.

## The fix

A return at the body's own level always wins; branches are searched only when there is none. That keeps Vite's documented conditional form working, since it has no top-level return:

```js
export default defineConfig(({ command }) => {
  if (command === "serve") { return { ... }; } else { return { ... }; }
});
```

## The test that should have caught it

`guard_clause_then_top_level_return_is_unchanged` asserted `None` — the regressed value. It was written against the new implementation rather than against the behaviour it replaced, so it locked the bug in instead of catching it. Its name even claimed the opposite of what it asserted.

It is replaced by `guard_clause_does_not_shadow_the_top_level_return`, which pins the trailing return, plus `else_if_chain_does_not_shadow_the_top_level_return` for the chained form. `conditional_config_callback_extracts_branch_return` was also rewritten: it carried a top-level return, so it never exercised the descent it was named for.

## Verification

- Guard-clause and else-if fixtures: `canvas` and the setup file credited, unrelated `left-pad` still reported.
- Branch-only fixture: unchanged, still credited.
- Real-project probe holds at 752 issues with all seven genuine unused dependencies still reported.
- Full workspace suite green.
