### PR TITLE
fix(release): create version tag after publication

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -11,8 +11,9 @@ description: Prepare and publish a Fallow release with version, changelog, gener
    `docs/development/task-context-map.md`, and
    `docs/development/release-security.md`.
 2. Confirm `main` is clean, current with `origin/main`, reviewed, and green.
-   Check that the planned version tag is absent remotely and that no unresolved
-   draft release or concurrent release is in progress.
+   Require repository release immutability to be enabled. Check that the
+   planned version tag is absent remotely and that no unresolved draft release
+   or concurrent release is in progress.
 3. Derive the semantic-version bump from every commit since the prior release
    unless the user supplied an explicit bump. Confirm a major bump before
    mutating versions unless the user explicitly requested it.
@@ -25,8 +26,8 @@ description: Prepare and publish a Fallow release with version, changelog, gener
    issues, discussions, and external contributors since the prior tag. Ground
    public names, flags, rule IDs, and contributor handles in source or GitHub,
    not memory.
-6. Draft curated public GitHub release notes before pushing the release tag.
-   They must:
+6. Draft curated public GitHub release notes before starting the publication
+   workflow. They must:
 
    - explain user-visible value rather than repeat commit subjects;
    - cover every material changelog entry and any breaking or migration detail;
@@ -41,49 +42,90 @@ description: Prepare and publish a Fallow release with version, changelog, gener
    `fallow-docs` and `fallow-skills` from their canonical sources.
 8. Run package dry-runs, generated-contract checks, companion-repository
    checks, and the repository's full release gates. Review the exact staged
-   paths before creating a signed release commit and signed version tag.
+   paths before creating a signed release commit. Do not create the version tag
+   yet.
 
 ## Publish
 
-9. Push the release commit to `main`, then push the signed version tag. Create
-   the curated GitHub Release immediately so the tag-triggered workflow can
-   only upload assets to an already-documented release:
+9. Push the release commit to `main`. While the version tag is still absent,
+   dispatch the release workflow from `main` with the planned tag:
 
    ```bash
    # Use the verified values established during release preparation.
    TAG="v${VERSION}"
    TITLE="${TAG}: ${SUMMARY}"
    NOTES_FILE="/tmp/fallow-release-${TAG}.md"
+   RELEASE_COMMIT="$(git rev-parse HEAD)"
 
    test -s "$NOTES_FILE"
    grep -qF "https://github.com/fallow-rs/fallow/compare/${PREVIOUS_TAG}...${TAG}" "$NOTES_FILE"
 
    git push origin main
-   git push origin "$TAG"
-
-   if gh release view "$TAG" --repo fallow-rs/fallow >/dev/null 2>&1; then
-     gh release edit "$TAG" --repo fallow-rs/fallow \
-       --title "$TITLE" --notes-file "$NOTES_FILE"
-   else
-     gh release create "$TAG" --repo fallow-rs/fallow --verify-tag \
-       --title "$TITLE" --notes-file "$NOTES_FILE"
+   git fetch origin main
+   if [ "$(git rev-parse origin/main)" != "$RELEASE_COMMIT" ]; then
+     echo "origin/main moved away from the prepared release commit" >&2
+     exit 1
    fi
+   if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+     echo "release tag already exists: ${TAG}" >&2
+     exit 1
+   fi
+
+   gh workflow run release.yml --ref main \
+     -f tag="$TAG"
    ```
 
