### PR TITLE
fix(audit): label empty boundary-zone warnings from the base revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-saved. (Closes
   [#2029](https://github.com/fallow-rs/fallow/issues/2029).)
 
+- **`fallow audit --base` now labels empty-boundary-zone warnings that come
+  from the base revision.** The base revision is analyzed in its own worktree,
+  so a zone whose files only exist in the working tree matched nothing there
+  and produced the same unqualified `boundary zone ... matched 0 reachable
+  files` warning used for the working tree. That read as a broken current
+  configuration even though `fallow dead-code --boundary-violations` stayed
+  silent. The base pass now prefixes the warning with
+  `base revision snapshot (audit --base)` and says the finding is about the
+  base revision only. The working-tree warning, all output formats, and exit
+  codes are unchanged; `--quiet` still shows the warning, since suppressing it
+  would hide a real problem in the recommended agent mode. (Closes
+  [#2013](https://github.com/fallow-rs/fallow/issues/2013).)
+
 - **`fallow dupes` again fails when duplication exceeds the configured
   threshold.** Standalone runs rendered through a code path that returned the
   renderer's exit code without ever consulting the threshold, so

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -279,6 +279,7 @@ fn compute_base_snapshot(
                 None,
                 base_changed_files_ref,
                 share_dead_code_parse_with_health,
+                fallow_config::AnalysisSnapshot::Base,
             )
         },
         || run_audit_dupes(&base_opts, None, base_changed_files.as_ref(), None),
@@ -871,6 +872,7 @@ fn run_audit_head_analyses(
         changed_since,
         changed_files,
         share_dead_code_parse_with_health,
+        fallow_config::AnalysisSnapshot::Current,
     )?;
     let dupes_files = if share_dead_code_files_with_dupes {
         check
@@ -2006,6 +2008,7 @@ fn run_audit_check<'a>(
     changed_since: Option<&'a str>,
     changed_files: &FxHashSet<PathBuf>,
     retain_modules_for_health: bool,
+    analysis_snapshot: fallow_config::AnalysisSnapshot,
 ) -> Result<Option<CheckResult>, ExitCode> {
     let filters = IssueFilters::default();
     // The review brief needs the module graph for the impact closure, which
@@ -2064,6 +2067,7 @@ fn run_audit_check<'a>(
         },
         retain_modules_for_health,
         defer_performance: false,
+        analysis_snapshot,
     }) {
         Ok(mut result) => {
             fallow_engine::changed_files::filter_results_by_changed_files(

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -356,6 +356,10 @@ pub struct CheckOptions<'a> {
     /// When true, return timings without printing them so combined mode can add
     /// later stages before rendering the table.
     pub defer_performance: bool,
+    /// Which revision this pass analyzes. `Base` marks the isolated
+    /// `audit --base` pass so revision-specific diagnostics name the base
+    /// revision instead of reading as a current-configuration defect.
+    pub analysis_snapshot: fallow_config::AnalysisSnapshot,
 }
 
 /// Result of executing check analysis without printing.
@@ -517,6 +521,7 @@ fn prepare_check_config(opts: &CheckOptions<'_>) -> Result<ResolvedConfig, ExitC
         },
         fallow_config::ProductionAnalysis::DeadCode,
     )?;
+    config.analysis_snapshot = opts.analysis_snapshot;
     if opts.include_entry_exports {
         config.include_entry_exports = true;
     }

--- a/crates/cli/src/check/output.rs
+++ b/crates/cli/src/check/output.rs
@@ -489,6 +489,7 @@ mod tests {
             cache_max_size_mb: None,
             cache_config_hash: 0,
             max_file_size_bytes: None,
+            analysis_snapshot: fallow_config::AnalysisSnapshot::Current,
         }
     }
 

--- a/crates/cli/src/combined/mod.rs
+++ b/crates/cli/src/combined/mod.rs
@@ -176,6 +176,7 @@ fn build_combined_check_options<'a>(
         regression_opts: opts.regression_opts,
         retain_modules_for_health: opts.run_health,
         defer_performance: true,
+        analysis_snapshot: fallow_config::AnalysisSnapshot::Current,
     })
 }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4649,6 +4649,7 @@ fn dispatch_check(dispatch: &DispatchContext<'_>, args: &CheckDispatchArgs) -> E
         ),
         retain_modules_for_health: false,
         defer_performance: false,
+        analysis_snapshot: fallow_config::AnalysisSnapshot::Current,
     })
 }
 

