### PR TITLE
fix(release): require curated release notes

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -5,17 +5,88 @@ description: Prepare and publish a Fallow release with version, changelog, gener
 
 # Release
 
-1. Read `docs/development/quality-gates.md` and the release section of
-   `docs/development/task-context-map.md`.
-2. Confirm `main` is clean, current, reviewed, and green.
-3. Verify the unreleased changelog against commits since the prior tag.
-4. Regenerate public contracts and synchronize `fallow-docs` and
-   `fallow-skills`.
-5. Apply version changes transactionally and run package dry-runs.
-6. Create signed release commits and tags.
-7. Monitor all publication, registry, companion, and deployment workflows.
-8. Verify released binaries, packages, docs, schemas, and public health from
-   their real endpoints.
+## Preflight
 
-Do not report a release complete while any required publication or verification
-workflow is pending.
+1. Read `docs/development/quality-gates.md`, the release row in
+   `docs/development/task-context-map.md`, and
+   `docs/development/release-security.md`.
+2. Confirm `main` is clean, current with `origin/main`, reviewed, and green.
+   Check that the planned version tag is absent remotely and that no unresolved
+   draft release or concurrent release is in progress.
+3. Derive the semantic-version bump from every commit since the prior release
+   unless the user supplied an explicit bump. Confirm a major bump before
+   mutating versions unless the user explicitly requested it.
+4. Dispatch the reusable release-validation workflow against `main` and require
+   a completed successful result before changing versions or creating a tag.
+
+## Prepare
+
+5. Verify the complete `[Unreleased]` changelog against the commit range,
+   issues, discussions, and external contributors since the prior tag. Ground
+   public names, flags, rule IDs, and contributor handles in source or GitHub,
+   not memory.
+6. Draft curated public GitHub release notes before pushing the release tag.
+   They must:
+
+   - explain user-visible value rather than repeat commit subjects;
+   - cover every material changelog entry and any breaking or migration detail;
+   - use only public, generic examples;
+   - verify contributor attribution;
+   - end with the exact full-changelog comparison URL.
+
+   Store the notes outside the repository, for example
+   `/tmp/fallow-release-vX.Y.Z.md`, and require the file to be non-empty.
+7. Apply version changes transactionally. Regenerate every public contract,
+   adapter, packaged skill, and version-bearing artifact. Synchronize
+   `fallow-docs` and `fallow-skills` from their canonical sources.
+8. Run package dry-runs, generated-contract checks, companion-repository
+   checks, and the repository's full release gates. Review the exact staged
+   paths before creating a signed release commit and signed version tag.
+
+## Publish
+
+9. Push the release commit to `main`, then push the signed version tag. Create
+   the curated GitHub Release immediately so the tag-triggered workflow can
+   only upload assets to an already-documented release:
+
+   ```bash
+   # Use the verified values established during release preparation.
+   TAG="v${VERSION}"
+   TITLE="${TAG}: ${SUMMARY}"
+   NOTES_FILE="/tmp/fallow-release-${TAG}.md"
+
+   test -s "$NOTES_FILE"
+   grep -qF "https://github.com/fallow-rs/fallow/compare/${PREVIOUS_TAG}...${TAG}" "$NOTES_FILE"
+
+   git push origin main
+   git push origin "$TAG"
+
+   if gh release view "$TAG" --repo fallow-rs/fallow >/dev/null 2>&1; then
+     gh release edit "$TAG" --repo fallow-rs/fallow \
+       --title "$TITLE" --notes-file "$NOTES_FILE"
+   else
+     gh release create "$TAG" --repo fallow-rs/fallow --verify-tag \
+       --title "$TITLE" --notes-file "$NOTES_FILE"
+   fi
+   ```
+
+   The release workflow deliberately keeps `generate_release_notes: false`.
+   It fails when the curated release, title, body, or comparison link is
+   missing. Do not treat generated commit lists as curated release notes.
+10. Update the rolling Action tags from maintainer credentials. Monitor the
+    release workflow through `status=completed` and `conclusion=success`; a
+    successful watch command alone is not sufficient evidence.
+
+## Verify and close
+
+11. Query the GitHub Release and require a non-draft, non-prerelease release
+    with the expected title, a non-empty body, the exact comparison link, and
+    uploaded assets. Then verify every published crate, npm package, editor
+    package, binary, schema, documentation deployment, and companion contract
+    from its real public endpoint.
+12. Complete the required post-publication NAPI, Docker, rolling-tag, issue,
+    discussion, and companion-repository follow-ups. Require their resulting
+    `main` workflows to finish green and every touched worktree to be clean.
+
+Do not report a release complete while any publication, public release-note,
+registry, companion, deployment, or post-release verification gate is pending.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -6,17 +6,88 @@ description: Prepare and publish a Fallow release with version, changelog, gener
 
 # Release
 