-   The release workflow deliberately keeps `generate_release_notes: false`.
-   It fails when the curated release, title, body, or comparison link is
-   missing. Do not treat generated commit lists as curated release notes.
-10. Update the rolling Action tags from maintainer credentials. Monitor the
-    release workflow through `status=completed` and `conclusion=success`; a
-    successful watch command alone is not sufficient evidence.
+   The workflow deliberately has no tag trigger and never creates a tag or
+   GitHub Release. It validates and builds the release, stores the complete
+   flattened GitHub asset bundle as the `release-assets` Actions artifact, and
+   publishes registries while the tag remains absent.
+10. Monitor the specific workflow run through `status=completed` and
+    `conclusion=success`; a successful watch command alone is not sufficient
+    evidence. Require the `Release ready for signed tag` job to pass, then
+    verify every registry and marketplace publication is live.
+    Download the `release-assets` artifact from that exact run and confirm it
+    is non-empty. Only then create and push the signed tag and create the
+    immutable GitHub Release:
+
+    ```bash
+    ASSET_DIR="$(mktemp -d)"
+    gh run download "$RUN_ID" \
+      --name release-assets \
+      --dir "$ASSET_DIR"
+    test -n "$(find "$ASSET_DIR" -maxdepth 1 -type f -print -quit)"
+
+    if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+      echo "release tag appeared before publication completed: ${TAG}" >&2
+      exit 1
+    fi
+
+    git tag -s "$TAG" "$RELEASE_COMMIT" -m "Fallow ${VERSION}"
+    git verify-tag "$TAG"
+    git push origin "$TAG"
+
+    gh release create "$TAG" "$ASSET_DIR"/* \
+      --repo fallow-rs/fallow \
+      --verify-tag \
+      --title "$TITLE" \
+      --notes-file "$NOTES_FILE"
+    ```
+
+    GitHub CLI creates a draft internally, uploads every asset, and only then
+    publishes it, matching GitHub's immutable-release guidance. If the workflow
+    fails, repair and rerun it without burning a tag. If release creation fails
+    after tag push, keep the signed tag, remove only an incomplete draft if one
+    exists, and retry release creation. Never recreate or move the signed tag.
+    Update the rolling Action tags from maintainer credentials only after the
+    immutable release is published.
 
 ## Verify and close
 
 11. Query the GitHub Release and require a non-draft, non-prerelease release
-    with the expected title, a non-empty body, the exact comparison link, and
-    uploaded assets. Then verify every published crate, npm package, editor
-    package, binary, schema, documentation deployment, and companion contract
-    from its real public endpoint.
+    marked immutable, with the expected title, a non-empty body, the exact
+    comparison link, the signed tag at `RELEASE_COMMIT`, and uploaded assets.
+    Then verify every published crate, npm package, editor package, binary,
+    schema, documentation deployment, and companion contract from its real
+    public endpoint.
 12. Complete the required post-publication NAPI, Docker, rolling-tag, issue,
     discussion, and companion-repository follow-ups. Require their resulting
     `main` workflows to finish green and every touched worktree to be clean.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -12,8 +12,9 @@ description: Prepare and publish a Fallow release with version, changelog, gener
    `docs/development/task-context-map.md`, and
    `docs/development/release-security.md`.
 2. Confirm `main` is clean, current with `origin/main`, reviewed, and green.
-   Check that the planned version tag is absent remotely and that no unresolved
-   draft release or concurrent release is in progress.
+   Require repository release immutability to be enabled. Check that the
+   planned version tag is absent remotely and that no unresolved draft release
+   or concurrent release is in progress.
 3. Derive the semantic-version bump from every commit since the prior release
    unless the user supplied an explicit bump. Confirm a major bump before
    mutating versions unless the user explicitly requested it.
@@ -26,8 +27,8 @@ description: Prepare and publish a Fallow release with version, changelog, gener
    issues, discussions, and external contributors since the prior tag. Ground
    public names, flags, rule IDs, and contributor handles in source or GitHub,
    not memory.
-6. Draft curated public GitHub release notes before pushing the release tag.
-   They must:
+6. Draft curated public GitHub release notes before starting the publication
+   workflow. They must:
 
    - explain user-visible value rather than repeat commit subjects;
    - cover every material changelog entry and any breaking or migration detail;
@@ -42,49 +43,90 @@ description: Prepare and publish a Fallow release with version, changelog, gener
    `fallow-docs` and `fallow-skills` from their canonical sources.
 8. Run package dry-runs, generated-contract checks, companion-repository
    checks, and the repository's full release gates. Review the exact staged
-   paths before creating a signed release commit and signed version tag.
+   paths before creating a signed release commit. Do not create the version tag
+   yet.
 
 ## Publish
 