--- a/crates/config/src/config/mod.rs
+++ b/crates/config/src/config/mod.rs
@@ -32,7 +32,7 @@ pub use format::OutputFormat;
 pub use health::{EmailMode, HealthConfig, HealthThresholdOverride, OwnershipConfig};
 pub use parsing::ConfigLoadOptions;
 pub use resolution::{
-    CompiledIgnoreCatalogReferenceRule, CompiledIgnoreDependencyOverrideRule,
+    AnalysisSnapshot, CompiledIgnoreCatalogReferenceRule, CompiledIgnoreDependencyOverrideRule,
     CompiledIgnoreExportRule, ConfigOverride, DEFAULT_MAX_FILE_SIZE_BYTES,
     DEFAULT_MAX_FILE_SIZE_MB, IgnoreCatalogReferenceRule, IgnoreDependencyOverrideRule,
     IgnoreExportRule, ResolvedConfig, ResolvedOverride, resolve_max_file_size_bytes,

--- a/crates/config/src/config/resolution.rs
+++ b/crates/config/src/config/resolution.rs
@@ -165,6 +165,29 @@ pub struct ResolvedOverride {
     pub rules: PartialRulesConfig,
 }
 
+/// Which revision an analysis pass describes.
+///
+/// `fallow audit --base <ref>` analyzes the base revision in an isolated
+/// worktree in addition to the working tree. Diagnostics raised while the base
+/// pass runs must say which revision they came from, otherwise a base-only
+/// condition reads as a defect in the current configuration (issue #2013).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AnalysisSnapshot {
+    /// The working tree, which is what every command analyzes by default.
+    #[default]
+    Current,
+    /// The base revision analyzed by `audit --base`.
+    Base,
+}
+
+impl AnalysisSnapshot {
+    /// True when this pass analyzes the `audit --base` revision.
+    #[must_use]
+    pub const fn is_base(self) -> bool {
+        matches!(self, Self::Base)
+    }
+}
+
 /// Fully resolved configuration with all globs pre-compiled.
 #[derive(Debug, Clone)]
 pub struct ResolvedConfig {
@@ -229,6 +252,11 @@ pub struct ResolvedConfig {
     /// [`DEFAULT_MAX_FILE_SIZE_MB`] MB; the CLI overrides it post-resolve from
     /// `--max-file-size` / `FALLOW_MAX_FILE_SIZE` (`0` = unlimited).
     pub max_file_size_bytes: Option<u64>,
+    /// Which revision this analysis pass describes. Always
+    /// [`AnalysisSnapshot::Current`] out of [`FallowConfig::resolve`]; the CLI
+    /// sets [`AnalysisSnapshot::Base`] post-resolve for the isolated
+    /// `audit --base` pass so diagnostics can name the base revision.
+    pub analysis_snapshot: AnalysisSnapshot,
 }
 
 /// Default per-file size ceiling (in megabytes) for source discovery. A value
@@ -678,6 +706,7 @@ impl FallowConfig {
             include_entry_exports: self.include_entry_exports,
             auto_imports: self.auto_imports,
             max_file_size_bytes: Some(DEFAULT_MAX_FILE_SIZE_BYTES),
+            analysis_snapshot: AnalysisSnapshot::Current,
         }
     }
 }

--- a/crates/core/src/analyze/boundary.rs
+++ b/crates/core/src/analyze/boundary.rs
@@ -210,13 +210,29 @@ fn warn_unmatched_boundary_zones(
         zone_cache.values().filter_map(|z| z.as_deref()).collect();
     for zone in &config.boundaries.zones {
         if !classified_zones.contains(zone.name.as_str()) {
-            tracing::warn!(
-                "boundary zone '{}' matched 0 reachable files, check your directory \
-                 structure, pattern, or whether these files are all currently unreachable",
-                zone.name
-            );
+            tracing::warn!("{}", unmatched_zone_warning(&zone.name, config));
         }
     }
+}
+
+/// Message for a boundary zone that classified no reachable file.
+///
+/// The `audit --base` pass analyzes the base revision, where a zone can be
+/// legitimately empty while the working tree matches it. That pass is labelled
+/// explicitly so the warning is not read as a defect in the current
+/// configuration (issue #2013). The working-tree wording is unchanged.
+fn unmatched_zone_warning(zone: &str, config: &ResolvedConfig) -> String {
+    if config.analysis_snapshot.is_base() {
+        return format!(
+            "base revision snapshot (audit --base): boundary zone '{zone}' matched 0 reachable \
+             files in the base revision, this is about the base revision only and not about your \
+             current configuration"
+        );
+    }
+    format!(
+        "boundary zone '{zone}' matched 0 reachable files, check your directory \
+         structure, pattern, or whether these files are all currently unreachable"
+    )
 }
 
 #[cfg(test)]
@@ -683,6 +699,38 @@ mod tests {
         assert!(
             violations.is_empty(),
             "import already in `allow` must not fire regardless of allowTypeOnly"
+        );
+    }
+
+    #[test]
+    fn unmatched_zone_warning_keeps_current_revision_wording() {
+        let config = make_config(PathBuf::from("/project"), BoundaryConfig::default());
+
+        assert_eq!(
+            unmatched_zone_warning("ui", &config),
+            "boundary zone 'ui' matched 0 reachable files, check your directory structure, \
+             pattern, or whether these files are all currently unreachable"
+        );
+    }
+
+    #[test]
+    fn unmatched_zone_warning_labels_the_base_revision_snapshot() {
+        let mut config = make_config(PathBuf::from("/project"), BoundaryConfig::default());
+        config.analysis_snapshot = fallow_config::AnalysisSnapshot::Base;
+
+        let message = unmatched_zone_warning("ui", &config);
+
+        assert!(
+            message.starts_with("base revision snapshot (audit --base): "),
+            "base-revision warning must be labelled, got: {message}"
+        );
+        assert_ne!(
+            message,
+            unmatched_zone_warning(
+                "ui",
+                &make_config(PathBuf::from("/project"), BoundaryConfig::default())
+            ),
+            "base-revision warning must differ from the current-revision warning"
         );
     }
 }


### PR DESCRIPTION
`audit --base` analyzes the base revision in its own worktree. A boundary zone whose files only exist in the working tree matched nothing there, so the base pass emitted the same unqualified "matched 0 reachable files" warning that the working tree uses, which reads as a broken current configuration.

`ResolvedConfig` now carries an `AnalysisSnapshot`, set to `Base` for the isolated base pass, and the boundary warning names the base revision when that is where it came from. The working-tree wording, output formats, and exit codes are unchanged, and `--quiet` still shows the warning because suppressing it would hide a real problem in the recommended agent mode.

Closes #2013