### PR TITLE
feat(plugins): drive config-value dependency credits from a catalogue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,23 @@ ecosystem = "core"
 - Do **not** add framework-plugin packages (`vite-plugin-*`, `prettier-plugin-*`, `eslint-plugin-*`, `@rollup/plugin-*`, or scoped forms like `@ianvs/prettier-plugin-sort-imports`). Those must be credited by the relevant plugin's config parser when they actually appear in the config file; listing them here would hide a declared-but-unused plugin. The catalogue's parse tests reject such entries.
 - Run `cargo test -p fallow-core plugins::tooling` to validate the catalogue (it checks the TOML parses, has no empty/whitespace prefixes, no duplicates, and no framework-plugin entries). The file is embedded into the binary via `include_str!`, so a passing test means a working release.
 
+## Crediting a dependency named by a config value
+
+Some packages are loaded at runtime only because a config value names them, with no import anywhere: `test.environment: "jsdom"` makes jsdom lazily require its optional peer `canvas`, and Vite's `css.transformer: "lightningcss"` makes Vite require `lightningcss`. Those rules live in a second data-driven catalogue at `crates/core/data/config_value_credits.toml`, next to `tooling.toml` and parsed the same way (embedded via `include_str!`, no regeneration step):
+
+```toml
+[[credit]]
+surface = "test-environment-optional-peer"
+value = "jsdom"
+credits = ["canvas"]
+notes = "optional, human context only"
+```
+
+- `surface` says which config location the value came from. The set is closed, because each surface has a call site in a plugin that knows how to normalize the value first. Adding a row for an existing surface is pure data; adding a surface means adding the `CreditSurface` variant and its call site in the same change.
+- `value` is matched exactly, after that normalization (the test-environment surfaces strip the `jest-environment-` / `vitest-environment-` prefix). `credits` must be non-empty. Only packages the project actually declares are ever reported, so a credit never invents a dependency.
+- Do **not** turn this into "credit every optional peer of a used package". Vite alone declares twelve optional peers, so that rule would silently exempt all of them and hide genuinely unused dependencies. Every row needs a specific, config-observable reason the package is loaded.
+- Run `cargo test -p fallow-core config_value_credits` to validate the catalogue (it checks the TOML parses, rejects unknown surfaces and fields, empty values or credits, and duplicate rows).
+
 ## Editing the JSON output contract
 
 Fallow's JSON output schema lives in `docs/output-schema.json` (JSON Schema draft-07) and is consumed by downstream tools (VS Code extension TypeScript codegen, GitHub Action jq scripts, AI agents using AJV validation).

--- a/crates/core/data/config_value_credits.toml
+++ b/crates/core/data/config_value_credits.toml
@@ -1,0 +1,75 @@
+# Community-maintainable catalogue of config-value dependency credits.
+#
+# Some packages are loaded at runtime purely because a config VALUE names them,
+# with no import anywhere in the project. `test.environment = "jsdom"` makes
+# jsdom lazily require its optional peer `canvas`; `css.transformer =
+# "lightningcss"` makes Vite require `lightningcss`. Without a credit those
+# declared dependencies are reported as unused, and removing them breaks the
+# build or the test run.
+#
+# This file is the single source of truth for those rules: it is embedded into
+# the binary via `include_str!` and parsed once at startup (see
+# `crates/core/src/plugins/config_value_credits.rs`). There is NO regeneration
+# step. To add a rule for an existing surface, add one entry below and open a
+# PR.
+#
+# Each entry is `(surface, value) -> credits`:
+#   - `surface`: which config location the value was read from. The set of
+#     surfaces is closed, because each one has a call site in a plugin; an
+#     unknown surface fails the catalogue parse loudly. Adding a surface means
+#     adding the enum variant and its call site in the same PR.
+#   - `value`: the exact config value, after any surface-specific
+#     normalization (the test-environment surfaces strip the
+#     `jest-environment-` / `vitest-environment-` prefix first).
+#   - `credits`: the packages to credit as referenced. Must be non-empty. Only
+#     names the project actually declares are ever reported, so a credit never
+#     invents a dependency.
+#   - `notes`: optional human context; does not affect matching.
+#
+# This catalogue is deliberately NOT "credit every optional peer of a used
+# package". Vite alone declares twelve optional peers, so that rule would
+# silently exempt all of them. Each row here is a specific, config-observable
+# reason a package is loaded.
+
+# ── test-environment-optional-peer ────────────────────────────────────────
+# Read from Jest `testEnvironment` and Vitest `test.environment`. Credits the
+# optional peers the selected environment requires at runtime, in ADDITION to
+# whatever package the environment name itself resolves to.
+
+[[credit]]
+surface = "test-environment-optional-peer"
+value = "jsdom"
+credits = ["canvas"]
+notes = """
+jsdom declares `canvas` as an optional peer and requires it lazily when it is
+installed, so a project that installs it for real canvas support has no import
+of it anywhere. happy-dom ships its own canvas stub and takes no such peer, so
+it gets no row here (issue #2005).
+"""
+
+# ── vitest-builtin-environment ────────────────────────────────────────────
+# Read from Vitest `test.environment`. These values name a built-in Vitest
+# environment rather than an installable package: there is no
+# `vitest-environment-<value>` package, and the bare name may belong to an
+# unrelated package. Only the listed credits are recorded, so the wrong
+# dependency is never exempted.
+
+[[credit]]
+surface = "vitest-builtin-environment"
+value = "edge-runtime"
+credits = ["@edge-runtime/vm"]
+notes = """
+`edge-runtime` is a built-in Vitest environment backed by the optional peer
+`@edge-runtime/vm`. The unrelated `edge-runtime` CLI package and the
+non-existent `vitest-environment-edge-runtime` must not be credited.
+"""
+
+# ── vite-css-implementation ───────────────────────────────────────────────
+# Read from Vite `css.transformer` and `build.cssMinify`. Vite ships the
+# integration but not the implementation package, so naming one here makes the
+# build fail until the project installs it itself.
+
+[[credit]]
+surface = "vite-css-implementation"
+value = "lightningcss"
+credits = ["lightningcss"]