-9. Push the release commit to `main`, then push the signed version tag. Create
-   the curated GitHub Release immediately so the tag-triggered workflow can
-   only upload assets to an already-documented release:
+9. Push the release commit to `main`. While the version tag is still absent,
+   dispatch the release workflow from `main` with the planned tag:
 
    ```bash
    # Use the verified values established during release preparation.
    TAG="v${VERSION}"
    TITLE="${TAG}: ${SUMMARY}"
    NOTES_FILE="/tmp/fallow-release-${TAG}.md"
+   RELEASE_COMMIT="$(git rev-parse HEAD)"
 
    test -s "$NOTES_FILE"
    grep -qF "https://github.com/fallow-rs/fallow/compare/${PREVIOUS_TAG}...${TAG}" "$NOTES_FILE"
 
    git push origin main
-   git push origin "$TAG"
-
-   if gh release view "$TAG" --repo fallow-rs/fallow >/dev/null 2>&1; then
-     gh release edit "$TAG" --repo fallow-rs/fallow \
-       --title "$TITLE" --notes-file "$NOTES_FILE"
-   else
-     gh release create "$TAG" --repo fallow-rs/fallow --verify-tag \
-       --title "$TITLE" --notes-file "$NOTES_FILE"
+   git fetch origin main
+   if [ "$(git rev-parse origin/main)" != "$RELEASE_COMMIT" ]; then
+     echo "origin/main moved away from the prepared release commit" >&2
+     exit 1
    fi
+   if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+     echo "release tag already exists: ${TAG}" >&2
+     exit 1
+   fi
+
+   gh workflow run release.yml --ref main \
+     -f tag="$TAG"
    ```
 
-   The release workflow deliberately keeps `generate_release_notes: false`.
-   It fails when the curated release, title, body, or comparison link is
-   missing. Do not treat generated commit lists as curated release notes.
-10. Update the rolling Action tags from maintainer credentials. Monitor the
-    release workflow through `status=completed` and `conclusion=success`; a
-    successful watch command alone is not sufficient evidence.
+   The workflow deliberately has no tag trigger and never creates a tag or
+   GitHub Release. It validates and builds the release, stores the complete
+   flattened GitHub asset bundle as the `release-assets` Actions artifact, and
+   publishes registries while the tag remains absent.
+10. Monitor the specific workflow run through `status=completed` and
+    `conclusion=success`; a successful watch command alone is not sufficient
+    evidence. Require the `Release ready for signed tag` job to pass, then
+    verify every registry and marketplace publication is live.
+    Download the `release-assets` artifact from that exact run and confirm it
+    is non-empty. Only then create and push the signed tag and create the
+    immutable GitHub Release:
+
+    ```bash
+    ASSET_DIR="$(mktemp -d)"
+    gh run download "$RUN_ID" \
+      --name release-assets \
+      --dir "$ASSET_DIR"
+    test -n "$(find "$ASSET_DIR" -maxdepth 1 -type f -print -quit)"
+
+    if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+      echo "release tag appeared before publication completed: ${TAG}" >&2
+      exit 1
+    fi
+
+    git tag -s "$TAG" "$RELEASE_COMMIT" -m "Fallow ${VERSION}"
+    git verify-tag "$TAG"
+    git push origin "$TAG"
+
+    gh release create "$TAG" "$ASSET_DIR"/* \
+      --repo fallow-rs/fallow \
+      --verify-tag \
+      --title "$TITLE" \
+      --notes-file "$NOTES_FILE"
+    ```
+
+    GitHub CLI creates a draft internally, uploads every asset, and only then
+    publishes it, matching GitHub's immutable-release guidance. If the workflow
+    fails, repair and rerun it without burning a tag. If release creation fails
+    after tag push, keep the signed tag, remove only an incomplete draft if one
+    exists, and retry release creation. Never recreate or move the signed tag.
+    Update the rolling Action tags from maintainer credentials only after the
+    immutable release is published.
 
 ## Verify and close
 
 11. Query the GitHub Release and require a non-draft, non-prerelease release
-    with the expected title, a non-empty body, the exact comparison link, and
-    uploaded assets. Then verify every published crate, npm package, editor
-    package, binary, schema, documentation deployment, and companion contract
-    from its real public endpoint.
+    marked immutable, with the expected title, a non-empty body, the exact
+    comparison link, the signed tag at `RELEASE_COMMIT`, and uploaded assets.
+    Then verify every published crate, npm package, editor package, binary,
+    schema, documentation deployment, and companion contract from its real
+    public endpoint.
 12. Complete the required post-publication NAPI, Docker, rolling-tag, issue,
     discussion, and companion-repository follow-ups. Require their resulting
     `main` workflows to finish green and every touched worktree to be clean.

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,7 +1,7 @@
 # Every release-gating validation job, extracted so it can run BEFORE a
 # version number exists anywhere. Three consumers:
