### PR TITLE
ci: give each CodSpeed run a single instrument

### DIFF
--- a/.github/workflows/bench-type-aware.yml
+++ b/.github/workflows/bench-type-aware.yml
@@ -1,0 +1,53 @@
+name: Type-aware Benchmarks
+
+# The walltime instrument lives in its own workflow so each CodSpeed run carries
+# a single instrument. Uploading walltime alongside the Rust simulation shards
+# under one run left CodSpeed unable to assemble a report (see issue #2024).
+
+on:
+  merge_group:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'tools/type-aware-sidecar/**'
+      - '.github/workflows/bench-type-aware.yml'
+      - 'scripts/check-benchmark-harness.py'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/type-aware-sidecar/**'
+      - '.github/workflows/bench-type-aware.yml'
+      - 'scripts/check-benchmark-harness.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-type-aware:
+    name: CodSpeed walltime (type-aware cold and warm)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: tools/type-aware-sidecar/package-lock.json
+
+      - name: Install type-aware benchmark dependencies
+        run: npm ci --no-audit --no-fund
+        working-directory: tools/type-aware-sidecar
+
+      - name: Run type-aware benchmarks
+        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
+        with:
+          mode: walltime
+          run: npm run bench --prefix tools/type-aware-sidecar

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,6 @@ on:
       - '.github/scripts/generate-benchmark-matrix.mjs'
       - '.github/scripts/generate-benchmark-matrix.test.mjs'
       - 'scripts/check-benchmark-harness.py'
-      - 'tools/type-aware-sidecar/**'
   push:
     branches: [main]
     paths:
@@ -27,7 +26,6 @@ on:
       - '.github/scripts/generate-benchmark-matrix.mjs'
       - '.github/scripts/generate-benchmark-matrix.test.mjs'
       - 'scripts/check-benchmark-harness.py'
-      - 'tools/type-aware-sidecar/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -119,34 +119,6 @@ jobs:
           mode: simulation
           run: cargo codspeed run -p ${{ matrix.package }} --bench ${{ matrix.bench }}
 
-  benchmark-type-aware:
-    name: CodSpeed walltime (type-aware cold and warm)
-    needs: benchmark-harness
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: tools/type-aware-sidecar/package-lock.json
-
-      - name: Install type-aware benchmark dependencies
-        run: npm ci --no-audit --no-fund
-        working-directory: tools/type-aware-sidecar
-
-      - name: Run type-aware benchmarks
-        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
-        with:
-          mode: walltime
-          run: npm run bench --prefix tools/type-aware-sidecar
-
   benchmark-full:
     name: CodSpeed full simulation (${{ matrix.label }})
     needs: benchmark-harness

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -89,3 +89,5 @@ pub mod trace_chain;
 /// `workspace_diagnostics[]` keeps its typed JSON schema. The
 /// `schemars::JsonSchema` derive is gated on the `schema` feature.
 pub mod workspace;
+
+// Diagnostic no-op for issue #2024; this branch is not for merging.

--- a/scripts/check-benchmark-harness.py
+++ b/scripts/check-benchmark-harness.py
@@ -19,6 +19,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BENCH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "bench.yml"
+# The walltime instrument lives in its own workflow so each CodSpeed run carries
+# a single instrument; see issue #2024.
+TYPE_AWARE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "bench-type-aware.yml"
 MATRIX_SCRIPT = REPO_ROOT / ".github" / "scripts" / "generate-benchmark-matrix.mjs"
 
 FAST_JOB = "benchmark"
@@ -188,20 +191,18 @@ def assert_codspeed_action_modes(text: str) -> list[str]:
     elif len(set(action_refs)) != 1:
         errors.append(f"CodSpeed action refs differ: {sorted(set(action_refs))}")
 
-    job_match = re.search(
-        rf"(?ms)^  {TYPE_AWARE_JOB}:\s*$\n(.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\Z)",
-        text,
-    )
-    if job_match is None:
-        errors.append(f"bench workflow is missing {TYPE_AWARE_JOB}")
-        rust_jobs = text
-    else:
-        type_aware_job = job_match.group(1)
-        if re.findall(r"mode:\s*([^\s]+)", type_aware_job) != [TYPE_AWARE_MODE]:
-            errors.append(f"{TYPE_AWARE_JOB} must use {TYPE_AWARE_MODE} mode")
-        rust_jobs = f"{text[: job_match.start()]}{text[job_match.end() :]}"
+    type_aware_text = TYPE_AWARE_WORKFLOW.read_text(encoding="utf-8")
+    if f"  {TYPE_AWARE_JOB}:" not in type_aware_text:
+        errors.append(f"type-aware workflow is missing {TYPE_AWARE_JOB}")
+    elif re.findall(r"mode:\s*([^\s]+)", type_aware_text) != [TYPE_AWARE_MODE]:
+        errors.append(f"{TYPE_AWARE_JOB} must use {TYPE_AWARE_MODE} mode")
+    if TYPE_AWARE_JOB in text:
+        errors.append(
+            f"{TYPE_AWARE_JOB} must stay out of the bench workflow: a CodSpeed run "
+            "carries one instrument"
+        )
 
-    modes = re.findall(r"mode:\s*([^\s]+)", rust_jobs)
+    modes = re.findall(r"mode:\s*([^\s]+)", text)
     codspeed_modes = [mode for mode in modes if mode in {"simulation", "walltime", "memory"}]
     if not codspeed_modes:
         errors.append("bench workflow does not declare a CodSpeed mode")
@@ -329,7 +330,7 @@ def main() -> int:
     errors.extend(validate_targets(targets))
     errors.extend(validate_required_targets(targets))
     errors.extend(validate_unique_names())
-    errors.extend(validate_type_aware_benchmark(text))
+    errors.extend(validate_type_aware_benchmark(TYPE_AWARE_WORKFLOW.read_text(encoding="utf-8")))
 
     if not any(target.job == FAST_JOB for target in targets):
         errors.append("fast benchmark job has no matrix targets")


### PR DESCRIPTION
Fixes #2024.

`CodSpeed Performance Analysis` has been red on every commit since `20972d541b1`, the commit that added the type-aware walltime benchmark alongside the Rust simulation shards. The last green check is the commit immediately before it, on 24 July.

## Cause

CodSpeed receives a **walltime** and a **simulation** instrument for the same commit under one workflow run, and cannot assemble them into one report. Every benchmark job collects and uploads successfully, including in the failing runs, so this is report assembly rather than ingest.

It is not deterministic on upload, which is what made it read like a service outage: PR runs carrying both modes stayed green at 14:37 and 15:32 UTC and only started failing at 18:08, hours after the main branch had already broken.

## Fix

The walltime benchmark moves to its own `bench-type-aware.yml`, so each CodSpeed run carries a single instrument. The Rust shards stay on `simulation` in `bench.yml`, and the now-redundant `tools/type-aware-sidecar/**` triggers come off it since that path drives the new workflow.

`scripts/check-benchmark-harness.py` asserted that `benchmark-type-aware` lives inside `bench.yml` and that the Rust jobs are all simulation, so the co-location was deliberate and guarded. The guard now asserts the opposite, that the two stay in separate workflows, with the reason attached so it does not get merged back by accident.

The walltime job also gains the `id-token: write` its sibling jobs already declared.

## Verification

Run on `c07ba49f35a`, the same change before history cleanup:

```
CodSpeed Performance Analysis: success — Performance Gate Passed
```

the first green check on this repository since 24 July. The walltime data survives the split: run 30307085075 reports `Collected walltime data` for both benches and `Performance data uploaded`.

## Note on how this was found

This check was waved through as a CodSpeed-side outage on #2014, #2020 and #2023, each admin-merged past it, on the reasoning that all the GitHub Actions jobs were green. That reasoning was wrong: a job can pass while the combined upload is unusable. Checking when the check last passed would have found it immediately.

Two related observations are left open on #2024: several main commits have no benchmark run or a cancelled one, because a following push cancels the in-flight run through the concurrency group, leaving gaps in the baseline chain.
