### PR TITLE
feat(config): report ignoreFindings patterns that match nothing

### DIFF
--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -1181,6 +1181,7 @@ pub fn print_check_result(result: &CheckResult, opts: PrintCheckOptions) -> Exit
 
     print_load_data_key_abstain_note(result, prepared.quiet);
     print_unused_component_props_exempted_note(result, prepared.quiet);
+    print_unmatched_ignore_findings_note(result, prepared.quiet);
     issue_severity_exit_code(result, &prepared.effective_rules)
 }
 
@@ -1315,6 +1316,28 @@ fn print_unused_component_props_exempted_note(result: &CheckResult, quiet: bool)
     eprintln!(
         "Note: {count} component {noun} exempted by unusedComponentProps.ignorePattern \
          (matched on the local binding name, e.g. _stage, not the public prop name)."
+    );
+}
+
+/// Human-output note when an `ignoreFindings` pattern matched no candidate
+/// finding this run. A typo'd pattern is otherwise a silent no-op.
+fn print_unmatched_ignore_findings_note(result: &CheckResult, quiet: bool) {
+    if quiet || !matches!(result.config.output, OutputFormat::Human) {
+        return;
+    }
+    let unmatched = result.config.ignore_findings.unmatched_patterns();
+    if unmatched.is_empty() {
+        return;
+    }
+    let noun = if unmatched.len() == 1 {
+        "pattern"
+    } else {
+        "patterns"
+    };
+    eprintln!(
+        "Note: ignoreFindings {noun} matched no finding this run: {} (patterns are \
+         project-root-relative globs; check for typos).",
+        unmatched.join(", ")
     );
 }
 

--- a/crates/cli/tests/check_tests.rs
+++ b/crates/cli/tests/check_tests.rs
@@ -810,3 +810,92 @@ fn check_human_output_unused_deps_has_content() {
         "should list unused-dep"
     );
 }