-#   1. release.yml `uses:` this workflow (workflow_call), so tag runs gate
-#      publishes on exactly this set;
+#   1. release.yml `uses:` this workflow (workflow_call), so the manually
+#      dispatched tag-last flow gates publishes on exactly this set;
 #   2. the /fallow-release pre-flight dispatches it on main and waits for
 #      green BEFORE bumping any version (workflow_dispatch), so a failing
 #      check can never burn a release tag again (v3.4.0 and v3.4.1 were both

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Version tag to publish, for example v3.11.0
+        required: true
+        type: string
+
+run-name: Release ${{ inputs.tag }} from ${{ github.sha }}
 
 concurrency:
   group: release
@@ -13,11 +18,78 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
+  RELEASE_TAG: ${{ inputs.tag }}
 
 jobs:
+  release-context:
+    name: Verify tag-last release context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify dispatch inputs and release version
+        shell: bash
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Release workflow must be dispatched from main"
+            exit 1
+          fi
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          workspace_version="$(
+            sed -n '/^\[workspace.package\]/,/^\[/s/^version = "\([^"]*\)"/\1/p' Cargo.toml
+          )"
+          if [ "$TAG_NAME" != "v${workspace_version}" ]; then
+            echo "::error::Release tag ${TAG_NAME} does not match workspace version ${workspace_version}"
+            exit 1
+          fi
+
+      - name: Verify release immutability is enabled
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/immutable-releases" \
+            --jq 'select(.enabled == true) | .enabled' >/dev/null
+
+      - name: Verify release tag is absent
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          set +e
+          tag_error="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" 2>&1
+          )"
+          tag_status=$?
+          set -e
+          if [ "$tag_status" -eq 0 ]; then
+            echo "::error::Release tag ${TAG_NAME} already exists; tag creation must remain near the end"
+            exit 1
+          fi
+          if ! grep -qF "(HTTP 404)" <<<"$tag_error"; then
+            printf '%s\n' "$tag_error"
+            echo "::error::Could not prove that release tag ${TAG_NAME} is absent"
+            exit 1
+          fi
+
   publish-crates:
     name: Publish Rust crates
-    needs: [release-verified, release]
+    needs: [release-verified, release-assets]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,7 +110,7 @@ jobs:
       # would compile every transitive dependency's build.rs with
       # CARGO_REGISTRY_TOKEN available in the environment; a single compromised
       # build script could exfiltrate the token. The same code already built
-      # cleanly in CI on the commit that produced this tag, so the verify build
+      # cleanly in CI on the commit selected for this release, so the verify build
       # is a redundant safety net we can drop on the privileged path.
 
       - name: Authenticate to crates.io
@@ -104,6 +176,7 @@ jobs:
 
   build:
     name: Build (${{ matrix.target }})
+    needs: release-context
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     permissions:
@@ -438,84 +511,77 @@ jobs:
 
   validate:
     name: Release validation
+    needs: release-context
     uses: ./.github/workflows/release-validation.yml
     permissions:
       contents: read
 
-  release:
-    name: Upload Release assets
+  release-assets:
+    name: Stage GitHub Release assets
     needs: release-verified
     runs-on: ubuntu-latest
     permissions:
-      # Required only to validate the curated GitHub Release and upload assets.
-      # Release metadata, tag creation, and rolling Action tag updates stay in
-      # the maintainer release workflow.
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: fallow-*
 
-      - name: Verify curated release metadata
+      - name: Reconfirm release tag is absent
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if ! release_json="$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json name,body,isDraft,isPrerelease)"; then
-            echo "::error::Create the curated GitHub Release before the tag workflow reaches publication"
+          set +e
+          tag_error="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" 2>&1
+          )"
+          tag_status=$?
+          set -e
+          if [ "$tag_status" -eq 0 ]; then
+            echo "::error::Release tag ${TAG_NAME} appeared before publication completed"
+            exit 1
+          fi
+          if ! grep -qF "(HTTP 404)" <<<"$tag_error"; then
+            printf '%s\n' "$tag_error"
+            echo "::error::Could not reconfirm that release tag ${TAG_NAME} is absent"
             exit 1
           fi
 
