### PR TITLE
feat(scripts): follow package-manager script indirection

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1893,7 +1893,8 @@ fn analyze_root_scripts(
     } else {
         pkg_scripts.clone()
     };
-    let catalog = scripts::ScriptCatalog::from_scripts(&scripts_to_analyze);
+    let catalog =
+        scripts::ScriptCatalog::from_scripts_with_bodies(pkg_scripts, &scripts_to_analyze);
     let script_analysis = scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         &config.root,
@@ -1964,7 +1965,7 @@ fn analyze_one_workspace_scripts(
     } else {
         ws_scripts.clone()
     };
-    let catalog = scripts::ScriptCatalog::from_scripts(&scripts_to_analyze);
+    let catalog = scripts::ScriptCatalog::from_scripts_with_bodies(ws_scripts, &scripts_to_analyze);
     let ws_analysis = scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         &ws.root,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1851,7 +1851,7 @@ fn collect_all_scripts(
     }
     for (_, ws_pkg) in workspace_pkgs {
         if let Some(ref ws_scripts) = ws_pkg.scripts {
-            catalog.merge_scripts(ws_scripts);
+            catalog.merge_workspace_scripts(ws_scripts);
         }
     }
     catalog
@@ -1893,7 +1893,7 @@ fn analyze_root_scripts(
     } else {
         pkg_scripts.clone()
     };
-    let catalog = scripts::ScriptCatalog::from_scripts(pkg_scripts);
+    let catalog = scripts::ScriptCatalog::from_scripts(&scripts_to_analyze);
     let script_analysis = scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         &config.root,
@@ -1964,7 +1964,7 @@ fn analyze_one_workspace_scripts(
     } else {
         ws_scripts.clone()
     };
-    let catalog = scripts::ScriptCatalog::from_scripts(ws_scripts);
+    let catalog = scripts::ScriptCatalog::from_scripts(&scripts_to_analyze);
     let ws_analysis = scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         &ws.root,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1800,7 +1800,7 @@ fn analyze_all_scripts(
 ) {
     let all_dep_names = collect_all_dependency_names(root_pkg, workspace_pkgs);
     let all_dep_set: FxHashSet<String> = all_dep_names.iter().cloned().collect();
-    let all_script_names = collect_all_script_names(root_pkg, workspace_pkgs);
+    let all_scripts = collect_all_scripts(root_pkg, workspace_pkgs);
 
     let nm_roots = collect_node_modules_roots(config, workspaces);
     let bin_map = scripts::build_bin_to_package_map(&nm_roots, &all_dep_names);
@@ -1813,13 +1813,7 @@ fn analyze_all_scripts(
         &all_dep_set,
         plugin_result,
     );
-    analyze_ci_scripts(
-        config,
-        &bin_map,
-        &all_dep_set,
-        &all_script_names,
-        plugin_result,
-    );
+    analyze_ci_scripts(config, &bin_map, &all_dep_set, &all_scripts, plugin_result);
 
     plugin_result
         .entry_point_roles
@@ -1844,23 +1838,23 @@ fn collect_all_dependency_names(
     all_dep_names
 }
 
-/// Gather the union of script names declared in the root and workspace packages.
-fn collect_all_script_names(
+/// Gather the scripts declared by the root and workspace packages.
+fn collect_all_scripts(
     root_pkg: Option<&PackageJson>,
     workspace_pkgs: &[LoadedWorkspacePackage],
-) -> FxHashSet<String> {
-    let mut all_script_names: FxHashSet<String> = FxHashSet::default();
+) -> scripts::ScriptCatalog {
+    let mut catalog = scripts::ScriptCatalog::default();
     if let Some(pkg) = root_pkg
         && let Some(ref pkg_scripts) = pkg.scripts
     {
-        all_script_names.extend(pkg_scripts.keys().cloned());
+        catalog.merge_scripts(pkg_scripts);
     }
     for (_, ws_pkg) in workspace_pkgs {
         if let Some(ref ws_scripts) = ws_pkg.scripts {
-            all_script_names.extend(ws_scripts.keys().cloned());
+            catalog.merge_scripts(ws_scripts);
         }
     }
-    all_script_names
+    catalog
 }
 
 /// Collect every directory (root and workspaces) that has a local `node_modules`.
@@ -1899,13 +1893,13 @@ fn analyze_root_scripts(
     } else {
         pkg_scripts.clone()
     };
-    let script_names: FxHashSet<String> = pkg_scripts.keys().cloned().collect();
+    let catalog = scripts::ScriptCatalog::from_scripts(pkg_scripts);
     let script_analysis = scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         &config.root,
         bin_map,
         all_dep_set,
-        &script_names,
+        &catalog,
     );
     plugin_result.script_used_packages = script_analysis.used_packages;
 
@@ -1970,13 +1964,13 @@ fn analyze_one_workspace_scripts(
     } else {
         ws_scripts.clone()
     };
-    let script_names: FxHashSet<String> = ws_scripts.keys().cloned().collect();
+    let catalog = scripts::ScriptCatalog::from_scripts(ws_scripts);
     let ws_analysis = scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         &ws.root,
         bin_map,
         all_dep_set,
-        &script_names,
+        &catalog,
     );
     used_packages.extend(ws_analysis.used_packages);
 
@@ -2001,11 +1995,11 @@ fn analyze_ci_scripts(
     config: &ResolvedConfig,
     bin_map: &rustc_hash::FxHashMap<String, String>,
     all_dep_set: &FxHashSet<String>,
-    all_script_names: &FxHashSet<String>,
+    all_scripts: &scripts::ScriptCatalog,
     plugin_result: &mut plugins::AggregatedPluginResult,
 ) {
     let ci_analysis =
-        scripts::ci::analyze_ci_files(&config.root, bin_map, all_dep_set, all_script_names);
+        scripts::ci::analyze_ci_files(&config.root, bin_map, all_dep_set, all_scripts);
     plugin_result
         .script_used_packages
         .extend(ci_analysis.used_packages);

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -1367,7 +1367,8 @@ fn script_activation_packages(
     }
     let bin_map = scripts::build_bin_to_package_map(&nm_roots, all_deps);
     let dep_set: FxHashSet<String> = all_deps.iter().cloned().collect();
-    let catalog = scripts::ScriptCatalog::from_scripts(pkg_scripts);
+    let catalog =
+        scripts::ScriptCatalog::from_scripts_with_bodies(pkg_scripts, &scripts_to_analyze);
 
     scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -1367,14 +1367,14 @@ fn script_activation_packages(
     }
     let bin_map = scripts::build_bin_to_package_map(&nm_roots, all_deps);
     let dep_set: FxHashSet<String> = all_deps.iter().cloned().collect();
-    let script_names: FxHashSet<String> = pkg_scripts.keys().cloned().collect();
+    let catalog = scripts::ScriptCatalog::from_scripts(pkg_scripts);
 
     scripts::analyze_scripts_with_dependency_context(
         &scripts_to_analyze,
         root,
         &bin_map,
         &dep_set,
-        &script_names,
+        &catalog,
     )
     .used_packages
 }

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -122,6 +122,45 @@ fn opennext_cloudflare_detected_from_adapter_script() {
     );
 }
 