+
+/// Build a project with one unused file under `src/legacy` and one under `src`,
+/// plus the given `ignoreFindings` patterns.
+fn ignore_findings_project(patterns: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temporary project");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src/legacy")).expect("create source directories");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"ignore-findings","private":true,"type":"module","main":"src/index.ts"}"#,
+    )
+    .expect("write package");
+    std::fs::write(
+        root.join(".fallowrc.json"),
+        format!(r#"{{"ignoreFindings": {patterns}}}"#),
+    )
+    .expect("write config");
+    std::fs::write(
+        root.join("src/index.ts"),
+        "export const main = (): void => {};\n",
+    )
+    .expect("write entry point");
+    std::fs::write(root.join("src/legacy/old.ts"), "export const old = 1;\n")
+        .expect("write legacy file");
+    std::fs::write(root.join("src/orphan.ts"), "export const orphan = 1;\n")
+        .expect("write orphan file");
+    dir
+}
+
+#[test]
+fn ignore_findings_pattern_matching_nothing_prints_note() {
+    let dir = ignore_findings_project(r#"["src/legacy/**", "src/legcy/**"]"#);
+    let output = run_fallow_in_root("dead-code", dir.path(), &["--unused-files"]);
+
+    assert!(
+        output
+            .stderr
+            .contains("ignoreFindings pattern matched no finding")
+            && output.stderr.contains("src/legcy/**"),
+        "stderr should name the pattern that matched nothing; stderr: {}",
+        output.stderr
+    );
+    assert!(
+        !output.stderr.contains("src/legacy/**"),
+        "the matching pattern should not be named; stderr: {}",
+        output.stderr
+    );
+}
+
+#[test]
+fn ignore_findings_pattern_that_matches_prints_no_note() {
+    let dir = ignore_findings_project(r#"["src/legacy/**"]"#);
+    let output = run_fallow_in_root("dead-code", dir.path(), &["--unused-files"]);
+
+    assert!(
+        !output.stderr.contains("ignoreFindings"),
+        "a matching pattern should stay silent; stderr: {}",
+        output.stderr
+    );
+}
+
+#[test]
+fn no_ignore_findings_configuration_prints_no_note() {
+    let dir = ignore_findings_project("[]");
+    let output = run_fallow_in_root("dead-code", dir.path(), &["--unused-files"]);
+
+    assert!(
+        !output.stderr.contains("ignoreFindings"),
+        "an empty configuration should stay silent; stderr: {}",
+        output.stderr
+    );
+}
+
+#[test]
+fn ignore_findings_note_stays_out_of_json_output() {
+    let dir = ignore_findings_project(r#"["src/legacy/**", "src/legcy/**"]"#);
+    let output = run_fallow_in_root(
+        "dead-code",
+        dir.path(),
+        &["--unused-files", "--format", "json"],
+    );
+
+    assert!(
+        !output.stdout.contains("ignoreFindings") && !output.stderr.contains("ignoreFindings"),
+        "json output must not carry the human note; stdout: {}\nstderr: {}",
+        output.stdout,
+        output.stderr
+    );
+}

--- a/crates/config/src/config/finding_ignore.rs
+++ b/crates/config/src/config/finding_ignore.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
 /// Compiled project-relative patterns for hiding source-owned findings.
@@ -9,7 +12,43 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 pub struct FindingIgnoreMatcher {
     hidden: GlobSet,
     reported: GlobSet,
-    has_patterns: bool,
+    usage: Option<Arc<PatternUsage>>,
+}
+
+/// Per-pattern hit state for the shared matcher.
+///
+/// The matcher is cloned along with the resolved config and consulted from
+/// several pipeline stages, so the state lives behind an `Arc` and every clone
+/// records into the same run.
+#[derive(Debug)]
+struct PatternUsage {
+    patterns: Vec<String>,
+    /// Original pattern index for each glob in `hidden`, in build order.
+    hidden_origins: Vec<usize>,
+    /// Original pattern index for each glob in `reported`, in build order.
+    reported_origins: Vec<usize>,
+    matched: Vec<AtomicBool>,
+    consulted: AtomicBool,
+}
+
+impl PatternUsage {
+    fn record(&self, origins: &[usize], set_indices: &[usize]) {
+        for &index in set_indices {
+            if let Some(&origin) = origins.get(index)
+                && let Some(flag) = self.matched.get(origin)
+            {
+                flag.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// Compiled glob sets plus the mapping back to the configured pattern order.
+struct CompiledSets {
+    hidden: GlobSet,
+    reported: GlobSet,
+    hidden_origins: Vec<usize>,
+    reported_origins: Vec<usize>,
 }
 
 impl FindingIgnoreMatcher {
@@ -22,13 +61,19 @@ impl FindingIgnoreMatcher {
             return Self::default();
         }
 
-        let (hidden, reported) = Self::build_sets(patterns)
+        let sets = Self::build_sets(patterns)
             .expect("ignoreFindings pattern sets were validated before config resolution");
 
         Self {
-            hidden,
-            reported,
-            has_patterns: true,
+            hidden: sets.hidden,
+            reported: sets.reported,
+            usage: Some(Arc::new(PatternUsage {
+                patterns: patterns.to_vec(),
+                hidden_origins: sets.hidden_origins,
+                reported_origins: sets.reported_origins,
+                matched: patterns.iter().map(|_| AtomicBool::new(false)).collect(),
+                consulted: AtomicBool::new(false),
+            })),
         }
     }
 
@@ -36,35 +81,80 @@ impl FindingIgnoreMatcher {
         Self::build_sets(patterns).map(|_| ())
     }
 
-    fn build_sets(patterns: &[String]) -> Result<(GlobSet, GlobSet), globset::Error> {
+    fn build_sets(patterns: &[String]) -> Result<CompiledSets, globset::Error> {
         let mut hidden = GlobSetBuilder::new();
         let mut reported = GlobSetBuilder::new();
+        let mut hidden_origins = Vec::new();
+        let mut reported_origins = Vec::new();
 
-        for pattern in patterns {
-            let (builder, pattern) = if let Some(pattern) = pattern.strip_prefix('!') {
-                (&mut reported, pattern)
+        for (index, pattern) in patterns.iter().enumerate() {
+            let (builder, origins, pattern) = if let Some(pattern) = pattern.strip_prefix('!') {
+                (&mut reported, &mut reported_origins, pattern)
             } else {
-                (&mut hidden, pattern.as_str())
+                (&mut hidden, &mut hidden_origins, pattern.as_str())
             };
             let pattern = pattern.strip_prefix("./").unwrap_or(pattern);
             builder.add(Glob::new(pattern)?);
+            origins.push(index);
         }
 
-        Ok((hidden.build()?, reported.build()?))
+        Ok(CompiledSets {
+            hidden: hidden.build()?,
+            reported: reported.build()?,
+            hidden_origins,
+            reported_origins,
+        })
     }
 
     /// Whether no finding-ignore patterns were configured.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        !self.has_patterns
+        self.usage.is_none()
     }
 
     /// Whether a normalized project-root-relative source path is hidden.
     #[must_use]
     pub fn is_ignored(&self, path: &str) -> bool {
-        self.has_patterns
-            && (self.hidden.is_empty() || self.hidden.is_match(path))
-            && !self.reported.is_match(path)
+        let Some(usage) = self.usage.as_deref() else {
+            return false;
+        };
+        usage.consulted.store(true, Ordering::Relaxed);
+
+        // Both sets are matched unconditionally so a negated pattern is not
+        // reported as a no-op merely because the positive set short-circuited.
+        let mut indices = Vec::new();
+        self.hidden.matches_into(path, &mut indices);
+        let hidden_hit = !indices.is_empty();
+        usage.record(&usage.hidden_origins, &indices);
+
+        self.reported.matches_into(path, &mut indices);
+        let reported_hit = !indices.is_empty();
+        usage.record(&usage.reported_origins, &indices);
+
+        (self.hidden.is_empty() || hidden_hit) && !reported_hit
+    }
+
+    /// Configured patterns that matched no candidate finding path, in config
+    /// order.
+    ///
+    /// Empty when nothing was configured or when the matcher was never
+    /// consulted, because a run without candidate paths says nothing about
+    /// whether a pattern is a typo.
+    #[must_use]
+    pub fn unmatched_patterns(&self) -> Vec<&str> {
+        let Some(usage) = self.usage.as_deref() else {
+            return Vec::new();
+        };
+        if !usage.consulted.load(Ordering::Relaxed) {
+            return Vec::new();
+        }
+        usage
+            .patterns
+            .iter()
+            .zip(&usage.matched)
+            .filter(|(_, matched)| !matched.load(Ordering::Relaxed))
+            .map(|(pattern, _)| pattern.as_str())
+            .collect()
     }
 }
 
@@ -129,6 +219,55 @@ mod tests {
         for path in ["src/private/app.ts", "src/public/app.ts", "README.md"] {
             assert_eq!(first.is_ignored(path), second.is_ignored(path));
         }
+    }
+
+    #[test]
+    fn empty_configuration_reports_no_unmatched_patterns() {
+        let matcher = matcher(&[]);
+
+        assert!(!matcher.is_ignored("src/app.ts"));
+        assert!(matcher.unmatched_patterns().is_empty());
+    }
+
+    #[test]
+    fn matching_pattern_is_not_reported_as_unmatched() {
+        let matcher = matcher(&["**/*.test.ts"]);
+
+        assert!(matcher.is_ignored("src/app.test.ts"));
+        assert!(matcher.unmatched_patterns().is_empty());
+    }
+
+    #[test]
+    fn pattern_matching_nothing_is_reported() {
+        let matcher = matcher(&["**/*.test.ts", "src/legcy/**"]);
+
+        assert!(matcher.is_ignored("src/app.test.ts"));
+        assert_eq!(matcher.unmatched_patterns(), vec!["src/legcy/**"]);
+    }
+
+    #[test]
+    fn unconsulted_matcher_reports_no_unmatched_patterns() {
+        let matcher = matcher(&["src/legcy/**"]);
+
+        assert!(matcher.unmatched_patterns().is_empty());
+    }
+
+    #[test]
+    fn negated_pattern_matching_nothing_is_reported() {
+        let matcher = matcher(&["**/*.ts", "!src/public/**", "!src/publik/**"]);
+
+        assert!(matcher.is_ignored("src/private/app.ts"));
+        assert!(!matcher.is_ignored("src/public/app.ts"));
+        assert_eq!(matcher.unmatched_patterns(), vec!["!src/publik/**"]);
+    }
+
+    #[test]
+    fn usage_state_is_shared_across_clones() {
+        let matcher = matcher(&["**/*.test.ts"]);
+        let clone = matcher.clone();
+
+        assert!(clone.is_ignored("src/app.test.ts"));
+        assert!(matcher.unmatched_patterns().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
A typo'd `ignoreFindings` pattern was a silent no-op: the pattern simply never matched, findings kept showing up, and nothing told you the config line was dead.

## What changes

The compiled `ignoreFindings` matcher now records which configured pattern matched a candidate finding path. After a `check` run, human output prints a note naming the patterns that matched nothing, next to the existing `unusedComponentProps.ignorePattern` note.

## How

- Hit state lives behind an `Arc` inside the matcher, so every clone of the resolved config records into the same run.
- Both glob sets are matched unconditionally, so a negated pattern is not reported as a no-op merely because the positive set short-circuited.
- The note is human-output only. JSON, SARIF, and every other format are untouched, so no schema or contract changes.
- The note is suppressed when the matcher was never consulted, so a run that produced no candidate findings does not claim every pattern is dead.

## Validation

Rebased on current `main`. Ran `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `cargo check --workspace --benches`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` after the type-aware sidecar install. All green.

Refs #2017