-1. Read `docs/development/quality-gates.md` and the release section of
-   `docs/development/task-context-map.md`.
-2. Confirm `main` is clean, current, reviewed, and green.
-3. Verify the unreleased changelog against commits since the prior tag.
-4. Regenerate public contracts and synchronize `fallow-docs` and
-   `fallow-skills`.
-5. Apply version changes transactionally and run package dry-runs.
-6. Create signed release commits and tags.
-7. Monitor all publication, registry, companion, and deployment workflows.
-8. Verify released binaries, packages, docs, schemas, and public health from
-   their real endpoints.
+## Preflight
 
-Do not report a release complete while any required publication or verification
-workflow is pending.
+1. Read `docs/development/quality-gates.md`, the release row in
+   `docs/development/task-context-map.md`, and
+   `docs/development/release-security.md`.
+2. Confirm `main` is clean, current with `origin/main`, reviewed, and green.
+   Check that the planned version tag is absent remotely and that no unresolved
+   draft release or concurrent release is in progress.
+3. Derive the semantic-version bump from every commit since the prior release
+   unless the user supplied an explicit bump. Confirm a major bump before
+   mutating versions unless the user explicitly requested it.
+4. Dispatch the reusable release-validation workflow against `main` and require
+   a completed successful result before changing versions or creating a tag.
+
+## Prepare
+
+5. Verify the complete `[Unreleased]` changelog against the commit range,
+   issues, discussions, and external contributors since the prior tag. Ground
+   public names, flags, rule IDs, and contributor handles in source or GitHub,
+   not memory.
+6. Draft curated public GitHub release notes before pushing the release tag.
+   They must:
+
+   - explain user-visible value rather than repeat commit subjects;
+   - cover every material changelog entry and any breaking or migration detail;
+   - use only public, generic examples;
+   - verify contributor attribution;
+   - end with the exact full-changelog comparison URL.
+
+   Store the notes outside the repository, for example
+   `/tmp/fallow-release-vX.Y.Z.md`, and require the file to be non-empty.
+7. Apply version changes transactionally. Regenerate every public contract,
+   adapter, packaged skill, and version-bearing artifact. Synchronize
+   `fallow-docs` and `fallow-skills` from their canonical sources.
+8. Run package dry-runs, generated-contract checks, companion-repository
+   checks, and the repository's full release gates. Review the exact staged
+   paths before creating a signed release commit and signed version tag.
+
+## Publish
+
+9. Push the release commit to `main`, then push the signed version tag. Create
+   the curated GitHub Release immediately so the tag-triggered workflow can
+   only upload assets to an already-documented release:
+
+   ```bash
+   # Use the verified values established during release preparation.
+   TAG="v${VERSION}"
+   TITLE="${TAG}: ${SUMMARY}"
+   NOTES_FILE="/tmp/fallow-release-${TAG}.md"
+
+   test -s "$NOTES_FILE"
+   grep -qF "https://github.com/fallow-rs/fallow/compare/${PREVIOUS_TAG}...${TAG}" "$NOTES_FILE"
+
+   git push origin main
+   git push origin "$TAG"
+
+   if gh release view "$TAG" --repo fallow-rs/fallow >/dev/null 2>&1; then
+     gh release edit "$TAG" --repo fallow-rs/fallow \
+       --title "$TITLE" --notes-file "$NOTES_FILE"
+   else
+     gh release create "$TAG" --repo fallow-rs/fallow --verify-tag \
+       --title "$TITLE" --notes-file "$NOTES_FILE"
+   fi
+   ```
+
+   The release workflow deliberately keeps `generate_release_notes: false`.
+   It fails when the curated release, title, body, or comparison link is
+   missing. Do not treat generated commit lists as curated release notes.
+10. Update the rolling Action tags from maintainer credentials. Monitor the
+    release workflow through `status=completed` and `conclusion=success`; a
+    successful watch command alone is not sufficient evidence.
+
+## Verify and close
+
+11. Query the GitHub Release and require a non-draft, non-prerelease release
+    with the expected title, a non-empty body, the exact comparison link, and
+    uploaded assets. Then verify every published crate, npm package, editor
+    package, binary, schema, documentation deployment, and companion contract
+    from its real public endpoint.
+12. Complete the required post-publication NAPI, Docker, rolling-tag, issue,
+    discussion, and companion-repository follow-ups. Require their resulting
+    `main` workflows to finish green and every touched worktree to be clean.
+
+Do not report a release complete while any publication, public release-note,
+registry, companion, deployment, or post-release verification gate is pending.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   publish-crates:
     name: Publish Rust crates