+/// Production filtering must reach plugin activation as well. An
+/// argument-bearing call into a script body that production filtering skipped
+/// must not credit the adapter binary, because activating the plugin would add
+/// entry patterns and always-used config that suppress findings (issue #2016).
+#[test]
+fn production_activation_does_not_follow_indirection_into_filtered_script_bodies() {
+    let json = serde_json::json!({
+        "dependencies": deps_json(&["next"]),
+        "scripts": {
+            "build": "npm run deploy -- --env ci",
+            "deploy": "opennextjs-cloudflare deploy"
+        }
+    });
+    let pkg: PackageJson = serde_json::from_value(json).unwrap();
+    let registry = PluginRegistry::default();
+    let root = Path::new("/project");
+
+    let production = registry
+        .try_run_with_search_roots(&pkg, root, &[], &[root], true, None)
+        .expect("plugin run should succeed");
+    assert!(
+        !production
+            .active_plugins
+            .contains(&"opennext-cloudflare".to_string()),
+        "the deploy body is filtered out of production, got {:?}",
+        production.active_plugins
+    );
+
+    let full = registry
+        .try_run_with_search_roots(&pkg, root, &[], &[root], false, None)
+        .expect("plugin run should succeed");
+    assert!(
+        full.active_plugins
+            .contains(&"opennext-cloudflare".to_string()),
+        "outside production the deploy script is analyzed, got {:?}",
+        full.active_plugins
+    );
+}
+
 #[test]
 fn opennext_cloudflare_not_detected_for_plain_nextjs_project() {
     let registry = PluginRegistry::default();

--- a/crates/core/src/scripts/ci.rs
+++ b/crates/core/src/scripts/ci.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use super::{analyze_commands_with_context, could_be_file_path};
+use super::{ScriptCatalog, analyze_commands_with_context, could_be_file_path};
 
 /// Result of scanning CI config files: package names used by CI tooling AND
 /// project-relative file paths referenced as command-line arguments.
@@ -37,7 +37,7 @@ pub fn analyze_ci_files(
     root: &Path,
     bin_map: &FxHashMap<String, String>,
     declared_packages: &FxHashSet<String>,
-    script_names: &FxHashSet<String>,
+    scripts: &ScriptCatalog,
 ) -> CiAnalysis {
     let _span = tracing::info_span!("analyze_ci_files").entered();
     let mut analysis = CiAnalysis::default();
@@ -49,7 +49,7 @@ pub fn analyze_ci_files(
             root,
             bin_map,
             declared_packages,
-            script_names,
+            scripts,
             &mut analysis,
         );
     }
@@ -67,7 +67,7 @@ pub fn analyze_ci_files(
                     root,
                     bin_map,
                     declared_packages,
-                    script_names,
+                    scripts,
                     &mut analysis,
                 );
             }
@@ -92,12 +92,12 @@ fn extract_ci_signals(
     root: &Path,
     bin_map: &FxHashMap<String, String>,
     declared_packages: &FxHashSet<String>,
-    script_names: &FxHashSet<String>,
+    scripts: &ScriptCatalog,
     analysis: &mut CiAnalysis,
 ) {
     let commands = extract_ci_commands(content);
     let parsed =
-        analyze_commands_with_context(&commands, root, bin_map, declared_packages, script_names);
+        analyze_commands_with_context(&commands, root, bin_map, declared_packages, scripts);
     analysis.used_packages.extend(parsed.used_packages);
     analysis.entry_files.extend(
         parsed
@@ -265,6 +265,18 @@ mod tests {
         values.iter().map(|value| (*value).to_string()).collect()
     }
 
+    fn catalog(scripts: &[(&str, &str)]) -> ScriptCatalog {
+        #[expect(
+            clippy::disallowed_types,
+            reason = "ScriptCatalog is built from serde-deserialized HashMap"
+        )]
+        let scripts: std::collections::HashMap<String, String> = scripts
+            .iter()
+            .map(|(name, body)| ((*name).to_string(), (*body).to_string()))
+            .collect();
+        ScriptCatalog::from_scripts(&scripts)
+    }
+
     fn analyze_content(content: &str) -> CiAnalysis {
         let mut analysis = CiAnalysis::default();
         extract_ci_signals(
@@ -272,7 +284,7 @@ mod tests {
             Path::new("/nonexistent"),
             &FxHashMap::default(),
             &empty_set(),
-            &empty_set(),
+            &catalog(&[]),
             &mut analysis,
         );
         analysis
@@ -440,7 +452,7 @@ jobs:
             Path::new("/nonexistent"),
             &FxHashMap::default(),
             &set(&["envinfo"]),
-            &empty_set(),
+            &catalog(&[]),
             &mut analysis,
         );
         assert!(analysis.used_packages.contains("envinfo"));
@@ -460,10 +472,33 @@ jobs:
             Path::new("/nonexistent"),
             &FxHashMap::default(),
             &set(&["build"]),
-            &set(&["build"]),
+            &catalog(&[("build", "vite build")]),
             &mut analysis,
         );
         assert!(!analysis.used_packages.contains("build"));
+    }
+
+    /// The dominant real-world shape: CI never names the linter, it runs the
+    /// package.json script and adds the CI formatter flag (issue #2016).
+    #[test]
+    fn github_actions_npm_run_script_forwards_formatter_flag() {
+        let content = r"
+jobs:
+  lint:
+    steps:
+      - run: npm run lint -- --format gha
+";
+        let mut analysis = CiAnalysis::default();
+        extract_ci_signals(
+            content,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &set(&["eslint", "eslint-formatter-gha"]),
+            &catalog(&[("lint", "eslint .")]),
+            &mut analysis,
+        );
+        assert!(analysis.used_packages.contains("eslint"));
+        assert!(analysis.used_packages.contains("eslint-formatter-gha"));
     }
 
     #[test]

--- a/crates/core/src/scripts/ci.rs
+++ b/crates/core/src/scripts/ci.rs
@@ -33,6 +33,9 @@ pub struct CiAnalysis {
 ///
 /// CI files always live at `.gitlab-ci.yml` or `.github/workflows/*.yml`
 /// relative to the project root, so no workspace-prefix transformation applies.
+/// The catalog spans the whole project, so a CI step that resolves to a script
+/// declared only by a workspace package credits that body's dependencies but
+/// contributes none of its file arguments, which are relative to that package.
 pub fn analyze_ci_files(
     root: &Path,
     bin_map: &FxHashMap<String, String>,
@@ -499,6 +502,39 @@ jobs:
         );
         assert!(analysis.used_packages.contains("eslint"));
         assert!(analysis.used_packages.contains("eslint-formatter-gha"));
+    }
+
+    /// A root CI step resolving to a workspace-only script must not turn that
+    /// body's file arguments into root-relative entry patterns (issue #2016).
+    #[test]
+    fn workspace_only_script_body_does_not_seed_root_entry_files() {
+        let content = r"
+jobs:
+  build:
+    steps:
+      - run: npm run build -- --mode ci
+";
+        #[expect(
+            clippy::disallowed_types,
+            reason = "ScriptCatalog is built from serde-deserialized HashMap"
+        )]
+        let ws_scripts: std::collections::HashMap<String, String> =
+            std::iter::once(("build".to_string(), "esbuild scripts/bundle.js".to_string()))
+                .collect();
+        let mut scripts = ScriptCatalog::default();
+        scripts.merge_workspace_scripts(&ws_scripts);
+
+        let mut analysis = CiAnalysis::default();
+        extract_ci_signals(
+            content,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &set(&["esbuild"]),
+            &scripts,
+            &mut analysis,
+        );
+        assert!(analysis.used_packages.contains("esbuild"));
+        assert!(analysis.entry_files.is_empty());
     }
 
     #[test]

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -86,9 +86,123 @@ const PNPM_BUILTIN_COMMANDS: &[&str] = &[
 /// Boolean pnpm flags that can appear before an implicit binary invocation.
 const PNPM_IMPLICIT_EXEC_FLAGS: &[&str] = &["--silent", "-s"];
 
+/// Package manager subcommands that never name a package.json script, even when
+/// a script with the same name exists. `yarn install` runs the installer, not a
+/// script called `install`.
+const PACKAGE_MANAGER_BUILTIN_COMMANDS: &[&str] = &[
+    "add",
+    "audit",
+    "bin",
+    "cache",
+    "config",
+    "create",
+    "dedupe",
+    "dlx",
+    "exec",
+    "global",
+    "import",
+    "info",
+    "init",
+    "install",
+    "link",
+    "list",
+    "login",
+    "logout",
+    "ls",
+    "node",
+    "outdated",
+    "pack",
+    "patch",
+    "publish",
+    "remove",
+    "run",
+    "run-script",
+    "set",
+    "unlink",
+    "up",
+    "upgrade",
+    "version",
+    "why",
+    "workspace",
+    "workspaces",
+];
+
+/// Maximum depth of `npm run <script>` indirection that is followed. Guards
+/// against pathological nesting on top of the cycle guard.
+const MAX_SCRIPT_INDIRECTION_DEPTH: usize = 8;
+
+/// Script names declared by a project, with the bodies that a package manager
+/// invocation such as `npm run lint -- --format gha` resolves to.
+///
+/// A name whose body is ambiguous (declared by several packages with different
+/// bodies) keeps its name but drops its body, so the indirection is not
+/// followed and nothing is credited from the wrong package.
+#[derive(Debug, Default, Clone)]
+pub struct ScriptCatalog {
+    names: FxHashSet<String>,
+    bodies: FxHashMap<String, String>,
+}
+
+impl ScriptCatalog {
+    /// Build a catalog from one package's `scripts` map.
+    #[must_use]
+    #[expect(
+        clippy::disallowed_types,
+        reason = "API matches serde-deserialized HashMap from package.json"
+    )]
+    pub fn from_scripts(scripts: &HashMap<String, String>) -> Self {
+        let mut catalog = Self::default();
+        catalog.merge_scripts(scripts);
+        catalog
+    }
+
+    /// Fold another package's `scripts` map into the catalog.
+    #[expect(
+        clippy::disallowed_types,
+        reason = "API matches serde-deserialized HashMap from package.json"
+    )]
+    pub fn merge_scripts(&mut self, scripts: &HashMap<String, String>) {
+        for (name, body) in scripts {
+            self.names.insert(name.clone());
+            match self.bodies.get(name) {
+                Some(existing) if existing == body => {}
+                Some(_) => {
+                    self.bodies.remove(name);
+                }
+                None => {
+                    self.bodies.insert(name.clone(), body.clone());
+                }
+            }
+        }
+    }
+
+    /// Whether a script with this name is declared anywhere in the project.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+
+    fn body(&self, name: &str) -> Option<&str> {
+        self.bodies.get(name).map(String::as_str)
+    }
+}
+
 struct ScriptCommandContext<'a> {
     declared_packages: &'a FxHashSet<String>,