-          title="$(jq -r '.name // ""' <<<"$release_json")"
-          body="$(jq -r '.body // ""' <<<"$release_json")"
-          is_draft="$(jq -r '.isDraft' <<<"$release_json")"
-          is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
-
-          if [ -z "${title//[[:space:]]/}" ]; then
-            echo "::error::Curated GitHub Release title is empty"
-            exit 1
-          fi
-          if [[ "$title" != "$TAG_NAME: "* ]]; then
-            echo "::error::Curated GitHub Release title must start with '$TAG_NAME: '"
-            exit 1
-          fi
-          summary="${title#"$TAG_NAME: "}"
-          if [ -z "${summary//[[:space:]]/}" ]; then
-            echo "::error::Curated GitHub Release title is missing a user-facing summary"
-            exit 1
-          fi
-          if [ -z "${body//[[:space:]]/}" ]; then
-            echo "::error::Curated GitHub Release body is empty"
-            exit 1
-          fi
-          compare_prefix="https://github.com/${GITHUB_REPOSITORY}/compare/"
-          compare_suffix="...${TAG_NAME}"
-          if ! grep -qF "$compare_prefix" <<<"$body" || ! grep -qF "$compare_suffix" <<<"$body"; then
-            echo "::error::Curated GitHub Release body is missing the full changelog comparison link"
-            exit 1
-          fi
-          if [ "$is_draft" != "false" ] || [ "$is_prerelease" != "false" ]; then
-            echo "::error::Stable GitHub Release must be published and not marked as a prerelease"
+      - name: Assemble release asset bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -d '' assets < <(find artifacts -type f -print0)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "::error::No release assets were downloaded"
             exit 1
           fi
 
-      - name: Upload assets to curated GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+          mkdir release-assets
+          declare -A asset_names=()
+          for asset in "${assets[@]}"; do
+            name="$(basename "$asset")"
+            if [[ -n "${asset_names[$name]+present}" ]]; then
+              echo "::error::Duplicate release asset name: ${name}"
+              exit 1
+            fi
+            asset_names["$name"]=1
+            cp "$asset" "release-assets/$name"
+          done
+
+      - name: Upload release asset bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          files: artifacts/**/*
-          fail_on_unmatched_files: true
-          generate_release_notes: false
-          draft: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: release-assets
+          path: release-assets/
+          if-no-files-found: error
+          retention-days: 7
+          include-hidden-files: false
 
       # The rolling v1/v3 action tags are pushed by the maintainer's release
       # workflow, not from here: GITHUB_TOKEN can never update a ref whose diff
@@ -527,7 +593,7 @@ jobs:
   # hand. These are refreshed by the maintainer's release workflow, not from
   # here. Like the crates/napi lockfile catch-up and the rolling v1/v3 tags,
   # the pin depends on the musl
-  # binaries the `build` matrix compiles and `release` uploads, which only exist
+  # binaries the `build` matrix compiles and `release-assets` stages, which only exist
   # after the publish this workflow performs. The maintainer workflow downloads
   # those assets, re-hashes them, runs
   # .github/scripts/update-dockerfile-pins.mjs, and pushes the
@@ -536,9 +602,9 @@ jobs:
 
   # Belt-and-suspenders generated contract drift check before either privileged
   # publish job runs. PR CI runs `npm run generate:contracts:check` on every relevant
-  # contract change, but a release tag could in theory be cut on a commit where
+  # contract change, but a release could in theory be dispatched from a commit where
   # a committed generated surface disagrees with what regen would produce
-  # (force-push to main, history rewrite, tag pointed at an old SHA). The root
+  # (force-push to main or history rewrite). The root
   # bundle validates config/plugin/rule-pack schemas, output schema, npm
   # capability metadata, issue registry export, TS output contracts, NAPI types,
   # and agent docs.
@@ -608,13 +674,8 @@ jobs:
           done
 
       - name: Update versions
-        env:
-          # The ref is read via process.env in the embedded node script, not
-          # interpolated into a heredoc, so a malformed ref cannot break out
-          # of the script body.
-          PKG_VERSION_REF: ${{ github.ref }}
         run: |