-    needs: release-verified
+    needs: [release-verified, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -443,12 +443,13 @@ jobs:
       contents: read
 
   release:
-    name: Create Release
+    name: Upload Release assets
     needs: release-verified
     runs-on: ubuntu-latest
     permissions:
-      # Required only to create the GitHub Release. Tag creation and rolling
-      # Action tag updates stay in the maintainer release workflow.
+      # Required only to validate the curated GitHub Release and upload assets.
+      # Release metadata, tag creation, and rolling Action tag updates stay in
+      # the maintainer release workflow.
       contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -461,10 +462,56 @@ jobs:
           path: artifacts
           pattern: fallow-*
 
-      - name: Create GitHub Release
+      - name: Verify curated release metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! release_json="$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json name,body,isDraft,isPrerelease)"; then
+            echo "::error::Create the curated GitHub Release before the tag workflow reaches publication"
+            exit 1
+          fi
+
+          title="$(jq -r '.name // ""' <<<"$release_json")"
+          body="$(jq -r '.body // ""' <<<"$release_json")"
+          is_draft="$(jq -r '.isDraft' <<<"$release_json")"
+          is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+
+          if [ -z "${title//[[:space:]]/}" ]; then
+            echo "::error::Curated GitHub Release title is empty"
+            exit 1
+          fi
+          if [[ "$title" != "$TAG_NAME: "* ]]; then
+            echo "::error::Curated GitHub Release title must start with '$TAG_NAME: '"
+            exit 1
+          fi
+          summary="${title#"$TAG_NAME: "}"
+          if [ -z "${summary//[[:space:]]/}" ]; then
+            echo "::error::Curated GitHub Release title is missing a user-facing summary"
+            exit 1
+          fi
+          if [ -z "${body//[[:space:]]/}" ]; then
+            echo "::error::Curated GitHub Release body is empty"
+            exit 1
+          fi
+          compare_prefix="https://github.com/${GITHUB_REPOSITORY}/compare/"
+          compare_suffix="...${TAG_NAME}"
+          if ! grep -qF "$compare_prefix" <<<"$body" || ! grep -qF "$compare_suffix" <<<"$body"; then
+            echo "::error::Curated GitHub Release body is missing the full changelog comparison link"
+            exit 1
+          fi
+          if [ "$is_draft" != "false" ] || [ "$is_prerelease" != "false" ]; then
+            echo "::error::Stable GitHub Release must be published and not marked as a prerelease"
+            exit 1
+          fi
+
+      - name: Upload assets to curated GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: artifacts/**/*
+          fail_on_unmatched_files: true
           generate_release_notes: false
           draft: false
         env:

--- a/docs/development/release-security.md
+++ b/docs/development/release-security.md
@@ -11,7 +11,7 @@ maintainer release flow. It never creates or moves Git tags itself.
 | `build` | Build and sign release artifacts | Artifact signing only |
 | `validate` | Reusable release validation | Read only |
 | `release-verified` | Join build and validation | None |
-| `release` | Create the GitHub Release from artifacts | GitHub contents write |
+| `release` | Validate curated release metadata and upload artifacts | GitHub contents write |
 | `publish-crates` | Publish prevalidated crates in dependency order | crates.io OIDC |
 | `npm-prep` | Install, assemble, and pack npm artifacts | Read only |
 | `npm-publish` | Publish downloaded tarballs | npm publication |
@@ -37,6 +37,12 @@ globally with `--ignore-scripts`.
   release publish-list test.
 - Keep artifact inventory and package-name constants aligned with the build
   matrix.
+- Create the curated GitHub Release from the maintainer flow immediately after
+  pushing the signed tag. The credential-bearing workflow only validates its
+  title and body and uploads assets to it.
+- Keep `generate_release_notes: false`. Require a non-empty title, a non-empty
+  body, the repository comparison URL, and at least one matched release asset.
+  Missing curated metadata must fail before package publication can continue.
 - Push rolling Action tags and refresh Dockerfile binary pins from the
   maintainer release workflow after published assets exist, not from the
   credential-bearing GitHub workflow.

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -342,10 +342,36 @@ test("release publication waits for the aggregate verification gate", () => {
 
   assert.match(gate, /needs: \[build, validate\]/);
   assert.match(gate, /permissions: \{\}/);
-  assert.match(publishCrates, /needs: release-verified/);
+  assert.match(publishCrates, /needs: \[release-verified, release\]/);
   assert.match(release, /needs: release-verified/);
   assert.match(npmPublish, /needs: \[npm-prep, release\]/);
   assert.match(vscodePublish, /needs: \[vscode-prep, release\]/);
+});
+
+test("release requires curated public notes before uploading assets", () => {
+  const workflow = readWorkflow(".github/workflows/release.yml");
+  const release = indentedBlock(workflow, "release", 2);
+  const skill = readFileSync(".agents/skills/release/SKILL.md", "utf8");
+  const verifyStep = release.indexOf("- name: Verify curated release metadata");
+  const uploadStep = release.indexOf("- name: Upload assets to curated GitHub Release");
+
+  assert.notEqual(verifyStep, -1, "release must verify curated metadata");
+  assert.notEqual(uploadStep, -1, "release must upload to the curated release");
+  assert.ok(verifyStep < uploadStep, "curated metadata must be verified before asset upload");
+  assert.match(release, /gh release view "\$TAG_NAME"/u);
+  assert.match(release, /Curated GitHub Release title is empty/u);
+  assert.match(release, /title is missing a user-facing summary/u);
+  assert.match(release, /Curated GitHub Release body is empty/u);
+  assert.match(release, /compare_suffix="\.\.\.\$\{TAG_NAME\}"/u);
+  assert.match(release, /full changelog comparison link/u);
+  assert.match(release, /fail_on_unmatched_files: true/u);
+  assert.match(release, /generate_release_notes: false/u);
+
+  assert.match(skill, /Draft curated public GitHub release notes before pushing the release tag/u);
+  assert.match(skill, /gh release create "\$TAG"/u);
+  assert.match(skill, /--notes-file "\$NOTES_FILE"/u);
+  assert.match(skill, /exact full-changelog comparison URL/u);
+  assert.match(skill, /non-empty body/u);
 });
 
 test("release verifies committed signing-key parity before signing", () => {


### PR DESCRIPTION
## Summary
- require curated GitHub release notes before tag-triggered publication
- fail publication when the title, summary, body, compare link, or release assets are missing
- keep the Claude adapter generated from the canonical release skill

## Validation
- `npm run verify:full`
- `npm run verify:fast` after rebasing onto current `main`
- repository workflow policy tests
- `actionlint` and `zizmor` on the release workflow
- live v3.10.0 metadata smoke plus negative guard cases