-    script_names: &'a FxHashSet<String>,
+    scripts: &'a ScriptCatalog,
+}
+
+/// Where the real command starts once the package manager prefix is consumed.
+enum PackageManagerTarget {
+    /// A binary invocation starting at this token index.
+    Binary(usize),
+    /// A package.json script invocation. The script body is re-scanned with the
+    /// call-site arguments starting at `extra_args_from` appended, which is what
+    /// the package manager itself does.
+    Script {
+        name: String,
+        extra_args_from: usize,
+    },
 }
 
 /// Result of analyzing all package.json scripts.
@@ -243,17 +357,11 @@ pub fn analyze_scripts_with_dependencies(
     bin_map: &FxHashMap<String, String>,
     declared_packages: &FxHashSet<String>,
 ) -> ScriptAnalysis {
-    let script_names: FxHashSet<String> = scripts.keys().cloned().collect();
-    analyze_scripts_with_dependency_context(
-        scripts,
-        root,
-        bin_map,
-        declared_packages,
-        &script_names,
-    )
+    let catalog = ScriptCatalog::from_scripts(scripts);
+    analyze_scripts_with_dependency_context(scripts, root, bin_map, declared_packages, &catalog)
 }
 
-/// Analyze scripts with dependency context and an explicit full package script-name set.
+/// Analyze scripts with dependency context and the project-wide script catalog.
 #[must_use]
 #[expect(
     clippy::disallowed_types,
@@ -264,25 +372,24 @@ pub fn analyze_scripts_with_dependency_context(
     root: &Path,
     bin_map: &FxHashMap<String, String>,
     declared_packages: &FxHashSet<String>,
-    script_names: &FxHashSet<String>,
+    catalog: &ScriptCatalog,
 ) -> ScriptAnalysis {
-    analyze_commands_with_context(
-        scripts.values(),
-        root,
-        bin_map,
-        declared_packages,
-        script_names,
-    )
+    analyze_commands_with_context(scripts.values(), root, bin_map, declared_packages, catalog)
 }
 
-/// Analyze arbitrary shell commands with dependency and script-name context.
+/// Analyze arbitrary shell commands with dependency and script-catalog context.
+///
+/// A command that invokes a declared script through a package manager
+/// (`npm run lint -- --format gha`) is resolved to that script's body with the
+/// call-site arguments appended, so binaries and flag values behind the
+/// indirection are credited.
 #[must_use]
 pub fn analyze_commands_with_context<'a, I>(
     commands: I,
     root: &Path,
     bin_map: &FxHashMap<String, String>,
     declared_packages: &FxHashSet<String>,
-    script_names: &FxHashSet<String>,
+    catalog: &ScriptCatalog,
 ) -> ScriptAnalysis
 where
     I: IntoIterator<Item = &'a String>,