--- a/crates/core/src/plugins/config_value_credits.rs
+++ b/crates/core/src/plugins/config_value_credits.rs
@@ -1,0 +1,282 @@
+//! Config-value dependency crediting.
+//!
+//! Some packages are loaded at runtime only because a config value names them,
+//! with no import anywhere in the project. Crediting them keeps a declared
+//! dependency out of the unused-dependency report.
+//!
+//! The rules are data, not code: the `(surface, value) -> credits` rows live in
+//! `crates/core/data/config_value_credits.toml`, embedded via `include_str!`
+//! and parsed once at startup. There is no regeneration step. Adding a rule for
+//! an existing surface is a one-entry change. See `CONTRIBUTING.md`.
+
+use rustc_hash::FxHashMap;
+
+/// Embedded catalogue source. Because it is `include_str!`-embedded at compile
+/// time, a green `catalogue_parses` test guarantees the released binary parses.
+const CATALOGUE_TOML: &str = include_str!("../../data/config_value_credits.toml");
+
+/// The config locations a credited value can be read from.
+///
+/// The set is closed on purpose: every surface has a call site that knows how
+/// to normalize the value before the lookup, so an unknown surface in the TOML
+/// is a bug rather than a new rule. Serde rejects unknown variants, which makes
+/// the catalogue parse fail loudly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CreditSurface {
+    /// Jest `testEnvironment` / Vitest `test.environment`, after the runner
+    /// prefix is stripped. Credits are additive: the environment package itself
+    /// is credited by the runner plugin.
+    TestEnvironmentOptionalPeer,
+    /// Vitest `test.environment` values that name a built-in environment rather
+    /// than an installable package. Credits replace the name-derived
+    /// dependencies entirely.
+    VitestBuiltinEnvironment,
+    /// Vite `css.transformer` / `build.cssMinify`, naming the CSS
+    /// implementation package Vite loads but does not ship.
+    ViteCssImplementation,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogueFile {
+    #[serde(default)]
+    credit: Vec<CreditEntry>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreditEntry {
+    surface: CreditSurface,
+    /// The exact config value, after surface-specific normalization.
+    value: String,
+    /// Packages credited as referenced. Must be non-empty; an empty list would
+    /// be a silently inert row.
+    credits: Vec<String>,
+    /// Optional human context; does not affect matching.
+    #[expect(
+        dead_code,
+        reason = "documentation field, surfaced via the catalogue source"
+    )]
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+type Catalogue = FxHashMap<(CreditSurface, String), Vec<String>>;
+
+/// Parse and validate catalogue source.
+///
+/// # Errors
+///
+/// Returns a human-readable message when the TOML is malformed, an entry names
+/// an unknown surface, a value or credit is empty or whitespace, or two entries
+/// claim the same `(surface, value)` key.
+fn parse(source: &str) -> Result<Catalogue, String> {
+    let parsed: CatalogueFile = toml::from_str(source).map_err(|e| e.to_string())?;
+    let mut catalogue = Catalogue::default();
+
+    for entry in parsed.credit {
+        if entry.value.trim().is_empty() {
+            return Err(format!(
+                "credit entry for {:?} has an empty value",
+                entry.surface
+            ));
+        }
+        if entry.credits.is_empty() {
+            return Err(format!(
+                "credit entry {:?} / {:?} credits no packages",
+                entry.surface, entry.value
+            ));
+        }
+        if let Some(blank) = entry.credits.iter().find(|c| c.trim().is_empty()) {
+            return Err(format!(
+                "credit entry {:?} / {:?} has an empty credit {blank:?}",
+                entry.surface, entry.value
+            ));
+        }
+        let key = (entry.surface, entry.value);
+        if catalogue.contains_key(&key) {
+            return Err(format!("duplicate credit entry: {:?} / {:?}", key.0, key.1));
+        }
+        catalogue.insert(key, entry.credits);
+    }
+
+    Ok(catalogue)
+}
+
+/// Parse and cache the embedded catalogue once. Panics with a clear message if
+/// the embedded TOML is invalid; this is unreachable in a released binary
+/// because the bytes are compile-time-embedded and gated by `catalogue_parses`.
+#[expect(
+    clippy::expect_used,
+    reason = "embedded credit catalogue is compile-time data pinned by catalogue_parses"
+)]
+fn catalogue() -> &'static Catalogue {
+    static CATALOGUE: std::sync::OnceLock<Catalogue> = std::sync::OnceLock::new();
+    CATALOGUE.get_or_init(|| {
+        parse(CATALOGUE_TOML).expect(
+            "embedded crates/core/data/config_value_credits.toml must be valid; run \
+             `cargo test -p fallow-core config_value_credits` to see the error",
+        )
+    })
+}
+
+/// Packages credited because `value` was read from `surface`.
+///
+/// Returns `None` when no rule matches, which callers distinguish from a rule
+/// crediting nothing: a row always credits at least one package.
+#[must_use]
+pub fn credited_packages(surface: CreditSurface, value: &str) -> Option<&'static [String]> {
+    catalogue()
+        .get(&(surface, value.to_string()))
+        .map(Vec::as_slice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogue_parses() {
+        let cat = catalogue();
+        assert!(!cat.is_empty(), "catalogue must have entries");
+    }
+
+    #[test]
+    fn jsdom_credits_canvas() {
+        assert_eq!(
+            credited_packages(CreditSurface::TestEnvironmentOptionalPeer, "jsdom"),
+            Some(["canvas".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn edge_runtime_credits_vm_package() {
+        assert_eq!(
+            credited_packages(CreditSurface::VitestBuiltinEnvironment, "edge-runtime"),
+            Some(["@edge-runtime/vm".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn lightningcss_credits_itself() {
+        assert_eq!(
+            credited_packages(CreditSurface::ViteCssImplementation, "lightningcss"),
+            Some(["lightningcss".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn happy_dom_has_no_optional_peer_credit() {
+        assert!(
+            credited_packages(CreditSurface::TestEnvironmentOptionalPeer, "happy-dom").is_none()
+        );
+    }
+
+    #[test]
+    fn surfaces_do_not_leak_into_each_other() {
+        assert!(credited_packages(CreditSurface::ViteCssImplementation, "jsdom").is_none());
+        assert!(
+            credited_packages(CreditSurface::TestEnvironmentOptionalPeer, "lightningcss").is_none()
+        );
+    }
+
+    #[test]
+    fn unknown_surface_is_rejected() {
+        let err = parse(
+            r#"
+[[credit]]
+surface = "vite-postcss-plugin"
+value = "x"
+credits = ["y"]
+"#,
+        )
+        .expect_err("unknown surface must fail");
+        assert!(err.contains("vite-postcss-plugin"), "got: {err}");
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let err = parse(
+            r#"
+[[credit]]
+surface = "vite-css-implementation"
+value = "x"
+credits = ["y"]
+ecosystem = "css"
+"#,
+        )
+        .expect_err("unknown field must fail");
+        assert!(err.contains("ecosystem"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_value_is_rejected() {
+        parse(
+            r#"
+[[credit]]
+surface = "vite-css-implementation"
+value = "  "
+credits = ["y"]
+"#,
+        )
+        .expect_err("empty value must fail");
+    }
+
+    #[test]
+    fn empty_credits_are_rejected() {
+        parse(
+            r#"
+[[credit]]
+surface = "vite-css-implementation"
+value = "x"
+credits = []
+"#,
+        )
+        .expect_err("empty credits must fail");
+    }
+
+    #[test]
+    fn blank_credit_is_rejected() {
+        parse(
+            r#"
+[[credit]]
+surface = "vite-css-implementation"
+value = "x"
+credits = [""]
+"#,
+        )
+        .expect_err("blank credit must fail");
+    }
+
+    #[test]
+    fn duplicate_entry_is_rejected() {
+        let err = parse(
+            r#"
+[[credit]]
+surface = "vite-css-implementation"
+value = "x"
+credits = ["y"]
+
+[[credit]]
+surface = "vite-css-implementation"
+value = "x"
+credits = ["z"]
+"#,
+        )
+        .expect_err("duplicate entry must fail");
+        assert!(err.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn missing_required_field_is_rejected() {
+        parse(
+            r#"
+[[credit]]
+surface = "vite-css-implementation"
+credits = ["y"]
+"#,
+        )
+        .expect_err("missing value must fail");
+    }
+}

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -1138,6 +1138,7 @@ macro_rules! define_plugin {
 }
 
 pub mod config_parser;
+mod config_value_credits;
 mod manifest;
 pub mod manifest_entries;
 pub mod registry;
@@ -1157,19 +1158,39 @@ fn add_import_referenced_dependencies(result: &mut PluginResult, source: &str, c
 
 /// Credit the optional peer dependencies a test environment loads at runtime.
 ///
-/// `jsdom` declares `canvas` as an optional peer and requires it lazily when it
-/// is installed, so a project that installs `canvas` to give jsdom real canvas
-/// support has no import of it anywhere in its own source. Without this credit
-/// the dependency is reported as unused and removing it silently breaks every
-/// canvas-backed test (issue #2005).
+/// The rules are data: see the `test-environment-optional-peer` rows in
+/// `crates/core/data/config_value_credits.toml`. `jsdom` requires its optional
+/// peer `canvas` lazily when it is installed, so a project installing it for
+/// real canvas support has no import of it anywhere and would see the
+/// dependency reported as unused (issue #2005). Environments without such a
+/// peer, like `happy-dom`, have no row.
 ///
-/// `happy-dom` ships its own canvas stub and takes no such peer, so it gets no
-/// credit here. Only names already declared in the manifest can be credited, so
-/// this never invents an unlisted dependency.
+/// Only names already declared in the manifest can be credited, so this never
+/// invents an unlisted dependency.
 fn credit_environment_optional_peers(environment: &str, result: &mut PluginResult) {
-    if canonical_test_environment(environment) == "jsdom" {
-        result.referenced_dependencies.push("canvas".to_string());
-    }
+    credit_config_value(
+        config_value_credits::CreditSurface::TestEnvironmentOptionalPeer,
+        canonical_test_environment(environment),
+        result,
+    );
+}
+
+/// Record the catalogue credits for a config value, if any.
+///
+/// Returns whether a rule matched, which callers use when the credited packages
+/// replace the dependencies derived from the value itself.
+fn credit_config_value(
+    surface: config_value_credits::CreditSurface,
+    value: &str,
+    result: &mut PluginResult,
+) -> bool {
+    let Some(packages) = config_value_credits::credited_packages(surface, value) else {
+        return false;
+    };
+    result
+        .referenced_dependencies
+        .extend(packages.iter().cloned());
+    true
 }
 
 /// Strip the runner prefix from a test environment specifier.
@@ -1336,6 +1357,30 @@ mod tests {
         let plugin = nextjs::NextJsPlugin;
         let deps: Vec<String> = vec![];
         assert!(!plugin.is_enabled_with_deps(&deps, Path::new("/project")));
+    }
+
+    #[test]
+    fn environment_optional_peers_come_from_the_credit_catalogue() {
+        for environment in [
+            "jsdom",
+            "jest-environment-jsdom",
+            "vitest-environment-jsdom",
+        ] {
+            let mut result = PluginResult::default();
+            credit_environment_optional_peers(environment, &mut result);
+            assert_eq!(
+                result.referenced_dependencies,
+                vec!["canvas".to_string()],
+                "expected the catalogue credit for {environment}"
+            );
+        }
+    }
+
+    #[test]
+    fn environment_without_a_catalogue_row_credits_nothing() {
+        let mut result = PluginResult::default();
+        credit_environment_optional_peers("happy-dom", &mut result);
+        assert!(result.referenced_dependencies.is_empty());
     }
 
     #[test]

--- a/crates/core/src/plugins/vite.rs
+++ b/crates/core/src/plugins/vite.rs
@@ -8,9 +8,12 @@ use super::{Plugin, PluginResult};
 
 const CONFIG_EXPORTS: &[&str] = &["default"];
 
-/// Vite ships the lightningcss integration but not the package: either of these
-/// config values makes the build fail until the project installs it itself.
-const LIGHTNINGCSS_SELECTOR_PATHS: &[&[&str]] = &[&["css", "transformer"], &["build", "cssMinify"]];
+/// Vite ships the CSS integrations but not the implementation packages: naming
+/// one under either of these keys makes the build fail until the project
+/// installs it itself. The value-to-package rules are catalogue rows under the
+/// `vite-css-implementation` surface.
+const CSS_IMPLEMENTATION_SELECTOR_PATHS: &[&[&str]] =
+    &[&["css", "transformer"], &["build", "cssMinify"]];
 
 fn additional_data_entry_pattern(
     root: &std::path::Path,
@@ -82,6 +85,30 @@ fn local_style_candidate_exists(root: &std::path::Path, normalized: &str) -> boo
             || root.join(path).join(format!("_index.{ext}")).is_file()
             || root.join(path).join(format!("index.{ext}")).is_file()
     })
+}
+
+/// Credit the CSS implementation package named under one of the CSS keys.
+///
+/// The first key that carries a catalogued value wins; Vite loads one
+/// implementation, so a second credit would exempt a package it never requires.
+fn add_css_implementation_dependency(
+    result: &mut PluginResult,
+    source: &str,
+    config_path: &std::path::Path,
+) {
+    for selector in CSS_IMPLEMENTATION_SELECTOR_PATHS {
+        let Some(value) = config_parser::extract_config_string(source, config_path, selector)
+        else {
+            continue;
+        };
+        if super::credit_config_value(
+            super::config_value_credits::CreditSurface::ViteCssImplementation,
+            &value,
+            result,
+        ) {
+            break;
+        }
+    }
 }
 
 define_plugin!(
@@ -179,16 +206,7 @@ define_plugin!(
                 .push(crate::resolve::extract_package_name(dep));
         }
 
-        for selector in LIGHTNINGCSS_SELECTOR_PATHS {
-            if config_parser::extract_config_string(source, config_path, selector)
-                .is_some_and(|value| value == "lightningcss")
-            {
-                result
-                    .referenced_dependencies
-                    .push("lightningcss".to_string());
-                break;
-            }
-        }
+        add_css_implementation_dependency(&mut result, source, config_path);
 
         for preprocessor in ["scss", "sass", "less", "stylus"] {
             let body = config_parser::extract_config_string_or_array(

--- a/crates/core/src/plugins/vitest.rs
+++ b/crates/core/src/plugins/vitest.rs
@@ -248,20 +248,23 @@ fn add_vitest_environment_dependency(result: &mut PluginResult, source: &str, co
             result.referenced_dependencies.push(env.clone());
             super::credit_environment_optional_peers(&env, result);
         }
-        // A built-in vitest environment backed by an optional peer. There is no
-        // `vitest-environment-edge-runtime` package, and `edge-runtime` is an
-        // unrelated CLI package, so crediting either name exempted the wrong
-        // dependency while leaving the one vitest actually loads unreported.
-        "edge-runtime" => {
-            result
-                .referenced_dependencies
-                .push("@edge-runtime/vm".to_string());
-        }
         _ => {
-            result
-                .referenced_dependencies
-                .push(format!("vitest-environment-{env}"));
-            result.referenced_dependencies.push(env);
+            // A built-in vitest environment names no installable package: there
+            // is no `vitest-environment-<value>` package, and the bare name may
+            // belong to an unrelated one, so crediting either exempts the wrong
+            // dependency while leaving the peer vitest actually loads
+            // unreported. The catalogue rows carry that peer instead.
+            let credited = super::credit_config_value(
+                super::config_value_credits::CreditSurface::VitestBuiltinEnvironment,
+                &env,
+                result,
+            );
+            if !credited {
+                result
+                    .referenced_dependencies
+                    .push(format!("vitest-environment-{env}"));
+                result.referenced_dependencies.push(env);
+            }
         }
     }
 }


### PR DESCRIPTION
Three hardcoded arms credited packages named by a config value: jsdom's optional peer canvas, vitest's edge-runtime peer, and vite's lightningcss. Every further rule was another Rust arm and another PR.

They now read from `crates/core/data/config_value_credits.toml`, embedded and parsed once like `tooling.toml`, keyed on (surface, value) -> credits. Adding a rule for an existing surface is a one-entry data change. The surface set stays closed because each surface has a call site that normalizes the value first; an unknown surface, unknown field, empty value or credit, or duplicate row fails the catalogue parse loudly.

Behavior is unchanged for the three migrated cases. This deliberately does not become 'credit every optional peer of a used package', which would exempt all twelve of vite's optional peers.

Fixes #2018