-          VERSION="${PKG_VERSION_REF#refs/tags/v}"
+          VERSION="${RELEASE_TAG#v}"
           export PKG_VERSION="$VERSION"
           for pkg in npm/*/package.json; do
             PKG_PATH="$pkg" node -e '
@@ -688,10 +749,8 @@ jobs:
         run: cd crates/napi && npm ci --omit=optional --ignore-scripts
 
       - name: Update NAPI package version
-        env:
-          PKG_VERSION_REF: ${{ github.ref }}
         run: |
-          VERSION="${PKG_VERSION_REF#refs/tags/v}"
+          VERSION="${RELEASE_TAG#v}"
           PKG_VERSION="$VERSION" node -e '
             const fs = require("fs");
             const path = "crates/napi/package.json";
@@ -830,7 +889,7 @@ jobs:
     # - --ignore-scripts on every publish blocks lifecycle scripts inside the
     #   tarballs from executing here.
     # Anything that needs `npm ci` or runs dependency code belongs in npm-prep.
-    needs: [npm-prep, release]
+    needs: [npm-prep, release-assets]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -873,14 +932,12 @@ jobs:
 
       - name: Publish all tarballs
         shell: bash
-        env:
-          PKG_VERSION_REF: ${{ github.ref }}
         run: |
           if [ ! -s tarballs/manifest.tsv ]; then
             echo "::error::tarballs/manifest.tsv missing or empty; npm-prep did not produce any tarballs"
             exit 1
           fi
-          VERSION="${PKG_VERSION_REF#refs/tags/v}"
+          VERSION="${RELEASE_TAG#v}"
           # Fixed expected count: 8 cli platform + 1 type-aware companion +
           # 1 cli root + 8 napi platform + 1 napi root = 19 entries. If this number changes, update the
           # numbered-stage matrix in npm-prep AND this constant together.
@@ -995,10 +1052,8 @@ jobs:
         run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Update extension version
-        env:
-          PKG_VERSION_REF: ${{ github.ref }}
         run: |
-          VERSION="${PKG_VERSION_REF#refs/tags/v}"
+          VERSION="${RELEASE_TAG#v}"
           PKG_VERSION="$VERSION" node -e '
             const fs = require("fs");
             const path = "editors/vscode/package.json";
@@ -1024,7 +1079,7 @@ jobs:
 
   vscode-publish:
     name: Publish VS Code Extension
-    needs: [vscode-prep, release]
+    needs: [vscode-prep, release-assets]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1078,3 +1133,34 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
           VSIX_PATH: ${{ steps.vsix.outputs.path }}
         run: ovsx publish "$VSIX_PATH" --no-dependencies
+
+  release-ready:
+    name: Release ready for signed tag
+    needs: [publish-crates, npm-publish, vscode-publish, release-assets]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require the release tag to remain absent
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          set +e
+          tag_error="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" 2>&1
+          )"
+          tag_status=$?
+          set -e
+          if [ "$tag_status" -eq 0 ]; then
+            echo "::error::Release tag ${TAG_NAME} appeared before the release workflow completed"
+            exit 1
+          fi
+          if ! grep -qF "(HTTP 404)" <<<"$tag_error"; then
+            printf '%s\n' "$tag_error"
+            echo "::error::Could not prove that release tag ${TAG_NAME} remains absent"
+            exit 1
+          fi
+          echo "Release workflow completed with ${TAG_NAME} still absent"

--- a/docs/development/release-security.md
+++ b/docs/development/release-security.md
@@ -1,17 +1,20 @@
 # Release security
 
 Use this reference when editing `.github/workflows/release.yml` or the release
-workflow skill. The workflow is triggered by a version tag created by the
-maintainer release flow. It never creates or moves Git tags itself.
+workflow skill. The maintainer dispatches the workflow against the signed
+release commit while the version tag is still absent. The workflow never
+creates, moves, or publishes Git tags or GitHub Releases.
 
 ## Job boundaries
 
 | Job | Responsibility | Credentials |
 |---|---|---|
+| `release-context` | Bind the dispatch to `main`, the release version, release immutability, and an absent tag | Read only |
 | `build` | Build and sign release artifacts | Artifact signing only |
 | `validate` | Reusable release validation | Read only |
 | `release-verified` | Join build and validation | None |
-| `release` | Validate curated release metadata and upload artifacts | GitHub contents write |
+| `release-assets` | Flatten and store the complete GitHub asset bundle as a run artifact | Read only |
+| `release-ready` | Join publication jobs and prove the tag is still absent | Read only |
 | `publish-crates` | Publish prevalidated crates in dependency order | crates.io OIDC |
 | `npm-prep` | Install, assemble, and pack npm artifacts | Read only |
 | `npm-publish` | Publish downloaded tarballs | npm publication |
@@ -37,12 +40,22 @@ globally with `--ignore-scripts`.
   release publish-list test.
 - Keep artifact inventory and package-name constants aligned with the build
   matrix.
-- Create the curated GitHub Release from the maintainer flow immediately after
-  pushing the signed tag. The credential-bearing workflow only validates its
-  title and body and uploads assets to it.
-- Keep `generate_release_notes: false`. Require a non-empty title, a non-empty
-  body, the repository comparison URL, and at least one matched release asset.
-  Missing curated metadata must fail before package publication can continue.
+- Require repository release immutability before publication.
+- Dispatch the release workflow from `main` with the strict semantic-version
+  tag. Reject a mismatched version or existing remote tag before expensive work
+  starts, then reconfirm tag absence before staging the final asset bundle.
+- Flatten the complete binary inventory into the `release-assets` Actions
+  artifact. Reject an empty inventory or duplicate asset name.
+- Keep the version tag absent until validation, asset staging, and every
+  registry and marketplace publication have completed successfully.
+- Create and push the signed version tag near the end of the maintainer flow.
+  Immediately create the GitHub Release with the curated notes and the exact
+  `release-assets` bundle. GitHub CLI creates a draft, uploads every asset, and
+  publishes only after upload, so release immutability is applied to a complete
+  release.
+- Do not generate release notes. Require a non-empty title, a non-empty body,
+  the exact repository comparison URL, and the complete asset inventory before
+  creating the tag.
 - Push rolling Action tags and refresh Dockerfile binary pins from the
   maintainer release workflow after published assets exist, not from the
   credential-bearing GitHub workflow.

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -334,44 +334,88 @@ test("release runs Zed verification on macOS and Windows without credentials", (
 
 test("release publication waits for the aggregate verification gate", () => {
   const workflow = readWorkflow(".github/workflows/release.yml");
+  const context = indentedBlock(workflow, "release-context", 2);
+  const build = indentedBlock(workflow, "build", 2);
+  const validate = indentedBlock(workflow, "validate", 2);
   const gate = indentedBlock(workflow, "release-verified", 2);
   const publishCrates = indentedBlock(workflow, "publish-crates", 2);
-  const release = indentedBlock(workflow, "release", 2);
+  const releaseAssets = indentedBlock(workflow, "release-assets", 2);
+  const releaseReady = indentedBlock(workflow, "release-ready", 2);
   const npmPublish = indentedBlock(workflow, "npm-publish", 2);
   const vscodePublish = indentedBlock(workflow, "vscode-publish", 2);
 
+  assert.match(context, /permissions:\n\s+contents: read/);
+  assert.match(build, /needs: release-context/);
+  assert.match(validate, /needs: release-context/);
   assert.match(gate, /needs: \[build, validate\]/);
   assert.match(gate, /permissions: \{\}/);
-  assert.match(publishCrates, /needs: \[release-verified, release\]/);
-  assert.match(release, /needs: release-verified/);
-  assert.match(npmPublish, /needs: \[npm-prep, release\]/);
-  assert.match(vscodePublish, /needs: \[vscode-prep, release\]/);
+  assert.match(publishCrates, /needs: \[release-verified, release-assets\]/);
+  assert.match(releaseAssets, /needs: release-verified/);
+  assert.match(releaseAssets, /permissions:\n\s+contents: read/);
+  assert.match(npmPublish, /needs: \[npm-prep, release-assets\]/);
+  assert.match(vscodePublish, /needs: \[vscode-prep, release-assets\]/);
+  assert.match(
+    releaseReady,
+    /needs: \[publish-crates, npm-publish, vscode-publish, release-assets\]/,
+  );
+  assert.match(releaseReady, /permissions:\n\s+contents: read/);
+  assert.match(releaseReady, /Release tag .* appeared before the release workflow completed/u);
 });
 
-test("release requires curated public notes before uploading assets", () => {
+test("release keeps the version tag last and requires curated public notes", () => {
   const workflow = readWorkflow(".github/workflows/release.yml");
-  const release = indentedBlock(workflow, "release", 2);
+  const context = indentedBlock(workflow, "release-context", 2);
+  const releaseAssets = indentedBlock(workflow, "release-assets", 2);
   const skill = readFileSync(".agents/skills/release/SKILL.md", "utf8");
-  const verifyStep = release.indexOf("- name: Verify curated release metadata");
-  const uploadStep = release.indexOf("- name: Upload assets to curated GitHub Release");
+  const downloadStep = releaseAssets.indexOf("- name: Download all artifacts");
+  const absentTagStep = releaseAssets.indexOf("- name: Reconfirm release tag is absent");
+  const assembleStep = releaseAssets.indexOf("- name: Assemble release asset bundle");
+  const uploadStep = releaseAssets.indexOf("- name: Upload release asset bundle");
+  const workflowDispatch = skill.indexOf("gh workflow run release.yml");
+  const downloadBundle = skill.indexOf('gh run download "$RUN_ID"');
+  const signedTag = skill.indexOf('git tag -s "$TAG"');
+  const createRelease = skill.indexOf('gh release create "$TAG"');
 
-  assert.notEqual(verifyStep, -1, "release must verify curated metadata");
-  assert.notEqual(uploadStep, -1, "release must upload to the curated release");
-  assert.ok(verifyStep < uploadStep, "curated metadata must be verified before asset upload");
-  assert.match(release, /gh release view "\$TAG_NAME"/u);
-  assert.match(release, /Curated GitHub Release title is empty/u);
-  assert.match(release, /title is missing a user-facing summary/u);
-  assert.match(release, /Curated GitHub Release body is empty/u);
-  assert.match(release, /compare_suffix="\.\.\.\$\{TAG_NAME\}"/u);
-  assert.match(release, /full changelog comparison link/u);
-  assert.match(release, /fail_on_unmatched_files: true/u);
-  assert.match(release, /generate_release_notes: false/u);
+  assert.notEqual(downloadStep, -1, "release must download every built artifact");
+  assert.notEqual(absentTagStep, -1, "release must reconfirm tag absence");
+  assert.notEqual(assembleStep, -1, "release must assemble the final asset bundle");
+  assert.notEqual(uploadStep, -1, "release must store the final asset bundle");
+  assert.ok(downloadStep < absentTagStep);
+  assert.ok(absentTagStep < assembleStep);
+  assert.ok(assembleStep < uploadStep);
+  assert.match(workflow, /^  workflow_dispatch:$/mu);
+  assert.match(workflow, /^\s{6}tag:$/mu);
+  assert.doesNotMatch(workflow, /^\s{6}release_id:$/mu);
+  assert.doesNotMatch(workflow, /^  push:\n\s+tags:/mu);
+  assert.doesNotMatch(workflow, /github\.ref_name|refs\/tags\/v/mu);
+  assert.match(context, /GITHUB_REF.*refs\/heads\/main/su);
+  assert.match(context, /Release tag must match vMAJOR\.MINOR\.PATCH/u);
+  assert.match(context, /immutable-releases/u);
+  assert.match(context, /Release tag .* already exists; tag creation must remain near the end/u);
+  assert.match(releaseAssets, /Release tag .* appeared before publication completed/u);
+  assert.match(releaseAssets, /No release assets were downloaded/u);
+  assert.match(releaseAssets, /Duplicate release asset name/u);
+  assert.match(releaseAssets, /name: release-assets/u);
+  assert.match(releaseAssets, /if-no-files-found: error/u);
+  assert.match(releaseAssets, /retention-days: 7/u);
+  assert.doesNotMatch(
+    workflow,
+    /gh release create|softprops\/action-gh-release|git tag|git push origin/u,
+  );
 
-  assert.match(skill, /Draft curated public GitHub release notes before pushing the release tag/u);
-  assert.match(skill, /gh release create "\$TAG"/u);
-  assert.match(skill, /--notes-file "\$NOTES_FILE"/u);
+  assert.match(skill, /Draft curated public GitHub release notes before starting the publication/u);
   assert.match(skill, /exact full-changelog comparison URL/u);
   assert.match(skill, /non-empty body/u);
+  assert.match(skill, /--name release-assets/u);
+  assert.match(skill, /--verify-tag/u);
+  assert.match(skill, /--notes-file "\$NOTES_FILE"/u);
+  assert.notEqual(workflowDispatch, -1, "skill must dispatch the release workflow");
+  assert.notEqual(downloadBundle, -1, "skill must download the exact run asset bundle");
+  assert.notEqual(signedTag, -1, "skill must create a signed release tag");
+  assert.notEqual(createRelease, -1, "skill must create the immutable release");
+  assert.ok(workflowDispatch < downloadBundle, "workflow must complete before asset download");
+  assert.ok(downloadBundle < signedTag, "asset bundle must exist before tag creation");
+  assert.ok(signedTag < createRelease, "signed tag must exist before release creation");
 });
 
 test("release verifies committed signing-key parity before signing", () => {


### PR DESCRIPTION
## Summary

- run release validation and registry publication from an explicit main dispatch while the version tag is absent
- stage the complete GitHub asset bundle as an Actions artifact and expose one final tag-ready gate
- create the signed tag and immutable GitHub Release only after the workflow and public registry checks succeed

## Validation

- `npm run verify:full`
- `npm run verify:fast`
- workflow policy tests
- actionlint and zizmor on the release workflows
- agent adapter and knowledge architecture checks