@@ -290,7 +397,7 @@ where
     let mut result = ScriptAnalysis::default();
     let context = ScriptCommandContext {
         declared_packages,
-        script_names,
+        scripts: catalog,
     };
 
     for command in commands {
@@ -387,9 +494,18 @@ fn accumulate_parsed_commands(
 /// Splits on shell operators (`&&`, `||`, `;`, `|`, `&`) and parses each segment.
 #[must_use]
 pub fn parse_script(script: &str) -> Vec<ScriptCommand> {
-    parse_script_internal(script, |tokens, idx| {
-        shell::advance_past_package_manager(tokens, idx)
-    })
+    let mut commands = Vec::new();
+    let mut active = Vec::new();
+    parse_script_internal(
+        script,
+        &|tokens, idx| {
+            shell::advance_past_package_manager(tokens, idx).map(PackageManagerTarget::Binary)
+        },
+        None,
+        &mut active,
+        &mut commands,
+    );
+    commands
 }
 
 fn parse_script_with_context(
@@ -398,28 +514,83 @@ fn parse_script_with_context(
     bin_map: &FxHashMap<String, String>,
     context: &ScriptCommandContext<'_>,
 ) -> Vec<ScriptCommand> {
-    parse_script_internal(script, |tokens, idx| {
-        advance_past_package_manager_with_context(tokens, idx, root, bin_map, context)
-    })
+    let mut commands = Vec::new();
+    let mut active = Vec::new();
+    parse_script_internal(
+        script,
+        &|tokens, idx| {
+            advance_past_package_manager_with_context(tokens, idx, root, bin_map, context)
+        },
+        Some(context.scripts),
+        &mut active,
+        &mut commands,
+    );
+    commands
 }
 
 fn parse_script_internal(
     script: &str,
-    advance_package_manager: impl Fn(&[&str], usize) -> Option<usize>,
-) -> Vec<ScriptCommand> {
-    let mut commands = Vec::new();
-
+    advance_package_manager: &impl Fn(&[&str], usize) -> Option<PackageManagerTarget>,
+    catalog: Option<&ScriptCatalog>,
+    active: &mut Vec<String>,
+    commands: &mut Vec<ScriptCommand>,
+) {
     for segment in shell::split_shell_operators(script) {
         let segment = segment.trim();
         if segment.is_empty() {
             continue;
         }
-        if let Some(cmd) = parse_command_segment(segment, &advance_package_manager) {
-            commands.push(cmd);
+        match parse_command_segment(segment, advance_package_manager) {
+            Some(SegmentOutcome::Command(cmd)) => commands.push(cmd),
+            Some(SegmentOutcome::ScriptCall { name, extra_args }) => {
+                resolve_script_call(
+                    &name,
+                    &extra_args,
+                    advance_package_manager,
+                    catalog,
+                    active,
+                    commands,
+                );
+            }
+            None => {}
         }
     }
+}
 
-    commands
+/// Re-scan the body of a script invoked through a package manager, with the
+/// call-site arguments appended.
+///
+/// Only follows the indirection when the call site adds arguments: without them
+/// the body is already analyzed as a script of its own package, and following it
+/// anyway would credit script bodies that script filtering deliberately skipped.
+fn resolve_script_call(
+    name: &str,
+    extra_args: &str,
+    advance_package_manager: &impl Fn(&[&str], usize) -> Option<PackageManagerTarget>,
+    catalog: Option<&ScriptCatalog>,
+    active: &mut Vec<String>,
+    commands: &mut Vec<ScriptCommand>,
+) {
+    if extra_args.is_empty() || active.len() >= MAX_SCRIPT_INDIRECTION_DEPTH {
+        return;
+    }
+    let Some(body) = catalog.and_then(|catalog| catalog.body(name)) else {
+        return;
+    };
+    if active.iter().any(|active_name| active_name == name) {
+        return;
+    }
+
+    let expanded = format!("{body} {extra_args}");
+    active.push(name.to_string());
+    parse_script_internal(
+        &expanded,
+        advance_package_manager,
+        catalog,
+        active,
+        commands,
+    );
+    active.pop();
 }
 
 /// Extract file path arguments and `--config`/`-c` arguments from the remaining tokens.
@@ -491,9 +662,13 @@ fn advance_past_package_manager_with_context(
     root: &Path,
     bin_map: &FxHashMap<String, String>,
     context: &ScriptCommandContext<'_>,
-) -> Option<usize> {
+) -> Option<PackageManagerTarget> {
+    if let Some(target) = script_invocation_target(tokens, idx, context) {
+        return Some(target);
+    }
+
     if tokens[idx] != "pnpm" {
-        return shell::advance_past_package_manager(tokens, idx);
+        return shell::advance_past_package_manager(tokens, idx).map(PackageManagerTarget::Binary);
     }
 
     let mut next = idx + 1;
@@ -510,24 +685,91 @@ fn advance_past_package_manager_with_context(
         while next < tokens.len() && PNPM_IMPLICIT_EXEC_FLAGS.contains(&tokens[next]) {
             next += 1;
         }
-        return (next < tokens.len()).then_some(next);
+        return (next < tokens.len())
+            .then_some(next)
+            .map(PackageManagerTarget::Binary);
     }
 
     if subcmd.starts_with('-')
         || PNPM_BUILTIN_COMMANDS.contains(&subcmd)
-        || context.script_names.contains(subcmd)
+        || context.scripts.contains(subcmd)
     {
         return None;
     }
 
-    resolve_known_dependency_binary(subcmd, root, bin_map, context.declared_packages).map(|_| next)
+    resolve_known_dependency_binary(subcmd, root, bin_map, context.declared_packages)
+        .map(|_| PackageManagerTarget::Binary(next))
+}
+
+/// Recognize a package manager invocation of a package.json script.
+///
+/// Handles the explicit `run` form for npm, pnpm, yarn, and bun, plus the bare
+/// `yarn <script>` and `pnpm <script>` forms. npm only forwards arguments that
+/// follow `--`; the other managers forward them directly and tolerate a `--`
+/// separator.
+fn script_invocation_target(
+    tokens: &[&str],
+    idx: usize,
+    context: &ScriptCommandContext<'_>,
+) -> Option<PackageManagerTarget> {
+    let manager = tokens[idx];
+    if !matches!(manager, "npm" | "pnpm" | "yarn" | "bun") {
+        return None;
+    }
+
+    let mut next = idx + 1;
+    if manager == "pnpm" {
+        while next < tokens.len() && PNPM_IMPLICIT_EXEC_FLAGS.contains(&tokens[next]) {
+            next += 1;
+        }
+    }
+    let subcmd = *tokens.get(next)?;
+
+    let (name_idx, requires_double_dash) = if matches!(subcmd, "run" | "run-script") {
+        (next + 1, manager == "npm")
+    } else if matches!(manager, "yarn" | "pnpm")
+        && !subcmd.starts_with('-')
+        && !PACKAGE_MANAGER_BUILTIN_COMMANDS.contains(&subcmd)
+    {
+        (next, false)
+    } else {
+        return None;
+    };
+
+    let name = *tokens.get(name_idx)?;
+    if !context.scripts.contains(name) {
+        return None;
+    }
+
+    let mut extra_args_from = name_idx + 1;
+    if tokens.get(extra_args_from) == Some(&"--") {
+        extra_args_from += 1;
+    } else if requires_double_dash {
+        return None;
+    }
+
+    Some(PackageManagerTarget::Script {
+        name: name.to_string(),
+        extra_args_from,
+    })
+}
+
+/// What a command segment resolved to.
+enum SegmentOutcome {
+    Command(ScriptCommand),
+    /// A package manager invocation of a package.json script, with the
+    /// arguments the call site forwards to that script's body.
+    ScriptCall {
+        name: String,
+        extra_args: String,
+    },
 }
 
 /// Parse a single command segment (after splitting on shell operators).
 fn parse_command_segment(
     segment: &str,
-    advance_package_manager: &impl Fn(&[&str], usize) -> Option<usize>,
-) -> Option<ScriptCommand> {
+    advance_package_manager: &impl Fn(&[&str], usize) -> Option<PackageManagerTarget>,
+) -> Option<SegmentOutcome> {
     let tokens: Vec<&str> = segment
         .split_whitespace()
         .map(strip_surrounding_quotes)
@@ -537,29 +779,50 @@ fn parse_command_segment(
     }
 
     let idx = shell::skip_initial_wrappers(&tokens, 0)?;
-    let idx = advance_package_manager(&tokens, idx)?;
+    let idx = match advance_package_manager(&tokens, idx)? {
+        PackageManagerTarget::Binary(idx) => idx,
+        PackageManagerTarget::Script {
+            name,
+            extra_args_from,
+        } => {
+            return Some(SegmentOutcome::ScriptCall {
+                name,
+                extra_args: forwarded_arguments(segment, extra_args_from),
+            });
+        }
+    };
 
     let binary = tokens[idx].to_string();
 
     if SCRIPT_MULTIPLEXERS.contains(&binary.as_str()) {
-        return Some(ScriptCommand {
+        return Some(SegmentOutcome::Command(ScriptCommand {
             binary,
             config_args: Vec::new(),
             file_args: Vec::new(),
             flag_packages: Vec::new(),
-        });
+        }));
     }
 
     let is_node_runner = NODE_RUNNERS.contains(&binary.as_str());
     let (file_args, config_args) = extract_args_for_binary(&tokens, idx + 1, is_node_runner);
     let flag_packages = flag_referenced_packages(&binary, &tokens[idx + 1..]);
 
-    Some(ScriptCommand {
+    Some(SegmentOutcome::Command(ScriptCommand {
         binary,
         config_args,
         file_args,
         flag_packages,
-    })
+    }))
+}
+
+/// The raw tail of a segment, keeping quoting intact so the re-scanned script
+/// body sees the arguments as the shell would pass them.
+fn forwarded_arguments(segment: &str, from_token: usize) -> String {
+    segment
+        .split_whitespace()
+        .skip(from_token)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Packages a CLI names through a flag value rather than a positional argument.
@@ -775,6 +1038,27 @@ mod tests {
     fn formatter_packages(command: &str) -> Vec<String> {
         let tokens: Vec<&str> = command.split_whitespace().collect();
         flag_referenced_packages("eslint", &tokens)
+    }
+
+    /// Analyze a CI-style command against a project whose package.json declares
+    /// `scripts` and every package in `declared`.
+    fn analyze_ci_command(
+        command: &str,
+        scripts: &[(&str, &str)],
+        declared: &[&str],
+    ) -> ScriptAnalysis {
+        let scripts: HashMap<String, String> = scripts
+            .iter()
+            .map(|(name, body)| ((*name).to_string(), (*body).to_string()))
+            .collect();
+        let commands = vec![command.to_string()];
+        analyze_commands_with_context(
+            &commands,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(declared),
+            &ScriptCatalog::from_scripts(&scripts),
+        )
     }
 
     #[test]
@@ -1456,19 +1740,166 @@ mod tests {
     }
 
     #[test]
+    fn npm_run_forwards_call_site_flags_into_script_body() {
+        let result = analyze_ci_command(
+            "npm run lint -- --format gha",
+            &[("lint", "eslint .")],
+            &["eslint", "eslint-formatter-gha"],
+        );
+        assert!(result.used_packages.contains("eslint"));
+        assert!(result.used_packages.contains("eslint-formatter-gha"));
+    }
+
+    #[test]
+    fn yarn_script_without_double_dash_forwards_call_site_flags() {
+        let result = analyze_ci_command(
+            "yarn lint --format gha",
+            &[("lint", "eslint .")],
+            &["eslint", "eslint-formatter-gha"],
+        );
+        assert!(result.used_packages.contains("eslint-formatter-gha"));
+    }
+
+    #[test]
+    fn pnpm_and_bun_script_forms_forward_call_site_flags() {
+        for command in ["pnpm lint --format gha", "bun run lint --format gha"] {
+            let result = analyze_ci_command(
+                command,
+                &[("lint", "eslint .")],
+                &["eslint", "eslint-formatter-gha"],
+            );
+            assert!(
+                result.used_packages.contains("eslint-formatter-gha"),
+                "{command} credited nothing"
+            );
+        }
+    }
+
+    #[test]
+    fn script_body_flags_and_call_site_flags_are_both_credited() {
+        let result = analyze_ci_command(
+            "npm run lint -- --format gha",
+            &[("lint", "eslint . --format json")],
+            &["eslint"],
+        );
+        assert!(result.used_packages.contains("eslint-formatter-json"));
+        assert!(result.used_packages.contains("eslint-formatter-gha"));
+    }
+
+    #[test]
+    fn unknown_script_name_credits_nothing() {
+        let result = analyze_ci_command(
+            "npm run typecheck -- --format gha",
+            &[("lint", "eslint .")],
+            &["eslint"],
+        );
+        assert!(result.used_packages.is_empty());
+    }
+
+    #[test]
+    fn npm_run_without_double_dash_credits_nothing() {
+        let result = analyze_ci_command(
+            "npm run lint --format gha",
+            &[("lint", "eslint .")],
+            &["eslint"],
+        );
+        assert!(result.used_packages.is_empty());
+    }
+
+    #[test]
+    fn package_manager_builtin_is_not_a_script_invocation() {
+        let result = analyze_ci_command(
+            "yarn install --frozen-lockfile",
+            &[("install", "eslint .")],
+            &["eslint"],
+        );
+        assert!(result.used_packages.is_empty());
+    }
+
+    #[test]
+    fn mutually_recursive_scripts_terminate() {
+        let result = analyze_ci_command(
+            "npm run a -- --fix",
+            &[
+                ("a", "npm run b -- --format gha"),
+                ("b", "npm run a -- --format json"),
+            ],
+            &["eslint"],
+        );
+        assert!(result.used_packages.is_empty());
+    }
+
+    #[test]
+    fn self_recursive_script_terminates_after_one_expansion() {
+        let result = analyze_ci_command(
+            "npm run loop -- --fix",
+            &[("loop", "eslint . && npm run loop -- --format gha")],
+            &["eslint"],
+        );
+        assert!(result.used_packages.contains("eslint"));
+        assert!(!result.used_packages.contains("eslint-formatter-gha"));
+    }
+
+    #[test]
+    fn deep_script_chain_stops_at_the_depth_limit() {
+        let chain: Vec<(String, String)> = (0..12)
+            .map(|step| {
+                (
+                    format!("s{step}"),
+                    if step == 11 {
+                        "eslint .".to_string()
+                    } else {
+                        format!("npm run s{} -- --cache", step + 1)
+                    },
+                )
+            })
+            .collect();
+        let scripts: Vec<(&str, &str)> = chain
+            .iter()
+            .map(|(name, body)| (name.as_str(), body.as_str()))
+            .collect();
+        let result = analyze_ci_command("npm run s0 -- --fix", &scripts, &["eslint"]);
+        assert!(result.used_packages.is_empty());
+
+        let shallow = analyze_ci_command("npm run s9 -- --fix", &scripts, &["eslint"]);
+        assert!(shallow.used_packages.contains("eslint"));
+    }
+
+    #[test]
+    fn ambiguous_script_body_is_not_followed() {
+        let mut catalog = ScriptCatalog::from_scripts(&HashMap::from([(
+            "lint".to_string(),
+            "eslint .".to_string(),
+        )]));
+        catalog.merge_scripts(&HashMap::from([(
+            "lint".to_string(),
+            "biome check".to_string(),
+        )]));
+        let commands = vec!["npm run lint -- --format gha".to_string()];
+        let result = analyze_commands_with_context(
+            &commands,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(&["eslint", "biome"]),
+            &catalog,
+        );
+        assert!(catalog.contains("lint"));
+        assert!(result.used_packages.is_empty());
+    }
+
+    #[test]
     fn production_filtered_context_skips_non_production_script_name() {
         let scripts = HashMap::from([
             ("build".to_string(), "pnpm lint".to_string()),
             ("lint".to_string(), "eslint src".to_string()),
         ]);
         let filtered = filter_production_scripts(&scripts);
-        let script_names: FxHashSet<String> = scripts.keys().cloned().collect();
         let result = analyze_scripts_with_dependency_context(
             &filtered,
             Path::new("/nonexistent"),
             &FxHashMap::default(),
             &package_set(&["lint"]),
-            &script_names,
+            &ScriptCatalog::from_scripts(&scripts),
         );
         assert!(!result.used_packages.contains("lint"));
     }

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -131,16 +131,34 @@ const PACKAGE_MANAGER_BUILTIN_COMMANDS: &[&str] = &[
 /// against pathological nesting on top of the cycle guard.
 const MAX_SCRIPT_INDIRECTION_DEPTH: usize = 8;
 
+/// Maximum number of script bodies expanded while analyzing a single command.
+/// The depth limit bounds one path; this bounds the total fan-out when many
+/// scripts call each other with arguments.
+const MAX_SCRIPT_EXPANSIONS: usize = 64;
+
+/// A script body in the catalog, plus whether its file arguments are relative
+/// to the root the analysis resolves paths against.
+#[derive(Debug, Clone)]
+struct CatalogBody {
+    body: String,
+    /// `false` for a body merged from another workspace package: its positional
+    /// file arguments are relative to that package, not to the analysis root.
+    local: bool,
+}
+
 /// Script names declared by a project, with the bodies that a package manager
 /// invocation such as `npm run lint -- --format gha` resolves to.
 ///
 /// A name whose body is ambiguous (declared by several packages with different
-/// bodies) keeps its name but drops its body, so the indirection is not
-/// followed and nothing is credited from the wrong package.
+/// bodies) keeps its name but permanently loses its body, so the indirection is
+/// not followed and nothing is credited from the wrong package. Ambiguity is
+/// sticky: a later package re-declaring one of the conflicting bodies does not
+/// restore it.
 #[derive(Debug, Default, Clone)]
 pub struct ScriptCatalog {
     names: FxHashSet<String>,
-    bodies: FxHashMap<String, String>,
+    bodies: FxHashMap<String, CatalogBody>,
+    ambiguous: FxHashSet<String>,
 }
 
 impl ScriptCatalog {
@@ -156,21 +174,52 @@ impl ScriptCatalog {
         catalog
     }
 
-    /// Fold another package's `scripts` map into the catalog.
+    /// Fold the analyzed package's own `scripts` map into the catalog.
     #[expect(
         clippy::disallowed_types,
         reason = "API matches serde-deserialized HashMap from package.json"
     )]
     pub fn merge_scripts(&mut self, scripts: &HashMap<String, String>) {
+        self.merge(scripts, true);
+    }
+
+    /// Fold another workspace package's `scripts` map into the catalog. Bodies
+    /// merged this way still credit dependencies, but their file arguments are
+    /// dropped because they are relative to that package's own root.
+    #[expect(
+        clippy::disallowed_types,
+        reason = "API matches serde-deserialized HashMap from package.json"
+    )]
+    pub fn merge_workspace_scripts(&mut self, scripts: &HashMap<String, String>) {
+        self.merge(scripts, false);
+    }
+
+    #[expect(
+        clippy::disallowed_types,
+        reason = "API matches serde-deserialized HashMap from package.json"
+    )]
+    fn merge(&mut self, scripts: &HashMap<String, String>, local: bool) {
         for (name, body) in scripts {
             self.names.insert(name.clone());
-            match self.bodies.get(name) {
-                Some(existing) if existing == body => {}
+            if self.ambiguous.contains(name) {
+                continue;
+            }
+            match self.bodies.get_mut(name) {
+                Some(existing) if existing.body == *body => {
+                    existing.local = existing.local || local;
+                }
                 Some(_) => {
                     self.bodies.remove(name);
+                    self.ambiguous.insert(name.clone());
                 }
                 None => {
-                    self.bodies.insert(name.clone(), body.clone());
+                    self.bodies.insert(
+                        name.clone(),
+                        CatalogBody {
+                            body: body.clone(),
+                            local,
+                        },
+                    );
                 }
             }
         }
@@ -182,8 +231,31 @@ impl ScriptCatalog {
         self.names.contains(name)
     }
 
-    fn body(&self, name: &str) -> Option<&str> {
-        self.bodies.get(name).map(String::as_str)
+    fn body(&self, name: &str) -> Option<&CatalogBody> {
+        if self.ambiguous.contains(name) {
+            return None;
+        }
+        self.bodies.get(name)
+    }
+}
+
+/// Bookkeeping for one top-level command while script indirection is followed.
+struct ScriptExpansion {
+    /// Script names on the current expansion path, for the cycle guard.
+    active: Vec<String>,
+    /// Bodies expanded so far, bounded by [`MAX_SCRIPT_EXPANSIONS`].
+    expansions: usize,
+    /// `false` once a body from another workspace package has been entered.
+    local_paths: bool,
+}
+
+impl ScriptExpansion {
+    fn new() -> Self {
+        Self {
+            active: Vec::new(),
+            expansions: 0,
+            local_paths: true,
+        }
     }
 }
 
@@ -495,14 +567,14 @@ fn accumulate_parsed_commands(
 #[must_use]
 pub fn parse_script(script: &str) -> Vec<ScriptCommand> {
     let mut commands = Vec::new();
-    let mut active = Vec::new();
+    let mut state = ScriptExpansion::new();
     parse_script_internal(
         script,
         &|tokens, idx| {
             shell::advance_past_package_manager(tokens, idx).map(PackageManagerTarget::Binary)
         },
         None,
-        &mut active,
+        &mut state,
         &mut commands,
     );
     commands
@@ -515,14 +587,14 @@ fn parse_script_with_context(
     context: &ScriptCommandContext<'_>,
 ) -> Vec<ScriptCommand> {
     let mut commands = Vec::new();
-    let mut active = Vec::new();
+    let mut state = ScriptExpansion::new();
     parse_script_internal(
         script,
         &|tokens, idx| {
             advance_past_package_manager_with_context(tokens, idx, root, bin_map, context)
         },
         Some(context.scripts),
-        &mut active,
+        &mut state,
         &mut commands,
     );
     commands
@@ -532,7 +604,7 @@ fn parse_script_internal(
     script: &str,
     advance_package_manager: &impl Fn(&[&str], usize) -> Option<PackageManagerTarget>,
     catalog: Option<&ScriptCatalog>,
-    active: &mut Vec<String>,
+    state: &mut ScriptExpansion,
     commands: &mut Vec<ScriptCommand>,
 ) {
     for segment in shell::split_shell_operators(script) {
@@ -541,14 +613,20 @@ fn parse_script_internal(
             continue;
         }
         match parse_command_segment(segment, advance_package_manager) {
-            Some(SegmentOutcome::Command(cmd)) => commands.push(cmd),
+            Some(SegmentOutcome::Command(mut cmd)) => {
+                if !state.local_paths {
+                    cmd.config_args.clear();
+                    cmd.file_args.clear();
+                }
+                commands.push(cmd);
+            }
             Some(SegmentOutcome::ScriptCall { name, extra_args }) => {
                 resolve_script_call(
                     &name,
                     &extra_args,
                     advance_package_manager,
                     catalog,
-                    active,
+                    state,
                     commands,
                 );
             }
@@ -562,35 +640,46 @@ fn parse_script_internal(
 ///
 /// Only follows the indirection when the call site adds arguments: without them
 /// the body is already analyzed as a script of its own package, and following it
-/// anyway would credit script bodies that script filtering deliberately skipped.
+/// anyway would add nothing.
+///
+/// Reachability is exactly what the caller put in the catalog. A production run
+/// that analyzes filtered scripts must also build the catalog from the filtered
+/// map, otherwise `npm run lint -- --fix` would reach a dev-only body that
+/// script filtering deliberately skipped.
+///
+/// Expansion is bounded twice: [`MAX_SCRIPT_INDIRECTION_DEPTH`] bounds a single
+/// path, [`MAX_SCRIPT_EXPANSIONS`] bounds the total number of bodies expanded
+/// for one command, because the cycle guard only rejects names on the current
+/// path and mutually calling scripts otherwise fan out per path.
 fn resolve_script_call(
     name: &str,
     extra_args: &str,
     advance_package_manager: &impl Fn(&[&str], usize) -> Option<PackageManagerTarget>,
     catalog: Option<&ScriptCatalog>,
-    active: &mut Vec<String>,
+    state: &mut ScriptExpansion,
     commands: &mut Vec<ScriptCommand>,
 ) {
-    if extra_args.is_empty() || active.len() >= MAX_SCRIPT_INDIRECTION_DEPTH {
+    if extra_args.is_empty()
+        || state.active.len() >= MAX_SCRIPT_INDIRECTION_DEPTH
+        || state.expansions >= MAX_SCRIPT_EXPANSIONS
+    {
         return;
     }
-    let Some(body) = catalog.and_then(|catalog| catalog.body(name)) else {
+    let Some(entry) = catalog.and_then(|catalog| catalog.body(name)) else {
         return;
     };
-    if active.iter().any(|active_name| active_name == name) {
+    if state.active.iter().any(|active_name| active_name == name) {
         return;
     }
 
-    let expanded = format!("{body} {extra_args}");
-    active.push(name.to_string());
-    parse_script_internal(
-        &expanded,
-        advance_package_manager,
-        catalog,
-        active,
-        commands,
-    );
-    active.pop();
+    let expanded = format!("{} {extra_args}", entry.body);
+    let outer_local_paths = state.local_paths;
+    state.local_paths = state.local_paths && entry.local;
+    state.expansions += 1;
+    state.active.push(name.to_string());
+    parse_script_internal(&expanded, advance_package_manager, catalog, state, commands);
+    state.active.pop();
+    state.local_paths = outer_local_paths;
 }
 
 /// Extract file path arguments and `--config`/`-c` arguments from the remaining tokens.
@@ -1885,6 +1974,129 @@ mod tests {
         );
         assert!(catalog.contains("lint"));
         assert!(result.used_packages.is_empty());
+    }
+
+    /// A third package restating one of the conflicting bodies must not undo the
+    /// ambiguity: which body wins would otherwise depend on workspace order.
+    #[test]
+    fn ambiguity_survives_a_third_package_restating_the_first_body() {
+        let mut catalog = ScriptCatalog::from_scripts(&HashMap::from([(
+            "lint".to_string(),
+            "eslint .".to_string(),
+        )]));
+        catalog.merge_scripts(&HashMap::from([(
+            "lint".to_string(),
+            "biome check".to_string(),
+        )]));
+        catalog.merge_scripts(&HashMap::from([(
+            "lint".to_string(),
+            "eslint .".to_string(),
+        )]));
+        let commands = vec!["npm run lint -- --format gha".to_string()];
+        let result = analyze_commands_with_context(
+            &commands,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(&["eslint", "biome", "eslint-formatter-gha"]),
+            &catalog,
+        );
+        assert!(catalog.contains("lint"));
+        assert!(result.used_packages.is_empty());
+    }
+
+    /// The cycle guard only rejects names on the current path, so a branching
+    /// chain fans out per path. The expansion budget bounds the total work.
+    #[test]
+    fn branching_script_chain_is_bounded_by_the_expansion_budget() {
+        let levels = MAX_SCRIPT_INDIRECTION_DEPTH;
+        let chain: Vec<(String, String)> = (0..levels)
+            .map(|step| {
+                (
+                    format!("s{step}"),
+                    if step + 1 == levels {
+                        "eslint leaf.js".to_string()
+                    } else {
+                        format!(
+                            "npm run s{next} -- --a && npm run s{next} -- --b",
+                            next = step + 1
+                        )
+                    },
+                )
+            })
+            .collect();
+        let scripts: Vec<(&str, &str)> = chain
+            .iter()
+            .map(|(name, body)| (name.as_str(), body.as_str()))
+            .collect();
+        let result = analyze_ci_command("npm run s0 -- --go", &scripts, &["eslint"]);
+
+        assert!(result.used_packages.contains("eslint"));
+        assert!(!result.entry_files.is_empty());
+        assert!(
+            result.entry_files.len() <= MAX_SCRIPT_EXPANSIONS,
+            "expansion budget should cap leaf visits, got {}",
+            result.entry_files.len()
+        );
+    }
+
+    /// Under production filtering the catalog is built from the same filtered
+    /// map, so an argument-bearing call cannot reach a dev-only body.
+    #[test]
+    fn production_filtered_catalog_does_not_reach_a_dev_script_body() {
+        let scripts = HashMap::from([
+            (
+                "build".to_string(),
+                "npm run lint -- --fix && vite build".to_string(),
+            ),
+            ("lint".to_string(), "eslint .".to_string()),
+        ]);
+        let filtered = filter_production_scripts(&scripts);
+        let result = analyze_scripts_with_dependency_context(
+            &filtered,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(&["eslint", "vite"]),
+            &ScriptCatalog::from_scripts(&filtered),
+        );
+        assert!(result.used_packages.contains("vite"));
+        assert!(!result.used_packages.contains("eslint"));
+    }
+
+    /// A body merged from another workspace package still credits dependencies,
+    /// but its file arguments are relative to that package, not to the analysis
+    /// root, so they must not become entry files here.
+    #[test]
+    fn workspace_body_credits_packages_without_leaking_file_arguments() {
+        let mut catalog = ScriptCatalog::default();
+        catalog.merge_workspace_scripts(&HashMap::from([(
+            "build".to_string(),
+            "esbuild scripts/bundle.js".to_string(),
+        )]));
+        let commands = vec!["npm run build -- --mode ci".to_string()];
+        let result = analyze_commands_with_context(
+            &commands,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(&["esbuild"]),
+            &catalog,
+        );
+        assert!(result.used_packages.contains("esbuild"));
+        assert!(result.entry_files.is_empty());
+    }
+
+    #[test]
+    fn local_body_still_contributes_file_arguments() {
+        let result = analyze_ci_command(
+            "npm run build -- --mode ci",
+            &[("build", "esbuild scripts/bundle.js")],
+            &["esbuild"],
+        );
+        assert!(result.used_packages.contains("esbuild"));
+        assert!(
+            result
+                .entry_files
+                .contains(&"scripts/bundle.js".to_string())
+        );
     }
 
     #[test]

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -174,6 +174,29 @@ impl ScriptCatalog {
         catalog
     }
 
+    /// Build a catalog whose names come from `all` but whose bodies are limited
+    /// to `analyzed`.
+    ///
+    /// Production runs analyze only production-relevant scripts. Names and
+    /// bodies must be filtered separately: a package manager resolves
+    /// `pnpm <name>` to the declared script and never to a same-named binary,
+    /// so dropping a filtered script's name would credit a dependency that
+    /// shares the name. The body of a filtered script must stay unreachable, so
+    /// argument-bearing indirection cannot enter a script the filter skipped.
+    #[must_use]
+    #[expect(
+        clippy::disallowed_types,
+        reason = "API matches serde-deserialized HashMap from package.json"
+    )]
+    pub fn from_scripts_with_bodies(
+        all: &HashMap<String, String>,
+        analyzed: &HashMap<String, String>,
+    ) -> Self {
+        let mut catalog = Self::from_scripts(analyzed);
+        catalog.names.extend(all.keys().cloned());
+        catalog
+    }
+
     /// Fold the analyzed package's own `scripts` map into the catalog.
     #[expect(
         clippy::disallowed_types,
@@ -286,6 +309,23 @@ pub struct ScriptAnalysis {
     pub config_files: Vec<String>,
     /// File paths extracted as positional arguments (entry point candidates).
     pub entry_files: Vec<String>,
+}
+
+impl ScriptAnalysis {
+    /// Drop repeated config and entry paths, keeping first-seen order.
+    ///
+    /// A body reached both as its own script and through package-manager
+    /// indirection is scanned more than once, and every consumer turns these
+    /// lists into patterns one by one.
+    fn dedupe_paths(&mut self) {
+        retain_first_seen(&mut self.config_files);
+        retain_first_seen(&mut self.entry_files);
+    }
+}
+
+fn retain_first_seen(values: &mut Vec<String>) {
+    let mut seen: FxHashSet<String> = FxHashSet::default();
+    values.retain(|value| seen.insert(value.clone()));
 }
 
 /// Normalize a script-extracted file path into a project-relative entry pattern.
@@ -476,6 +516,7 @@ where
         accumulate_command_with_context(command, root, bin_map, &context, &mut result);
     }
 
+    result.dedupe_paths();
     result
 }
 
@@ -643,9 +684,12 @@ fn parse_script_internal(
 /// anyway would add nothing.
 ///
 /// Reachability is exactly what the caller put in the catalog. A production run
-/// that analyzes filtered scripts must also build the catalog from the filtered
-/// map, otherwise `npm run lint -- --fix` would reach a dev-only body that
-/// script filtering deliberately skipped.
+/// that analyzes filtered scripts must build the catalog with
+/// [`ScriptCatalog::from_scripts_with_bodies`]: the names stay complete so the
+/// package-manager form still resolves to the script rather than to a
+/// same-named binary, while only the analyzed bodies are reachable, so
+/// `npm run lint -- --fix` cannot enter a dev-only body that script filtering
+/// deliberately skipped.
 ///
 /// Expansion is bounded twice: [`MAX_SCRIPT_INDIRECTION_DEPTH`] bounds a single
 /// path, [`MAX_SCRIPT_EXPANSIONS`] bounds the total number of bodies expanded
@@ -2039,8 +2083,9 @@ mod tests {
         );
     }
 
-    /// Under production filtering the catalog is built from the same filtered
-    /// map, so an argument-bearing call cannot reach a dev-only body.
+    /// Under production filtering only the bodies are filtered, so an
+    /// argument-bearing call still resolves to the script name but cannot reach
+    /// the dev-only body behind it.
     #[test]
     fn production_filtered_catalog_does_not_reach_a_dev_script_body() {
         let scripts = HashMap::from([
@@ -2056,10 +2101,50 @@ mod tests {
             Path::new("/nonexistent"),
             &FxHashMap::default(),
             &package_set(&["eslint", "vite"]),
-            &ScriptCatalog::from_scripts(&filtered),
+            &ScriptCatalog::from_scripts_with_bodies(&scripts, &filtered),
         );
         assert!(result.used_packages.contains("vite"));
         assert!(!result.used_packages.contains("eslint"));
+    }
+
+    /// The filtered catalog keeps every declared name, so a body reached
+    /// through indirection is unreachable while the name itself still resolves.
+    #[test]
+    fn filtered_catalog_keeps_names_and_drops_bodies() {
+        let scripts = HashMap::from([
+            ("build".to_string(), "vite build".to_string()),
+            ("lint".to_string(), "eslint .".to_string()),
+        ]);
+        let filtered = filter_production_scripts(&scripts);
+        let catalog = ScriptCatalog::from_scripts_with_bodies(&scripts, &filtered);
+        assert!(catalog.contains("lint"));
+        assert!(catalog.contains("build"));
+        assert!(catalog.body("lint").is_none());
+        assert!(catalog.body("build").is_some());
+    }
+
+    /// A body reached both as its own script and through indirection must not
+    /// contribute the same entry file twice.
+    #[test]
+    fn repeated_expansion_does_not_duplicate_entry_files() {
+        let scripts = HashMap::from([
+            (
+                "build".to_string(),
+                "npm run bundle -- --minify && npm run bundle -- --watch".to_string(),
+            ),
+            (
+                "bundle".to_string(),
+                "esbuild scripts/bundle.js".to_string(),
+            ),
+        ]);
+        let result = analyze_scripts_with_dependency_context(
+            &scripts,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(&["esbuild"]),
+            &ScriptCatalog::from_scripts(&scripts),
+        );
+        assert_eq!(result.entry_files, vec!["scripts/bundle.js".to_string()]);
     }
 
     /// A body merged from another workspace package still credits dependencies,
@@ -2099,6 +2184,8 @@ mod tests {
         );
     }
 
+    /// Built the same way as the production callers build it, so the guard this
+    /// test covers is the one that actually runs.
     #[test]
     fn production_filtered_context_skips_non_production_script_name() {
         let scripts = HashMap::from([
@@ -2111,9 +2198,34 @@ mod tests {
             Path::new("/nonexistent"),
             &FxHashMap::default(),
             &package_set(&["lint"]),
-            &ScriptCatalog::from_scripts(&scripts),
+            &ScriptCatalog::from_scripts_with_bodies(&scripts, &filtered),
         );
         assert!(!result.used_packages.contains("lint"));
+    }
+
+    /// `pnpm <name>` runs the declared script, never a same-named binary. A
+    /// filtered-out script keeps its name for exactly that reason: dropping it
+    /// would credit the dependency and pick up the remaining tokens as files.
+    #[test]
+    fn filtered_script_name_shadowing_a_dependency_bin_credits_nothing() {
+        let scripts = HashMap::from([
+            (
+                "build".to_string(),
+                "pnpm lint --fix src/app.ts".to_string(),
+            ),
+            ("lint".to_string(), "eslint src".to_string()),
+        ]);
+        let filtered = filter_production_scripts(&scripts);
+        let result = analyze_scripts_with_dependency_context(
+            &filtered,
+            Path::new("/nonexistent"),
+            &FxHashMap::default(),
+            &package_set(&["lint", "eslint"]),
+            &ScriptCatalog::from_scripts_with_bodies(&scripts, &filtered),
+        );
+        assert!(!result.used_packages.contains("lint"));
+        assert!(!result.used_packages.contains("eslint"));
+        assert!(result.entry_files.is_empty());
     }
 
     #[test]

--- a/crates/core/tests/integration_test/production_mode.rs
+++ b/crates/core/tests/integration_test/production_mode.rs
@@ -259,3 +259,46 @@ fn analyze_project_honors_per_analysis_dead_code_production() {
         "per-analysis production.deadCode=true should exclude *.test.ts from analyze_project, found: {unused_file_names:?}"
     );
 }
+
+/// Under production filtering the script catalog is filtered too, so
+/// `npm run lint -- --fix` inside a production script cannot reach the
+/// dev-only `lint` body and credit its binary (issue #2016).
+#[test]
+fn production_mode_does_not_follow_indirection_into_filtered_scripts() {
+    let root = fixture_path("production-script-indirection");
+    let config = create_production_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|dep| dep.dep.package_name.as_str())
+        .collect();
+
+    assert!(
+        unused.contains(&"indirect-only-tool"),
+        "indirect-only-tool is only reachable through a filtered-out script, got {unused:?}"
+    );
+}
+
+#[test]
+fn non_production_mode_follows_indirection_into_dev_scripts() {
+    let root = fixture_path("production-script-indirection");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|dep| dep.dep.package_name.as_str())
+        .collect();
+
+    assert!(
+        !unused.contains(&"indirect-only-tool"),
+        "the lint script is analyzed outside production mode, got {unused:?}"
+    );
+    assert!(
+        unused.contains(&"unused-control"),
+        "an unreferenced control dependency must still be reported, got {unused:?}"
+    );
+}

--- a/crates/core/tests/integration_test/production_mode.rs
+++ b/crates/core/tests/integration_test/production_mode.rs
@@ -281,6 +281,15 @@ fn production_mode_does_not_follow_indirection_into_filtered_scripts() {
     );
 }
 
+/// Counterpart of the production case: the same fixture must still credit
+/// `indirect-only-tool` when nothing is filtered.
+///
+/// This is a control, not a falsification of the indirection feature. Outside
+/// production the `lint` script is analyzed as a script of its own, so its
+/// binary would be credited even without following `npm run lint -- --fix`.
+/// The falsifying coverage for the indirection itself lives in the unit tests
+/// in `crates/core/src/scripts/mod.rs`, where the reached binary is named only
+/// inside the body that indirection has to enter.
 #[test]
 fn non_production_mode_follows_indirection_into_dev_scripts() {
     let root = fixture_path("production-script-indirection");

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -73,6 +73,31 @@ error by suppressing a downstream detector.
 - Security findings are verification candidates until an agent or human
   confirms the evidence.
 
+## Script indirection crediting
+
+`crates/core/src/scripts/` credits dependencies, config files, and entry files
+from package.json scripts and from CI workflow commands. A package-manager
+invocation of a declared script (`npm run lint -- --format gha`,
+`yarn lint --fix`) is resolved to that script's body with the call-site
+arguments appended, so binaries and flag values behind the indirection are
+credited. The indirection is only followed when the call site adds arguments,
+because a plain `npm run build` reaches a body that is already analyzed on its
+own.
+
+The script catalog separates names from bodies. Names are always the full set of
+declared scripts, because a package manager resolves `pnpm <name>` to the script
+and never to a same-named binary. Bodies are only the scripts the current run
+analyzes, so a production run cannot enter a body that script filtering skipped.
+A name declared with different bodies in several workspace packages keeps its
+name but permanently loses its body.
+
+Expansion is bounded twice. `MAX_SCRIPT_INDIRECTION_DEPTH` caps the depth of a
+single chain, and `MAX_SCRIPT_EXPANSIONS` caps the total number of bodies
+expanded for one command, because the cycle guard only rejects names on the
+current path and mutually calling scripts otherwise fan out per path. Both
+bounds are deliberate ceilings: a project that exceeds them loses crediting for
+the deepest calls rather than degrading analysis time.
+
 ## Adding or changing an analyzer
 
 Follow [analyzer authoring](../analyzer-authoring.md). Update the shared issue

--- a/tests/fixtures/production-script-indirection/package.json
+++ b/tests/fixtures/production-script-indirection/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "production-script-indirection",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "node src/index.ts",
+    "build": "npm run lint -- --fix && tsc",
+    "lint": "indirect-only-tool ."
+  },
+  "dependencies": {
+    "unused-control": "^1.0.0",
+    "indirect-only-tool": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/tests/fixtures/production-script-indirection/src/index.ts
+++ b/tests/fixtures/production-script-indirection/src/index.ts
@@ -1,0 +1,1 @@
+export const main = (): string => "ok";


### PR DESCRIPTION
Refs #2016

## Probleem

CI noemt een linter bijna nooit direct. Het draait `npm run lint -- --format gha` of `yarn lint --format gha`. De package-manager prefix liet het hele segment verdwijnen voor de flag-scan, waardoor de flag-value crediting uit #2006 nooit de projecten bereikte die het nodig hebben.

## Oplossing

Script-bodies reizen nu mee met de analysecontext. Een package-manager aanroep van een gedeclareerd script wordt opgelost naar zijn body met de call-site argumenten erachter, precies zoals de package manager het doet, zodat zowel de flags in de body als de call-site flags gecrediteerd worden.

Guards tegen over-crediting:

- de indirectie wordt alleen gevolgd als de call site argumenten toevoegt, dus een kale `npm run build` crediteert niets nieuws
- npm forwardt alleen argumenten na `--`
- package-manager builtins (`yarn install`) resolven nooit naar een script
- een scriptnaam die in meerdere packages met verschillende bodies is gedeclareerd behoudt zijn naam maar verliest zijn body (sticky ambiguity)
- een cycle guard plus dieptelimiet stoppen recursieve scripts

## Validatie

Gates uit `docs/development/quality-gates.md`, na `npm --prefix tools/type-aware-sidecar install`:

- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `cargo test --workspace --lib --bins --tests --examples`: pass
- `cargo check --workspace --benches`: pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`: pass
- `npm run check:knowledge-architecture`: pass (docs-wijziging in `docs/reference/detection-internals.md`)

Nieuwe fixture `production-script-indirection` dekt het end-to-end pad in production mode.
