### PR TITLE
fix(health): respect mocked modules in test reachability

### DIFF
--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -2312,6 +2312,89 @@ fn health_crap_estimation_excludes_vitest_replacement_targets() {
 }
 
 #[test]
+fn health_vitest_unmock_restores_coverage_and_crap_credit() {
+    let coverage_output = run_fallow(
+        "health",
+        "issue-2031-unmocked-test-reachability",
+        &[
+            "--coverage-gaps",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        coverage_output.code, 0,
+        "coverage gaps default to warn severity: {}",
+        coverage_output.stderr
+    );
+
+    let coverage_json = parse_json(&coverage_output);
+    let coverage = coverage_json["coverage_gaps"]
+        .as_object()
+        .expect("coverage_gaps should be an object");
+    assert_eq!(coverage["summary"]["runtime_files"].as_u64(), Some(3));
+    assert_eq!(
+        coverage["summary"]["covered_files"].as_u64(),
+        Some(2),
+        "the final unmock should restore the real dependency path"
+    );
+    let uncovered_files: Vec<_> = coverage["files"]
+        .as_array()
+        .expect("coverage_gaps.files should be an array")
+        .iter()
+        .filter_map(|file| file["path"].as_str())
+        .map(|path| path.replace('\\', "/"))
+        .collect();
+    assert_eq!(
+        uncovered_files,
+        vec!["src/entry.ts"],
+        "only the runtime-only entry should remain uncovered"
+    );
+
+    let crap_output = run_fallow(
+        "health",
+        "issue-2031-unmocked-test-reachability",
+        &[
+            "--max-crap",
+            "1",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        crap_output.code, 1,
+        "the low CRAP threshold should surface covered findings: {}",
+        crap_output.stderr
+    );
+    let crap_json = parse_json(&crap_output);
+    let findings = crap_json["findings"].as_array().expect("findings array");
+    for (path, name) in [
+        ("src/dependency.ts", "renderDependency"),
+        ("src/wrapper.ts", "renderWrapper"),
+    ] {
+        let finding = findings
+            .iter()
+            .find(|finding| {
+                finding["name"] == name
+                    && finding["path"]
+                        .as_str()
+                        .is_some_and(|candidate| candidate.replace('\\', "/") == path)
+            })
+            .unwrap_or_else(|| panic!("expected {path}:{name} finding, got: {findings:#?}"));
+        assert_eq!(finding["coverage_source"], "estimated");
+        assert_eq!(
+            finding["crap"].as_f64(),
+            Some(1.0),
+            "the final unmock should retain covered CRAP: {finding:#?}"
+        );
+    }
+}
+
+#[test]
 fn health_coverage_gaps_keep_targets_reached_by_an_unmasked_test_root() {
     let output = run_fallow(
         "health",

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -2338,7 +2338,7 @@ fn health_vitest_unmock_restores_coverage_and_crap_credit() {
     assert_eq!(
         coverage["summary"]["covered_files"].as_u64(),
         Some(2),
-        "the final unmock should restore the real dependency path"
+        "the final equivalent-specifier unmock should restore the real dependency path"
     );
     let uncovered_files: Vec<_> = coverage["files"]
         .as_array()
@@ -2389,7 +2389,7 @@ fn health_vitest_unmock_restores_coverage_and_crap_credit() {
         assert_eq!(
             finding["crap"].as_f64(),
             Some(1.0),
-            "the final unmock should retain covered CRAP: {finding:#?}"
+            "the final equivalent-specifier unmock should retain covered CRAP: {finding:#?}"
         );
     }
 }

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -913,6 +913,86 @@ fn health_angular_template_crap_inherits_from_component_ts() {
 }
 
 #[test]
+fn health_angular_template_inheritance_respects_mocked_component() {
+    let dir = tempdir().unwrap();
+    let fixture = fixture_path("angular-template-complexity");
+    copy_dir_recursive(&fixture, dir.path());
+
+    write_file(
+        &dir.path().join("package.json"),
+        r#"{
+            "name": "mocked-angular-template-inheritance",
+            "main": "src/main.ts",
+            "dependencies": {
+                "@angular/core": "^19.0.0",
+                "@angular/platform-browser": "^19.0.0"
+            },
+            "devDependencies": {
+                "vitest": "^3.2.4"
+            }
+        }"#,
+    );
+    write_file(
+        &dir.path().join("src/permissions-wrapper.ts"),
+        "import { PermissionsComponent } from './permissions.component';\n\
+         export const permissionsType = (): unknown => PermissionsComponent;\n",
+    );
+    write_file(
+        &dir.path().join("src/permissions-wrapper.test.ts"),
+        "import { expect, it, vi } from 'vitest';\n\
+         import { permissionsType } from './permissions-wrapper';\n\
+         vi.mock('./permissions.component', () => ({ PermissionsComponent: class {} }));\n\
+         it('uses the replacement', () => {\n  \
+           expect(permissionsType()).toBeDefined();\n\
+         });\n",
+    );
+
+    let output = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &[
+            "--complexity",
+            "--max-cyclomatic",
+            "3",
+            "--max-cognitive",
+            "3",
+            "--max-crap",
+            "30",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    let json = parse_json(&output);
+    let findings = json["findings"].as_array().expect("findings array");
+    let template = findings
+        .iter()
+        .find(|finding| {
+            finding["name"] == "<template>"
+                && finding["path"]
+                    .as_str()
+                    .is_some_and(|path| path.ends_with("permissions.component.html"))
+        })
+        .unwrap_or_else(|| panic!("expected <template> finding, got: {findings:#?}"));
+
+    assert_eq!(
+        template["coverage_source"], "estimated_component_inherited",
+        "the template should retain its component-owned coverage contract: {template:#?}"
+    );
+    assert_eq!(
+        template["coverage_tier"], "none",
+        "a test root that replaces the owning component must not cover its template: {template:#?}"
+    );
+    assert!(
+        template["inherited_from"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("permissions.component.ts")),
+        "template coverage provenance must still identify the owning component: {template:#?}"
+    );
+}
+
+#[test]
 fn health_angular_template_inherit_rejects_non_component_owner() {
     let dir = tempdir().unwrap();
     write_file(
@@ -2182,6 +2262,56 @@ fn health_coverage_gaps_exclude_vitest_replacement_targets() {
 }
 
 #[test]
+fn health_crap_estimation_excludes_vitest_replacement_targets() {
+    let output = run_fallow(
+        "health",
+        "issue-2031-mocked-test-reachability",
+        &[
+            "--max-crap",
+            "1",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        output.code, 1,
+        "the low CRAP threshold should surface findings: {}",
+        output.stderr
+    );
+
+    let json = parse_json(&output);
+    let findings = json["findings"].as_array().expect("findings array");
+    let crap_for = |path: &str, name: &str| {
+        findings
+            .iter()
+            .find(|finding| {
+                finding["name"] == name
+                    && finding["path"]
+                        .as_str()
+                        .is_some_and(|candidate| candidate.replace('\\', "/") == path)
+            })
+            .unwrap_or_else(|| panic!("expected {path}:{name} finding, got: {findings:#?}"))
+    };
+    let dependency = crap_for("src/dependency.ts", "renderDependency");
+    let wrapper = crap_for("src/wrapper.ts", "renderWrapper");
+
+    assert_eq!(dependency["coverage_source"], "estimated");
+    assert_eq!(
+        dependency["crap"].as_f64(),
+        Some(2.0),
+        "the replacement must not lower the real dependency's estimated CRAP: {dependency:#?}"
+    );
+    assert_eq!(wrapper["coverage_source"], "estimated");
+    assert_eq!(
+        wrapper["crap"].as_f64(),
+        Some(1.0),
+        "the directly exercised wrapper should retain covered CRAP: {wrapper:#?}"
+    );
+}
+
+#[test]
 fn health_coverage_gaps_keep_targets_reached_by_an_unmasked_test_root() {
     let output = run_fallow(
         "health",
@@ -2237,6 +2367,46 @@ fn health_coverage_gaps_keep_targets_reached_by_an_unmasked_test_root() {
     assert!(
         !export_names.contains(&"renderDependency"),
         "an unmasked reference should cover the dependency export: {export_names:?}"
+    );
+}
+
+#[test]
+fn health_crap_estimation_accepts_an_unmasked_test_root() {
+    let output = run_fallow(
+        "health",
+        "issue-2031-mixed-test-reachability",
+        &[
+            "--max-crap",
+            "1",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        output.code, 1,
+        "the low CRAP threshold should surface findings: {}",
+        output.stderr
+    );
+
+    let json = parse_json(&output);
+    let findings = json["findings"].as_array().expect("findings array");
+    let dependency = findings
+        .iter()
+        .find(|finding| {
+            finding["name"] == "renderDependency"
+                && finding["path"]
+                    .as_str()
+                    .is_some_and(|path| path.replace('\\', "/") == "src/dependency.ts")
+        })
+        .unwrap_or_else(|| panic!("expected dependency CRAP finding, got: {findings:#?}"));
+
+    assert_eq!(dependency["coverage_source"], "estimated");
+    assert_eq!(
+        dependency["crap"].as_f64(),
+        Some(1.0),
+        "an independent unmasked test root should restore covered CRAP: {dependency:#?}"
     );
 }
 

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -2113,6 +2113,75 @@ fn health_coverage_gaps_flag_reports_runtime_gaps() {
 }
 
 #[test]
+fn health_coverage_gaps_exclude_vitest_replacement_targets() {
+    let output = run_fallow(
+        "health",
+        "issue-2031-mocked-test-reachability",
+        &[
+            "--coverage-gaps",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        output.code, 0,
+        "coverage gaps default to warn severity: {}",
+        output.stderr
+    );
+
+    let json = parse_json(&output);
+    let coverage = json["coverage_gaps"]
+        .as_object()
+        .expect("coverage_gaps should be an object");
+    let summary = coverage["summary"]
+        .as_object()
+        .expect("coverage_gaps.summary should be an object");
+    assert_eq!(summary["runtime_files"].as_u64(), Some(3));
+    assert_eq!(
+        summary["covered_files"].as_u64(),
+        Some(1),
+        "only the real wrapper executes through the test root"
+    );
+
+    let file_names: Vec<_> = coverage["files"]
+        .as_array()
+        .expect("coverage_gaps.files should be an array")
+        .iter()
+        .filter_map(|item| item["path"].as_str())
+        .map(|path| path.replace('\\', "/"))
+        .collect();
+    assert!(
+        file_names
+            .iter()
+            .any(|path| path.ends_with("src/dependency.ts")),
+        "the replaced dependency should remain an untested runtime file: {file_names:?}"
+    );
+    assert!(
+        !file_names
+            .iter()
+            .any(|path| path.ends_with("src/wrapper.ts")),
+        "the wrapper itself should remain test-covered: {file_names:?}"
+    );
+
+    let export_names: Vec<_> = coverage["exports"]
+        .as_array()
+        .expect("coverage_gaps.exports should be an array")
+        .iter()
+        .filter_map(|item| item["export_name"].as_str())
+        .collect();
+    assert!(
+        export_names.contains(&"renderDependency"),
+        "the replacement must not cover the real dependency export: {export_names:?}"
+    );
+    assert!(
+        !export_names.contains(&"renderWrapper"),
+        "the directly tested wrapper export should remain covered: {export_names:?}"
+    );
+}
+
+#[test]
 fn health_coverage_gaps_config_error_enforces_without_flag() {
     let dir = tempfile::tempdir().expect("create temp dir");
     let config_path = dir.path().join("fallow.json");

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -2182,6 +2182,65 @@ fn health_coverage_gaps_exclude_vitest_replacement_targets() {
 }
 
 #[test]
+fn health_coverage_gaps_keep_targets_reached_by_an_unmasked_test_root() {
+    let output = run_fallow(
+        "health",
+        "issue-2031-mixed-test-reachability",
+        &[
+            "--coverage-gaps",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        output.code, 0,
+        "coverage gaps default to warn severity: {}",
+        output.stderr
+    );
+
+    let json = parse_json(&output);
+    let coverage = json["coverage_gaps"]
+        .as_object()
+        .expect("coverage_gaps should be an object");
+    let summary = coverage["summary"]
+        .as_object()
+        .expect("coverage_gaps.summary should be an object");
+    assert_eq!(summary["runtime_files"].as_u64(), Some(3));
+    assert_eq!(
+        summary["covered_files"].as_u64(),
+        Some(2),
+        "the wrapper and the independently tested dependency should be covered"
+    );
+
+    let file_names: Vec<_> = coverage["files"]
+        .as_array()
+        .expect("coverage_gaps.files should be an array")
+        .iter()
+        .filter_map(|item| item["path"].as_str())
+        .map(|path| path.replace('\\', "/"))
+        .collect();
+    assert!(
+        !file_names
+            .iter()
+            .any(|path| path.ends_with("src/dependency.ts")),
+        "an unmasked root should cover the real dependency: {file_names:?}"
+    );
+
+    let export_names: Vec<_> = coverage["exports"]
+        .as_array()
+        .expect("coverage_gaps.exports should be an array")
+        .iter()
+        .filter_map(|item| item["export_name"].as_str())
+        .collect();
+    assert!(
+        !export_names.contains(&"renderDependency"),
+        "an unmasked reference should cover the dependency export: {export_names:?}"
+    );
+}
+
+#[test]
 fn health_coverage_gaps_config_error_enforces_without_flag() {
     let dir = tempfile::tempdir().expect("create temp dir");
     let config_path = dir.path().join("fallow.json");

--- a/crates/core/src/analyze/members/tests.rs
+++ b/crates/core/src/analyze/members/tests.rs
@@ -138,6 +138,7 @@ fn make_export_with_members(
             vec![SymbolReference {
                 from_file: FileId(from),
                 kind: crate::graph::ReferenceKind::NamedImport,
+                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
                 import_span: Span::new(0, 10),
             }]
         })

--- a/crates/core/src/analyze/members/tests.rs
+++ b/crates/core/src/analyze/members/tests.rs
@@ -2,10 +2,10 @@ use super::*;
 use crate::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
 use crate::extract::{
     ExportInfo, ExportName, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, VisibilityTag,
+    ModuleInfo, ReExportInfo, VisibilityTag,
 };
-use crate::graph::{ExportSymbol, ModuleGraph, SymbolReference};
-use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
+use crate::graph::ModuleGraph;
+use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport};
 use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
 use fallow_types::extract::{
     ClassHeritageInfo, FactoryCallMemberAccessFact, FluentChainMemberAccessFact,
@@ -14,6 +14,8 @@ use fallow_types::extract::{
     SemanticFact,
 };
 use oxc_span::Span;
+use std::cell::OnceCell;
+use std::ops::Deref;
 use std::path::PathBuf;
 
 #[expect(
@@ -55,7 +57,7 @@ fn find_unused_members(
     clippy::cast_possible_truncation,
     reason = "test file counts are trivially small"
 )]
-fn build_graph(file_specs: &[(&str, bool)]) -> ModuleGraph {
+fn build_graph(file_specs: &[(&str, bool)]) -> TestGraphFixture {
     let files: Vec<DiscoveredFile> = file_specs
         .iter()
         .enumerate()
@@ -84,7 +86,67 @@ fn build_graph(file_specs: &[(&str, bool)]) -> ModuleGraph {
         })
         .collect();
 
-    ModuleGraph::build(&resolved_modules, &entry_points, &files)
+    TestGraphFixture {
+        files,
+        entry_points,
+        resolved_modules,
+        forced_reachable: FxHashSet::default(),
+        graph: OnceCell::new(),
+    }
+}
+
+struct TestGraphFixture {
+    files: Vec<DiscoveredFile>,
+    entry_points: Vec<EntryPoint>,
+    resolved_modules: Vec<ResolvedModule>,
+    forced_reachable: FxHashSet<FileId>,
+    graph: OnceCell<ModuleGraph>,
+}
+
+impl TestGraphFixture {
+    fn assert_configuring(&self) {
+        assert!(
+            self.graph.get().is_none(),
+            "fixture inputs must be complete before graph construction"
+        );
+    }
+
+    fn set_reachable(&mut self, file_id: u32) {
+        self.assert_configuring();
+        self.forced_reachable.insert(FileId(file_id));
+    }
+
+    fn set_re_exports(&mut self, file_id: usize, re_exports: Vec<crate::graph::ReExportEdge>) {
+        self.assert_configuring();
+        self.resolved_modules[file_id].re_exports = re_exports
+            .into_iter()
+            .map(|re_export| ResolvedReExport {
+                info: ReExportInfo {
+                    source: format!("./fixture-{}", re_export.source_file.0),
+                    imported_name: re_export.imported_name,
+                    exported_name: re_export.exported_name,
+                    is_type_only: re_export.is_type_only,
+                    span: re_export.span,
+                },
+                target: ResolveResult::InternalModule(re_export.source_file),
+            })
+            .collect();
+    }
+}
+
+impl Deref for TestGraphFixture {
+    type Target = ModuleGraph;
+
+    fn deref(&self) -> &Self::Target {
+        self.graph.get_or_init(|| {
+            let mut graph =
+                ModuleGraph::build(&self.resolved_modules, &self.entry_points, &self.files);
+            for file_id in &self.forced_reachable {
+                graph.modules[file_id.0 as usize].set_reachable(true);
+            }
+            graph
+        })
+    }
 }
 
 fn make_member(name: &str, kind: MemberKind) -> MemberInfo {
@@ -128,30 +190,55 @@ fn make_resolved_import(source: &str, imported: &str, local: &str, target: u32) 
     }
 }
 
+struct TestExport {
+    info: ExportInfo,
+    ref_from: Option<FileId>,
+}
+
+fn export_name_str(name: &ExportName) -> &str {
+    match name {
+        ExportName::Named(name) => name,
+        ExportName::Default => "default",
+    }
+}
+
 fn make_export_with_members(
     name: &str,
     members: Vec<MemberInfo>,
     ref_from: Option<u32>,
-) -> ExportSymbol {
-    let references = ref_from
-        .map(|from| {
-            vec![SymbolReference {
-                from_file: FileId(from),
-                kind: crate::graph::ReferenceKind::NamedImport,
-                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
-                import_span: Span::new(0, 10),
-            }]
-        })
-        .unwrap_or_default();
-    ExportSymbol {
-        name: ExportName::Named(name.to_string()),
-        is_type_only: false,
-        is_side_effect_used: false,
-        visibility: VisibilityTag::None,
-        expected_unused_reason: None,
-        span: Span::new(0, 10),
-        references,
-        members,
+) -> TestExport {
+    TestExport {
+        ref_from: ref_from.map(FileId),
+        info: ExportInfo {
+            name: ExportName::Named(name.to_string()),
+            local_name: None,
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: Span::new(0, 10),
+            members,
+            super_class: None,
+        },
+    }
+}
+
+/// Add canonical resolver inputs before the fixture builds its graph.
+fn set_exports(graph: &mut TestGraphFixture, target: usize, exports: &[TestExport]) {
+    graph.assert_configuring();
+    graph.resolved_modules[target].exports =
+        exports.iter().map(|export| export.info.clone()).collect();
+    for export in exports {
+        if let Some(from_file) = export.ref_from {
+            graph.resolved_modules[from_file.0 as usize]
+                .resolved_imports
+                .push(make_resolved_import(
+                    &format!("./fixture-{target}"),
+                    export_name_str(&export.info.name),
+                    export_name_str(&export.info.name),
+                    target as u32,
+                ));
+        }
     }
 }
 
@@ -162,14 +249,22 @@ fn typed_playwright_fixture_use_fact_credits_fixture_member() {
         ("/src/fixtures.ts", false),
         ("/src/admin-page.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members("test", vec![], Some(0))];
-    graph.modules[2].set_reachable(true);
-    graph.modules[2].exports = vec![make_export_with_members(
-        "AdminPage",
-        vec![make_member("assertGreeting", MemberKind::ClassMethod)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("test", vec![], Some(0))],
+    );
+    graph.set_reachable(2);
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -239,16 +334,28 @@ fn typed_playwright_fixture_alias_fact_expands_fixture_targets() {
         ("/src/wrapped-fixtures.ts", false),
         ("/src/admin-page.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members("testPrimary", vec![], Some(2))];
-    graph.modules[2].set_reachable(true);
-    graph.modules[2].exports = vec![make_export_with_members("mergedTest", vec![], Some(0))];
-    graph.modules[3].set_reachable(true);
-    graph.modules[3].exports = vec![make_export_with_members(
-        "AdminPage",
-        vec![make_member("assertGreeting", MemberKind::ClassMethod)],
-        Some(1),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("testPrimary", vec![], Some(2))],
+    );
+    graph.set_reachable(2);
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members("mergedTest", vec![], Some(0))],
+    );
+    graph.set_reachable(3);
+    set_exports(
+        &mut graph,
+        3,
+        &[make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(1),
+        )],
+    );
 
     let resolved_modules = vec![
         ResolvedModule {
@@ -334,16 +441,28 @@ fn typed_playwright_fixture_type_fact_expands_nested_fixture_targets() {
         ("/src/pages.ts", false),
         ("/src/admin-page.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members("test", vec![], Some(0))];
-    graph.modules[2].set_reachable(true);
-    graph.modules[2].exports = vec![make_export_with_members("Pages", vec![], Some(0))];
-    graph.modules[3].set_reachable(true);
-    graph.modules[3].exports = vec![make_export_with_members(
-        "AdminPage",
-        vec![make_member("assertGreeting", MemberKind::ClassMethod)],
-        Some(2),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("test", vec![], Some(0))],
+    );
+    graph.set_reachable(2);
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members("Pages", vec![], Some(0))],
+    );
+    graph.set_reachable(3);
+    set_exports(
+        &mut graph,
+        3,
+        &[make_export_with_members(
+            "AdminPage",
+            vec![make_member("assertGreeting", MemberKind::ClassMethod)],
+            Some(2),
+        )],
+    );
 
     let resolved_modules = vec![
         ResolvedModule {
@@ -412,11 +531,23 @@ fn typed_instance_export_binding_fact_builds_target_map() {
         ("/src/service.ts", false),
         ("/src/stale-service.ts", false),
     ]);
-    graph.modules[0].exports = vec![make_export_with_members("service", vec![], Some(0))];
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members("Service", vec![], Some(0))];
-    graph.modules[2].set_reachable(true);
-    graph.modules[2].exports = vec![make_export_with_members("StaleService", vec![], Some(0))];
+    set_exports(
+        &mut graph,
+        0,
+        &[make_export_with_members("service", vec![], Some(0))],
+    );
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("Service", vec![], Some(0))],
+    );
+    graph.set_reachable(2);
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members("StaleService", vec![], Some(0))],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -448,15 +579,19 @@ fn typed_instance_export_binding_fact_builds_target_map() {
 #[test]
 fn typed_factory_call_fact_credits_class_member() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/my-class.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyClass",
-        vec![
-            make_factory_member("getInstance"),
-            make_member("getData", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyClass",
+            vec![
+                make_factory_member("getInstance"),
+                make_member("getData", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let class_export = ExportInfo {
         name: ExportName::Named("MyClass".to_string()),
@@ -519,17 +654,21 @@ fn typed_factory_call_fact_credits_class_member() {
 #[test]
 fn typed_fluent_chain_fact_credits_class_member() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/event-builder.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "EventBuilder",
-        vec![
-            make_factory_member("create"),
-            make_self_member("setProcessId"),
-            make_self_member("setSubject"),
-            make_member("build", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "EventBuilder",
+            vec![
+                make_factory_member("create"),
+                make_self_member("setProcessId"),
+                make_self_member("setSubject"),
+                make_member("build", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let class_export = ExportInfo {
         name: ExportName::Named("EventBuilder".to_string()),
@@ -595,16 +734,20 @@ fn typed_fluent_chain_fact_credits_class_member() {
 #[test]
 fn typed_fluent_chain_new_fact_credits_class_member() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/option-builder.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "OptionBuilder",
-        vec![
-            make_self_member("addDefault"),
-            make_self_member("addFromCli"),
-            make_member("build", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "OptionBuilder",
+            vec![
+                make_self_member("addDefault"),
+                make_self_member("addFromCli"),
+                make_member("build", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let class_export = ExportInfo {
         name: ExportName::Named("OptionBuilder".to_string()),
@@ -779,15 +922,19 @@ fn unused_members_empty_graph() {
 #[test]
 fn unused_enum_member_detected() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("Active", MemberKind::EnumMember),
-            make_member("Inactive", MemberKind::EnumMember),
-        ],
-        Some(0), // referenced from entry
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("Active", MemberKind::EnumMember),
+                make_member("Inactive", MemberKind::EnumMember),
+            ],
+            Some(0), // referenced from entry
+        )],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,
@@ -811,15 +958,19 @@ fn unused_enum_member_detected() {
 #[test]
 fn accessed_enum_member_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("Active", MemberKind::EnumMember),
-            make_member("Inactive", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("Active", MemberKind::EnumMember),
+                make_member("Inactive", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -863,31 +1014,42 @@ fn accessed_enum_member_via_re_export_not_flagged() {
         ("/lib/index.ts", true),
         ("/lib/types.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
+    graph.set_reachable(1);
+    graph.set_reachable(2);
 
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![],
-        Some(0), // referenced from consumer
-    )];
-    graph.modules[1].re_exports = vec![crate::graph::ReExportEdge {
-        source_file: FileId(2),
-        imported_name: "Status".to_string(),
-        exported_name: "Status".to_string(),
-        is_type_only: false,
-        span: Span::default(),
-    }];
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![],
+            Some(0), // referenced from consumer
+        )],
+    );
+    graph.set_re_exports(
+        1,
+        vec![crate::graph::ReExportEdge {
+            source_file: FileId(2),
+            imported_name: "Status".to_string(),
+            exported_name: "Status".to_string(),
+            is_type_only: false,
+            span: Span::default(),
+        }],
+    );
 
-    graph.modules[2].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("Active", MemberKind::EnumMember),
-            make_member("Inactive", MemberKind::EnumMember),
-            make_member("Archived", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("Active", MemberKind::EnumMember),
+                make_member("Inactive", MemberKind::EnumMember),
+                make_member("Archived", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -939,26 +1101,37 @@ fn accessed_class_static_member_via_re_export_not_flagged() {
         ("/lib/index.ts", true),
         ("/lib/utils.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
+    graph.set_reachable(1);
+    graph.set_reachable(2);
 
-    graph.modules[1].exports = vec![make_export_with_members("StringUtils", vec![], Some(0))];
-    graph.modules[1].re_exports = vec![crate::graph::ReExportEdge {
-        source_file: FileId(2),
-        imported_name: "StringUtils".to_string(),
-        exported_name: "StringUtils".to_string(),
-        is_type_only: false,
-        span: Span::default(),
-    }];
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("StringUtils", vec![], Some(0))],
+    );
+    graph.set_re_exports(
+        1,
+        vec![crate::graph::ReExportEdge {
+            source_file: FileId(2),
+            imported_name: "StringUtils".to_string(),
+            exported_name: "StringUtils".to_string(),
+            is_type_only: false,
+            span: Span::default(),
+        }],
+    );
 
-    graph.modules[2].exports = vec![make_export_with_members(
-        "StringUtils",
-        vec![
-            make_member("toUpper", MemberKind::ClassMethod),
-            make_member("toLower", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "StringUtils",
+            vec![
+                make_member("toUpper", MemberKind::ClassMethod),
+                make_member("toLower", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -1003,26 +1176,37 @@ fn accessed_member_via_renamed_re_export_not_flagged() {
         ("/lib/index.ts", true),
         ("/lib/types.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
+    graph.set_reachable(1);
+    graph.set_reachable(2);
 
-    graph.modules[1].exports = vec![make_export_with_members("Renamed", vec![], Some(0))];
-    graph.modules[1].re_exports = vec![crate::graph::ReExportEdge {
-        source_file: FileId(2),
-        imported_name: "Original".to_string(),
-        exported_name: "Renamed".to_string(),
-        is_type_only: false,
-        span: Span::default(),
-    }];
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("Renamed", vec![], Some(0))],
+    );
+    graph.set_re_exports(
+        1,
+        vec![crate::graph::ReExportEdge {
+            source_file: FileId(2),
+            imported_name: "Original".to_string(),
+            exported_name: "Renamed".to_string(),
+            is_type_only: false,
+            span: Span::default(),
+        }],
+    );
 
-    graph.modules[2].exports = vec![make_export_with_members(
-        "Original",
-        vec![
-            make_member("A", MemberKind::EnumMember),
-            make_member("B", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "Original",
+            vec![
+                make_member("A", MemberKind::EnumMember),
+                make_member("B", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -1068,25 +1252,32 @@ fn accessed_member_via_star_re_export_not_flagged() {
         ("/lib/index.ts", true),
         ("/lib/types.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
+    graph.set_reachable(1);
+    graph.set_reachable(2);
 
-    graph.modules[1].re_exports = vec![crate::graph::ReExportEdge {
-        source_file: FileId(2),
-        imported_name: "*".to_string(),
-        exported_name: "*".to_string(),
-        is_type_only: false,
-        span: Span::default(),
-    }];
+    graph.set_re_exports(
+        1,
+        vec![crate::graph::ReExportEdge {
+            source_file: FileId(2),
+            imported_name: "*".to_string(),
+            exported_name: "*".to_string(),
+            is_type_only: false,
+            span: Span::default(),
+        }],
+    );
 
-    graph.modules[2].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("Active", MemberKind::EnumMember),
-            make_member("Inactive", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("Active", MemberKind::EnumMember),
+                make_member("Inactive", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -1127,15 +1318,19 @@ fn accessed_member_via_star_re_export_not_flagged() {
 #[test]
 fn whole_object_use_skips_all_members() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("Active", MemberKind::EnumMember),
-            make_member("Inactive", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("Active", MemberKind::EnumMember),
+                make_member("Inactive", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -1172,20 +1367,24 @@ fn whole_object_use_skips_all_members() {
 #[test]
 fn decorated_class_member_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/entity.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "User",
-        vec![MemberInfo {
-            name: "name".to_string(),
-            kind: MemberKind::ClassProperty,
-            span: Span::new(10, 20),
-            has_decorator: true, // @Column() etc.
-            decorator_names: vec!["Column".to_string()],
-            is_instance_returning_static: false,
-            is_self_returning: false,
-        }],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "User",
+            vec![MemberInfo {
+                name: "name".to_string(),
+                kind: MemberKind::ClassProperty,
+                span: Span::new(10, 20),
+                has_decorator: true, // @Column() etc.
+                decorator_names: vec!["Column".to_string()],
+                is_instance_returning_static: false,
+                is_self_returning: false,
+            }],
+            Some(0),
+        )],
+    );
 
     let (_, class_members) = find_unused_members(
         &graph,
@@ -1230,16 +1429,20 @@ fn ignore_decorator_set_dotted_record_seen_distinct_from_bare() {
 #[test]
 fn react_lifecycle_method_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/component.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyComponent",
-        vec![
-            make_member("render", MemberKind::ClassMethod),
-            make_member("componentDidMount", MemberKind::ClassMethod),
-            make_member("customMethod", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyComponent",
+            vec![
+                make_member("render", MemberKind::ClassMethod),
+                make_member("componentDidMount", MemberKind::ClassMethod),
+                make_member("customMethod", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let (_, class_members) = find_unused_members(
         &graph,
@@ -1257,16 +1460,20 @@ fn react_lifecycle_method_not_flagged() {
 #[test]
 fn angular_lifecycle_method_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/component.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "AppComponent",
-        vec![
-            make_member("ngOnInit", MemberKind::ClassMethod),
-            make_member("ngOnDestroy", MemberKind::ClassMethod),
-            make_member("myHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "AppComponent",
+            vec![
+                make_member("ngOnInit", MemberKind::ClassMethod),
+                make_member("ngOnDestroy", MemberKind::ClassMethod),
+                make_member("myHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let (_, class_members) = find_unused_members(
         &graph,
@@ -1284,16 +1491,20 @@ fn angular_lifecycle_method_not_flagged() {
 #[test]
 fn user_class_member_allowlist_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/renderer.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyRendererComponent",
-        vec![
-            make_member("agInit", MemberKind::ClassMethod),
-            make_member("refresh", MemberKind::ClassMethod),
-            make_member("customHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyRendererComponent",
+            vec![
+                make_member("agInit", MemberKind::ClassMethod),
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let allowlist = vec![
         UsedClassMemberRule::from("agInit"),
@@ -1320,17 +1531,21 @@ fn user_class_member_allowlist_not_flagged() {
 #[test]
 fn user_class_member_allowlist_globs_match_member_names() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/listener.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "GrammarListener",
-        vec![
-            make_member("enterRule", MemberKind::ClassMethod),
-            make_member("exitRule", MemberKind::ClassMethod),
-            make_member("onNodeEvent", MemberKind::ClassMethod),
-            make_member("customHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "GrammarListener",
+            vec![
+                make_member("enterRule", MemberKind::ClassMethod),
+                make_member("exitRule", MemberKind::ClassMethod),
+                make_member("onNodeEvent", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let allowlist = vec![
         UsedClassMemberRule::from("enter*"),
@@ -1372,12 +1587,16 @@ fn member_glob_patterns_track_whether_they_matched() {
 #[test]
 fn user_class_member_allowlist_does_not_affect_enums() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/status.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![make_member("refresh", MemberKind::EnumMember)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![make_member("refresh", MemberKind::EnumMember)],
+            Some(0),
+        )],
+    );
 
     let allowlist = vec![UsedClassMemberRule::from("refresh")];
 
@@ -1397,15 +1616,19 @@ fn user_class_member_allowlist_does_not_affect_enums() {
 #[test]
 fn scoped_allowlist_matches_implements_only() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/renderer.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyRendererComponent",
-        vec![
-            make_member("refresh", MemberKind::ClassMethod),
-            make_member("customHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyRendererComponent",
+            vec![
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let modules = vec![make_module_with_class_heritage(
         1,
@@ -1440,22 +1663,30 @@ fn scoped_allowlist_globs_match_only_matching_heritage() {
         ("/src/listener.ts", false),
         ("/src/unrelated.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "GrammarListener",
-        vec![
-            make_member("enterRule", MemberKind::ClassMethod),
-            make_member("exitRule", MemberKind::ClassMethod),
-            make_member("customHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
-    graph.modules[2].set_reachable(true);
-    graph.modules[2].exports = vec![make_export_with_members(
-        "DashboardComponent",
-        vec![make_member("enterRule", MemberKind::ClassMethod)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "GrammarListener",
+            vec![
+                make_member("enterRule", MemberKind::ClassMethod),
+                make_member("exitRule", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
+    graph.set_reachable(2);
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "DashboardComponent",
+            vec![make_member("enterRule", MemberKind::ClassMethod)],
+            Some(0),
+        )],
+    );
 
     let modules = vec![make_module_with_class_heritage(
         1,
@@ -1509,15 +1740,19 @@ fn scoped_allowlist_globs_match_only_matching_heritage() {
 #[test]
 fn scoped_allowlist_matches_extends_only() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/command.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "GenerateReport",
-        vec![
-            make_member("execute", MemberKind::ClassMethod),
-            make_member("customHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "GenerateReport",
+            vec![
+                make_member("execute", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let modules = vec![make_module_with_class_heritage(
         1,
@@ -1585,15 +1820,19 @@ fn is_native_error_base_name_recognizes_native_errors() {
 #[test]
 fn error_subclass_name_member_not_flagged_but_other_members_are() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/errors.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "DomainError",
-        vec![
-            make_member("name", MemberKind::ClassProperty),
-            make_member("unusedHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "DomainError",
+            vec![
+                make_member("name", MemberKind::ClassProperty),
+                make_member("unusedHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let modules = vec![make_module_with_class_heritage(
         1,
@@ -1619,12 +1858,16 @@ fn error_subclass_name_member_not_flagged_but_other_members_are() {
 #[test]
 fn ordinary_class_name_member_still_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/person.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Person",
-        vec![make_member("name", MemberKind::ClassProperty)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Person",
+            vec![make_member("name", MemberKind::ClassProperty)],
+            Some(0),
+        )],
+    );
 
     let modules = vec![make_module_with_class_heritage(1, "Person", None, &[])];
 
@@ -1645,19 +1888,23 @@ fn ordinary_class_name_member_still_flagged() {
 #[test]
 fn transitive_error_subclass_name_member_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/errors.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![
-        make_export_with_members(
-            "DomainError",
-            vec![make_member("name", MemberKind::ClassProperty)],
-            Some(0),
-        ),
-        make_export_with_members(
-            "ApiError",
-            vec![make_member("name", MemberKind::ClassProperty)],
-            Some(0),
-        ),
-    ];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[
+            make_export_with_members(
+                "DomainError",
+                vec![make_member("name", MemberKind::ClassProperty)],
+                Some(0),
+            ),
+            make_export_with_members(
+                "ApiError",
+                vec![make_member("name", MemberKind::ClassProperty)],
+                Some(0),
+            ),
+        ],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(1),
@@ -1700,15 +1947,19 @@ fn transitive_error_subclass_name_member_not_flagged() {
 #[test]
 fn this_member_access_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/service.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Service",
-        vec![
-            make_member("label", MemberKind::ClassProperty),
-            make_member("unused_prop", MemberKind::ClassProperty),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Service",
+            vec![
+                make_member("label", MemberKind::ClassProperty),
+                make_member("unused_prop", MemberKind::ClassProperty),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(1), // same file as the service
@@ -1736,12 +1987,16 @@ fn this_member_access_not_flagged() {
 #[test]
 fn unreferenced_export_skips_member_analysis() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![make_member("Active", MemberKind::EnumMember)],
-        None, // no references
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![make_member("Active", MemberKind::EnumMember)],
+            None, // no references
+        )],
+    );
 
     let (enum_members, _) = find_unused_members(
         &graph,
@@ -1757,12 +2012,20 @@ fn unreferenced_export_skips_member_analysis() {
 
 #[test]
 fn unreachable_module_skips_member_analysis() {
-    let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/dead.ts", false)]);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "DeadEnum",
-        vec![make_member("X", MemberKind::EnumMember)],
-        Some(0),
-    )];
+    let mut graph = build_graph(&[
+        ("/src/entry.ts", true),
+        ("/src/dead.ts", false),
+        ("/src/unreachable-consumer.ts", false),
+    ]);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "DeadEnum",
+            vec![make_member("X", MemberKind::EnumMember)],
+            Some(2),
+        )],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,
@@ -1780,11 +2043,15 @@ fn unreachable_module_skips_member_analysis() {
 #[test]
 fn entry_point_module_skips_member_analysis() {
     let mut graph = build_graph(&[("/src/entry.ts", true)]);
-    graph.modules[0].exports = vec![make_export_with_members(
-        "EntryEnum",
-        vec![make_member("X", MemberKind::EnumMember)],
-        None,
-    )];
+    set_exports(
+        &mut graph,
+        0,
+        &[make_export_with_members(
+            "EntryEnum",
+            vec![make_member("X", MemberKind::EnumMember)],
+            None,
+        )],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,
@@ -1802,12 +2069,16 @@ fn entry_point_module_skips_member_analysis() {
 #[test]
 fn enum_member_kind_routed_to_enum_results() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![make_member("Active", MemberKind::EnumMember)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![make_member("Active", MemberKind::EnumMember)],
+            Some(0),
+        )],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,
@@ -1826,15 +2097,19 @@ fn enum_member_kind_routed_to_enum_results() {
 #[test]
 fn class_member_kind_routed_to_class_results() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/class.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyClass",
-        vec![
-            make_member("myMethod", MemberKind::ClassMethod),
-            make_member("myProp", MemberKind::ClassProperty),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyClass",
+            vec![
+                make_member("myMethod", MemberKind::ClassMethod),
+                make_member("myProp", MemberKind::ClassProperty),
+            ],
+            Some(0),
+        )],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,
@@ -1862,15 +2137,19 @@ fn class_member_kind_routed_to_class_results() {
 #[test]
 fn instance_member_access_not_flagged() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/service.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyService",
-        vec![
-            make_member("greet", MemberKind::ClassMethod),
-            make_member("unusedMethod", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyService",
+            vec![
+                make_member("greet", MemberKind::ClassMethod),
+                make_member("unusedMethod", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -1910,15 +2189,19 @@ fn instance_member_access_not_flagged() {
 #[test]
 fn this_access_does_not_skip_enum_members() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Direction",
-        vec![
-            make_member("Up", MemberKind::EnumMember),
-            make_member("Down", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Direction",
+            vec![
+                make_member("Up", MemberKind::EnumMember),
+                make_member("Down", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(1),
@@ -1945,19 +2228,23 @@ fn this_access_does_not_skip_enum_members() {
 #[test]
 fn mixed_enum_and_class_in_same_module() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/mixed.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![
-        make_export_with_members(
-            "Status",
-            vec![make_member("Active", MemberKind::EnumMember)],
-            Some(0),
-        ),
-        make_export_with_members(
-            "Service",
-            vec![make_member("doWork", MemberKind::ClassMethod)],
-            Some(0),
-        ),
-    ];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[
+            make_export_with_members(
+                "Status",
+                vec![make_member("Active", MemberKind::EnumMember)],
+                Some(0),
+            ),
+            make_export_with_members(
+                "Service",
+                vec![make_member("doWork", MemberKind::ClassMethod)],
+                Some(0),
+            ),
+        ],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,
@@ -1977,15 +2264,19 @@ fn mixed_enum_and_class_in_same_module() {
 #[test]
 fn local_name_mapped_to_imported_name() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("Active", MemberKind::EnumMember),
-            make_member("Inactive", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("Active", MemberKind::EnumMember),
+                make_member("Inactive", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -2025,15 +2316,19 @@ fn local_name_mapped_to_imported_name() {
 #[test]
 fn default_import_maps_to_default_export() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "default",
-        vec![
-            make_member("X", MemberKind::EnumMember),
-            make_member("Y", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "default",
+            vec![
+                make_member("X", MemberKind::EnumMember),
+                make_member("Y", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -2075,12 +2370,16 @@ fn suppressed_enum_member_not_flagged() {
     use crate::suppress::{IssueKind, Suppression};
 
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![make_member("Active", MemberKind::EnumMember)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![make_member("Active", MemberKind::EnumMember)],
+            Some(0),
+        )],
+    );
 
     let supps = vec![Suppression::issue(1, 0, IssueKind::UnusedEnumMember)];
     let mut supp_map: FxHashMap<FileId, &[Suppression]> = FxHashMap::default();
@@ -2107,12 +2406,16 @@ fn suppressed_class_member_not_flagged() {
     use crate::suppress::{IssueKind, Suppression};
 
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/service.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Service",
-        vec![make_member("doWork", MemberKind::ClassMethod)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Service",
+            vec![make_member("doWork", MemberKind::ClassMethod)],
+            Some(0),
+        )],
+    );
 
     let supps = vec![Suppression::issue(1, 0, IssueKind::UnusedClassMember)];
     let mut supp_map: FxHashMap<FileId, &[Suppression]> = FxHashMap::default();
@@ -2137,15 +2440,19 @@ fn suppressed_class_member_not_flagged() {
 #[test]
 fn whole_object_use_via_aliased_import() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/enums.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Status",
-        vec![
-            make_member("A", MemberKind::EnumMember),
-            make_member("B", MemberKind::EnumMember),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Status",
+            vec![
+                make_member("A", MemberKind::EnumMember),
+                make_member("B", MemberKind::EnumMember),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -2184,15 +2491,19 @@ fn whole_object_use_via_aliased_import() {
 #[test]
 fn this_field_chained_access_not_flagged() {
     let mut graph = build_graph(&[("/src/main.ts", true), ("/src/service.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "MyService",
-        vec![
-            make_member("doWork", MemberKind::ClassMethod),
-            make_member("unusedMethod", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "MyService",
+            vec![
+                make_member("doWork", MemberKind::ClassMethod),
+                make_member("unusedMethod", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -2241,24 +2552,32 @@ fn interface_member_usage_propagates_to_implementers() {
         ("/src/fixed-size-strategy.ts", false),
         ("/src/scroll-viewport.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
-    graph.modules[3].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "VirtualScrollStrategy",
-        vec![],
-        Some(3),
-    )];
-    graph.modules[2].exports = vec![make_export_with_members(
-        "FixedSizeScrollStrategy",
-        vec![
-            make_member("attached", MemberKind::ClassProperty),
-            make_member("attach", MemberKind::ClassMethod),
-            make_member("detach", MemberKind::ClassMethod),
-            make_member("unusedHelper", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    graph.set_reachable(2);
+    graph.set_reachable(3);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "VirtualScrollStrategy",
+            vec![],
+            Some(3),
+        )],
+    );
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "FixedSizeScrollStrategy",
+            vec![
+                make_member("attached", MemberKind::ClassProperty),
+                make_member("attach", MemberKind::ClassMethod),
+                make_member("detach", MemberKind::ClassMethod),
+                make_member("unusedHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let modules = vec![make_module_with_class_heritage(
         2,
@@ -2365,23 +2684,39 @@ fn same_named_interfaces_do_not_share_member_usage() {
         ("/src/two-impl.ts", false),
         ("/src/consumer.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
-    graph.modules[3].set_reachable(true);
-    graph.modules[4].set_reachable(true);
-    graph.modules[5].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members("Strategy", vec![], Some(5))];
-    graph.modules[2].exports = vec![make_export_with_members("Strategy", vec![], Some(0))];
-    graph.modules[3].exports = vec![make_export_with_members(
-        "OneStrategy",
-        vec![make_member("attach", MemberKind::ClassMethod)],
-        Some(0),
-    )];
-    graph.modules[4].exports = vec![make_export_with_members(
-        "TwoStrategy",
-        vec![make_member("attach", MemberKind::ClassMethod)],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    graph.set_reachable(2);
+    graph.set_reachable(3);
+    graph.set_reachable(4);
+    graph.set_reachable(5);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members("Strategy", vec![], Some(5))],
+    );
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members("Strategy", vec![], Some(0))],
+    );
+    set_exports(
+        &mut graph,
+        3,
+        &[make_export_with_members(
+            "OneStrategy",
+            vec![make_member("attach", MemberKind::ClassMethod)],
+            Some(0),
+        )],
+    );
+    set_exports(
+        &mut graph,
+        4,
+        &[make_export_with_members(
+            "TwoStrategy",
+            vec![make_member("attach", MemberKind::ClassMethod)],
+            Some(0),
+        )],
+    );
 
     let modules = vec![
         make_module_with_class_heritage(3, "OneStrategy", None, &["Strategy"]),
@@ -2478,24 +2813,32 @@ fn same_named_exports_do_not_share_member_usage() {
         ("/src/one.ts", false),
         ("/src/two.ts", false),
     ]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[2].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "Widget",
-        vec![
-            make_member("refresh", MemberKind::ClassMethod),
-            make_member("unusedOne", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
-    graph.modules[2].exports = vec![make_export_with_members(
-        "Widget",
-        vec![
-            make_member("refresh", MemberKind::ClassMethod),
-            make_member("unusedTwo", MemberKind::ClassMethod),
-        ],
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    graph.set_reachable(2);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "Widget",
+            vec![
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("unusedOne", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
+    set_exports(
+        &mut graph,
+        2,
+        &[make_export_with_members(
+            "Widget",
+            vec![
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("unusedTwo", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )],
+    );
 
     let resolved_modules = vec![ResolvedModule {
         file_id: FileId(0),
@@ -2570,12 +2913,16 @@ fn same_named_exports_do_not_share_member_usage() {
 #[test]
 fn export_with_no_members_skipped() {
     let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/utils.ts", false)]);
-    graph.modules[1].set_reachable(true);
-    graph.modules[1].exports = vec![make_export_with_members(
-        "helper",
-        vec![], // no members
-        Some(0),
-    )];
+    graph.set_reachable(1);
+    set_exports(
+        &mut graph,
+        1,
+        &[make_export_with_members(
+            "helper",
+            vec![], // no members
+            Some(0),
+        )],
+    );
 
     let (enum_members, class_members) = find_unused_members(
         &graph,

--- a/crates/core/src/analyze/react_resolve.rs
+++ b/crates/core/src/analyze/react_resolve.rs
@@ -51,6 +51,16 @@ pub(super) struct ChildResolver<'a> {
     sole_component: FxHashMap<FileId, &'a str>,
 }
 
+fn component_import_target(target: &ResolveResult) -> Option<FileId> {
+    match target {
+        ResolveResult::InternalModule(file_id)
+        | ResolveResult::CommonJsInternalModule(file_id)
+        | ResolveResult::InternalPackageModule { file_id, .. }
+        | ResolveResult::CommonJsInternalPackageModule { file_id, .. } => Some(*file_id),
+        _ => None,
+    }
+}
+
 impl<'a> ChildResolver<'a> {
     /// Build the resolver over every reachable React module. The
     /// `components_per_file` / `sole_component` maps come straight from
@@ -86,14 +96,10 @@ impl<'a> ChildResolver<'a> {
         for (file, resolved) in resolved_by_id {
             let mut map: FxHashMap<&'a str, FileId> = FxHashMap::default();
             for import in &resolved.resolved_imports {
-                if let ResolveResult::InternalModule(target)
-                | ResolveResult::InternalPackageModule {
-                    file_id: target, ..
-                } = &import.target
-                {
+                if let Some(target) = component_import_target(&import.target) {
                     let local = import.info.local_name.as_str();
                     if !local.is_empty() {
-                        map.insert(local, *target);
+                        map.insert(local, target);
                     }
                 }
             }
@@ -165,5 +171,31 @@ impl<'a> ChildResolver<'a> {
         self.import_targets
             .get(&parent_file)
             .is_some_and(|map| map.contains_key(child_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::component_import_target;
+    use crate::discover::FileId;
+    use crate::resolve::ResolveResult;
+
+    #[test]
+    fn component_import_target_preserves_commonjs_internal_edges() {
+        assert_eq!(
+            component_import_target(&ResolveResult::CommonJsInternalModule(FileId(7))),
+            Some(FileId(7))
+        );
+        assert_eq!(
+            component_import_target(&ResolveResult::CommonJsInternalPackageModule {
+                file_id: FileId(8),
+                package_name: "@repo/ui".to_string(),
+            }),
+            Some(FileId(8))
+        );
+        assert_eq!(
+            component_import_target(&ResolveResult::SyntheticAutoImport(FileId(9))),
+            None
+        );
     }
 }

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -1307,22 +1307,13 @@ fn workspace_dependency_map(
     ws_dep_map
 }
 
-fn import_spans_by_file<'a>(
-    resolved_modules: &'a [ResolvedModule],
-    workspaces: &'a [fallow_config::WorkspaceInfo],
-) -> FxHashMap<FileId, Vec<(&'a str, &'a str, u32)>> {
-    let workspace_names: FxHashSet<&str> = workspaces
-        .iter()
-        .map(|workspace| workspace.name.as_str())
-        .collect();
+fn import_spans_by_file(
+    resolved_modules: &[ResolvedModule],
+) -> FxHashMap<FileId, Vec<(&str, &str, u32)>> {
     let mut import_spans_by_file: FxHashMap<FileId, Vec<(&str, &str, u32)>> = FxHashMap::default();
     for rm in resolved_modules {
         for edge in rm.all_resolved_source_edges() {
-            if let Some(name) = crate::resolved_package_usage_name(
-                edge.target(),
-                edge.source_specifier(),
-                &workspace_names,
-            ) {
+            if let Some(name) = edge.target().package_usage_name() {
                 import_spans_by_file.entry(rm.file_id).or_default().push((
                     name,
                     edge.source_specifier(),
@@ -1435,7 +1426,7 @@ fn build_unlisted_dependency_context_parts<'a>(
     let ws_dep_map = workspace_dependency_map(input.workspaces, input.config);
 
     let plugin_parts = build_unlisted_dependency_plugin_parts(input.plugin_result);
-    let import_spans_by_file = import_spans_by_file(input.resolved_modules, input.workspaces);
+    let import_spans_by_file = import_spans_by_file(input.resolved_modules);
 
     let ignore_deps = input
         .config

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -1307,13 +1307,22 @@ fn workspace_dependency_map(
     ws_dep_map
 }
 
-fn import_spans_by_file(
-    resolved_modules: &[ResolvedModule],
-) -> FxHashMap<FileId, Vec<(&str, &str, u32)>> {
+fn import_spans_by_file<'a>(
+    resolved_modules: &'a [ResolvedModule],
+    workspaces: &'a [fallow_config::WorkspaceInfo],
+) -> FxHashMap<FileId, Vec<(&'a str, &'a str, u32)>> {
+    let workspace_names: FxHashSet<&str> = workspaces
+        .iter()
+        .map(|workspace| workspace.name.as_str())
+        .collect();
     let mut import_spans_by_file: FxHashMap<FileId, Vec<(&str, &str, u32)>> = FxHashMap::default();
     for rm in resolved_modules {
         for edge in rm.all_resolved_source_edges() {
-            if let Some(name) = edge.target().package_usage_name() {
+            if let Some(name) = crate::resolved_package_usage_name(
+                edge.target(),
+                edge.source_specifier(),
+                &workspace_names,
+            ) {
                 import_spans_by_file.entry(rm.file_id).or_default().push((
                     name,
                     edge.source_specifier(),
@@ -1426,7 +1435,7 @@ fn build_unlisted_dependency_context_parts<'a>(
     let ws_dep_map = workspace_dependency_map(input.workspaces, input.config);
 
     let plugin_parts = build_unlisted_dependency_plugin_parts(input.plugin_result);
-    let import_spans_by_file = import_spans_by_file(input.resolved_modules);
+    let import_spans_by_file = import_spans_by_file(input.resolved_modules, input.workspaces);
 
     let ignore_deps = input
         .config

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -227,6 +227,70 @@ fn undeclared_workspace_package_names_are_reported_as_unlisted() {
 }
 
 #[test]
+fn undeclared_workspace_commonjs_require_retains_import_site() {
+    let source_path = PathBuf::from("/project/src/index.js");
+    let workspace_source_path = PathBuf::from("/project/packages/utils/src/index.ts");
+    let files = vec![
+        DiscoveredFile {
+            id: FileId(0),
+            path: source_path.clone(),
+            size_bytes: 100,
+        },
+        DiscoveredFile {
+            id: FileId(1),
+            path: workspace_source_path,
+            size_bytes: 100,
+        },
+    ];
+    let entry_points = vec![EntryPoint {
+        path: source_path.clone(),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: source_path.clone(),
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "@myorg/utils".to_string(),
+                imported_name: ImportedName::Namespace,
+                local_name: "utils".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(42, 73),
+                source_span: oxc_span::Span::new(64, 76),
+            },
+            target: ResolveResult::CommonJsInternalModule(FileId(1)),
+        }],
+        ..ResolvedModule::default()
+    }];
+    let workspaces = vec![WorkspaceInfo {
+        root: PathBuf::from("/project/packages/utils"),
+        name: "@myorg/utils".to_string(),
+        is_internal_dependency: false,
+    }];
+    let mut graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    crate::credit_workspace_package_usage(&mut graph, &resolved_modules, &workspaces);
+
+    let line_offsets_storage = [0, 18, 36];
+    let line_offsets = FxHashMap::from_iter([(FileId(0), line_offsets_storage.as_slice())]);
+    let unlisted = find_unlisted_dependencies(
+        &graph,
+        &make_pkg(&[], &[], &[]),
+        &test_config(PathBuf::from("/project")),
+        &workspaces,
+        None,
+        &resolved_modules,
+        &line_offsets,
+    );
+
+    assert_eq!(unlisted.len(), 1);
+    assert_eq!(unlisted[0].package_name, "@myorg/utils");
+    assert_eq!(unlisted[0].imported_from.len(), 1);
+    assert_eq!(unlisted[0].imported_from[0].path, source_path);
+    assert_eq!(unlisted[0].imported_from[0].line, 3);
+}
+
+#[test]
 fn plugin_virtual_prefixes_not_reported_as_unlisted() {
     let pkg = make_pkg(&[], &[], &[]);
     let config = test_config(PathBuf::from("/project"));

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -259,7 +259,10 @@ fn undeclared_workspace_commonjs_require_retains_import_site() {
                 span: oxc_span::Span::new(42, 73),
                 source_span: oxc_span::Span::new(64, 76),
             },
-            target: ResolveResult::CommonJsInternalModule(FileId(1)),
+            target: ResolveResult::CommonJsInternalPackageModule {
+                file_id: FileId(1),
+                package_name: "@myorg/utils".to_string(),
+            },
         }],
         ..ResolvedModule::default()
     }];
@@ -268,8 +271,7 @@ fn undeclared_workspace_commonjs_require_retains_import_site() {
         name: "@myorg/utils".to_string(),
         is_internal_dependency: false,
     }];
-    let mut graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
-    crate::credit_workspace_package_usage(&mut graph, &resolved_modules, &workspaces);
+    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
 
     let line_offsets_storage = [0, 18, 36];
     let line_offsets = FxHashMap::from_iter([(FileId(0), line_offsets_storage.as_slice())]);

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -1495,6 +1495,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(from),
                 kind: crate::graph::ReferenceKind::NamedImport,
+                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
                 import_span: Span::new(0, 10),
             }],
             members: vec![],
@@ -3024,6 +3025,7 @@ mod tests {
                 references: vec![SymbolReference {
                     from_file: FileId(2),
                     kind: crate::graph::ReferenceKind::NamedImport,
+                    mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
                     import_span: Span::new(0, 10),
                 }],
                 members: vec![],
@@ -3071,6 +3073,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(0),
                 kind: crate::graph::ReferenceKind::NamedImport,
+                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
                 import_span: Span::new(0, 10),
             }],
             members: vec![],

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -1394,9 +1394,9 @@ fn export_reference_locations(
 mod tests {
     use super::*;
     use crate::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
-    use crate::extract::{ExportName, VisibilityTag};
-    use crate::graph::{ExportSymbol, ModuleGraph, ReExportEdge, SymbolReference};
-    use crate::resolve::ResolvedModule;
+    use crate::extract::{ExportInfo, ExportName, ImportInfo, ImportedName, VisibilityTag};
+    use crate::graph::{ExportSymbol, ModuleGraph, ReExportEdge};
+    use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
     use crate::suppress::Suppression;
     use oxc_span::Span;
     use std::path::PathBuf;
@@ -1479,27 +1479,70 @@ mod tests {
         }
     }
 
-    fn make_referenced_export(
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test file counts are trivially small"
+    )]
+    fn build_graph_with_referenced_export(
+        file_specs: &[(&str, bool)],
+        target: usize,
         name: &str,
         span_start: u32,
         span_end: u32,
         from: u32,
-    ) -> ExportSymbol {
-        ExportSymbol {
+    ) -> ModuleGraph {
+        let files: Vec<DiscoveredFile> = file_specs
+            .iter()
+            .enumerate()
+            .map(|(index, (path, _))| DiscoveredFile {
+                id: FileId(index as u32),
+                path: PathBuf::from(path),
+                size_bytes: 0,
+            })
+            .collect();
+        let entry_points: Vec<EntryPoint> = file_specs
+            .iter()
+            .filter(|(_, is_entry)| *is_entry)
+            .map(|(path, _)| EntryPoint {
+                path: PathBuf::from(path),
+                source: EntryPointSource::ManualEntry,
+            })
+            .collect();
+        let mut resolved_modules: Vec<ResolvedModule> = files
+            .iter()
+            .map(|file| ResolvedModule {
+                file_id: file.id,
+                path: file.path.clone(),
+                ..Default::default()
+            })
+            .collect();
+        resolved_modules[target].exports.push(ExportInfo {
             name: ExportName::Named(name.to_string()),
+            local_name: None,
             is_type_only: false,
             is_side_effect_used: false,
             visibility: VisibilityTag::None,
             expected_unused_reason: None,
             span: Span::new(span_start, span_end),
-            references: vec![SymbolReference {
-                from_file: FileId(from),
-                kind: crate::graph::ReferenceKind::NamedImport,
-                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
-                import_span: Span::new(0, 10),
-            }],
             members: vec![],
-        }
+            super_class: None,
+        });
+        resolved_modules[from as usize]
+            .resolved_imports
+            .push(ResolvedImport {
+                info: ImportInfo {
+                    source: format!("./fixture-{target}"),
+                    imported_name: ImportedName::Named(name.to_string()),
+                    local_name: name.to_string(),
+                    is_type_only: false,
+                    from_style: false,
+                    span: Span::new(0, 10),
+                    source_span: Span::default(),
+                },
+                target: ResolveResult::InternalModule(FileId(target as u32)),
+            });
+
+        ModuleGraph::build(&resolved_modules, &entry_points, &files)
     }
 
     #[test]
@@ -2389,12 +2432,17 @@ mod tests {
 
     #[test]
     fn unused_exports_skips_referenced_export() {
-        let mut graph = build_graph(&[
-            ("/tmp/test/src/entry.ts", true),
-            ("/tmp/test/src/utils.ts", false),
-        ]);
-        graph.modules[1].set_reachable(true);
-        graph.modules[1].exports = vec![make_referenced_export("helper", 10, 20, 0)];
+        let graph = build_graph_with_referenced_export(
+            &[
+                ("/tmp/test/src/entry.ts", true),
+                ("/tmp/test/src/utils.ts", false),
+            ],
+            1,
+            "helper",
+            10,
+            20,
+            0,
+        );
         let config = test_config();
         let suppressions = SuppressionContext::empty();
         let (exports, types, _stale) = find_unused_exports(
@@ -2977,8 +3025,14 @@ mod tests {
 
     #[test]
     fn collect_usages_counts_references() {
-        let mut graph = build_graph(&[("/src/utils.ts", true), ("/src/app.ts", false)]);
-        graph.modules[0].exports = vec![make_referenced_export("helper", 10, 20, 1)];
+        let graph = build_graph_with_referenced_export(
+            &[("/src/utils.ts", true), ("/src/app.ts", false)],
+            0,
+            "helper",
+            10,
+            20,
+            1,
+        );
         let result = collect_export_usages(&graph, &FxHashMap::default());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].export_name, "helper");
@@ -3009,30 +3063,21 @@ mod tests {
 
     #[test]
     fn unused_exports_checks_unreachable_module_with_mixed_references() {
-        let mut graph = build_graph(&[
-            ("/tmp/test/src/entry.ts", true),
-            ("/tmp/test/src/helpers.ts", false),
-            ("/tmp/test/src/setup.ts", false),
-        ]);
-        graph.modules[1].exports = vec![
-            ExportSymbol {
-                name: ExportName::Named("usedByUnreachable".to_string()),
-                is_type_only: false,
-                is_side_effect_used: false,
-                visibility: VisibilityTag::None,
-                expected_unused_reason: None,
-                span: Span::new(10, 30),
-                references: vec![SymbolReference {
-                    from_file: FileId(2),
-                    kind: crate::graph::ReferenceKind::NamedImport,
-                    mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
-                    import_span: Span::new(0, 10),
-                }],
-                members: vec![],
-            },
-            make_export("totallyUnused", 40, 55),
-        ];
-        graph.modules[2].exports = vec![];
+        let mut graph = build_graph_with_referenced_export(
+            &[
+                ("/tmp/test/src/entry.ts", true),
+                ("/tmp/test/src/helpers.ts", false),
+                ("/tmp/test/src/setup.ts", false),
+            ],
+            1,
+            "usedByUnreachable",
+            10,
+            30,
+            2,
+        );
+        graph.modules[1]
+            .exports
+            .push(make_export("totallyUnused", 40, 55));
 
         let config = test_config();
         let suppressions = SuppressionContext::empty();
@@ -3059,25 +3104,17 @@ mod tests {
 
     #[test]
     fn unused_exports_skips_export_referenced_by_reachable() {
-        let mut graph = build_graph(&[
-            ("/tmp/test/src/entry.ts", true),
-            ("/tmp/test/src/helpers.ts", false),
-        ]);
-        graph.modules[1].exports = vec![ExportSymbol {
-            name: ExportName::Named("usedByReachable".to_string()),
-            is_type_only: false,
-            is_side_effect_used: false,
-            visibility: VisibilityTag::None,
-            expected_unused_reason: None,
-            span: Span::new(10, 28),
-            references: vec![SymbolReference {
-                from_file: FileId(0),
-                kind: crate::graph::ReferenceKind::NamedImport,
-                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
-                import_span: Span::new(0, 10),
-            }],
-            members: vec![],
-        }];
+        let graph = build_graph_with_referenced_export(
+            &[
+                ("/tmp/test/src/entry.ts", true),
+                ("/tmp/test/src/helpers.ts", false),
+            ],
+            1,
+            "usedByReachable",
+            10,
+            28,
+            0,
+        );
 
         let config = test_config();
         let suppressions = SuppressionContext::empty();

--- a/crates/core/src/analyze/unused_files.rs
+++ b/crates/core/src/analyze/unused_files.rs
@@ -183,6 +183,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(2),
                 kind: ReferenceKind::NamedImport,
+                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
                 import_span: Span::new(0, 10),
             }],
             members: vec![],
@@ -208,6 +209,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(0),
                 kind: ReferenceKind::NamedImport,
+                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
                 import_span: Span::new(0, 10),
             }],
             members: vec![],

--- a/crates/core/src/analyze/unused_files.rs
+++ b/crates/core/src/analyze/unused_files.rs
@@ -83,9 +83,9 @@ fn has_reachable_export_reference(file_id: FileId, graph: &ModuleGraph) -> bool 
 mod tests {
     use super::*;
     use crate::discover::{DiscoveredFile, EntryPoint, EntryPointSource};
-    use crate::extract::{ExportName, VisibilityTag};
-    use crate::graph::{ExportSymbol, ModuleGraph, ReferenceKind, SymbolReference};
-    use crate::resolve::ResolvedModule;
+    use crate::extract::{ExportInfo, ExportName, ImportInfo, ImportedName, VisibilityTag};
+    use crate::graph::ModuleGraph;
+    use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
     use crate::suppress::Suppression;
     use oxc_span::Span;
     use rustc_hash::{FxHashMap, FxHashSet};
@@ -143,6 +143,65 @@ mod tests {
         ModuleGraph::build(&resolved_modules, &entry_points, &files)
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test file counts are trivially small"
+    )]
+    fn build_graph_with_reference(file_specs: &[(&str, bool)], from: u32) -> ModuleGraph {
+        let files: Vec<DiscoveredFile> = file_specs
+            .iter()
+            .enumerate()
+            .map(|(index, (path, _))| DiscoveredFile {
+                id: FileId(index as u32),
+                path: PathBuf::from(path),
+                size_bytes: 0,
+            })
+            .collect();
+        let entry_points: Vec<EntryPoint> = file_specs
+            .iter()
+            .filter(|(_, is_entry)| *is_entry)
+            .map(|(path, _)| EntryPoint {
+                path: PathBuf::from(path),
+                source: EntryPointSource::ManualEntry,
+            })
+            .collect();
+        let mut resolved_modules: Vec<ResolvedModule> = files
+            .iter()
+            .map(|file| ResolvedModule {
+                file_id: file.id,
+                path: file.path.clone(),
+                ..Default::default()
+            })
+            .collect();
+        resolved_modules[1].exports.push(ExportInfo {
+            name: ExportName::Named("helper".to_string()),
+            local_name: None,
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: Span::new(0, 10),
+            members: vec![],
+            super_class: None,
+        });
+        resolved_modules[from as usize]
+            .resolved_imports
+            .push(ResolvedImport {
+                info: ImportInfo {
+                    source: "./helper".to_string(),
+                    imported_name: ImportedName::Named("helper".to_string()),
+                    local_name: "helper".to_string(),
+                    is_type_only: false,
+                    from_style: false,
+                    span: Span::new(0, 10),
+                    source_span: Span::default(),
+                },
+                target: ResolveResult::InternalModule(FileId(1)),
+            });
+
+        ModuleGraph::build(&resolved_modules, &entry_points, &files)
+    }
+
     #[test]
     fn has_reachable_importer_out_of_bounds_file_id() {
         let graph = build_graph(&[("/src/entry.ts", true)]);
@@ -167,27 +226,14 @@ mod tests {
 
     #[test]
     fn has_reachable_export_reference_ignores_unreachable_references() {
-        let mut graph = build_graph(&[
-            ("/src/entry.ts", true),
-            ("/src/helper.ts", false),
-            ("/src/setup.ts", false),
-        ]);
-
-        graph.modules[1].exports = vec![ExportSymbol {
-            name: ExportName::Named("helper".to_string()),
-            is_type_only: false,
-            is_side_effect_used: false,
-            visibility: VisibilityTag::None,
-            expected_unused_reason: None,
-            span: Span::new(0, 10),
-            references: vec![SymbolReference {
-                from_file: FileId(2),
-                kind: ReferenceKind::NamedImport,
-                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
-                import_span: Span::new(0, 10),
-            }],
-            members: vec![],
-        }];
+        let graph = build_graph_with_reference(
+            &[
+                ("/src/entry.ts", true),
+                ("/src/helper.ts", false),
+                ("/src/setup.ts", false),
+            ],
+            2,
+        );
 
         assert!(
             !has_reachable_export_reference(FileId(1), &graph),
@@ -197,23 +243,8 @@ mod tests {
 
     #[test]
     fn has_reachable_export_reference_detects_reachable_references() {
-        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/helper.ts", false)]);
-
-        graph.modules[1].exports = vec![ExportSymbol {
-            name: ExportName::Named("helper".to_string()),
-            is_type_only: false,
-            is_side_effect_used: false,
-            visibility: VisibilityTag::None,
-            expected_unused_reason: None,
-            span: Span::new(0, 10),
-            references: vec![SymbolReference {
-                from_file: FileId(0),
-                kind: ReferenceKind::NamedImport,
-                mechanism: fallow_types::extract::ModuleLoadMechanism::EsModule,
-                import_span: Span::new(0, 10),
-            }],
-            members: vec![],
-        }];
+        let graph =
+            build_graph_with_reference(&[("/src/entry.ts", true), ("/src/helper.ts", false)], 0);
 
         assert!(
             has_reachable_export_reference(FileId(1), &graph),

--- a/crates/core/src/external_style_usage.rs
+++ b/crates/core/src/external_style_usage.rs
@@ -274,7 +274,7 @@ impl<'a> ExternalStylePackageScanner<'a> {
             &self.session,
         );
 
-        let Some(resolved_module) = resolved.first() else {
+        let Some(resolved_module) = resolved.modules.first() else {
             return;
         };
         for import in resolved_module.all_resolved_imports() {

--- a/crates/core/src/external_style_usage.rs
+++ b/crates/core/src/external_style_usage.rs
@@ -28,7 +28,9 @@ pub fn augment_external_style_package_usage(
         let existing_packages: FxHashSet<String> = module
             .all_resolved_imports()
             .filter_map(|import| match &import.target {
-                ResolveResult::NpmPackage(name) => Some(name.clone()),
+                ResolveResult::NpmPackage(name) | ResolveResult::CommonJsNpmPackage(name) => {
+                    Some(name.clone())
+                }
                 _ => None,
             })
             .collect();
@@ -291,7 +293,7 @@ impl<'a> ExternalStylePackageScanner<'a> {
         packages: &mut FxHashSet<String>,
     ) {
         match &import.target {
-            ResolveResult::NpmPackage(name) => {
+            ResolveResult::NpmPackage(name) | ResolveResult::CommonJsNpmPackage(name) => {
                 packages.insert(name.clone());
             }
             ResolveResult::ExternalFile(child) => {

--- a/crates/core/src/external_style_usage.rs
+++ b/crates/core/src/external_style_usage.rs
@@ -307,8 +307,10 @@ impl<'a> ExternalStylePackageScanner<'a> {
                 }
             }
             ResolveResult::InternalModule(_)
+            | ResolveResult::CommonJsInternalModule(_)
             | ResolveResult::SyntheticAutoImport(_)
-            | ResolveResult::InternalPackageModule { .. } => {}
+            | ResolveResult::InternalPackageModule { .. }
+            | ResolveResult::CommonJsInternalPackageModule { .. } => {}
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -80,13 +80,29 @@ fn record_graph_package_usage(
 
 fn workspace_package_name<'a>(
     source: &str,
-    workspace_names: &'a FxHashSet<&str>,
+    workspace_names: &FxHashSet<&'a str>,
 ) -> Option<&'a str> {
     if !resolve::is_bare_specifier(source) {
         return None;
     }
     let package_name = resolve::extract_package_name(source);
     workspace_names.get(package_name.as_str()).copied()
+}
+
+pub(crate) fn resolved_package_usage_name<'a>(
+    target: &'a resolve::ResolveResult,
+    source: &str,
+    workspace_names: &FxHashSet<&'a str>,
+) -> Option<&'a str> {
+    target.package_usage_name().or_else(|| {
+        matches!(
+            target,
+            resolve::ResolveResult::InternalModule(_)
+                | resolve::ResolveResult::CommonJsInternalModule(_)
+        )
+        .then(|| workspace_package_name(source, workspace_names))
+        .flatten()
+    })
 }
 
 fn credit_workspace_package_usage(
@@ -100,30 +116,19 @@ fn credit_workspace_package_usage(
 
     let workspace_names: FxHashSet<&str> = workspaces.iter().map(|ws| ws.name.as_str()).collect();
     for module in resolved {
-        for import in module.all_resolved_imports() {
-            if matches!(import.target, resolve::ResolveResult::InternalModule(_))
-                && let Some(package_name) =
-                    workspace_package_name(&import.info.source, &workspace_names)
+        for edge in module.all_resolved_source_edges() {
+            if edge.target().package_usage_name().is_none()
+                && let Some(package_name) = resolved_package_usage_name(
+                    edge.target(),
+                    edge.source_specifier(),
+                    &workspace_names,
+                )
             {
                 record_graph_package_usage(
                     graph,
                     package_name,
                     module.file_id,
-                    import.info.is_type_only,
-                );
-            }
-        }
-
-        for re_export in &module.re_exports {
-            if matches!(re_export.target, resolve::ResolveResult::InternalModule(_))
-                && let Some(package_name) =
-                    workspace_package_name(&re_export.info.source, &workspace_names)
-            {
-                record_graph_package_usage(
-                    graph,
-                    package_name,
-                    module.file_id,
-                    re_export.info.is_type_only,
+                    edge.is_type_only(),
                 );
             }
         }
@@ -2572,9 +2577,9 @@ fn num_cpus() -> usize {
 mod tests {
     use super::{
         AnalysisSession, bucket_files_by_workspace, bucket_files_by_workspace_roots,
-        collect_config_search_roots, default_config, format_undeclared_workspace_warning,
-        parse_analysis_modules, plugin_config_hash, resolver_options_hash,
-        warn_undeclared_workspaces,
+        collect_config_search_roots, credit_workspace_package_usage, default_config,
+        format_undeclared_workspace_warning, parse_analysis_modules, plugin_config_hash,
+        resolver_options_hash, warn_undeclared_workspaces,
     };
     use std::path::{Path, PathBuf};
     use std::time::Instant;
@@ -2583,6 +2588,7 @@ mod tests {
         AutoImportKind, AutoImportRule, WorkspaceDiagnostic, WorkspaceDiagnosticKind,
     };
     use fallow_types::discover::{DiscoveredFile, FileId};
+    use fallow_types::extract::{ImportInfo, ImportedName};
 
     fn plugin_result() -> crate::plugins::AggregatedPluginResult {
         let mut result = crate::plugins::AggregatedPluginResult::default();
@@ -2591,6 +2597,39 @@ mod tests {
             .path_aliases
             .push(("@/".to_string(), "src/".to_string()));
         result
+    }
+
+    #[test]
+    fn commonjs_internal_import_credits_workspace_package_usage() {
+        let workspace = fallow_config::WorkspaceInfo {
+            root: PathBuf::from("/repo/packages/shared"),
+            name: "@repo/shared".to_string(),
+            is_internal_dependency: true,
+        };
+        let resolved = vec![crate::resolve::ResolvedModule {
+            file_id: FileId(0),
+            resolved_imports: vec![crate::resolve::ResolvedImport {
+                info: ImportInfo {
+                    source: "@repo/shared".to_string(),
+                    imported_name: ImportedName::Namespace,
+                    local_name: "shared".to_string(),
+                    is_type_only: false,
+                    from_style: false,
+                    span: oxc_span::Span::new(0, 20),
+                    source_span: oxc_span::Span::new(8, 20),
+                },
+                target: crate::resolve::ResolveResult::CommonJsInternalModule(FileId(1)),
+            }],
+            ..crate::resolve::ResolvedModule::default()
+        }];
+        let mut graph = crate::graph::ModuleGraph::build(&[], &[], &[]);
+
+        credit_workspace_package_usage(&mut graph, &resolved, &[workspace]);
+
+        assert_eq!(
+            graph.package_usage.get("@repo/shared"),
+            Some(&vec![FileId(0)])
+        );
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -89,22 +89,6 @@ fn workspace_package_name<'a>(
     workspace_names.get(package_name.as_str()).copied()
 }
 
-pub(crate) fn resolved_package_usage_name<'a>(
-    target: &'a resolve::ResolveResult,
-    source: &str,
-    workspace_names: &FxHashSet<&'a str>,
-) -> Option<&'a str> {
-    target.package_usage_name().or_else(|| {
-        matches!(
-            target,
-            resolve::ResolveResult::InternalModule(_)
-                | resolve::ResolveResult::CommonJsInternalModule(_)
-        )
-        .then(|| workspace_package_name(source, workspace_names))
-        .flatten()
-    })
-}
-
 fn credit_workspace_package_usage(
     graph: &mut graph::ModuleGraph,
     resolved: &[resolve::ResolvedModule],
@@ -116,19 +100,34 @@ fn credit_workspace_package_usage(
 
     let workspace_names: FxHashSet<&str> = workspaces.iter().map(|ws| ws.name.as_str()).collect();
     for module in resolved {
-        for edge in module.all_resolved_source_edges() {
-            if edge.target().package_usage_name().is_none()
-                && let Some(package_name) = resolved_package_usage_name(
-                    edge.target(),
-                    edge.source_specifier(),
-                    &workspace_names,
-                )
+        for import in module.all_resolved_imports() {
+            if matches!(
+                import.target,
+                resolve::ResolveResult::InternalModule(_)
+                    | resolve::ResolveResult::CommonJsInternalModule(_)
+            )
+                && let Some(package_name) =
+                    workspace_package_name(&import.info.source, &workspace_names)
             {
                 record_graph_package_usage(
                     graph,
                     package_name,
                     module.file_id,
-                    edge.is_type_only(),
+                    import.info.is_type_only,
+                );
+            }
+        }
+
+        for re_export in &module.re_exports {
+            if matches!(re_export.target, resolve::ResolveResult::InternalModule(_))
+                && let Some(package_name) =
+                    workspace_package_name(&re_export.info.source, &workspace_names)
+            {
+                record_graph_package_usage(
+                    graph,
+                    package_name,
+                    module.file_id,
+                    re_export.info.is_type_only,
                 );
             }
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1513,8 +1513,9 @@ fn build_analysis_graph(input: &BuildAnalysisGraphInput<'_>) -> graph::ModuleGra
         )
     });
 
-    let mut graph = graph::ModuleGraph::build_with_reachability_roots(
+    let mut graph = graph::ModuleGraph::build_with_reachability_roots_and_replacements(
         &input.project.modules,
+        &input.project.replaced_module_targets,
         &input.entry_points.all,
         &input.entry_points.runtime,
         &input.entry_points.test,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -105,9 +105,8 @@ fn credit_workspace_package_usage(
                 import.target,
                 resolve::ResolveResult::InternalModule(_)
                     | resolve::ResolveResult::CommonJsInternalModule(_)
-            )
-                && let Some(package_name) =
-                    workspace_package_name(&import.info.source, &workspace_names)
+            ) && let Some(package_name) =
+                workspace_package_name(&import.info.source, &workspace_names)
             {
                 record_graph_package_usage(
                     graph,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -600,30 +600,29 @@ impl<'a> AnalysisSession<'a> {
         };
 
         let entry_points = discover_analysis_entry_points(&shared);
-        let (resolved, graph) = if let Some(hit) =
-            try_load_analysis_graph_cache(&shared, &entry_points, &modules)
-        {
-            (
-                TimedResolvedModules {
-                    resolved: hit.resolved,
-                    elapsed_ms: 0.0,
-                },
-                TimedGraph {
-                    graph: hit.graph,
-                    elapsed_ms: hit.elapsed_ms,
-                },
-            )
-        } else {
-            let resolved = resolve_analysis_imports_timed(&shared, &modules);
-            let graph =
-                build_analysis_graph_timed(&shared, &resolved.resolved, &entry_points, &modules);
-            (resolved, graph)
-        };
+        let (resolved, graph) =
+            if let Some(hit) = try_load_analysis_graph_cache(&shared, &entry_points, &modules) {
+                (
+                    TimedResolvedModules {
+                        project: hit.project,
+                        elapsed_ms: 0.0,
+                    },
+                    TimedGraph {
+                        graph: hit.graph,
+                        elapsed_ms: hit.elapsed_ms,
+                    },
+                )
+            } else {
+                let resolved = resolve_analysis_imports_timed(&shared, &modules);
+                let graph =
+                    build_analysis_graph_timed(&shared, &resolved.project, &entry_points, &modules);
+                (resolved, graph)
+            };
         release_resolution_payloads(&mut modules);
         let analysis = analyze_dead_code_timed(
             &shared,
             &graph.graph,
-            &resolved.resolved,
+            &resolved.project.modules,
             &modules,
             collect_usages,
             entry_points.summary,
@@ -820,7 +819,7 @@ impl DeadCodeEntryPoints {
 /// Import-resolution result for an engine-owned dead-code pipeline.
 #[doc(hidden)]
 pub struct DeadCodeResolvedModules {
-    pub resolved: Vec<resolve::ResolvedModule>,
+    pub project: resolve::ResolvedProject,
     pub elapsed_ms: f64,
 }
 
@@ -894,7 +893,7 @@ pub fn try_load_dead_code_graph_cache(
     try_load_analysis_graph_cache(&shared, &entry_points.inner, modules).map(|hit| {
         (
             DeadCodeResolvedModules {
-                resolved: hit.resolved,
+                project: hit.project,
                 elapsed_ms: 0.0,
             },
             DeadCodeGraphRun {
@@ -914,7 +913,7 @@ pub fn resolve_dead_code_imports(
     let shared = prelude.shared_input();
     let resolved = resolve_analysis_imports_timed(&shared, modules);
     DeadCodeResolvedModules {
-        resolved: resolved.resolved,
+        project: resolved.project,
         elapsed_ms: resolved.elapsed_ms,
     }
 }
@@ -923,12 +922,12 @@ pub fn resolve_dead_code_imports(
 #[must_use]
 pub fn build_dead_code_graph(
     prelude: &DeadCodeBackendPrelude<'_>,
-    resolved: &[resolve::ResolvedModule],
+    project: &resolve::ResolvedProject,
     entry_points: &DeadCodeEntryPoints,
     modules: &[extract::ModuleInfo],
 ) -> DeadCodeGraphRun {
     let shared = prelude.shared_input();
-    let graph = build_analysis_graph_timed(&shared, resolved, &entry_points.inner, modules);
+    let graph = build_analysis_graph_timed(&shared, project, &entry_points.inner, modules);
     DeadCodeGraphRun {
         graph: graph.graph,
         elapsed_ms: graph.elapsed_ms,
@@ -1038,7 +1037,7 @@ struct TimedEntryPoints {
 }
 
 struct TimedResolvedModules {
-    resolved: Vec<resolve::ResolvedModule>,
+    project: resolve::ResolvedProject,
     elapsed_ms: f64,
 }
 
@@ -1049,7 +1048,7 @@ struct TimedGraph {
 
 struct GraphCacheHit {
     graph: graph::ModuleGraph,
-    resolved: Vec<resolve::ResolvedModule>,
+    project: resolve::ResolvedProject,
     elapsed_ms: f64,
 }
 
@@ -1109,17 +1108,17 @@ fn try_load_analysis_graph_cache(
     );
     let store = graph_cache::GraphCacheStore::load(&input.config.cache_dir)?;
     if store.manifest.matches_inputs(&current) {
-        let resolved = graph_cache::restore_resolved_modules(
+        let project = graph_cache::restore_resolved_project(
             &input.config.root,
             modules,
             input.files,
-            &store.resolved_modules,
+            &store.resolved_project,
         )?;
         tracing::debug!("Graph cache hit: skipping import resolution and graph build");
 
         return Some(GraphCacheHit {
             graph: store.graph,
-            resolved,
+            project,
             elapsed_ms: t.elapsed().as_secs_f64() * 1000.0,
         });
     }
@@ -1128,18 +1127,18 @@ fn try_load_analysis_graph_cache(
         return None;
     }
 
-    let resolved = graph_cache::restore_resolved_modules(
+    let project = graph_cache::restore_resolved_project(
         &input.config.root,
         modules,
         input.files,
-        &store.resolved_modules,
+        &store.resolved_project,
     )?;
     tracing::debug!("Graph resolver cache hit: skipping import resolution and rebuilding graph");
-    let graph = build_analysis_graph_timed(input, &resolved, entry_points, modules);
+    let graph = build_analysis_graph_timed(input, &project, entry_points, modules);
 
     Some(GraphCacheHit {
         graph: graph.graph,
-        resolved,
+        project,
         elapsed_ms: t.elapsed().as_secs_f64() * 1000.0,
     })
 }
@@ -1150,7 +1149,7 @@ fn resolve_analysis_imports_timed(
 ) -> TimedResolvedModules {
     let t = Instant::now();
     input.progress.set_stage("resolving imports...");
-    let resolved = resolve_analysis_imports(
+    let project = resolve_analysis_imports(
         modules,
         input.files,
         input.workspaces,
@@ -1158,14 +1157,14 @@ fn resolve_analysis_imports_timed(
         input.config,
     );
     TimedResolvedModules {
-        resolved,
+        project,
         elapsed_ms: t.elapsed().as_secs_f64() * 1000.0,
     }
 }
 
 fn build_analysis_graph_timed(
     input: &AnalysisCoreSharedInput<'_>,
-    resolved: &[resolve::ResolvedModule],
+    project: &resolve::ResolvedProject,
     entry_points: &TimedEntryPoints,
     modules: &[extract::ModuleInfo],
 ) -> TimedGraph {
@@ -1174,7 +1173,7 @@ fn build_analysis_graph_timed(
     let graph = build_analysis_graph(&BuildAnalysisGraphInput {
         config: input.config,
         plugin_result: input.plugin_result,
-        resolved,
+        project,
         entry_points: &entry_points.entry_points,
         files: input.files,
         modules,
@@ -1464,8 +1463,8 @@ fn resolve_analysis_imports(
     workspaces: &[fallow_config::WorkspaceInfo],
     plugin_result: &plugins::AggregatedPluginResult,
     config: &ResolvedConfig,
-) -> Vec<resolve::ResolvedModule> {
-    let mut resolved = resolve::resolve_all_imports(&resolve::ResolveAllImportsInput {
+) -> resolve::ResolvedProject {
+    let mut project = resolve::resolve_all_imports(&resolve::ResolveAllImportsInput {
         modules,
         files,
         workspaces,
@@ -1478,18 +1477,18 @@ fn resolve_analysis_imports(
         extra_conditions: &config.resolve.conditions,
     });
     external_style_usage::augment_external_style_package_usage(
-        &mut resolved,
+        &mut project.modules,
         config,
         workspaces,
         plugin_result,
     );
-    resolved
+    project
 }
 
 struct BuildAnalysisGraphInput<'a> {
     config: &'a ResolvedConfig,
     plugin_result: &'a plugins::AggregatedPluginResult,
-    resolved: &'a [resolve::ResolvedModule],
+    project: &'a resolve::ResolvedProject,
     entry_points: &'a discover::CategorizedEntryPoints,
     files: &'a [discover::DiscoveredFile],
     modules: &'a [extract::ModuleInfo],
@@ -1515,18 +1514,18 @@ fn build_analysis_graph(input: &BuildAnalysisGraphInput<'_>) -> graph::ModuleGra
     });
 
     let mut graph = graph::ModuleGraph::build_with_reachability_roots(
-        input.resolved,
+        &input.project.modules,
         &input.entry_points.all,
         &input.entry_points.runtime,
         &input.entry_points.test,
         input.files,
     );
     credit_package_path_references(&mut graph, input.modules);
-    credit_workspace_package_usage(&mut graph, input.resolved, input.workspaces);
+    credit_workspace_package_usage(&mut graph, &input.project.modules, input.workspaces);
 
     if let Some(manifest) = current_manifest {
-        let Some(resolved_modules) =
-            graph_cache::cache_resolved_modules(&input.config.root, input.files, input.resolved)
+        let Some(resolved_project) =
+            graph_cache::cache_resolved_project(&input.config.root, input.files, input.project)
         else {
             return graph;
         };
@@ -1534,7 +1533,7 @@ fn build_analysis_graph(input: &BuildAnalysisGraphInput<'_>) -> graph::ModuleGra
             version: graph_cache::GRAPH_CACHE_VERSION,
             manifest,
             graph,
-            resolved_modules,
+            resolved_project,
         };
         store.save(&input.config.cache_dir);
         // `save` borrows the store, so the freshly built graph is moved back out

--- a/crates/engine/src/core_backend.rs
+++ b/crates/engine/src/core_backend.rs
@@ -66,7 +66,7 @@ impl DeadCodeEntryPoints {
 }
 
 pub struct DeadCodeResolvedModules {
-    pub resolved: Vec<fallow_graph::resolve::ResolvedModule>,
+    pub project: fallow_graph::resolve::ResolvedProject,
     pub elapsed_ms: f64,
 }
 
@@ -138,7 +138,7 @@ pub fn try_load_dead_code_graph_cache(
         |(resolved, graph)| {
             (
                 DeadCodeResolvedModules {
-                    resolved: resolved.resolved,
+                    project: resolved.project,
                     elapsed_ms: resolved.elapsed_ms,
                 },
                 DeadCodeGraphRun {
@@ -156,19 +156,19 @@ pub fn resolve_dead_code_imports(
 ) -> DeadCodeResolvedModules {
     let resolved = fallow_core::resolve_dead_code_imports(&prelude.inner, modules);
     DeadCodeResolvedModules {
-        resolved: resolved.resolved,
+        project: resolved.project,
         elapsed_ms: resolved.elapsed_ms,
     }
 }
 
 pub fn build_dead_code_graph(
     prelude: &DeadCodeBackendPrelude<'_>,
-    resolved: &[fallow_graph::resolve::ResolvedModule],
+    project: &fallow_graph::resolve::ResolvedProject,
     entry_points: &DeadCodeEntryPoints,
     modules: &[ModuleInfo],
 ) -> DeadCodeGraphRun {
     let graph =
-        fallow_core::build_dead_code_graph(&prelude.inner, resolved, &entry_points.inner, modules);
+        fallow_core::build_dead_code_graph(&prelude.inner, project, &entry_points.inner, modules);
     DeadCodeGraphRun {
         graph: RetainedModuleGraph::from(graph.graph),
         elapsed_ms: graph.elapsed_ms,

--- a/crates/engine/src/health/coverage_gaps.rs
+++ b/crates/engine/src/health/coverage_gaps.rs
@@ -68,7 +68,7 @@ fn collect_untested_exports(
         let has_test_dependency = export
             .references
             .iter()
-            .any(|reference| test_coverage.covers_reference(node.file_id, reference));
+            .any(|reference| test_coverage.covers_reference(reference));
         if has_test_dependency {
             continue;
         }

--- a/crates/engine/src/health/coverage_gaps.rs
+++ b/crates/engine/src/health/coverage_gaps.rs
@@ -2,6 +2,8 @@ use crate::{discover::FileId, source::ModuleInfo, suppress};
 use fallow_graph::graph::{ModuleGraph, ModuleNode};
 use fallow_output::{CoverageGapSummary, CoverageGaps, UntestedExport, UntestedFile};
 
+use crate::module_graph::StaticTestCoverage;
+
 pub struct CoverageGapData {
     pub report: CoverageGaps,
     pub runtime_paths: Vec<std::path::PathBuf>,
@@ -49,7 +51,7 @@ fn module_is_coverage_suppressed(module: Option<&ModuleInfo>) -> bool {
 /// reference and not already flagged unused) to `exports`.
 fn collect_untested_exports(
     exports: &mut Vec<UntestedExport>,
-    graph: &ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     node: &ModuleNode,
     module: &ModuleInfo,
     path: &std::path::Path,
@@ -63,12 +65,10 @@ fn collect_untested_exports(
             continue;
         }
 
-        let has_test_dependency = export.references.iter().any(|reference| {
-            graph
-                .modules
-                .get(reference.from_file.0 as usize)
-                .is_some_and(|module| module.is_test_reachable())
-        });
+        let has_test_dependency = export
+            .references
+            .iter()
+            .any(|reference| test_coverage.covers_reference(node.file_id, reference.from_file));
         if has_test_dependency {
             continue;
         }
@@ -96,6 +96,7 @@ struct CoverageGapScan {
 /// Walk runtime-reachable modules, collecting untested files and exports.
 fn scan_runtime_files(
     graph: &ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     file_paths: &rustc_hash::FxHashMap<FileId, &std::path::PathBuf>,
     module_by_id: &rustc_hash::FxHashMap<FileId, &ModuleInfo>,
     unused_exports: &rustc_hash::FxHashSet<(&std::path::Path, String)>,
@@ -129,7 +130,7 @@ fn scan_runtime_files(
         scan.runtime_paths.push((*path).clone());
 
         scan.runtime_files += 1;
-        if node.is_test_reachable() {
+        if test_coverage.covers_file(node.file_id) {
             scan.covered_files += 1;
         } else {
             scan.files.push(UntestedFile {
@@ -142,7 +143,14 @@ fn scan_runtime_files(
             continue;
         };
 
-        collect_untested_exports(&mut scan.exports, graph, node, module, path, unused_exports);
+        collect_untested_exports(
+            &mut scan.exports,
+            test_coverage,
+            node,
+            module,
+            path,
+            unused_exports,
+        );
     }
 
     scan
@@ -194,11 +202,18 @@ fn build_coverage_gap_data(scan: CoverageGapScan, root: &std::path::Path) -> Cov
 
 pub(super) fn compute_coverage_gaps(
     graph: &ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     file_paths: &rustc_hash::FxHashMap<FileId, &std::path::PathBuf>,
     module_by_id: &rustc_hash::FxHashMap<FileId, &ModuleInfo>,
     unused_exports: &rustc_hash::FxHashSet<(&std::path::Path, String)>,
     root: &std::path::Path,
 ) -> CoverageGapData {
-    let scan = scan_runtime_files(graph, file_paths, module_by_id, unused_exports);
+    let scan = scan_runtime_files(
+        graph,
+        test_coverage,
+        file_paths,
+        module_by_id,
+        unused_exports,
+    );
     build_coverage_gap_data(scan, root)
 }

--- a/crates/engine/src/health/coverage_gaps.rs
+++ b/crates/engine/src/health/coverage_gaps.rs
@@ -68,7 +68,7 @@ fn collect_untested_exports(
         let has_test_dependency = export
             .references
             .iter()
-            .any(|reference| test_coverage.covers_reference(node.file_id, reference.from_file));
+            .any(|reference| test_coverage.covers_reference(node.file_id, reference));
         if has_test_dependency {
             continue;
         }

--- a/crates/engine/src/health/css_analytics/token_consumers.rs
+++ b/crates/engine/src/health/css_analytics/token_consumers.rs
@@ -359,7 +359,7 @@ fn resolve_css_in_js_import_targets(
         extra_conditions: &config.resolve.conditions,
     };
     let mut targets = ResolvedCssInJsImportTargets::default();
-    for resolved in fallow_graph::resolve::resolve_all_imports(&input) {
+    for resolved in fallow_graph::resolve::resolve_all_imports(&input).modules {
         for import in resolved.resolved_imports {
             let Some(file_id) = import.target.internal_file_id() else {
                 continue;

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -678,7 +678,7 @@ fn build_test_referenced_exports(
         let has_test_ref = export
             .references
             .iter()
-            .any(|reference| test_coverage.covers_reference(target_file, reference.from_file));
+            .any(|reference| test_coverage.covers_reference(target_file, reference));
         if has_test_ref {
             set.insert(export.name.to_string());
         }

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -1,5 +1,7 @@
 use fallow_output::{DirectCallerEvidence, DirectCallerSymbolEvidence, FileHealthScore};
 
+use crate::module_graph::StaticTestCoverage;
+
 use super::coverage_gaps::compute_coverage_gaps;
 pub(super) use super::coverage_gaps::{CoverageGapData, build_coverage_summary};
 
@@ -532,13 +534,14 @@ pub(super) struct TemplateInheritContext {
 /// scoring loop falls through to the existing path unchanged.
 fn build_template_inherit_contexts(
     graph: &fallow_graph::graph::ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     module_by_id: &rustc_hash::FxHashMap<crate::discover::FileId, &crate::source::ModuleInfo>,
     file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
 ) -> rustc_hash::FxHashMap<crate::discover::FileId, TemplateInheritContext> {
     let mut out = rustc_hash::FxHashMap::default();
     for node in &graph.modules {
         if let Some(context) =
-            template_inherit_context_for_node(node, graph, module_by_id, file_paths)
+            template_inherit_context_for_node(node, graph, test_coverage, module_by_id, file_paths)
         {
             out.insert(node.file_id, context);
         }
@@ -549,6 +552,7 @@ fn build_template_inherit_contexts(
 fn template_inherit_context_for_node(
     node: &fallow_graph::graph::ModuleNode,
     graph: &fallow_graph::graph::ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     module_by_id: &rustc_hash::FxHashMap<crate::discover::FileId, &crate::source::ModuleInfo>,
     file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
 ) -> Option<TemplateInheritContext> {
@@ -556,7 +560,13 @@ fn template_inherit_context_for_node(
         return None;
     }
     let importers = graph.reverse_deps.get(node.file_id.0 as usize)?;
-    template_inherit_context_from_importers(importers, graph, module_by_id, file_paths)
+    template_inherit_context_from_importers(
+        importers,
+        graph,
+        test_coverage,
+        module_by_id,
+        file_paths,
+    )
 }
 
 fn is_template_inherit_candidate(
@@ -585,6 +595,7 @@ fn is_template_inherit_candidate(
 fn template_inherit_context_from_importers(
     importers: &[crate::discover::FileId],
     graph: &fallow_graph::graph::ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     module_by_id: &rustc_hash::FxHashMap<crate::discover::FileId, &crate::source::ModuleInfo>,
     file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
 ) -> Option<TemplateInheritContext> {
@@ -602,10 +613,14 @@ fn template_inherit_context_from_importers(
         if first_owner.is_none() {
             first_owner = Some((*owner_path).clone());
         }
-        if owner_node.is_test_reachable() {
+        if test_coverage.covers_file(owner_node.file_id) {
             any_reachable = true;
             provenance.get_or_insert_with(|| (*owner_path).clone());
-            let refs = build_test_referenced_exports(&owner_node.exports, &graph.modules);
+            let refs = build_test_referenced_exports(
+                owner_node.file_id,
+                &owner_node.exports,
+                test_coverage,
+            );
             combined_refs.extend(refs);
         }
     }
@@ -651,19 +666,19 @@ fn is_template_owner_path(path: &std::path::Path) -> bool {
 /// This is the per-function signal: if an export named "foo" has a reference from
 /// a test-reachable module, the function "foo" is considered directly tested.
 fn build_test_referenced_exports(
+    target_file: crate::discover::FileId,
     exports: &[fallow_graph::graph::ExportSymbol],
-    graph_modules: &[fallow_graph::graph::ModuleNode],
+    test_coverage: StaticTestCoverage<'_>,
 ) -> rustc_hash::FxHashSet<String> {
     let mut set = rustc_hash::FxHashSet::default();
     for export in exports {
         if export.is_type_only {
             continue;
         }
-        let has_test_ref = export.references.iter().any(|reference| {
-            graph_modules
-                .get(reference.from_file.0 as usize)
-                .is_some_and(fallow_graph::graph::ModuleNode::is_test_reachable)
-        });
+        let has_test_ref = export
+            .references
+            .iter()
+            .any(|reference| test_coverage.covers_reference(target_file, reference.from_file));
         if has_test_ref {
             set.insert(export.name.to_string());
         }
@@ -1158,6 +1173,7 @@ pub(super) fn compute_file_scores(
     root: &std::path::Path,
 ) -> Result<FileScoreOutput, String> {
     let retained_graph = analysis_output.graph.ok_or("graph not available")?;
+    let test_coverage = retained_graph.static_test_coverage();
     let graph = retained_graph.as_graph();
     let results = &analysis_output.results;
 
@@ -1178,14 +1194,16 @@ pub(super) fn compute_file_scores(
     let FileScoreCoverageSetup {
         module_by_id,
         coverage,
-    } = prepare_file_score_coverage_setup(modules, file_paths, results, graph, root);
+    } = prepare_file_score_coverage_setup(modules, file_paths, results, graph, test_coverage, root);
 
-    let template_inherit = build_template_inherit_contexts(graph, &module_by_id, file_paths);
+    let template_inherit =
+        build_template_inherit_contexts(graph, test_coverage, &module_by_id, file_paths);
 
     let mut acc = accumulate_file_scores(
         unused_export_names,
         &FileScoreLoopCtx {
             graph,
+            test_coverage,
             file_paths,
             module_by_id: &module_by_id,
             unused_files: &unused_files,
@@ -1219,6 +1237,7 @@ pub(super) fn compute_file_scores(
 /// Read-only inputs threaded into the per-node file-score loop.
 struct FileScoreLoopCtx<'a> {
     graph: &'a fallow_graph::graph::ModuleGraph,
+    test_coverage: StaticTestCoverage<'a>,
     file_paths: &'a rustc_hash::FxHashMap<crate::discover::FileId, &'a std::path::PathBuf>,
     module_by_id: &'a rustc_hash::FxHashMap<crate::discover::FileId, &'a crate::source::ModuleInfo>,
     unused_files: &'a rustc_hash::FxHashSet<&'a std::path::Path>,
@@ -1324,7 +1343,7 @@ fn compute_one_file_score(
     let crap = compute_file_score_crap(
         node,
         ctx.module_by_id.get(&node.file_id).copied(),
-        ctx.graph,
+        ctx.test_coverage,
         ctx.template_inherit.get(&node.file_id),
         ctx.istanbul_coverage,
         &path_owned,
@@ -1518,7 +1537,7 @@ impl FileScoreCrap {
 fn compute_file_score_crap(
     node: &fallow_graph::graph::ModuleNode,
     module: Option<&crate::source::ModuleInfo>,
-    graph: &fallow_graph::graph::ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     template_inherit: Option<&TemplateInheritContext>,
     istanbul_coverage: Option<&IstanbulCoverage>,
     path: &std::path::Path,
@@ -1531,7 +1550,7 @@ fn compute_file_score_crap(
         &module.suppressions,
         fallow_types::suppress::IssueKind::CoverageGaps,
     );
-    let is_test_reachable = node.is_test_reachable() || is_coverage_suppressed;
+    let is_test_reachable = test_coverage.covers_file(node.file_id) || is_coverage_suppressed;
     let resolution = resolve_crap_coverage(template_inherit, istanbul_coverage, path);
     match resolution {
         CrapCoverageResolution::TemplateInherited(inherit_ctx) => {
@@ -1540,9 +1559,13 @@ fn compute_file_score_crap(
         CrapCoverageResolution::Istanbul { file_coverage } => {
             compute_istanbul_file_crap(module, file_coverage, is_test_reachable)
         }
-        CrapCoverageResolution::StaticEstimated => {
-            compute_static_file_crap(module, &node.exports, &graph.modules, is_test_reachable)
-        }
+        CrapCoverageResolution::StaticEstimated => compute_static_file_crap(
+            module,
+            node.file_id,
+            &node.exports,
+            test_coverage,
+            is_test_reachable,
+        ),
     }
 }
 
@@ -1572,11 +1595,12 @@ fn compute_istanbul_file_crap(
 
 fn compute_static_file_crap(
     module: &crate::source::ModuleInfo,
+    target_file: crate::discover::FileId,
     exports: &[fallow_graph::graph::ExportSymbol],
-    graph_modules: &[fallow_graph::graph::ModuleNode],
+    test_coverage: StaticTestCoverage<'_>,
     is_test_reachable: bool,
 ) -> FileScoreCrap {
-    let test_refs = build_test_referenced_exports(exports, graph_modules);
+    let test_refs = build_test_referenced_exports(target_file, exports, test_coverage);
     FileScoreCrap::estimated(compute_crap_scores_estimated(
         &module.complexity,
         &test_refs,
@@ -1605,6 +1629,7 @@ fn prepare_file_score_coverage_setup<'a>(
     file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
     results: &crate::results::AnalysisResults,
     graph: &fallow_graph::graph::ModuleGraph,
+    test_coverage: StaticTestCoverage<'_>,
     root: &std::path::Path,
 ) -> FileScoreCoverageSetup<'a> {
     let module_by_id: rustc_hash::FxHashMap<_, _> =
@@ -1619,7 +1644,14 @@ fn prepare_file_score_coverage_setup<'a>(
             )
         })
         .collect();
-    let coverage = compute_coverage_gaps(graph, file_paths, &module_by_id, &unused_exports, root);
+    let coverage = compute_coverage_gaps(
+        graph,
+        test_coverage,
+        file_paths,
+        &module_by_id,
+        &unused_exports,
+        root,
+    );
     FileScoreCoverageSetup {
         module_by_id,
         coverage,
@@ -4631,16 +4663,24 @@ mod tests {
     #[test]
     fn build_test_refs_empty() {
         let exports: Vec<fallow_graph::graph::ExportSymbol> = vec![];
-        let modules: Vec<fallow_graph::graph::ModuleNode> = vec![];
-        let refs = build_test_referenced_exports(&exports, &modules);
+        let graph = fallow_graph::graph::ModuleGraph::build(&[], &[], &[]);
+        let refs = build_test_referenced_exports(
+            crate::discover::FileId(0),
+            &exports,
+            StaticTestCoverage::new(&graph),
+        );
         assert!(refs.is_empty());
     }
 
     #[test]
     fn build_test_refs_empty_inputs() {
         let exports: Vec<fallow_graph::graph::ExportSymbol> = vec![];
-        let modules: Vec<fallow_graph::graph::ModuleNode> = vec![];
-        let refs = build_test_referenced_exports(&exports, &modules);
+        let graph = fallow_graph::graph::ModuleGraph::build(&[], &[], &[]);
+        let refs = build_test_referenced_exports(
+            crate::discover::FileId(0),
+            &exports,
+            StaticTestCoverage::new(&graph),
+        );
         assert!(refs.is_empty());
     }
 

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -616,11 +616,7 @@ fn template_inherit_context_from_importers(
         if test_coverage.covers_file(owner_node.file_id) {
             any_reachable = true;
             provenance.get_or_insert_with(|| (*owner_path).clone());
-            let refs = build_test_referenced_exports(
-                owner_node.file_id,
-                &owner_node.exports,
-                test_coverage,
-            );
+            let refs = build_test_referenced_exports(&owner_node.exports, test_coverage);
             combined_refs.extend(refs);
         }
     }
@@ -666,7 +662,6 @@ fn is_template_owner_path(path: &std::path::Path) -> bool {
 /// This is the per-function signal: if an export named "foo" has a reference from
 /// a test-reachable module, the function "foo" is considered directly tested.
 fn build_test_referenced_exports(
-    target_file: crate::discover::FileId,
     exports: &[fallow_graph::graph::ExportSymbol],
     test_coverage: StaticTestCoverage<'_>,
 ) -> rustc_hash::FxHashSet<String> {
@@ -678,7 +673,7 @@ fn build_test_referenced_exports(
         let has_test_ref = export
             .references
             .iter()
-            .any(|reference| test_coverage.covers_reference(target_file, reference));
+            .any(|reference| test_coverage.covers_reference(reference));
         if has_test_ref {
             set.insert(export.name.to_string());
         }
@@ -1559,13 +1554,9 @@ fn compute_file_score_crap(
         CrapCoverageResolution::Istanbul { file_coverage } => {
             compute_istanbul_file_crap(module, file_coverage, is_test_reachable)
         }
-        CrapCoverageResolution::StaticEstimated => compute_static_file_crap(
-            module,
-            node.file_id,
-            &node.exports,
-            test_coverage,
-            is_test_reachable,
-        ),
+        CrapCoverageResolution::StaticEstimated => {
+            compute_static_file_crap(module, &node.exports, test_coverage, is_test_reachable)
+        }
     }
 }
 
@@ -1595,12 +1586,11 @@ fn compute_istanbul_file_crap(
 
 fn compute_static_file_crap(
     module: &crate::source::ModuleInfo,
-    target_file: crate::discover::FileId,
     exports: &[fallow_graph::graph::ExportSymbol],
     test_coverage: StaticTestCoverage<'_>,
     is_test_reachable: bool,
 ) -> FileScoreCrap {
-    let test_refs = build_test_referenced_exports(target_file, exports, test_coverage);
+    let test_refs = build_test_referenced_exports(exports, test_coverage);
     FileScoreCrap::estimated(compute_crap_scores_estimated(
         &module.complexity,
         &test_refs,
@@ -4664,11 +4654,7 @@ mod tests {
     fn build_test_refs_empty() {
         let exports: Vec<fallow_graph::graph::ExportSymbol> = vec![];
         let graph = fallow_graph::graph::ModuleGraph::build(&[], &[], &[]);
-        let refs = build_test_referenced_exports(
-            crate::discover::FileId(0),
-            &exports,
-            StaticTestCoverage::new(&graph),
-        );
+        let refs = build_test_referenced_exports(&exports, StaticTestCoverage::new(&graph));
         assert!(refs.is_empty());
     }
 
@@ -4676,11 +4662,7 @@ mod tests {
     fn build_test_refs_empty_inputs() {
         let exports: Vec<fallow_graph::graph::ExportSymbol> = vec![];
         let graph = fallow_graph::graph::ModuleGraph::build(&[], &[], &[]);
-        let refs = build_test_referenced_exports(
-            crate::discover::FileId(0),
-            &exports,
-            StaticTestCoverage::new(&graph),
-        );
+        let refs = build_test_referenced_exports(&exports, StaticTestCoverage::new(&graph));
         assert!(refs.is_empty());
     }
 

--- a/crates/engine/src/module_graph.rs
+++ b/crates/engine/src/module_graph.rs
@@ -106,12 +106,8 @@ impl<'a> StaticTestCoverage<'a> {
         self.graph.is_test_reachable(file_id)
     }
 
-    pub(crate) fn covers_reference(
-        self,
-        target_file: FileId,
-        reference: &fallow_graph::graph::SymbolReference,
-    ) -> bool {
-        self.graph.is_test_reference_covered(target_file, reference)
+    pub(crate) fn covers_reference(self, reference: &fallow_graph::graph::SymbolReference) -> bool {
+        self.graph.is_test_reference_covered(reference)
     }
 }
 
@@ -279,7 +275,7 @@ pub fn module_value_exports(graph: &RetainedModuleGraph) -> Vec<ModuleValueExpor
                     test_referenced: export
                         .references
                         .iter()
-                        .any(|reference| test_coverage.covers_reference(node.file_id, reference)),
+                        .any(|reference| test_coverage.covers_reference(reference)),
                 })
         })
         .collect()

--- a/crates/engine/src/module_graph.rs
+++ b/crates/engine/src/module_graph.rs
@@ -18,7 +18,7 @@ use fallow_graph::graph::{
 };
 use fallow_graph::graph::{
     DirectImporterSummary as GraphDirectImporterSummary,
-    ImportedSymbolSummary as GraphImportedSymbolSummary, ModuleNode,
+    ImportedSymbolSummary as GraphImportedSymbolSummary,
 };
 
 /// Engine-owned retained graph handle.
@@ -39,6 +39,11 @@ impl RetainedModuleGraph {
 
     pub(crate) const fn as_graph(&self) -> &ModuleGraph {
         &self.inner
+    }
+
+    /// Borrow the shared static test-coverage view for health analysis.
+    pub(crate) const fn static_test_coverage(&self) -> StaticTestCoverage<'_> {
+        StaticTestCoverage::new(&self.inner)
     }
 
     /// Number of modules in the retained graph.
@@ -80,6 +85,30 @@ impl RetainedModuleGraph {
             .into_iter()
             .map(DirectImporterSummary::from)
             .collect()
+    }
+}
+
+/// Engine-owned view of root-correlated static test reachability.
+///
+/// This keeps health consumers on one contract while the graph crate owns the
+/// traversal and replacement-mask representation.
+#[derive(Clone, Copy)]
+pub(crate) struct StaticTestCoverage<'a> {
+    graph: &'a ModuleGraph,
+}
+
+impl<'a> StaticTestCoverage<'a> {
+    pub(crate) const fn new(graph: &'a ModuleGraph) -> Self {
+        Self { graph }
+    }
+
+    pub(crate) fn covers_file(self, file_id: FileId) -> bool {
+        self.graph.is_test_reachable(file_id)
+    }
+
+    pub(crate) fn covers_reference(self, target_file: FileId, source_file: FileId) -> bool {
+        self.graph
+            .shares_test_reachability_profile(target_file, source_file)
     }
 }
 
@@ -230,13 +259,8 @@ impl From<GraphFocusFileFactsPaths> for FocusFileFactsPaths {
 /// internals to downstream crates.
 #[must_use]
 pub fn module_value_exports(graph: &RetainedModuleGraph) -> Vec<ModuleValueExport> {
+    let test_coverage = graph.static_test_coverage();
     let graph = graph.as_graph();
-    let is_test_reachable = |file_id: FileId| {
-        graph
-            .modules
-            .get(file_id.0 as usize)
-            .is_some_and(ModuleNode::is_test_reachable)
-    };
 
     graph
         .modules
@@ -249,10 +273,9 @@ pub fn module_value_exports(graph: &RetainedModuleGraph) -> Vec<ModuleValueExpor
                     file_id: node.file_id,
                     name: export.name.to_string(),
                     span_start: export.span.start,
-                    test_referenced: export
-                        .references
-                        .iter()
-                        .any(|reference| is_test_reachable(reference.from_file)),
+                    test_referenced: export.references.iter().any(|reference| {
+                        test_coverage.covers_reference(node.file_id, reference.from_file)
+                    }),
                 })
         })
         .collect()
@@ -415,4 +438,123 @@ fn relative_key_path(path: &Path, root: &Path) -> String {
         .unwrap_or(simple_path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RetainedModuleGraph, module_value_exports};
+    use fallow_graph::graph::ModuleGraph;
+    use fallow_graph::resolve::{
+        ResolveResult, ResolvedImport, ResolvedModule, ResolvedReplacedModuleTarget,
+    };
+    use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
+    use fallow_types::extract::{ExportInfo, ExportName, ImportInfo, ImportedName, VisibilityTag};
+    use std::path::PathBuf;
+
+    fn import(target: FileId, imported_name: ImportedName) -> ResolvedImport {
+        ResolvedImport {
+            info: ImportInfo {
+                source: "./target".to_string(),
+                imported_name,
+                local_name: "target".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(0, 10),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(target),
+        }
+    }
+
+    fn mixed_root_graph(unmasked_root_imports_export: bool) -> RetainedModuleGraph {
+        let files: Vec<_> = (0..3)
+            .map(|id| DiscoveredFile {
+                id: FileId(id),
+                path: PathBuf::from(format!("/project/file{id}.ts")),
+                size_bytes: 1,
+            })
+            .collect();
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_imports: vec![import(
+                    FileId(2),
+                    ImportedName::Named("target".to_string()),
+                )],
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                resolved_imports: vec![import(
+                    FileId(2),
+                    if unmasked_root_imports_export {
+                        ImportedName::Named("target".to_string())
+                    } else {
+                        ImportedName::SideEffect
+                    },
+                )],
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: files[2].path.clone(),
+                exports: vec![ExportInfo {
+                    name: ExportName::Named("target".to_string()),
+                    local_name: Some("target".to_string()),
+                    is_type_only: false,
+                    visibility: VisibilityTag::None,
+                    expected_unused_reason: None,
+                    span: oxc_span::Span::new(0, 20),
+                    members: Vec::new(),
+                    is_side_effect_used: false,
+                    super_class: None,
+                }],
+                ..ResolvedModule::default()
+            },
+        ];
+        let test_entry_points = vec![
+            EntryPoint {
+                path: files[0].path.clone(),
+                source: EntryPointSource::TestFile,
+            },
+            EntryPoint {
+                path: files[1].path.clone(),
+                source: EntryPointSource::TestFile,
+            },
+        ];
+        let graph = ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(2),
+            }],
+            &test_entry_points,
+            &[],
+            &test_entry_points,
+            &files,
+        );
+        RetainedModuleGraph::from(graph)
+    }
+
+    #[test]
+    fn export_coverage_requires_one_root_to_reach_consumer_and_target() {
+        let graph = mixed_root_graph(false);
+
+        let exports = module_value_exports(&graph);
+
+        assert_eq!(exports.len(), 1);
+        assert!(!exports[0].test_referenced);
+    }
+
+    #[test]
+    fn export_coverage_accepts_an_unmasked_correlated_reference() {
+        let graph = mixed_root_graph(true);
+
+        let exports = module_value_exports(&graph);
+
+        assert_eq!(exports.len(), 1);
+        assert!(exports[0].test_referenced);
+    }
 }

--- a/crates/engine/src/module_graph.rs
+++ b/crates/engine/src/module_graph.rs
@@ -106,9 +106,12 @@ impl<'a> StaticTestCoverage<'a> {
         self.graph.is_test_reachable(file_id)
     }
 
-    pub(crate) fn covers_reference(self, target_file: FileId, source_file: FileId) -> bool {
-        self.graph
-            .shares_test_reachability_profile(target_file, source_file)
+    pub(crate) fn covers_reference(
+        self,
+        target_file: FileId,
+        reference: &fallow_graph::graph::SymbolReference,
+    ) -> bool {
+        self.graph.is_test_reference_covered(target_file, reference)
     }
 }
 
@@ -273,9 +276,10 @@ pub fn module_value_exports(graph: &RetainedModuleGraph) -> Vec<ModuleValueExpor
                     file_id: node.file_id,
                     name: export.name.to_string(),
                     span_start: export.span.start,
-                    test_referenced: export.references.iter().any(|reference| {
-                        test_coverage.covers_reference(node.file_id, reference.from_file)
-                    }),
+                    test_referenced: export
+                        .references
+                        .iter()
+                        .any(|reference| test_coverage.covers_reference(node.file_id, reference)),
                 })
         })
         .collect()
@@ -452,6 +456,14 @@ mod tests {
     use std::path::PathBuf;
 
     fn import(target: FileId, imported_name: ImportedName) -> ResolvedImport {
+        import_with_mechanism(target, imported_name, false)
+    }
+
+    fn import_with_mechanism(
+        target: FileId,
+        imported_name: ImportedName,
+        commonjs: bool,
+    ) -> ResolvedImport {
         ResolvedImport {
             info: ImportInfo {
                 source: "./target".to_string(),
@@ -462,7 +474,25 @@ mod tests {
                 span: oxc_span::Span::new(0, 10),
                 source_span: oxc_span::Span::default(),
             },
-            target: ResolveResult::InternalModule(target),
+            target: if commonjs {
+                ResolveResult::CommonJsInternalModule(target)
+            } else {
+                ResolveResult::InternalModule(target)
+            },
+        }
+    }
+
+    fn value_export(name: &str, span_start: u32) -> ExportInfo {
+        ExportInfo {
+            name: ExportName::Named(name.to_string()),
+            local_name: Some(name.to_string()),
+            is_type_only: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: oxc_span::Span::new(span_start, span_start + 10),
+            members: Vec::new(),
+            is_side_effect_used: false,
+            super_class: None,
         }
     }
 
@@ -500,17 +530,7 @@ mod tests {
             ResolvedModule {
                 file_id: FileId(2),
                 path: files[2].path.clone(),
-                exports: vec![ExportInfo {
-                    name: ExportName::Named("target".to_string()),
-                    local_name: Some("target".to_string()),
-                    is_type_only: false,
-                    visibility: VisibilityTag::None,
-                    expected_unused_reason: None,
-                    span: oxc_span::Span::new(0, 20),
-                    members: Vec::new(),
-                    is_side_effect_used: false,
-                    super_class: None,
-                }],
+                exports: vec![value_export("target", 0)],
                 ..ResolvedModule::default()
             },
         ];
@@ -556,5 +576,66 @@ mod tests {
 
         assert_eq!(exports.len(), 1);
         assert!(exports[0].test_referenced);
+    }
+
+    #[test]
+    fn commonjs_reference_does_not_credit_a_mocked_esm_export() {
+        let files: Vec<_> = (0..2)
+            .map(|id| DiscoveredFile {
+                id: FileId(id),
+                path: PathBuf::from(format!("/project/file{id}.ts")),
+                size_bytes: 1,
+            })
+            .collect();
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_imports: vec![
+                    import_with_mechanism(
+                        FileId(1),
+                        ImportedName::Named("esmOnly".to_string()),
+                        false,
+                    ),
+                    import_with_mechanism(
+                        FileId(1),
+                        ImportedName::Named("required".to_string()),
+                        true,
+                    ),
+                ],
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                exports: vec![value_export("esmOnly", 0), value_export("required", 20)],
+                ..ResolvedModule::default()
+            },
+        ];
+        let test_entry_points = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+        let graph =
+            RetainedModuleGraph::from(ModuleGraph::build_with_reachability_roots_and_replacements(
+                &modules,
+                &[ResolvedReplacedModuleTarget {
+                    source_file: FileId(0),
+                    target_file: FileId(1),
+                }],
+                &test_entry_points,
+                &[],
+                &test_entry_points,
+                &files,
+            ));
+
+        let exports = module_value_exports(&graph);
+        let coverage: rustc_hash::FxHashMap<_, _> = exports
+            .into_iter()
+            .map(|export| (export.name, export.test_referenced))
+            .collect();
+
+        assert_eq!(coverage.get("esmOnly"), Some(&false));
+        assert_eq!(coverage.get("required"), Some(&true));
     }
 }

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -1295,6 +1295,76 @@ export default function Home() {
     }
 
     #[test]
+    fn replaced_module_coverage_matches_across_cold_and_warm_graph_cache() {
+        let project = tempfile::tempdir().expect("project");
+        let root = project.path();
+        std::fs::create_dir(root.join("src")).expect("create source directory");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"name":"mock-cache-parity","main":"src/index.ts","devDependencies":{"vitest":"latest"}}"#,
+        )
+        .expect("write package manifest");
+        std::fs::write(
+            root.join("src/dependency.ts"),
+            "export function dependency() { return 'real'; }\n",
+        )
+        .expect("write dependency");
+        std::fs::write(
+            root.join("src/wrapper.ts"),
+            "import { dependency } from './dependency';\nexport function wrapper() { return dependency(); }\n",
+        )
+        .expect("write wrapper");
+        std::fs::write(
+            root.join("src/index.ts"),
+            "export { wrapper } from './wrapper';\n",
+        )
+        .expect("write entry point");
+        std::fs::write(
+            root.join("src/wrapper.test.ts"),
+            r#"
+import { vi } from "vitest";
+vi.mock("./dependency", () => ({ dependency: () => "mock" }));
+import { wrapper } from "./wrapper";
+wrapper();
+"#,
+        )
+        .expect("write test");
+
+        let cold_session = AnalysisSession::load(root, None).expect("cold session loads");
+        let dependency_id = cold_session
+            .files()
+            .iter()
+            .find(|file| file.path == root.join("src/dependency.ts"))
+            .expect("dependency discovered")
+            .id;
+        let cold = cold_session
+            .analyze_dead_code_with_artifacts(false, true)
+            .expect("cold analysis succeeds");
+        let cold_exports = crate::module_graph::module_value_exports(
+            cold.graph.as_ref().expect("cold graph retained"),
+        );
+        assert!(
+            fallow_graph::cache::GraphCacheStore::load(&cold_session.config().cache_dir).is_some(),
+            "cold analysis must persist the graph cache"
+        );
+
+        let warm_session = AnalysisSession::load(root, None).expect("warm session loads");
+        let warm = warm_session
+            .analyze_dead_code_with_artifacts(false, true)
+            .expect("warm analysis succeeds");
+        let warm_exports = crate::module_graph::module_value_exports(
+            warm.graph.as_ref().expect("warm graph retained"),
+        );
+
+        let dependency = cold_exports
+            .iter()
+            .find(|export| export.file_id == dependency_id && export.name == "dependency")
+            .expect("dependency export retained");
+        assert!(!dependency.test_referenced);
+        assert_eq!(warm_exports, cold_exports);
+    }
+
+    #[test]
     fn session_parse_surfaces_removed_source_with_sparse_file_ids() {
         let project = tempfile::tempdir().expect("project");
         let root = project.path();

--- a/crates/engine/src/session.rs
+++ b/crates/engine/src/session.rs
@@ -907,7 +907,7 @@ fn run_engine_owned_dead_code_pipeline(
     let mut detector = core_backend::run_dead_code_detectors(
         &prelude,
         &graph.graph,
-        &resolved.resolved,
+        &resolved.project.modules,
         &modules,
         collect_usages,
         &entry_points,
@@ -958,7 +958,7 @@ fn resolve_or_build_dead_code_graph(
 
     let resolved = core_backend::resolve_dead_code_imports(prelude, modules);
     let graph =
-        core_backend::build_dead_code_graph(prelude, &resolved.resolved, entry_points, modules);
+        core_backend::build_dead_code_graph(prelude, &resolved.project, entry_points, modules);
     (resolved, graph)
 }
 

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -156,6 +156,7 @@ fn cached_dynamic_patterns_to_module(
             prefix: pattern.prefix.clone(),
             suffix: pattern.suffix.clone(),
             span: Span::new(pattern.span_start, pattern.span_end),
+            mechanism: pattern.mechanism,
         })
         .collect()
 }
@@ -361,6 +362,7 @@ fn module_dynamic_patterns_to_cached(
             suffix: pattern.suffix.clone(),
             span_start: pattern.span.start,
             span_end: pattern.span.end,
+            mechanism: pattern.mechanism,
         })
         .collect()
 }

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1149,6 +1149,9 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 class_local_name: "Service".to_string(),
                 object: "this.client".to_string(),
             }),
+            SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+                source: "./dependency".to_string(),
+            }),
         ]
         .into(),
         whole_object_uses: Box::default(),
@@ -1296,6 +1299,9 @@ fn module_to_cached_roundtrip_dynamic_imports() {
             SemanticFact::ClassThisWholeObjectUse(ClassThisWholeObjectUseFact {
                 class_local_name: "Service".to_string(),
                 object: "this.client".to_string(),
+            }),
+            SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+                source: "./dependency".to_string(),
             }),
         ][..]
     );
@@ -4294,7 +4300,9 @@ fn warm_cache_load_matches_cold_parse() {
     let dir = test_cache_dir("warm_equals_cold");
     let path = Path::new("src/warm.tsx");
     let source = "import { useEffect } from 'react';\n\
+         import { vi } from 'vitest';\n\
          import type { Props } from './types';\n\
+         vi.mock('./dependency', () => ({ dependency: vi.fn() }));\n\
          export const App = ({ name }: Props) => {\n\
            useEffect(() => {}, [name]);\n\
            return <Child id={name} />;\n\
@@ -4339,6 +4347,14 @@ fn warm_cache_load_matches_cold_parse() {
     assert_eq!(
         warm_module.render_edges.len(),
         cold_module.render_edges.len()
+    );
+    assert_eq!(warm_module.semantic_facts, cold_module.semantic_facts);
+    assert!(
+        warm_module.semantic_facts.iter().any(|fact| matches!(
+            fact,
+            SemanticFact::ReplacedModuleTarget(target) if target.source == "./dependency"
+        )),
+        "warm cache should retain the proven replacement target"
     );
 
     let _ = std::fs::remove_dir_all(&dir);

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -3232,11 +3232,13 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
                 prefix: "./components/".to_string(),
                 suffix: Some(".vue".to_string()),
                 span: Span::new(0, 50),
+                mechanism: crate::ModuleLoadMechanism::EsModule,
             },
             crate::DynamicImportPattern {
                 prefix: "./pages/**/".to_string(),
                 suffix: None,
                 span: Span::new(60, 100),
+                mechanism: crate::ModuleLoadMechanism::CommonJsRequire,
             },
         ],
         has_cjs_exports: false,
@@ -3317,8 +3319,16 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
     );
     assert_eq!(restored.dynamic_import_patterns[0].span.start, 0);
     assert_eq!(restored.dynamic_import_patterns[0].span.end, 50);
+    assert_eq!(
+        restored.dynamic_import_patterns[0].mechanism,
+        crate::ModuleLoadMechanism::EsModule
+    );
     assert_eq!(restored.dynamic_import_patterns[1].prefix, "./pages/**/");
     assert!(restored.dynamic_import_patterns[1].suffix.is_none());
+    assert_eq!(
+        restored.dynamic_import_patterns[1].mechanism,
+        crate::ModuleLoadMechanism::CommonJsRequire
+    );
 }
 
 #[test]

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1149,8 +1149,12 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 class_local_name: "Service".to_string(),
                 object: "this.client".to_string(),
             }),
-            SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+            SemanticFact::VitestModuleMockOperation(VitestModuleMockOperationFact {
                 source: "./dependency".to_string(),
+                call_start: 42,
+                action: VitestModuleMockAction::Mock {
+                    factory_replaces_original: true,
+                },
             }),
         ]
         .into(),
@@ -1300,8 +1304,12 @@ fn module_to_cached_roundtrip_dynamic_imports() {
                 class_local_name: "Service".to_string(),
                 object: "this.client".to_string(),
             }),
-            SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+            SemanticFact::VitestModuleMockOperation(VitestModuleMockOperationFact {
                 source: "./dependency".to_string(),
+                call_start: 42,
+                action: VitestModuleMockAction::Mock {
+                    factory_replaces_original: true,
+                },
             }),
         ][..]
     );
@@ -4362,9 +4370,11 @@ fn warm_cache_load_matches_cold_parse() {
     assert!(
         warm_module.semantic_facts.iter().any(|fact| matches!(
             fact,
-            SemanticFact::ReplacedModuleTarget(target) if target.source == "./dependency"
+            SemanticFact::VitestModuleMockOperation(operation)
+                if operation.source == "./dependency"
+                    && operation.action.replaces_original()
         )),
-        "warm cache should retain the proven replacement target"
+        "warm cache should retain the proven replacement operation"
     );
 
     let _ = std::fs::remove_dir_all(&dir);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -845,7 +845,7 @@ use crate::MemberKind;
 /// members and reproduce the old false positives.
 ///
 /// Bumped to 242 for issue #2031: proven Vitest replacement factories append a
-/// `SemanticFact::ReplacedModuleTarget`. Warm 241 caches omit that typed fact
+/// typed replacement fact. Warm 241 caches omit that fact
 /// and would continue crediting replaced modules as statically test-covered.
 ///
 /// Bumped to 243: Vitest replacement facts now require the `vi.mock` object to
@@ -866,8 +866,13 @@ use crate::MemberKind;
 /// factory whose only callable dependency is the imported `vi.fn`.
 ///
 /// Bumped to 247: Vitest replacement facts now reflect the final semantically
-/// proven `vi.mock` or `vi.unmock` operation for each target.
-pub(super) const CACHE_VERSION: u32 = 247;
+/// proven `vi.mock` or `vi.unmock` operation for each literal target.
+///
+/// Bumped to 248: extraction now preserves every typed Vitest mock/unmock
+/// operation and its source position so resolution can select final state by
+/// canonical module identity. Factory proof also rejects all value dependencies
+/// other than the semantically proven imported `vi`.
+pub(super) const CACHE_VERSION: u32 = 248;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -864,7 +864,10 @@ use crate::MemberKind;
 ///
 /// Bumped to 246: proven Vitest replacements now require a structurally closed
 /// factory whose only callable dependency is the imported `vi.fn`.
-pub(super) const CACHE_VERSION: u32 = 246;
+///
+/// Bumped to 247: Vitest replacement facts now reflect the final semantically
+/// proven `vi.mock` or `vi.unmock` operation for each target.
+pub(super) const CACHE_VERSION: u32 = 247;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -856,7 +856,12 @@ use crate::MemberKind;
 /// Bumped to 244: dynamic import patterns now retain their module load
 /// mechanism. Warm 243 caches cannot distinguish ESM patterns from
 /// `require.context` CommonJS patterns.
-pub(super) const CACHE_VERSION: u32 = 244;
+///
+/// Bumped to 245: proven Vitest replacements now abstain whenever
+/// `vi.importActual` escapes through a property read or destructuring, not only
+/// when it is called directly. Warm 244 caches can retain false replacement
+/// facts for aliased original-module loaders.
+pub(super) const CACHE_VERSION: u32 = 245;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -844,34 +844,13 @@ use crate::MemberKind;
 /// extracted as reportable class members. Warm 240 caches can retain those
 /// members and reproduce the old false positives.
 ///
-/// Bumped to 242 for issue #2031: proven Vitest replacement factories append a
-/// typed replacement fact. Warm 241 caches omit that fact
-/// and would continue crediting replaced modules as statically test-covered.
-///
-/// Bumped to 243: Vitest replacement facts now require the `vi.mock` object to
-/// resolve to the direct `vi` import and recognize computed `vi["importActual"]`
-/// as an original-module load. Warm 242 caches can retain false replacement
-/// facts from shadowed bindings or computed original loaders.
-///
-/// Bumped to 244: dynamic import patterns now retain their module load
-/// mechanism. Warm 243 caches cannot distinguish ESM patterns from
-/// `require.context` CommonJS patterns.
-///
-/// Bumped to 245: proven Vitest replacements now abstain whenever
-/// `vi.importActual` escapes through a property read or destructuring, not only
-/// when it is called directly. Warm 244 caches can retain false replacement
-/// facts for aliased original-module loaders.
-///
-/// Bumped to 246: proven Vitest replacements now require a structurally closed
-/// factory whose only callable dependency is the imported `vi.fn`.
-///
-/// Bumped to 247: Vitest replacement facts now reflect the final semantically
-/// proven `vi.mock` or `vi.unmock` operation for each literal target.
-///
-/// Bumped to 248: extraction now preserves every typed Vitest mock/unmock
-/// operation and its source position so resolution can select final state by
-/// canonical module identity. Factory proof also rejects all value dependencies
-/// other than the semantically proven imported `vi`.
+/// Bumped to 248 for issue #2031: extraction now persists ordered,
+/// provenance-checked Vitest mock/unmock operations and module-load mechanisms.
+/// This lets resolution select final replacement state by canonical module
+/// identity without accepting uncertain factories or original-module loaders.
+/// Warm 241 caches lack those contracts. Versions 242 through 247 were used by
+/// published development commits for this change, so the final version remains
+/// 248 rather than reusing a potentially stale intermediate cache version.
 pub(super) const CACHE_VERSION: u32 = 248;
 
 /// Duplication token cache version. Bump when duplicate tokenization,

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -861,7 +861,10 @@ use crate::MemberKind;
 /// `vi.importActual` escapes through a property read or destructuring, not only
 /// when it is called directly. Warm 244 caches can retain false replacement
 /// facts for aliased original-module loaders.
-pub(super) const CACHE_VERSION: u32 = 245;
+///
+/// Bumped to 246: proven Vitest replacements now require a structurally closed
+/// factory whose only callable dependency is the imported `vi.fn`.
+pub(super) const CACHE_VERSION: u32 = 246;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -847,7 +847,12 @@ use crate::MemberKind;
 /// Bumped to 242 for issue #2031: proven Vitest replacement factories append a
 /// `SemanticFact::ReplacedModuleTarget`. Warm 241 caches omit that typed fact
 /// and would continue crediting replaced modules as statically test-covered.
-pub(super) const CACHE_VERSION: u32 = 242;
+///
+/// Bumped to 243: Vitest replacement facts now require the `vi.mock` object to
+/// resolve to the direct `vi` import and recognize computed `vi["importActual"]`
+/// as an original-module load. Warm 242 caches can retain false replacement
+/// facts from shadowed bindings or computed original loaders.
+pub(super) const CACHE_VERSION: u32 = 243;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -852,7 +852,11 @@ use crate::MemberKind;
 /// resolve to the direct `vi` import and recognize computed `vi["importActual"]`
 /// as an original-module load. Warm 242 caches can retain false replacement
 /// facts from shadowed bindings or computed original loaders.
-pub(super) const CACHE_VERSION: u32 = 243;
+///
+/// Bumped to 244: dynamic import patterns now retain their module load
+/// mechanism. Warm 243 caches cannot distinguish ESM patterns from
+/// `require.context` CommonJS patterns.
+pub(super) const CACHE_VERSION: u32 = 244;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.
@@ -923,7 +927,7 @@ assert_cached_type_size!(CachedDynamicImport, 88);
 assert_cached_type_size!(CachedRequireCall, 88);
 assert_cached_type_size!(CachedReExport, 88);
 assert_cached_type_size!(CachedMember, 64);
-assert_cached_type_size!(CachedDynamicImportPattern, 56);
+assert_cached_type_size!(CachedDynamicImportPattern, 64);
 assert_cached_type_size!(crate::MemberAccess, 48);
 assert_cached_type_size!(fallow_types::extract::SemanticFact, 96);
 assert_cached_type_size!(fallow_types::extract::CalleeUse, 32);
@@ -1384,4 +1388,6 @@ pub struct CachedDynamicImportPattern {
     pub(crate) span_start: u32,
     /// Byte offset of the span end.
     pub(crate) span_end: u32,
+    /// Runtime mechanism used to load modules matching this pattern.
+    pub(crate) mechanism: crate::ModuleLoadMechanism,
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -843,7 +843,11 @@ use crate::MemberKind;
 /// Bumped to 241: ECMAScript `#private` methods and properties are no longer
 /// extracted as reportable class members. Warm 240 caches can retain those
 /// members and reproduce the old false positives.
-pub(super) const CACHE_VERSION: u32 = 241;
+///
+/// Bumped to 242 for issue #2031: proven Vitest replacement factories append a
+/// `SemanticFact::ReplacedModuleTarget`. Warm 241 caches omit that typed fact
+/// and would continue crediting replaced modules as statically test-covered.
+pub(super) const CACHE_VERSION: u32 = 242;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -62,8 +62,8 @@ pub use fallow_types::extract::{
     InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind,
     ModuleInfo, ParseResult, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
     PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
-    ReExportInfo, RequireCallInfo, SemanticFact, SourceReadFailure, TypeMemberTypeEntry,
-    TypedPropertyMemberAccessFact, VisibilityTag, compute_line_offsets,
+    ReExportInfo, ReplacedModuleTargetFact, RequireCallInfo, SemanticFact, SourceReadFailure,
+    TypeMemberTypeEntry, TypedPropertyMemberAccessFact, VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -60,10 +60,11 @@ pub use fallow_types::extract::{
     FactoryReturnExport, FactoryReturnObjectPropertyAccessFact, FactoryReturnObjectShapeExport,
     FluentChainMemberAccessFact, FluentChainNewMemberAccessFact, ImportInfo, ImportedName,
     InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind,
-    ModuleInfo, ParseResult, PlaywrightFixtureAliasFact, PlaywrightFixtureDefinitionFact,
-    PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact, PublicSignatureTypeReference,
-    ReExportInfo, ReplacedModuleTargetFact, RequireCallInfo, SemanticFact, SourceReadFailure,
-    TypeMemberTypeEntry, TypedPropertyMemberAccessFact, VisibilityTag, compute_line_offsets,
+    ModuleInfo, ModuleLoadMechanism, ParseResult, PlaywrightFixtureAliasFact,
+    PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
+    PublicSignatureTypeReference, ReExportInfo, ReplacedModuleTargetFact, RequireCallInfo,
+    SemanticFact, SourceReadFailure, TypeMemberTypeEntry, TypedPropertyMemberAccessFact,
+    VisibilityTag, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -62,9 +62,9 @@ pub use fallow_types::extract::{
     InstanceExportBindingFact, LocalTypeDeclaration, MemberAccess, MemberInfo, MemberKind,
     ModuleInfo, ModuleLoadMechanism, ParseResult, PlaywrightFixtureAliasFact,
     PlaywrightFixtureDefinitionFact, PlaywrightFixtureTypeFact, PlaywrightFixtureUseFact,
-    PublicSignatureTypeReference, ReExportInfo, ReplacedModuleTargetFact, RequireCallInfo,
-    SemanticFact, SourceReadFailure, TypeMemberTypeEntry, TypedPropertyMemberAccessFact,
-    VisibilityTag, compute_line_offsets,
+    PublicSignatureTypeReference, ReExportInfo, RequireCallInfo, SemanticFact, SourceReadFailure,
+    TypeMemberTypeEntry, TypedPropertyMemberAccessFact, VisibilityTag, VitestModuleMockAction,
+    VitestModuleMockOperationFact, compute_line_offsets,
 };
 
 pub use astro::{

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -237,7 +237,7 @@ fn build_primary_extractor(
         collect_glimmer_template_into_extractor(&mut extractor, path, source);
     let semantic_usage =
         compute_semantic_usage(program, &extractor.imports, &template_used_imports);
-    extractor.resolve_vitest_replacement_candidates(&semantic_usage.vitest_vi_reference_spans);
+    extractor.resolve_vitest_mock_operations(&semantic_usage.vitest_vi_reference_spans);
     (extractor, semantic_usage)
 }
 
@@ -381,7 +381,7 @@ fn parse_with_jsx_retry(input: &JsxRetryInput<'_>) -> Option<JsxRetryParse> {
         &extractor.imports,
         &template_used_imports,
     );
-    extractor.resolve_vitest_replacement_candidates(&semantic_usage.vitest_vi_reference_spans);
+    extractor.resolve_vitest_mock_operations(&semantic_usage.vitest_vi_reference_spans);
     let complexity = retry_complexity(
         input.need_complexity,
         &retry_return.program,

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -1,10 +1,13 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Comment, Program};
+use oxc_ast::{
+    AstKind,
+    ast::{Comment, Program},
+};
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{SourceType, Span};
 
 use crate::ExportInfo;
 use crate::ModuleInfo;
@@ -17,7 +20,7 @@ use crate::mdx::{is_mdx_file, parse_mdx_to_module};
 use crate::sfc::{is_sfc_file, parse_sfc_to_module};
 use crate::visitor::{ModuleInfoExtractor, RouteLoadHarvestMode};
 use fallow_types::discover::FileId;
-use fallow_types::extract::{FlagUse, FunctionComplexity, ImportInfo, VisibilityTag};
+use fallow_types::extract::{FlagUse, FunctionComplexity, ImportInfo, ImportedName, VisibilityTag};
 
 struct JsxRetryParse {
     extractor: ModuleInfoExtractor,
@@ -234,6 +237,7 @@ fn build_primary_extractor(
         collect_glimmer_template_into_extractor(&mut extractor, path, source);
     let semantic_usage =
         compute_semantic_usage(program, &extractor.imports, &template_used_imports);
+    extractor.resolve_vitest_replacement_candidates(&semantic_usage.vitest_vi_reference_spans);
     (extractor, semantic_usage)
 }
 
@@ -377,6 +381,7 @@ fn parse_with_jsx_retry(input: &JsxRetryInput<'_>) -> Option<JsxRetryParse> {
         &extractor.imports,
         &template_used_imports,
     );
+    extractor.resolve_vitest_replacement_candidates(&semantic_usage.vitest_vi_reference_spans);
     let complexity = retry_complexity(
         input.need_complexity,
         &retry_return.program,
@@ -1084,6 +1089,7 @@ pub struct ImportBindingUsage {
 pub struct SemanticUsage {
     pub import_binding_usage: ImportBindingUsage,
     pub auto_import_candidates: Vec<String>,
+    pub(crate) vitest_vi_reference_spans: rustc_hash::FxHashSet<Span>,
 }
 
 pub fn compute_semantic_usage(
@@ -1142,6 +1148,8 @@ pub fn compute_semantic_usage(
     let mut value_referenced_bindings: Vec<String> =
         value_referenced_bindings.into_iter().collect();
     value_referenced_bindings.sort_unstable();
+    let vitest_vi_reference_spans =
+        compute_vitest_vi_reference_spans(&semantic, imports, root_scope);
 
     SemanticUsage {
         import_binding_usage: ImportBindingUsage {
@@ -1150,7 +1158,41 @@ pub fn compute_semantic_usage(
             value_referenced: value_referenced_bindings,
         },
         auto_import_candidates: compute_auto_import_candidates_from_semantic(scoping),
+        vitest_vi_reference_spans,
     }
+}
+
+fn compute_vitest_vi_reference_spans(
+    semantic: &oxc_semantic::Semantic<'_>,
+    imports: &[ImportInfo],
+    root_scope: oxc_semantic::ScopeId,
+) -> rustc_hash::FxHashSet<Span> {
+    let has_direct_vitest_import = imports.iter().any(|import| {
+        import.source == "vitest"
+            && import.local_name == "vi"
+            && !import.is_type_only
+            && matches!(&import.imported_name, ImportedName::Named(name) if name == "vi")
+    });
+    if !has_direct_vitest_import {
+        return rustc_hash::FxHashSet::default();
+    }
+
+    let scoping = semantic.scoping();
+    let Some(symbol_id) = scoping.get_binding(root_scope, oxc_str::Ident::from("vi")) else {
+        return rustc_hash::FxHashSet::default();
+    };
+
+    scoping
+        .get_resolved_references(symbol_id)
+        .filter_map(|reference| {
+            let AstKind::IdentifierReference(identifier) =
+                semantic.nodes().kind(reference.node_id())
+            else {
+                return None;
+            };
+            Some(identifier.span)
+        })
+        .collect()
 }
 
 pub fn compute_auto_import_candidates(program: &Program<'_>) -> Vec<String> {

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -374,6 +374,45 @@ fn vitest_non_replacement_forms_abstain() {
 }
 
 #[test]
+fn vitest_replacement_uses_final_mock_operation_per_target() {
+    for source in [
+        r#"import { vi } from "vitest"; vi.mock("./dep", () => ({})); vi.unmock("./dep");"#,
+        r#"import { vi } from "vitest"; vi.mock("./dep", () => ({})); vi.mock("./dep", importOriginal => importOriginal());"#,
+        r#"import { vi } from "vitest"; vi.mock("./dep", () => ({})); vi.mock("./dep", async () => loadOriginal());"#,
+    ] {
+        let info = parse_source(source);
+        assert!(
+            replaced_module_targets(&info).is_empty(),
+            "a final non-replacement operation must clear earlier proof: {source}"
+        );
+    }
+
+    let info = parse_source(
+        r#"
+        import { vi } from "vitest";
+        vi.unmock("./dep");
+        vi.mock("./dep", () => ({ request: vi.fn() }));
+        "#,
+    );
+    assert_eq!(replaced_module_targets(&info), vec!["./dep"]);
+}
+
+#[test]
+fn shadowed_vitest_operations_do_not_change_imported_vi_state() {
+    let info = parse_source(
+        r#"
+        import { vi } from "vitest";
+        vi.mock("./dep", () => ({}));
+        function configure(vi) {
+          vi.unmock("./dep");
+        }
+        "#,
+    );
+
+    assert_eq!(replaced_module_targets(&info), vec!["./dep"]);
+}
+
+#[test]
 fn dynamic_import_await_captures_local_name() {
     let info = parse_source(
         "async function f() { const mod = await import('./service'); mod.doStuff(); }",

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -1,4 +1,15 @@
 use crate::tests::parse_ts as parse_source;
+use crate::{ModuleInfo, SemanticFact};
+
+fn replaced_module_targets(info: &ModuleInfo) -> Vec<&str> {
+    info.semantic_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            SemanticFact::ReplacedModuleTarget(target) => Some(target.source.as_str()),
+            _ => None,
+        })
+        .collect()
+}
 
 #[test]
 fn extracts_template_literal_dynamic_import_pattern() {
@@ -228,6 +239,58 @@ fn vitest_mock_with_options_object_still_synthesizes_auto_mock() {
         .find(|imp| imp.source == "./services/__mocks__/api")
         .expect("auto-mock import should be recorded");
     assert_eq!(auto_mock.local_name, Some(String::new()));
+}
+
+#[test]
+fn vitest_replacement_factory_records_typed_target() {
+    let info = parse_source(
+        r#"
+        import { vi } from "vitest";
+        vi.mock("./services/api", () => ({ request: vi.fn() }));
+        "#,
+    );
+
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+    assert_eq!(
+        info.dynamic_imports
+            .iter()
+            .map(|import| import.source.as_str())
+            .collect::<Vec<_>>(),
+        vec!["./services/api"],
+        "the ordinary dependency edge remains intact"
+    );
+}
+
+#[test]
+fn vitest_function_replacement_supports_import_expression_target() {
+    let info = parse_source(
+        r#"
+        import { vi } from "vitest";
+        vi.mock(import("./services/api"), function () {
+          return { request: vi.fn() };
+        });
+        "#,
+    );
+
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+}
+
+#[test]
+fn vitest_non_replacement_forms_abstain() {
+    for source in [
+        r#"import { vi } from "vitest"; vi.mock("./auto");"#,
+        r#"import { vi } from "vitest"; vi.mock("./spy", { spy: true });"#,
+        r#"import { vi } from "vitest"; vi.mock("./partial", (importOriginal) => importOriginal());"#,
+        r#"import { vi } from "vitest"; vi.mock("./actual", async () => vi.importActual("./actual"));"#,
+        r#"const vi = localMockApi; vi.mock("./local", () => ({}));"#,
+        r#"vi.mock("./global", () => ({}));"#,
+    ] {
+        let info = parse_source(source);
+        assert!(
+            replaced_module_targets(&info).is_empty(),
+            "ambiguous or original-loading form should abstain: {source}"
+        );
+    }
 }
 
 #[test]

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -356,6 +356,12 @@ fn vitest_non_replacement_forms_abstain() {
         r#"import { vi } from "vitest"; vi.mock("./destructured", async () => { const { importActual: loadActual } = vi; return loadActual("./destructured"); });"#,
         r#"import { vi } from "vitest"; vi.mock("./call", async () => vi.importActual.call(vi, "./call"));"#,
         r#"import { vi } from "vitest"; vi.mock("./reflect", async () => Reflect.apply(vi.importActual, vi, ["./reflect"]));"#,
+        r#"import { vi } from "vitest"; vi.mock("./arguments", function () { return arguments[0](); });"#,
+        r#"import { vi } from "vitest"; const loadOriginal = () => vi.importActual("./helper"); vi.mock("./helper", async () => loadOriginal());"#,
+        r#"import { vi } from "vitest"; import { loadOriginal } from "./loader"; vi.mock("./external-helper", async () => loadOriginal());"#,
+        r#"import { vi } from "vitest"; vi.mock("./dynamic", async () => import("./dynamic"));"#,
+        r#"import { vi } from "vitest"; vi.mock("./constructed", () => new Replacement());"#,
+        r#"import { vi } from "vitest"; const localVi = vi; vi.mock("./local-vi", () => ({ request: localVi.fn() }));"#,
         r#"const vi = localMockApi; vi.mock("./local", () => ({}));"#,
         r#"vi.mock("./global", () => ({}));"#,
     ] {

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -352,6 +352,10 @@ fn vitest_non_replacement_forms_abstain() {
         r#"import { vi } from "vitest"; vi.mock("./partial", (importOriginal) => importOriginal());"#,
         r#"import { vi } from "vitest"; vi.mock("./actual", async () => vi.importActual("./actual"));"#,
         r#"import { vi } from "vitest"; vi.mock("./computed", async () => vi["importActual"]("./computed"));"#,
+        r#"import { vi } from "vitest"; vi.mock("./alias", async () => { const loadActual = vi.importActual; return loadActual("./alias"); });"#,
+        r#"import { vi } from "vitest"; vi.mock("./destructured", async () => { const { importActual: loadActual } = vi; return loadActual("./destructured"); });"#,
+        r#"import { vi } from "vitest"; vi.mock("./call", async () => vi.importActual.call(vi, "./call"));"#,
+        r#"import { vi } from "vitest"; vi.mock("./reflect", async () => Reflect.apply(vi.importActual, vi, ["./reflect"]));"#,
         r#"const vi = localMockApi; vi.mock("./local", () => ({}));"#,
         r#"vi.mock("./global", () => ({}));"#,
     ] {

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -1,5 +1,5 @@
 use crate::tests::parse_ts as parse_source;
-use crate::{ModuleInfo, SemanticFact};
+use crate::{ModuleInfo, ModuleLoadMechanism, SemanticFact};
 
 fn replaced_module_targets(info: &ModuleInfo) -> Vec<&str> {
     info.semantic_facts
@@ -20,6 +20,10 @@ fn extracts_template_literal_dynamic_import_pattern() {
         info.dynamic_import_patterns[0].suffix,
         Some(".json".to_string())
     );
+    assert_eq!(
+        info.dynamic_import_patterns[0].mechanism,
+        ModuleLoadMechanism::EsModule
+    );
 }
 
 #[test]
@@ -28,6 +32,10 @@ fn extracts_concat_dynamic_import_pattern() {
     assert_eq!(info.dynamic_import_patterns.len(), 1);
     assert_eq!(info.dynamic_import_patterns[0].prefix, "./pages/");
     assert!(info.dynamic_import_patterns[0].suffix.is_none());
+    assert_eq!(
+        info.dynamic_import_patterns[0].mechanism,
+        ModuleLoadMechanism::EsModule
+    );
 }
 
 #[test]
@@ -78,6 +86,10 @@ fn extracts_import_meta_glob_pattern() {
     let info = parse_source("const mods = import.meta.glob('./components/*.tsx');");
     assert_eq!(info.dynamic_import_patterns.len(), 1);
     assert_eq!(info.dynamic_import_patterns[0].prefix, "./components/*.tsx");
+    assert_eq!(
+        info.dynamic_import_patterns[0].mechanism,
+        ModuleLoadMechanism::EsModule
+    );
 }
 
 #[test]
@@ -86,6 +98,11 @@ fn extracts_import_meta_glob_array() {
     assert_eq!(info.dynamic_import_patterns.len(), 2);
     assert_eq!(info.dynamic_import_patterns[0].prefix, "./pages/*.ts");
     assert_eq!(info.dynamic_import_patterns[1].prefix, "./layouts/*.ts");
+    assert!(
+        info.dynamic_import_patterns
+            .iter()
+            .all(|pattern| pattern.mechanism == ModuleLoadMechanism::EsModule)
+    );
 }
 
 #[test]
@@ -93,6 +110,10 @@ fn extracts_require_context_pattern() {
     let info = parse_source("const ctx = require.context('./icons', false);");
     assert_eq!(info.dynamic_import_patterns.len(), 1);
     assert_eq!(info.dynamic_import_patterns[0].prefix, "./icons/");
+    assert_eq!(
+        info.dynamic_import_patterns[0].mechanism,
+        ModuleLoadMechanism::CommonJsRequire
+    );
 }
 
 #[test]
@@ -100,6 +121,10 @@ fn extracts_require_context_recursive() {
     let info = parse_source("const ctx = require.context('./icons', true);");
     assert_eq!(info.dynamic_import_patterns.len(), 1);
     assert_eq!(info.dynamic_import_patterns[0].prefix, "./icons/**/");
+    assert_eq!(
+        info.dynamic_import_patterns[0].mechanism,
+        ModuleLoadMechanism::CommonJsRequire
+    );
 }
 
 #[test]

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -262,6 +262,50 @@ fn vitest_replacement_factory_records_typed_target() {
 }
 
 #[test]
+fn vitest_replacement_import_provenance_is_order_independent() {
+    let info = parse_source(
+        r#"
+        vi.mock("./services/api", () => ({ request: vi.fn() }));
+        import { vi } from "vitest";
+        "#,
+    );
+
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+}
+
+#[test]
+fn vitest_replacement_shadowed_bindings_abstain() {
+    for source in [
+        r#"
+        import { vi } from "vitest";
+        function register(vi: { mock: Function }) {
+          vi.mock("./parameter", () => ({}));
+        }
+        "#,
+        r#"
+        import { vi } from "vitest";
+        {
+          const vi = localMockApi;
+          vi.mock("./block", () => ({}));
+        }
+        "#,
+        r#"
+        import { vi } from "vitest";
+        function register() {
+          const vi = localMockApi;
+          vi.mock("./local", () => ({}));
+        }
+        "#,
+    ] {
+        let info = parse_source(source);
+        assert!(
+            replaced_module_targets(&info).is_empty(),
+            "a shadowed vi binding must not emit a Vitest replacement: {source}"
+        );
+    }
+}
+
+#[test]
 fn vitest_function_replacement_supports_import_expression_target() {
     let info = parse_source(
         r#"
@@ -282,6 +326,7 @@ fn vitest_non_replacement_forms_abstain() {
         r#"import { vi } from "vitest"; vi.mock("./spy", { spy: true });"#,
         r#"import { vi } from "vitest"; vi.mock("./partial", (importOriginal) => importOriginal());"#,
         r#"import { vi } from "vitest"; vi.mock("./actual", async () => vi.importActual("./actual"));"#,
+        r#"import { vi } from "vitest"; vi.mock("./computed", async () => vi["importActual"]("./computed"));"#,
         r#"const vi = localMockApi; vi.mock("./local", () => ({}));"#,
         r#"vi.mock("./global", () => ({}));"#,
     ] {

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -1,11 +1,27 @@
 use crate::tests::parse_ts as parse_source;
-use crate::{ModuleInfo, ModuleLoadMechanism, SemanticFact};
+use crate::{ModuleInfo, ModuleLoadMechanism, SemanticFact, VitestModuleMockAction};
 
 fn replaced_module_targets(info: &ModuleInfo) -> Vec<&str> {
     info.semantic_facts
         .iter()
         .filter_map(|fact| match fact {
-            SemanticFact::ReplacedModuleTarget(target) => Some(target.source.as_str()),
+            SemanticFact::VitestModuleMockOperation(operation)
+                if operation.action.replaces_original() =>
+            {
+                Some(operation.source.as_str())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn vitest_mock_actions(info: &ModuleInfo) -> Vec<(&str, VitestModuleMockAction)> {
+    info.semantic_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            SemanticFact::VitestModuleMockOperation(operation) => {
+                Some((operation.source.as_str(), operation.action))
+            }
             _ => None,
         })
         .collect()
@@ -359,6 +375,7 @@ fn vitest_non_replacement_forms_abstain() {
         r#"import { vi } from "vitest"; vi.mock("./arguments", function () { return arguments[0](); });"#,
         r#"import { vi } from "vitest"; const loadOriginal = () => vi.importActual("./helper"); vi.mock("./helper", async () => loadOriginal());"#,
         r#"import { vi } from "vitest"; import { loadOriginal } from "./loader"; vi.mock("./external-helper", async () => loadOriginal());"#,
+        r#"import { vi } from "vitest"; const actual = await vi.importActual("./preloaded"); vi.mock("./preloaded", () => actual);"#,
         r#"import { vi } from "vitest"; vi.mock("./dynamic", async () => import("./dynamic"));"#,
         r#"import { vi } from "vitest"; vi.mock("./constructed", () => new Replacement());"#,
         r#"import { vi } from "vitest"; const localVi = vi; vi.mock("./local-vi", () => ({ request: localVi.fn() }));"#,
@@ -374,27 +391,33 @@ fn vitest_non_replacement_forms_abstain() {
 }
 
 #[test]
-fn vitest_replacement_uses_final_mock_operation_per_target() {
-    for source in [
-        r#"import { vi } from "vitest"; vi.mock("./dep", () => ({})); vi.unmock("./dep");"#,
-        r#"import { vi } from "vitest"; vi.mock("./dep", () => ({})); vi.mock("./dep", importOriginal => importOriginal());"#,
-        r#"import { vi } from "vitest"; vi.mock("./dep", () => ({})); vi.mock("./dep", async () => loadOriginal());"#,
-    ] {
-        let info = parse_source(source);
-        assert!(
-            replaced_module_targets(&info).is_empty(),
-            "a final non-replacement operation must clear earlier proof: {source}"
-        );
-    }
-
+fn vitest_mock_operations_preserve_typed_source_order() {
     let info = parse_source(
         r#"
         import { vi } from "vitest";
-        vi.unmock("./dep");
         vi.mock("./dep", () => ({ request: vi.fn() }));
+        vi.unmock("./dep.ts");
+        vi.mock("./dep", importOriginal => importOriginal());
         "#,
     );
-    assert_eq!(replaced_module_targets(&info), vec!["./dep"]);
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![
+            (
+                "./dep",
+                VitestModuleMockAction::Mock {
+                    factory_replaces_original: true,
+                },
+            ),
+            ("./dep.ts", VitestModuleMockAction::Unmock),
+            (
+                "./dep",
+                VitestModuleMockAction::Mock {
+                    factory_replaces_original: false,
+                },
+            ),
+        ]
+    );
 }
 
 #[test]

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -244,6 +244,12 @@ struct LitCustomElementCandidate {
 }
 
 #[derive(Debug, Clone)]
+pub(super) struct PendingVitestReplacement {
+    source: String,
+    vi_reference_span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct InlineTemplateFinding {
     pub(crate) template_source: String,
     pub(crate) decorator_start: u32,
@@ -260,6 +266,7 @@ pub(crate) struct ModuleInfoExtractor {
     package_path_references: Vec<String>,
     pub(crate) member_accesses: Vec<MemberAccess>,
     semantic_facts: Vec<SemanticFact>,
+    pending_vitest_replacements: Vec<PendingVitestReplacement>,
     pub(crate) whole_object_uses: Vec<String>,
     has_cjs_exports: bool,
     has_angular_component_template_url: bool,

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -247,6 +247,7 @@ struct LitCustomElementCandidate {
 pub(super) struct PendingVitestReplacement {
     source: String,
     vi_reference_span: Span,
+    factory_vi_reference_spans: Vec<Span>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -244,11 +244,18 @@ struct LitCustomElementCandidate {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct PendingVitestReplacement {
+pub(super) struct PendingVitestMockOperation {
     source: String,
     vi_reference_span: Span,
     call_start: u32,
-    factory_vi_reference_spans: Option<Vec<Span>>,
+    proof: PendingVitestMockProof,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum PendingVitestMockProof {
+    ClosedFactory { vi_reference_spans: Vec<Span> },
+    UnprovenMock,
+    Unmock,
 }
 
 #[derive(Debug, Clone)]
@@ -268,7 +275,7 @@ pub(crate) struct ModuleInfoExtractor {
     package_path_references: Vec<String>,
     pub(crate) member_accesses: Vec<MemberAccess>,
     semantic_facts: Vec<SemanticFact>,
-    pending_vitest_replacements: Vec<PendingVitestReplacement>,
+    pending_vitest_mock_operations: Vec<PendingVitestMockOperation>,
     pub(crate) whole_object_uses: Vec<String>,
     has_cjs_exports: bool,
     has_angular_component_template_url: bool,

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -247,7 +247,8 @@ struct LitCustomElementCandidate {
 pub(super) struct PendingVitestReplacement {
     source: String,
     vi_reference_span: Span,
-    factory_vi_reference_spans: Vec<Span>,
+    call_start: u32,
+    factory_vi_reference_spans: Option<Vec<Span>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2448,6 +2448,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
 
         self.bind_iterable_callback_parameter(expr);
         self.record_vitest_mock_imports(expr);
+        self.record_vitest_unmock(expr);
 
         self.try_record_pino_transport_targets(expr);
         self.try_record_node_module_register(expr);

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2446,7 +2446,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
 
         self.bind_iterable_callback_parameter(expr);
-        self.record_vitest_mock_dynamic_imports(expr);
+        self.record_vitest_mock_imports(expr);
 
         self.try_record_pino_transport_targets(expr);
         self.try_record_node_module_register(expr);

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crate::{
     DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, ImportInfo, ImportedName,
-    MemberAccess, ReExportInfo, RequireCallInfo, VisibilityTag,
+    MemberAccess, ModuleLoadMechanism, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
 use fallow_types::extract::{
     AngularComponentSelector, CalleeUse, ClassHeritageInfo, DiFramework, DiKeySite, DiRole,
@@ -2351,6 +2351,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                             prefix,
                             suffix,
                             span: expr.span,
+                            mechanism: ModuleLoadMechanism::EsModule,
                         });
                     }
                 }

--- a/crates/extract/src/visitor/visit_impl_dynamic_imports.rs
+++ b/crates/extract/src/visitor/visit_impl_dynamic_imports.rs
@@ -9,6 +9,7 @@ impl<'a> ModuleInfoExtractor {
                 prefix,
                 suffix: None,
                 span,
+                mechanism: ModuleLoadMechanism::EsModule,
             });
         }
     }
@@ -64,6 +65,7 @@ impl<'a> ModuleInfoExtractor {
                     prefix,
                     suffix,
                     span: expr.span,
+                    mechanism: ModuleLoadMechanism::CommonJsRequire,
                 });
             }
         }
@@ -189,6 +191,7 @@ impl<'a> ModuleInfoExtractor {
             prefix,
             suffix,
             span,
+            mechanism: ModuleLoadMechanism::EsModule,
         });
     }
 }

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -349,6 +349,76 @@ pub(super) fn vi_mock_has_factory(call: &CallExpression<'_>) -> bool {
     call.arguments.get(1).is_some_and(is_factory_arg)
 }
 
+/// Return the target of a Vitest mock whose factory provably replaces the
+/// original module without loading it.
+///
+/// Import provenance is checked by the caller. This helper stays conservative:
+/// factories with parameters can receive `importOriginal`, and a zero-argument
+/// factory can still call `vi.importActual`, so both shapes abstain.
+pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option<String> {
+    fn factory_has_no_parameters(argument: &Argument<'_>) -> Option<bool> {
+        fn expression_has_no_parameters(expression: &Expression<'_>) -> Option<bool> {
+            match expression {
+                Expression::ArrowFunctionExpression(factory) => {
+                    Some(factory.params.items.is_empty())
+                }
+                Expression::FunctionExpression(factory) => Some(factory.params.items.is_empty()),
+                Expression::ParenthesizedExpression(parenthesized) => {
+                    expression_has_no_parameters(&parenthesized.expression)
+                }
+                _ => None,
+            }
+        }
+
+        match argument {
+            Argument::ArrowFunctionExpression(factory) => Some(factory.params.items.is_empty()),
+            Argument::FunctionExpression(factory) => Some(factory.params.items.is_empty()),
+            Argument::ParenthesizedExpression(parenthesized) => {
+                expression_has_no_parameters(&parenthesized.expression)
+            }
+            _ => None,
+        }
+    }
+
+    struct ImportActualVisitor {
+        found: bool,
+    }
+
+    impl<'a> Visit<'a> for ImportActualVisitor {
+        fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+            if let Expression::StaticMemberExpression(member) = &call.callee
+                && member.property.name == "importActual"
+                && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+            {
+                self.found = true;
+                return;
+            }
+            walk::walk_call_expression(self, call);
+        }
+    }
+
+    let target = vitest_mock_source(call)?;
+    let factory = call.arguments.get(1)?;
+    if factory_has_no_parameters(factory) != Some(true) {
+        return None;
+    }
+
+    let mut import_actual = ImportActualVisitor { found: false };
+    match factory {
+        Argument::ArrowFunctionExpression(factory) => {
+            import_actual.visit_arrow_function_expression(factory)
+        }
+        Argument::FunctionExpression(factory) => {
+            import_actual.visit_function(factory, ScopeFlags::Function);
+        }
+        Argument::ParenthesizedExpression(parenthesized) => {
+            import_actual.visit_expression(&parenthesized.expression);
+        }
+        _ => return None,
+    }
+    (!import_actual.found).then_some(target)
+}
+
 /// Whether `callee` is a `useMemo` / `React.useMemo` reference.
 ///
 /// `useMemo(factory)` returns the factory's product directly, so

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -193,18 +193,7 @@ pub(super) fn is_private_member_key(key: &PropertyKey<'_>) -> bool {
 }
 
 pub(super) fn vitest_mock_source(call: &CallExpression<'_>) -> Option<String> {
-    let Expression::StaticMemberExpression(member) = &call.callee else {
-        return None;
-    };
-    if member.property.name != "mock" {
-        return None;
-    }
-    let Expression::Identifier(object) = &member.object else {
-        return None;
-    };
-    if object.name != "vi" {
-        return None;
-    }
+    vitest_mock_object_span(call)?;
 
     call.arguments.first().and_then(|argument| match argument {
         Argument::StringLiteral(value) => Some(value.value.to_string()),
@@ -218,6 +207,23 @@ pub(super) fn vitest_mock_source(call: &CallExpression<'_>) -> Option<String> {
         },
         _ => None,
     })
+}
+
+pub(super) fn vitest_mock_object_span(call: &CallExpression<'_>) -> Option<Span> {
+    let Expression::StaticMemberExpression(member) = &call.callee else {
+        return None;
+    };
+    if member.property.name != "mock" {
+        return None;
+    }
+    let Expression::Identifier(object) = &member.object else {
+        return None;
+    };
+    if object.name != "vi" {
+        return None;
+    }
+
+    Some(object.span)
 }
 
 pub(super) fn vitest_auto_mock_source(source: &str) -> Option<String> {
@@ -386,10 +392,20 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
 
     impl<'a> Visit<'a> for ImportActualVisitor {
         fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
-            if let Expression::StaticMemberExpression(member) = &call.callee
-                && member.property.name == "importActual"
-                && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
-            {
+            let loads_actual = match &call.callee {
+                Expression::StaticMemberExpression(member) => {
+                    member.property.name == "importActual"
+                        && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+                }
+                Expression::ComputedMemberExpression(member) => {
+                    member
+                        .static_property_name()
+                        .is_some_and(|name| name == "importActual")
+                        && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+                }
+                _ => false,
+            };
+            if loads_actual {
                 self.found = true;
                 return;
             }

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -355,13 +355,22 @@ pub(super) fn vi_mock_has_factory(call: &CallExpression<'_>) -> bool {
     call.arguments.get(1).is_some_and(is_factory_arg)
 }
 
-/// Return the target of a Vitest mock whose factory provably replaces the
-/// original module without loading it.
+#[derive(Debug)]
+pub(super) struct VitestReplacementCandidate {
+    pub(super) source: String,
+    pub(super) factory_vi_reference_spans: Vec<Span>,
+}
+
+/// Return a Vitest mock whose factory provably replaces the original module
+/// without loading it.
 ///
 /// Import provenance is checked by the caller. This helper stays conservative:
-/// factories with parameters can receive `importOriginal`, and a zero-argument
-/// factory can still call `vi.importActual`, so both shapes abstain.
-pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option<String> {
+/// factories with parameters can receive `importOriginal`; zero-argument
+/// factories abstain when they use `arguments`, construct values, dynamically
+/// import code, invoke an unproven helper, or call an original-module loader.
+pub(super) fn vitest_replacement_candidate(
+    call: &CallExpression<'_>,
+) -> Option<VitestReplacementCandidate> {
     fn factory_has_no_parameters(argument: &Argument<'_>) -> Option<bool> {
         fn expression_has_no_parameters(expression: &Expression<'_>) -> Option<bool> {
             match expression {
@@ -386,16 +395,53 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
         }
     }
 
-    struct ImportActualVisitor {
-        found: bool,
+    struct FactoryProofVisitor {
+        unsafe_escape: bool,
+        vi_reference_spans: Vec<Span>,
     }
 
-    impl<'a> Visit<'a> for ImportActualVisitor {
+    impl<'a> Visit<'a> for FactoryProofVisitor {
+        fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+            let Expression::StaticMemberExpression(member) = &call.callee else {
+                self.unsafe_escape = true;
+                return;
+            };
+            let Expression::Identifier(object) = &member.object else {
+                self.unsafe_escape = true;
+                return;
+            };
+            if object.name != "vi" || member.property.name != "fn" {
+                self.unsafe_escape = true;
+                return;
+            }
+
+            self.vi_reference_spans.push(object.span);
+            walk::walk_call_expression(self, call);
+        }
+
+        fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'a>) {
+            if identifier.name == "arguments" {
+                self.unsafe_escape = true;
+            }
+        }
+
+        fn visit_import_expression(&mut self, _expression: &ImportExpression<'a>) {
+            self.unsafe_escape = true;
+        }
+
+        fn visit_new_expression(&mut self, _expression: &NewExpression<'a>) {
+            self.unsafe_escape = true;
+        }
+
+        fn visit_tagged_template_expression(&mut self, _expression: &TaggedTemplateExpression<'a>) {
+            self.unsafe_escape = true;
+        }
+
         fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
             if member.property.name == "importActual"
                 && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
             {
-                self.found = true;
+                self.unsafe_escape = true;
                 return;
             }
             walk::walk_static_member_expression(self, member);
@@ -407,7 +453,7 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
                 .is_some_and(|name| name == "importActual")
                 && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
             {
-                self.found = true;
+                self.unsafe_escape = true;
                 return;
             }
             walk::walk_computed_member_expression(self, member);
@@ -424,7 +470,7 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
                         .is_some_and(|name| name == "importActual")
                 })
             {
-                self.found = true;
+                self.unsafe_escape = true;
                 return;
             }
             walk::walk_variable_declarator(self, declarator);
@@ -437,20 +483,26 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
         return None;
     }
 
-    let mut import_actual = ImportActualVisitor { found: false };
+    let mut proof = FactoryProofVisitor {
+        unsafe_escape: false,
+        vi_reference_spans: Vec::new(),
+    };
     match factory {
         Argument::ArrowFunctionExpression(factory) => {
-            import_actual.visit_arrow_function_expression(factory);
+            proof.visit_arrow_function_expression(factory);
         }
         Argument::FunctionExpression(factory) => {
-            import_actual.visit_function(factory, ScopeFlags::Function);
+            proof.visit_function(factory, ScopeFlags::Function);
         }
         Argument::ParenthesizedExpression(parenthesized) => {
-            import_actual.visit_expression(&parenthesized.expression);
+            proof.visit_expression(&parenthesized.expression);
         }
         _ => return None,
     }
-    (!import_actual.found).then_some(target)
+    (!proof.unsafe_escape).then_some(VitestReplacementCandidate {
+        source: target,
+        factory_vi_reference_spans: proof.vi_reference_spans,
+    })
 }
 
 /// Whether `callee` is a `useMemo` / `React.useMemo` reference.

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -391,25 +391,48 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
     }
 
     impl<'a> Visit<'a> for ImportActualVisitor {
-        fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
-            let loads_actual = match &call.callee {
-                Expression::StaticMemberExpression(member) => {
-                    member.property.name == "importActual"
-                        && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
-                }
-                Expression::ComputedMemberExpression(member) => {
-                    member
-                        .static_property_name()
-                        .is_some_and(|name| name == "importActual")
-                        && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
-                }
-                _ => false,
-            };
-            if loads_actual {
+        fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
+            if member.property.name == "importActual"
+                && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+            {
                 self.found = true;
                 return;
             }
-            walk::walk_call_expression(self, call);
+            walk::walk_static_member_expression(self, member);
+        }
+
+        fn visit_computed_member_expression(&mut self, member: &ComputedMemberExpression<'a>) {
+            if member
+                .static_property_name()
+                .is_some_and(|name| name == "importActual")
+                && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+            {
+                self.found = true;
+                return;
+            }
+            walk::walk_computed_member_expression(self, member);
+        }
+
+        fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
+            if let (
+                BindingPattern::ObjectPattern(pattern),
+                Some(Expression::Identifier(object)),
+            ) = (&declarator.id, &declarator.init)
+                && object.name == "vi"
+                && pattern
+                    .properties
+                    .iter()
+                    .any(|property| {
+                        property
+                            .key
+                            .static_name()
+                            .is_some_and(|name| name == "importActual")
+                    })
+            {
+                self.found = true;
+                return;
+            }
+            walk::walk_variable_declarator(self, declarator);
         }
     }
 

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -414,20 +414,15 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
         }
 
         fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
-            if let (
-                BindingPattern::ObjectPattern(pattern),
-                Some(Expression::Identifier(object)),
-            ) = (&declarator.id, &declarator.init)
+            if let (BindingPattern::ObjectPattern(pattern), Some(Expression::Identifier(object))) =
+                (&declarator.id, &declarator.init)
                 && object.name == "vi"
-                && pattern
-                    .properties
-                    .iter()
-                    .any(|property| {
-                        property
-                            .key
-                            .static_name()
-                            .is_some_and(|name| name == "importActual")
-                    })
+                && pattern.properties.iter().any(|property| {
+                    property
+                        .key
+                        .static_name()
+                        .is_some_and(|name| name == "importActual")
+                })
             {
                 self.found = true;
                 return;

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -406,7 +406,7 @@ pub(super) fn vitest_replaced_module_source(call: &CallExpression<'_>) -> Option
     let mut import_actual = ImportActualVisitor { found: false };
     match factory {
         Argument::ArrowFunctionExpression(factory) => {
-            import_actual.visit_arrow_function_expression(factory)
+            import_actual.visit_arrow_function_expression(factory);
         }
         Argument::FunctionExpression(factory) => {
             import_actual.visit_function(factory, ScopeFlags::Function);

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -193,8 +193,16 @@ pub(super) fn is_private_member_key(key: &PropertyKey<'_>) -> bool {
 }
 
 pub(super) fn vitest_mock_source(call: &CallExpression<'_>) -> Option<String> {
-    vitest_mock_object_span(call)?;
+    vitest_method_object_span(call, "mock")?;
+    vitest_static_target_source(call)
+}
 
+pub(super) fn vitest_unmock_source(call: &CallExpression<'_>) -> Option<String> {
+    vitest_method_object_span(call, "unmock")?;
+    vitest_static_target_source(call)
+}
+
+fn vitest_static_target_source(call: &CallExpression<'_>) -> Option<String> {
     call.arguments.first().and_then(|argument| match argument {
         Argument::StringLiteral(value) => Some(value.value.to_string()),
         Argument::TemplateLiteral(value) if value.expressions.is_empty() => value
@@ -210,10 +218,18 @@ pub(super) fn vitest_mock_source(call: &CallExpression<'_>) -> Option<String> {
 }
 
 pub(super) fn vitest_mock_object_span(call: &CallExpression<'_>) -> Option<Span> {
+    vitest_method_object_span(call, "mock")
+}
+
+pub(super) fn vitest_unmock_object_span(call: &CallExpression<'_>) -> Option<Span> {
+    vitest_method_object_span(call, "unmock")
+}
+
+fn vitest_method_object_span(call: &CallExpression<'_>, expected_method: &str) -> Option<Span> {
     let Expression::StaticMemberExpression(member) = &call.callee else {
         return None;
     };
-    if member.property.name != "mock" {
+    if member.property.name != expected_method {
         return None;
     }
     let Expression::Identifier(object) = &member.object else {
@@ -357,7 +373,6 @@ pub(super) fn vi_mock_has_factory(call: &CallExpression<'_>) -> bool {
 
 #[derive(Debug)]
 pub(super) struct VitestReplacementCandidate {
-    pub(super) source: String,
     pub(super) factory_vi_reference_spans: Vec<Span>,
 }
 
@@ -477,7 +492,7 @@ pub(super) fn vitest_replacement_candidate(
         }
     }
 
-    let target = vitest_mock_source(call)?;
+    vitest_mock_source(call)?;
     let factory = call.arguments.get(1)?;
     if factory_has_no_parameters(factory) != Some(true) {
         return None;
@@ -500,7 +515,6 @@ pub(super) fn vitest_replacement_candidate(
         _ => return None,
     }
     (!proof.unsafe_escape).then_some(VitestReplacementCandidate {
-        source: target,
         factory_vi_reference_spans: proof.vi_reference_spans,
     })
 }

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -419,12 +419,13 @@ impl<'a> Visit<'a> for VitestFactoryProofVisitor {
             return;
         }
 
-        self.vi_reference_spans.push(object.span);
         walk::walk_call_expression(self, call);
     }
 
     fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'a>) {
-        if identifier.name == "arguments" {
+        if identifier.name == "vi" {
+            self.vi_reference_spans.push(identifier.span);
+        } else {
             self.unsafe_escape = true;
         }
     }
@@ -486,8 +487,9 @@ impl<'a> Visit<'a> for VitestFactoryProofVisitor {
 ///
 /// Import provenance is checked by the caller. This helper stays conservative:
 /// factories with parameters can receive `importOriginal`; zero-argument
-/// factories abstain when they use `arguments`, construct values, dynamically
-/// import code, invoke an unproven helper, or call an original-module loader.
+/// factories abstain when they depend on any value other than the imported
+/// `vi`, construct values, dynamically import code, invoke an unproven helper,
+/// or call an original-module loader.
 pub(super) fn vitest_replacement_candidate(
     call: &CallExpression<'_>,
 ) -> Option<VitestReplacementCandidate> {

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -376,6 +376,111 @@ pub(super) struct VitestReplacementCandidate {
     pub(super) factory_vi_reference_spans: Vec<Span>,
 }
 
+fn vitest_factory_has_no_parameters(argument: &Argument<'_>) -> Option<bool> {
+    fn expression_has_no_parameters(expression: &Expression<'_>) -> Option<bool> {
+        match expression {
+            Expression::ArrowFunctionExpression(factory) => Some(factory.params.items.is_empty()),
+            Expression::FunctionExpression(factory) => Some(factory.params.items.is_empty()),
+            Expression::ParenthesizedExpression(parenthesized) => {
+                expression_has_no_parameters(&parenthesized.expression)
+            }
+            _ => None,
+        }
+    }
+
+    match argument {
+        Argument::ArrowFunctionExpression(factory) => Some(factory.params.items.is_empty()),
+        Argument::FunctionExpression(factory) => Some(factory.params.items.is_empty()),
+        Argument::ParenthesizedExpression(parenthesized) => {
+            expression_has_no_parameters(&parenthesized.expression)
+        }
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+struct VitestFactoryProofVisitor {
+    unsafe_escape: bool,
+    vi_reference_spans: Vec<Span>,
+}
+
+impl<'a> Visit<'a> for VitestFactoryProofVisitor {
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            self.unsafe_escape = true;
+            return;
+        };
+        let Expression::Identifier(object) = &member.object else {
+            self.unsafe_escape = true;
+            return;
+        };
+        if object.name != "vi" || member.property.name != "fn" {
+            self.unsafe_escape = true;
+            return;
+        }
+
+        self.vi_reference_spans.push(object.span);
+        walk::walk_call_expression(self, call);
+    }
+
+    fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'a>) {
+        if identifier.name == "arguments" {
+            self.unsafe_escape = true;
+        }
+    }
+
+    fn visit_import_expression(&mut self, _expression: &ImportExpression<'a>) {
+        self.unsafe_escape = true;
+    }
+
+    fn visit_new_expression(&mut self, _expression: &NewExpression<'a>) {
+        self.unsafe_escape = true;
+    }
+
+    fn visit_tagged_template_expression(&mut self, _expression: &TaggedTemplateExpression<'a>) {
+        self.unsafe_escape = true;
+    }
+
+    fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
+        if member.property.name == "importActual"
+            && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+        {
+            self.unsafe_escape = true;
+            return;
+        }
+        walk::walk_static_member_expression(self, member);
+    }
+
+    fn visit_computed_member_expression(&mut self, member: &ComputedMemberExpression<'a>) {
+        if member
+            .static_property_name()
+            .is_some_and(|name| name == "importActual")
+            && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+        {
+            self.unsafe_escape = true;
+            return;
+        }
+        walk::walk_computed_member_expression(self, member);
+    }
+
+    fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
+        if let (BindingPattern::ObjectPattern(pattern), Some(Expression::Identifier(object))) =
+            (&declarator.id, &declarator.init)
+            && object.name == "vi"
+            && pattern.properties.iter().any(|property| {
+                property
+                    .key
+                    .static_name()
+                    .is_some_and(|name| name == "importActual")
+            })
+        {
+            self.unsafe_escape = true;
+            return;
+        }
+        walk::walk_variable_declarator(self, declarator);
+    }
+}
+
 /// Return a Vitest mock whose factory provably replaces the original module
 /// without loading it.
 ///
@@ -386,122 +491,13 @@ pub(super) struct VitestReplacementCandidate {
 pub(super) fn vitest_replacement_candidate(
     call: &CallExpression<'_>,
 ) -> Option<VitestReplacementCandidate> {
-    fn factory_has_no_parameters(argument: &Argument<'_>) -> Option<bool> {
-        fn expression_has_no_parameters(expression: &Expression<'_>) -> Option<bool> {
-            match expression {
-                Expression::ArrowFunctionExpression(factory) => {
-                    Some(factory.params.items.is_empty())
-                }
-                Expression::FunctionExpression(factory) => Some(factory.params.items.is_empty()),
-                Expression::ParenthesizedExpression(parenthesized) => {
-                    expression_has_no_parameters(&parenthesized.expression)
-                }
-                _ => None,
-            }
-        }
-
-        match argument {
-            Argument::ArrowFunctionExpression(factory) => Some(factory.params.items.is_empty()),
-            Argument::FunctionExpression(factory) => Some(factory.params.items.is_empty()),
-            Argument::ParenthesizedExpression(parenthesized) => {
-                expression_has_no_parameters(&parenthesized.expression)
-            }
-            _ => None,
-        }
-    }
-
-    struct FactoryProofVisitor {
-        unsafe_escape: bool,
-        vi_reference_spans: Vec<Span>,
-    }
-
-    impl<'a> Visit<'a> for FactoryProofVisitor {
-        fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
-            let Expression::StaticMemberExpression(member) = &call.callee else {
-                self.unsafe_escape = true;
-                return;
-            };
-            let Expression::Identifier(object) = &member.object else {
-                self.unsafe_escape = true;
-                return;
-            };
-            if object.name != "vi" || member.property.name != "fn" {
-                self.unsafe_escape = true;
-                return;
-            }
-
-            self.vi_reference_spans.push(object.span);
-            walk::walk_call_expression(self, call);
-        }
-
-        fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'a>) {
-            if identifier.name == "arguments" {
-                self.unsafe_escape = true;
-            }
-        }
-
-        fn visit_import_expression(&mut self, _expression: &ImportExpression<'a>) {
-            self.unsafe_escape = true;
-        }
-
-        fn visit_new_expression(&mut self, _expression: &NewExpression<'a>) {
-            self.unsafe_escape = true;
-        }
-
-        fn visit_tagged_template_expression(&mut self, _expression: &TaggedTemplateExpression<'a>) {
-            self.unsafe_escape = true;
-        }
-
-        fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
-            if member.property.name == "importActual"
-                && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
-            {
-                self.unsafe_escape = true;
-                return;
-            }
-            walk::walk_static_member_expression(self, member);
-        }
-
-        fn visit_computed_member_expression(&mut self, member: &ComputedMemberExpression<'a>) {
-            if member
-                .static_property_name()
-                .is_some_and(|name| name == "importActual")
-                && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
-            {
-                self.unsafe_escape = true;
-                return;
-            }
-            walk::walk_computed_member_expression(self, member);
-        }
-
-        fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
-            if let (BindingPattern::ObjectPattern(pattern), Some(Expression::Identifier(object))) =
-                (&declarator.id, &declarator.init)
-                && object.name == "vi"
-                && pattern.properties.iter().any(|property| {
-                    property
-                        .key
-                        .static_name()
-                        .is_some_and(|name| name == "importActual")
-                })
-            {
-                self.unsafe_escape = true;
-                return;
-            }
-            walk::walk_variable_declarator(self, declarator);
-        }
-    }
-
     vitest_mock_source(call)?;
     let factory = call.arguments.get(1)?;
-    if factory_has_no_parameters(factory) != Some(true) {
+    if vitest_factory_has_no_parameters(factory) != Some(true) {
         return None;
     }
 
-    let mut proof = FactoryProofVisitor {
-        unsafe_escape: false,
-        vi_reference_spans: Vec::new(),
-    };
+    let mut proof = VitestFactoryProofVisitor::default();
     match factory {
         Argument::ArrowFunctionExpression(factory) => {
             proof.visit_arrow_function_expression(factory);

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -4,11 +4,11 @@ use oxc_ast::ast::{
 
 use crate::{DynamicImportInfo, ReplacedModuleTargetFact, SemanticFact};
 
-use super::super::{ModuleInfoExtractor, PendingPlaywrightFactory};
+use super::super::{ModuleInfoExtractor, PendingPlaywrightFactory, PendingVitestReplacement};
 use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
-    playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source, vitest_mock_source,
-    vitest_replaced_module_source,
+    playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source,
+    vitest_mock_object_span, vitest_mock_source, vitest_replaced_module_source,
 };
 
 impl ModuleInfoExtractor {
@@ -251,13 +251,33 @@ impl ModuleInfoExtractor {
             });
         }
 
-        if self.is_named_import_from("vi", "vitest", "vi")
-            && let Some(source) = vitest_replaced_module_source(expr)
+        if let Some(source) = vitest_replaced_module_source(expr)
+            && let Some(vi_reference_span) = vitest_mock_object_span(expr)
         {
-            self.semantic_facts.push(SemanticFact::ReplacedModuleTarget(
-                ReplacedModuleTargetFact { source },
-            ));
+            self.pending_vitest_replacements
+                .push(PendingVitestReplacement {
+                    source,
+                    vi_reference_span,
+                });
         }
+    }
+
+    pub(crate) fn resolve_vitest_replacement_candidates(
+        &mut self,
+        vitest_vi_reference_spans: &rustc_hash::FxHashSet<oxc_span::Span>,
+    ) {
+        self.semantic_facts.extend(
+            self.pending_vitest_replacements
+                .drain(..)
+                .filter(|candidate| {
+                    vitest_vi_reference_spans.contains(&candidate.vi_reference_span)
+                })
+                .map(|candidate| {
+                    SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+                        source: candidate.source,
+                    })
+                }),
+        );
     }
 }
 

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -8,7 +8,7 @@ use super::super::{ModuleInfoExtractor, PendingPlaywrightFactory, PendingVitestR
 use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
     playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source,
-    vitest_mock_object_span, vitest_mock_source, vitest_replaced_module_source,
+    vitest_mock_object_span, vitest_mock_source, vitest_replacement_candidate,
 };
 
 impl ModuleInfoExtractor {
@@ -251,13 +251,14 @@ impl ModuleInfoExtractor {
             });
         }
 
-        if let Some(source) = vitest_replaced_module_source(expr)
+        if let Some(candidate) = vitest_replacement_candidate(expr)
             && let Some(vi_reference_span) = vitest_mock_object_span(expr)
         {
             self.pending_vitest_replacements
                 .push(PendingVitestReplacement {
-                    source,
+                    source: candidate.source,
                     vi_reference_span,
+                    factory_vi_reference_spans: candidate.factory_vi_reference_spans,
                 });
         }
     }
@@ -271,6 +272,10 @@ impl ModuleInfoExtractor {
                 .drain(..)
                 .filter(|candidate| {
                     vitest_vi_reference_spans.contains(&candidate.vi_reference_span)
+                        && candidate
+                            .factory_vi_reference_spans
+                            .iter()
+                            .all(|span| vitest_vi_reference_spans.contains(span))
                 })
                 .map(|candidate| {
                     SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -9,6 +9,7 @@ use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
     playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source,
     vitest_mock_object_span, vitest_mock_source, vitest_replacement_candidate,
+    vitest_unmock_object_span, vitest_unmock_source,
 };
 
 impl ModuleInfoExtractor {
@@ -251,14 +252,29 @@ impl ModuleInfoExtractor {
             });
         }
 
-        if let Some(candidate) = vitest_replacement_candidate(expr)
-            && let Some(vi_reference_span) = vitest_mock_object_span(expr)
+        if let Some(vi_reference_span) = vitest_mock_object_span(expr) {
+            let factory_vi_reference_spans = vitest_replacement_candidate(expr)
+                .map(|candidate| candidate.factory_vi_reference_spans);
+            self.pending_vitest_replacements
+                .push(PendingVitestReplacement {
+                    source: target_source,
+                    vi_reference_span,
+                    call_start: expr.span.start,
+                    factory_vi_reference_spans,
+                });
+        }
+    }
+
+    pub(super) fn record_vitest_unmock(&mut self, expr: &CallExpression<'_>) {
+        if let Some(source) = vitest_unmock_source(expr)
+            && let Some(vi_reference_span) = vitest_unmock_object_span(expr)
         {
             self.pending_vitest_replacements
                 .push(PendingVitestReplacement {
-                    source: candidate.source,
+                    source,
                     vi_reference_span,
-                    factory_vi_reference_spans: candidate.factory_vi_reference_spans,
+                    call_start: expr.span.start,
+                    factory_vi_reference_spans: None,
                 });
         }
     }
@@ -267,22 +283,42 @@ impl ModuleInfoExtractor {
         &mut self,
         vitest_vi_reference_spans: &rustc_hash::FxHashSet<oxc_span::Span>,
     ) {
-        self.semantic_facts.extend(
-            self.pending_vitest_replacements
-                .drain(..)
-                .filter(|candidate| {
-                    vitest_vi_reference_spans.contains(&candidate.vi_reference_span)
-                        && candidate
-                            .factory_vi_reference_spans
+        let mut operations: Vec<_> = self
+            .pending_vitest_replacements
+            .drain(..)
+            .filter(|operation| vitest_vi_reference_spans.contains(&operation.vi_reference_span))
+            .collect();
+        operations.sort_unstable_by_key(|operation| operation.call_start);
+
+        let mut final_operations = rustc_hash::FxHashMap::default();
+        for operation in operations {
+            final_operations.insert(operation.source.clone(), operation);
+        }
+
+        let mut replacements: Vec<_> = final_operations
+            .into_values()
+            .filter(|operation| {
+                operation
+                    .factory_vi_reference_spans
+                    .as_ref()
+                    .is_some_and(|spans| {
+                        spans
                             .iter()
                             .all(|span| vitest_vi_reference_spans.contains(span))
-                })
-                .map(|candidate| {
-                    SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
-                        source: candidate.source,
                     })
-                }),
-        );
+            })
+            .collect();
+        replacements.sort_unstable_by(|left, right| {
+            left.call_start
+                .cmp(&right.call_start)
+                .then_with(|| left.source.cmp(&right.source))
+        });
+        self.semantic_facts
+            .extend(replacements.into_iter().map(|operation| {
+                SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+                    source: operation.source,
+                })
+            }));
     }
 }
 

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -2,9 +2,14 @@ use oxc_ast::ast::{
     Argument, CallExpression, Expression, TSInterfaceDeclaration, TSType, TSTypeAliasDeclaration,
 };
 
-use crate::{DynamicImportInfo, ReplacedModuleTargetFact, SemanticFact};
+use crate::{
+    DynamicImportInfo, SemanticFact, VitestModuleMockAction, VitestModuleMockOperationFact,
+};
 
-use super::super::{ModuleInfoExtractor, PendingPlaywrightFactory, PendingVitestReplacement};
+use super::super::{
+    ModuleInfoExtractor, PendingPlaywrightFactory, PendingVitestMockOperation,
+    PendingVitestMockProof,
+};
 use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
     playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source,
@@ -253,14 +258,18 @@ impl ModuleInfoExtractor {
         }
 
         if let Some(vi_reference_span) = vitest_mock_object_span(expr) {
-            let factory_vi_reference_spans = vitest_replacement_candidate(expr)
-                .map(|candidate| candidate.factory_vi_reference_spans);
-            self.pending_vitest_replacements
-                .push(PendingVitestReplacement {
+            let proof = vitest_replacement_candidate(expr).map_or(
+                PendingVitestMockProof::UnprovenMock,
+                |candidate| PendingVitestMockProof::ClosedFactory {
+                    vi_reference_spans: candidate.factory_vi_reference_spans,
+                },
+            );
+            self.pending_vitest_mock_operations
+                .push(PendingVitestMockOperation {
                     source: target_source,
                     vi_reference_span,
                     call_start: expr.span.start,
-                    factory_vi_reference_spans,
+                    proof,
                 });
         }
     }
@@ -269,54 +278,46 @@ impl ModuleInfoExtractor {
         if let Some(source) = vitest_unmock_source(expr)
             && let Some(vi_reference_span) = vitest_unmock_object_span(expr)
         {
-            self.pending_vitest_replacements
-                .push(PendingVitestReplacement {
+            self.pending_vitest_mock_operations
+                .push(PendingVitestMockOperation {
                     source,
                     vi_reference_span,
                     call_start: expr.span.start,
-                    factory_vi_reference_spans: None,
+                    proof: PendingVitestMockProof::Unmock,
                 });
         }
     }
 
-    pub(crate) fn resolve_vitest_replacement_candidates(
+    pub(crate) fn resolve_vitest_mock_operations(
         &mut self,
         vitest_vi_reference_spans: &rustc_hash::FxHashSet<oxc_span::Span>,
     ) {
         let mut operations: Vec<_> = self
-            .pending_vitest_replacements
+            .pending_vitest_mock_operations
             .drain(..)
             .filter(|operation| vitest_vi_reference_spans.contains(&operation.vi_reference_span))
             .collect();
         operations.sort_unstable_by_key(|operation| operation.call_start);
 
-        let mut final_operations = rustc_hash::FxHashMap::default();
-        for operation in operations {
-            final_operations.insert(operation.source.clone(), operation);
-        }
-
-        let mut replacements: Vec<_> = final_operations
-            .into_values()
-            .filter(|operation| {
-                operation
-                    .factory_vi_reference_spans
-                    .as_ref()
-                    .is_some_and(|spans| {
-                        spans
-                            .iter()
-                            .all(|span| vitest_vi_reference_spans.contains(span))
-                    })
-            })
-            .collect();
-        replacements.sort_unstable_by(|left, right| {
-            left.call_start
-                .cmp(&right.call_start)
-                .then_with(|| left.source.cmp(&right.source))
-        });
         self.semantic_facts
-            .extend(replacements.into_iter().map(|operation| {
-                SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+            .extend(operations.into_iter().map(|operation| {
+                let action = match operation.proof {
+                    PendingVitestMockProof::ClosedFactory { vi_reference_spans } => {
+                        VitestModuleMockAction::Mock {
+                            factory_replaces_original: vi_reference_spans
+                                .iter()
+                                .all(|span| vitest_vi_reference_spans.contains(span)),
+                        }
+                    }
+                    PendingVitestMockProof::UnprovenMock => VitestModuleMockAction::Mock {
+                        factory_replaces_original: false,
+                    },
+                    PendingVitestMockProof::Unmock => VitestModuleMockAction::Unmock,
+                };
+                SemanticFact::VitestModuleMockOperation(VitestModuleMockOperationFact {
                     source: operation.source,
+                    call_start: operation.call_start,
+                    action,
                 })
             }));
     }

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -2,12 +2,13 @@ use oxc_ast::ast::{
     Argument, CallExpression, Expression, TSInterfaceDeclaration, TSType, TSTypeAliasDeclaration,
 };
 
-use crate::DynamicImportInfo;
+use crate::{DynamicImportInfo, ReplacedModuleTargetFact, SemanticFact};
 
 use super::super::{ModuleInfoExtractor, PendingPlaywrightFactory};
 use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
     playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source, vitest_mock_source,
+    vitest_replaced_module_source,
 };
 
 impl ModuleInfoExtractor {
@@ -225,7 +226,7 @@ impl ModuleInfoExtractor {
         }
     }
 
-    pub(super) fn record_vitest_mock_dynamic_imports(&mut self, expr: &CallExpression<'_>) {
+    pub(super) fn record_vitest_mock_imports(&mut self, expr: &CallExpression<'_>) {
         let Some(target_source) = vitest_mock_source(expr) else {
             return;
         };
@@ -248,6 +249,14 @@ impl ModuleInfoExtractor {
                 local_name: Some(String::new()),
                 is_speculative: true,
             });
+        }
+
+        if self.is_named_import_from("vi", "vitest", "vi")
+            && let Some(source) = vitest_replaced_module_source(expr)
+        {
+            self.semantic_facts.push(SemanticFact::ReplacedModuleTarget(
+                ReplacedModuleTargetFact { source },
+            ));
         }
     }
 }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -34,9 +34,9 @@ pub use store::GraphCacheStore;
 /// classification change replays the old classification verbatim on an
 /// unmodified tree and silently hides the new behaviour. The same applies to
 /// plugin config extraction, which seeds entry points and path aliases.
-/// Bumped to 8 for issue #2031: the resolver cache now persists the typed
-/// project-level replacement sidecar alongside ordinary resolved modules.
-pub const GRAPH_CACHE_VERSION: u32 = 8;
+/// Bumped to 9 for issue #2031: cached graphs now retain grouped, root-specific
+/// replacement masks and their test reachability results.
+pub const GRAPH_CACHE_VERSION: u32 = 9;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -34,9 +34,9 @@ pub use store::GraphCacheStore;
 /// classification change replays the old classification verbatim on an
 /// unmodified tree and silently hides the new behaviour. The same applies to
 /// plugin config extraction, which seeds entry points and path aliases.
-/// Bumped to 10 for issue #2031: cached resolver targets now distinguish bare
-/// CommonJS package edges before cross-tsconfig specifier upgrades.
-pub const GRAPH_CACHE_VERSION: u32 = 10;
+/// Bumped to 11 for issue #2031: cached graphs retain compact root-correlation
+/// profiles plus exact ESM/CommonJS reference and dynamic-pattern mechanisms.
+pub const GRAPH_CACHE_VERSION: u32 = 11;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -36,7 +36,10 @@ pub use store::GraphCacheStore;
 /// plugin config extraction, which seeds entry points and path aliases.
 /// Bumped to 11 for issue #2031: cached graphs retain compact root-correlation
 /// profiles plus exact ESM/CommonJS reference and dynamic-pattern mechanisms.
-pub const GRAPH_CACHE_VERSION: u32 = 11;
+///
+/// Bumped to 12: test profile masks use target-sparse rows and profiled
+/// reachability uses the bit-parallel worklist schema.
+pub const GRAPH_CACHE_VERSION: u32 = 12;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -48,7 +48,10 @@ pub use store::GraphCacheStore;
 ///
 /// Bumped to 15: Vitest mock and unmock state is selected after specifiers
 /// resolve, using the canonical target file rather than literal source text.
-pub const GRAPH_CACHE_VERSION: u32 = 15;
+///
+/// Bumped to 16: namespace references persist compact transition graphs
+/// instead of materialized simple re-export paths.
+pub const GRAPH_CACHE_VERSION: u32 = 16;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -39,7 +39,10 @@ pub use store::GraphCacheStore;
 ///
 /// Bumped to 12: test profile masks use target-sparse rows and profiled
 /// reachability uses the bit-parallel worklist schema.
-pub const GRAPH_CACHE_VERSION: u32 = 12;
+///
+/// Bumped to 13: export references now retain interned linked module-load paths
+/// so cached coverage checks include every re-export hop.
+pub const GRAPH_CACHE_VERSION: u32 = 13;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -31,7 +31,10 @@ pub use store::GraphCacheStore;
 /// classification change replays the old classification verbatim on an
 /// unmodified tree and silently hides the new behaviour. The same applies to
 /// plugin config extraction, which seeds entry points and path aliases.
-pub const GRAPH_CACHE_VERSION: u32 = 6;
+/// Bumped to 7 for issue #2031: internal CommonJS resolution results retain
+/// their import mechanism so test-time ESM replacement masks cannot suppress a
+/// genuine `require()` path.
+pub const GRAPH_CACHE_VERSION: u32 = 7;
 
 /// Cached form of a resolved target.
 ///
@@ -44,6 +47,8 @@ pub const GRAPH_CACHE_VERSION: u32 = 6;
 pub enum CachedResolveResult {
     /// Resolved to a file within the project.
     InternalModule(StableFileKey),
+    /// Resolved from CommonJS to a file within the project.
+    CommonJsInternalModule(StableFileKey),
     /// Resolved to a project file through a framework convention auto-import.
     SyntheticAutoImport(StableFileKey),
     /// Resolved to a workspace or self package source file.
@@ -51,6 +56,13 @@ pub enum CachedResolveResult {
         /// Stable source file reached by the package map.
         key: StableFileKey,
         /// Package name that was used in the import specifier.
+        package_name: String,
+    },
+    /// Resolved from CommonJS to workspace or self-package source.
+    CommonJsInternalPackageModule {
+        /// Stable source file reached by the package map.
+        key: StableFileKey,
+        /// Package name used in the require specifier.
         package_name: String,
     },
     /// Resolved to a file outside the project.
@@ -70,6 +82,9 @@ impl CachedResolveResult {
             ResolveResult::InternalModule(file_id) => {
                 Self::InternalModule(key_by_file_id.get(file_id)?.clone())
             }
+            ResolveResult::CommonJsInternalModule(file_id) => {
+                Self::CommonJsInternalModule(key_by_file_id.get(file_id)?.clone())
+            }
             ResolveResult::SyntheticAutoImport(file_id) => {
                 Self::SyntheticAutoImport(key_by_file_id.get(file_id)?.clone())
             }
@@ -77,6 +92,13 @@ impl CachedResolveResult {
                 file_id,
                 package_name,
             } => Self::InternalPackageModule {
+                key: key_by_file_id.get(file_id)?.clone(),
+                package_name: package_name.clone(),
+            },
+            ResolveResult::CommonJsInternalPackageModule {
+                file_id,
+                package_name,
+            } => Self::CommonJsInternalPackageModule {
                 key: key_by_file_id.get(file_id)?.clone(),
                 package_name: package_name.clone(),
             },
@@ -92,11 +114,20 @@ impl CachedResolveResult {
     ) -> Option<ResolveResult> {
         Some(match self {
             Self::InternalModule(key) => ResolveResult::InternalModule(*id_by_key.get(&key)?),
+            Self::CommonJsInternalModule(key) => {
+                ResolveResult::CommonJsInternalModule(*id_by_key.get(&key)?)
+            }
             Self::SyntheticAutoImport(key) => {
                 ResolveResult::SyntheticAutoImport(*id_by_key.get(&key)?)
             }
             Self::InternalPackageModule { key, package_name } => {
                 ResolveResult::InternalPackageModule {
+                    file_id: *id_by_key.get(&key)?,
+                    package_name,
+                }
+            }
+            Self::CommonJsInternalPackageModule { key, package_name } => {
+                ResolveResult::CommonJsInternalPackageModule {
                     file_id: *id_by_key.get(&key)?,
                     package_name,
                 }
@@ -830,6 +861,30 @@ mod tests {
                 file_id: FileId(9),
                 ref package_name,
             } if package_name == "@scope/pkg"
+        ));
+    }
+
+    #[test]
+    fn cached_resolve_result_preserves_commonjs_provenance() {
+        let key = StableFileKey::from_root_relative(
+            Path::new("/project"),
+            Path::new("/project/src/dependency.ts"),
+        );
+        let key_by_file_id = FxHashMap::from_iter([(FileId(3), key.clone())]);
+        let id_by_key = FxHashMap::from_iter([(key, FileId(8))]);
+
+        let cached = CachedResolveResult::from_resolve_result(
+            &ResolveResult::CommonJsInternalModule(FileId(3)),
+            &key_by_file_id,
+        )
+        .expect("CommonJS target should map to a stable key");
+        let restored = cached
+            .into_resolve_result(&id_by_key)
+            .expect("stable key should map to the current FileId");
+
+        assert!(matches!(
+            restored,
+            ResolveResult::CommonJsInternalModule(FileId(8))
         ));
     }
 

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -12,7 +12,10 @@ use fallow_types::extract::{ImportInfo, ReExportInfo};
 use fallow_types::source_fingerprint::SourceFingerprint;
 use oxc_span::Span;
 
-use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport};
+use crate::resolve::{
+    ResolveResult, ResolvedImport, ResolvedModule, ResolvedProject, ResolvedReExport,
+    ResolvedReplacedModuleTarget,
+};
 
 mod store;
 
@@ -31,10 +34,9 @@ pub use store::GraphCacheStore;
 /// classification change replays the old classification verbatim on an
 /// unmodified tree and silently hides the new behaviour. The same applies to
 /// plugin config extraction, which seeds entry points and path aliases.
-/// Bumped to 7 for issue #2031: internal CommonJS resolution results retain
-/// their import mechanism so test-time ESM replacement masks cannot suppress a
-/// genuine `require()` path.
-pub const GRAPH_CACHE_VERSION: u32 = 7;
+/// Bumped to 8 for issue #2031: the resolver cache now persists the typed
+/// project-level replacement sidecar alongside ordinary resolved modules.
+pub const GRAPH_CACHE_VERSION: u32 = 8;
 
 /// Cached form of a resolved target.
 ///
@@ -338,41 +340,102 @@ impl CachedResolvedModule {
     }
 }
 
-/// Convert resolved modules into the compact graph-cache resolver payload.
-#[must_use]
-pub fn cache_resolved_modules(
-    root: &Path,
-    files: &[DiscoveredFile],
-    resolved: &[ResolvedModule],
-) -> Option<Vec<CachedResolvedModule>> {
-    let key_by_file_id = stable_key_by_file_id(root, files);
-    resolved
-        .iter()
-        .map(|module| CachedResolvedModule::from_resolved(module, &key_by_file_id))
-        .collect()
+/// Stable-key cache form of one resolved project-internal replacement.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct CachedResolvedReplacedModuleTarget {
+    source_key: StableFileKey,
+    target_key: StableFileKey,
 }
 
-/// Restore resolved modules from cached resolver payloads and current parsed modules.
+impl CachedResolvedReplacedModuleTarget {
+    fn from_resolved(
+        target: ResolvedReplacedModuleTarget,
+        key_by_file_id: &rustc_hash::FxHashMap<FileId, StableFileKey>,
+    ) -> Option<Self> {
+        Some(Self {
+            source_key: key_by_file_id.get(&target.source_file)?.clone(),
+            target_key: key_by_file_id.get(&target.target_file)?.clone(),
+        })
+    }
+
+    fn into_resolved(
+        self,
+        id_by_key: &rustc_hash::FxHashMap<StableFileKey, FileId>,
+    ) -> Option<ResolvedReplacedModuleTarget> {
+        Some(ResolvedReplacedModuleTarget {
+            source_file: *id_by_key.get(&self.source_key)?,
+            target_file: *id_by_key.get(&self.target_key)?,
+        })
+    }
+}
+
+/// Cache-friendly mirror of the complete resolver output.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CachedResolvedProject {
+    modules: Vec<CachedResolvedModule>,
+    replaced_module_targets: Vec<CachedResolvedReplacedModuleTarget>,
+}
+
+/// Convert a resolved project into the compact graph-cache resolver payload.
+#[must_use]
+pub fn cache_resolved_project(
+    root: &Path,
+    files: &[DiscoveredFile],
+    resolved: &ResolvedProject,
+) -> Option<CachedResolvedProject> {
+    let key_by_file_id = stable_key_by_file_id(root, files);
+    let modules = resolved
+        .modules
+        .iter()
+        .map(|module| CachedResolvedModule::from_resolved(module, &key_by_file_id))
+        .collect::<Option<Vec<_>>>()?;
+    let replaced_module_targets = resolved
+        .replaced_module_targets
+        .iter()
+        .copied()
+        .map(|target| CachedResolvedReplacedModuleTarget::from_resolved(target, &key_by_file_id))
+        .collect::<Option<Vec<_>>>()?;
+    Some(CachedResolvedProject {
+        modules,
+        replaced_module_targets,
+    })
+}
+
+/// Restore a resolved project from cached resolver payloads and current parsed modules.
 ///
 /// Returns `None` if the payload no longer aligns with the current parse result.
 /// A normal graph-cache manifest hit should keep these aligned; this extra check
 /// keeps corrupt or hand-edited cache files on the safe miss path.
 #[must_use]
-pub fn restore_resolved_modules(
+pub fn restore_resolved_project(
     root: &Path,
     modules: &[fallow_types::extract::ModuleInfo],
     files: &[DiscoveredFile],
-    cached: &[CachedResolvedModule],
-) -> Option<Vec<ResolvedModule>> {
-    if modules.len() != cached.len() {
+    cached: &CachedResolvedProject,
+) -> Option<ResolvedProject> {
+    if modules.len() != cached.modules.len() {
         return None;
     }
 
     let mut indexes = RestoreResolvedModuleIndexes::new(root, modules, files);
-    cached
+    let resolved_modules = cached
+        .modules
         .iter()
         .map(|entry| restore_cached_resolved_module(entry, &mut indexes))
-        .collect()
+        .collect::<Option<Vec<_>>>()?;
+    let mut replaced_module_targets = cached
+        .replaced_module_targets
+        .iter()
+        .cloned()
+        .map(|target| target.into_resolved(&indexes.file_ids))
+        .collect::<Option<Vec<_>>>()?;
+    replaced_module_targets
+        .sort_unstable_by_key(|target| (target.source_file.0, target.target_file.0));
+    replaced_module_targets.dedup();
+    Some(ResolvedProject {
+        modules: resolved_modules,
+        replaced_module_targets,
+    })
 }
 
 struct RestoreResolvedModuleIndexes<'a> {
@@ -889,7 +952,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_resolved_modules_rejects_unknown_internal_targets() {
+    fn cache_resolved_project_rejects_unknown_internal_targets() {
         let files = vec![file(0, "/project/src/a.ts")];
         let module = ResolvedModule {
             file_id: FileId(0),
@@ -900,8 +963,67 @@ mod tests {
             }],
             ..ResolvedModule::default()
         };
+        let project = ResolvedProject {
+            modules: vec![module],
+            replaced_module_targets: Vec::new(),
+        };
 
-        let cached = cache_resolved_modules(Path::new("/project"), &files, &[module]);
+        let cached = cache_resolved_project(Path::new("/project"), &files, &project);
+
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn cached_replaced_target_remaps_both_file_ids_by_stable_key() {
+        let source_key = StableFileKey::from_root_relative(
+            Path::new("/project"),
+            Path::new("/project/src/example.test.ts"),
+        );
+        let target_key = StableFileKey::from_root_relative(
+            Path::new("/project"),
+            Path::new("/project/src/dependency.ts"),
+        );
+        let key_by_file_id = FxHashMap::from_iter([
+            (FileId(2), source_key.clone()),
+            (FileId(3), target_key.clone()),
+        ]);
+        let id_by_key = FxHashMap::from_iter([(source_key, FileId(8)), (target_key, FileId(9))]);
+        let resolved = ResolvedReplacedModuleTarget {
+            source_file: FileId(2),
+            target_file: FileId(3),
+        };
+
+        let cached = CachedResolvedReplacedModuleTarget::from_resolved(resolved, &key_by_file_id)
+            .expect("both file ids should map to stable keys");
+        let restored = cached
+            .into_resolved(&id_by_key)
+            .expect("both stable keys should map to current file ids");
+
+        assert_eq!(
+            restored,
+            ResolvedReplacedModuleTarget {
+                source_file: FileId(8),
+                target_file: FileId(9),
+            }
+        );
+    }
+
+    #[test]
+    fn cache_resolved_project_rejects_unknown_replacement_targets() {
+        let files = vec![file(0, "/project/src/example.test.ts")];
+        let project = ResolvedProject {
+            modules: vec![ResolvedModule {
+                file_id: FileId(0),
+                path: PathBuf::from("/project/src/example.test.ts"),
+                ..ResolvedModule::default()
+            }],
+            replaced_module_targets: vec![ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+        };
+
+        let cached = cache_resolved_project(Path::new("/project"), &files, &project);
 
         assert!(cached.is_none());
     }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -49,9 +49,9 @@ pub use store::GraphCacheStore;
 /// Bumped to 15: Vitest mock and unmock state is selected after specifiers
 /// resolve, using the canonical target file rather than literal source text.
 ///
-/// Bumped to 16: namespace references persist compact transition graphs
-/// instead of materialized simple re-export paths.
-pub const GRAPH_CACHE_VERSION: u32 = 16;
+/// Bumped to 17: legacy reachability omits unused reference provenance, while
+/// profiled reachability persists non-zero interned path identifiers.
+pub const GRAPH_CACHE_VERSION: u32 = 17;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -34,9 +34,9 @@ pub use store::GraphCacheStore;
 /// classification change replays the old classification verbatim on an
 /// unmodified tree and silently hides the new behaviour. The same applies to
 /// plugin config extraction, which seeds entry points and path aliases.
-/// Bumped to 9 for issue #2031: cached graphs now retain grouped, root-specific
-/// replacement masks and their test reachability results.
-pub const GRAPH_CACHE_VERSION: u32 = 9;
+/// Bumped to 10 for issue #2031: cached resolver targets now distinguish bare
+/// CommonJS package edges before cross-tsconfig specifier upgrades.
+pub const GRAPH_CACHE_VERSION: u32 = 10;
 
 /// Cached form of a resolved target.
 ///
@@ -71,6 +71,8 @@ pub enum CachedResolveResult {
     ExternalFile(PathBuf),
     /// Bare specifier.
     NpmPackage(String),
+    /// Bare specifier referenced through CommonJS `require()`.
+    CommonJsNpmPackage(String),
     /// Could not resolve.
     Unresolvable(String),
 }
@@ -106,6 +108,9 @@ impl CachedResolveResult {
             },
             ResolveResult::ExternalFile(path) => Self::ExternalFile(path.clone()),
             ResolveResult::NpmPackage(package_name) => Self::NpmPackage(package_name.clone()),
+            ResolveResult::CommonJsNpmPackage(package_name) => {
+                Self::CommonJsNpmPackage(package_name.clone())
+            }
             ResolveResult::Unresolvable(specifier) => Self::Unresolvable(specifier.clone()),
         })
     }
@@ -136,6 +141,9 @@ impl CachedResolveResult {
             }
             Self::ExternalFile(path) => ResolveResult::ExternalFile(path),
             Self::NpmPackage(package_name) => ResolveResult::NpmPackage(package_name),
+            Self::CommonJsNpmPackage(package_name) => {
+                ResolveResult::CommonJsNpmPackage(package_name)
+            }
             Self::Unresolvable(specifier) => ResolveResult::Unresolvable(specifier),
         })
     }
@@ -948,6 +956,24 @@ mod tests {
         assert!(matches!(
             restored,
             ResolveResult::CommonJsInternalModule(FileId(8))
+        ));
+    }
+
+    #[test]
+    fn cached_resolve_result_preserves_commonjs_bare_package_provenance() {
+        let cached = CachedResolveResult::from_resolve_result(
+            &ResolveResult::CommonJsNpmPackage("shared-package".to_string()),
+            &FxHashMap::default(),
+        )
+        .expect("bare CommonJS package should not need a stable file key");
+        let restored = cached
+            .into_resolve_result(&FxHashMap::default())
+            .expect("bare CommonJS package should restore without a file map");
+
+        assert!(matches!(
+            restored,
+            ResolveResult::CommonJsNpmPackage(package_name)
+                if package_name == "shared-package"
         ));
     }
 

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -34,23 +34,13 @@ pub use store::GraphCacheStore;
 /// classification change replays the old classification verbatim on an
 /// unmodified tree and silently hides the new behaviour. The same applies to
 /// plugin config extraction, which seeds entry points and path aliases.
-/// Bumped to 11 for issue #2031: cached graphs retain compact root-correlation
-/// profiles plus exact ESM/CommonJS reference and dynamic-pattern mechanisms.
 ///
-/// Bumped to 12: test profile masks use target-sparse rows and profiled
-/// reachability uses the bit-parallel worklist schema.
-///
-/// Bumped to 13: export references now retain interned linked module-load paths
-/// so cached coverage checks include every re-export hop.
-///
-/// Bumped to 14: namespace-derived references retain the exact consumer and
-/// re-export path instead of collapsing onto the ultimate target.
-///
-/// Bumped to 15: Vitest mock and unmock state is selected after specifiers
-/// resolve, using the canonical target file rather than literal source text.
-///
-/// Bumped to 17: legacy reachability omits unused reference provenance, while
-/// profiled reachability persists non-zero interned path identifiers.
+/// Bumped to 17 for issue #2031: cached resolver output retains canonical
+/// test-root replacements and ESM/CommonJS mechanisms, while profiled graphs
+/// retain target-sparse reachability masks plus exact compact reference routes.
+/// Ordinary graphs omit unused provenance. Versions 7 through 16 were used by
+/// published development commits for this change, so the final version remains
+/// 17 rather than reusing a potentially stale intermediate cache version.
 pub const GRAPH_CACHE_VERSION: u32 = 17;
 
 /// Cached form of a resolved target.

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -42,7 +42,10 @@ pub use store::GraphCacheStore;
 ///
 /// Bumped to 13: export references now retain interned linked module-load paths
 /// so cached coverage checks include every re-export hop.
-pub const GRAPH_CACHE_VERSION: u32 = 13;
+///
+/// Bumped to 14: namespace-derived references retain the exact consumer and
+/// re-export path instead of collapsing onto the ultimate target.
+pub const GRAPH_CACHE_VERSION: u32 = 14;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -45,7 +45,10 @@ pub use store::GraphCacheStore;
 ///
 /// Bumped to 14: namespace-derived references retain the exact consumer and
 /// re-export path instead of collapsing onto the ultimate target.
-pub const GRAPH_CACHE_VERSION: u32 = 14;
+///
+/// Bumped to 15: Vitest mock and unmock state is selected after specifiers
+/// resolve, using the canonical target file rather than literal source text.
+pub const GRAPH_CACHE_VERSION: u32 = 15;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/store.rs
+++ b/crates/graph/src/cache/store.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use super::{CachedResolvedModule, GRAPH_CACHE_VERSION, GraphCacheManifest};
+use super::{CachedResolvedProject, GRAPH_CACHE_VERSION, GraphCacheManifest};
 use crate::graph::ModuleGraph;
 
 /// Filename of the persisted graph cache inside the cache directory.
@@ -29,10 +29,10 @@ pub struct GraphCacheStore {
     /// The previously-built graph. Its `namespace_imported` bitset is
     /// `#[serde(skip)]`, so the loader reconstructs it from the edge set.
     pub graph: ModuleGraph,
-    /// Resolver outputs aligned with the cached graph. Exact manifest hits use
-    /// these alongside the graph; stable-key resolver hits remap them and
-    /// rebuild the graph with current `FileId`s.
-    pub resolved_modules: Vec<CachedResolvedModule>,
+    /// Resolver output aligned with the cached graph. Exact manifest hits use
+    /// it alongside the graph; stable-key resolver hits remap it and rebuild
+    /// the graph with current `FileId`s.
+    pub resolved_project: CachedResolvedProject,
 }
 
 impl GraphCacheStore {

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -7,8 +7,8 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 use fallow_types::extract::{ExportName, ImportedName, ModuleLoadMechanism, VisibilityTag};
 
 use super::narrowing::attach_symbol_reference;
-use super::types::ModuleNode;
 use super::types::{ExportSymbol, ReExportEdge};
+use super::types::{ModuleNode, ReferencePathInterner};
 use super::{Edge, ImportedSymbol, ModuleGraph};
 
 pub(super) struct PopulateEdgesInput<'a> {
@@ -402,6 +402,7 @@ impl ModuleGraph {
                 runtime_entry_points: runtime_entry_point_ids.clone(),
                 test_entry_points: test_entry_point_ids.clone(),
                 test_reachability_index: super::TestReachabilityIndex::default(),
+                reference_paths: Vec::new(),
                 reverse_deps,
                 namespace_imported: acc.namespace_imported,
                 re_export_cycles: Vec::new(),
@@ -419,6 +420,7 @@ impl ModuleGraph {
         &mut self,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
         entry_point_ids: &FxHashSet<FileId>,
+        reference_paths: &mut ReferencePathInterner,
     ) {
         for edge_idx in 0..self.edges.len() {
             let source_id = self.edges[edge_idx].source;
@@ -434,6 +436,7 @@ impl ModuleGraph {
                     sym,
                     module_by_id,
                     entry_point_ids,
+                    reference_paths,
                 );
             }
         }

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -4,12 +4,12 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::resolve::{ResolvedImport, ResolvedModule};
 use fallow_types::discover::{DiscoveredFile, FileId};
-use fallow_types::extract::{ExportName, ImportedName, VisibilityTag};
+use fallow_types::extract::{ExportName, ImportedName, ModuleLoadMechanism, VisibilityTag};
 
 use super::narrowing::attach_symbol_reference;
 use super::types::ModuleNode;
 use super::types::{ExportSymbol, ReExportEdge};
-use super::{Edge, ImportMechanism, ImportedSymbol, ModuleGraph};
+use super::{Edge, ImportedSymbol, ModuleGraph};
 
 pub(super) struct PopulateEdgesInput<'a> {
     pub(super) files: &'a [DiscoveredFile],
@@ -94,9 +94,9 @@ fn collect_import_edge(
                 import_span: import.info.span,
                 is_type_only: import.info.is_type_only,
                 mechanism: if import.target.is_commonjs_require() {
-                    ImportMechanism::CommonJsRequire
+                    ModuleLoadMechanism::CommonJsRequire
                 } else {
-                    ImportMechanism::EsModule
+                    ModuleLoadMechanism::EsModule
                 },
             });
     }
@@ -130,7 +130,7 @@ fn collect_edges_for_module(
                     local_name: String::new(),
                     import_span: oxc_span::Span::new(0, 0),
                     is_type_only: re_export.info.is_type_only,
-                    mechanism: ImportMechanism::EsModule,
+                    mechanism: ModuleLoadMechanism::EsModule,
                 });
         }
     }
@@ -139,24 +139,18 @@ fn collect_edges_for_module(
         collect_import_edge(import, file_id, &mut edges_by_target, acc);
     }
 
-    // Glob-matched dynamic-import patterns (`import(`./${x}`)`, `require(`./${x}`)`)
-    // each resolve to a set of target files, and a single importing file can hold
-    // many such patterns whose match sets overlap heavily (or are identical). Each
-    // match would otherwise push a fresh `Namespace` symbol onto the target's edge,
-    // so a file with P patterns matching F files accumulates F*P symbols, and Phase 2
-    // attaches a `SymbolReference` per symbol: O(patterns * files) memory that drives
-    // the LSP into tens of GB on large React Native / Expo trees (issue #963). The
-    // duplicate symbols carry no information: a `Namespace` symbol with an empty
-    // `local_name` credits the whole target module for reachability, and the first
-    // one already does that (reachability BFS reads only `edge.target`, never the
-    // symbol list; Phase 2 `attach_reference` already dedups by `from_file`). Credit
-    // each distinct target at most once per importing file. The set is per-file
-    // (not global), so two different importers matching the same target still each
-    // create their own edge.
-    let mut credited_pattern_targets: FxHashSet<FileId> = FxHashSet::default();
-    for (_pattern, matched_ids) in &resolved.resolved_dynamic_patterns {
+    // Patterns from `import()`, `import.meta.glob`, and `require.context` each
+    // resolve to a set of target files. A single importer can hold many patterns
+    // whose match sets overlap heavily, so duplicate matches would otherwise add
+    // redundant namespace symbols and references. Deduplicate by target and load
+    // mechanism: matches with the same mechanism carry no additional information,
+    // while ESM and CommonJS matches must remain distinct for mock-aware coverage.
+    // The set is per-file, so different importers still create their own edges.
+    let mut credited_pattern_targets: FxHashSet<(FileId, ModuleLoadMechanism)> =
+        FxHashSet::default();
+    for (pattern, matched_ids) in &resolved.resolved_dynamic_patterns {
         for target_id in matched_ids {
-            if !credited_pattern_targets.insert(*target_id) {
+            if !credited_pattern_targets.insert((*target_id, pattern.mechanism)) {
                 continue;
             }
             record_namespace_import(*target_id, &mut acc.namespace_imported, acc.total_capacity);
@@ -168,7 +162,7 @@ fn collect_edges_for_module(
                     local_name: String::new(),
                     import_span: oxc_span::Span::new(0, 0),
                     is_type_only: false,
-                    mechanism: ImportMechanism::EsModule,
+                    mechanism: pattern.mechanism,
                 });
         }
     }
@@ -407,7 +401,7 @@ impl ModuleGraph {
                 entry_points: entry_point_ids.clone(),
                 runtime_entry_points: runtime_entry_point_ids.clone(),
                 test_entry_points: test_entry_point_ids.clone(),
-                test_reachability_profiles: Vec::new(),
+                test_reachability_index: super::TestReachabilityIndex::default(),
                 reverse_deps,
                 namespace_imported: acc.namespace_imported,
                 re_export_cycles: Vec::new(),
@@ -677,7 +671,10 @@ mod tests {
             ImportedName::Named(ref n) if n == "foo"
         ));
         assert!(!acc.namespace_imported.contains(2));
-        assert_eq!(edges[&FileId(2)][0].mechanism, ImportMechanism::EsModule);
+        assert_eq!(
+            edges[&FileId(2)][0].mechanism,
+            ModuleLoadMechanism::EsModule
+        );
     }
 
     #[test]
@@ -693,7 +690,7 @@ mod tests {
 
         assert_eq!(
             edges[&FileId(2)][0].mechanism,
-            ImportMechanism::CommonJsRequire
+            ModuleLoadMechanism::CommonJsRequire
         );
     }
 
@@ -908,6 +905,7 @@ mod tests {
             prefix: "./locales/".to_string(),
             suffix: Some(".json".to_string()),
             span: oxc_span::Span::new(0, 10),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         let resolved = ResolvedModule {
             file_id: FileId(0),
@@ -933,6 +931,7 @@ mod tests {
             prefix: prefix.to_string(),
             suffix: None,
             span: oxc_span::Span::new(0, 1),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         let resolved = ResolvedModule {
             file_id: FileId(0),
@@ -971,6 +970,7 @@ mod tests {
             prefix: "./x/".to_string(),
             suffix: None,
             span: oxc_span::Span::new(0, 1),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         let importer_a = ResolvedModule {
             file_id: FileId(0),
@@ -1000,6 +1000,42 @@ mod tests {
         );
         assert_eq!(edges_a[0].0, FileId(2));
         assert_eq!(edges_b[0].0, FileId(2));
+    }
+
+    #[test]
+    fn collect_edges_dynamic_patterns_dedup_by_target_and_mechanism() {
+        let pattern = |mechanism| fallow_types::extract::DynamicImportPattern {
+            prefix: "./modules/".to_string(),
+            suffix: None,
+            span: oxc_span::Span::new(0, 1),
+            mechanism,
+        };
+        let resolved = ResolvedModule {
+            file_id: FileId(0),
+            path: std::path::PathBuf::from("/project/loader.ts"),
+            resolved_dynamic_patterns: vec![
+                (pattern(ModuleLoadMechanism::EsModule), vec![FileId(1)]),
+                (
+                    pattern(ModuleLoadMechanism::CommonJsRequire),
+                    vec![FileId(1)],
+                ),
+            ],
+            ..Default::default()
+        };
+        let mut acc = make_acc(2);
+
+        let edges = collect_edges_for_module(&resolved, FileId(0), &mut acc);
+        let mechanisms: FxHashSet<_> = edges[0].1.iter().map(|symbol| symbol.mechanism).collect();
+
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].1.len(), 2);
+        assert_eq!(
+            mechanisms,
+            FxHashSet::from_iter([
+                ModuleLoadMechanism::EsModule,
+                ModuleLoadMechanism::CommonJsRequire,
+            ])
+        );
     }
 
     #[test]

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -403,6 +403,7 @@ impl ModuleGraph {
                 test_entry_points: test_entry_point_ids.clone(),
                 test_reachability_index: super::TestReachabilityIndex::default(),
                 reference_paths: Vec::new(),
+                reference_routes: super::types::ReferenceRoutes::default(),
                 reverse_deps,
                 namespace_imported: acc.namespace_imported,
                 re_export_cycles: Vec::new(),

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -9,7 +9,7 @@ use fallow_types::extract::{ExportName, ImportedName, VisibilityTag};
 use super::narrowing::attach_symbol_reference;
 use super::types::ModuleNode;
 use super::types::{ExportSymbol, ReExportEdge};
-use super::{Edge, ImportedSymbol, ModuleGraph};
+use super::{Edge, ImportMechanism, ImportedSymbol, ModuleGraph};
 
 pub(super) struct PopulateEdgesInput<'a> {
     pub(super) files: &'a [DiscoveredFile],
@@ -93,6 +93,11 @@ fn collect_import_edge(
                 local_name: import.info.local_name.clone(),
                 import_span: import.info.span,
                 is_type_only: import.info.is_type_only,
+                mechanism: if import.target.is_commonjs_require() {
+                    ImportMechanism::CommonJsRequire
+                } else {
+                    ImportMechanism::EsModule
+                },
             });
     }
 }
@@ -125,6 +130,7 @@ fn collect_edges_for_module(
                     local_name: String::new(),
                     import_span: oxc_span::Span::new(0, 0),
                     is_type_only: re_export.info.is_type_only,
+                    mechanism: ImportMechanism::EsModule,
                 });
         }
     }
@@ -162,6 +168,7 @@ fn collect_edges_for_module(
                     local_name: String::new(),
                     import_span: oxc_span::Span::new(0, 0),
                     is_type_only: false,
+                    mechanism: ImportMechanism::EsModule,
                 });
         }
     }
@@ -669,6 +676,24 @@ mod tests {
             ImportedName::Named(ref n) if n == "foo"
         ));
         assert!(!acc.namespace_imported.contains(2));
+        assert_eq!(edges[&FileId(2)][0].mechanism, ImportMechanism::EsModule);
+    }
+
+    #[test]
+    fn collect_import_edge_retains_commonjs_mechanism() {
+        let mut acc = make_acc(4);
+        let mut edges: FxHashMap<FileId, Vec<ImportedSymbol>> = FxHashMap::default();
+        let import = make_import(
+            ImportedName::Namespace,
+            ResolveResult::CommonJsInternalModule(FileId(2)),
+        );
+
+        collect_import_edge(&import, FileId(0), &mut edges, &mut acc);
+
+        assert_eq!(
+            edges[&FileId(2)][0].mechanism,
+            ImportMechanism::CommonJsRequire
+        );
     }
 
     #[test]

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -407,6 +407,7 @@ impl ModuleGraph {
                 entry_points: entry_point_ids.clone(),
                 runtime_entry_points: runtime_entry_point_ids.clone(),
                 test_entry_points: test_entry_point_ids.clone(),
+                test_reachability_profiles: Vec::new(),
                 reverse_deps,
                 namespace_imported: acc.namespace_imported,
                 re_export_cycles: Vec::new(),

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -131,6 +131,15 @@ pub struct ImportedSymbol {
     /// Whether this import is type-only (`import type { ... }`).
     /// Used to skip type-only edges in circular dependency detection.
     pub is_type_only: bool,
+    /// Runtime module mechanism that created this symbol edge.
+    mechanism: ImportMechanism,
+}
+
+/// Runtime module mechanism retained for root-aware traversal policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+enum ImportMechanism {
+    EsModule,
+    CommonJsRequire,
 }
 
 /// Importer details for one file that directly imports a target module.

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use fixedbitset::FixedBitSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::resolve::ResolvedModule;
+use crate::resolve::{ResolvedModule, ResolvedReplacedModuleTarget};
 use fallow_types::discover::{DiscoveredFile, EntryPoint, FileId};
 use fallow_types::extract::ImportedName;
 
@@ -81,6 +81,11 @@ pub struct ModuleGraph {
     pub runtime_entry_points: FxHashSet<FileId>,
     /// Test entry point `FileId`s.
     pub test_entry_points: FxHashSet<FileId>,
+    /// Distinct test-root mask profiles and their reachable files.
+    ///
+    /// Empty when no test root declares a project-internal replacement. That
+    /// preserves the ordinary single-BFS test reachability path.
+    test_reachability_profiles: Vec<TestReachabilityProfile>,
     /// Reverse index: for each `FileId`, which files import it.
     pub reverse_deps: Vec<Vec<FileId>>,
     /// Precomputed: which modules have namespace imports (import * as ns).
@@ -140,6 +145,20 @@ pub struct ImportedSymbol {
 enum ImportMechanism {
     EsModule,
     CommonJsRequire,
+}
+
+impl ImportMechanism {
+    const fn is_commonjs(self) -> bool {
+        matches!(self, Self::CommonJsRequire)
+    }
+}
+
+/// Test roots that share one replacement mask and therefore one BFS result.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TestReachabilityProfile {
+    roots: Vec<FileId>,
+    masked_targets: Vec<FileId>,
+    reachable_files: Vec<FileId>,
 }
 
 /// Importer details for one file that directly imports a target module.
@@ -224,6 +243,25 @@ impl ModuleGraph {
         test_entry_points: &[EntryPoint],
         files: &[DiscoveredFile],
     ) -> Self {
+        Self::build_with_reachability_roots_and_replacements(
+            resolved_modules,
+            &[],
+            entry_points,
+            runtime_entry_points,
+            test_entry_points,
+            files,
+        )
+    }
+
+    /// Build the module graph with root-specific test-time module replacements.
+    pub fn build_with_reachability_roots_and_replacements(
+        resolved_modules: &[ResolvedModule],
+        replaced_module_targets: &[ResolvedReplacedModuleTarget],
+        entry_points: &[EntryPoint],
+        runtime_entry_points: &[EntryPoint],
+        test_entry_points: &[EntryPoint],
+        files: &[DiscoveredFile],
+    ) -> Self {
         let _span = tracing::info_span!("build_graph").entered();
 
         let module_count = files.len();
@@ -272,6 +310,7 @@ impl ModuleGraph {
             &entry_point_ids,
             &runtime_entry_point_ids,
             &test_entry_point_ids,
+            replaced_module_targets,
             total_capacity,
         );
 

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -25,6 +25,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::resolve::{ResolvedModule, ResolvedReplacedModuleTarget};
 use fallow_types::discover::{DiscoveredFile, EntryPoint, FileId};
 use fallow_types::extract::{ImportedName, ModuleLoadMechanism};
+use types::{ReferencePathInterner, ReferencePathIter, ReferencePathNode};
 
 pub use fan_io::{FocusFileFacts, FocusFileFactsPaths};
 pub use impact_closure::{
@@ -86,6 +87,8 @@ pub struct ModuleGraph {
     /// Empty when no test root declares a project-internal replacement. That
     /// preserves the ordinary single-BFS test reachability path.
     test_reachability_index: TestReachabilityIndex,
+    /// Flat interned linked paths used by exact export references.
+    reference_paths: Vec<ReferencePathNode>,
     /// Reverse index: for each `FileId`, which files import it.
     pub reverse_deps: Vec<Vec<FileId>>,
     /// Precomputed: which modules have namespace imports (import * as ns).
@@ -196,35 +199,47 @@ impl TestReachabilityIndex {
             .map(|index| self.masked_profiles[index].profiles.as_slice())
     }
 
-    fn shares_profile(
-        &self,
-        target: FileId,
-        source: FileId,
-        mechanism: ModuleLoadMechanism,
-    ) -> bool {
-        let Some(target_profiles) = self.profiles_for(&self.reachable_profiles, target) else {
-            return false;
-        };
+    fn covers_path<I>(&self, source: FileId, hops: &I) -> bool
+    where
+        I: Iterator<Item = (FileId, ModuleLoadMechanism)> + Clone,
+    {
         let Some(source_profiles) = self.profiles_for(&self.reachable_profiles, source) else {
             return false;
         };
-        let masked_profiles = self.masked_profiles_for(target);
 
-        target_profiles
-            .iter()
-            .zip(source_profiles)
-            .enumerate()
-            .any(|(word_index, (&target_word, &source_word))| {
-                let shared = target_word & source_word;
-                if matches!(mechanism, ModuleLoadMechanism::CommonJsRequire) {
-                    return shared != 0;
-                }
-                let masked_word = masked_profiles
+        for (word_index, &source_word) in source_profiles.iter().enumerate() {
+            let mut active_profiles = source_word;
+            if active_profiles == 0 {
+                continue;
+            }
+
+            for (target, mechanism) in (*hops).clone() {
+                let Some(target_word) = self
+                    .profiles_for(&self.reachable_profiles, target)
                     .and_then(|profiles| profiles.get(word_index))
-                    .copied()
-                    .unwrap_or_default();
-                shared & !masked_word != 0
-            })
+                else {
+                    return false;
+                };
+                active_profiles &= target_word;
+                if matches!(mechanism, ModuleLoadMechanism::EsModule)
+                    && let Some(masked_profiles) = self.masked_profiles_for(target)
+                {
+                    let Some(masked_word) = masked_profiles.get(word_index) else {
+                        return false;
+                    };
+                    active_profiles &= !masked_word;
+                }
+                if active_profiles == 0 {
+                    break;
+                }
+            }
+
+            if active_profiles != 0 {
+                return true;
+            }
+        }
+
+        false
     }
 
     #[cfg(test)]
@@ -279,13 +294,19 @@ fn propagate_namespace_references(
     graph: &mut ModuleGraph,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     features: build::NamespaceFeatures,
+    reference_paths: &mut ReferencePathInterner,
 ) {
     let indexes = namespace_indexes::NamespacePropagationIndexes::new(graph, module_by_id);
     if features.has_aliases {
-        namespace_aliases::propagate_cross_package_aliases(graph, module_by_id, &indexes);
+        namespace_aliases::propagate_cross_package_aliases(
+            graph,
+            module_by_id,
+            &indexes,
+            reference_paths,
+        );
     }
     if features.has_re_exports {
-        namespace_re_exports::propagate_namespace_re_exports(graph, &indexes);
+        namespace_re_exports::propagate_namespace_re_exports(graph, &indexes, reference_paths);
     }
 }
 
@@ -386,10 +407,16 @@ impl ModuleGraph {
             total_capacity,
         });
 
-        graph.populate_references(&module_by_id, &entry_point_ids);
+        let mut reference_paths = ReferencePathInterner::default();
+        graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
 
         if namespace_features.has_aliases || namespace_features.has_re_exports {
-            propagate_namespace_references(&mut graph, &module_by_id, namespace_features);
+            propagate_namespace_references(
+                &mut graph,
+                &module_by_id,
+                namespace_features,
+                &mut reference_paths,
+            );
         }
 
         graph.mark_reachable(
@@ -400,7 +427,9 @@ impl ModuleGraph {
             total_capacity,
         );
 
-        graph.re_export_cycles = graph.resolve_re_export_chains(&module_by_id);
+        graph.re_export_cycles =
+            graph.resolve_re_export_chains(&module_by_id, &mut reference_paths);
+        graph.reference_paths = reference_paths.finalize(&mut graph.modules);
 
         graph
     }
@@ -427,22 +456,30 @@ impl ModuleGraph {
 
     /// Return whether one test-root traversal covers this exact export reference.
     ///
-    /// ESM references require a profile that reaches both the referencing file
-    /// and target without replacing the target. CommonJS references only
-    /// require correlated reachability because Vitest replacement mocks do not
-    /// intercept `require()`. Re-export propagation records ESM mechanism, so a
-    /// CommonJS-loaded barrel cannot bypass a replacement on its ESM source.
+    /// Coverage requires one profile that reaches the referencing file and
+    /// every target hop. ESM hops also require that profile not to replace the
+    /// hop target; CommonJS hops remain active because Vitest replacement mocks
+    /// do not intercept `require()`.
     #[must_use]
-    pub fn is_test_reference_covered(&self, target: FileId, reference: &SymbolReference) -> bool {
+    pub fn is_test_reference_covered(&self, reference: &SymbolReference) -> bool {
+        let hops = ReferencePathIter::new(&self.reference_paths, reference.path);
         if self.test_reachability_index.profile_count == 0 {
-            return self.is_test_reachable(target) && self.is_test_reachable(reference.from_file);
+            return self.is_test_reachable(reference.from_file)
+                && hops
+                    .clone()
+                    .all(|(target, _mechanism)| self.is_test_reachable(target));
         }
 
-        self.test_reachability_index.shares_profile(
-            target,
-            reference.from_file,
-            reference.mechanism,
-        )
+        self.test_reachability_index
+            .covers_path(reference.from_file, &hops)
+    }
+
+    #[cfg(test)]
+    fn reference_path_hops(
+        &self,
+        reference: &SymbolReference,
+    ) -> Vec<(FileId, ModuleLoadMechanism)> {
+        ReferencePathIter::new(&self.reference_paths, reference.path).collect()
     }
 
     /// Rebuild the `namespace_imported` bitset from the edge set.

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -462,14 +462,11 @@ impl ModuleGraph {
     /// do not intercept `require()`.
     #[must_use]
     pub fn is_test_reference_covered(&self, reference: &SymbolReference) -> bool {
-        let hops = ReferencePathIter::new(&self.reference_paths, reference.path);
         if self.test_reachability_index.profile_count == 0 {
-            return self.is_test_reachable(reference.from_file)
-                && hops
-                    .clone()
-                    .all(|(target, _mechanism)| self.is_test_reachable(target));
+            return self.is_test_reachable(reference.from_file);
         }
 
+        let hops = ReferencePathIter::new(&self.reference_paths, reference.path);
         self.test_reachability_index
             .covers_path(reference.from_file, &hops)
     }

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -559,6 +559,12 @@ impl ModuleGraph {
             total_capacity,
         });
 
+        let test_reachability_plan = reachability::TestReachabilityPlan::new(
+            &test_entry_point_ids,
+            replaced_module_targets,
+            total_capacity,
+        );
+
         let mut reference_paths = ReferencePathInterner::default();
         graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
 
@@ -574,8 +580,7 @@ impl ModuleGraph {
         graph.mark_reachable(
             &entry_point_ids,
             &runtime_entry_point_ids,
-            &test_entry_point_ids,
-            replaced_module_targets,
+            test_reachability_plan,
             total_capacity,
         );
 

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -24,7 +24,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::resolve::{ResolvedModule, ResolvedReplacedModuleTarget};
 use fallow_types::discover::{DiscoveredFile, EntryPoint, FileId};
-use fallow_types::extract::ImportedName;
+use fallow_types::extract::{ImportedName, ModuleLoadMechanism};
 
 pub use fan_io::{FocusFileFacts, FocusFileFactsPaths};
 pub use impact_closure::{
@@ -81,11 +81,11 @@ pub struct ModuleGraph {
     pub runtime_entry_points: FxHashSet<FileId>,
     /// Test entry point `FileId`s.
     pub test_entry_points: FxHashSet<FileId>,
-    /// Distinct test-root mask profiles and their reachable files.
+    /// Compact correlation index for distinct test-root replacement profiles.
     ///
     /// Empty when no test root declares a project-internal replacement. That
     /// preserves the ordinary single-BFS test reachability path.
-    test_reachability_profiles: Vec<TestReachabilityProfile>,
+    test_reachability_index: TestReachabilityIndex,
     /// Reverse index: for each `FileId`, which files import it.
     pub reverse_deps: Vec<Vec<FileId>>,
     /// Precomputed: which modules have namespace imports (import * as ns).
@@ -137,28 +137,123 @@ pub struct ImportedSymbol {
     /// Used to skip type-only edges in circular dependency detection.
     pub is_type_only: bool,
     /// Runtime module mechanism that created this symbol edge.
-    mechanism: ImportMechanism,
+    mechanism: ModuleLoadMechanism,
 }
 
-/// Runtime module mechanism retained for root-aware traversal policy.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-enum ImportMechanism {
-    EsModule,
-    CommonJsRequire,
+/// Flat bitset index mapping files to the test profiles that reach or mask them.
+///
+/// Each file owns `words_per_file` contiguous words in both arrays. This bounds
+/// storage by `files * ceil(distinct_profiles / 64)` and lets correlation
+/// queries intersect machine words instead of scanning profile file lists.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct TestReachabilityIndex {
+    profile_count: usize,
+    words_per_file: usize,
+    reachable_profiles: Vec<u64>,
+    masked_profiles: Vec<u64>,
 }
 
-impl ImportMechanism {
-    const fn is_commonjs(self) -> bool {
-        matches!(self, Self::CommonJsRequire)
+impl TestReachabilityIndex {
+    fn new(file_capacity: usize, profile_count: usize) -> Self {
+        let words_per_file = profile_count.div_ceil(u64::BITS as usize);
+        let storage_len = file_capacity.saturating_mul(words_per_file);
+        Self {
+            profile_count,
+            words_per_file,
+            reachable_profiles: vec![0; storage_len],
+            masked_profiles: vec![0; storage_len],
+        }
     }
-}
 
-/// Test roots that share one replacement mask and therefore one BFS result.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct TestReachabilityProfile {
-    roots: Vec<FileId>,
-    masked_targets: Vec<FileId>,
-    reachable_files: Vec<FileId>,
+    fn set_reachable(&mut self, file_id: FileId, profile: usize) {
+        let words_per_file = self.words_per_file;
+        Self::set_profile_bit(
+            &mut self.reachable_profiles,
+            words_per_file,
+            file_id,
+            profile,
+        );
+    }
+
+    fn set_masked(&mut self, file_id: FileId, profile: usize) {
+        let words_per_file = self.words_per_file;
+        Self::set_profile_bit(&mut self.masked_profiles, words_per_file, file_id, profile);
+    }
+
+    fn set_profile_bit(
+        storage: &mut [u64],
+        words_per_file: usize,
+        file_id: FileId,
+        profile: usize,
+    ) {
+        if words_per_file == 0 {
+            return;
+        }
+        let Some(file_start) = (file_id.0 as usize).checked_mul(words_per_file) else {
+            return;
+        };
+        let word = profile / u64::BITS as usize;
+        let Some(slot_index) = file_start.checked_add(word) else {
+            return;
+        };
+        let Some(slot) = storage.get_mut(slot_index) else {
+            return;
+        };
+        *slot |= 1_u64 << (profile % u64::BITS as usize);
+    }
+
+    fn profiles_for<'a>(&self, storage: &'a [u64], file_id: FileId) -> Option<&'a [u64]> {
+        let start = (file_id.0 as usize).checked_mul(self.words_per_file)?;
+        let end = start.checked_add(self.words_per_file)?;
+        storage.get(start..end)
+    }
+
+    fn shares_profile(
+        &self,
+        target: FileId,
+        source: FileId,
+        mechanism: ModuleLoadMechanism,
+    ) -> bool {
+        let Some(target_profiles) = self.profiles_for(&self.reachable_profiles, target) else {
+            return false;
+        };
+        let Some(source_profiles) = self.profiles_for(&self.reachable_profiles, source) else {
+            return false;
+        };
+        let Some(masked_profiles) = self.profiles_for(&self.masked_profiles, target) else {
+            return false;
+        };
+
+        target_profiles
+            .iter()
+            .zip(source_profiles)
+            .zip(masked_profiles)
+            .any(|((&target_word, &source_word), &masked_word)| {
+                let shared = target_word & source_word;
+                if matches!(mechanism, ModuleLoadMechanism::CommonJsRequire) {
+                    shared != 0
+                } else {
+                    shared & !masked_word != 0
+                }
+            })
+    }
+
+    #[cfg(test)]
+    fn profile_contains(&self, storage: &[u64], file_id: FileId, profile: usize) -> bool {
+        self.profiles_for(storage, file_id)
+            .and_then(|words| words.get(profile / u64::BITS as usize))
+            .is_some_and(|word| word & (1_u64 << (profile % u64::BITS as usize)) != 0)
+    }
+
+    #[cfg(test)]
+    fn profile_reaches(&self, file_id: FileId, profile: usize) -> bool {
+        self.profile_contains(&self.reachable_profiles, file_id, profile)
+    }
+
+    #[cfg(test)]
+    fn profile_masks(&self, file_id: FileId, profile: usize) -> bool {
+        self.profile_contains(&self.masked_profiles, file_id, profile)
+    }
 }
 
 /// Importer details for one file that directly imports a target module.
@@ -339,28 +434,24 @@ impl ModuleGraph {
             .is_some_and(ModuleNode::is_test_reachable)
     }
 
-    /// Return whether one root-specific test traversal reaches both files.
+    /// Return whether one test-root traversal covers this exact export reference.
     ///
-    /// This is stronger than testing the unioned `is_test_reachable` flags:
-    /// two files reached by different test roots do not correlate. When no
-    /// replacement masks exist, the graph keeps no profiles and the ordinary
-    /// unioned reachability flags are equivalent to the legacy result.
+    /// ESM references require a profile that reaches both the referencing file
+    /// and target without replacing the target. CommonJS references only
+    /// require correlated reachability because Vitest replacement mocks do not
+    /// intercept `require()`. Re-export propagation records ESM mechanism, so a
+    /// CommonJS-loaded barrel cannot bypass a replacement on its ESM source.
     #[must_use]
-    pub fn shares_test_reachability_profile(&self, first: FileId, second: FileId) -> bool {
-        if self.test_reachability_profiles.is_empty() {
-            return self.is_test_reachable(first) && self.is_test_reachable(second);
+    pub fn is_test_reference_covered(&self, target: FileId, reference: &SymbolReference) -> bool {
+        if self.test_reachability_index.profile_count == 0 {
+            return self.is_test_reachable(target) && self.is_test_reachable(reference.from_file);
         }
 
-        self.test_reachability_profiles.iter().any(|profile| {
-            profile
-                .reachable_files
-                .binary_search_by_key(&first.0, |file_id| file_id.0)
-                .is_ok()
-                && profile
-                    .reachable_files
-                    .binary_search_by_key(&second.0, |file_id| file_id.0)
-                    .is_ok()
-        })
+        self.test_reachability_index.shares_profile(
+            target,
+            reference.from_file,
+            reference.mechanism,
+        )
     }
 
     /// Rebuild the `namespace_imported` bitset from the edge set.

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -331,6 +331,38 @@ impl ModuleGraph {
         self.edges.len()
     }
 
+    /// Return whether any test-root traversal reaches `file_id`.
+    #[must_use]
+    pub fn is_test_reachable(&self, file_id: FileId) -> bool {
+        self.modules
+            .get(file_id.0 as usize)
+            .is_some_and(ModuleNode::is_test_reachable)
+    }
+
+    /// Return whether one root-specific test traversal reaches both files.
+    ///
+    /// This is stronger than testing the unioned `is_test_reachable` flags:
+    /// two files reached by different test roots do not correlate. When no
+    /// replacement masks exist, the graph keeps no profiles and the ordinary
+    /// unioned reachability flags are equivalent to the legacy result.
+    #[must_use]
+    pub fn shares_test_reachability_profile(&self, first: FileId, second: FileId) -> bool {
+        if self.test_reachability_profiles.is_empty() {
+            return self.is_test_reachable(first) && self.is_test_reachable(second);
+        }
+
+        self.test_reachability_profiles.iter().any(|profile| {
+            profile
+                .reachable_files
+                .binary_search_by_key(&first.0, |file_id| file_id.0)
+                .is_ok()
+                && profile
+                    .reachable_files
+                    .binary_search_by_key(&second.0, |file_id| file_id.0)
+                    .is_ok()
+        })
+    }
+
     /// Rebuild the `namespace_imported` bitset from the edge set.
     ///
     /// `namespace_imported` is `#[serde(skip)]`, so a graph loaded from the

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -25,7 +25,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::resolve::{ResolvedModule, ResolvedReplacedModuleTarget};
 use fallow_types::discover::{DiscoveredFile, EntryPoint, FileId};
 use fallow_types::extract::{ImportedName, ModuleLoadMechanism};
-use types::{ReferencePathInterner, ReferencePathIter, ReferencePathNode};
+use types::{ReferencePathInterner, ReferencePathNode, ReferenceRouteNodeId, ReferenceRoutes};
 
 pub use fan_io::{FocusFileFacts, FocusFileFactsPaths};
 pub use impact_closure::{
@@ -89,6 +89,8 @@ pub struct ModuleGraph {
     test_reachability_index: TestReachabilityIndex,
     /// Flat interned linked paths used by exact export references.
     reference_paths: Vec<ReferencePathNode>,
+    /// Compact transition graphs used by namespace-derived references.
+    reference_routes: ReferenceRoutes,
     /// Reverse index: for each `FileId`, which files import it.
     pub reverse_deps: Vec<Vec<FileId>>,
     /// Precomputed: which modules have namespace imports (import * as ns).
@@ -199,10 +201,13 @@ impl TestReachabilityIndex {
             .map(|index| self.masked_profiles[index].profiles.as_slice())
     }
 
-    fn covers_path<I>(&self, source: FileId, hops: &I) -> bool
-    where
-        I: Iterator<Item = (FileId, ModuleLoadMechanism)> + Clone,
-    {
+    fn covers_reference_path(
+        &self,
+        source: FileId,
+        path: types::ReferencePathId,
+        paths: &[ReferencePathNode],
+        routes: &ReferenceRoutes,
+    ) -> bool {
         let Some(source_profiles) = self.profiles_for(&self.reachable_profiles, source) else {
             return false;
         };
@@ -213,22 +218,32 @@ impl TestReachabilityIndex {
                 continue;
             }
 
-            for (target, mechanism) in (*hops).clone() {
-                let Some(target_word) = self
-                    .profiles_for(&self.reachable_profiles, target)
-                    .and_then(|profiles| profiles.get(word_index))
-                else {
+            let mut next = Some(path);
+            while let Some(path_id) = next {
+                let Some(path_node) = paths.get(path_id.index()) else {
                     return false;
                 };
-                active_profiles &= target_word;
-                if matches!(mechanism, ModuleLoadMechanism::EsModule)
-                    && let Some(masked_profiles) = self.masked_profiles_for(target)
-                {
-                    let Some(masked_word) = masked_profiles.get(word_index) else {
-                        return false;
-                    };
-                    active_profiles &= !masked_word;
-                }
+                next = path_node.parent();
+                active_profiles = match *path_node {
+                    ReferencePathNode::Hop {
+                        target, mechanism, ..
+                    } => self.active_hop_profiles(target, mechanism, word_index, active_profiles),
+                    ReferencePathNode::Route {
+                        graph,
+                        start,
+                        terminal,
+                        start_mechanism,
+                        ..
+                    } => self.active_route_profiles(
+                        routes,
+                        graph,
+                        start,
+                        terminal,
+                        start_mechanism,
+                        word_index,
+                        active_profiles,
+                    ),
+                };
                 if active_profiles == 0 {
                     break;
                 }
@@ -240,6 +255,143 @@ impl TestReachabilityIndex {
         }
 
         false
+    }
+
+    #[cfg(test)]
+    fn covers_path<I>(&self, source: FileId, hops: &I) -> bool
+    where
+        I: Iterator<Item = (FileId, ModuleLoadMechanism)> + Clone,
+    {
+        let Some(source_profiles) = self.profiles_for(&self.reachable_profiles, source) else {
+            return false;
+        };
+        for (word_index, &source_word) in source_profiles.iter().enumerate() {
+            let mut active_profiles = source_word;
+            for (target, mechanism) in (*hops).clone() {
+                active_profiles =
+                    self.active_hop_profiles(target, mechanism, word_index, active_profiles);
+                if active_profiles == 0 {
+                    break;
+                }
+            }
+            if active_profiles != 0 {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn active_hop_profiles(
+        &self,
+        target: FileId,
+        mechanism: ModuleLoadMechanism,
+        word_index: usize,
+        mut active_profiles: u64,
+    ) -> u64 {
+        let Some(target_word) = self
+            .profiles_for(&self.reachable_profiles, target)
+            .and_then(|profiles| profiles.get(word_index))
+        else {
+            return 0;
+        };
+        active_profiles &= target_word;
+        if matches!(mechanism, ModuleLoadMechanism::EsModule)
+            && let Some(masked_profiles) = self.masked_profiles_for(target)
+        {
+            let Some(masked_word) = masked_profiles.get(word_index) else {
+                return 0;
+            };
+            active_profiles &= !masked_word;
+        }
+        active_profiles
+    }
+
+    /// Evaluate one compact namespace transition graph with a monotone
+    /// profile-bit worklist. Each `(route node, profile bit)` is processed at
+    /// most once, including cyclic graphs.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the route identity and profile word form one evaluation contract"
+    )]
+    fn active_route_profiles(
+        &self,
+        routes: &ReferenceRoutes,
+        graph_id: types::ReferenceRouteGraphId,
+        start: ReferenceRouteNodeId,
+        terminal: ReferenceRouteNodeId,
+        start_mechanism: Option<ModuleLoadMechanism>,
+        word_index: usize,
+        candidate_profiles: u64,
+    ) -> u64 {
+        let Some(graph) = routes.graphs.get(graph_id.0 as usize) else {
+            return 0;
+        };
+        let node_count = graph.nodes.end.saturating_sub(graph.nodes.start) as usize;
+        let start_index = start.0 as usize;
+        let terminal_index = terminal.0 as usize;
+        if start_index >= node_count || terminal_index >= node_count {
+            return 0;
+        }
+
+        let mut attempted = vec![0_u64; node_count];
+        let mut pending = vec![0_u64; node_count];
+        let mut queued = vec![false; node_count];
+        let mut queue = std::collections::VecDeque::from([start_index]);
+        pending[start_index] = candidate_profiles;
+        queued[start_index] = true;
+        let mut successful_profiles = 0_u64;
+
+        while let Some(local_index) = queue.pop_front() {
+            queued[local_index] = false;
+            let incoming = pending[local_index] & !attempted[local_index];
+            pending[local_index] = 0;
+            attempted[local_index] |= incoming;
+            if incoming == 0 {
+                continue;
+            }
+
+            let Some(node) = routes.nodes.get(graph.nodes.start as usize + local_index) else {
+                return 0;
+            };
+            let active = if local_index == start_index {
+                start_mechanism.map_or(incoming, |mechanism| {
+                    self.active_hop_profiles(node.target, mechanism, word_index, incoming)
+                })
+            } else {
+                self.active_hop_profiles(node.target, node.mechanism, word_index, incoming)
+            };
+            if active == 0 {
+                continue;
+            }
+            if local_index == terminal_index {
+                successful_profiles |= active;
+                continue;
+            }
+
+            let Some(successors) = routes
+                .edges
+                .get(node.successors.start as usize..node.successors.end as usize)
+            else {
+                return 0;
+            };
+            for successor in successors {
+                let successor_index = successor.0 as usize;
+                if successor_index >= node_count {
+                    return 0;
+                }
+                let new_profiles = active & !attempted[successor_index] & !pending[successor_index];
+                if new_profiles == 0 {
+                    continue;
+                }
+                pending[successor_index] |= new_profiles;
+                if !queued[successor_index] {
+                    queued[successor_index] = true;
+                    queue.push_back(successor_index);
+                }
+            }
+        }
+
+        successful_profiles
     }
 
     #[cfg(test)]
@@ -429,7 +581,9 @@ impl ModuleGraph {
 
         graph.re_export_cycles =
             graph.resolve_re_export_chains(&module_by_id, &mut reference_paths);
-        graph.reference_paths = reference_paths.finalize(&mut graph.modules);
+        let finalized_paths = reference_paths.finalize(&mut graph.modules);
+        graph.reference_paths = finalized_paths.paths;
+        graph.reference_routes = finalized_paths.routes;
 
         graph
     }
@@ -466,9 +620,12 @@ impl ModuleGraph {
             return self.is_test_reachable(reference.from_file);
         }
 
-        let hops = ReferencePathIter::new(&self.reference_paths, reference.path);
-        self.test_reachability_index
-            .covers_path(reference.from_file, &hops)
+        self.test_reachability_index.covers_reference_path(
+            reference.from_file,
+            reference.path,
+            &self.reference_paths,
+            &self.reference_routes,
+        )
     }
 
     #[cfg(test)]
@@ -476,7 +633,32 @@ impl ModuleGraph {
         &self,
         reference: &SymbolReference,
     ) -> Vec<(FileId, ModuleLoadMechanism)> {
-        ReferencePathIter::new(&self.reference_paths, reference.path).collect()
+        let mut hops = Vec::new();
+        let mut next = Some(reference.path);
+        while let Some(path_id) = next {
+            let Some(node) = self.reference_paths.get(path_id.index()) else {
+                return Vec::new();
+            };
+            next = node.parent();
+            match *node {
+                ReferencePathNode::Hop {
+                    target, mechanism, ..
+                } => hops.push((target, mechanism)),
+                ReferencePathNode::Route {
+                    graph,
+                    start,
+                    terminal,
+                    start_mechanism,
+                    ..
+                } => hops.extend(self.reference_routes.canonical_hops(
+                    graph,
+                    start,
+                    terminal,
+                    start_mechanism,
+                )),
+            }
+        }
+        hops
     }
 
     /// Rebuild the `namespace_imported` bitset from the edge set.

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -140,17 +140,26 @@ pub struct ImportedSymbol {
     mechanism: ModuleLoadMechanism,
 }
 
-/// Flat bitset index mapping files to the test profiles that reach or mask them.
+/// Flat bitset index mapping files to the test profiles that reach them.
 ///
-/// Each file owns `words_per_file` contiguous words in both arrays. This bounds
-/// storage by `files * ceil(distinct_profiles / 64)` and lets correlation
-/// queries intersect machine words instead of scanning profile file lists.
+/// Each file owns `words_per_file` contiguous reachable-profile words. Masks are
+/// target-sparse: only explicit replacement targets own a row, while every row
+/// retains dense profile words for constant-time word lookup. Retained storage
+/// is `O((files + replaced_targets) * ceil(profiles / 64))`; correlation queries
+/// intersect machine words instead of scanning profile file lists.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct TestReachabilityIndex {
     profile_count: usize,
     words_per_file: usize,
     reachable_profiles: Vec<u64>,
-    masked_profiles: Vec<u64>,
+    masked_profiles: Vec<MaskedTestProfiles>,
+}
+
+/// Sparse profile-mask row for one replaced target.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct MaskedTestProfiles {
+    target: FileId,
+    profiles: Vec<u64>,
 }
 
 impl TestReachabilityIndex {
@@ -161,51 +170,30 @@ impl TestReachabilityIndex {
             profile_count,
             words_per_file,
             reachable_profiles: vec![0; storage_len],
-            masked_profiles: vec![0; storage_len],
+            masked_profiles: Vec::new(),
         }
     }
 
-    fn set_reachable(&mut self, file_id: FileId, profile: usize) {
-        let words_per_file = self.words_per_file;
-        Self::set_profile_bit(
-            &mut self.reachable_profiles,
-            words_per_file,
-            file_id,
-            profile,
-        );
-    }
-
-    fn set_masked(&mut self, file_id: FileId, profile: usize) {
-        let words_per_file = self.words_per_file;
-        Self::set_profile_bit(&mut self.masked_profiles, words_per_file, file_id, profile);
-    }
-
-    fn set_profile_bit(
-        storage: &mut [u64],
-        words_per_file: usize,
-        file_id: FileId,
-        profile: usize,
-    ) {
-        if words_per_file == 0 {
-            return;
-        }
-        let Some(file_start) = (file_id.0 as usize).checked_mul(words_per_file) else {
-            return;
-        };
-        let word = profile / u64::BITS as usize;
-        let Some(slot_index) = file_start.checked_add(word) else {
-            return;
-        };
-        let Some(slot) = storage.get_mut(slot_index) else {
-            return;
-        };
-        *slot |= 1_u64 << (profile % u64::BITS as usize);
+    fn set_sparse_masks(&mut self, masks: FxHashMap<FileId, Vec<u64>>) {
+        let mut rows: Vec<_> = masks
+            .into_iter()
+            .map(|(target, profiles)| MaskedTestProfiles { target, profiles })
+            .collect();
+        rows.sort_unstable_by_key(|row| row.target.0);
+        self.masked_profiles = rows;
     }
 
     fn profiles_for<'a>(&self, storage: &'a [u64], file_id: FileId) -> Option<&'a [u64]> {
         let start = (file_id.0 as usize).checked_mul(self.words_per_file)?;
         let end = start.checked_add(self.words_per_file)?;
         storage.get(start..end)
+    }
+
+    fn masked_profiles_for(&self, file_id: FileId) -> Option<&[u64]> {
+        self.masked_profiles
+            .binary_search_by_key(&file_id.0, |row| row.target.0)
+            .ok()
+            .map(|index| self.masked_profiles[index].profiles.as_slice())
     }
 
     fn shares_profile(
@@ -220,21 +208,22 @@ impl TestReachabilityIndex {
         let Some(source_profiles) = self.profiles_for(&self.reachable_profiles, source) else {
             return false;
         };
-        let Some(masked_profiles) = self.profiles_for(&self.masked_profiles, target) else {
-            return false;
-        };
+        let masked_profiles = self.masked_profiles_for(target);
 
         target_profiles
             .iter()
             .zip(source_profiles)
-            .zip(masked_profiles)
-            .any(|((&target_word, &source_word), &masked_word)| {
+            .enumerate()
+            .any(|(word_index, (&target_word, &source_word))| {
                 let shared = target_word & source_word;
                 if matches!(mechanism, ModuleLoadMechanism::CommonJsRequire) {
-                    shared != 0
-                } else {
-                    shared & !masked_word != 0
+                    return shared != 0;
                 }
+                let masked_word = masked_profiles
+                    .and_then(|profiles| profiles.get(word_index))
+                    .copied()
+                    .unwrap_or_default();
+                shared & !masked_word != 0
             })
     }
 
@@ -252,7 +241,9 @@ impl TestReachabilityIndex {
 
     #[cfg(test)]
     fn profile_masks(&self, file_id: FileId, profile: usize) -> bool {
-        self.profile_contains(&self.masked_profiles, file_id, profile)
+        self.masked_profiles_for(file_id)
+            .and_then(|words| words.get(profile / u64::BITS as usize))
+            .is_some_and(|word| word & (1_u64 << (profile % u64::BITS as usize)) != 0)
     }
 }
 

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -565,7 +565,8 @@ impl ModuleGraph {
             total_capacity,
         );
 
-        let mut reference_paths = ReferencePathInterner::default();
+        let mut reference_paths =
+            ReferencePathInterner::new(test_reachability_plan.requires_reference_provenance());
         graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
 
         if namespace_features.has_aliases || namespace_features.has_re_exports {
@@ -625,9 +626,13 @@ impl ModuleGraph {
             return self.is_test_reachable(reference.from_file);
         }
 
+        let Some(path) = reference.path else {
+            return false;
+        };
+
         self.test_reachability_index.covers_reference_path(
             reference.from_file,
-            reference.path,
+            path,
             &self.reference_paths,
             &self.reference_routes,
         )
@@ -639,7 +644,7 @@ impl ModuleGraph {
         reference: &SymbolReference,
     ) -> Vec<(FileId, ModuleLoadMechanism)> {
         let mut hops = Vec::new();
-        let mut next = Some(reference.path);
+        let mut next = reference.path;
         while let Some(path_id) = next {
             let Some(node) = self.reference_paths.get(path_id.index()) else {
                 return Vec::new();

--- a/crates/graph/src/graph/namespace_aliases.rs
+++ b/crates/graph/src/graph/namespace_aliases.rs
@@ -52,7 +52,7 @@ struct PendingCredit {
     /// Span of the consumer's import that brought the aliased export into scope.
     import_span: oxc_span::Span,
     /// Exact consumer-to-target path, including every alias/re-export hop.
-    path: ReferencePathId,
+    path: Option<ReferencePathId>,
 }
 
 /// Propagate cross-package consumer accesses through `NamespaceObjectAlias`
@@ -173,7 +173,7 @@ struct ConsumerCreditInput<'a> {
     import: &'a crate::resolve::ResolvedImport,
     prefix_match: &'a str,
     target_module_idx: usize,
-    path: ReferencePathId,
+    path: Option<ReferencePathId>,
     pending: &'a mut Vec<PendingCredit>,
     reference_paths: &'a mut ReferencePathInterner,
 }
@@ -366,7 +366,7 @@ impl AliasChain {
         Self { states }
     }
 
-    fn collect_credits(&self, ctx: &mut ChainWalkContext<'_>, base_path: ReferencePathId) {
+    fn collect_credits(&self, ctx: &mut ChainWalkContext<'_>, base_path: Option<ReferencePathId>) {
         if self.states.len() == 1 {
             return;
         }
@@ -418,7 +418,7 @@ impl AliasChain {
             }
             let state = &self.states[state_index].key;
             let path = ctx.reference_paths.route(
-                Some(base_path),
+                base_path,
                 graph,
                 root,
                 route_node_by_state[state_index],
@@ -456,7 +456,7 @@ fn collect_chained_re_export_credits(
     barrel_module_idx: usize,
     credited_name: &str,
     accessor_prefix: &str,
-    path: ReferencePathId,
+    path: Option<ReferencePathId>,
 ) {
     AliasChain::build(
         ctx.graph,
@@ -477,7 +477,7 @@ fn collect_chained_re_export_credits(
 /// member exports are stubbed so Phase 4 chain resolution can propagate the
 /// reference to the real defining file.
 fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
-    type GroupKey = (usize, FileId, oxc_span::Span, ReferencePathId);
+    type GroupKey = (usize, FileId, oxc_span::Span, Option<ReferencePathId>);
 
     let mut groups: FxHashMap<GroupKey, Vec<String>> = FxHashMap::default();
     for credit in pending {

--- a/crates/graph/src/graph/namespace_aliases.rs
+++ b/crates/graph/src/graph/namespace_aliases.rs
@@ -18,7 +18,9 @@
 //! (reachability) so any reference attached here participates in reachability
 //! and re-export chain propagation downstream.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashMap;
 
 use fallow_types::discover::FileId;
 use fallow_types::extract::{ImportedName, ModuleLoadMechanism, NamespaceObjectAlias};
@@ -26,12 +28,17 @@ use fallow_types::extract::{ImportedName, ModuleLoadMechanism, NamespaceObjectAl
 use crate::resolve::ResolvedModule;
 
 use super::ModuleGraph;
-use super::namespace_indexes::{NamespacePropagationIndexes, ReachableNamespaceExports};
+use super::namespace_indexes::{
+    NamespacePropagationIndexes, NamespaceReferenceRoutes, ReachableNamespaceExports,
+};
 use super::narrowing::{
     ReferenceSite, create_synthetic_exports_for_star_re_exports_at_site,
     mark_member_exports_referenced_at_site,
 };
-use super::types::{ReferenceKind, ReferencePathId, ReferencePathInterner};
+use super::types::{
+    ReferenceKind, ReferencePathId, ReferencePathInterner, ReferenceRouteGraphSpec,
+    ReferenceRouteNodeId, ReferenceRouteNodeSpec,
+};
 
 /// One credit operation collected during the scan and applied after the loop
 /// to keep mutable borrows of `ModuleGraph::modules` localised.
@@ -70,7 +77,9 @@ fn collect_pending_credits(
 ) -> Vec<PendingCredit> {
     let mut pending = Vec::new();
 
-    for alias_module in module_by_id.values() {
+    let mut alias_modules: Vec<_> = module_by_id.values().copied().collect();
+    alias_modules.sort_unstable_by_key(|module| module.file_id.0);
+    for alias_module in alias_modules {
         if alias_module.namespace_object_aliases.is_empty() {
             continue;
         }
@@ -85,6 +94,11 @@ fn collect_pending_credits(
             };
             let reachable =
                 indexes.enumerate_reachable_barrels(alias_file_id, &alias.via_export_name);
+            let routes = reachable.intern_routes(
+                namespace_target.file_id,
+                namespace_target.mechanism,
+                reference_paths,
+            );
             collect_credits_for_alias(NamespaceCreditInput {
                 graph,
                 indexes,
@@ -92,7 +106,7 @@ fn collect_pending_credits(
                 alias,
                 target_module_idx,
                 reachable: &reachable,
-                namespace_target,
+                routes: &routes,
                 pending: &mut pending,
                 reference_paths,
             });
@@ -148,7 +162,7 @@ struct NamespaceCreditInput<'a> {
     alias: &'a NamespaceObjectAlias,
     target_module_idx: usize,
     reachable: &'a ReachableNamespaceExports,
-    namespace_target: NamespaceTarget,
+    routes: &'a NamespaceReferenceRoutes,
     pending: &'a mut Vec<PendingCredit>,
     reference_paths: &'a mut ReferencePathInterner,
 }
@@ -172,7 +186,7 @@ fn collect_credits_for_alias(input: NamespaceCreditInput<'_>) {
         alias,
         target_module_idx,
         reachable,
-        namespace_target,
+        routes,
         pending,
         reference_paths,
     } = input;
@@ -184,13 +198,7 @@ fn collect_credits_for_alias(input: NamespaceCreditInput<'_>) {
             if consumer.file_id == alias_file_id {
                 continue;
             }
-            let path = reachable.consumer_path(
-                export,
-                indexed,
-                namespace_target.file_id,
-                namespace_target.mechanism,
-                reference_paths,
-            );
+            let path = routes.consumer_path(export, indexed, reference_paths);
             collect_credits_for_consumer_import(&mut ConsumerCreditInput {
                 graph,
                 consumer,
@@ -234,8 +242,6 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
             import_span: import.info.span,
             path,
         });
-        let mut visited: FxHashSet<usize> = FxHashSet::default();
-        visited.insert(target_module_idx);
         let mut ctx = ChainWalkContext {
             graph,
             consumer,
@@ -249,7 +255,6 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
             &access.member,
             &format!("{expected_object}.{}", access.member),
             path,
-            &mut visited,
         );
     }
 }
@@ -266,6 +271,180 @@ struct ChainWalkContext<'a> {
     reference_paths: &'a mut ReferencePathInterner,
 }
 
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct AliasChainStateKey {
+    module_idx: usize,
+    credited_name: String,
+    accessor_prefix: String,
+}
+
+struct AliasChainState {
+    key: AliasChainStateKey,
+    successors: Vec<usize>,
+}
+
+struct AliasChain {
+    states: Vec<AliasChainState>,
+}
+
+impl AliasChain {
+    fn build(
+        graph: &ModuleGraph,
+        consumer: &ResolvedModule,
+        target_module_idx: usize,
+        credited_name: &str,
+        accessor_prefix: &str,
+    ) -> Self {
+        let root = AliasChainStateKey {
+            module_idx: target_module_idx,
+            credited_name: credited_name.to_string(),
+            accessor_prefix: accessor_prefix.to_string(),
+        };
+        let mut states = vec![AliasChainState {
+            key: root.clone(),
+            successors: Vec::new(),
+        }];
+        let mut state_by_key = FxHashMap::from_iter([(root, 0)]);
+        let mut frontier = VecDeque::from([0]);
+
+        while let Some(state_index) = frontier.pop_front() {
+            let state = &states[state_index].key;
+            let Some(barrel) = graph.modules.get(state.module_idx) else {
+                continue;
+            };
+            let mut chained_targets: Vec<FileId> = barrel
+                .re_exports
+                .iter()
+                .filter(|edge| {
+                    edge.imported_name == "*" && edge.exported_name == state.credited_name
+                })
+                .map(|edge| edge.source_file)
+                .collect();
+            chained_targets.sort_unstable_by_key(|file_id| file_id.0);
+            chained_targets.dedup();
+
+            let mut accessed_members: Vec<String> = consumer
+                .member_accesses
+                .iter()
+                .filter(|access| access.object == state.accessor_prefix)
+                .map(|access| access.member.clone())
+                .collect();
+            accessed_members.sort_unstable();
+            accessed_members.dedup();
+
+            let accessor_prefix = state.accessor_prefix.clone();
+            for source_file in chained_targets {
+                let Some(source_module_idx) = module_index_for_file(graph, source_file) else {
+                    continue;
+                };
+                for member in &accessed_members {
+                    let key = AliasChainStateKey {
+                        module_idx: source_module_idx,
+                        credited_name: member.clone(),
+                        accessor_prefix: format!("{accessor_prefix}.{member}"),
+                    };
+                    let successor = if let Some(index) = state_by_key.get(&key) {
+                        *index
+                    } else {
+                        let index = states.len();
+                        states.push(AliasChainState {
+                            key: key.clone(),
+                            successors: Vec::new(),
+                        });
+                        state_by_key.insert(key, index);
+                        frontier.push_back(index);
+                        index
+                    };
+                    states[state_index].successors.push(successor);
+                }
+            }
+        }
+        for state in &mut states {
+            state.successors.sort_unstable();
+            state.successors.dedup();
+        }
+        Self { states }
+    }
+
+    fn collect_credits(&self, ctx: &mut ChainWalkContext<'_>, base_path: ReferencePathId) {
+        if self.states.len() == 1 {
+            return;
+        }
+
+        let mut canonical_order: Vec<usize> = (0..self.states.len()).collect();
+        canonical_order.sort_unstable_by(|&left, &right| {
+            let left_state = &self.states[left].key;
+            let right_state = &self.states[right].key;
+            (
+                ctx.graph.modules[left_state.module_idx].file_id.0,
+                left_state.credited_name.as_str(),
+                left_state.accessor_prefix.as_str(),
+            )
+                .cmp(&(
+                    ctx.graph.modules[right_state.module_idx].file_id.0,
+                    right_state.credited_name.as_str(),
+                    right_state.accessor_prefix.as_str(),
+                ))
+        });
+
+        let mut route_node_by_state = vec![ReferenceRouteNodeId(0); self.states.len()];
+        for (route_index, state_index) in canonical_order.iter().copied().enumerate() {
+            route_node_by_state[state_index] = ReferenceRouteNodeId(route_index as u32);
+        }
+
+        let nodes = canonical_order
+            .iter()
+            .map(|&state_index| {
+                let state = &self.states[state_index];
+                ReferenceRouteNodeSpec::new(
+                    ctx.graph.modules[state.key.module_idx].file_id,
+                    ModuleLoadMechanism::EsModule,
+                    state
+                        .successors
+                        .iter()
+                        .map(|&successor| route_node_by_state[successor])
+                        .collect(),
+                )
+            })
+            .collect();
+        let graph = ctx
+            .reference_paths
+            .intern_route_graph(ReferenceRouteGraphSpec::new(nodes));
+        let root = route_node_by_state[0];
+
+        for state_index in canonical_order {
+            if state_index == 0 {
+                continue;
+            }
+            let state = &self.states[state_index].key;
+            let path = ctx.reference_paths.route(
+                Some(base_path),
+                graph,
+                root,
+                route_node_by_state[state_index],
+                None,
+            );
+            ctx.pending.push(PendingCredit {
+                target_module_idx: state.module_idx,
+                member: state.credited_name.clone(),
+                consumer_file_id: ctx.consumer.file_id,
+                import_span: ctx.import_span,
+                path,
+            });
+        }
+    }
+
+    #[cfg(test)]
+    fn state_count(&self) -> usize {
+        self.states.len()
+    }
+
+    #[cfg(test)]
+    fn transition_count(&self) -> usize {
+        self.states.iter().map(|state| state.successors.len()).sum()
+    }
+}
+
 /// Follow `export * as <name> from './source'` chains on the alias target
 /// side. When `barrel_module_idx.re_exports` contains an edge with
 /// `imported_name == "*" && exported_name == credited_name`, every consumer
@@ -278,53 +457,15 @@ fn collect_chained_re_export_credits(
     credited_name: &str,
     accessor_prefix: &str,
     path: ReferencePathId,
-    visited: &mut FxHashSet<usize>,
 ) {
-    let Some(barrel) = ctx.graph.modules.get(barrel_module_idx) else {
-        return;
-    };
-    let chained_targets: Vec<FileId> = barrel
-        .re_exports
-        .iter()
-        .filter(|edge| edge.imported_name == "*" && edge.exported_name == credited_name)
-        .map(|edge| edge.source_file)
-        .collect();
-    for source_file in chained_targets {
-        let Some(source_module_idx) = module_index_for_file(ctx.graph, source_file) else {
-            continue;
-        };
-        if !visited.insert(source_module_idx) {
-            continue;
-        }
-        let source_path =
-            ctx.reference_paths
-                .extend(path, source_file, ModuleLoadMechanism::EsModule);
-        let accessed_members: Vec<String> = ctx
-            .consumer
-            .member_accesses
-            .iter()
-            .filter(|access| access.object == accessor_prefix)
-            .map(|access| access.member.clone())
-            .collect();
-        for member in accessed_members {
-            ctx.pending.push(PendingCredit {
-                target_module_idx: source_module_idx,
-                member: member.clone(),
-                consumer_file_id: ctx.consumer.file_id,
-                import_span: ctx.import_span,
-                path: source_path,
-            });
-            collect_chained_re_export_credits(
-                ctx,
-                source_module_idx,
-                &member,
-                &format!("{accessor_prefix}.{member}"),
-                source_path,
-                visited,
-            );
-        }
-        visited.remove(&source_module_idx);
-    }
+    AliasChain::build(
+        ctx.graph,
+        ctx.consumer,
+        barrel_module_idx,
+        credited_name,
+        accessor_prefix,
+    )
+    .collect_credits(ctx, path);
 }
 
 /// Apply collected credits, grouping by `(target_module_idx, consumer, import_span)`
@@ -367,5 +508,113 @@ fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
             &members,
             &found_members,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use crate::resolve::{ResolveResult, ResolvedModule, ResolvedReExport};
+    use fallow_types::discover::DiscoveredFile;
+    use fallow_types::extract::{MemberAccess, ReExportInfo};
+
+    fn build_namespace_reexport_graph(adjacency: &[Vec<u32>]) -> ModuleGraph {
+        let files: Vec<_> = adjacency
+            .iter()
+            .enumerate()
+            .map(|(index, _)| DiscoveredFile {
+                id: FileId(index as u32),
+                path: PathBuf::from(format!("/project/module-{index}.ts")),
+                size_bytes: 10,
+            })
+            .collect();
+        let modules: Vec<_> = adjacency
+            .iter()
+            .enumerate()
+            .map(|(index, targets)| ResolvedModule {
+                file_id: FileId(index as u32),
+                path: files[index].path.clone(),
+                re_exports: targets
+                    .iter()
+                    .map(|&target| ResolvedReExport {
+                        info: ReExportInfo {
+                            source: format!("./module-{target}"),
+                            imported_name: "*".to_string(),
+                            exported_name: "N".to_string(),
+                            is_type_only: false,
+                            span: oxc_span::Span::default(),
+                        },
+                        target: ResolveResult::InternalModule(FileId(target)),
+                    })
+                    .collect(),
+                ..Default::default()
+            })
+            .collect();
+        ModuleGraph::build(&modules, &[], &files)
+    }
+
+    fn chain_consumer(depth: usize) -> ResolvedModule {
+        let mut object = "API.foo.N".to_string();
+        let mut member_accesses = Vec::with_capacity(depth);
+        for _ in 0..depth {
+            member_accesses.push(MemberAccess {
+                object: object.clone(),
+                member: "N".to_string(),
+            });
+            object.push_str(".N");
+        }
+        ResolvedModule {
+            file_id: FileId(u32::MAX),
+            member_accesses,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn dense_alias_cycle_is_bounded_by_member_states() {
+        const MODULES: usize = 10;
+        const DEPTH: usize = 8;
+        let adjacency: Vec<Vec<u32>> = (0..MODULES)
+            .map(|source| {
+                (0..MODULES)
+                    .filter(|&target| target != source)
+                    .map(|target| target as u32)
+                    .collect()
+            })
+            .collect();
+        let graph = build_namespace_reexport_graph(&adjacency);
+        let consumer = chain_consumer(DEPTH);
+
+        let chain = AliasChain::build(&graph, &consumer, 0, "N", "API.foo.N");
+
+        assert!(chain.state_count() <= 1 + (MODULES * DEPTH));
+        assert!(chain.transition_count() <= MODULES * (MODULES - 1) * DEPTH);
+    }
+
+    #[test]
+    fn repeated_alias_diamonds_grow_by_states_and_edges_not_paths() {
+        const LAYERS: usize = 24;
+        let module_count = 1 + (LAYERS * 2);
+        let mut adjacency = vec![Vec::new(); module_count];
+        let mut previous = vec![0_usize];
+        let mut next_module = 1_usize;
+        for _ in 0..LAYERS {
+            let next = vec![next_module, next_module + 1];
+            next_module += 2;
+            for source in &previous {
+                adjacency[*source].extend(next.iter().map(|target| *target as u32));
+            }
+            previous = next;
+        }
+        let graph = build_namespace_reexport_graph(&adjacency);
+        let consumer = chain_consumer(LAYERS);
+
+        let chain = AliasChain::build(&graph, &consumer, 0, "N", "API.foo.N");
+
+        assert_eq!(chain.state_count(), 1 + (LAYERS * 2));
+        assert_eq!(chain.transition_count(), 2 + ((LAYERS - 1) * 4));
     }
 }

--- a/crates/graph/src/graph/namespace_aliases.rs
+++ b/crates/graph/src/graph/namespace_aliases.rs
@@ -371,6 +371,20 @@ impl AliasChain {
             return;
         }
 
+        if !ctx.reference_paths.tracks_provenance() {
+            debug_assert!(base_path.is_none());
+            for state in self.states.iter().skip(1).map(|state| &state.key) {
+                ctx.pending.push(PendingCredit {
+                    target_module_idx: state.module_idx,
+                    member: state.credited_name.clone(),
+                    consumer_file_id: ctx.consumer.file_id,
+                    import_span: ctx.import_span,
+                    path: None,
+                });
+            }
+            return;
+        }
+
         let mut canonical_order: Vec<usize> = (0..self.states.len()).collect();
         canonical_order.sort_unstable_by(|&left, &right| {
             let left_state = &self.states[left].key;
@@ -616,5 +630,33 @@ mod tests {
 
         assert_eq!(chain.state_count(), 1 + (LAYERS * 2));
         assert_eq!(chain.transition_count(), 2 + ((LAYERS - 1) * 4));
+    }
+
+    #[test]
+    fn untracked_alias_chain_credits_states_without_interning_routes() {
+        let mut graph = build_namespace_reexport_graph(&[vec![1], vec![]]);
+        let consumer = chain_consumer(1);
+        let chain = AliasChain::build(&graph, &consumer, 0, "N", "API.foo.N");
+        let mut pending = Vec::new();
+        let mut reference_paths = ReferencePathInterner::new(false);
+
+        chain.collect_credits(
+            &mut ChainWalkContext {
+                graph: &graph,
+                consumer: &consumer,
+                import_span: oxc_span::Span::new(3, 9),
+                pending: &mut pending,
+                reference_paths: &mut reference_paths,
+            },
+            None,
+        );
+
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].target_module_idx, 1);
+        assert_eq!(pending[0].member, "N");
+        assert!(pending[0].path.is_none());
+        let finalized = reference_paths.finalize(&mut graph.modules);
+        assert!(finalized.paths.is_empty());
+        assert!(finalized.routes.graphs.is_empty());
     }
 }

--- a/crates/graph/src/graph/namespace_aliases.rs
+++ b/crates/graph/src/graph/namespace_aliases.rs
@@ -28,9 +28,9 @@ use crate::resolve::ResolvedModule;
 use super::ModuleGraph;
 use super::namespace_indexes::NamespacePropagationIndexes;
 use super::narrowing::{
-    create_synthetic_exports_for_star_re_exports, mark_member_exports_referenced,
+    ReferenceTarget, create_synthetic_exports_for_star_re_exports, mark_member_exports_referenced,
 };
-use super::types::ReferenceKind;
+use super::types::{ReferenceKind, ReferencePathInterner};
 
 /// One credit operation collected during the scan and applied after the loop
 /// to keep mutable borrows of `ModuleGraph::modules` localised.
@@ -53,9 +53,10 @@ pub(super) fn propagate_cross_package_aliases(
     graph: &mut ModuleGraph,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     indexes: &NamespacePropagationIndexes<'_>,
+    reference_paths: &mut ReferencePathInterner,
 ) {
     let pending = collect_pending_credits(graph, module_by_id, indexes);
-    apply_pending_credits(graph, &pending);
+    apply_pending_credits(graph, &pending, reference_paths);
 }
 
 fn collect_pending_credits(
@@ -284,7 +285,11 @@ fn collect_chained_re_export_credits(
 /// namespace target is a star barrel (`export * from './bar'`): missing
 /// member exports are stubbed so Phase 4 chain resolution can propagate the
 /// reference to the real defining file.
-fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
+fn apply_pending_credits(
+    graph: &mut ModuleGraph,
+    pending: &[PendingCredit],
+    reference_paths: &mut ReferencePathInterner,
+) {
     type GroupKey = (usize, FileId, oxc_span::Span);
 
     let mut groups: FxHashMap<GroupKey, Vec<String>> = FxHashMap::default();
@@ -301,20 +306,22 @@ fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
 
     for ((target_module_idx, consumer_file_id, import_span), members) in groups {
         let module = &mut graph.modules[target_module_idx];
-        let found_members = mark_member_exports_referenced(
-            &mut module.exports,
-            consumer_file_id,
-            &members,
+        let target_file = module.file_id;
+        let target = ReferenceTarget {
+            source_id: consumer_file_id,
+            target_id: target_file,
             import_span,
-            ReferenceKind::NamespaceImport,
-        );
+            kind: ReferenceKind::NamespaceImport,
+        };
+        let found_members =
+            mark_member_exports_referenced(&mut module.exports, target, &members, reference_paths);
         create_synthetic_exports_for_star_re_exports(
             &mut module.exports,
             &module.re_exports,
-            consumer_file_id,
+            target,
             &members,
             &found_members,
-            import_span,
+            reference_paths,
         );
     }
 }

--- a/crates/graph/src/graph/namespace_aliases.rs
+++ b/crates/graph/src/graph/namespace_aliases.rs
@@ -21,16 +21,17 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::discover::FileId;
-use fallow_types::extract::{ImportedName, NamespaceObjectAlias};
+use fallow_types::extract::{ImportedName, ModuleLoadMechanism, NamespaceObjectAlias};
 
 use crate::resolve::ResolvedModule;
 
 use super::ModuleGraph;
-use super::namespace_indexes::NamespacePropagationIndexes;
+use super::namespace_indexes::{NamespacePropagationIndexes, ReachableNamespaceExports};
 use super::narrowing::{
-    ReferenceTarget, create_synthetic_exports_for_star_re_exports, mark_member_exports_referenced,
+    ReferenceSite, create_synthetic_exports_for_star_re_exports_at_site,
+    mark_member_exports_referenced_at_site,
 };
-use super::types::{ReferenceKind, ReferencePathInterner};
+use super::types::{ReferenceKind, ReferencePathId, ReferencePathInterner};
 
 /// One credit operation collected during the scan and applied after the loop
 /// to keep mutable borrows of `ModuleGraph::modules` localised.
@@ -43,6 +44,8 @@ struct PendingCredit {
     consumer_file_id: FileId,
     /// Span of the consumer's import that brought the aliased export into scope.
     import_span: oxc_span::Span,
+    /// Exact consumer-to-target path, including every alias/re-export hop.
+    path: ReferencePathId,
 }
 
 /// Propagate cross-package consumer accesses through `NamespaceObjectAlias`
@@ -55,14 +58,15 @@ pub(super) fn propagate_cross_package_aliases(
     indexes: &NamespacePropagationIndexes<'_>,
     reference_paths: &mut ReferencePathInterner,
 ) {
-    let pending = collect_pending_credits(graph, module_by_id, indexes);
-    apply_pending_credits(graph, &pending, reference_paths);
+    let pending = collect_pending_credits(graph, module_by_id, indexes, reference_paths);
+    apply_pending_credits(graph, &pending);
 }
 
 fn collect_pending_credits(
     graph: &ModuleGraph,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     indexes: &NamespacePropagationIndexes<'_>,
+    reference_paths: &mut ReferencePathInterner,
 ) -> Vec<PendingCredit> {
     let mut pending = Vec::new();
 
@@ -72,10 +76,11 @@ fn collect_pending_credits(
         }
         let alias_file_id = alias_module.file_id;
         for alias in &alias_module.namespace_object_aliases {
-            let Some(namespace_target_id) = resolve_namespace_target(alias_module, alias) else {
+            let Some(namespace_target) = resolve_namespace_target(alias_module, alias) else {
                 continue;
             };
-            let Some(target_module_idx) = module_index_for_file(graph, namespace_target_id) else {
+            let Some(target_module_idx) = module_index_for_file(graph, namespace_target.file_id)
+            else {
                 continue;
             };
             let reachable =
@@ -87,7 +92,9 @@ fn collect_pending_credits(
                 alias,
                 target_module_idx,
                 reachable: &reachable,
+                namespace_target,
                 pending: &mut pending,
+                reference_paths,
             });
         }
     }
@@ -98,10 +105,16 @@ fn collect_pending_credits(
 /// Resolve the file_id of a namespace import on `alias_module` whose local
 /// name matches `alias.namespace_local`. Only `InternalModule` targets count;
 /// external packages cannot have references propagated.
+#[derive(Clone, Copy)]
+struct NamespaceTarget {
+    file_id: FileId,
+    mechanism: ModuleLoadMechanism,
+}
+
 fn resolve_namespace_target(
     alias_module: &ResolvedModule,
     alias: &NamespaceObjectAlias,
-) -> Option<FileId> {
+) -> Option<NamespaceTarget> {
     alias_module.resolved_imports.iter().find_map(|import| {
         if import.info.local_name != alias.namespace_local {
             return None;
@@ -109,7 +122,14 @@ fn resolve_namespace_target(
         if !matches!(import.info.imported_name, ImportedName::Namespace) {
             return None;
         }
-        import.target.internal_file_id()
+        Some(NamespaceTarget {
+            file_id: import.target.internal_file_id()?,
+            mechanism: if import.target.is_commonjs_require() {
+                ModuleLoadMechanism::CommonJsRequire
+            } else {
+                ModuleLoadMechanism::EsModule
+            },
+        })
     })
 }
 
@@ -127,8 +147,10 @@ struct NamespaceCreditInput<'a> {
     alias_file_id: FileId,
     alias: &'a NamespaceObjectAlias,
     target_module_idx: usize,
-    reachable: &'a FxHashSet<(FileId, String)>,
+    reachable: &'a ReachableNamespaceExports,
+    namespace_target: NamespaceTarget,
     pending: &'a mut Vec<PendingCredit>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 struct ConsumerCreditInput<'a> {
@@ -137,7 +159,9 @@ struct ConsumerCreditInput<'a> {
     import: &'a crate::resolve::ResolvedImport,
     prefix_match: &'a str,
     target_module_idx: usize,
+    path: ReferencePathId,
     pending: &'a mut Vec<PendingCredit>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 fn collect_credits_for_alias(input: NamespaceCreditInput<'_>) {
@@ -148,23 +172,34 @@ fn collect_credits_for_alias(input: NamespaceCreditInput<'_>) {
         alias,
         target_module_idx,
         reachable,
+        namespace_target,
         pending,
+        reference_paths,
     } = input;
     let prefix_match = format!(".{}", alias.suffix);
-    for (target, imported_name) in reachable {
-        for indexed in indexes.consumers_for(*target, imported_name) {
+    for export in reachable.iter() {
+        for indexed in indexes.consumers_for(export.file_id, &export.exported_name) {
             let consumer = indexed.consumer;
             let import = indexed.import;
             if consumer.file_id == alias_file_id {
                 continue;
             }
+            let path = reachable.consumer_path(
+                export,
+                indexed,
+                namespace_target.file_id,
+                namespace_target.mechanism,
+                reference_paths,
+            );
             collect_credits_for_consumer_import(&mut ConsumerCreditInput {
                 graph,
                 consumer,
                 import,
                 prefix_match: &prefix_match,
                 target_module_idx,
+                path,
                 pending,
+                reference_paths,
             });
         }
     }
@@ -179,7 +214,9 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
     let import = input.import;
     let prefix_match = input.prefix_match;
     let target_module_idx = input.target_module_idx;
+    let path = input.path;
     let pending = &mut *input.pending;
+    let reference_paths = &mut *input.reference_paths;
 
     let consumer_local = import.info.local_name.as_str();
     if consumer_local.is_empty() {
@@ -195,21 +232,24 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
             member: access.member.clone(),
             consumer_file_id: consumer.file_id,
             import_span: import.info.span,
+            path,
         });
         let mut visited: FxHashSet<usize> = FxHashSet::default();
         visited.insert(target_module_idx);
-        let ctx = ChainWalkCtx {
+        let mut ctx = ChainWalkContext {
             graph,
             consumer,
             import_span: import.info.span,
+            pending,
+            reference_paths,
         };
         collect_chained_re_export_credits(
-            &ctx,
+            &mut ctx,
             target_module_idx,
             &access.member,
             &format!("{expected_object}.{}", access.member),
+            path,
             &mut visited,
-            pending,
         );
     }
 }
@@ -217,12 +257,13 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
 /// Invariant context passed through the chain walker: the read-only graph,
 /// the consumer module producing the accesses, and the original import span
 /// to use as the `from` site on every resulting `SymbolReference`. Grouped
-/// into a struct so the recursive helper stays under the workspace's 7-arg
-/// clippy limit.
-struct ChainWalkCtx<'a> {
+/// into a struct so the recursive helper keeps one explicit traversal contract.
+struct ChainWalkContext<'a> {
     graph: &'a ModuleGraph,
     consumer: &'a ResolvedModule,
     import_span: oxc_span::Span,
+    pending: &'a mut Vec<PendingCredit>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 /// Follow `export * as <name> from './source'` chains on the alias target
@@ -232,12 +273,12 @@ struct ChainWalkCtx<'a> {
 /// the re-export's `source_file`. Recurses if the new credit also lands on
 /// another namespace re-export, bounded by `visited` to short-circuit cycles.
 fn collect_chained_re_export_credits(
-    ctx: &ChainWalkCtx<'_>,
+    ctx: &mut ChainWalkContext<'_>,
     barrel_module_idx: usize,
     credited_name: &str,
     accessor_prefix: &str,
+    path: ReferencePathId,
     visited: &mut FxHashSet<usize>,
-    pending: &mut Vec<PendingCredit>,
 ) {
     let Some(barrel) = ctx.graph.modules.get(barrel_module_idx) else {
         return;
@@ -255,25 +296,34 @@ fn collect_chained_re_export_credits(
         if !visited.insert(source_module_idx) {
             continue;
         }
-        for access in &ctx.consumer.member_accesses {
-            if access.object != accessor_prefix {
-                continue;
-            }
-            pending.push(PendingCredit {
+        let source_path =
+            ctx.reference_paths
+                .extend(path, source_file, ModuleLoadMechanism::EsModule);
+        let accessed_members: Vec<String> = ctx
+            .consumer
+            .member_accesses
+            .iter()
+            .filter(|access| access.object == accessor_prefix)
+            .map(|access| access.member.clone())
+            .collect();
+        for member in accessed_members {
+            ctx.pending.push(PendingCredit {
                 target_module_idx: source_module_idx,
-                member: access.member.clone(),
+                member: member.clone(),
                 consumer_file_id: ctx.consumer.file_id,
                 import_span: ctx.import_span,
+                path: source_path,
             });
             collect_chained_re_export_credits(
                 ctx,
                 source_module_idx,
-                &access.member,
-                &format!("{accessor_prefix}.{}", access.member),
+                &member,
+                &format!("{accessor_prefix}.{member}"),
+                source_path,
                 visited,
-                pending,
             );
         }
+        visited.remove(&source_module_idx);
     }
 }
 
@@ -285,12 +335,8 @@ fn collect_chained_re_export_credits(
 /// namespace target is a star barrel (`export * from './bar'`): missing
 /// member exports are stubbed so Phase 4 chain resolution can propagate the
 /// reference to the real defining file.
-fn apply_pending_credits(
-    graph: &mut ModuleGraph,
-    pending: &[PendingCredit],
-    reference_paths: &mut ReferencePathInterner,
-) {
-    type GroupKey = (usize, FileId, oxc_span::Span);
+fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
+    type GroupKey = (usize, FileId, oxc_span::Span, ReferencePathId);
 
     let mut groups: FxHashMap<GroupKey, Vec<String>> = FxHashMap::default();
     for credit in pending {
@@ -299,29 +345,27 @@ fn apply_pending_credits(
                 credit.target_module_idx,
                 credit.consumer_file_id,
                 credit.import_span,
+                credit.path,
             ))
             .or_default()
             .push(credit.member.clone());
     }
 
-    for ((target_module_idx, consumer_file_id, import_span), members) in groups {
+    for ((target_module_idx, consumer_file_id, import_span, path), members) in groups {
         let module = &mut graph.modules[target_module_idx];
-        let target_file = module.file_id;
-        let target = ReferenceTarget {
-            source_id: consumer_file_id,
-            target_id: target_file,
-            import_span,
-            kind: ReferenceKind::NamespaceImport,
-        };
-        let found_members =
-            mark_member_exports_referenced(&mut module.exports, target, &members, reference_paths);
-        create_synthetic_exports_for_star_re_exports(
+        let site = ReferenceSite::exact(consumer_file_id, import_span, path);
+        let found_members = mark_member_exports_referenced_at_site(
+            &mut module.exports,
+            site,
+            &members,
+            ReferenceKind::NamespaceImport,
+        );
+        create_synthetic_exports_for_star_re_exports_at_site(
             &mut module.exports,
             &module.re_exports,
-            target,
+            site,
             &members,
             &found_members,
-            reference_paths,
         );
     }
 }

--- a/crates/graph/src/graph/namespace_indexes.rs
+++ b/crates/graph/src/graph/namespace_indexes.rs
@@ -102,10 +102,13 @@ impl NamespaceTraversal {
 
 /// One canonical persisted route graph plus the local node for every export
 /// state in `ReachableNamespaceExports`.
-pub(super) struct NamespaceReferenceRoutes {
-    graph: ReferenceRouteGraphId,
-    route_node_by_state: Vec<ReferenceRouteNodeId>,
-    terminal: ReferenceRouteNodeId,
+pub(super) enum NamespaceReferenceRoutes {
+    Untracked,
+    Exact {
+        graph: ReferenceRouteGraphId,
+        route_node_by_state: Vec<ReferenceRouteNodeId>,
+        terminal: ReferenceRouteNodeId,
+    },
 }
 
 impl NamespaceReferenceRoutes {
@@ -116,7 +119,15 @@ impl NamespaceReferenceRoutes {
         export: &ReachableNamespaceExport,
         consumer: &ConsumerImport<'_>,
         reference_paths: &mut ReferencePathInterner,
-    ) -> ReferencePathId {
+    ) -> Option<ReferencePathId> {
+        let Self::Exact {
+            graph,
+            route_node_by_state,
+            terminal,
+        } = self
+        else {
+            return None;
+        };
         let mechanism = if consumer.import.target.is_commonjs_require() {
             ModuleLoadMechanism::CommonJsRequire
         } else {
@@ -124,9 +135,9 @@ impl NamespaceReferenceRoutes {
         };
         reference_paths.route(
             None,
-            self.graph,
-            self.route_node_by_state[export.state_index],
-            self.terminal,
+            *graph,
+            route_node_by_state[export.state_index],
+            *terminal,
             Some(mechanism),
         )
     }
@@ -137,12 +148,20 @@ impl NamespaceReferenceRoutes {
         &self,
         export: &ReachableNamespaceExport,
         reference_paths: &mut ReferencePathInterner,
-    ) -> ReferencePathId {
+    ) -> Option<ReferencePathId> {
+        let Self::Exact {
+            graph,
+            route_node_by_state,
+            terminal,
+        } = self
+        else {
+            return None;
+        };
         reference_paths.route(
             None,
-            self.graph,
-            self.route_node_by_state[export.state_index],
-            self.terminal,
+            *graph,
+            route_node_by_state[export.state_index],
+            *terminal,
             None,
         )
     }
@@ -161,6 +180,10 @@ impl ReachableNamespaceExports {
         final_mechanism: ModuleLoadMechanism,
         reference_paths: &mut ReferencePathInterner,
     ) -> NamespaceReferenceRoutes {
+        if !reference_paths.tracks_provenance() {
+            return NamespaceReferenceRoutes::Untracked;
+        }
+
         let mut canonical_order: Vec<usize> = (0..self.exports.len()).collect();
         canonical_order.sort_unstable_by(|&left, &right| {
             let left_export = &self.exports[left];
@@ -199,7 +222,7 @@ impl ReachableNamespaceExports {
         ));
 
         let graph = reference_paths.intern_route_graph(ReferenceRouteGraphSpec::new(nodes));
-        NamespaceReferenceRoutes {
+        NamespaceReferenceRoutes::Exact {
             graph,
             route_node_by_state,
             terminal,

--- a/crates/graph/src/graph/namespace_indexes.rs
+++ b/crates/graph/src/graph/namespace_indexes.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use fallow_types::discover::FileId;
 use fallow_types::extract::{ImportedName, ModuleLoadMechanism};
@@ -10,7 +10,10 @@ use fallow_types::extract::{ImportedName, ModuleLoadMechanism};
 use crate::resolve::{ResolvedImport, ResolvedModule};
 
 use super::ModuleGraph;
-use super::types::{ReferencePathId, ReferencePathInterner};
+use super::types::{
+    ReferencePathId, ReferencePathInterner, ReferenceRouteGraphId, ReferenceRouteGraphSpec,
+    ReferenceRouteNodeId, ReferenceRouteNodeSpec,
+};
 
 #[derive(Default)]
 struct ReExportTargets {
@@ -24,83 +27,28 @@ pub(super) struct ConsumerImport<'a> {
     pub(super) import: &'a ResolvedImport,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct NamespaceRouteId(usize);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct NamespaceRouteNode {
-    parent: Option<NamespaceRouteId>,
-    file_id: FileId,
-    exported_name: String,
-}
-
-#[derive(Default)]
-struct NamespaceRouteInterner {
-    nodes: Vec<NamespaceRouteNode>,
-    ids: FxHashMap<NamespaceRouteNode, NamespaceRouteId>,
-}
-
-impl NamespaceRouteInterner {
-    fn extend(
-        &mut self,
-        parent: Option<NamespaceRouteId>,
-        file_id: FileId,
-        exported_name: &str,
-    ) -> NamespaceRouteId {
-        let node = NamespaceRouteNode {
-            parent,
-            file_id,
-            exported_name: exported_name.to_string(),
-        };
-        if let Some(route) = self.ids.get(&node) {
-            return *route;
-        }
-        let route = NamespaceRouteId(self.nodes.len());
-        self.nodes.push(node.clone());
-        self.ids.insert(node, route);
-        route
-    }
-
-    fn contains(
-        &self,
-        mut route: Option<NamespaceRouteId>,
-        file_id: FileId,
-        exported_name: &str,
-    ) -> bool {
-        while let Some(route_id) = route {
-            let Some(node) = self.nodes.get(route_id.0) else {
-                return false;
-            };
-            if node.file_id == file_id && node.exported_name == exported_name {
-                return true;
-            }
-            route = node.parent;
-        }
-        false
-    }
-}
-
-/// One outward-reachable namespace export plus its exact inward re-export route.
+/// One namespace export state in the compact transition graph.
 pub(super) struct ReachableNamespaceExport {
     pub(super) file_id: FileId,
     pub(super) exported_name: String,
-    route: Option<NamespaceRouteId>,
+    state_index: usize,
+    /// Inward transitions from this outward export toward the namespace seed.
+    inward: Vec<usize>,
 }
 
-/// All simple named/star re-export paths reachable from one namespace export.
+/// All reachable `(file, export-name)` states for one namespace export.
 ///
-/// Distinct routes to the same `(file, name)` remain distinct. Coverage must
-/// evaluate the route actually used by each consumer rather than collapsing a
-/// diamond into aggregate file reachability.
+/// A state is retained once, while named/star diamonds become transition
+/// edges. Cycles remain ordinary graph cycles and are evaluated later by the
+/// profile-aware monotone worklist; no simple paths are materialized.
 pub(super) struct ReachableNamespaceExports {
     exports: Vec<ReachableNamespaceExport>,
-    routes: NamespaceRouteInterner,
 }
 
 struct NamespaceTraversal {
     reachable: ReachableNamespaceExports,
     frontier: VecDeque<usize>,
-    seen: FxHashSet<(FileId, String, Option<NamespaceRouteId>)>,
+    state_by_export: FxHashMap<(FileId, String), usize>,
 }
 
 impl NamespaceTraversal {
@@ -108,51 +56,95 @@ impl NamespaceTraversal {
         let seed = ReachableNamespaceExport {
             file_id: seed_file,
             exported_name: seed_name.to_string(),
-            route: None,
+            state_index: 0,
+            inward: Vec::new(),
         };
         Self {
             reachable: ReachableNamespaceExports {
                 exports: vec![seed],
-                routes: NamespaceRouteInterner::default(),
             },
             frontier: VecDeque::from([0]),
-            seen: FxHashSet::from_iter([(seed_file, seed_name.to_string(), None)]),
+            state_by_export: FxHashMap::from_iter([((seed_file, seed_name.to_string()), 0)]),
         }
     }
 
-    fn push(
-        &mut self,
-        source_file: FileId,
-        source_name: &str,
-        source_route: Option<NamespaceRouteId>,
-        barrel_file: FileId,
-        exported_name: &str,
-    ) {
-        if (barrel_file == source_file && exported_name == source_name)
-            || self
-                .reachable
-                .routes
-                .contains(source_route, barrel_file, exported_name)
-        {
-            return;
+    fn connect(&mut self, source_index: usize, barrel_file: FileId, exported_name: &str) {
+        let key = (barrel_file, exported_name.to_string());
+        let barrel_index = if let Some(index) = self.state_by_export.get(&key) {
+            *index
+        } else {
+            let index = self.reachable.exports.len();
+            self.reachable.exports.push(ReachableNamespaceExport {
+                file_id: barrel_file,
+                exported_name: exported_name.to_string(),
+                state_index: index,
+                inward: Vec::new(),
+            });
+            self.state_by_export.insert(key, index);
+            self.frontier.push_back(index);
+            index
+        };
+        if source_index != barrel_index {
+            self.reachable.exports[barrel_index]
+                .inward
+                .push(source_index);
         }
-        let route = Some(
-            self.reachable
-                .routes
-                .extend(source_route, source_file, source_name),
-        );
-        if !self
-            .seen
-            .insert((barrel_file, exported_name.to_string(), route))
-        {
-            return;
+    }
+
+    fn finish(mut self) -> ReachableNamespaceExports {
+        for export in &mut self.reachable.exports {
+            export.inward.sort_unstable();
+            export.inward.dedup();
         }
-        self.reachable.exports.push(ReachableNamespaceExport {
-            file_id: barrel_file,
-            exported_name: exported_name.to_string(),
-            route,
-        });
-        self.frontier.push_back(self.reachable.exports.len() - 1);
+        self.reachable
+    }
+}
+
+/// One canonical persisted route graph plus the local node for every export
+/// state in `ReachableNamespaceExports`.
+pub(super) struct NamespaceReferenceRoutes {
+    graph: ReferenceRouteGraphId,
+    route_node_by_state: Vec<ReferenceRouteNodeId>,
+    terminal: ReferenceRouteNodeId,
+}
+
+impl NamespaceReferenceRoutes {
+    /// Intern the complete consumer-to-target route without expanding its
+    /// named/star alternatives.
+    pub(super) fn consumer_path(
+        &self,
+        export: &ReachableNamespaceExport,
+        consumer: &ConsumerImport<'_>,
+        reference_paths: &mut ReferencePathInterner,
+    ) -> ReferencePathId {
+        let mechanism = if consumer.import.target.is_commonjs_require() {
+            ModuleLoadMechanism::CommonJsRequire
+        } else {
+            ModuleLoadMechanism::EsModule
+        };
+        reference_paths.route(
+            None,
+            self.graph,
+            self.route_node_by_state[export.state_index],
+            self.terminal,
+            Some(mechanism),
+        )
+    }
+
+    /// Intern an external-entry traversal. The entry module is the reference
+    /// source, so traversal begins after its export state.
+    pub(super) fn entry_path(
+        &self,
+        export: &ReachableNamespaceExport,
+        reference_paths: &mut ReferencePathInterner,
+    ) -> ReferencePathId {
+        reference_paths.route(
+            None,
+            self.graph,
+            self.route_node_by_state[export.state_index],
+            self.terminal,
+            None,
+        )
     }
 }
 
@@ -161,54 +153,67 @@ impl ReachableNamespaceExports {
         self.exports.iter()
     }
 
-    fn route_hops(&self, export: &ReachableNamespaceExport) -> impl Iterator<Item = FileId> + '_ {
-        let mut next = export.route;
-        std::iter::from_fn(move || {
-            let route = next?;
-            let node = self.routes.nodes.get(route.0)?;
-            next = node.parent;
-            Some(node.file_id)
-        })
-    }
-
-    /// Intern the complete consumer-to-target module-load path.
-    pub(super) fn consumer_path(
+    /// Intern one canonical transition graph shared by every consumer and
+    /// entry-point reference for this namespace seed.
+    pub(super) fn intern_routes(
         &self,
-        export: &ReachableNamespaceExport,
-        consumer: &ConsumerImport<'_>,
         final_target: FileId,
         final_mechanism: ModuleLoadMechanism,
         reference_paths: &mut ReferencePathInterner,
-    ) -> ReferencePathId {
-        let direct_mechanism = if consumer.import.target.is_commonjs_require() {
-            ModuleLoadMechanism::CommonJsRequire
-        } else {
-            ModuleLoadMechanism::EsModule
-        };
-        let mut path = reference_paths.direct(export.file_id, direct_mechanism);
-        for hop in self.route_hops(export) {
-            path = reference_paths.extend(path, hop, ModuleLoadMechanism::EsModule);
+    ) -> NamespaceReferenceRoutes {
+        let mut canonical_order: Vec<usize> = (0..self.exports.len()).collect();
+        canonical_order.sort_unstable_by(|&left, &right| {
+            let left_export = &self.exports[left];
+            let right_export = &self.exports[right];
+            (left_export.file_id.0, left_export.exported_name.as_str())
+                .cmp(&(right_export.file_id.0, right_export.exported_name.as_str()))
+        });
+
+        let mut route_node_by_state = vec![ReferenceRouteNodeId(0); self.exports.len()];
+        for (route_index, state_index) in canonical_order.iter().copied().enumerate() {
+            route_node_by_state[state_index] = ReferenceRouteNodeId(route_index as u32);
         }
-        reference_paths.extend(path, final_target, final_mechanism)
+        let terminal = ReferenceRouteNodeId(self.exports.len() as u32);
+
+        let mut nodes = Vec::with_capacity(self.exports.len() + 1);
+        for state_index in canonical_order {
+            let export = &self.exports[state_index];
+            let mut successors: Vec<_> = export
+                .inward
+                .iter()
+                .map(|&inward| route_node_by_state[inward])
+                .collect();
+            if state_index == 0 {
+                successors.push(terminal);
+            }
+            nodes.push(ReferenceRouteNodeSpec::new(
+                export.file_id,
+                ModuleLoadMechanism::EsModule,
+                successors,
+            ));
+        }
+        nodes.push(ReferenceRouteNodeSpec::new(
+            final_target,
+            final_mechanism,
+            Vec::new(),
+        ));
+
+        let graph = reference_paths.intern_route_graph(ReferenceRouteGraphSpec::new(nodes));
+        NamespaceReferenceRoutes {
+            graph,
+            route_node_by_state,
+            terminal,
+        }
     }
 
-    /// Intern the synthetic external-entry-to-target path for an entry barrel.
-    pub(super) fn entry_path(
-        &self,
-        export: &ReachableNamespaceExport,
-        final_target: FileId,
-        final_mechanism: ModuleLoadMechanism,
-        reference_paths: &mut ReferencePathInterner,
-    ) -> ReferencePathId {
-        let mut hops = self.route_hops(export);
-        let Some(first_hop) = hops.next() else {
-            return reference_paths.direct(final_target, final_mechanism);
-        };
-        let mut path = reference_paths.direct(first_hop, ModuleLoadMechanism::EsModule);
-        for hop in hops {
-            path = reference_paths.extend(path, hop, ModuleLoadMechanism::EsModule);
-        }
-        reference_paths.extend(path, final_target, final_mechanism)
+    #[cfg(test)]
+    pub(super) fn state_count(&self) -> usize {
+        self.exports.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn transition_count(&self) -> usize {
+        self.exports.iter().map(|export| export.inward.len()).sum()
     }
 }
 
@@ -236,6 +241,18 @@ impl<'a> NamespacePropagationIndexes<'a> {
                         .or_default()
                         .push((module.file_id, edge.exported_name.clone()));
                 }
+            }
+        }
+        for targets in re_exports_by_source.values_mut() {
+            targets
+                .star_barrels
+                .sort_unstable_by_key(|file_id| file_id.0);
+            targets.star_barrels.dedup();
+            for named in targets.named.values_mut() {
+                named.sort_unstable_by(|left, right| {
+                    (left.0.0, left.1.as_str()).cmp(&(right.0.0, right.1.as_str()))
+                });
+                named.dedup();
             }
         }
 
@@ -284,38 +301,25 @@ impl<'a> NamespacePropagationIndexes<'a> {
     ) -> ReachableNamespaceExports {
         let mut traversal = NamespaceTraversal::new(seed_file, seed_name);
 
-        while let Some(export_index) = traversal.frontier.pop_front() {
-            let source_file = traversal.reachable.exports[export_index].file_id;
-            let source_name = traversal.reachable.exports[export_index]
+        while let Some(source_index) = traversal.frontier.pop_front() {
+            let source_file = traversal.reachable.exports[source_index].file_id;
+            let source_name = traversal.reachable.exports[source_index]
                 .exported_name
                 .clone();
-            let source_route = traversal.reachable.exports[export_index].route;
             let Some(targets) = self.re_exports_by_source.get(&source_file) else {
                 continue;
             };
             if let Some(named) = targets.named.get(source_name.as_str()) {
                 for (barrel_file, exported_name) in named {
-                    traversal.push(
-                        source_file,
-                        &source_name,
-                        source_route,
-                        *barrel_file,
-                        exported_name,
-                    );
+                    traversal.connect(source_index, *barrel_file, exported_name);
                 }
             }
             for &barrel_file in &targets.star_barrels {
-                traversal.push(
-                    source_file,
-                    &source_name,
-                    source_route,
-                    barrel_file,
-                    &source_name,
-                );
+                traversal.connect(source_index, barrel_file, &source_name);
             }
         }
 
-        traversal.reachable
+        traversal.finish()
     }
 
     pub(super) fn consumers_for(
@@ -327,5 +331,71 @@ impl<'a> NamespacePropagationIndexes<'a> {
             .get(&target)
             .and_then(|by_name| by_name.get(imported_name))
             .map_or(&[], Vec::as_slice)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_indexes() -> NamespacePropagationIndexes<'static> {
+        NamespacePropagationIndexes {
+            re_exports_by_source: FxHashMap::default(),
+            consumers_by_target: FxHashMap::default(),
+        }
+    }
+
+    #[test]
+    fn dense_namespace_cycle_retains_one_state_per_export() {
+        const BARREL_COUNT: u32 = 14;
+        let mut indexes = empty_indexes();
+        for source in 0..BARREL_COUNT {
+            let targets = indexes
+                .re_exports_by_source
+                .entry(FileId(source))
+                .or_default();
+            targets.star_barrels.extend(
+                (0..BARREL_COUNT)
+                    .filter(|&barrel| barrel != source)
+                    .map(FileId),
+            );
+        }
+
+        let reachable = indexes.enumerate_reachable_barrels(FileId(0), "Ns");
+
+        assert_eq!(reachable.state_count(), BARREL_COUNT as usize);
+        assert_eq!(
+            reachable.transition_count(),
+            (BARREL_COUNT * (BARREL_COUNT - 1)) as usize
+        );
+    }
+
+    #[test]
+    fn repeated_namespace_diamonds_grow_by_states_and_edges_not_paths() {
+        const LAYERS: u32 = 24;
+        let mut indexes = empty_indexes();
+        let mut previous = vec![FileId(0)];
+        let mut next_file = 1_u32;
+        for _ in 0..LAYERS {
+            let next = vec![FileId(next_file), FileId(next_file + 1)];
+            next_file += 2;
+            for source in &previous {
+                indexes
+                    .re_exports_by_source
+                    .entry(*source)
+                    .or_default()
+                    .star_barrels
+                    .extend(next.iter().copied());
+            }
+            previous = next;
+        }
+
+        let reachable = indexes.enumerate_reachable_barrels(FileId(0), "Ns");
+
+        assert_eq!(reachable.state_count(), 1 + (LAYERS as usize * 2));
+        assert_eq!(
+            reachable.transition_count(),
+            2 + ((LAYERS as usize - 1) * 4)
+        );
     }
 }

--- a/crates/graph/src/graph/namespace_indexes.rs
+++ b/crates/graph/src/graph/namespace_indexes.rs
@@ -1,13 +1,16 @@
 //! Ephemeral indexes shared by namespace propagation passes.
 
+use std::collections::VecDeque;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::discover::FileId;
-use fallow_types::extract::ImportedName;
+use fallow_types::extract::{ImportedName, ModuleLoadMechanism};
 
 use crate::resolve::{ResolvedImport, ResolvedModule};
 
 use super::ModuleGraph;
+use super::types::{ReferencePathId, ReferencePathInterner};
 
 #[derive(Default)]
 struct ReExportTargets {
@@ -19,6 +22,194 @@ struct ReExportTargets {
 pub(super) struct ConsumerImport<'a> {
     pub(super) consumer: &'a ResolvedModule,
     pub(super) import: &'a ResolvedImport,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct NamespaceRouteId(usize);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct NamespaceRouteNode {
+    parent: Option<NamespaceRouteId>,
+    file_id: FileId,
+    exported_name: String,
+}
+
+#[derive(Default)]
+struct NamespaceRouteInterner {
+    nodes: Vec<NamespaceRouteNode>,
+    ids: FxHashMap<NamespaceRouteNode, NamespaceRouteId>,
+}
+
+impl NamespaceRouteInterner {
+    fn extend(
+        &mut self,
+        parent: Option<NamespaceRouteId>,
+        file_id: FileId,
+        exported_name: &str,
+    ) -> NamespaceRouteId {
+        let node = NamespaceRouteNode {
+            parent,
+            file_id,
+            exported_name: exported_name.to_string(),
+        };
+        if let Some(route) = self.ids.get(&node) {
+            return *route;
+        }
+        let route = NamespaceRouteId(self.nodes.len());
+        self.nodes.push(node.clone());
+        self.ids.insert(node, route);
+        route
+    }
+
+    fn contains(
+        &self,
+        mut route: Option<NamespaceRouteId>,
+        file_id: FileId,
+        exported_name: &str,
+    ) -> bool {
+        while let Some(route_id) = route {
+            let Some(node) = self.nodes.get(route_id.0) else {
+                return false;
+            };
+            if node.file_id == file_id && node.exported_name == exported_name {
+                return true;
+            }
+            route = node.parent;
+        }
+        false
+    }
+}
+
+/// One outward-reachable namespace export plus its exact inward re-export route.
+pub(super) struct ReachableNamespaceExport {
+    pub(super) file_id: FileId,
+    pub(super) exported_name: String,
+    route: Option<NamespaceRouteId>,
+}
+
+/// All simple named/star re-export paths reachable from one namespace export.
+///
+/// Distinct routes to the same `(file, name)` remain distinct. Coverage must
+/// evaluate the route actually used by each consumer rather than collapsing a
+/// diamond into aggregate file reachability.
+pub(super) struct ReachableNamespaceExports {
+    exports: Vec<ReachableNamespaceExport>,
+    routes: NamespaceRouteInterner,
+}
+
+struct NamespaceTraversal {
+    reachable: ReachableNamespaceExports,
+    frontier: VecDeque<usize>,
+    seen: FxHashSet<(FileId, String, Option<NamespaceRouteId>)>,
+}
+
+impl NamespaceTraversal {
+    fn new(seed_file: FileId, seed_name: &str) -> Self {
+        let seed = ReachableNamespaceExport {
+            file_id: seed_file,
+            exported_name: seed_name.to_string(),
+            route: None,
+        };
+        Self {
+            reachable: ReachableNamespaceExports {
+                exports: vec![seed],
+                routes: NamespaceRouteInterner::default(),
+            },
+            frontier: VecDeque::from([0]),
+            seen: FxHashSet::from_iter([(seed_file, seed_name.to_string(), None)]),
+        }
+    }
+
+    fn push(
+        &mut self,
+        source_file: FileId,
+        source_name: &str,
+        source_route: Option<NamespaceRouteId>,
+        barrel_file: FileId,
+        exported_name: &str,
+    ) {
+        if (barrel_file == source_file && exported_name == source_name)
+            || self
+                .reachable
+                .routes
+                .contains(source_route, barrel_file, exported_name)
+        {
+            return;
+        }
+        let route = Some(
+            self.reachable
+                .routes
+                .extend(source_route, source_file, source_name),
+        );
+        if !self
+            .seen
+            .insert((barrel_file, exported_name.to_string(), route))
+        {
+            return;
+        }
+        self.reachable.exports.push(ReachableNamespaceExport {
+            file_id: barrel_file,
+            exported_name: exported_name.to_string(),
+            route,
+        });
+        self.frontier.push_back(self.reachable.exports.len() - 1);
+    }
+}
+
+impl ReachableNamespaceExports {
+    pub(super) fn iter(&self) -> impl Iterator<Item = &ReachableNamespaceExport> {
+        self.exports.iter()
+    }
+
+    fn route_hops(&self, export: &ReachableNamespaceExport) -> impl Iterator<Item = FileId> + '_ {
+        let mut next = export.route;
+        std::iter::from_fn(move || {
+            let route = next?;
+            let node = self.routes.nodes.get(route.0)?;
+            next = node.parent;
+            Some(node.file_id)
+        })
+    }
+
+    /// Intern the complete consumer-to-target module-load path.
+    pub(super) fn consumer_path(
+        &self,
+        export: &ReachableNamespaceExport,
+        consumer: &ConsumerImport<'_>,
+        final_target: FileId,
+        final_mechanism: ModuleLoadMechanism,
+        reference_paths: &mut ReferencePathInterner,
+    ) -> ReferencePathId {
+        let direct_mechanism = if consumer.import.target.is_commonjs_require() {
+            ModuleLoadMechanism::CommonJsRequire
+        } else {
+            ModuleLoadMechanism::EsModule
+        };
+        let mut path = reference_paths.direct(export.file_id, direct_mechanism);
+        for hop in self.route_hops(export) {
+            path = reference_paths.extend(path, hop, ModuleLoadMechanism::EsModule);
+        }
+        reference_paths.extend(path, final_target, final_mechanism)
+    }
+
+    /// Intern the synthetic external-entry-to-target path for an entry barrel.
+    pub(super) fn entry_path(
+        &self,
+        export: &ReachableNamespaceExport,
+        final_target: FileId,
+        final_mechanism: ModuleLoadMechanism,
+        reference_paths: &mut ReferencePathInterner,
+    ) -> ReferencePathId {
+        let mut hops = self.route_hops(export);
+        let Some(first_hop) = hops.next() else {
+            return reference_paths.direct(final_target, final_mechanism);
+        };
+        let mut path = reference_paths.direct(first_hop, ModuleLoadMechanism::EsModule);
+        for hop in hops {
+            path = reference_paths.extend(path, hop, ModuleLoadMechanism::EsModule);
+        }
+        reference_paths.extend(path, final_target, final_mechanism)
+    }
 }
 
 /// Build-only indexes used by both namespace propagation passes.
@@ -68,6 +259,17 @@ impl<'a> NamespacePropagationIndexes<'a> {
                     .push(ConsumerImport { consumer, import });
             }
         }
+        for by_name in consumers_by_target.values_mut() {
+            for consumers in by_name.values_mut() {
+                consumers.sort_unstable_by_key(|consumer| {
+                    (
+                        consumer.consumer.file_id.0,
+                        consumer.import.info.span.start,
+                        consumer.import.info.span.end,
+                    )
+                });
+            }
+        }
 
         Self {
             re_exports_by_source,
@@ -79,31 +281,41 @@ impl<'a> NamespacePropagationIndexes<'a> {
         &self,
         seed_file: FileId,
         seed_name: &str,
-    ) -> FxHashSet<(FileId, String)> {
-        let mut reachable = FxHashSet::default();
-        reachable.insert((seed_file, seed_name.to_string()));
-        let mut frontier = vec![(seed_file, seed_name.to_string())];
+    ) -> ReachableNamespaceExports {
+        let mut traversal = NamespaceTraversal::new(seed_file, seed_name);
 
-        while let Some((source_file, source_name)) = frontier.pop() {
+        while let Some(export_index) = traversal.frontier.pop_front() {
+            let source_file = traversal.reachable.exports[export_index].file_id;
+            let source_name = traversal.reachable.exports[export_index]
+                .exported_name
+                .clone();
+            let source_route = traversal.reachable.exports[export_index].route;
             let Some(targets) = self.re_exports_by_source.get(&source_file) else {
                 continue;
             };
             if let Some(named) = targets.named.get(source_name.as_str()) {
-                for pair in named {
-                    if reachable.insert(pair.clone()) {
-                        frontier.push(pair.clone());
-                    }
+                for (barrel_file, exported_name) in named {
+                    traversal.push(
+                        source_file,
+                        &source_name,
+                        source_route,
+                        *barrel_file,
+                        exported_name,
+                    );
                 }
             }
             for &barrel_file in &targets.star_barrels {
-                let pair = (barrel_file, source_name.clone());
-                if reachable.insert(pair.clone()) {
-                    frontier.push(pair);
-                }
+                traversal.push(
+                    source_file,
+                    &source_name,
+                    source_route,
+                    barrel_file,
+                    &source_name,
+                );
             }
         }
 
-        reachable
+        traversal.reachable
     }
 
     pub(super) fn consumers_for(

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -34,7 +34,9 @@ use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
 use super::ModuleGraph;
-use super::namespace_indexes::{NamespacePropagationIndexes, ReachableNamespaceExports};
+use super::namespace_indexes::{
+    NamespacePropagationIndexes, NamespaceReferenceRoutes, ReachableNamespaceExports,
+};
 use super::narrowing::{
     ReferenceSite, create_synthetic_exports_for_star_re_exports_at_site,
     mark_all_exports_referenced_at_site, mark_member_exports_referenced_at_site,
@@ -99,6 +101,11 @@ pub(super) fn propagate_namespace_re_exports(
         };
 
         let reachable = indexes.enumerate_reachable_barrels(*barrel_file_id, exported_name);
+        let routes = reachable.intern_routes(
+            *source_file_id,
+            ModuleLoadMechanism::EsModule,
+            reference_paths,
+        );
 
         for export in reachable.iter().filter(|export| {
             graph
@@ -106,12 +113,7 @@ pub(super) fn propagate_namespace_re_exports(
                 .get(export.file_id.0 as usize)
                 .is_some_and(super::types::ModuleNode::is_entry_point)
         }) {
-            let path = reachable.entry_path(
-                export,
-                *source_file_id,
-                ModuleLoadMechanism::EsModule,
-                reference_paths,
-            );
+            let path = routes.entry_path(export, reference_paths);
             pending.push(PendingCredit {
                 target_module_idx,
                 kind: CreditKind::AllExports,
@@ -125,9 +127,8 @@ pub(super) fn propagate_namespace_re_exports(
             indexes,
             seed_barrel_file: *barrel_file_id,
             target_module_idx,
-            final_target: *source_file_id,
         };
-        collect_consumer_credits(&context, &reachable, &mut pending, reference_paths);
+        collect_consumer_credits(&context, &reachable, &routes, &mut pending, reference_paths);
     }
 
     apply_pending_credits(graph, &pending);
@@ -148,12 +149,12 @@ struct ConsumerCreditContext<'indexes, 'modules> {
     indexes: &'indexes NamespacePropagationIndexes<'modules>,
     seed_barrel_file: FileId,
     target_module_idx: usize,
-    final_target: FileId,
 }
 
 fn collect_consumer_credits(
     context: &ConsumerCreditContext<'_, '_>,
     reachable: &ReachableNamespaceExports,
+    routes: &NamespaceReferenceRoutes,
     pending: &mut Vec<PendingCredit>,
     reference_paths: &mut ReferencePathInterner,
 ) {
@@ -167,13 +168,7 @@ fn collect_consumer_credits(
             if consumer.file_id == context.seed_barrel_file {
                 continue;
             }
-            let path = reachable.consumer_path(
-                export,
-                indexed,
-                context.final_target,
-                ModuleLoadMechanism::EsModule,
-                reference_paths,
-            );
+            let path = routes.consumer_path(export, indexed, reference_paths);
 
             let consumer_local = import.info.local_name.as_str();
             if consumer_local.is_empty() {
@@ -343,6 +338,21 @@ mod tests {
         }
     }
 
+    fn side_effect_import(source: &str, target: FileId, span: oxc_span::Span) -> ResolvedImport {
+        ResolvedImport {
+            info: ImportInfo {
+                source: source.to_string(),
+                imported_name: ImportedName::SideEffect,
+                local_name: String::new(),
+                is_type_only: false,
+                from_style: false,
+                span,
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(target),
+        }
+    }
+
     fn ns_re_export(source: &str, alias: &str, target: FileId) -> ResolvedReExport {
         ResolvedReExport {
             info: ReExportInfo {
@@ -369,6 +379,19 @@ mod tests {
         }
     }
 
+    fn star_re_export(source: &str, target: FileId) -> ResolvedReExport {
+        ResolvedReExport {
+            info: ReExportInfo {
+                source: source.to_string(),
+                imported_name: "*".to_string(),
+                exported_name: "*".to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::new(0, 10),
+            },
+            target: ResolveResult::InternalModule(target),
+        }
+    }
+
     fn namespace_coverage_graph(commonjs_consumer: bool) -> ModuleGraph {
         let files = vec![
             discovered_file(0, "/project/consumer.test.ts", 100),
@@ -382,18 +405,7 @@ mod tests {
                 path: files[0].path.clone(),
                 resolved_imports: vec![
                     named_import_with_mechanism("./barrel", "Ns", FileId(1), commonjs_consumer),
-                    ResolvedImport {
-                        info: ImportInfo {
-                            source: "./alternate".to_string(),
-                            imported_name: ImportedName::SideEffect,
-                            local_name: String::new(),
-                            is_type_only: false,
-                            from_style: false,
-                            span: oxc_span::Span::new(20, 30),
-                            source_span: oxc_span::Span::default(),
-                        },
-                        target: ResolveResult::InternalModule(FileId(3)),
-                    },
+                    side_effect_import("./alternate", FileId(3), oxc_span::Span::new(20, 30)),
                 ],
                 member_accesses: vec![MemberAccess {
                     object: "Ns".to_string(),
@@ -416,18 +428,11 @@ mod tests {
             ResolvedModule {
                 file_id: FileId(3),
                 path: files[3].path.clone(),
-                resolved_imports: vec![ResolvedImport {
-                    info: ImportInfo {
-                        source: "./source".to_string(),
-                        imported_name: ImportedName::SideEffect,
-                        local_name: String::new(),
-                        is_type_only: false,
-                        from_style: false,
-                        span: oxc_span::Span::new(0, 10),
-                        source_span: oxc_span::Span::default(),
-                    },
-                    target: ResolveResult::InternalModule(FileId(2)),
-                }],
+                resolved_imports: vec![side_effect_import(
+                    "./source",
+                    FileId(2),
+                    oxc_span::Span::new(0, 10),
+                )],
                 ..Default::default()
             },
         ];
@@ -442,6 +447,93 @@ mod tests {
                 source_file: FileId(0),
                 target_file: FileId(1),
             }],
+            &test_entries,
+            &[],
+            &test_entries,
+            &files,
+        )
+    }
+
+    fn namespace_diamond_graph(mask_both_branches: bool) -> ModuleGraph {
+        let files: Vec<_> = (0..7)
+            .map(|id| discovered_file(id, &format!("/project/file-{id}.ts"), 50))
+            .collect();
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_imports: vec![
+                    named_import_from("./outer", "Ns", FileId(1)),
+                    side_effect_import("./alternate", FileId(6), oxc_span::Span::new(20, 30)),
+                ],
+                member_accesses: vec![MemberAccess {
+                    object: "Ns".to_string(),
+                    member: "used".to_string(),
+                }],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                re_exports: vec![
+                    star_re_export("./left", FileId(2)),
+                    star_re_export("./right", FileId(3)),
+                ],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: files[2].path.clone(),
+                re_exports: vec![star_re_export("./namespace", FileId(4))],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(3),
+                path: files[3].path.clone(),
+                re_exports: vec![star_re_export("./namespace", FileId(4))],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(4),
+                path: files[4].path.clone(),
+                re_exports: vec![ns_re_export("./source", "Ns", FileId(5))],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(5),
+                path: files[5].path.clone(),
+                exports: vec![named_export("used")],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(6),
+                path: files[6].path.clone(),
+                resolved_imports: vec![side_effect_import(
+                    "./source",
+                    FileId(5),
+                    oxc_span::Span::new(0, 10),
+                )],
+                ..Default::default()
+            },
+        ];
+        let test_entries = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+        let mut replacements = vec![ResolvedReplacedModuleTarget {
+            source_file: FileId(0),
+            target_file: FileId(2),
+        }];
+        if mask_both_branches {
+            replacements.push(ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(3),
+            });
+        }
+
+        ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &replacements,
             &test_entries,
             &[],
             &test_entries,
@@ -478,6 +570,45 @@ mod tests {
             ]
         );
         assert!(graph.is_test_reference_covered(reference));
+    }
+
+    #[test]
+    fn compact_namespace_routes_survive_graph_cache_roundtrip() {
+        let graph = namespace_coverage_graph(false);
+        let encoded = postcard::to_allocvec(&graph).expect("encode namespace route graph");
+        let decoded: ModuleGraph =
+            postcard::from_bytes(&encoded).expect("decode namespace route graph");
+        let reference = &decoded.modules[2].exports[0].references[0];
+
+        assert_eq!(
+            decoded.reference_path_hops(reference),
+            vec![
+                (FileId(2), ModuleLoadMechanism::EsModule),
+                (FileId(1), ModuleLoadMechanism::EsModule),
+            ]
+        );
+        assert!(!decoded.is_test_reference_covered(reference));
+        assert_eq!(decoded.reference_routes.graphs.len(), 1);
+        assert_eq!(decoded.reference_routes.nodes.len(), 2);
+    }
+
+    #[test]
+    fn namespace_diamond_is_covered_when_one_route_remains_active() {
+        let graph = namespace_diamond_graph(false);
+        let references = &graph.modules[5].exports[0].references;
+
+        assert_eq!(references.len(), 1);
+        assert!(graph.is_test_reference_covered(&references[0]));
+    }
+
+    #[test]
+    fn namespace_diamond_is_uncovered_when_every_route_is_masked() {
+        let graph = namespace_diamond_graph(true);
+        let references = &graph.modules[5].exports[0].references;
+
+        assert!(graph.modules[5].is_test_reachable());
+        assert_eq!(references.len(), 1);
+        assert!(!graph.is_test_reference_covered(&references[0]));
     }
 
     #[test]

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -34,10 +34,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use super::ModuleGraph;
 use super::namespace_indexes::NamespacePropagationIndexes;
 use super::narrowing::{
-    create_synthetic_exports_for_star_re_exports, mark_all_exports_referenced,
+    ReferenceTarget, create_synthetic_exports_for_star_re_exports, mark_all_exports_referenced,
     mark_member_exports_referenced,
 };
-use super::types::ReferenceKind;
+use super::types::{ReferenceKind, ReferencePathInterner};
 use fallow_types::discover::FileId;
 
 /// Either credit a specific member on the target, or credit every export
@@ -65,6 +65,7 @@ struct PendingCredit {
 pub(super) fn propagate_namespace_re_exports(
     graph: &mut ModuleGraph,
     indexes: &NamespacePropagationIndexes<'_>,
+    reference_paths: &mut ReferencePathInterner,
 ) {
     let ns_edges: Vec<(FileId, FileId, String)> = graph
         .modules
@@ -117,7 +118,7 @@ pub(super) fn propagate_namespace_re_exports(
         );
     }
 
-    apply_pending_credits(graph, &pending);
+    apply_pending_credits(graph, &pending, reference_paths);
 }
 
 /// Map a `FileId` to its index in `graph.modules`. Returns `None` if the id
@@ -190,7 +191,11 @@ fn collect_consumer_credits(
 /// pipeline that `narrow_namespace_references` uses for direct namespace
 /// imports. `AllExports` credits short-circuit to `mark_all_exports_referenced`
 /// for the whole-object and entry-point cases.
-fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
+fn apply_pending_credits(
+    graph: &mut ModuleGraph,
+    pending: &[PendingCredit],
+    reference_paths: &mut ReferencePathInterner,
+) {
     type GroupKey = (usize, FileId, oxc_span::Span);
 
     let mut groups: FxHashMap<GroupKey, GroupState> = FxHashMap::default();
@@ -216,28 +221,29 @@ fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
 
     for ((target_module_idx, consumer_file_id, import_span), state) in groups {
         let module = &mut graph.modules[target_module_idx];
+        let target_file = module.file_id;
+        let target = ReferenceTarget {
+            source_id: consumer_file_id,
+            target_id: target_file,
+            import_span,
+            kind: ReferenceKind::NamespaceImport,
+        };
         if state.whole_object {
-            mark_all_exports_referenced(
-                &mut module.exports,
-                consumer_file_id,
-                import_span,
-                ReferenceKind::NamespaceImport,
-            );
+            mark_all_exports_referenced(&mut module.exports, target, reference_paths);
         } else {
             let found = mark_member_exports_referenced(
                 &mut module.exports,
-                consumer_file_id,
+                target,
                 &state.members,
-                import_span,
-                ReferenceKind::NamespaceImport,
+                reference_paths,
             );
             create_synthetic_exports_for_star_re_exports(
                 &mut module.exports,
                 &module.re_exports,
-                consumer_file_id,
+                target,
                 &state.members,
                 &found,
-                import_span,
+                reference_paths,
             );
         }
     }

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -65,7 +65,7 @@ struct PendingCredit {
     /// into scope; used as `import_span` on the resulting reference.
     import_span: oxc_span::Span,
     /// Exact consumer-to-target path, including every named/star barrel.
-    path: ReferencePathId,
+    path: Option<ReferencePathId>,
 }
 
 /// Phase 2c: credit `export * as Foo from './bar'` member accesses onto `./bar`.
@@ -217,7 +217,7 @@ fn collect_consumer_credits(
 /// imports. `AllExports` credits short-circuit to `mark_all_exports_referenced`
 /// for the whole-object and entry-point cases.
 fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
-    type GroupKey = (usize, FileId, oxc_span::Span, ReferencePathId);
+    type GroupKey = (usize, FileId, oxc_span::Span, Option<ReferencePathId>);
 
     let mut groups: FxHashMap<GroupKey, GroupState> = FxHashMap::default();
     for credit in pending {

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -29,16 +29,19 @@
 //! (reachability) so credits attached here participate in reachability and
 //! Phase 4 chain propagation downstream. See issue #324.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
+#[cfg(test)]
+use rustc_hash::FxHashSet;
 
 use super::ModuleGraph;
-use super::namespace_indexes::NamespacePropagationIndexes;
+use super::namespace_indexes::{NamespacePropagationIndexes, ReachableNamespaceExports};
 use super::narrowing::{
-    ReferenceTarget, create_synthetic_exports_for_star_re_exports, mark_all_exports_referenced,
-    mark_member_exports_referenced,
+    ReferenceSite, create_synthetic_exports_for_star_re_exports_at_site,
+    mark_all_exports_referenced_at_site, mark_member_exports_referenced_at_site,
 };
-use super::types::{ReferenceKind, ReferencePathInterner};
+use super::types::{ReferenceKind, ReferencePathId, ReferencePathInterner};
 use fallow_types::discover::FileId;
+use fallow_types::extract::ModuleLoadMechanism;
 
 /// Either credit a specific member on the target, or credit every export
 /// (whole-object use, or entry-point exposure where the external accesses
@@ -59,6 +62,8 @@ struct PendingCredit {
     /// Span of the consumer's import that brought the re-exported binding
     /// into scope; used as `import_span` on the resulting reference.
     import_span: oxc_span::Span,
+    /// Exact consumer-to-target path, including every named/star barrel.
+    path: ReferencePathId,
 }
 
 /// Phase 2c: credit `export * as Foo from './bar'` member accesses onto `./bar`.
@@ -95,30 +100,37 @@ pub(super) fn propagate_namespace_re_exports(
 
         let reachable = indexes.enumerate_reachable_barrels(*barrel_file_id, exported_name);
 
-        if reachable.iter().any(|(file_id, _)| {
+        for export in reachable.iter().filter(|export| {
             graph
                 .modules
-                .get(file_id.0 as usize)
+                .get(export.file_id.0 as usize)
                 .is_some_and(super::types::ModuleNode::is_entry_point)
         }) {
+            let path = reachable.entry_path(
+                export,
+                *source_file_id,
+                ModuleLoadMechanism::EsModule,
+                reference_paths,
+            );
             pending.push(PendingCredit {
                 target_module_idx,
                 kind: CreditKind::AllExports,
-                consumer_file_id: *barrel_file_id,
+                consumer_file_id: export.file_id,
                 import_span: oxc_span::Span::default(),
+                path,
             });
         }
 
-        collect_consumer_credits(
+        let context = ConsumerCreditContext {
             indexes,
-            *barrel_file_id,
+            seed_barrel_file: *barrel_file_id,
             target_module_idx,
-            &reachable,
-            &mut pending,
-        );
+            final_target: *source_file_id,
+        };
+        collect_consumer_credits(&context, &reachable, &mut pending, reference_paths);
     }
 
-    apply_pending_credits(graph, &pending, reference_paths);
+    apply_pending_credits(graph, &pending);
 }
 
 /// Map a `FileId` to its index in `graph.modules`. Returns `None` if the id
@@ -132,20 +144,36 @@ fn module_index_for_file(graph: &ModuleGraph, file_id: FileId) -> Option<usize> 
 /// For every consumer in `module_by_id` that imports a name reachable from
 /// the seed namespace re-export, collect a `PendingCredit` per
 /// `<local>.<member>` access and per whole-object use.
-fn collect_consumer_credits(
-    indexes: &NamespacePropagationIndexes<'_>,
+struct ConsumerCreditContext<'indexes, 'modules> {
+    indexes: &'indexes NamespacePropagationIndexes<'modules>,
     seed_barrel_file: FileId,
     target_module_idx: usize,
-    reachable: &FxHashSet<(FileId, String)>,
+    final_target: FileId,
+}
+
+fn collect_consumer_credits(
+    context: &ConsumerCreditContext<'_, '_>,
+    reachable: &ReachableNamespaceExports,
     pending: &mut Vec<PendingCredit>,
+    reference_paths: &mut ReferencePathInterner,
 ) {
-    for (import_target, imported_name) in reachable {
-        for indexed in indexes.consumers_for(*import_target, imported_name) {
+    for export in reachable.iter() {
+        for indexed in context
+            .indexes
+            .consumers_for(export.file_id, &export.exported_name)
+        {
             let consumer = indexed.consumer;
             let import = indexed.import;
-            if consumer.file_id == seed_barrel_file {
+            if consumer.file_id == context.seed_barrel_file {
                 continue;
             }
+            let path = reachable.consumer_path(
+                export,
+                indexed,
+                context.final_target,
+                ModuleLoadMechanism::EsModule,
+                reference_paths,
+            );
 
             let consumer_local = import.info.local_name.as_str();
             if consumer_local.is_empty() {
@@ -162,10 +190,11 @@ fn collect_consumer_credits(
                 .any(|n| n == consumer_local);
             if whole_object {
                 pending.push(PendingCredit {
-                    target_module_idx,
+                    target_module_idx: context.target_module_idx,
                     kind: CreditKind::AllExports,
                     consumer_file_id: consumer.file_id,
                     import_span: import.info.span,
+                    path,
                 });
                 continue;
             }
@@ -175,28 +204,25 @@ fn collect_consumer_credits(
                     continue;
                 }
                 pending.push(PendingCredit {
-                    target_module_idx,
+                    target_module_idx: context.target_module_idx,
                     kind: CreditKind::Member(access.member.clone()),
                     consumer_file_id: consumer.file_id,
                     import_span: import.info.span,
+                    path,
                 });
             }
         }
     }
 }
 
-/// Apply the collected credits, grouping by `(target_module_idx, consumer_file_id, import_span)`
-/// so each `(consumer file, namespace target, import site)` runs through the
+/// Apply the collected credits, grouping by the exact reference site so each
+/// `(consumer file, namespace target, import site, path)` runs through the
 /// same `mark_member_exports_referenced` plus `create_synthetic_exports_for_star_re_exports`
 /// pipeline that `narrow_namespace_references` uses for direct namespace
 /// imports. `AllExports` credits short-circuit to `mark_all_exports_referenced`
 /// for the whole-object and entry-point cases.
-fn apply_pending_credits(
-    graph: &mut ModuleGraph,
-    pending: &[PendingCredit],
-    reference_paths: &mut ReferencePathInterner,
-) {
-    type GroupKey = (usize, FileId, oxc_span::Span);
+fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
+    type GroupKey = (usize, FileId, oxc_span::Span, ReferencePathId);
 
     let mut groups: FxHashMap<GroupKey, GroupState> = FxHashMap::default();
     for credit in pending {
@@ -204,6 +230,7 @@ fn apply_pending_credits(
             credit.target_module_idx,
             credit.consumer_file_id,
             credit.import_span,
+            credit.path,
         );
         let entry = groups.entry(key).or_default();
         match &credit.kind {
@@ -219,31 +246,28 @@ fn apply_pending_credits(
         }
     }
 
-    for ((target_module_idx, consumer_file_id, import_span), state) in groups {
+    for ((target_module_idx, consumer_file_id, import_span, path), state) in groups {
         let module = &mut graph.modules[target_module_idx];
-        let target_file = module.file_id;
-        let target = ReferenceTarget {
-            source_id: consumer_file_id,
-            target_id: target_file,
-            import_span,
-            kind: ReferenceKind::NamespaceImport,
-        };
+        let site = ReferenceSite::exact(consumer_file_id, import_span, path);
         if state.whole_object {
-            mark_all_exports_referenced(&mut module.exports, target, reference_paths);
-        } else {
-            let found = mark_member_exports_referenced(
+            mark_all_exports_referenced_at_site(
                 &mut module.exports,
-                target,
-                &state.members,
-                reference_paths,
+                site,
+                ReferenceKind::NamespaceImport,
             );
-            create_synthetic_exports_for_star_re_exports(
+        } else {
+            let found = mark_member_exports_referenced_at_site(
+                &mut module.exports,
+                site,
+                &state.members,
+                ReferenceKind::NamespaceImport,
+            );
+            create_synthetic_exports_for_star_re_exports_at_site(
                 &mut module.exports,
                 &module.re_exports,
-                target,
+                site,
                 &state.members,
                 &found,
-                reference_paths,
             );
         }
     }
@@ -259,7 +283,10 @@ struct GroupState {
 mod tests {
     use super::*;
     use crate::graph::ModuleGraph;
-    use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport};
+    use crate::resolve::{
+        ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport,
+        ResolvedReplacedModuleTarget,
+    };
     use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource};
     use fallow_types::extract::{
         ExportInfo, ExportName, ImportInfo, ImportedName, MemberAccess, ReExportInfo, VisibilityTag,
@@ -289,6 +316,15 @@ mod tests {
     }
 
     fn named_import_from(source: &str, name: &str, target: FileId) -> ResolvedImport {
+        named_import_with_mechanism(source, name, target, false)
+    }
+
+    fn named_import_with_mechanism(
+        source: &str,
+        name: &str,
+        target: FileId,
+        commonjs: bool,
+    ) -> ResolvedImport {
         ResolvedImport {
             info: ImportInfo {
                 source: source.to_string(),
@@ -299,7 +335,11 @@ mod tests {
                 span: oxc_span::Span::new(0, 10),
                 source_span: oxc_span::Span::default(),
             },
-            target: ResolveResult::InternalModule(target),
+            target: if commonjs {
+                ResolveResult::CommonJsInternalModule(target)
+            } else {
+                ResolveResult::InternalModule(target)
+            },
         }
     }
 
@@ -327,6 +367,117 @@ mod tests {
             },
             target: ResolveResult::InternalModule(target),
         }
+    }
+
+    fn namespace_coverage_graph(commonjs_consumer: bool) -> ModuleGraph {
+        let files = vec![
+            discovered_file(0, "/project/consumer.test.ts", 100),
+            discovered_file(1, "/project/barrel.ts", 50),
+            discovered_file(2, "/project/source.ts", 50),
+            discovered_file(3, "/project/alternate.ts", 50),
+        ];
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_imports: vec![
+                    named_import_with_mechanism("./barrel", "Ns", FileId(1), commonjs_consumer),
+                    ResolvedImport {
+                        info: ImportInfo {
+                            source: "./alternate".to_string(),
+                            imported_name: ImportedName::SideEffect,
+                            local_name: String::new(),
+                            is_type_only: false,
+                            from_style: false,
+                            span: oxc_span::Span::new(20, 30),
+                            source_span: oxc_span::Span::default(),
+                        },
+                        target: ResolveResult::InternalModule(FileId(3)),
+                    },
+                ],
+                member_accesses: vec![MemberAccess {
+                    object: "Ns".to_string(),
+                    member: "used".to_string(),
+                }],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                re_exports: vec![ns_re_export("./source", "Ns", FileId(2))],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: files[2].path.clone(),
+                exports: vec![named_export("used")],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(3),
+                path: files[3].path.clone(),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./source".to_string(),
+                        imported_name: ImportedName::SideEffect,
+                        local_name: String::new(),
+                        is_type_only: false,
+                        from_style: false,
+                        span: oxc_span::Span::new(0, 10),
+                        source_span: oxc_span::Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(2)),
+                }],
+                ..Default::default()
+            },
+        ];
+        let test_entries = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+
+        ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+            &test_entries,
+            &[],
+            &test_entries,
+            &files,
+        )
+    }
+
+    #[test]
+    fn mocked_namespace_barrel_stays_uncovered_when_target_has_an_alternate_route() {
+        let graph = namespace_coverage_graph(false);
+        let reference = &graph.modules[2].exports[0].references[0];
+
+        assert!(graph.modules[2].is_test_reachable());
+        assert_eq!(
+            graph.reference_path_hops(reference),
+            vec![
+                (FileId(2), ModuleLoadMechanism::EsModule),
+                (FileId(1), ModuleLoadMechanism::EsModule),
+            ]
+        );
+        assert!(!graph.is_test_reference_covered(reference));
+    }
+
+    #[test]
+    fn commonjs_namespace_consumer_retains_its_exact_load_path() {
+        let graph = namespace_coverage_graph(true);
+        let reference = &graph.modules[2].exports[0].references[0];
+
+        assert_eq!(
+            graph.reference_path_hops(reference),
+            vec![
+                (FileId(2), ModuleLoadMechanism::EsModule),
+                (FileId(1), ModuleLoadMechanism::CommonJsRequire),
+            ]
+        );
+        assert!(graph.is_test_reference_covered(reference));
     }
 
     #[test]

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -8,12 +8,37 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::resolve::ResolvedModule;
 use fallow_types::discover::FileId;
-use fallow_types::extract::{ImportedName, VisibilityTag};
+use fallow_types::extract::{ImportedName, ModuleLoadMechanism, VisibilityTag};
 
 use super::types::{ExportSymbol, ReExportEdge, ReferenceKind, SymbolReference};
 use super::{ImportedSymbol, ModuleNode};
 
 use super::build::{export_matches, is_css_module_path};
+
+#[derive(Clone, Copy)]
+struct ReferenceSite {
+    from_file: FileId,
+    import_span: oxc_span::Span,
+    mechanism: ModuleLoadMechanism,
+}
+
+impl ReferenceSite {
+    const fn esm(source_id: FileId, import_span: oxc_span::Span) -> Self {
+        Self {
+            from_file: source_id,
+            import_span,
+            mechanism: ModuleLoadMechanism::EsModule,
+        }
+    }
+
+    const fn from_symbol(source_id: FileId, symbol: &ImportedSymbol) -> Self {
+        Self {
+            from_file: source_id,
+            import_span: symbol.import_span,
+            mechanism: symbol.mechanism,
+        }
+    }
+}
 
 /// Check whether an import binding is unused in the source file.
 ///
@@ -43,29 +68,42 @@ fn extract_accessed_members(source_mod: Option<&&ResolvedModule>, local_name: &s
 
 /// Mark all exports on a module as referenced by a given source file.
 ///
-/// Deduplicates: skips exports already referenced by `source_id`.
+/// Deduplicates by source and runtime mechanism. A source can retain one ESM
+/// and one CommonJS reference because replacement coverage treats them
+/// differently.
 pub(super) fn mark_all_exports_referenced(
     exports: &mut Vec<ExportSymbol>,
     source_id: FileId,
     import_span: oxc_span::Span,
     kind: ReferenceKind,
 ) {
+    mark_all_exports_referenced_with_mechanism(
+        exports,
+        ReferenceSite::esm(source_id, import_span),
+        kind,
+    );
+}
+
+fn mark_all_exports_referenced_with_mechanism(
+    exports: &mut Vec<ExportSymbol>,
+    site: ReferenceSite,
+    kind: ReferenceKind,
+) {
     for export in exports {
-        attach_reference(export, source_id, kind, import_span);
+        attach_reference(export, site, kind);
     }
 }
 
-fn attach_reference(
-    export: &mut ExportSymbol,
-    source_id: FileId,
-    kind: ReferenceKind,
-    import_span: oxc_span::Span,
-) {
-    if export.references.iter().all(|r| r.from_file != source_id) {
+fn attach_reference(export: &mut ExportSymbol, site: ReferenceSite, kind: ReferenceKind) {
+    let already_referenced = export.references.iter().any(|reference| {
+        reference.from_file == site.from_file && reference.mechanism == site.mechanism
+    });
+    if !already_referenced {
         export.references.push(SymbolReference {
-            from_file: source_id,
+            from_file: site.from_file,
             kind,
-            import_span,
+            mechanism: site.mechanism,
+            import_span: site.import_span,
         });
     }
 }
@@ -80,6 +118,20 @@ pub(super) fn mark_member_exports_referenced(
     import_span: oxc_span::Span,
     kind: ReferenceKind,
 ) -> FxHashSet<String> {
+    mark_member_exports_referenced_with_mechanism(
+        exports,
+        ReferenceSite::esm(source_id, import_span),
+        accessed_members,
+        kind,
+    )
+}
+
+fn mark_member_exports_referenced_with_mechanism(
+    exports: &mut [ExportSymbol],
+    site: ReferenceSite,
+    accessed_members: &[String],
+    kind: ReferenceKind,
+) -> FxHashSet<String> {
     let member_set: FxHashSet<&str> = accessed_members.iter().map(String::as_str).collect();
     let mut found_members: FxHashSet<String> = FxHashSet::default();
     for export in exports {
@@ -89,7 +141,7 @@ pub(super) fn mark_member_exports_referenced(
         };
         if member_set.contains(name_str) {
             found_members.insert(name_str.to_owned());
-            attach_reference(export, source_id, kind, import_span);
+            attach_reference(export, site, kind);
         }
     }
     found_members
@@ -105,6 +157,22 @@ pub(super) fn create_synthetic_exports_for_star_re_exports(
     accessed_members: &[String],
     found_members: &FxHashSet<String>,
     import_span: oxc_span::Span,
+) {
+    create_synthetic_exports_for_star_re_exports_with_mechanism(
+        exports,
+        re_exports,
+        ReferenceSite::esm(source_id, import_span),
+        accessed_members,
+        found_members,
+    );
+}
+
+fn create_synthetic_exports_for_star_re_exports_with_mechanism(
+    exports: &mut Vec<ExportSymbol>,
+    re_exports: &[ReExportEdge],
+    site: ReferenceSite,
+    accessed_members: &[String],
+    found_members: &FxHashSet<String>,
 ) {
     let has_star_re_exports = re_exports.iter().any(|re| re.exported_name == "*");
     if !has_star_re_exports {
@@ -122,9 +190,10 @@ pub(super) fn create_synthetic_exports_for_star_re_exports(
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 0),
             references: vec![SymbolReference {
-                from_file: source_id,
+                from_file: site.from_file,
                 kind: ReferenceKind::NamespaceImport,
-                import_span,
+                mechanism: site.mechanism,
+                import_span: site.import_span,
             }],
             members: Vec::new(),
         });
@@ -137,13 +206,12 @@ pub(super) fn create_synthetic_exports_for_star_re_exports(
 /// Otherwise, all exports are conservatively marked as referenced.
 fn narrow_namespace_references(
     module: &mut ModuleNode,
-    source_id: FileId,
+    site: ReferenceSite,
     sym_local_name: &str,
-    sym_import_span: oxc_span::Span,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     entry_point_ids: &FxHashSet<FileId>,
 ) {
-    let source_mod = module_by_id.get(&source_id);
+    let source_mod = module_by_id.get(&site.from_file);
     let accessed_members = extract_accessed_members(source_mod, sym_local_name);
 
     let is_whole_object =
@@ -153,37 +221,35 @@ fn narrow_namespace_references(
         m.exports
             .iter()
             .any(|e| e.local_name.as_deref() == Some(sym_local_name))
-    }) && !entry_point_ids.contains(&source_id);
+    }) && !entry_point_ids.contains(&site.from_file);
 
-    let is_entry_with_no_access =
-        accessed_members.is_empty() && !is_whole_object && entry_point_ids.contains(&source_id);
+    let is_entry_with_no_access = accessed_members.is_empty()
+        && !is_whole_object
+        && entry_point_ids.contains(&site.from_file);
 
     if is_whole_object
         || (!is_entry_with_no_access
             && (accessed_members.is_empty() || is_re_exported_from_non_entry))
     {
-        mark_all_exports_referenced(
+        mark_all_exports_referenced_with_mechanism(
             &mut module.exports,
-            source_id,
-            sym_import_span,
+            site,
             ReferenceKind::NamespaceImport,
         );
     } else {
-        let found_members = mark_member_exports_referenced(
+        let found_members = mark_member_exports_referenced_with_mechanism(
             &mut module.exports,
-            source_id,
+            site,
             &accessed_members,
-            sym_import_span,
             ReferenceKind::NamespaceImport,
         );
 
-        create_synthetic_exports_for_star_re_exports(
+        create_synthetic_exports_for_star_re_exports_with_mechanism(
             &mut module.exports,
             &module.re_exports,
-            source_id,
+            site,
             &accessed_members,
             &found_members,
-            sym_import_span,
         );
     }
 }
@@ -195,29 +261,22 @@ fn narrow_namespace_references(
 /// as namespace objects where each property corresponds to a class name (named export).
 fn narrow_css_module_references(
     exports: &mut Vec<ExportSymbol>,
-    source_id: FileId,
+    site: ReferenceSite,
     sym_local_name: &str,
-    sym_import_span: oxc_span::Span,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
 ) {
-    let source_mod = module_by_id.get(&source_id);
+    let source_mod = module_by_id.get(&site.from_file);
     let is_whole_object =
         source_mod.is_some_and(|m| m.whole_object_uses.iter().any(|n| n == sym_local_name));
     let accessed_members = extract_accessed_members(source_mod, sym_local_name);
 
     if is_whole_object || accessed_members.is_empty() {
-        mark_all_exports_referenced(
-            exports,
-            source_id,
-            sym_import_span,
-            ReferenceKind::DefaultImport,
-        );
+        mark_all_exports_referenced_with_mechanism(exports, site, ReferenceKind::DefaultImport);
     } else {
-        mark_member_exports_referenced(
+        mark_member_exports_referenced_with_mechanism(
             exports,
-            source_id,
+            site,
             &accessed_members,
-            sym_import_span,
             ReferenceKind::DefaultImport,
         );
     }
@@ -314,9 +373,8 @@ fn attach_direct_export_references(
     if let Some(idx) = fallback_idx {
         attach_reference(
             &mut target_module.exports[idx],
-            source_id,
+            ReferenceSite::from_symbol(source_id, sym),
             ref_kind,
-            sym.import_span,
         );
     }
 }
@@ -366,9 +424,8 @@ fn attach_to_export_groups(
         for idx in group {
             attach_reference(
                 &mut target_module.exports[*idx],
-                source_id,
+                ReferenceSite::from_symbol(source_id, sym),
                 ref_kind,
-                sym.import_span,
             );
         }
     }
@@ -394,19 +451,18 @@ pub(super) fn attach_symbol_reference(
     attach_direct_export_references(target_module, source_id, sym, source_mod, ref_kind);
 
     if matches!(sym.imported_name, ImportedName::Namespace) {
+        let site = ReferenceSite::from_symbol(source_id, sym);
         if sym.local_name.is_empty() {
-            mark_all_exports_referenced(
+            mark_all_exports_referenced_with_mechanism(
                 &mut target_module.exports,
-                source_id,
-                sym.import_span,
+                site,
                 ReferenceKind::NamespaceImport,
             );
         } else {
             narrow_namespace_references(
                 target_module,
-                source_id,
+                site,
                 &sym.local_name,
-                sym.import_span,
                 module_by_id,
                 entry_point_ids,
             );
@@ -419,9 +475,8 @@ pub(super) fn attach_symbol_reference(
     {
         narrow_css_module_references(
             &mut target_module.exports,
-            source_id,
+            ReferenceSite::from_symbol(source_id, sym),
             &sym.local_name,
-            sym.import_span,
             module_by_id,
         );
     }
@@ -583,6 +638,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(5),
                 kind: ReferenceKind::NamedImport,
+                mechanism: ModuleLoadMechanism::EsModule,
                 import_span: oxc_span::Span::new(0, 10),
             }],
             members: Vec::new(),
@@ -1229,6 +1285,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(0),
                 kind: ReferenceKind::NamedImport,
+                mechanism: ModuleLoadMechanism::EsModule,
                 import_span: oxc_span::Span::new(0, 10),
             }],
             members: Vec::new(),

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -100,9 +100,10 @@ fn extract_accessed_members(source_mod: Option<&&ResolvedModule>, local_name: &s
 
 /// Mark all exports on a module as referenced by a given source file.
 ///
-/// Deduplicates by source and runtime mechanism. A source can retain one ESM
-/// and one CommonJS reference because replacement coverage treats them
-/// differently.
+/// Profiled reachability deduplicates by source and exact runtime path, so ESM
+/// and CommonJS references remain distinct when replacements can affect them.
+/// Legacy reachability deliberately retains the pre-profile source-only
+/// behavior because no replacement mask can distinguish those paths.
 #[cfg(test)]
 pub(super) fn mark_all_exports_referenced(
     exports: &mut Vec<ExportSymbol>,
@@ -684,6 +685,35 @@ mod tests {
             &mut reference_paths,
         );
         assert_eq!(exports[0].references.len(), 1);
+    }
+
+    #[test]
+    fn untracked_reference_sites_preserve_legacy_source_deduplication() {
+        let mut export = ExportSymbol {
+            name: ExportName::Named("a".to_string()),
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: oxc_span::Span::new(0, 5),
+            references: Vec::new(),
+            members: Vec::new(),
+        };
+
+        attach_reference(
+            &mut export,
+            ReferenceSite::exact(FileId(5), oxc_span::Span::new(0, 10), None),
+            ReferenceKind::NamedImport,
+        );
+        attach_reference(
+            &mut export,
+            ReferenceSite::exact(FileId(5), oxc_span::Span::new(20, 30), None),
+            ReferenceKind::NamespaceImport,
+        );
+
+        assert_eq!(export.references.len(), 1);
+        assert_eq!(export.references[0].kind, ReferenceKind::NamedImport);
+        assert_eq!(export.references[0].import_span, oxc_span::Span::new(0, 10));
     }
 
     #[test]

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -8,7 +8,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::resolve::ResolvedModule;
 use fallow_types::discover::FileId;
-use fallow_types::extract::{ImportedName, ModuleLoadMechanism, VisibilityTag};
+#[cfg(test)]
+use fallow_types::extract::ModuleLoadMechanism;
+use fallow_types::extract::{ImportedName, VisibilityTag};
 
 use super::types::{
     ExportSymbol, ReExportEdge, ReferenceKind, ReferencePathId, ReferencePathInterner,
@@ -19,13 +21,14 @@ use super::{ImportedSymbol, ModuleNode};
 use super::build::{export_matches, is_css_module_path};
 
 #[derive(Clone, Copy)]
-struct ReferenceSite {
+pub(super) struct ReferenceSite {
     from_file: FileId,
     import_span: oxc_span::Span,
     path: ReferencePathId,
 }
 
 #[derive(Clone, Copy)]
+#[cfg(test)]
 pub(super) struct ReferenceTarget {
     pub(super) source_id: FileId,
     pub(super) target_id: FileId,
@@ -34,6 +37,19 @@ pub(super) struct ReferenceTarget {
 }
 
 impl ReferenceSite {
+    pub(super) const fn exact(
+        from_file: FileId,
+        import_span: oxc_span::Span,
+        path: ReferencePathId,
+    ) -> Self {
+        Self {
+            from_file,
+            import_span,
+            path,
+        }
+    }
+
+    #[cfg(test)]
     fn esm(target: ReferenceTarget, reference_paths: &mut ReferencePathInterner) -> Self {
         Self {
             from_file: target.source_id,
@@ -87,6 +103,7 @@ fn extract_accessed_members(source_mod: Option<&&ResolvedModule>, local_name: &s
 /// Deduplicates by source and runtime mechanism. A source can retain one ESM
 /// and one CommonJS reference because replacement coverage treats them
 /// differently.
+#[cfg(test)]
 pub(super) fn mark_all_exports_referenced(
     exports: &mut Vec<ExportSymbol>,
     target: ReferenceTarget,
@@ -99,7 +116,7 @@ pub(super) fn mark_all_exports_referenced(
     );
 }
 
-fn mark_all_exports_referenced_at_site(
+pub(super) fn mark_all_exports_referenced_at_site(
     exports: &mut Vec<ExportSymbol>,
     site: ReferenceSite,
     kind: ReferenceKind,
@@ -127,6 +144,7 @@ fn attach_reference(export: &mut ExportSymbol, site: ReferenceSite, kind: Refere
 /// Mark only exports whose names appear in `accessed_members` as referenced.
 ///
 /// Returns the set of member names that were found among the exports.
+#[cfg(test)]
 pub(super) fn mark_member_exports_referenced(
     exports: &mut [ExportSymbol],
     target: ReferenceTarget,
@@ -141,7 +159,7 @@ pub(super) fn mark_member_exports_referenced(
     )
 }
 
-fn mark_member_exports_referenced_at_site(
+pub(super) fn mark_member_exports_referenced_at_site(
     exports: &mut [ExportSymbol],
     site: ReferenceSite,
     accessed_members: &[String],
@@ -165,6 +183,7 @@ fn mark_member_exports_referenced_at_site(
 /// Create synthetic `ExportSymbol` entries for members accessed via namespace import
 /// that were not found among the target's own exports, but the target has `export *`
 /// re-exports that may forward those names.
+#[cfg(test)]
 pub(super) fn create_synthetic_exports_for_star_re_exports(
     exports: &mut Vec<ExportSymbol>,
     re_exports: &[ReExportEdge],
@@ -182,7 +201,7 @@ pub(super) fn create_synthetic_exports_for_star_re_exports(
     );
 }
 
-fn create_synthetic_exports_for_star_re_exports_at_site(
+pub(super) fn create_synthetic_exports_for_star_re_exports_at_site(
     exports: &mut Vec<ExportSymbol>,
     re_exports: &[ReExportEdge],
     site: ReferenceSite,

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -10,7 +10,10 @@ use crate::resolve::ResolvedModule;
 use fallow_types::discover::FileId;
 use fallow_types::extract::{ImportedName, ModuleLoadMechanism, VisibilityTag};
 
-use super::types::{ExportSymbol, ReExportEdge, ReferenceKind, SymbolReference};
+use super::types::{
+    ExportSymbol, ReExportEdge, ReferenceKind, ReferencePathId, ReferencePathInterner,
+    SymbolReference,
+};
 use super::{ImportedSymbol, ModuleNode};
 
 use super::build::{export_matches, is_css_module_path};
@@ -19,23 +22,36 @@ use super::build::{export_matches, is_css_module_path};
 struct ReferenceSite {
     from_file: FileId,
     import_span: oxc_span::Span,
-    mechanism: ModuleLoadMechanism,
+    path: ReferencePathId,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ReferenceTarget {
+    pub(super) source_id: FileId,
+    pub(super) target_id: FileId,
+    pub(super) import_span: oxc_span::Span,
+    pub(super) kind: ReferenceKind,
 }
 
 impl ReferenceSite {
-    const fn esm(source_id: FileId, import_span: oxc_span::Span) -> Self {
+    fn esm(target: ReferenceTarget, reference_paths: &mut ReferencePathInterner) -> Self {
         Self {
-            from_file: source_id,
-            import_span,
-            mechanism: ModuleLoadMechanism::EsModule,
+            from_file: target.source_id,
+            import_span: target.import_span,
+            path: reference_paths.direct(target.target_id, ModuleLoadMechanism::EsModule),
         }
     }
 
-    const fn from_symbol(source_id: FileId, symbol: &ImportedSymbol) -> Self {
+    fn from_symbol(
+        source_id: FileId,
+        target_id: FileId,
+        symbol: &ImportedSymbol,
+        reference_paths: &mut ReferencePathInterner,
+    ) -> Self {
         Self {
             from_file: source_id,
             import_span: symbol.import_span,
-            mechanism: symbol.mechanism,
+            path: reference_paths.direct(target_id, symbol.mechanism),
         }
     }
 }
@@ -73,18 +89,17 @@ fn extract_accessed_members(source_mod: Option<&&ResolvedModule>, local_name: &s
 /// differently.
 pub(super) fn mark_all_exports_referenced(
     exports: &mut Vec<ExportSymbol>,
-    source_id: FileId,
-    import_span: oxc_span::Span,
-    kind: ReferenceKind,
+    target: ReferenceTarget,
+    reference_paths: &mut ReferencePathInterner,
 ) {
-    mark_all_exports_referenced_with_mechanism(
+    mark_all_exports_referenced_at_site(
         exports,
-        ReferenceSite::esm(source_id, import_span),
-        kind,
+        ReferenceSite::esm(target, reference_paths),
+        target.kind,
     );
 }
 
-fn mark_all_exports_referenced_with_mechanism(
+fn mark_all_exports_referenced_at_site(
     exports: &mut Vec<ExportSymbol>,
     site: ReferenceSite,
     kind: ReferenceKind,
@@ -95,14 +110,15 @@ fn mark_all_exports_referenced_with_mechanism(
 }
 
 fn attach_reference(export: &mut ExportSymbol, site: ReferenceSite, kind: ReferenceKind) {
-    let already_referenced = export.references.iter().any(|reference| {
-        reference.from_file == site.from_file && reference.mechanism == site.mechanism
-    });
+    let already_referenced = export
+        .references
+        .iter()
+        .any(|reference| reference.from_file == site.from_file && reference.path == site.path);
     if !already_referenced {
         export.references.push(SymbolReference {
             from_file: site.from_file,
             kind,
-            mechanism: site.mechanism,
+            path: site.path,
             import_span: site.import_span,
         });
     }
@@ -113,20 +129,19 @@ fn attach_reference(export: &mut ExportSymbol, site: ReferenceSite, kind: Refere
 /// Returns the set of member names that were found among the exports.
 pub(super) fn mark_member_exports_referenced(
     exports: &mut [ExportSymbol],
-    source_id: FileId,
+    target: ReferenceTarget,
     accessed_members: &[String],
-    import_span: oxc_span::Span,
-    kind: ReferenceKind,
+    reference_paths: &mut ReferencePathInterner,
 ) -> FxHashSet<String> {
-    mark_member_exports_referenced_with_mechanism(
+    mark_member_exports_referenced_at_site(
         exports,
-        ReferenceSite::esm(source_id, import_span),
+        ReferenceSite::esm(target, reference_paths),
         accessed_members,
-        kind,
+        target.kind,
     )
 }
 
-fn mark_member_exports_referenced_with_mechanism(
+fn mark_member_exports_referenced_at_site(
     exports: &mut [ExportSymbol],
     site: ReferenceSite,
     accessed_members: &[String],
@@ -153,21 +168,21 @@ fn mark_member_exports_referenced_with_mechanism(
 pub(super) fn create_synthetic_exports_for_star_re_exports(
     exports: &mut Vec<ExportSymbol>,
     re_exports: &[ReExportEdge],
-    source_id: FileId,
+    target: ReferenceTarget,
     accessed_members: &[String],
     found_members: &FxHashSet<String>,
-    import_span: oxc_span::Span,
+    reference_paths: &mut ReferencePathInterner,
 ) {
-    create_synthetic_exports_for_star_re_exports_with_mechanism(
+    create_synthetic_exports_for_star_re_exports_at_site(
         exports,
         re_exports,
-        ReferenceSite::esm(source_id, import_span),
+        ReferenceSite::esm(target, reference_paths),
         accessed_members,
         found_members,
     );
 }
 
-fn create_synthetic_exports_for_star_re_exports_with_mechanism(
+fn create_synthetic_exports_for_star_re_exports_at_site(
     exports: &mut Vec<ExportSymbol>,
     re_exports: &[ReExportEdge],
     site: ReferenceSite,
@@ -192,7 +207,7 @@ fn create_synthetic_exports_for_star_re_exports_with_mechanism(
             references: vec![SymbolReference {
                 from_file: site.from_file,
                 kind: ReferenceKind::NamespaceImport,
-                mechanism: site.mechanism,
+                path: site.path,
                 import_span: site.import_span,
             }],
             members: Vec::new(),
@@ -231,20 +246,20 @@ fn narrow_namespace_references(
         || (!is_entry_with_no_access
             && (accessed_members.is_empty() || is_re_exported_from_non_entry))
     {
-        mark_all_exports_referenced_with_mechanism(
+        mark_all_exports_referenced_at_site(
             &mut module.exports,
             site,
             ReferenceKind::NamespaceImport,
         );
     } else {
-        let found_members = mark_member_exports_referenced_with_mechanism(
+        let found_members = mark_member_exports_referenced_at_site(
             &mut module.exports,
             site,
             &accessed_members,
             ReferenceKind::NamespaceImport,
         );
 
-        create_synthetic_exports_for_star_re_exports_with_mechanism(
+        create_synthetic_exports_for_star_re_exports_at_site(
             &mut module.exports,
             &module.re_exports,
             site,
@@ -271,9 +286,9 @@ fn narrow_css_module_references(
     let accessed_members = extract_accessed_members(source_mod, sym_local_name);
 
     if is_whole_object || accessed_members.is_empty() {
-        mark_all_exports_referenced_with_mechanism(exports, site, ReferenceKind::DefaultImport);
+        mark_all_exports_referenced_at_site(exports, site, ReferenceKind::DefaultImport);
     } else {
-        mark_member_exports_referenced_with_mechanism(
+        mark_member_exports_referenced_at_site(
             exports,
             site,
             &accessed_members,
@@ -312,7 +327,7 @@ fn import_binding_has_value_usage(source_mod: Option<&&ResolvedModule>, local_na
 
 fn attach_direct_export_references(
     target_module: &mut ModuleNode,
-    source_id: FileId,
+    site: ReferenceSite,
     sym: &ImportedSymbol,
     source_mod: Option<&&ResolvedModule>,
     ref_kind: ReferenceKind,
@@ -349,8 +364,7 @@ fn attach_direct_export_references(
     if attach_type_exports || attach_value_exports {
         attach_to_export_groups(
             target_module,
-            source_id,
-            sym,
+            site,
             ref_kind,
             (&type_exports, attach_type_exports),
             (&value_exports, attach_value_exports),
@@ -371,11 +385,7 @@ fn attach_direct_export_references(
     };
 
     if let Some(idx) = fallback_idx {
-        attach_reference(
-            &mut target_module.exports[idx],
-            ReferenceSite::from_symbol(source_id, sym),
-            ref_kind,
-        );
+        attach_reference(&mut target_module.exports[idx], site, ref_kind);
     }
 }
 
@@ -411,8 +421,7 @@ fn decide_attach_targets(
 /// corresponding attach flag is set.
 fn attach_to_export_groups(
     target_module: &mut ModuleNode,
-    source_id: FileId,
-    sym: &ImportedSymbol,
+    site: ReferenceSite,
     ref_kind: ReferenceKind,
     type_group: (&[usize], bool),
     value_group: (&[usize], bool),
@@ -422,11 +431,7 @@ fn attach_to_export_groups(
             continue;
         }
         for idx in group {
-            attach_reference(
-                &mut target_module.exports[*idx],
-                ReferenceSite::from_symbol(source_id, sym),
-                ref_kind,
-            );
+            attach_reference(&mut target_module.exports[*idx], site, ref_kind);
         }
     }
 }
@@ -440,6 +445,7 @@ pub(super) fn attach_symbol_reference(
     sym: &ImportedSymbol,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     entry_point_ids: &FxHashSet<FileId>,
+    reference_paths: &mut ReferencePathInterner,
 ) {
     let ref_kind = reference_kind_for(&sym.imported_name);
     let source_mod = module_by_id.get(&source_id);
@@ -448,12 +454,12 @@ pub(super) fn attach_symbol_reference(
         return;
     }
 
-    attach_direct_export_references(target_module, source_id, sym, source_mod, ref_kind);
+    let site = ReferenceSite::from_symbol(source_id, target_module.file_id, sym, reference_paths);
+    attach_direct_export_references(target_module, site, sym, source_mod, ref_kind);
 
     if matches!(sym.imported_name, ImportedName::Namespace) {
-        let site = ReferenceSite::from_symbol(source_id, sym);
         if sym.local_name.is_empty() {
-            mark_all_exports_referenced_with_mechanism(
+            mark_all_exports_referenced_at_site(
                 &mut target_module.exports,
                 site,
                 ReferenceKind::NamespaceImport,
@@ -475,7 +481,7 @@ pub(super) fn attach_symbol_reference(
     {
         narrow_css_module_references(
             &mut target_module.exports,
-            ReferenceSite::from_symbol(source_id, sym),
+            site,
             &sym.local_name,
             module_by_id,
         );
@@ -490,6 +496,15 @@ mod tests {
     use fallow_types::extract::{ExportName, VisibilityTag};
 
     use super::super::ModuleGraph;
+
+    fn namespace_target(source_id: FileId, target_id: FileId) -> ReferenceTarget {
+        ReferenceTarget {
+            source_id,
+            target_id,
+            import_span: oxc_span::Span::new(0, 10),
+            kind: ReferenceKind::NamespaceImport,
+        }
+    }
 
     #[test]
     fn is_unused_binding_true() {
@@ -593,6 +608,7 @@ mod tests {
 
     #[test]
     fn mark_all_exports_referenced_adds_refs() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![
             ExportSymbol {
                 name: ExportName::Named("a".to_string()),
@@ -617,9 +633,8 @@ mod tests {
         ];
         mark_all_exports_referenced(
             &mut exports,
-            FileId(5),
-            oxc_span::Span::new(0, 10),
-            ReferenceKind::NamespaceImport,
+            namespace_target(FileId(5), FileId(9)),
+            &mut reference_paths,
         );
         assert_eq!(exports[0].references.len(), 1);
         assert_eq!(exports[0].references[0].from_file, FileId(5));
@@ -628,6 +643,7 @@ mod tests {
 
     #[test]
     fn mark_all_exports_referenced_deduplicates() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![ExportSymbol {
             name: ExportName::Named("a".to_string()),
             is_type_only: false,
@@ -638,22 +654,22 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(5),
                 kind: ReferenceKind::NamedImport,
-                mechanism: ModuleLoadMechanism::EsModule,
+                path: reference_paths.direct(FileId(9), ModuleLoadMechanism::EsModule),
                 import_span: oxc_span::Span::new(0, 10),
             }],
             members: Vec::new(),
         }];
         mark_all_exports_referenced(
             &mut exports,
-            FileId(5),
-            oxc_span::Span::new(0, 10),
-            ReferenceKind::NamespaceImport,
+            namespace_target(FileId(5), FileId(9)),
+            &mut reference_paths,
         );
         assert_eq!(exports[0].references.len(), 1);
     }
 
     #[test]
     fn mark_member_exports_referenced_only_accessed() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![
             ExportSymbol {
                 name: ExportName::Named("foo".to_string()),
@@ -679,10 +695,9 @@ mod tests {
         let accessed = vec!["foo".to_string()];
         let found = mark_member_exports_referenced(
             &mut exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
-            oxc_span::Span::new(0, 10),
-            ReferenceKind::NamespaceImport,
+            &mut reference_paths,
         );
 
         assert_eq!(exports[0].references.len(), 1);
@@ -693,6 +708,7 @@ mod tests {
 
     #[test]
     fn create_synthetic_exports_with_star_re_export() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![ExportSymbol {
             name: ExportName::Named("existing".to_string()),
             is_type_only: false,
@@ -716,10 +732,10 @@ mod tests {
         create_synthetic_exports_for_star_re_exports(
             &mut exports,
             &re_exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
             &found,
-            oxc_span::Span::new(0, 10),
+            &mut reference_paths,
         );
 
         assert_eq!(exports.len(), 2);
@@ -729,6 +745,7 @@ mod tests {
 
     #[test]
     fn create_synthetic_exports_skips_already_found() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = Vec::new();
         let re_exports = vec![ReExportEdge {
             source_file: FileId(2),
@@ -744,10 +761,10 @@ mod tests {
         create_synthetic_exports_for_star_re_exports(
             &mut exports,
             &re_exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
             &found,
-            oxc_span::Span::new(0, 10),
+            &mut reference_paths,
         );
 
         assert!(
@@ -758,6 +775,7 @@ mod tests {
 
     #[test]
     fn create_synthetic_exports_no_star_re_exports() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = Vec::new();
         let re_exports = vec![ReExportEdge {
             source_file: FileId(2),
@@ -772,10 +790,10 @@ mod tests {
         create_synthetic_exports_for_star_re_exports(
             &mut exports,
             &re_exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
             &found,
-            oxc_span::Span::new(0, 10),
+            &mut reference_paths,
         );
 
         assert!(
@@ -1251,6 +1269,7 @@ mod tests {
 
     #[test]
     fn mark_member_exports_referenced_default_export() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![ExportSymbol {
             name: ExportName::Default,
             is_type_only: false,
@@ -1264,10 +1283,9 @@ mod tests {
         let accessed = vec!["default".to_string()];
         let found = mark_member_exports_referenced(
             &mut exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
-            oxc_span::Span::new(0, 10),
-            ReferenceKind::NamespaceImport,
+            &mut reference_paths,
         );
         assert_eq!(exports[0].references.len(), 1);
         assert!(found.contains("default"));
@@ -1275,6 +1293,7 @@ mod tests {
 
     #[test]
     fn mark_member_exports_referenced_deduplicates() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![ExportSymbol {
             name: ExportName::Named("foo".to_string()),
             is_type_only: false,
@@ -1285,7 +1304,7 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(0),
                 kind: ReferenceKind::NamedImport,
-                mechanism: ModuleLoadMechanism::EsModule,
+                path: reference_paths.direct(FileId(9), ModuleLoadMechanism::EsModule),
                 import_span: oxc_span::Span::new(0, 10),
             }],
             members: Vec::new(),
@@ -1293,10 +1312,9 @@ mod tests {
         let accessed = vec!["foo".to_string()];
         let found = mark_member_exports_referenced(
             &mut exports,
-            FileId(0), // same file as existing reference
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
-            oxc_span::Span::new(0, 10),
-            ReferenceKind::NamespaceImport,
+            &mut reference_paths,
         );
         assert_eq!(exports[0].references.len(), 1);
         assert!(found.contains("foo"));
@@ -1304,6 +1322,7 @@ mod tests {
 
     #[test]
     fn mark_member_exports_referenced_empty_accessed() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = vec![ExportSymbol {
             name: ExportName::Named("foo".to_string()),
             is_type_only: false,
@@ -1317,10 +1336,9 @@ mod tests {
         let accessed: Vec<String> = vec![];
         let found = mark_member_exports_referenced(
             &mut exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
-            oxc_span::Span::new(0, 10),
-            ReferenceKind::NamespaceImport,
+            &mut reference_paths,
         );
         assert!(exports[0].references.is_empty());
         assert!(found.is_empty());
@@ -1328,6 +1346,7 @@ mod tests {
 
     #[test]
     fn create_synthetic_exports_skips_default_member() {
+        let mut reference_paths = ReferencePathInterner::default();
         let mut exports = Vec::new();
         let re_exports = vec![ReExportEdge {
             source_file: FileId(2),
@@ -1342,10 +1361,10 @@ mod tests {
         create_synthetic_exports_for_star_re_exports(
             &mut exports,
             &re_exports,
-            FileId(0),
+            namespace_target(FileId(0), FileId(9)),
             &accessed,
             &found,
-            oxc_span::Span::new(0, 10),
+            &mut reference_paths,
         );
 
         assert!(exports.is_empty());

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -24,7 +24,7 @@ use super::build::{export_matches, is_css_module_path};
 pub(super) struct ReferenceSite {
     from_file: FileId,
     import_span: oxc_span::Span,
-    path: ReferencePathId,
+    path: Option<ReferencePathId>,
 }
 
 #[derive(Clone, Copy)]
@@ -40,7 +40,7 @@ impl ReferenceSite {
     pub(super) const fn exact(
         from_file: FileId,
         import_span: oxc_span::Span,
-        path: ReferencePathId,
+        path: Option<ReferencePathId>,
     ) -> Self {
         Self {
             from_file,

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -102,7 +102,7 @@ struct ReExportContext<'a> {
     edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
     named_import_origin_index: &'a NamedImportOriginIndex,
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
-    existing_refs: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    existing_refs: &'a mut FxHashSet<(FileId, Option<ReferencePathId>)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
     reference_paths: &'a mut ReferencePathInterner,
 }
@@ -319,7 +319,7 @@ impl ModuleGraph {
         let safety_cap = self.re_export_transition_safety_cap(re_export_info);
         let mut processed = 0usize;
         let mut plan = ReExportPropagationPlan::new(re_export_info);
-        let mut existing_refs: FxHashSet<(FileId, ReferencePathId)> = FxHashSet::default();
+        let mut existing_refs: FxHashSet<(FileId, Option<ReferencePathId>)> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
         while let Some(entry_idx) = plan.pop_front() {
@@ -480,7 +480,7 @@ impl ModuleGraph {
             reference_paths,
         } = input;
         let max_iterations = re_export_info.len().saturating_add(1);
-        let mut existing_refs: FxHashSet<(FileId, ReferencePathId)> = FxHashSet::default();
+        let mut existing_refs: FxHashSet<(FileId, Option<ReferencePathId>)> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
         for _ in 0..max_iterations {

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -13,6 +13,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
 
 use fallow_types::discover::FileId;
+use fallow_types::extract::ModuleLoadMechanism;
 
 use crate::resolve::ResolvedModule;
 
@@ -102,7 +103,7 @@ struct ReExportContext<'a> {
     edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
     named_import_origin_index: &'a NamedImportOriginIndex,
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
-    existing_refs: &'a mut FxHashSet<FileId>,
+    existing_refs: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
 }
 
@@ -305,7 +306,7 @@ impl ModuleGraph {
         let safety_cap = self.re_export_transition_safety_cap(re_export_info);
         let mut processed = 0usize;
         let mut plan = ReExportPropagationPlan::new(re_export_info);
-        let mut existing_refs: FxHashSet<FileId> = FxHashSet::default();
+        let mut existing_refs: FxHashSet<(FileId, ModuleLoadMechanism)> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
         while let Some(entry_idx) = plan.pop_front() {
@@ -362,7 +363,7 @@ impl ModuleGraph {
     }
 
     /// Bound scheduler work by the finite set of exports, synthetic names, and
-    /// reference source modules that monotone propagation can add.
+    /// reference source/mechanism pairs that monotone propagation can add.
     fn re_export_transition_safety_cap(&self, re_export_info: &[ReExportTuple]) -> usize {
         let initial_exports = self
             .modules
@@ -398,7 +399,7 @@ impl ModuleGraph {
             .saturating_mul(named_inputs)
             .saturating_mul(2);
         let max_exports = initial_exports.saturating_add(synthetic_exports);
-        let reference_additions = max_exports.saturating_mul(module_count);
+        let reference_additions = max_exports.saturating_mul(module_count).saturating_mul(2);
         let state_changes = synthetic_exports.saturating_add(reference_additions);
 
         re_export_info
@@ -461,7 +462,7 @@ impl ModuleGraph {
             module_by_id,
         } = input;
         let max_iterations = re_export_info.len().saturating_add(1);
-        let mut existing_refs: FxHashSet<FileId> = FxHashSet::default();
+        let mut existing_refs: FxHashSet<(FileId, ModuleLoadMechanism)> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
         for _ in 0..max_iterations {

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -12,11 +12,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 #[cfg(test)]
 use std::cell::{Cell, RefCell};
 
-use fallow_types::discover::FileId;
-use fallow_types::extract::ModuleLoadMechanism;
-
 use crate::resolve::ResolvedModule;
+use fallow_types::discover::FileId;
 
+use super::types::{ReferencePathId, ReferencePathInterner};
 use super::{Edge, ModuleGraph};
 
 use propagate::{
@@ -103,8 +102,18 @@ struct ReExportContext<'a> {
     edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
     named_import_origin_index: &'a NamedImportOriginIndex,
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
-    existing_refs: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
+    existing_refs: &'a mut FxHashSet<(FileId, ReferencePathId)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
+    reference_paths: &'a mut ReferencePathInterner,
+}
+
+struct ReExportFixpointInput<'a> {
+    re_export_info: &'a [ReExportTuple],
+    entry_star_targets: &'a FxHashSet<FileId>,
+    edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
+    named_import_origin_index: &'a NamedImportOriginIndex,
+    module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 #[cfg(test)]
@@ -116,6 +125,7 @@ struct LegacyReExportFullScan<'a> {
     edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
     named_import_origin_index: &'a NamedImportOriginIndex,
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 /// Deterministic scheduler for monotone re-export propagation.
@@ -178,6 +188,7 @@ impl ModuleGraph {
     pub(super) fn resolve_re_export_chains(
         &mut self,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
+        reference_paths: &mut ReferencePathInterner,
     ) -> Vec<GraphReExportCycle> {
         let re_export_info = self.collect_re_export_tuples();
 
@@ -196,13 +207,14 @@ impl ModuleGraph {
                 NamedImportOriginIndex::default()
             };
 
-        self.run_re_export_fixpoint(
-            &re_export_info,
-            &entry_star_targets,
-            &edges_by_target,
-            &named_import_origin_index,
+        self.run_re_export_fixpoint(ReExportFixpointInput {
+            re_export_info: &re_export_info,
+            entry_star_targets: &entry_star_targets,
+            edges_by_target: &edges_by_target,
+            named_import_origin_index: &named_import_origin_index,
             module_by_id,
-        );
+            reference_paths,
+        });
 
         cycles
     }
@@ -283,14 +295,15 @@ impl ModuleGraph {
     }
 
     /// Run monotone propagation, revisiting only tuples affected by new state.
-    fn run_re_export_fixpoint(
-        &mut self,
-        re_export_info: &[ReExportTuple],
-        entry_star_targets: &FxHashSet<FileId>,
-        edges_by_target: &FxHashMap<FileId, Vec<usize>>,
-        named_import_origin_index: &NamedImportOriginIndex,
-        module_by_id: &FxHashMap<FileId, &ResolvedModule>,
-    ) {
+    fn run_re_export_fixpoint(&mut self, input: ReExportFixpointInput<'_>) {
+        let ReExportFixpointInput {
+            re_export_info,
+            entry_star_targets,
+            edges_by_target,
+            named_import_origin_index,
+            module_by_id,
+            reference_paths,
+        } = input;
         #[cfg(test)]
         let mut legacy_modules: Option<Vec<super::types::ModuleNode>> = DIFFERENTIAL_CHECK_ENABLED
             .with(|enabled| {
@@ -306,7 +319,7 @@ impl ModuleGraph {
         let safety_cap = self.re_export_transition_safety_cap(re_export_info);
         let mut processed = 0usize;
         let mut plan = ReExportPropagationPlan::new(re_export_info);
-        let mut existing_refs: FxHashSet<(FileId, ModuleLoadMechanism)> = FxHashSet::default();
+        let mut existing_refs: FxHashSet<(FileId, ReferencePathId)> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
         while let Some(entry_idx) = plan.pop_front() {
@@ -330,6 +343,7 @@ impl ModuleGraph {
                 module_by_id,
                 existing_refs: &mut existing_refs,
                 synthetic_stubs: &mut synthetic_stubs,
+                reference_paths,
             };
 
             let entry = &re_export_info[entry_idx];
@@ -351,6 +365,7 @@ impl ModuleGraph {
                 edges_by_target,
                 named_import_origin_index,
                 module_by_id,
+                reference_paths,
             });
             assert_eq!(
                 serde_json::to_value(legacy_modules)
@@ -363,7 +378,7 @@ impl ModuleGraph {
     }
 
     /// Bound scheduler work by the finite set of exports, synthetic names, and
-    /// reference source/mechanism pairs that monotone propagation can add.
+    /// interned reference paths that monotone propagation can add.
     fn re_export_transition_safety_cap(&self, re_export_info: &[ReExportTuple]) -> usize {
         let initial_exports = self
             .modules
@@ -436,6 +451,7 @@ impl ModuleGraph {
                 entry_star_targets: context.entry_star_targets,
                 triggering_is_type_only: entry.is_type_only,
                 synthetic_stubs: context.synthetic_stubs,
+                reference_paths: context.reference_paths,
             })
         } else {
             propagate_named_re_export(NamedReExportPropagation {
@@ -446,6 +462,7 @@ impl ModuleGraph {
                 imported_name: &entry.imported_name,
                 exported_name: &entry.exported_name,
                 existing_refs: context.existing_refs,
+                reference_paths: context.reference_paths,
             })
         }
     }
@@ -460,9 +477,10 @@ impl ModuleGraph {
             edges_by_target,
             named_import_origin_index,
             module_by_id,
+            reference_paths,
         } = input;
         let max_iterations = re_export_info.len().saturating_add(1);
-        let mut existing_refs: FxHashSet<(FileId, ModuleLoadMechanism)> = FxHashSet::default();
+        let mut existing_refs: FxHashSet<(FileId, ReferencePathId)> = FxHashSet::default();
         let mut synthetic_stubs: FxHashSet<(FileId, String, bool)> = FxHashSet::default();
 
         for _ in 0..max_iterations {
@@ -475,6 +493,7 @@ impl ModuleGraph {
                     module_by_id,
                     existing_refs: &mut existing_refs,
                     synthetic_stubs: &mut synthetic_stubs,
+                    reference_paths,
                 };
                 changed |= Self::propagate_re_export_entry(modules, edges, entry, &mut context);
             }

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -11,7 +11,10 @@ use std::cell::Cell;
 use fallow_types::discover::FileId;
 use fallow_types::extract::{ExportName, ModuleLoadMechanism, VisibilityTag};
 
-use crate::graph::types::{ExportSymbol, ModuleNode, ReferenceKind, SymbolReference};
+use crate::graph::types::{
+    ExportSymbol, ModuleNode, ReferenceKind, ReferencePathId, ReferencePathInterner,
+    SymbolReference,
+};
 use crate::graph::{Edge, ImportedName};
 use crate::resolve::ResolvedModule;
 
@@ -57,6 +60,7 @@ pub(in crate::graph) struct StarReExportPropagation<'a> {
     pub(in crate::graph) entry_star_targets: &'a FxHashSet<FileId>,
     pub(in crate::graph) triggering_is_type_only: bool,
     pub(in crate::graph) synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
+    pub(in crate::graph) reference_paths: &'a mut ReferencePathInterner,
 }
 
 pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<'_>) -> bool {
@@ -73,23 +77,31 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
         entry_star_targets,
         triggering_is_type_only,
         synthetic_stubs,
+        reference_paths,
     } = input;
 
     if modules[barrel_idx].is_entry_point()
         || entry_star_targets.contains(&modules[barrel_idx].file_id)
     {
-        return propagate_entry_point_star(modules, barrel_id, source_idx);
+        return propagate_entry_point_star(
+            modules,
+            barrel_id,
+            source_idx,
+            source_id,
+            reference_paths,
+        );
     }
 
     let barrel_file_id = modules[barrel_idx].file_id;
-    let refs_by_name = collect_star_refs_by_name(
+    let refs_by_name = collect_star_refs_by_name(StarReferenceCollection {
         modules,
         edges,
         edges_by_target,
         named_import_origin_index,
         barrel_file_id,
         barrel_idx,
-    );
+        reference_paths,
+    });
 
     let source_has_star_re_exports = modules[source_idx]
         .re_exports
@@ -99,7 +111,7 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
     let matching_exports_by_name = build_named_export_index(&modules[source_idx]);
 
     let mut changed = false;
-    let mut existing_references: FxHashSet<(FileId, ModuleLoadMechanism)> = FxHashSet::default();
+    let mut existing_references: FxHashSet<(FileId, ReferencePathId)> = FxHashSet::default();
     let source = &mut modules[source_idx];
     for (name, refs) in &refs_by_name {
         let matching_exports: &[usize] = matching_exports_by_name
@@ -116,6 +128,7 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
             source_has_star_re_exports,
             existing_references: &mut existing_references,
             synthetic_stubs: &mut *synthetic_stubs,
+            reference_paths,
         });
     }
     changed
@@ -145,15 +158,29 @@ fn build_named_export_index(source: &ModuleNode) -> FxHashMap<String, Vec<usize>
 /// Collect the per-name references that must propagate through a star
 /// re-export: named imports made directly from the barrel plus any references
 /// already attached to the barrel's own exports.
-fn collect_star_refs_by_name(
-    modules: &[ModuleNode],
-    edges: &[Edge],
-    edges_by_target: &FxHashMap<FileId, Vec<usize>>,
-    named_import_origin_index: &NamedImportOriginIndex,
+struct StarReferenceCollection<'a> {
+    modules: &'a [ModuleNode],
+    edges: &'a [Edge],
+    edges_by_target: &'a FxHashMap<FileId, Vec<usize>>,
+    named_import_origin_index: &'a NamedImportOriginIndex,
     barrel_file_id: FileId,
     barrel_idx: usize,
+    reference_paths: &'a mut ReferencePathInterner,
+}
+
+fn collect_star_refs_by_name(
+    input: StarReferenceCollection<'_>,
 ) -> FxHashMap<String, Vec<StarReference>> {
-    let named_refs = named_star_refs(edges, edges_by_target, barrel_file_id);
+    let StarReferenceCollection {
+        modules,
+        edges,
+        edges_by_target,
+        named_import_origin_index,
+        barrel_file_id,
+        barrel_idx,
+        reference_paths,
+    } = input;
+    let named_refs = named_star_refs(edges, edges_by_target, barrel_file_id, reference_paths);
     let barrel_refs = barrel_star_refs(&modules[barrel_idx], named_import_origin_index);
 
     let mut refs_by_name: FxHashMap<String, Vec<StarReference>> = FxHashMap::default();
@@ -170,19 +197,23 @@ fn named_star_refs(
     edges: &[Edge],
     edges_by_target: &FxHashMap<FileId, Vec<usize>>,
     barrel_file_id: FileId,
+    reference_paths: &mut ReferencePathInterner,
 ) -> Vec<(String, StarReference)> {
     edges_by_target
         .get(&barrel_file_id)
         .map(|indices| {
             indices
                 .iter()
-                .flat_map(|&idx| named_refs_for_edge(&edges[idx]))
+                .flat_map(|&idx| named_refs_for_edge(&edges[idx], reference_paths))
                 .collect()
         })
         .unwrap_or_default()
 }
 
-fn named_refs_for_edge(edge: &Edge) -> Vec<(String, StarReference)> {
+fn named_refs_for_edge(
+    edge: &Edge,
+    reference_paths: &mut ReferencePathInterner,
+) -> Vec<(String, StarReference)> {
     edge.symbols
         .iter()
         .filter_map(|sym| {
@@ -198,7 +229,7 @@ fn named_refs_for_edge(edge: &Edge) -> Vec<(String, StarReference)> {
                     reference: SymbolReference {
                         from_file: edge.source,
                         kind: ReferenceKind::NamedImport,
-                        mechanism: sym.mechanism,
+                        path: reference_paths.direct(edge.target, sym.mechanism),
                         import_span: sym.import_span,
                     },
                     origin: StarReferenceOrigin::NamedImport {
@@ -327,8 +358,9 @@ struct ApplyStarRefs<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     source_has_star_re_exports: bool,
-    existing_references: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
+    existing_references: &'a mut FxHashSet<(FileId, ReferencePathId)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 /// Attach the collected references for one re-exported name to the source
@@ -346,6 +378,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
         source_has_star_re_exports,
         existing_references,
         synthetic_stubs,
+        reference_paths,
     } = input;
 
     if name == "default" {
@@ -364,6 +397,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
             matching_exports,
             existing_references,
             synthetic_stubs,
+            reference_paths,
         })
     } else if source_has_star_re_exports {
         create_synthetic_exports_for_refs(CreateSyntheticExports {
@@ -375,6 +409,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
             module_by_id,
             triggering_is_type_only,
             synthetic_stubs,
+            reference_paths,
         })
     } else {
         false
@@ -390,8 +425,9 @@ struct ApplyMatchingStarRefs<'a> {
     triggering_is_type_only: bool,
     source_has_star_re_exports: bool,
     matching_exports: &'a [usize],
-    existing_references: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
+    existing_references: &'a mut FxHashSet<(FileId, ReferencePathId)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 struct MatchingStarExports {
@@ -411,6 +447,7 @@ fn apply_star_refs_to_matching_exports(input: ApplyMatchingStarRefs<'_>) -> bool
         matching_exports,
         existing_references,
         synthetic_stubs,
+        reference_paths,
     } = input;
 
     let can_synthesize = source_has_star_re_exports;
@@ -440,6 +477,8 @@ fn apply_star_refs_to_matching_exports(input: ApplyMatchingStarRefs<'_>) -> bool
         triggering_is_type_only,
         exports: &exports,
         existing_references,
+        source_id,
+        reference_paths,
     });
     changed
 }
@@ -589,7 +628,9 @@ struct AttachMatchingStarRefs<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     exports: &'a MatchingStarExports,
-    existing_references: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
+    existing_references: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    source_id: FileId,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
@@ -600,6 +641,8 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
         triggering_is_type_only,
         exports,
         existing_references,
+        source_id,
+        reference_paths,
     } = input;
 
     let mut type_refs = Vec::new();
@@ -611,11 +654,12 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
             !exports.value_indices.is_empty(),
             triggering_is_type_only,
         );
+        let reference = through_re_export(star_ref.reference, source_id, reference_paths);
         if attach_type_exports {
-            type_refs.push(star_ref.reference.through_re_export());
+            type_refs.push(reference);
         }
         if attach_value_exports {
-            value_refs.push(star_ref.reference.through_re_export());
+            value_refs.push(reference);
         }
     }
 
@@ -648,6 +692,7 @@ struct CreateSyntheticExports<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
+    reference_paths: &'a mut ReferencePathInterner,
 }
 
 fn create_synthetic_exports_for_refs(input: CreateSyntheticExports<'_>) -> bool {
@@ -660,6 +705,7 @@ fn create_synthetic_exports_for_refs(input: CreateSyntheticExports<'_>) -> bool 
         module_by_id,
         triggering_is_type_only,
         synthetic_stubs,
+        reference_paths,
     } = input;
 
     let mut type_refs = Vec::new();
@@ -671,11 +717,12 @@ fn create_synthetic_exports_for_refs(input: CreateSyntheticExports<'_>) -> bool 
             !triggering_is_type_only,
             triggering_is_type_only,
         );
+        let reference = through_re_export(star_ref.reference, source_id, reference_paths);
         if attach_type_exports {
-            type_refs.push(star_ref.reference.through_re_export());
+            type_refs.push(reference);
         }
         if attach_value_exports {
-            value_refs.push(star_ref.reference.through_re_export());
+            value_refs.push(reference);
         }
     }
 
@@ -770,7 +817,7 @@ fn attach_star_refs_to_exports(
     source: &mut ModuleNode,
     export_indices: &[usize],
     references: &[SymbolReference],
-    existing_references: &mut FxHashSet<(FileId, ModuleLoadMechanism)>,
+    existing_references: &mut FxHashSet<(FileId, ReferencePathId)>,
 ) -> bool {
     let mut changed = false;
     for export_idx in export_indices {
@@ -782,17 +829,27 @@ fn attach_star_refs_to_exports(
             source.exports[*export_idx]
                 .references
                 .iter()
-                .map(|reference| (reference.from_file, reference.mechanism)),
+                .map(|reference| (reference.from_file, reference.path)),
         );
         for reference in references {
-            let reference = reference.through_re_export();
-            if existing_references.insert((reference.from_file, reference.mechanism)) {
-                source.exports[*export_idx].references.push(reference);
+            if existing_references.insert((reference.from_file, reference.path)) {
+                source.exports[*export_idx].references.push(*reference);
                 changed = true;
             }
         }
     }
     changed
+}
+
+fn through_re_export(
+    reference: SymbolReference,
+    target: FileId,
+    reference_paths: &mut ReferencePathInterner,
+) -> SymbolReference {
+    SymbolReference {
+        path: reference_paths.extend(reference.path, target, ModuleLoadMechanism::EsModule),
+        ..reference
+    }
 }
 
 impl StarReference {
@@ -896,20 +953,25 @@ fn propagate_entry_point_star(
     modules: &mut [ModuleNode],
     barrel_id: FileId,
     source_idx: usize,
+    source_id: FileId,
+    reference_paths: &mut ReferencePathInterner,
 ) -> bool {
+    let path = reference_paths.direct(source_id, ModuleLoadMechanism::EsModule);
     let mut changed = false;
     let source = &mut modules[source_idx];
     for export in &mut source.exports {
         if matches!(export.name, ExportName::Default) {
             continue;
         }
-        if export.references.iter().all(|reference| {
-            reference.from_file != barrel_id || reference.mechanism != ModuleLoadMechanism::EsModule
-        }) {
+        if export
+            .references
+            .iter()
+            .all(|reference| reference.from_file != barrel_id || reference.path != path)
+        {
             export.references.push(SymbolReference {
                 from_file: barrel_id,
                 kind: ReferenceKind::ReExport,
-                mechanism: ModuleLoadMechanism::EsModule,
+                path,
                 import_span: oxc_span::Span::new(0, 0),
             });
             changed = true;
@@ -929,7 +991,8 @@ pub(in crate::graph) struct NamedReExportPropagation<'a> {
     pub(in crate::graph) source_idx: usize,
     pub(in crate::graph) imported_name: &'a str,
     pub(in crate::graph) exported_name: &'a str,
-    pub(in crate::graph) existing_refs: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
+    pub(in crate::graph) existing_refs: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    pub(in crate::graph) reference_paths: &'a mut ReferencePathInterner,
 }
 
 pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagation<'_>) -> bool {
@@ -941,6 +1004,7 @@ pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagatio
         imported_name,
         exported_name,
         existing_refs,
+        reference_paths,
     } = input;
 
     let refs_on_barrel: Vec<SymbolReference> = modules[barrel_idx]
@@ -952,7 +1016,13 @@ pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagatio
 
     if refs_on_barrel.is_empty() {
         if modules[barrel_idx].is_entry_point() {
-            return propagate_entry_point_named(modules, barrel_id, source_idx, imported_name);
+            return propagate_entry_point_named(
+                modules,
+                barrel_id,
+                source_idx,
+                imported_name,
+                reference_paths,
+            );
         }
         return false;
     }
@@ -973,11 +1043,11 @@ pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagatio
             source.exports[export_idx]
                 .references
                 .iter()
-                .map(|reference| (reference.from_file, reference.mechanism)),
+                .map(|reference| (reference.from_file, reference.path)),
         );
         for ref_item in &refs_on_barrel {
-            let reference = ref_item.through_re_export();
-            if existing_refs.insert((reference.from_file, reference.mechanism)) {
+            let reference = through_re_export(*ref_item, source.file_id, reference_paths);
+            if existing_refs.insert((reference.from_file, reference.path)) {
                 source.exports[export_idx].references.push(reference);
                 changed = true;
             }
@@ -993,11 +1063,13 @@ fn propagate_entry_point_named(
     barrel_id: FileId,
     source_idx: usize,
     imported_name: &str,
+    reference_paths: &mut ReferencePathInterner,
 ) -> bool {
+    let source_id = modules[source_idx].file_id;
     let synthetic_ref = SymbolReference {
         from_file: barrel_id,
         kind: ReferenceKind::ReExport,
-        mechanism: ModuleLoadMechanism::EsModule,
+        path: reference_paths.direct(source_id, ModuleLoadMechanism::EsModule),
         import_span: oxc_span::Span::new(0, 0),
     };
     let mut changed = false;
@@ -1014,8 +1086,7 @@ fn propagate_entry_point_named(
             .references
             .iter()
             .all(|reference| {
-                reference.from_file != barrel_id
-                    || reference.mechanism != ModuleLoadMechanism::EsModule
+                reference.from_file != barrel_id || reference.path != synthetic_ref.path
             })
         {
             source.exports[export_idx].references.push(synthetic_ref);

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -9,7 +9,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::Cell;
 
 use fallow_types::discover::FileId;
-use fallow_types::extract::{ExportName, VisibilityTag};
+use fallow_types::extract::{ExportName, ModuleLoadMechanism, VisibilityTag};
 
 use crate::graph::types::{ExportSymbol, ModuleNode, ReferenceKind, SymbolReference};
 use crate::graph::{Edge, ImportedName};
@@ -99,7 +99,7 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
     let matching_exports_by_name = build_named_export_index(&modules[source_idx]);
 
     let mut changed = false;
-    let mut existing_files: FxHashSet<FileId> = FxHashSet::default();
+    let mut existing_references: FxHashSet<(FileId, ModuleLoadMechanism)> = FxHashSet::default();
     let source = &mut modules[source_idx];
     for (name, refs) in &refs_by_name {
         let matching_exports: &[usize] = matching_exports_by_name
@@ -114,7 +114,7 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
             module_by_id,
             triggering_is_type_only,
             source_has_star_re_exports,
-            existing_files: &mut existing_files,
+            existing_references: &mut existing_references,
             synthetic_stubs: &mut *synthetic_stubs,
         });
     }
@@ -198,6 +198,7 @@ fn named_refs_for_edge(edge: &Edge) -> Vec<(String, StarReference)> {
                     reference: SymbolReference {
                         from_file: edge.source,
                         kind: ReferenceKind::NamedImport,
+                        mechanism: sym.mechanism,
                         import_span: sym.import_span,
                     },
                     origin: StarReferenceOrigin::NamedImport {
@@ -326,7 +327,7 @@ struct ApplyStarRefs<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     source_has_star_re_exports: bool,
-    existing_files: &'a mut FxHashSet<FileId>,
+    existing_references: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
 }
 
@@ -343,7 +344,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
         module_by_id,
         triggering_is_type_only,
         source_has_star_re_exports,
-        existing_files,
+        existing_references,
         synthetic_stubs,
     } = input;
 
@@ -361,7 +362,7 @@ fn apply_star_refs_to_source(input: ApplyStarRefs<'_>) -> bool {
             triggering_is_type_only,
             source_has_star_re_exports,
             matching_exports,
-            existing_files,
+            existing_references,
             synthetic_stubs,
         })
     } else if source_has_star_re_exports {
@@ -389,7 +390,7 @@ struct ApplyMatchingStarRefs<'a> {
     triggering_is_type_only: bool,
     source_has_star_re_exports: bool,
     matching_exports: &'a [usize],
-    existing_files: &'a mut FxHashSet<FileId>,
+    existing_references: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
 }
 
@@ -408,7 +409,7 @@ fn apply_star_refs_to_matching_exports(input: ApplyMatchingStarRefs<'_>) -> bool
         triggering_is_type_only,
         source_has_star_re_exports,
         matching_exports,
-        existing_files,
+        existing_references,
         synthetic_stubs,
     } = input;
 
@@ -438,7 +439,7 @@ fn apply_star_refs_to_matching_exports(input: ApplyMatchingStarRefs<'_>) -> bool
         module_by_id,
         triggering_is_type_only,
         exports: &exports,
-        existing_files,
+        existing_references,
     });
     changed
 }
@@ -588,7 +589,7 @@ struct AttachMatchingStarRefs<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     exports: &'a MatchingStarExports,
-    existing_files: &'a mut FxHashSet<FileId>,
+    existing_references: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
 }
 
 fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
@@ -598,7 +599,7 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
         module_by_id,
         triggering_is_type_only,
         exports,
-        existing_files,
+        existing_references,
     } = input;
 
     let mut type_refs = Vec::new();
@@ -611,24 +612,28 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
             triggering_is_type_only,
         );
         if attach_type_exports {
-            type_refs.push(star_ref.reference);
+            type_refs.push(star_ref.reference.through_re_export());
         }
         if attach_value_exports {
-            value_refs.push(star_ref.reference);
+            value_refs.push(star_ref.reference.through_re_export());
         }
     }
 
     let mut changed = false;
     if !type_refs.is_empty() {
-        changed |=
-            attach_star_refs_to_exports(source, &exports.type_indices, &type_refs, existing_files);
+        changed |= attach_star_refs_to_exports(
+            source,
+            &exports.type_indices,
+            &type_refs,
+            existing_references,
+        );
     }
     if !value_refs.is_empty() {
         changed |= attach_star_refs_to_exports(
             source,
             &exports.value_indices,
             &value_refs,
-            existing_files,
+            existing_references,
         );
     }
     changed
@@ -667,10 +672,10 @@ fn create_synthetic_exports_for_refs(input: CreateSyntheticExports<'_>) -> bool 
             triggering_is_type_only,
         );
         if attach_type_exports {
-            type_refs.push(star_ref.reference);
+            type_refs.push(star_ref.reference.through_re_export());
         }
         if attach_value_exports {
-            value_refs.push(star_ref.reference);
+            value_refs.push(star_ref.reference.through_re_export());
         }
     }
 
@@ -765,23 +770,24 @@ fn attach_star_refs_to_exports(
     source: &mut ModuleNode,
     export_indices: &[usize],
     references: &[SymbolReference],
-    existing_files: &mut FxHashSet<FileId>,
+    existing_references: &mut FxHashSet<(FileId, ModuleLoadMechanism)>,
 ) -> bool {
     let mut changed = false;
     for export_idx in export_indices {
         #[cfg(test)]
         STAR_REFERENCE_SET_REBUILDS.set(STAR_REFERENCE_SET_REBUILDS.get() + 1);
 
-        existing_files.clear();
-        existing_files.extend(
+        existing_references.clear();
+        existing_references.extend(
             source.exports[*export_idx]
                 .references
                 .iter()
-                .map(|r| r.from_file),
+                .map(|reference| (reference.from_file, reference.mechanism)),
         );
         for reference in references {
-            if existing_files.insert(reference.from_file) {
-                source.exports[*export_idx].references.push(*reference);
+            let reference = reference.through_re_export();
+            if existing_references.insert((reference.from_file, reference.mechanism)) {
+                source.exports[*export_idx].references.push(reference);
                 changed = true;
             }
         }
@@ -897,10 +903,13 @@ fn propagate_entry_point_star(
         if matches!(export.name, ExportName::Default) {
             continue;
         }
-        if export.references.iter().all(|r| r.from_file != barrel_id) {
+        if export.references.iter().all(|reference| {
+            reference.from_file != barrel_id || reference.mechanism != ModuleLoadMechanism::EsModule
+        }) {
             export.references.push(SymbolReference {
                 from_file: barrel_id,
                 kind: ReferenceKind::ReExport,
+                mechanism: ModuleLoadMechanism::EsModule,
                 import_span: oxc_span::Span::new(0, 0),
             });
             changed = true;
@@ -920,7 +929,7 @@ pub(in crate::graph) struct NamedReExportPropagation<'a> {
     pub(in crate::graph) source_idx: usize,
     pub(in crate::graph) imported_name: &'a str,
     pub(in crate::graph) exported_name: &'a str,
-    pub(in crate::graph) existing_refs: &'a mut FxHashSet<FileId>,
+    pub(in crate::graph) existing_refs: &'a mut FxHashSet<(FileId, ModuleLoadMechanism)>,
 }
 
 pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagation<'_>) -> bool {
@@ -964,11 +973,12 @@ pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagatio
             source.exports[export_idx]
                 .references
                 .iter()
-                .map(|r| r.from_file),
+                .map(|reference| (reference.from_file, reference.mechanism)),
         );
         for ref_item in &refs_on_barrel {
-            if !existing_refs.contains(&ref_item.from_file) {
-                source.exports[export_idx].references.push(*ref_item);
+            let reference = ref_item.through_re_export();
+            if existing_refs.insert((reference.from_file, reference.mechanism)) {
+                source.exports[export_idx].references.push(reference);
                 changed = true;
             }
         }
@@ -987,6 +997,7 @@ fn propagate_entry_point_named(
     let synthetic_ref = SymbolReference {
         from_file: barrel_id,
         kind: ReferenceKind::ReExport,
+        mechanism: ModuleLoadMechanism::EsModule,
         import_span: oxc_span::Span::new(0, 0),
     };
     let mut changed = false;
@@ -1002,7 +1013,10 @@ fn propagate_entry_point_named(
         if source.exports[export_idx]
             .references
             .iter()
-            .all(|r| r.from_file != barrel_id)
+            .all(|reference| {
+                reference.from_file != barrel_id
+                    || reference.mechanism != ModuleLoadMechanism::EsModule
+            })
         {
             source.exports[export_idx].references.push(synthetic_ref);
             changed = true;

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -111,7 +111,8 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
     let matching_exports_by_name = build_named_export_index(&modules[source_idx]);
 
     let mut changed = false;
-    let mut existing_references: FxHashSet<(FileId, ReferencePathId)> = FxHashSet::default();
+    let mut existing_references: FxHashSet<(FileId, Option<ReferencePathId>)> =
+        FxHashSet::default();
     let source = &mut modules[source_idx];
     for (name, refs) in &refs_by_name {
         let matching_exports: &[usize] = matching_exports_by_name
@@ -358,7 +359,7 @@ struct ApplyStarRefs<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     source_has_star_re_exports: bool,
-    existing_references: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    existing_references: &'a mut FxHashSet<(FileId, Option<ReferencePathId>)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
     reference_paths: &'a mut ReferencePathInterner,
 }
@@ -425,7 +426,7 @@ struct ApplyMatchingStarRefs<'a> {
     triggering_is_type_only: bool,
     source_has_star_re_exports: bool,
     matching_exports: &'a [usize],
-    existing_references: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    existing_references: &'a mut FxHashSet<(FileId, Option<ReferencePathId>)>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
     reference_paths: &'a mut ReferencePathInterner,
 }
@@ -628,7 +629,7 @@ struct AttachMatchingStarRefs<'a> {
     module_by_id: &'a FxHashMap<FileId, &'a ResolvedModule>,
     triggering_is_type_only: bool,
     exports: &'a MatchingStarExports,
-    existing_references: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    existing_references: &'a mut FxHashSet<(FileId, Option<ReferencePathId>)>,
     source_id: FileId,
     reference_paths: &'a mut ReferencePathInterner,
 }
@@ -817,7 +818,7 @@ fn attach_star_refs_to_exports(
     source: &mut ModuleNode,
     export_indices: &[usize],
     references: &[SymbolReference],
-    existing_references: &mut FxHashSet<(FileId, ReferencePathId)>,
+    existing_references: &mut FxHashSet<(FileId, Option<ReferencePathId>)>,
 ) -> bool {
     let mut changed = false;
     for export_idx in export_indices {
@@ -991,7 +992,7 @@ pub(in crate::graph) struct NamedReExportPropagation<'a> {
     pub(in crate::graph) source_idx: usize,
     pub(in crate::graph) imported_name: &'a str,
     pub(in crate::graph) exported_name: &'a str,
-    pub(in crate::graph) existing_refs: &'a mut FxHashSet<(FileId, ReferencePathId)>,
+    pub(in crate::graph) existing_refs: &'a mut FxHashSet<(FileId, Option<ReferencePathId>)>,
     pub(in crate::graph) reference_paths: &'a mut ReferencePathInterner,
 }
 

--- a/crates/graph/src/graph/re_exports/tests.rs
+++ b/crates/graph/src/graph/re_exports/tests.rs
@@ -2611,6 +2611,7 @@ fn named_only_chain_safety_cap_excludes_synthetic_export_states() {
     let expected = re_export_info.len().saturating_add(
         initial_exports
             .saturating_mul(graph.modules.len())
+            .saturating_mul(2)
             .saturating_mul(re_export_info.len()),
     );
 

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -3,13 +3,26 @@
 use std::collections::VecDeque;
 
 use fixedbitset::FixedBitSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
-use super::ModuleGraph;
+use crate::resolve::ResolvedReplacedModuleTarget;
+use fallow_types::discover::FileId;
+
+use super::{ModuleGraph, TestReachabilityProfile};
 
 impl ModuleGraph {
     fn collect_reachable(
         &self,
-        entry_points: &rustc_hash::FxHashSet<fallow_types::discover::FileId>,
+        entry_points: &FxHashSet<FileId>,
+        total_capacity: usize,
+    ) -> FixedBitSet {
+        self.collect_reachable_with_mask(entry_points, &FixedBitSet::new(), total_capacity)
+    }
+
+    fn collect_reachable_with_mask(
+        &self,
+        entry_points: &FxHashSet<FileId>,
+        masked_targets: &FixedBitSet,
         total_capacity: usize,
     ) -> FixedBitSet {
         let mut visited = FixedBitSet::with_capacity(total_capacity);
@@ -29,6 +42,14 @@ impl ModuleGraph {
             let module = &self.modules[file_id.0 as usize];
             for edge in &self.edges[module.edge_range.clone()] {
                 let target_idx = edge.target.0 as usize;
+                let target_is_replaced = masked_targets.contains(target_idx)
+                    && edge
+                        .symbols
+                        .iter()
+                        .all(|symbol| !symbol.mechanism.is_commonjs());
+                if target_is_replaced {
+                    continue;
+                }
                 if target_idx < total_capacity && !visited.contains(target_idx) {
                     visited.insert(target_idx);
                     queue.push_back(edge.target);
@@ -39,14 +60,90 @@ impl ModuleGraph {
         visited
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "reachable indices originate from u32 FileIds"
+    )]
+    fn collect_test_reachable(
+        &self,
+        test_entry_points: &FxHashSet<FileId>,
+        replaced_module_targets: &[ResolvedReplacedModuleTarget],
+        total_capacity: usize,
+    ) -> (Option<FixedBitSet>, Vec<TestReachabilityProfile>) {
+        if test_entry_points.is_empty() {
+            return (None, Vec::new());
+        }
+
+        let mut targets_by_root: FxHashMap<FileId, Vec<FileId>> = FxHashMap::default();
+        for replacement in replaced_module_targets {
+            if test_entry_points.contains(&replacement.source_file)
+                && (replacement.target_file.0 as usize) < total_capacity
+            {
+                targets_by_root
+                    .entry(replacement.source_file)
+                    .or_default()
+                    .push(replacement.target_file);
+            }
+        }
+        for targets in targets_by_root.values_mut() {
+            targets.sort_unstable_by_key(|target| target.0);
+            targets.dedup();
+        }
+
+        if targets_by_root.is_empty() {
+            return (
+                Some(self.collect_reachable(test_entry_points, total_capacity)),
+                Vec::new(),
+            );
+        }
+
+        let mut roots_by_mask: FxHashMap<Vec<FileId>, FxHashSet<FileId>> = FxHashMap::default();
+        for &root in test_entry_points {
+            let mask = targets_by_root.remove(&root).unwrap_or_default();
+            roots_by_mask.entry(mask).or_default().insert(root);
+        }
+
+        let mut grouped_roots: Vec<_> = roots_by_mask.into_iter().collect();
+        grouped_roots.sort_by(|(left_mask, _), (right_mask, _)| {
+            left_mask
+                .iter()
+                .map(|file_id| file_id.0)
+                .cmp(right_mask.iter().map(|file_id| file_id.0))
+        });
+
+        let mut all_test_reachable = FixedBitSet::with_capacity(total_capacity);
+        let mut profiles = Vec::with_capacity(grouped_roots.len());
+        for (masked_targets, roots) in grouped_roots {
+            let mut roots: Vec<_> = roots.into_iter().collect();
+            roots.sort_unstable_by_key(|root| root.0);
+
+            let mut mask = FixedBitSet::with_capacity(total_capacity);
+            for target in &masked_targets {
+                mask.insert(target.0 as usize);
+            }
+            let root_set = roots.iter().copied().collect();
+            let reachable = self.collect_reachable_with_mask(&root_set, &mask, total_capacity);
+            all_test_reachable.union_with(&reachable);
+            let reachable_files = reachable.ones().map(|index| FileId(index as u32)).collect();
+            profiles.push(TestReachabilityProfile {
+                roots,
+                masked_targets,
+                reachable_files,
+            });
+        }
+
+        (Some(all_test_reachable), profiles)
+    }
+
     /// Mark modules reachable from overall, runtime, and test entry points via BFS.
     ///
     /// Skips redundant BFS passes when entry point sets are identical or empty.
     pub(super) fn mark_reachable(
         &mut self,
-        entry_points: &rustc_hash::FxHashSet<fallow_types::discover::FileId>,
-        runtime_entry_points: &rustc_hash::FxHashSet<fallow_types::discover::FileId>,
-        test_entry_points: &rustc_hash::FxHashSet<fallow_types::discover::FileId>,
+        entry_points: &FxHashSet<FileId>,
+        runtime_entry_points: &FxHashSet<FileId>,
+        test_entry_points: &FxHashSet<FileId>,
+        replaced_module_targets: &[ResolvedReplacedModuleTarget],
         total_capacity: usize,
     ) {
         let visited = self.collect_reachable(entry_points, total_capacity);
@@ -58,11 +155,9 @@ impl ModuleGraph {
             Some(self.collect_reachable(runtime_entry_points, total_capacity))
         };
 
-        let test_visited = if test_entry_points.is_empty() {
-            None
-        } else {
-            Some(self.collect_reachable(test_entry_points, total_capacity))
-        };
+        let (test_visited, test_reachability_profiles) =
+            self.collect_test_reachable(test_entry_points, replaced_module_targets, total_capacity);
+        self.test_reachability_profiles = test_reachability_profiles;
 
         for (idx, module) in self.modules.iter_mut().enumerate() {
             module.set_reachable(visited.contains(idx));
@@ -83,7 +178,9 @@ mod tests {
     use rustc_hash::FxHashSet;
 
     use crate::graph::ModuleGraph;
-    use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
+    use crate::resolve::{
+        ResolveResult, ResolvedImport, ResolvedModule, ResolvedReplacedModuleTarget,
+    };
     use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
     use fallow_types::extract::{ExportName, ImportInfo, ImportedName, VisibilityTag};
 
@@ -93,15 +190,29 @@ mod tests {
     /// `runtime_eps` and `test_eps` are file indices for each entry point
     /// category. All entry points (union of runtime + test) form the overall
     /// entry set.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "test file counts are trivially small"
-    )]
     fn build_reachability_graph(
         file_count: usize,
         edges_spec: &[(u32, u32)],
         runtime_eps: &[u32],
         test_eps: &[u32],
+    ) -> ModuleGraph {
+        let edges: Vec<_> = edges_spec
+            .iter()
+            .map(|&(source, target)| (source, target, false))
+            .collect();
+        build_reachability_graph_with_replacements(file_count, &edges, runtime_eps, test_eps, &[])
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test file counts are trivially small"
+    )]
+    fn build_reachability_graph_with_replacements(
+        file_count: usize,
+        edges_spec: &[(u32, u32, bool)],
+        runtime_eps: &[u32],
+        test_eps: &[u32],
+        replacements: &[ResolvedReplacedModuleTarget],
     ) -> ModuleGraph {
         let files: Vec<DiscoveredFile> = (0..file_count)
             .map(|i| DiscoveredFile {
@@ -115,10 +226,10 @@ mod tests {
             .map(|i| {
                 let imports: Vec<ResolvedImport> = edges_spec
                     .iter()
-                    .filter(|(src, _)| *src == i as u32)
-                    .map(|(_, tgt)| ResolvedImport {
+                    .filter(|(source, _, _)| *source == i as u32)
+                    .map(|(_, target, is_commonjs)| ResolvedImport {
                         info: ImportInfo {
-                            source: format!("./file{tgt}"),
+                            source: format!("./file{target}"),
                             imported_name: ImportedName::Named("x".to_string()),
                             local_name: "x".to_string(),
                             is_type_only: false,
@@ -126,7 +237,11 @@ mod tests {
                             span: oxc_span::Span::new(0, 10),
                             source_span: oxc_span::Span::default(),
                         },
-                        target: ResolveResult::InternalModule(FileId(*tgt)),
+                        target: if *is_commonjs {
+                            ResolveResult::CommonJsInternalModule(FileId(*target))
+                        } else {
+                            ResolveResult::InternalModule(FileId(*target))
+                        },
                     })
                     .collect();
 
@@ -183,8 +298,9 @@ mod tests {
         let mut all_entry_points = runtime_entry_points.clone();
         all_entry_points.extend(test_entry_points.iter().cloned());
 
-        ModuleGraph::build_with_reachability_roots(
+        ModuleGraph::build_with_reachability_roots_and_replacements(
             &resolved_modules,
+            replacements,
             &all_entry_points,
             &runtime_entry_points,
             &test_entry_points,
@@ -281,6 +397,166 @@ mod tests {
         assert!(!graph.modules[1].is_test_reachable());
         assert!(graph.modules[2].is_test_reachable());
         assert!(graph.modules[3].is_test_reachable());
+    }
+
+    #[test]
+    fn esm_replacement_masks_target_only_from_test_reachability() {
+        let graph = build_reachability_graph_with_replacements(
+            3,
+            &[(0, 1, false), (1, 2, false)],
+            &[],
+            &[0],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+        );
+
+        assert!(graph.modules[1].is_reachable());
+        assert!(!graph.modules[1].is_test_reachable());
+        assert!(!graph.modules[2].is_test_reachable());
+        assert_eq!(graph.test_reachability_profiles.len(), 1);
+        assert_eq!(
+            graph.test_reachability_profiles[0].reachable_files,
+            vec![FileId(0)]
+        );
+    }
+
+    #[test]
+    fn commonjs_path_preserves_a_replaced_target() {
+        let graph = build_reachability_graph_with_replacements(
+            2,
+            &[(0, 1, true)],
+            &[],
+            &[0],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+        );
+
+        assert!(graph.modules[1].is_test_reachable());
+    }
+
+    #[test]
+    fn mixed_commonjs_and_esm_symbols_preserve_a_replaced_target() {
+        let graph = build_reachability_graph_with_replacements(
+            2,
+            &[(0, 1, false), (0, 1, true)],
+            &[],
+            &[0],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+        );
+
+        assert!(graph.modules[1].is_test_reachable());
+    }
+
+    #[test]
+    fn identical_masks_share_one_reachability_profile() {
+        let graph = build_reachability_graph_with_replacements(
+            3,
+            &[(0, 2, false), (1, 2, false)],
+            &[],
+            &[0, 1],
+            &[
+                ResolvedReplacedModuleTarget {
+                    source_file: FileId(1),
+                    target_file: FileId(2),
+                },
+                ResolvedReplacedModuleTarget {
+                    source_file: FileId(0),
+                    target_file: FileId(2),
+                },
+            ],
+        );
+
+        assert_eq!(graph.test_reachability_profiles.len(), 1);
+        assert_eq!(
+            graph.test_reachability_profiles[0].roots,
+            vec![FileId(0), FileId(1)]
+        );
+        assert_eq!(
+            graph.test_reachability_profiles[0].masked_targets,
+            vec![FileId(2)]
+        );
+        assert!(!graph.modules[2].is_test_reachable());
+    }
+
+    #[test]
+    fn an_unmasked_root_keeps_the_shared_target_test_reachable() {
+        let graph = build_reachability_graph_with_replacements(
+            3,
+            &[(0, 2, false), (1, 2, false)],
+            &[],
+            &[0, 1],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(2),
+            }],
+        );
+
+        assert_eq!(graph.test_reachability_profiles.len(), 2);
+        assert!(graph.modules[2].is_test_reachable());
+        assert_eq!(
+            graph.test_reachability_profiles[0].masked_targets,
+            Vec::<FileId>::new()
+        );
+        assert_eq!(
+            graph.test_reachability_profiles[0].reachable_files,
+            vec![FileId(1), FileId(2)]
+        );
+        assert_eq!(
+            graph.test_reachability_profiles[1].reachable_files,
+            vec![FileId(0)]
+        );
+    }
+
+    #[test]
+    fn replacement_declared_outside_a_test_root_keeps_the_fast_path() {
+        let graph = build_reachability_graph_with_replacements(
+            3,
+            &[(0, 1, false)],
+            &[],
+            &[0],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(2),
+                target_file: FileId(1),
+            }],
+        );
+
+        assert!(graph.test_reachability_profiles.is_empty());
+        assert!(graph.modules[1].is_test_reachable());
+    }
+
+    #[test]
+    fn replacement_profiles_survive_graph_cache_serialization() {
+        let graph = build_reachability_graph_with_replacements(
+            2,
+            &[(0, 1, false)],
+            &[],
+            &[0],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+        );
+
+        let encoded = postcard::to_allocvec(&graph).expect("encode graph");
+        let decoded: ModuleGraph = postcard::from_bytes(&encoded).expect("decode graph");
+
+        assert_eq!(decoded.test_reachability_profiles.len(), 1);
+        assert_eq!(decoded.test_reachability_profiles[0].roots, vec![FileId(0)]);
+        assert_eq!(
+            decoded.test_reachability_profiles[0].masked_targets,
+            vec![FileId(1)]
+        );
+        assert_eq!(
+            decoded.test_reachability_profiles[0].reachable_files,
+            vec![FileId(0)]
+        );
     }
 
     #[test]

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -1489,7 +1489,7 @@ mod tests {
     }
 
     #[test]
-    fn no_profile_coverage_keeps_a_long_reference_path_on_the_fast_path() {
+    fn no_profile_coverage_omits_unused_reference_provenance() {
         const CHAIN_LENGTH: u32 = 128;
 
         let files: Vec<_> = (0..=CHAIN_LENGTH)
@@ -1559,10 +1559,8 @@ mod tests {
         let reference = &graph.modules[CHAIN_LENGTH as usize].exports[0].references[0];
 
         assert_eq!(graph.test_reachability_index.profile_count, 0);
-        assert_eq!(
-            graph.reference_path_hops(reference).len(),
-            CHAIN_LENGTH as usize
-        );
+        assert!(reference.path.is_none());
+        assert!(graph.reference_paths.is_empty());
         assert!(graph.is_test_reference_covered(reference));
     }
 

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -11,6 +11,74 @@ use fallow_types::extract::ModuleLoadMechanism;
 
 use super::{ModuleGraph, TestReachabilityIndex};
 
+pub(super) enum TestReachabilityPlan<'roots> {
+    NoRoots,
+    Legacy {
+        roots: &'roots FxHashSet<FileId>,
+    },
+    Profiled {
+        grouped_roots: Vec<(Vec<FileId>, Vec<FileId>)>,
+    },
+}
+
+impl<'roots> TestReachabilityPlan<'roots> {
+    pub(super) fn new(
+        test_entry_points: &'roots FxHashSet<FileId>,
+        replaced_module_targets: &[ResolvedReplacedModuleTarget],
+        total_capacity: usize,
+    ) -> Self {
+        if test_entry_points.is_empty() {
+            return Self::NoRoots;
+        }
+
+        let mut targets_by_root: FxHashMap<FileId, Vec<FileId>> = FxHashMap::default();
+        for replacement in replaced_module_targets {
+            if test_entry_points.contains(&replacement.source_file)
+                && (replacement.target_file.0 as usize) < total_capacity
+            {
+                targets_by_root
+                    .entry(replacement.source_file)
+                    .or_default()
+                    .push(replacement.target_file);
+            }
+        }
+        for targets in targets_by_root.values_mut() {
+            targets.sort_unstable_by_key(|target| target.0);
+            targets.dedup();
+        }
+
+        if targets_by_root.is_empty() {
+            return Self::Legacy {
+                roots: test_entry_points,
+            };
+        }
+
+        let mut roots_by_mask: FxHashMap<Vec<FileId>, Vec<FileId>> = FxHashMap::default();
+        for &root in test_entry_points {
+            let mask = targets_by_root.remove(&root).unwrap_or_default();
+            roots_by_mask.entry(mask).or_default().push(root);
+        }
+
+        let mut grouped_roots: Vec<_> = roots_by_mask.into_iter().collect();
+        grouped_roots.sort_by(|(left_mask, _), (right_mask, _)| {
+            left_mask
+                .iter()
+                .map(|file_id| file_id.0)
+                .cmp(right_mask.iter().map(|file_id| file_id.0))
+        });
+        for (_, roots) in &mut grouped_roots {
+            roots.sort_unstable_by_key(|root| root.0);
+            roots.dedup();
+        }
+
+        Self::Profiled { grouped_roots }
+    }
+
+    pub(super) const fn requires_reference_provenance(&self) -> bool {
+        matches!(self, Self::Profiled { .. })
+    }
+}
+
 enum TestReachability {
     NoRoots,
     Legacy(FixedBitSet),
@@ -242,64 +310,27 @@ impl ModuleGraph {
 
     fn collect_test_reachable(
         &self,
-        test_entry_points: &FxHashSet<FileId>,
-        replaced_module_targets: &[ResolvedReplacedModuleTarget],
+        plan: TestReachabilityPlan<'_>,
         total_capacity: usize,
     ) -> TestReachability {
-        if test_entry_points.is_empty() {
-            return TestReachability::NoRoots;
-        }
-
-        let mut targets_by_root: FxHashMap<FileId, Vec<FileId>> = FxHashMap::default();
-        for replacement in replaced_module_targets {
-            if test_entry_points.contains(&replacement.source_file)
-                && (replacement.target_file.0 as usize) < total_capacity
-            {
-                targets_by_root
-                    .entry(replacement.source_file)
-                    .or_default()
-                    .push(replacement.target_file);
+        match plan {
+            TestReachabilityPlan::NoRoots => TestReachability::NoRoots,
+            TestReachabilityPlan::Legacy { roots } => {
+                TestReachability::Legacy(self.collect_reachable(roots, total_capacity))
             }
-        }
-        for targets in targets_by_root.values_mut() {
-            targets.sort_unstable_by_key(|target| target.0);
-            targets.dedup();
-        }
+            TestReachabilityPlan::Profiled { grouped_roots } => {
+                let (reachable, index, dirty_word_pops) =
+                    self.collect_profiled_reachable(&grouped_roots, total_capacity);
+                #[cfg(not(test))]
+                let _ = dirty_word_pops;
 
-        if targets_by_root.is_empty() {
-            return TestReachability::Legacy(
-                self.collect_reachable(test_entry_points, total_capacity),
-            );
-        }
-
-        let mut roots_by_mask: FxHashMap<Vec<FileId>, Vec<FileId>> = FxHashMap::default();
-        for &root in test_entry_points {
-            let mask = targets_by_root.remove(&root).unwrap_or_default();
-            roots_by_mask.entry(mask).or_default().push(root);
-        }
-
-        let mut grouped_roots: Vec<_> = roots_by_mask.into_iter().collect();
-        grouped_roots.sort_by(|(left_mask, _), (right_mask, _)| {
-            left_mask
-                .iter()
-                .map(|file_id| file_id.0)
-                .cmp(right_mask.iter().map(|file_id| file_id.0))
-        });
-        for (_, roots) in &mut grouped_roots {
-            roots.sort_unstable_by_key(|root| root.0);
-            roots.dedup();
-        }
-
-        let (reachable, index, dirty_word_pops) =
-            self.collect_profiled_reachable(&grouped_roots, total_capacity);
-        #[cfg(not(test))]
-        let _ = dirty_word_pops;
-
-        TestReachability::Profiled {
-            reachable,
-            index,
-            #[cfg(test)]
-            dirty_word_pops,
+                TestReachability::Profiled {
+                    reachable,
+                    index,
+                    #[cfg(test)]
+                    dirty_word_pops,
+                }
+            }
         }
     }
 
@@ -310,8 +341,7 @@ impl ModuleGraph {
         &mut self,
         entry_points: &FxHashSet<FileId>,
         runtime_entry_points: &FxHashSet<FileId>,
-        test_entry_points: &FxHashSet<FileId>,
-        replaced_module_targets: &[ResolvedReplacedModuleTarget],
+        test_reachability_plan: TestReachabilityPlan<'_>,
         total_capacity: usize,
     ) {
         let visited = self.collect_reachable(entry_points, total_capacity);
@@ -323,9 +353,14 @@ impl ModuleGraph {
             Some(self.collect_reachable(runtime_entry_points, total_capacity))
         };
 
+        let requires_reference_provenance = test_reachability_plan.requires_reference_provenance();
         let (test_visited, test_reachability_index) = self
-            .collect_test_reachable(test_entry_points, replaced_module_targets, total_capacity)
+            .collect_test_reachable(test_reachability_plan, total_capacity)
             .into_parts();
+        debug_assert_eq!(
+            requires_reference_provenance,
+            test_reachability_index.profile_count > 0
+        );
         self.test_reachability_index = test_reachability_index;
 
         for (idx, module) in self.modules.iter_mut().enumerate() {
@@ -346,6 +381,7 @@ mod tests {
 
     use rustc_hash::FxHashSet;
 
+    use super::TestReachabilityPlan;
     use crate::graph::ModuleGraph;
     use crate::resolve::{
         ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport,
@@ -1186,6 +1222,77 @@ mod tests {
     }
 
     #[test]
+    fn test_reachability_plan_uses_no_roots_without_test_entries() {
+        let test_roots = FxHashSet::default();
+
+        let plan = TestReachabilityPlan::new(&test_roots, &[], 3);
+
+        assert!(matches!(&plan, TestReachabilityPlan::NoRoots));
+        assert!(!plan.requires_reference_provenance());
+    }
+
+    #[test]
+    fn test_reachability_plan_ignores_replacements_outside_test_roots() {
+        let test_roots = FxHashSet::from_iter([FileId(0)]);
+        let replacements = [ResolvedReplacedModuleTarget {
+            source_file: FileId(1),
+            target_file: FileId(2),
+        }];
+
+        let plan = TestReachabilityPlan::new(&test_roots, &replacements, 3);
+
+        assert!(matches!(&plan, TestReachabilityPlan::Legacy { .. }));
+        assert!(!plan.requires_reference_provenance());
+    }
+
+    #[test]
+    fn test_reachability_plan_ignores_out_of_capacity_targets() {
+        let test_roots = FxHashSet::from_iter([FileId(0)]);
+        let replacements = [ResolvedReplacedModuleTarget {
+            source_file: FileId(0),
+            target_file: FileId(3),
+        }];
+
+        let plan = TestReachabilityPlan::new(&test_roots, &replacements, 3);
+
+        assert!(matches!(&plan, TestReachabilityPlan::Legacy { .. }));
+        assert!(!plan.requires_reference_provenance());
+    }
+
+    #[test]
+    fn test_reachability_plan_groups_roots_by_normalized_replacement_mask() {
+        let test_roots = FxHashSet::from_iter([FileId(0), FileId(1), FileId(2)]);
+        let replacements = [
+            ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(4),
+            },
+            ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(4),
+            },
+            ResolvedReplacedModuleTarget {
+                source_file: FileId(1),
+                target_file: FileId(4),
+            },
+        ];
+
+        let plan = TestReachabilityPlan::new(&test_roots, &replacements, 5);
+
+        assert!(plan.requires_reference_provenance());
+        let TestReachabilityPlan::Profiled { grouped_roots } = plan else {
+            panic!("valid test-root replacements must use profiled reachability");
+        };
+        assert_eq!(
+            grouped_roots,
+            vec![
+                (Vec::new(), vec![FileId(2)]),
+                (vec![FileId(4)], vec![FileId(0), FileId(1)]),
+            ]
+        );
+    }
+
+    #[test]
     fn replacement_profiles_survive_graph_cache_serialization() {
         let graph = build_reachability_graph_with_replacements(
             2,
@@ -1221,7 +1328,8 @@ mod tests {
         let graph = build_reachability_graph(512, &[], &[], &test_roots);
         let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
 
-        let reachability = graph.collect_test_reachable(&root_set, &[], 512);
+        let plan = TestReachabilityPlan::new(&root_set, &[], 512);
+        let reachability = graph.collect_test_reachable(plan, 512);
 
         assert_eq!(reachability.traversal_count(), 1);
     }
@@ -1249,7 +1357,8 @@ mod tests {
         );
         let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
 
-        let reachability = graph.collect_test_reachable(&root_set, &replacements, 129);
+        let plan = TestReachabilityPlan::new(&root_set, &replacements, 129);
+        let reachability = graph.collect_test_reachable(plan, 129);
 
         assert_eq!(reachability.traversal_count(), 1);
         assert_eq!(reachability.dirty_word_pop_count(), 129);
@@ -1278,7 +1387,8 @@ mod tests {
         );
         let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
 
-        let reachability = graph.collect_test_reachable(&root_set, &replacements, 131);
+        let plan = TestReachabilityPlan::new(&root_set, &replacements, 131);
+        let reachability = graph.collect_test_reachable(plan, 131);
 
         assert_eq!(reachability.traversal_count(), 1);
         assert_eq!(reachability.dirty_word_pop_count(), 67);
@@ -1354,7 +1464,8 @@ mod tests {
         );
         let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
 
-        let reachability = graph.collect_test_reachable(&root_set, &replacements, file_count);
+        let plan = TestReachabilityPlan::new(&root_set, &replacements, file_count);
+        let reachability = graph.collect_test_reachable(plan, file_count);
 
         assert_eq!(graph.test_reachability_index.words_per_file, 2);
         let expected_dirty_word_pops =

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -10,6 +10,37 @@ use fallow_types::discover::FileId;
 
 use super::{ModuleGraph, TestReachabilityProfile};
 
+enum TestReachability {
+    NoRoots,
+    Legacy(FixedBitSet),
+    Profiled {
+        reachable: FixedBitSet,
+        profiles: Vec<TestReachabilityProfile>,
+    },
+}
+
+impl TestReachability {
+    fn into_parts(self) -> (Option<FixedBitSet>, Vec<TestReachabilityProfile>) {
+        match self {
+            Self::NoRoots => (None, Vec::new()),
+            Self::Legacy(reachable) => (Some(reachable), Vec::new()),
+            Self::Profiled {
+                reachable,
+                profiles,
+            } => (Some(reachable), profiles),
+        }
+    }
+
+    #[cfg(test)]
+    const fn traversal_count(&self) -> usize {
+        match self {
+            Self::NoRoots => 0,
+            Self::Legacy(_) => 1,
+            Self::Profiled { profiles, .. } => profiles.len(),
+        }
+    }
+}
+
 impl ModuleGraph {
     fn collect_reachable(
         &self,
@@ -69,9 +100,9 @@ impl ModuleGraph {
         test_entry_points: &FxHashSet<FileId>,
         replaced_module_targets: &[ResolvedReplacedModuleTarget],
         total_capacity: usize,
-    ) -> (Option<FixedBitSet>, Vec<TestReachabilityProfile>) {
+    ) -> TestReachability {
         if test_entry_points.is_empty() {
-            return (None, Vec::new());
+            return TestReachability::NoRoots;
         }
 
         let mut targets_by_root: FxHashMap<FileId, Vec<FileId>> = FxHashMap::default();
@@ -91,9 +122,8 @@ impl ModuleGraph {
         }
 
         if targets_by_root.is_empty() {
-            return (
-                Some(self.collect_reachable(test_entry_points, total_capacity)),
-                Vec::new(),
+            return TestReachability::Legacy(
+                self.collect_reachable(test_entry_points, total_capacity),
             );
         }
 
@@ -132,7 +162,10 @@ impl ModuleGraph {
             });
         }
 
-        (Some(all_test_reachable), profiles)
+        TestReachability::Profiled {
+            reachable: all_test_reachable,
+            profiles,
+        }
     }
 
     /// Mark modules reachable from overall, runtime, and test entry points via BFS.
@@ -155,8 +188,9 @@ impl ModuleGraph {
             Some(self.collect_reachable(runtime_entry_points, total_capacity))
         };
 
-        let (test_visited, test_reachability_profiles) =
-            self.collect_test_reachable(test_entry_points, replaced_module_targets, total_capacity);
+        let (test_visited, test_reachability_profiles) = self
+            .collect_test_reachable(test_entry_points, replaced_module_targets, total_capacity)
+            .into_parts();
         self.test_reachability_profiles = test_reachability_profiles;
 
         for (idx, module) in self.modules.iter_mut().enumerate() {
@@ -560,6 +594,45 @@ mod tests {
             decoded.test_reachability_profiles[0].reachable_files,
             vec![FileId(0)]
         );
+    }
+
+    #[test]
+    fn many_unmasked_roots_use_one_test_traversal() {
+        let test_roots: Vec<u32> = (0..512).collect();
+        let graph = build_reachability_graph(512, &[], &[], &test_roots);
+        let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
+
+        let reachability = graph.collect_test_reachable(&root_set, &[], 512);
+
+        assert_eq!(reachability.traversal_count(), 1);
+    }
+
+    #[test]
+    fn many_roots_use_one_traversal_per_distinct_mask() {
+        let test_roots: Vec<u32> = (0..128).collect();
+        let edges: Vec<_> = test_roots
+            .iter()
+            .copied()
+            .map(|root| (root, 128, false))
+            .collect();
+        let replacements: Vec<_> = (0..64)
+            .map(|root| ResolvedReplacedModuleTarget {
+                source_file: FileId(root),
+                target_file: FileId(128),
+            })
+            .collect();
+        let graph = build_reachability_graph_with_replacements(
+            129,
+            &edges,
+            &[],
+            &test_roots,
+            &replacements,
+        );
+        let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
+
+        let reachability = graph.collect_test_reachable(&root_set, &replacements, 129);
+
+        assert_eq!(reachability.traversal_count(), 2);
     }
 
     #[test]

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -17,6 +17,8 @@ enum TestReachability {
     Profiled {
         reachable: FixedBitSet,
         index: TestReachabilityIndex,
+        #[cfg(test)]
+        worklist_pops: usize,
     },
 }
 
@@ -25,7 +27,9 @@ impl TestReachability {
         match self {
             Self::NoRoots => (None, TestReachabilityIndex::default()),
             Self::Legacy(reachable) => (Some(reachable), TestReachabilityIndex::default()),
-            Self::Profiled { reachable, index } => (Some(reachable), index),
+            Self::Profiled {
+                reachable, index, ..
+            } => (Some(reachable), index),
         }
     }
 
@@ -34,7 +38,15 @@ impl TestReachability {
         match self {
             Self::NoRoots => 0,
             Self::Legacy(_) => 1,
-            Self::Profiled { index, .. } => index.profile_count,
+            Self::Profiled { .. } => 1,
+        }
+    }
+
+    #[cfg(test)]
+    const fn worklist_pop_count(&self) -> usize {
+        match self {
+            Self::Profiled { worklist_pops, .. } => *worklist_pops,
+            Self::NoRoots | Self::Legacy(_) => 0,
         }
     }
 }
@@ -72,50 +84,138 @@ impl ModuleGraph {
         visited
     }
 
-    fn collect_reachable_with_mask(
+    fn collect_profiled_reachable(
         &self,
-        entry_points: &FxHashSet<FileId>,
-        masked_targets: &FixedBitSet,
+        grouped_roots: &[(Vec<FileId>, Vec<FileId>)],
         total_capacity: usize,
-    ) -> FixedBitSet {
-        let mut visited = FixedBitSet::with_capacity(total_capacity);
+    ) -> (FixedBitSet, TestReachabilityIndex, usize) {
+        let profile_count = grouped_roots.len();
+        let mut index = TestReachabilityIndex::new(total_capacity, profile_count);
+        let words_per_file = index.words_per_file;
+        let mut masked_profiles: FxHashMap<FileId, Vec<u64>> = FxHashMap::default();
+
+        for (profile, (masked_targets, _)) in grouped_roots.iter().enumerate() {
+            let word_index = profile / u64::BITS as usize;
+            let profile_bit = 1_u64 << (profile % u64::BITS as usize);
+            for &target in masked_targets {
+                masked_profiles
+                    .entry(target)
+                    .or_insert_with(|| vec![0; words_per_file])[word_index] |= profile_bit;
+            }
+        }
+
+        let mut all_reachable = FixedBitSet::with_capacity(total_capacity);
+        let mut pending_profiles = vec![0_u64; index.reachable_profiles.len()];
+        let mut queued = FixedBitSet::with_capacity(total_capacity);
         let mut queue = VecDeque::new();
 
-        for &ep_id in entry_points {
-            if (ep_id.0 as usize) < total_capacity {
-                visited.insert(ep_id.0 as usize);
-                queue.push_back(ep_id);
-            }
-        }
-
-        while let Some(file_id) = queue.pop_front() {
-            if (file_id.0 as usize) >= self.modules.len() {
-                continue;
-            }
-            let module = &self.modules[file_id.0 as usize];
-            for edge in &self.edges[module.edge_range.clone()] {
-                let target_idx = edge.target.0 as usize;
-                let target_is_replaced = masked_targets.contains(target_idx)
-                    && edge.symbols.iter().all(|symbol| {
-                        !matches!(symbol.mechanism, ModuleLoadMechanism::CommonJsRequire)
-                    });
-                if target_is_replaced {
+        for (profile, (_, roots)) in grouped_roots.iter().enumerate() {
+            let word_index = profile / u64::BITS as usize;
+            let profile_bit = 1_u64 << (profile % u64::BITS as usize);
+            for &root in roots {
+                let root_index = root.0 as usize;
+                if root_index >= total_capacity {
                     continue;
                 }
-                if target_idx < total_capacity && !visited.contains(target_idx) {
-                    visited.insert(target_idx);
-                    queue.push_back(edge.target);
+                let Some(slot) = root_index
+                    .checked_mul(words_per_file)
+                    .and_then(|start| start.checked_add(word_index))
+                else {
+                    continue;
+                };
+                let Some(reachable_word) = index.reachable_profiles.get_mut(slot) else {
+                    continue;
+                };
+                if *reachable_word & profile_bit != 0 {
+                    continue;
+                }
+                *reachable_word |= profile_bit;
+                pending_profiles[slot] |= profile_bit;
+                all_reachable.insert(root_index);
+                if !queued.contains(root_index) {
+                    queued.insert(root_index);
+                    queue.push_back(root);
                 }
             }
         }
 
-        visited
+        let mut worklist_pops = 0;
+        let mut source_delta = vec![0_u64; words_per_file];
+        while let Some(file_id) = queue.pop_front() {
+            worklist_pops += 1;
+            let file_index = file_id.0 as usize;
+            queued.remove(file_index);
+            let Some(source_start) = file_index.checked_mul(words_per_file) else {
+                continue;
+            };
+            let Some(source_end) = source_start.checked_add(words_per_file) else {
+                continue;
+            };
+            let Some(pending_source) = pending_profiles.get_mut(source_start..source_end) else {
+                continue;
+            };
+            source_delta.copy_from_slice(pending_source);
+            pending_source.fill(0);
+
+            let Some(module) = self.modules.get(file_index) else {
+                continue;
+            };
+            for edge in &self.edges[module.edge_range.clone()] {
+                let target_idx = edge.target.0 as usize;
+                if target_idx >= total_capacity {
+                    continue;
+                }
+                let Some(target_start) = target_idx.checked_mul(words_per_file) else {
+                    continue;
+                };
+                let edge_is_esm_only = edge
+                    .symbols
+                    .iter()
+                    .all(|symbol| {
+                        !matches!(symbol.mechanism, ModuleLoadMechanism::CommonJsRequire)
+                    });
+                let edge_mask = if edge_is_esm_only {
+                    masked_profiles.get(&edge.target)
+                } else {
+                    None
+                };
+
+                let mut target_changed = false;
+                for (word_index, &delta_word) in source_delta.iter().enumerate() {
+                    let propagated = edge_mask
+                        .and_then(|mask| mask.get(word_index))
+                        .map_or(delta_word, |mask_word| delta_word & !mask_word);
+                    let Some(target_slot) = target_start.checked_add(word_index) else {
+                        continue;
+                    };
+                    let Some(reachable_word) =
+                        index.reachable_profiles.get_mut(target_slot)
+                    else {
+                        continue;
+                    };
+                    let new_profiles = propagated & !*reachable_word;
+                    if new_profiles == 0 {
+                        continue;
+                    }
+                    *reachable_word |= new_profiles;
+                    pending_profiles[target_slot] |= new_profiles;
+                    target_changed = true;
+                }
+
+                if target_changed {
+                    all_reachable.insert(target_idx);
+                    if !queued.contains(target_idx) {
+                        queued.insert(target_idx);
+                        queue.push_back(edge.target);
+                    }
+                }
+            }
+        }
+
+        index.set_sparse_masks(masked_profiles);
+        (all_reachable, index, worklist_pops)
     }
 
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "reachable indices originate from u32 FileIds"
-    )]
     fn collect_test_reachable(
         &self,
         test_entry_points: &FxHashSet<FileId>,
@@ -148,10 +248,10 @@ impl ModuleGraph {
             );
         }
 
-        let mut roots_by_mask: FxHashMap<Vec<FileId>, FxHashSet<FileId>> = FxHashMap::default();
+        let mut roots_by_mask: FxHashMap<Vec<FileId>, Vec<FileId>> = FxHashMap::default();
         for &root in test_entry_points {
             let mask = targets_by_root.remove(&root).unwrap_or_default();
-            roots_by_mask.entry(mask).or_default().insert(root);
+            roots_by_mask.entry(mask).or_default().push(root);
         }
 
         let mut grouped_roots: Vec<_> = roots_by_mask.into_iter().collect();
@@ -161,29 +261,19 @@ impl ModuleGraph {
                 .map(|file_id| file_id.0)
                 .cmp(right_mask.iter().map(|file_id| file_id.0))
         });
-
-        let mut all_test_reachable = FixedBitSet::with_capacity(total_capacity);
-        let mut index = TestReachabilityIndex::new(total_capacity, grouped_roots.len());
-        for (profile, (masked_targets, roots)) in grouped_roots.into_iter().enumerate() {
-            let mut roots: Vec<_> = roots.into_iter().collect();
+        for (_, roots) in &mut grouped_roots {
             roots.sort_unstable_by_key(|root| root.0);
-
-            let mut mask = FixedBitSet::with_capacity(total_capacity);
-            for target in &masked_targets {
-                mask.insert(target.0 as usize);
-                index.set_masked(*target, profile);
-            }
-            let root_set = roots.iter().copied().collect();
-            let reachable = self.collect_reachable_with_mask(&root_set, &mask, total_capacity);
-            all_test_reachable.union_with(&reachable);
-            for file_index in reachable.ones() {
-                index.set_reachable(FileId(file_index as u32), profile);
-            }
+            roots.dedup();
         }
 
+        let (reachable, index, _worklist_pops) =
+            self.collect_profiled_reachable(&grouped_roots, total_capacity);
+
         TestReachability::Profiled {
-            reachable: all_test_reachable,
+            reachable,
             index,
+            #[cfg(test)]
+            worklist_pops: _worklist_pops,
         }
     }
 
@@ -883,7 +973,7 @@ mod tests {
     }
 
     #[test]
-    fn many_roots_use_one_traversal_per_distinct_mask() {
+    fn many_roots_share_one_profile_worklist() {
         let test_roots: Vec<u32> = (0..128).collect();
         let edges: Vec<_> = test_roots
             .iter()
@@ -907,7 +997,86 @@ mod tests {
 
         let reachability = graph.collect_test_reachable(&root_set, &replacements, 129);
 
-        assert_eq!(reachability.traversal_count(), 2);
+        assert_eq!(reachability.traversal_count(), 1);
+        assert_eq!(reachability.worklist_pop_count(), 129);
+    }
+
+    #[test]
+    fn unique_masks_cross_profile_words_in_one_deterministic_worklist() {
+        let test_roots: Vec<u32> = (0..65).collect();
+        let mut edges = Vec::with_capacity(test_roots.len() * 2);
+        let mut replacements = Vec::with_capacity(test_roots.len());
+        for &root in &test_roots {
+            let masked_target = 65 + root;
+            edges.push((root, masked_target, false));
+            edges.push((root, 130, false));
+            replacements.push(ResolvedReplacedModuleTarget {
+                source_file: FileId(root),
+                target_file: FileId(masked_target),
+            });
+        }
+        let graph = build_reachability_graph_with_replacements(
+            131,
+            &edges,
+            &[],
+            &test_roots,
+            &replacements,
+        );
+        let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
+
+        let reachability = graph.collect_test_reachable(&root_set, &replacements, 131);
+
+        assert_eq!(reachability.traversal_count(), 1);
+        assert_eq!(reachability.worklist_pop_count(), 66);
+        assert_eq!(graph.test_reachability_index.profile_count, 65);
+        assert_eq!(graph.test_reachability_index.words_per_file, 2);
+        assert_eq!(graph.test_reachability_index.masked_profiles.len(), 65);
+        assert!(
+            graph
+                .test_reachability_index
+                .profile_reaches(FileId(130), 0)
+        );
+        assert!(
+            graph
+                .test_reachability_index
+                .profile_reaches(FileId(130), 64)
+        );
+        assert!(
+            graph
+                .test_reachability_index
+                .profile_masks(FileId(65), 0)
+        );
+        assert!(
+            graph
+                .test_reachability_index
+                .profile_masks(FileId(129), 64)
+        );
+        assert!(
+            !graph
+                .test_reachability_index
+                .profile_reaches(FileId(65), 0)
+        );
+        assert!(
+            !graph
+                .test_reachability_index
+                .profile_reaches(FileId(129), 64)
+        );
+
+        let encoded = postcard::to_allocvec(&graph).expect("encode graph");
+        let decoded: ModuleGraph = postcard::from_bytes(&encoded).expect("decode graph");
+        assert_eq!(decoded.test_reachability_index.profile_count, 65);
+        assert_eq!(decoded.test_reachability_index.words_per_file, 2);
+        assert_eq!(decoded.test_reachability_index.masked_profiles.len(), 65);
+        assert!(
+            decoded
+                .test_reachability_index
+                .profile_reaches(FileId(130), 64)
+        );
+        assert!(
+            decoded
+                .test_reachability_index
+                .profile_masks(FileId(129), 64)
+        );
     }
 
     #[test]

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -7,27 +7,25 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::resolve::ResolvedReplacedModuleTarget;
 use fallow_types::discover::FileId;
+use fallow_types::extract::ModuleLoadMechanism;
 
-use super::{ModuleGraph, TestReachabilityProfile};
+use super::{ModuleGraph, TestReachabilityIndex};
 
 enum TestReachability {
     NoRoots,
     Legacy(FixedBitSet),
     Profiled {
         reachable: FixedBitSet,
-        profiles: Vec<TestReachabilityProfile>,
+        index: TestReachabilityIndex,
     },
 }
 
 impl TestReachability {
-    fn into_parts(self) -> (Option<FixedBitSet>, Vec<TestReachabilityProfile>) {
+    fn into_parts(self) -> (Option<FixedBitSet>, TestReachabilityIndex) {
         match self {
-            Self::NoRoots => (None, Vec::new()),
-            Self::Legacy(reachable) => (Some(reachable), Vec::new()),
-            Self::Profiled {
-                reachable,
-                profiles,
-            } => (Some(reachable), profiles),
+            Self::NoRoots => (None, TestReachabilityIndex::default()),
+            Self::Legacy(reachable) => (Some(reachable), TestReachabilityIndex::default()),
+            Self::Profiled { reachable, index } => (Some(reachable), index),
         }
     }
 
@@ -36,7 +34,7 @@ impl TestReachability {
         match self {
             Self::NoRoots => 0,
             Self::Legacy(_) => 1,
-            Self::Profiled { profiles, .. } => profiles.len(),
+            Self::Profiled { index, .. } => index.profile_count,
         }
     }
 }
@@ -47,7 +45,31 @@ impl ModuleGraph {
         entry_points: &FxHashSet<FileId>,
         total_capacity: usize,
     ) -> FixedBitSet {
-        self.collect_reachable_with_mask(entry_points, &FixedBitSet::new(), total_capacity)
+        let mut visited = FixedBitSet::with_capacity(total_capacity);
+        let mut queue = VecDeque::new();
+
+        for &ep_id in entry_points {
+            if (ep_id.0 as usize) < total_capacity {
+                visited.insert(ep_id.0 as usize);
+                queue.push_back(ep_id);
+            }
+        }
+
+        while let Some(file_id) = queue.pop_front() {
+            if (file_id.0 as usize) >= self.modules.len() {
+                continue;
+            }
+            let module = &self.modules[file_id.0 as usize];
+            for edge in &self.edges[module.edge_range.clone()] {
+                let target_idx = edge.target.0 as usize;
+                if target_idx < total_capacity && !visited.contains(target_idx) {
+                    visited.insert(target_idx);
+                    queue.push_back(edge.target);
+                }
+            }
+        }
+
+        visited
     }
 
     fn collect_reachable_with_mask(
@@ -74,10 +96,9 @@ impl ModuleGraph {
             for edge in &self.edges[module.edge_range.clone()] {
                 let target_idx = edge.target.0 as usize;
                 let target_is_replaced = masked_targets.contains(target_idx)
-                    && edge
-                        .symbols
-                        .iter()
-                        .all(|symbol| !symbol.mechanism.is_commonjs());
+                    && edge.symbols.iter().all(|symbol| {
+                        !matches!(symbol.mechanism, ModuleLoadMechanism::CommonJsRequire)
+                    });
                 if target_is_replaced {
                     continue;
                 }
@@ -142,29 +163,27 @@ impl ModuleGraph {
         });
 
         let mut all_test_reachable = FixedBitSet::with_capacity(total_capacity);
-        let mut profiles = Vec::with_capacity(grouped_roots.len());
-        for (masked_targets, roots) in grouped_roots {
+        let mut index = TestReachabilityIndex::new(total_capacity, grouped_roots.len());
+        for (profile, (masked_targets, roots)) in grouped_roots.into_iter().enumerate() {
             let mut roots: Vec<_> = roots.into_iter().collect();
             roots.sort_unstable_by_key(|root| root.0);
 
             let mut mask = FixedBitSet::with_capacity(total_capacity);
             for target in &masked_targets {
                 mask.insert(target.0 as usize);
+                index.set_masked(*target, profile);
             }
             let root_set = roots.iter().copied().collect();
             let reachable = self.collect_reachable_with_mask(&root_set, &mask, total_capacity);
             all_test_reachable.union_with(&reachable);
-            let reachable_files = reachable.ones().map(|index| FileId(index as u32)).collect();
-            profiles.push(TestReachabilityProfile {
-                roots,
-                masked_targets,
-                reachable_files,
-            });
+            for file_index in reachable.ones() {
+                index.set_reachable(FileId(file_index as u32), profile);
+            }
         }
 
         TestReachability::Profiled {
             reachable: all_test_reachable,
-            profiles,
+            index,
         }
     }
 
@@ -188,10 +207,10 @@ impl ModuleGraph {
             Some(self.collect_reachable(runtime_entry_points, total_capacity))
         };
 
-        let (test_visited, test_reachability_profiles) = self
+        let (test_visited, test_reachability_index) = self
             .collect_test_reachable(test_entry_points, replaced_module_targets, total_capacity)
             .into_parts();
-        self.test_reachability_profiles = test_reachability_profiles;
+        self.test_reachability_index = test_reachability_index;
 
         for (idx, module) in self.modules.iter_mut().enumerate() {
             module.set_reachable(visited.contains(idx));
@@ -213,10 +232,13 @@ mod tests {
 
     use crate::graph::ModuleGraph;
     use crate::resolve::{
-        ResolveResult, ResolvedImport, ResolvedModule, ResolvedReplacedModuleTarget,
+        ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport,
+        ResolvedReplacedModuleTarget,
     };
     use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
-    use fallow_types::extract::{ExportName, ImportInfo, ImportedName, VisibilityTag};
+    use fallow_types::extract::{
+        ExportName, ImportInfo, ImportedName, ModuleLoadMechanism, ReExportInfo, VisibilityTag,
+    };
 
     /// Build a graph with separate runtime and test entry point sets.
     ///
@@ -342,6 +364,166 @@ mod tests {
         )
     }
 
+    fn build_masked_re_export_graph(
+        commonjs_to_barrel: bool,
+        commonjs_to_target: bool,
+    ) -> ModuleGraph {
+        let files: Vec<_> = (0..3)
+            .map(|id| DiscoveredFile {
+                id: FileId(id),
+                path: PathBuf::from(format!("/project/file{id}.ts")),
+                size_bytes: 100,
+            })
+            .collect();
+        let mut test_imports = vec![ResolvedImport {
+            info: ImportInfo {
+                source: "./barrel".to_string(),
+                imported_name: ImportedName::Named("value".to_string()),
+                local_name: "value".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(0, 10),
+                source_span: oxc_span::Span::default(),
+            },
+            target: if commonjs_to_barrel {
+                ResolveResult::CommonJsInternalModule(FileId(1))
+            } else {
+                ResolveResult::InternalModule(FileId(1))
+            },
+        }];
+        if commonjs_to_target {
+            test_imports.push(ResolvedImport {
+                info: ImportInfo {
+                    source: "./target".to_string(),
+                    imported_name: ImportedName::Named("value".to_string()),
+                    local_name: "requiredValue".to_string(),
+                    is_type_only: false,
+                    from_style: false,
+                    span: oxc_span::Span::new(20, 30),
+                    source_span: oxc_span::Span::default(),
+                },
+                target: ResolveResult::CommonJsInternalModule(FileId(2)),
+            });
+        }
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_imports: test_imports,
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                re_exports: vec![ResolvedReExport {
+                    info: ReExportInfo {
+                        source: "./target".to_string(),
+                        imported_name: "value".to_string(),
+                        exported_name: "value".to_string(),
+                        is_type_only: false,
+                        span: oxc_span::Span::new(0, 10),
+                    },
+                    target: ResolveResult::InternalModule(FileId(2)),
+                }],
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: files[2].path.clone(),
+                exports: vec![fallow_types::extract::ExportInfo {
+                    name: ExportName::Named("value".to_string()),
+                    local_name: Some("value".to_string()),
+                    is_type_only: false,
+                    visibility: VisibilityTag::None,
+                    expected_unused_reason: None,
+                    span: oxc_span::Span::new(0, 20),
+                    members: Vec::new(),
+                    is_side_effect_used: false,
+                    super_class: None,
+                }],
+                ..ResolvedModule::default()
+            },
+        ];
+        let test_entry_points = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+        ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(2),
+            }],
+            &test_entry_points,
+            &[],
+            &test_entry_points,
+            &files,
+        )
+    }
+
+    fn build_masked_pattern_graph(mechanisms: &[ModuleLoadMechanism]) -> ModuleGraph {
+        let files: Vec<_> = (0..2)
+            .map(|id| DiscoveredFile {
+                id: FileId(id),
+                path: PathBuf::from(format!("/project/file{id}.ts")),
+                size_bytes: 100,
+            })
+            .collect();
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_dynamic_patterns: mechanisms
+                    .iter()
+                    .copied()
+                    .map(|mechanism| {
+                        (
+                            fallow_types::extract::DynamicImportPattern {
+                                prefix: "./modules/".to_string(),
+                                suffix: None,
+                                span: oxc_span::Span::new(0, 10),
+                                mechanism,
+                            },
+                            vec![FileId(1)],
+                        )
+                    })
+                    .collect(),
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                exports: vec![fallow_types::extract::ExportInfo {
+                    name: ExportName::Named("value".to_string()),
+                    local_name: Some("value".to_string()),
+                    is_type_only: false,
+                    visibility: VisibilityTag::None,
+                    expected_unused_reason: None,
+                    span: oxc_span::Span::new(0, 20),
+                    members: Vec::new(),
+                    is_side_effect_used: false,
+                    super_class: None,
+                }],
+                ..ResolvedModule::default()
+            },
+        ];
+        let test_entry_points = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+        ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(1),
+            }],
+            &test_entry_points,
+            &[],
+            &test_entry_points,
+            &files,
+        )
+    }
+
     #[test]
     fn entry_point_is_reachable() {
         let graph = build_reachability_graph(1, &[], &[0], &[]);
@@ -449,11 +631,9 @@ mod tests {
         assert!(graph.modules[1].is_reachable());
         assert!(!graph.modules[1].is_test_reachable());
         assert!(!graph.modules[2].is_test_reachable());
-        assert_eq!(graph.test_reachability_profiles.len(), 1);
-        assert_eq!(
-            graph.test_reachability_profiles[0].reachable_files,
-            vec![FileId(0)]
-        );
+        assert_eq!(graph.test_reachability_index.profile_count, 1);
+        assert!(graph.test_reachability_index.profile_reaches(FileId(0), 0));
+        assert!(!graph.test_reachability_index.profile_reaches(FileId(1), 0));
     }
 
     #[test]
@@ -489,6 +669,104 @@ mod tests {
     }
 
     #[test]
+    fn replacement_masks_a_target_behind_an_esm_re_export() {
+        let graph = build_masked_re_export_graph(false, false);
+        let target_export = &graph.modules[2].exports[0];
+        let reference = target_export
+            .references
+            .first()
+            .expect("barrel consumer reference should propagate");
+
+        assert!(graph.modules[1].is_test_reachable());
+        assert!(!graph.modules[2].is_test_reachable());
+        assert_eq!(reference.mechanism, ModuleLoadMechanism::EsModule);
+        assert!(!graph.is_test_reference_covered(FileId(2), reference));
+    }
+
+    #[test]
+    fn commonjs_loaded_barrel_does_not_bypass_its_esm_re_export() {
+        let graph = build_masked_re_export_graph(true, false);
+        let target_export = &graph.modules[2].exports[0];
+        let reference = target_export
+            .references
+            .first()
+            .expect("barrel consumer reference should propagate");
+
+        assert!(graph.modules[1].is_test_reachable());
+        assert!(!graph.modules[2].is_test_reachable());
+        assert_eq!(reference.mechanism, ModuleLoadMechanism::EsModule);
+        assert!(!graph.is_test_reference_covered(FileId(2), reference));
+    }
+
+    #[test]
+    fn direct_commonjs_and_esm_re_export_retain_distinct_coverage() {
+        let graph = build_masked_re_export_graph(false, true);
+        let references = &graph.modules[2].exports[0].references;
+
+        assert_eq!(references.len(), 2);
+        let esm = references
+            .iter()
+            .find(|reference| reference.mechanism == ModuleLoadMechanism::EsModule)
+            .expect("ESM re-export reference");
+        let commonjs = references
+            .iter()
+            .find(|reference| reference.mechanism == ModuleLoadMechanism::CommonJsRequire)
+            .expect("direct CommonJS reference");
+        assert!(!graph.is_test_reference_covered(FileId(2), esm));
+        assert!(graph.is_test_reference_covered(FileId(2), commonjs));
+    }
+
+    #[test]
+    fn require_context_keeps_a_replaced_target_covered() {
+        let graph = build_masked_pattern_graph(&[ModuleLoadMechanism::CommonJsRequire]);
+        let reference = &graph.modules[1].exports[0].references[0];
+
+        assert!(graph.modules[1].is_test_reachable());
+        assert_eq!(reference.mechanism, ModuleLoadMechanism::CommonJsRequire);
+        assert!(graph.is_test_reference_covered(FileId(1), reference));
+    }
+
+    #[test]
+    fn overlapping_patterns_preserve_exact_esm_and_commonjs_coverage() {
+        let graph = build_masked_pattern_graph(&[
+            ModuleLoadMechanism::EsModule,
+            ModuleLoadMechanism::CommonJsRequire,
+        ]);
+        let references = &graph.modules[1].exports[0].references;
+
+        assert!(graph.modules[1].is_test_reachable());
+        assert_eq!(references.len(), 2);
+        let esm = references
+            .iter()
+            .find(|reference| reference.mechanism == ModuleLoadMechanism::EsModule)
+            .expect("ESM pattern reference");
+        let commonjs = references
+            .iter()
+            .find(|reference| reference.mechanism == ModuleLoadMechanism::CommonJsRequire)
+            .expect("CommonJS pattern reference");
+        assert!(!graph.is_test_reference_covered(FileId(1), esm));
+        assert!(graph.is_test_reference_covered(FileId(1), commonjs));
+    }
+
+    #[test]
+    fn replacement_stops_before_a_masked_cycle_member() {
+        let graph = build_reachability_graph_with_replacements(
+            3,
+            &[(0, 1, false), (1, 2, false), (2, 1, false)],
+            &[],
+            &[0],
+            &[ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(2),
+            }],
+        );
+
+        assert!(graph.modules[0].is_test_reachable());
+        assert!(graph.modules[1].is_test_reachable());
+        assert!(!graph.modules[2].is_test_reachable());
+    }
+
+    #[test]
     fn identical_masks_share_one_reachability_profile() {
         let graph = build_reachability_graph_with_replacements(
             3,
@@ -507,15 +785,10 @@ mod tests {
             ],
         );
 
-        assert_eq!(graph.test_reachability_profiles.len(), 1);
-        assert_eq!(
-            graph.test_reachability_profiles[0].roots,
-            vec![FileId(0), FileId(1)]
-        );
-        assert_eq!(
-            graph.test_reachability_profiles[0].masked_targets,
-            vec![FileId(2)]
-        );
+        assert_eq!(graph.test_reachability_index.profile_count, 1);
+        assert!(graph.test_reachability_index.profile_masks(FileId(2), 0));
+        assert!(graph.test_reachability_index.profile_reaches(FileId(0), 0));
+        assert!(graph.test_reachability_index.profile_reaches(FileId(1), 0));
         assert!(!graph.modules[2].is_test_reachable());
     }
 
@@ -532,22 +805,23 @@ mod tests {
             }],
         );
 
-        assert_eq!(graph.test_reachability_profiles.len(), 2);
+        assert_eq!(graph.test_reachability_index.profile_count, 2);
         assert!(graph.modules[2].is_test_reachable());
-        assert_eq!(
-            graph.test_reachability_profiles[0].masked_targets,
-            Vec::<FileId>::new()
-        );
-        assert_eq!(
-            graph.test_reachability_profiles[0].reachable_files,
-            vec![FileId(1), FileId(2)]
-        );
-        assert_eq!(
-            graph.test_reachability_profiles[1].reachable_files,
-            vec![FileId(0)]
-        );
-        assert!(!graph.shares_test_reachability_profile(FileId(0), FileId(2)));
-        assert!(graph.shares_test_reachability_profile(FileId(1), FileId(2)));
+        assert!(!graph.test_reachability_index.profile_masks(FileId(2), 0));
+        assert!(graph.test_reachability_index.profile_reaches(FileId(1), 0));
+        assert!(graph.test_reachability_index.profile_reaches(FileId(2), 0));
+        assert!(graph.test_reachability_index.profile_masks(FileId(2), 1));
+        assert!(graph.test_reachability_index.profile_reaches(FileId(0), 1));
+        assert!(!graph.test_reachability_index.shares_profile(
+            FileId(2),
+            FileId(0),
+            ModuleLoadMechanism::EsModule,
+        ));
+        assert!(graph.test_reachability_index.shares_profile(
+            FileId(2),
+            FileId(1),
+            ModuleLoadMechanism::EsModule,
+        ));
     }
 
     #[test]
@@ -563,9 +837,8 @@ mod tests {
             }],
         );
 
-        assert!(graph.test_reachability_profiles.is_empty());
+        assert_eq!(graph.test_reachability_index.profile_count, 0);
         assert!(graph.modules[1].is_test_reachable());
-        assert!(graph.shares_test_reachability_profile(FileId(0), FileId(1)));
     }
 
     #[test]
@@ -584,15 +857,17 @@ mod tests {
         let encoded = postcard::to_allocvec(&graph).expect("encode graph");
         let decoded: ModuleGraph = postcard::from_bytes(&encoded).expect("decode graph");
 
-        assert_eq!(decoded.test_reachability_profiles.len(), 1);
-        assert_eq!(decoded.test_reachability_profiles[0].roots, vec![FileId(0)]);
-        assert_eq!(
-            decoded.test_reachability_profiles[0].masked_targets,
-            vec![FileId(1)]
+        assert_eq!(decoded.test_reachability_index.profile_count, 1);
+        assert!(decoded.test_reachability_index.profile_masks(FileId(1), 0));
+        assert!(
+            decoded
+                .test_reachability_index
+                .profile_reaches(FileId(0), 0)
         );
-        assert_eq!(
-            decoded.test_reachability_profiles[0].reachable_files,
-            vec![FileId(0)]
+        assert!(
+            !decoded
+                .test_reachability_index
+                .profile_reaches(FileId(1), 0)
         );
     }
 

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -512,6 +512,8 @@ mod tests {
             graph.test_reachability_profiles[1].reachable_files,
             vec![FileId(0)]
         );
+        assert!(!graph.shares_test_reachability_profile(FileId(0), FileId(2)));
+        assert!(graph.shares_test_reachability_profile(FileId(1), FileId(2)));
     }
 
     #[test]
@@ -529,6 +531,7 @@ mod tests {
 
         assert!(graph.test_reachability_profiles.is_empty());
         assert!(graph.modules[1].is_test_reachable());
+        assert!(graph.shares_test_reachability_profile(FileId(0), FileId(1)));
     }
 
     #[test]

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -18,7 +18,7 @@ enum TestReachability {
         reachable: FixedBitSet,
         index: TestReachabilityIndex,
         #[cfg(test)]
-        worklist_pops: usize,
+        dirty_word_pops: usize,
     },
 }
 
@@ -42,9 +42,11 @@ impl TestReachability {
     }
 
     #[cfg(test)]
-    const fn worklist_pop_count(&self) -> usize {
+    const fn dirty_word_pop_count(&self) -> usize {
         match self {
-            Self::Profiled { worklist_pops, .. } => *worklist_pops,
+            Self::Profiled {
+                dirty_word_pops, ..
+            } => *dirty_word_pops,
             Self::NoRoots | Self::Legacy(_) => 0,
         }
     }
@@ -60,8 +62,8 @@ struct ProfileWorklist {
     all_reachable: FixedBitSet,
     pending_profiles: Vec<u64>,
     queued: FixedBitSet,
-    queue: VecDeque<FileId>,
-    worklist_pops: usize,
+    queue: VecDeque<(FileId, usize)>,
+    dirty_word_pops: usize,
 }
 
 impl ProfileWorklist {
@@ -87,9 +89,9 @@ impl ProfileWorklist {
             masked_profiles,
             all_reachable: FixedBitSet::with_capacity(total_capacity),
             pending_profiles,
-            queued: FixedBitSet::with_capacity(total_capacity),
+            queued: FixedBitSet::with_capacity(total_capacity.saturating_mul(words_per_file)),
             queue: VecDeque::new(),
-            worklist_pops: 0,
+            dirty_word_pops: 0,
         };
 
         for (profile, (_, roots)) in grouped_roots.iter().enumerate() {
@@ -115,9 +117,9 @@ impl ProfileWorklist {
                 *reachable_word |= profile_bit;
                 worklist.pending_profiles[slot] |= profile_bit;
                 worklist.all_reachable.insert(root_index);
-                if !worklist.queued.contains(root_index) {
-                    worklist.queued.insert(root_index);
-                    worklist.queue.push_back(root);
+                if !worklist.queued.contains(slot) {
+                    worklist.queued.insert(slot);
+                    worklist.queue.push_back((root, word_index));
                 }
             }
         }
@@ -127,24 +129,25 @@ impl ProfileWorklist {
 
     fn run(mut self, graph: &ModuleGraph) -> (FixedBitSet, TestReachabilityIndex, usize) {
         let words_per_file = self.index.words_per_file;
-        let mut source_delta = vec![0_u64; words_per_file];
 
-        while let Some(file_id) = self.queue.pop_front() {
-            self.worklist_pops += 1;
+        while let Some((file_id, word_index)) = self.queue.pop_front() {
+            self.dirty_word_pops += 1;
             let file_index = file_id.0 as usize;
-            self.queued.remove(file_index);
-            let Some(source_start) = file_index.checked_mul(words_per_file) else {
-                continue;
-            };
-            let Some(source_end) = source_start.checked_add(words_per_file) else {
-                continue;
-            };
-            let Some(pending_source) = self.pending_profiles.get_mut(source_start..source_end)
+            let Some(source_slot) = file_index
+                .checked_mul(words_per_file)
+                .and_then(|start| start.checked_add(word_index))
             else {
                 continue;
             };
-            source_delta.copy_from_slice(pending_source);
-            pending_source.fill(0);
+            self.queued.remove(source_slot);
+            let Some(source_delta) = self.pending_profiles.get_mut(source_slot) else {
+                continue;
+            };
+            let delta_word = *source_delta;
+            *source_delta = 0;
+            if delta_word == 0 {
+                continue;
+            }
 
             let Some(module) = graph.modules.get(file_index) else {
                 continue;
@@ -154,7 +157,10 @@ impl ProfileWorklist {
                 if target_idx >= self.all_reachable.len() {
                     continue;
                 }
-                let Some(target_start) = target_idx.checked_mul(words_per_file) else {
+                let Some(target_slot) = target_idx
+                    .checked_mul(words_per_file)
+                    .and_then(|start| start.checked_add(word_index))
+                else {
                     continue;
                 };
                 let edge_is_esm_only = edge.symbols.iter().all(|symbol| {
@@ -166,39 +172,30 @@ impl ProfileWorklist {
                     None
                 };
 
-                let mut target_changed = false;
-                for (word_index, &delta_word) in source_delta.iter().enumerate() {
-                    let propagated = edge_mask
-                        .and_then(|mask| mask.get(word_index))
-                        .map_or(delta_word, |mask_word| delta_word & !mask_word);
-                    let Some(target_slot) = target_start.checked_add(word_index) else {
-                        continue;
-                    };
-                    let Some(reachable_word) = self.index.reachable_profiles.get_mut(target_slot)
-                    else {
-                        continue;
-                    };
-                    let new_profiles = propagated & !*reachable_word;
-                    if new_profiles == 0 {
-                        continue;
-                    }
-                    *reachable_word |= new_profiles;
-                    self.pending_profiles[target_slot] |= new_profiles;
-                    target_changed = true;
+                let propagated = edge_mask
+                    .and_then(|mask| mask.get(word_index))
+                    .map_or(delta_word, |mask_word| delta_word & !mask_word);
+                let Some(reachable_word) = self.index.reachable_profiles.get_mut(target_slot)
+                else {
+                    continue;
+                };
+                let new_profiles = propagated & !*reachable_word;
+                if new_profiles == 0 {
+                    continue;
                 }
+                *reachable_word |= new_profiles;
+                self.pending_profiles[target_slot] |= new_profiles;
 
-                if target_changed {
-                    self.all_reachable.insert(target_idx);
-                    if !self.queued.contains(target_idx) {
-                        self.queued.insert(target_idx);
-                        self.queue.push_back(edge.target);
-                    }
+                self.all_reachable.insert(target_idx);
+                if !self.queued.contains(target_slot) {
+                    self.queued.insert(target_slot);
+                    self.queue.push_back((edge.target, word_index));
                 }
             }
         }
 
         self.index.set_sparse_masks(self.masked_profiles);
-        (self.all_reachable, self.index, self.worklist_pops)
+        (self.all_reachable, self.index, self.dirty_word_pops)
     }
 }
 
@@ -293,16 +290,16 @@ impl ModuleGraph {
             roots.dedup();
         }
 
-        let (reachable, index, worklist_pops) =
+        let (reachable, index, dirty_word_pops) =
             self.collect_profiled_reachable(&grouped_roots, total_capacity);
         #[cfg(not(test))]
-        let _ = worklist_pops;
+        let _ = dirty_word_pops;
 
         TestReachability::Profiled {
             reachable,
             index,
             #[cfg(test)]
-            worklist_pops,
+            dirty_word_pops,
         }
     }
 
@@ -1255,7 +1252,7 @@ mod tests {
         let reachability = graph.collect_test_reachable(&root_set, &replacements, 129);
 
         assert_eq!(reachability.traversal_count(), 1);
-        assert_eq!(reachability.worklist_pop_count(), 129);
+        assert_eq!(reachability.dirty_word_pop_count(), 129);
     }
 
     #[test]
@@ -1284,7 +1281,7 @@ mod tests {
         let reachability = graph.collect_test_reachable(&root_set, &replacements, 131);
 
         assert_eq!(reachability.traversal_count(), 1);
-        assert_eq!(reachability.worklist_pop_count(), 66);
+        assert_eq!(reachability.dirty_word_pop_count(), 67);
         assert_eq!(graph.test_reachability_index.profile_count, 65);
         assert_eq!(graph.test_reachability_index.words_per_file, 2);
         assert_eq!(graph.test_reachability_index.masked_profiles.len(), 65);
@@ -1322,6 +1319,140 @@ mod tests {
                 .test_reachability_index
                 .profile_masks(FileId(129), 64)
         );
+    }
+
+    #[test]
+    fn staggered_profile_words_propagate_without_clean_word_scans() {
+        const PROFILE_COUNT: u32 = 65;
+        const MASK_START: u32 = PROFILE_COUNT;
+        const FANOUT_START: u32 = MASK_START + PROFILE_COUNT;
+        const FANOUT_COUNT: u32 = 8;
+
+        let test_roots: Vec<u32> = (0..PROFILE_COUNT).collect();
+        let mut edges = Vec::new();
+        for root in 1..PROFILE_COUNT {
+            edges.push((root, root - 1, false));
+        }
+        for target in FANOUT_START..FANOUT_START + FANOUT_COUNT {
+            edges.push((0, target, false));
+        }
+        let replacements: Vec<_> = test_roots
+            .iter()
+            .copied()
+            .map(|root| ResolvedReplacedModuleTarget {
+                source_file: FileId(root),
+                target_file: FileId(MASK_START + root),
+            })
+            .collect();
+        let file_count = (FANOUT_START + FANOUT_COUNT) as usize;
+        let graph = build_reachability_graph_with_replacements(
+            file_count,
+            &edges,
+            &[],
+            &test_roots,
+            &replacements,
+        );
+        let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
+
+        let reachability = graph.collect_test_reachable(&root_set, &replacements, file_count);
+
+        assert_eq!(graph.test_reachability_index.words_per_file, 2);
+        let expected_dirty_word_pops =
+            (PROFILE_COUNT * (PROFILE_COUNT + 1) / 2 + FANOUT_COUNT * PROFILE_COUNT) as usize;
+        assert_eq!(
+            reachability.dirty_word_pop_count(),
+            expected_dirty_word_pops
+        );
+        for target in FANOUT_START..FANOUT_START + FANOUT_COUNT {
+            assert!(
+                graph
+                    .test_reachability_index
+                    .profile_reaches(FileId(target), 0)
+            );
+            assert!(
+                graph
+                    .test_reachability_index
+                    .profile_reaches(FileId(target), 64)
+            );
+        }
+    }
+
+    #[test]
+    fn no_profile_coverage_keeps_a_long_reference_path_on_the_fast_path() {
+        const CHAIN_LENGTH: u32 = 128;
+
+        let files: Vec<_> = (0..=CHAIN_LENGTH)
+            .map(|id| DiscoveredFile {
+                id: FileId(id),
+                path: PathBuf::from(format!("/project/file{id}.ts")),
+                size_bytes: 100,
+            })
+            .collect();
+        let mut modules = Vec::with_capacity(files.len());
+        modules.push(ResolvedModule {
+            file_id: FileId(0),
+            path: files[0].path.clone(),
+            resolved_imports: vec![intermediate_import(
+                "./file1",
+                FileId(1),
+                ImportedName::Named("value".to_string()),
+                false,
+            )],
+            ..ResolvedModule::default()
+        });
+        for id in 1..CHAIN_LENGTH {
+            modules.push(ResolvedModule {
+                file_id: FileId(id),
+                path: files[id as usize].path.clone(),
+                re_exports: vec![ResolvedReExport {
+                    info: ReExportInfo {
+                        source: format!("./file{}", id + 1),
+                        imported_name: "value".to_string(),
+                        exported_name: "value".to_string(),
+                        is_type_only: false,
+                        span: oxc_span::Span::new(0, 10),
+                    },
+                    target: ResolveResult::InternalModule(FileId(id + 1)),
+                }],
+                ..ResolvedModule::default()
+            });
+        }
+        modules.push(ResolvedModule {
+            file_id: FileId(CHAIN_LENGTH),
+            path: files[CHAIN_LENGTH as usize].path.clone(),
+            exports: vec![fallow_types::extract::ExportInfo {
+                name: ExportName::Named("value".to_string()),
+                local_name: Some("value".to_string()),
+                is_type_only: false,
+                visibility: VisibilityTag::None,
+                expected_unused_reason: None,
+                span: oxc_span::Span::new(0, 20),
+                members: Vec::new(),
+                is_side_effect_used: false,
+                super_class: None,
+            }],
+            ..ResolvedModule::default()
+        });
+        let test_entry_points = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+        let graph = ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &[],
+            &test_entry_points,
+            &[],
+            &test_entry_points,
+            &files,
+        );
+        let reference = &graph.modules[CHAIN_LENGTH as usize].exports[0].references[0];
+
+        assert_eq!(graph.test_reachability_index.profile_count, 0);
+        assert_eq!(
+            graph.reference_path_hops(reference).len(),
+            CHAIN_LENGTH as usize
+        );
+        assert!(graph.is_test_reference_covered(reference));
     }
 
     #[test]

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -65,10 +65,7 @@ struct ProfileWorklist {
 }
 
 impl ProfileWorklist {
-    fn new(
-        grouped_roots: &[(Vec<FileId>, Vec<FileId>)],
-        total_capacity: usize,
-    ) -> Self {
+    fn new(grouped_roots: &[(Vec<FileId>, Vec<FileId>)], total_capacity: usize) -> Self {
         let profile_count = grouped_roots.len();
         let index = TestReachabilityIndex::new(total_capacity, profile_count);
         let words_per_file = index.words_per_file;
@@ -128,10 +125,7 @@ impl ProfileWorklist {
         worklist
     }
 
-    fn run(
-        mut self,
-        graph: &ModuleGraph,
-    ) -> (FixedBitSet, TestReachabilityIndex, usize) {
+    fn run(mut self, graph: &ModuleGraph) -> (FixedBitSet, TestReachabilityIndex, usize) {
         let words_per_file = self.index.words_per_file;
         let mut source_delta = vec![0_u64; words_per_file];
 
@@ -145,8 +139,7 @@ impl ProfileWorklist {
             let Some(source_end) = source_start.checked_add(words_per_file) else {
                 continue;
             };
-            let Some(pending_source) =
-                self.pending_profiles.get_mut(source_start..source_end)
+            let Some(pending_source) = self.pending_profiles.get_mut(source_start..source_end)
             else {
                 continue;
             };
@@ -181,8 +174,7 @@ impl ProfileWorklist {
                     let Some(target_slot) = target_start.checked_add(word_index) else {
                         continue;
                     };
-                    let Some(reachable_word) =
-                        self.index.reachable_profiles.get_mut(target_slot)
+                    let Some(reachable_word) = self.index.reachable_profiles.get_mut(target_slot)
                     else {
                         continue;
                     };
@@ -651,6 +643,147 @@ mod tests {
         )
     }
 
+    fn intermediate_import(
+        source: &str,
+        target: FileId,
+        imported_name: ImportedName,
+        commonjs: bool,
+    ) -> ResolvedImport {
+        ResolvedImport {
+            info: ImportInfo {
+                source: source.to_string(),
+                imported_name,
+                local_name: "value".to_string(),
+                is_type_only: false,
+                from_style: false,
+                span: oxc_span::Span::new(0, 10),
+                source_span: oxc_span::Span::default(),
+            },
+            target: if commonjs {
+                ResolveResult::CommonJsInternalModule(target)
+            } else {
+                ResolveResult::InternalModule(target)
+            },
+        }
+    }
+
+    fn intermediate_modules(
+        files: &[DiscoveredFile],
+        commonjs_to_barrel: bool,
+        include_cycle: bool,
+    ) -> Vec<ResolvedModule> {
+        let mut target_re_exports = Vec::new();
+        if include_cycle {
+            target_re_exports.push(ResolvedReExport {
+                info: ReExportInfo {
+                    source: "./barrel".to_string(),
+                    imported_name: "*".to_string(),
+                    exported_name: "*".to_string(),
+                    is_type_only: false,
+                    span: oxc_span::Span::new(20, 30),
+                },
+                target: ResolveResult::InternalModule(FileId(1)),
+            });
+        }
+        vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                resolved_imports: vec![
+                    intermediate_import(
+                        "./barrel",
+                        FileId(1),
+                        ImportedName::Named("value".to_string()),
+                        commonjs_to_barrel,
+                    ),
+                    intermediate_import("./alternate", FileId(3), ImportedName::SideEffect, false),
+                ],
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                re_exports: vec![ResolvedReExport {
+                    info: ReExportInfo {
+                        source: "./target".to_string(),
+                        imported_name: "value".to_string(),
+                        exported_name: "value".to_string(),
+                        is_type_only: false,
+                        span: oxc_span::Span::new(0, 10),
+                    },
+                    target: ResolveResult::InternalModule(FileId(2)),
+                }],
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: files[2].path.clone(),
+                exports: vec![fallow_types::extract::ExportInfo {
+                    name: ExportName::Named("value".to_string()),
+                    local_name: Some("value".to_string()),
+                    is_type_only: false,
+                    visibility: VisibilityTag::None,
+                    expected_unused_reason: None,
+                    span: oxc_span::Span::new(0, 20),
+                    members: Vec::new(),
+                    is_side_effect_used: false,
+                    super_class: None,
+                }],
+                re_exports: target_re_exports,
+                ..ResolvedModule::default()
+            },
+            ResolvedModule {
+                file_id: FileId(3),
+                path: files[3].path.clone(),
+                resolved_imports: vec![intermediate_import(
+                    "./target",
+                    FileId(2),
+                    ImportedName::SideEffect,
+                    false,
+                )],
+                ..ResolvedModule::default()
+            },
+        ]
+    }
+
+    fn build_intermediate_replacement_graph(
+        commonjs_to_barrel: bool,
+        include_cycle: bool,
+        mask_final_target: bool,
+    ) -> ModuleGraph {
+        let files: Vec<_> = (0..4)
+            .map(|id| DiscoveredFile {
+                id: FileId(id),
+                path: PathBuf::from(format!("/project/file{id}.ts")),
+                size_bytes: 100,
+            })
+            .collect();
+        let modules = intermediate_modules(&files, commonjs_to_barrel, include_cycle);
+        let test_entry_points = vec![EntryPoint {
+            path: files[0].path.clone(),
+            source: EntryPointSource::TestFile,
+        }];
+        let mut replacements = vec![ResolvedReplacedModuleTarget {
+            source_file: FileId(0),
+            target_file: FileId(1),
+        }];
+        if mask_final_target {
+            replacements.push(ResolvedReplacedModuleTarget {
+                source_file: FileId(0),
+                target_file: FileId(2),
+            });
+        }
+
+        ModuleGraph::build_with_reachability_roots_and_replacements(
+            &modules,
+            &replacements,
+            &test_entry_points,
+            &[],
+            &test_entry_points,
+            &files,
+        )
+    }
+
     #[test]
     fn entry_point_is_reachable() {
         let graph = build_reachability_graph(1, &[], &[0], &[]);
@@ -806,8 +939,11 @@ mod tests {
 
         assert!(graph.modules[1].is_test_reachable());
         assert!(!graph.modules[2].is_test_reachable());
-        assert_eq!(reference.mechanism, ModuleLoadMechanism::EsModule);
-        assert!(!graph.is_test_reference_covered(FileId(2), reference));
+        assert_eq!(
+            graph.reference_path_hops(reference)[0].1,
+            ModuleLoadMechanism::EsModule
+        );
+        assert!(!graph.is_test_reference_covered(reference));
     }
 
     #[test]
@@ -821,8 +957,11 @@ mod tests {
 
         assert!(graph.modules[1].is_test_reachable());
         assert!(!graph.modules[2].is_test_reachable());
-        assert_eq!(reference.mechanism, ModuleLoadMechanism::EsModule);
-        assert!(!graph.is_test_reference_covered(FileId(2), reference));
+        assert_eq!(
+            graph.reference_path_hops(reference)[0].1,
+            ModuleLoadMechanism::EsModule
+        );
+        assert!(!graph.is_test_reference_covered(reference));
     }
 
     #[test]
@@ -833,14 +972,90 @@ mod tests {
         assert_eq!(references.len(), 2);
         let esm = references
             .iter()
-            .find(|reference| reference.mechanism == ModuleLoadMechanism::EsModule)
+            .find(|reference| {
+                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::EsModule
+            })
             .expect("ESM re-export reference");
         let commonjs = references
             .iter()
-            .find(|reference| reference.mechanism == ModuleLoadMechanism::CommonJsRequire)
+            .find(|reference| {
+                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::CommonJsRequire
+            })
             .expect("direct CommonJS reference");
-        assert!(!graph.is_test_reference_covered(FileId(2), esm));
-        assert!(graph.is_test_reference_covered(FileId(2), commonjs));
+        assert!(!graph.is_test_reference_covered(esm));
+        assert!(graph.is_test_reference_covered(commonjs));
+    }
+
+    #[test]
+    fn mocked_intermediate_barrel_blocks_a_reference_despite_an_alternate_target_route() {
+        let graph = build_intermediate_replacement_graph(false, false, false);
+        let reference = &graph.modules[2].exports[0].references[0];
+        let hops = graph.reference_path_hops(reference);
+
+        assert!(graph.modules[2].is_test_reachable());
+        assert_eq!(
+            hops,
+            vec![
+                (FileId(2), ModuleLoadMechanism::EsModule),
+                (FileId(1), ModuleLoadMechanism::EsModule),
+            ]
+        );
+        assert!(!graph.is_test_reference_covered(reference));
+    }
+
+    #[test]
+    fn mocked_re_export_cycle_member_blocks_the_cyclic_reference_path() {
+        let graph = build_intermediate_replacement_graph(false, true, false);
+        let reference = &graph.modules[2].exports[0].references[0];
+
+        assert!(
+            graph
+                .re_export_cycles
+                .iter()
+                .any(|cycle| cycle.file_ids == vec![FileId(1), FileId(2)])
+        );
+        assert!(graph.modules[2].is_test_reachable());
+        assert!(!graph.is_test_reference_covered(reference));
+    }
+
+    #[test]
+    fn commonjs_barrel_hop_bypasses_only_its_own_replacement() {
+        let graph = build_intermediate_replacement_graph(true, false, false);
+        let reference = &graph.modules[2].exports[0].references[0];
+
+        assert_eq!(
+            graph.reference_path_hops(reference),
+            vec![
+                (FileId(2), ModuleLoadMechanism::EsModule),
+                (FileId(1), ModuleLoadMechanism::CommonJsRequire),
+            ]
+        );
+        assert!(graph.is_test_reference_covered(reference));
+    }
+
+    #[test]
+    fn commonjs_barrel_hop_does_not_bypass_a_replaced_esm_target() {
+        let graph = build_intermediate_replacement_graph(true, false, true);
+        let reference = &graph.modules[2].exports[0].references[0];
+
+        assert!(!graph.is_test_reference_covered(reference));
+    }
+
+    #[test]
+    fn reference_paths_survive_graph_cache_serialization() {
+        let graph = build_intermediate_replacement_graph(false, false, false);
+        let encoded = postcard::to_allocvec(&graph).expect("encode graph");
+        let decoded: ModuleGraph = postcard::from_bytes(&encoded).expect("decode graph");
+        let reference = &decoded.modules[2].exports[0].references[0];
+
+        assert_eq!(
+            decoded.reference_path_hops(reference),
+            vec![
+                (FileId(2), ModuleLoadMechanism::EsModule),
+                (FileId(1), ModuleLoadMechanism::EsModule),
+            ]
+        );
+        assert!(!decoded.is_test_reference_covered(reference));
     }
 
     #[test]
@@ -849,8 +1064,11 @@ mod tests {
         let reference = &graph.modules[1].exports[0].references[0];
 
         assert!(graph.modules[1].is_test_reachable());
-        assert_eq!(reference.mechanism, ModuleLoadMechanism::CommonJsRequire);
-        assert!(graph.is_test_reference_covered(FileId(1), reference));
+        assert_eq!(
+            graph.reference_path_hops(reference)[0].1,
+            ModuleLoadMechanism::CommonJsRequire
+        );
+        assert!(graph.is_test_reference_covered(reference));
     }
 
     #[test]
@@ -865,14 +1083,18 @@ mod tests {
         assert_eq!(references.len(), 2);
         let esm = references
             .iter()
-            .find(|reference| reference.mechanism == ModuleLoadMechanism::EsModule)
+            .find(|reference| {
+                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::EsModule
+            })
             .expect("ESM pattern reference");
         let commonjs = references
             .iter()
-            .find(|reference| reference.mechanism == ModuleLoadMechanism::CommonJsRequire)
+            .find(|reference| {
+                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::CommonJsRequire
+            })
             .expect("CommonJS pattern reference");
-        assert!(!graph.is_test_reference_covered(FileId(1), esm));
-        assert!(graph.is_test_reference_covered(FileId(1), commonjs));
+        assert!(!graph.is_test_reference_covered(esm));
+        assert!(graph.is_test_reference_covered(commonjs));
     }
 
     #[test]
@@ -939,15 +1161,13 @@ mod tests {
         assert!(graph.test_reachability_index.profile_reaches(FileId(2), 0));
         assert!(graph.test_reachability_index.profile_masks(FileId(2), 1));
         assert!(graph.test_reachability_index.profile_reaches(FileId(0), 1));
-        assert!(!graph.test_reachability_index.shares_profile(
-            FileId(2),
+        assert!(!graph.test_reachability_index.covers_path(
             FileId(0),
-            ModuleLoadMechanism::EsModule,
+            &std::iter::once((FileId(2), ModuleLoadMechanism::EsModule)),
         ));
-        assert!(graph.test_reachability_index.shares_profile(
-            FileId(2),
+        assert!(graph.test_reachability_index.covers_path(
             FileId(1),
-            ModuleLoadMechanism::EsModule,
+            &std::iter::once((FileId(2), ModuleLoadMechanism::EsModule)),
         ));
     }
 
@@ -1078,21 +1298,9 @@ mod tests {
                 .test_reachability_index
                 .profile_reaches(FileId(130), 64)
         );
-        assert!(
-            graph
-                .test_reachability_index
-                .profile_masks(FileId(65), 0)
-        );
-        assert!(
-            graph
-                .test_reachability_index
-                .profile_masks(FileId(129), 64)
-        );
-        assert!(
-            !graph
-                .test_reachability_index
-                .profile_reaches(FileId(65), 0)
-        );
+        assert!(graph.test_reachability_index.profile_masks(FileId(65), 0));
+        assert!(graph.test_reachability_index.profile_masks(FileId(129), 64));
+        assert!(!graph.test_reachability_index.profile_reaches(FileId(65), 0));
         assert!(
             !graph
                 .test_reachability_index

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -11,13 +11,19 @@ use fallow_types::extract::ModuleLoadMechanism;
 
 use super::{ModuleGraph, TestReachabilityIndex};
 
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct TestReachabilityProfile {
+    masked_targets: Vec<FileId>,
+    roots: Vec<FileId>,
+}
+
 pub(super) enum TestReachabilityPlan<'roots> {
     NoRoots,
     Legacy {
         roots: &'roots FxHashSet<FileId>,
     },
     Profiled {
-        grouped_roots: Vec<(Vec<FileId>, Vec<FileId>)>,
+        profiles: Vec<TestReachabilityProfile>,
     },
 }
 
@@ -59,19 +65,25 @@ impl<'roots> TestReachabilityPlan<'roots> {
             roots_by_mask.entry(mask).or_default().push(root);
         }
 
-        let mut grouped_roots: Vec<_> = roots_by_mask.into_iter().collect();
-        grouped_roots.sort_by(|(left_mask, _), (right_mask, _)| {
-            left_mask
+        let mut profiles: Vec<_> = roots_by_mask
+            .into_iter()
+            .map(|(masked_targets, mut roots)| {
+                roots.sort_unstable_by_key(|root| root.0);
+                roots.dedup();
+                TestReachabilityProfile {
+                    masked_targets,
+                    roots,
+                }
+            })
+            .collect();
+        profiles.sort_by(|left, right| {
+            left.masked_targets
                 .iter()
                 .map(|file_id| file_id.0)
-                .cmp(right_mask.iter().map(|file_id| file_id.0))
+                .cmp(right.masked_targets.iter().map(|file_id| file_id.0))
         });
-        for (_, roots) in &mut grouped_roots {
-            roots.sort_unstable_by_key(|root| root.0);
-            roots.dedup();
-        }
 
-        Self::Profiled { grouped_roots }
+        Self::Profiled { profiles }
     }
 
     pub(super) const fn requires_reference_provenance(&self) -> bool {
@@ -135,16 +147,16 @@ struct ProfileWorklist {
 }
 
 impl ProfileWorklist {
-    fn new(grouped_roots: &[(Vec<FileId>, Vec<FileId>)], total_capacity: usize) -> Self {
-        let profile_count = grouped_roots.len();
+    fn new(profiles: &[TestReachabilityProfile], total_capacity: usize) -> Self {
+        let profile_count = profiles.len();
         let index = TestReachabilityIndex::new(total_capacity, profile_count);
         let words_per_file = index.words_per_file;
         let mut masked_profiles: FxHashMap<FileId, Vec<u64>> = FxHashMap::default();
 
-        for (profile, (masked_targets, _)) in grouped_roots.iter().enumerate() {
+        for (profile, reachability_profile) in profiles.iter().enumerate() {
             let word_index = profile / u64::BITS as usize;
             let profile_bit = 1_u64 << (profile % u64::BITS as usize);
-            for &target in masked_targets {
+            for &target in &reachability_profile.masked_targets {
                 masked_profiles
                     .entry(target)
                     .or_insert_with(|| vec![0; words_per_file])[word_index] |= profile_bit;
@@ -162,10 +174,10 @@ impl ProfileWorklist {
             dirty_word_pops: 0,
         };
 
-        for (profile, (_, roots)) in grouped_roots.iter().enumerate() {
+        for (profile, reachability_profile) in profiles.iter().enumerate() {
             let word_index = profile / u64::BITS as usize;
             let profile_bit = 1_u64 << (profile % u64::BITS as usize);
-            for &root in roots {
+            for &root in &reachability_profile.roots {
                 let root_index = root.0 as usize;
                 if root_index >= total_capacity {
                     continue;
@@ -302,10 +314,10 @@ impl ModuleGraph {
 
     fn collect_profiled_reachable(
         &self,
-        grouped_roots: &[(Vec<FileId>, Vec<FileId>)],
+        profiles: &[TestReachabilityProfile],
         total_capacity: usize,
     ) -> (FixedBitSet, TestReachabilityIndex, usize) {
-        ProfileWorklist::new(grouped_roots, total_capacity).run(self)
+        ProfileWorklist::new(profiles, total_capacity).run(self)
     }
 
     fn collect_test_reachable(
@@ -318,9 +330,9 @@ impl ModuleGraph {
             TestReachabilityPlan::Legacy { roots } => {
                 TestReachability::Legacy(self.collect_reachable(roots, total_capacity))
             }
-            TestReachabilityPlan::Profiled { grouped_roots } => {
+            TestReachabilityPlan::Profiled { profiles } => {
                 let (reachable, index, dirty_word_pops) =
-                    self.collect_profiled_reachable(&grouped_roots, total_capacity);
+                    self.collect_profiled_reachable(&profiles, total_capacity);
                 #[cfg(not(test))]
                 let _ = dirty_word_pops;
 
@@ -381,7 +393,7 @@ mod tests {
 
     use rustc_hash::FxHashSet;
 
-    use super::TestReachabilityPlan;
+    use super::{TestReachabilityPlan, TestReachabilityProfile};
     use crate::graph::ModuleGraph;
     use crate::resolve::{
         ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport,
@@ -1280,14 +1292,20 @@ mod tests {
         let plan = TestReachabilityPlan::new(&test_roots, &replacements, 5);
 
         assert!(plan.requires_reference_provenance());
-        let TestReachabilityPlan::Profiled { grouped_roots } = plan else {
+        let TestReachabilityPlan::Profiled { profiles } = plan else {
             panic!("valid test-root replacements must use profiled reachability");
         };
         assert_eq!(
-            grouped_roots,
+            profiles,
             vec![
-                (Vec::new(), vec![FileId(2)]),
-                (vec![FileId(4)], vec![FileId(0), FileId(1)]),
+                TestReachabilityProfile {
+                    masked_targets: Vec::new(),
+                    roots: vec![FileId(2)],
+                },
+                TestReachabilityProfile {
+                    masked_targets: vec![FileId(4)],
+                    roots: vec![FileId(0), FileId(1)],
+                },
             ]
         );
     }

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -37,8 +37,7 @@ impl TestReachability {
     const fn traversal_count(&self) -> usize {
         match self {
             Self::NoRoots => 0,
-            Self::Legacy(_) => 1,
-            Self::Profiled { .. } => 1,
+            Self::Legacy(_) | Self::Profiled { .. } => 1,
         }
     }
 
@@ -48,6 +47,166 @@ impl TestReachability {
             Self::Profiled { worklist_pops, .. } => *worklist_pops,
             Self::NoRoots | Self::Legacy(_) => 0,
         }
+    }
+}
+
+/// Owns the transient state for one bit-parallel profiled reachability pass.
+///
+/// Only `index` and `all_reachable` survive the pass. Pending deltas, queue
+/// membership, and the target-sparse mask map remain local to propagation.
+struct ProfileWorklist {
+    index: TestReachabilityIndex,
+    masked_profiles: FxHashMap<FileId, Vec<u64>>,
+    all_reachable: FixedBitSet,
+    pending_profiles: Vec<u64>,
+    queued: FixedBitSet,
+    queue: VecDeque<FileId>,
+    worklist_pops: usize,
+}
+
+impl ProfileWorklist {
+    fn new(
+        grouped_roots: &[(Vec<FileId>, Vec<FileId>)],
+        total_capacity: usize,
+    ) -> Self {
+        let profile_count = grouped_roots.len();
+        let index = TestReachabilityIndex::new(total_capacity, profile_count);
+        let words_per_file = index.words_per_file;
+        let mut masked_profiles: FxHashMap<FileId, Vec<u64>> = FxHashMap::default();
+
+        for (profile, (masked_targets, _)) in grouped_roots.iter().enumerate() {
+            let word_index = profile / u64::BITS as usize;
+            let profile_bit = 1_u64 << (profile % u64::BITS as usize);
+            for &target in masked_targets {
+                masked_profiles
+                    .entry(target)
+                    .or_insert_with(|| vec![0; words_per_file])[word_index] |= profile_bit;
+            }
+        }
+
+        let pending_profiles = vec![0_u64; index.reachable_profiles.len()];
+        let mut worklist = Self {
+            index,
+            masked_profiles,
+            all_reachable: FixedBitSet::with_capacity(total_capacity),
+            pending_profiles,
+            queued: FixedBitSet::with_capacity(total_capacity),
+            queue: VecDeque::new(),
+            worklist_pops: 0,
+        };
+
+        for (profile, (_, roots)) in grouped_roots.iter().enumerate() {
+            let word_index = profile / u64::BITS as usize;
+            let profile_bit = 1_u64 << (profile % u64::BITS as usize);
+            for &root in roots {
+                let root_index = root.0 as usize;
+                if root_index >= total_capacity {
+                    continue;
+                }
+                let Some(slot) = root_index
+                    .checked_mul(words_per_file)
+                    .and_then(|start| start.checked_add(word_index))
+                else {
+                    continue;
+                };
+                let Some(reachable_word) = worklist.index.reachable_profiles.get_mut(slot) else {
+                    continue;
+                };
+                if *reachable_word & profile_bit != 0 {
+                    continue;
+                }
+                *reachable_word |= profile_bit;
+                worklist.pending_profiles[slot] |= profile_bit;
+                worklist.all_reachable.insert(root_index);
+                if !worklist.queued.contains(root_index) {
+                    worklist.queued.insert(root_index);
+                    worklist.queue.push_back(root);
+                }
+            }
+        }
+
+        worklist
+    }
+
+    fn run(
+        mut self,
+        graph: &ModuleGraph,
+    ) -> (FixedBitSet, TestReachabilityIndex, usize) {
+        let words_per_file = self.index.words_per_file;
+        let mut source_delta = vec![0_u64; words_per_file];
+
+        while let Some(file_id) = self.queue.pop_front() {
+            self.worklist_pops += 1;
+            let file_index = file_id.0 as usize;
+            self.queued.remove(file_index);
+            let Some(source_start) = file_index.checked_mul(words_per_file) else {
+                continue;
+            };
+            let Some(source_end) = source_start.checked_add(words_per_file) else {
+                continue;
+            };
+            let Some(pending_source) =
+                self.pending_profiles.get_mut(source_start..source_end)
+            else {
+                continue;
+            };
+            source_delta.copy_from_slice(pending_source);
+            pending_source.fill(0);
+
+            let Some(module) = graph.modules.get(file_index) else {
+                continue;
+            };
+            for edge in &graph.edges[module.edge_range.clone()] {
+                let target_idx = edge.target.0 as usize;
+                if target_idx >= self.all_reachable.len() {
+                    continue;
+                }
+                let Some(target_start) = target_idx.checked_mul(words_per_file) else {
+                    continue;
+                };
+                let edge_is_esm_only = edge.symbols.iter().all(|symbol| {
+                    !matches!(symbol.mechanism, ModuleLoadMechanism::CommonJsRequire)
+                });
+                let edge_mask = if edge_is_esm_only {
+                    self.masked_profiles.get(&edge.target)
+                } else {
+                    None
+                };
+
+                let mut target_changed = false;
+                for (word_index, &delta_word) in source_delta.iter().enumerate() {
+                    let propagated = edge_mask
+                        .and_then(|mask| mask.get(word_index))
+                        .map_or(delta_word, |mask_word| delta_word & !mask_word);
+                    let Some(target_slot) = target_start.checked_add(word_index) else {
+                        continue;
+                    };
+                    let Some(reachable_word) =
+                        self.index.reachable_profiles.get_mut(target_slot)
+                    else {
+                        continue;
+                    };
+                    let new_profiles = propagated & !*reachable_word;
+                    if new_profiles == 0 {
+                        continue;
+                    }
+                    *reachable_word |= new_profiles;
+                    self.pending_profiles[target_slot] |= new_profiles;
+                    target_changed = true;
+                }
+
+                if target_changed {
+                    self.all_reachable.insert(target_idx);
+                    if !self.queued.contains(target_idx) {
+                        self.queued.insert(target_idx);
+                        self.queue.push_back(edge.target);
+                    }
+                }
+            }
+        }
+
+        self.index.set_sparse_masks(self.masked_profiles);
+        (self.all_reachable, self.index, self.worklist_pops)
     }
 }
 
@@ -89,131 +248,7 @@ impl ModuleGraph {
         grouped_roots: &[(Vec<FileId>, Vec<FileId>)],
         total_capacity: usize,
     ) -> (FixedBitSet, TestReachabilityIndex, usize) {
-        let profile_count = grouped_roots.len();
-        let mut index = TestReachabilityIndex::new(total_capacity, profile_count);
-        let words_per_file = index.words_per_file;
-        let mut masked_profiles: FxHashMap<FileId, Vec<u64>> = FxHashMap::default();
-
-        for (profile, (masked_targets, _)) in grouped_roots.iter().enumerate() {
-            let word_index = profile / u64::BITS as usize;
-            let profile_bit = 1_u64 << (profile % u64::BITS as usize);
-            for &target in masked_targets {
-                masked_profiles
-                    .entry(target)
-                    .or_insert_with(|| vec![0; words_per_file])[word_index] |= profile_bit;
-            }
-        }
-
-        let mut all_reachable = FixedBitSet::with_capacity(total_capacity);
-        let mut pending_profiles = vec![0_u64; index.reachable_profiles.len()];
-        let mut queued = FixedBitSet::with_capacity(total_capacity);
-        let mut queue = VecDeque::new();
-
-        for (profile, (_, roots)) in grouped_roots.iter().enumerate() {
-            let word_index = profile / u64::BITS as usize;
-            let profile_bit = 1_u64 << (profile % u64::BITS as usize);
-            for &root in roots {
-                let root_index = root.0 as usize;
-                if root_index >= total_capacity {
-                    continue;
-                }
-                let Some(slot) = root_index
-                    .checked_mul(words_per_file)
-                    .and_then(|start| start.checked_add(word_index))
-                else {
-                    continue;
-                };
-                let Some(reachable_word) = index.reachable_profiles.get_mut(slot) else {
-                    continue;
-                };
-                if *reachable_word & profile_bit != 0 {
-                    continue;
-                }
-                *reachable_word |= profile_bit;
-                pending_profiles[slot] |= profile_bit;
-                all_reachable.insert(root_index);
-                if !queued.contains(root_index) {
-                    queued.insert(root_index);
-                    queue.push_back(root);
-                }
-            }
-        }
-
-        let mut worklist_pops = 0;
-        let mut source_delta = vec![0_u64; words_per_file];
-        while let Some(file_id) = queue.pop_front() {
-            worklist_pops += 1;
-            let file_index = file_id.0 as usize;
-            queued.remove(file_index);
-            let Some(source_start) = file_index.checked_mul(words_per_file) else {
-                continue;
-            };
-            let Some(source_end) = source_start.checked_add(words_per_file) else {
-                continue;
-            };
-            let Some(pending_source) = pending_profiles.get_mut(source_start..source_end) else {
-                continue;
-            };
-            source_delta.copy_from_slice(pending_source);
-            pending_source.fill(0);
-
-            let Some(module) = self.modules.get(file_index) else {
-                continue;
-            };
-            for edge in &self.edges[module.edge_range.clone()] {
-                let target_idx = edge.target.0 as usize;
-                if target_idx >= total_capacity {
-                    continue;
-                }
-                let Some(target_start) = target_idx.checked_mul(words_per_file) else {
-                    continue;
-                };
-                let edge_is_esm_only = edge
-                    .symbols
-                    .iter()
-                    .all(|symbol| {
-                        !matches!(symbol.mechanism, ModuleLoadMechanism::CommonJsRequire)
-                    });
-                let edge_mask = if edge_is_esm_only {
-                    masked_profiles.get(&edge.target)
-                } else {
-                    None
-                };
-
-                let mut target_changed = false;
-                for (word_index, &delta_word) in source_delta.iter().enumerate() {
-                    let propagated = edge_mask
-                        .and_then(|mask| mask.get(word_index))
-                        .map_or(delta_word, |mask_word| delta_word & !mask_word);
-                    let Some(target_slot) = target_start.checked_add(word_index) else {
-                        continue;
-                    };
-                    let Some(reachable_word) =
-                        index.reachable_profiles.get_mut(target_slot)
-                    else {
-                        continue;
-                    };
-                    let new_profiles = propagated & !*reachable_word;
-                    if new_profiles == 0 {
-                        continue;
-                    }
-                    *reachable_word |= new_profiles;
-                    pending_profiles[target_slot] |= new_profiles;
-                    target_changed = true;
-                }
-
-                if target_changed {
-                    all_reachable.insert(target_idx);
-                    if !queued.contains(target_idx) {
-                        queued.insert(target_idx);
-                        queue.push_back(edge.target);
-                    }
-                }
-            }
-        }
-
-        index.set_sparse_masks(masked_profiles);
-        (all_reachable, index, worklist_pops)
+        ProfileWorklist::new(grouped_roots, total_capacity).run(self)
     }
 
     fn collect_test_reachable(
@@ -266,14 +301,16 @@ impl ModuleGraph {
             roots.dedup();
         }
 
-        let (reachable, index, _worklist_pops) =
+        let (reachable, index, worklist_pops) =
             self.collect_profiled_reachable(&grouped_roots, total_capacity);
+        #[cfg(not(test))]
+        let _ = worklist_pops;
 
         TestReachability::Profiled {
             reachable,
             index,
             #[cfg(test)]
-            worklist_pops: _worklist_pops,
+            worklist_pops,
         }
     }
 

--- a/crates/graph/src/graph/types.rs
+++ b/crates/graph/src/graph/types.rs
@@ -407,9 +407,16 @@ pub(crate) struct FinalizedReferencePaths {
 #[derive(Default)]
 pub(crate) struct ReferencePathInterner {
     nodes: Vec<ReferencePathNode>,
+    metadata: Vec<ReferencePathMetadata>,
     ids: FxHashMap<ReferencePathNode, ReferencePathId>,
     route_graphs: Vec<ReferenceRouteGraphSpec>,
     route_graph_ids: FxHashMap<ReferenceRouteGraphSpec, ReferenceRouteGraphId>,
+}
+
+#[derive(Clone, Copy)]
+struct ReferencePathMetadata {
+    depth: usize,
+    hop_target_bounds: Option<(FileId, FileId)>,
 }
 
 impl ReferencePathInterner {
@@ -433,7 +440,12 @@ impl ReferencePathInterner {
         target: FileId,
         mechanism: ModuleLoadMechanism,
     ) -> ReferencePathId {
-        if self.contains_target(parent, target) {
+        let may_contain_target = self
+            .metadata
+            .get(parent.index())
+            .and_then(|metadata| metadata.hop_target_bounds)
+            .is_some_and(|(minimum, maximum)| target.0 >= minimum.0 && target.0 <= maximum.0);
+        if may_contain_target && self.contains_target(parent, target) {
             return parent;
         }
         self.intern(ReferencePathNode::Hop {
@@ -503,7 +515,30 @@ impl ReferencePathInterner {
             return *path;
         }
         let path = ReferencePathId(self.nodes.len() as u32);
+        let parent_metadata = node
+            .parent()
+            .and_then(|parent| self.metadata.get(parent.index()).copied());
+        let depth = parent_metadata.map_or(0, |metadata| metadata.depth + 1);
+        let hop_target_bounds = match node {
+            ReferencePathNode::Hop { target, .. } => Some(
+                parent_metadata
+                    .and_then(|metadata| metadata.hop_target_bounds)
+                    .map_or((target, target), |(minimum, maximum)| {
+                        (
+                            FileId(minimum.0.min(target.0)),
+                            FileId(maximum.0.max(target.0)),
+                        )
+                    }),
+            ),
+            ReferencePathNode::Route { .. } => {
+                parent_metadata.and_then(|metadata| metadata.hop_target_bounds)
+            }
+        };
         self.nodes.push(node);
+        self.metadata.push(ReferencePathMetadata {
+            depth,
+            hop_target_bounds,
+        });
         self.ids.insert(node, path);
         path
     }
@@ -514,18 +549,24 @@ impl ReferencePathInterner {
     /// ID before its children are sorted. This keeps serialized graphs stable
     /// when equivalent imports or re-exports are discovered in another order.
     pub(crate) fn finalize(self, modules: &mut [ModuleNode]) -> FinalizedReferencePaths {
-        let (routes, route_remap) = finalize_route_graphs(&self.route_graphs);
-        let mut depths = Vec::with_capacity(self.nodes.len());
-        let mut max_depth = 0usize;
-        for node in &self.nodes {
-            let depth = node.parent().map_or(0, |parent| depths[parent.index()] + 1);
-            max_depth = max_depth.max(depth);
-            depths.push(depth);
+        if self.nodes.is_empty() && self.route_graphs.is_empty() {
+            return FinalizedReferencePaths {
+                paths: Vec::new(),
+                routes: ReferenceRoutes::default(),
+            };
         }
 
+        let (routes, route_remap) = finalize_route_graphs(&self.route_graphs);
+        let max_depth = self
+            .metadata
+            .iter()
+            .map(|metadata| metadata.depth)
+            .max()
+            .unwrap_or(0);
+
         let mut paths_by_depth = vec![Vec::new(); max_depth.saturating_add(1)];
-        for (old_index, depth) in depths.into_iter().enumerate() {
-            paths_by_depth[depth].push(old_index);
+        for (old_index, metadata) in self.metadata.iter().enumerate() {
+            paths_by_depth[metadata.depth].push(old_index);
         }
 
         let mut remap = vec![ReferencePathId(0); self.nodes.len()];
@@ -776,6 +817,28 @@ mod tests {
             re_exports: Vec::new(),
             flags: 0,
         }
+    }
+
+    #[test]
+    fn reference_path_metadata_tracks_exact_depth_and_hop_bounds() {
+        let mut interner = ReferencePathInterner::default();
+        let root = interner.direct(FileId(10), ModuleLoadMechanism::EsModule);
+        let lower = interner.extend(root, FileId(5), ModuleLoadMechanism::EsModule);
+        let upper = interner.extend(lower, FileId(20), ModuleLoadMechanism::EsModule);
+
+        assert_eq!(interner.metadata[root.index()].depth, 0);
+        assert_eq!(
+            interner.metadata[lower.index()].hop_target_bounds,
+            Some((FileId(5), FileId(10)))
+        );
+        assert_eq!(interner.metadata[upper.index()].depth, 2);
+        assert_eq!(
+            interner.metadata[upper.index()].hop_target_bounds,
+            Some((FileId(5), FileId(20)))
+        );
+
+        let repeated = interner.extend(upper, FileId(10), ModuleLoadMechanism::EsModule);
+        assert_eq!(repeated, upper);
     }
 
     #[test]

--- a/crates/graph/src/graph/types.rs
+++ b/crates/graph/src/graph/types.rs
@@ -1,6 +1,7 @@
 //! Shared graph types: module nodes, re-export edges, export symbols, and references.
 
 use std::cmp::Ordering;
+use std::num::NonZeroU32;
 use std::ops::Range;
 use std::path::PathBuf;
 
@@ -195,7 +196,10 @@ pub struct SymbolReference {
     /// How the export is referenced.
     pub kind: ReferenceKind,
     /// Interned linked path from `from_file` to the owning export.
-    pub(crate) path: ReferencePathId,
+    ///
+    /// Legacy reachability does not need root-specific provenance and stores
+    /// `None`; profiled reachability always stores an exact path.
+    pub(crate) path: Option<ReferencePathId>,
     /// Byte span of the import statement in the referencing file.
     /// Used by the LSP to locate references for Code Lens navigation.
     #[serde(with = "crate::cache::span_serde")]
@@ -204,7 +208,7 @@ pub struct SymbolReference {
 
 /// Compact identifier for an interned reference path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ReferencePathId(pub(crate) u32);
+pub(crate) struct ReferencePathId(NonZeroU32);
 
 /// One conjunctive step in an interned export-reference route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -404,8 +408,8 @@ pub(crate) struct FinalizedReferencePaths {
 }
 
 /// Build-time interner for shared linked reference paths.
-#[derive(Default)]
 pub(crate) struct ReferencePathInterner {
+    track_provenance: bool,
     nodes: Vec<ReferencePathNode>,
     metadata: Vec<ReferencePathMetadata>,
     ids: FxHashMap<ReferencePathNode, ReferencePathId>,
@@ -419,40 +423,71 @@ struct ReferencePathMetadata {
     hop_target_bounds: Option<(FileId, FileId)>,
 }
 
+impl Default for ReferencePathInterner {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
 impl ReferencePathInterner {
+    pub(crate) fn new(track_provenance: bool) -> Self {
+        Self {
+            track_provenance,
+            nodes: Vec::new(),
+            metadata: Vec::new(),
+            ids: FxHashMap::default(),
+            route_graphs: Vec::new(),
+            route_graph_ids: FxHashMap::default(),
+        }
+    }
+
+    pub(crate) const fn tracks_provenance(&self) -> bool {
+        self.track_provenance
+    }
+
     /// Intern a direct consumer-to-target path.
     pub(crate) fn direct(
         &mut self,
         target: FileId,
         mechanism: ModuleLoadMechanism,
-    ) -> ReferencePathId {
-        self.intern(ReferencePathNode::Hop {
-            parent: None,
-            target,
-            mechanism,
+    ) -> Option<ReferencePathId> {
+        self.track_provenance.then(|| {
+            self.intern(ReferencePathNode::Hop {
+                parent: None,
+                target,
+                mechanism,
+            })
         })
     }
 
     /// Append one typed hop to an existing path.
     pub(crate) fn extend(
         &mut self,
-        parent: ReferencePathId,
+        parent: Option<ReferencePathId>,
         target: FileId,
         mechanism: ModuleLoadMechanism,
-    ) -> ReferencePathId {
+    ) -> Option<ReferencePathId> {
+        if !self.track_provenance {
+            debug_assert!(parent.is_none());
+            return None;
+        }
+        let Some(parent) = parent else {
+            debug_assert!(false, "tracked reference paths require an interned parent");
+            return None;
+        };
         let may_contain_target = self
             .metadata
             .get(parent.index())
             .and_then(|metadata| metadata.hop_target_bounds)
             .is_some_and(|(minimum, maximum)| target.0 >= minimum.0 && target.0 <= maximum.0);
         if may_contain_target && self.contains_target(parent, target) {
-            return parent;
+            return Some(parent);
         }
-        self.intern(ReferencePathNode::Hop {
+        Some(self.intern(ReferencePathNode::Hop {
             parent: Some(parent),
             target,
             mechanism,
-        })
+        }))
     }
 
     /// Intern one compact namespace transition graph.
@@ -460,6 +495,7 @@ impl ReferencePathInterner {
         &mut self,
         graph: ReferenceRouteGraphSpec,
     ) -> ReferenceRouteGraphId {
+        debug_assert!(self.track_provenance);
         if let Some(id) = self.route_graph_ids.get(&graph) {
             return *id;
         }
@@ -477,14 +513,17 @@ impl ReferencePathInterner {
         start: ReferenceRouteNodeId,
         terminal: ReferenceRouteNodeId,
         start_mechanism: Option<ModuleLoadMechanism>,
-    ) -> ReferencePathId {
-        self.intern(ReferencePathNode::Route {
+    ) -> Option<ReferencePathId> {
+        if !self.track_provenance {
+            return None;
+        }
+        Some(self.intern(ReferencePathNode::Route {
             parent,
             graph,
             start,
             terminal,
             start_mechanism,
-        })
+        }))
     }
 
     fn contains_target(&self, mut path: ReferencePathId, target: FileId) -> bool {
@@ -506,15 +545,11 @@ impl ReferencePathInterner {
         }
     }
 
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "a process cannot allocate more than u32::MAX reference path nodes"
-    )]
     fn intern(&mut self, node: ReferencePathNode) -> ReferencePathId {
         if let Some(path) = self.ids.get(&node) {
             return *path;
         }
-        let path = ReferencePathId(self.nodes.len() as u32);
+        let path = ReferencePathId::from_index(self.nodes.len());
         let parent_metadata = node
             .parent()
             .and_then(|parent| self.metadata.get(parent.index()).copied());
@@ -569,7 +604,7 @@ impl ReferencePathInterner {
             paths_by_depth[metadata.depth].push(old_index);
         }
 
-        let mut remap = vec![ReferencePathId(0); self.nodes.len()];
+        let mut remap = vec![ReferencePathId::from_index(0); self.nodes.len()];
         let mut finalized = Vec::with_capacity(self.nodes.len());
         for mut paths in paths_by_depth {
             paths.sort_unstable_by(|&left, &right| {
@@ -581,7 +616,7 @@ impl ReferencePathInterner {
                 if let ReferencePathNode::Route { graph, .. } = &mut node {
                     *graph = route_remap[graph.0 as usize];
                 }
-                let canonical = ReferencePathId(finalized.len() as u32);
+                let canonical = ReferencePathId::from_index(finalized.len());
                 remap[old_index] = canonical;
                 finalized.push(node);
             }
@@ -592,7 +627,9 @@ impl ReferencePathInterner {
             .flat_map(|module| &mut module.exports)
             .flat_map(|export| &mut export.references)
         {
-            reference.path = remap[reference.path.index()];
+            if let Some(path) = reference.path {
+                reference.path = Some(remap[path.index()]);
+            }
         }
 
         FinalizedReferencePaths {
@@ -714,8 +751,19 @@ fn finalize_route_graphs(
 }
 
 impl ReferencePathId {
+    fn from_index(index: usize) -> Self {
+        let Some(encoded) = u32::try_from(index)
+            .ok()
+            .and_then(|index| index.checked_add(1))
+            .and_then(NonZeroU32::new)
+        else {
+            panic!("a process cannot allocate more than u32::MAX reference path nodes");
+        };
+        Self(encoded)
+    }
+
     pub(crate) const fn index(self) -> usize {
-        self.0 as usize
+        (self.0.get() - 1) as usize
     }
 }
 
@@ -790,7 +838,7 @@ mod tests {
         assert_eq!(debug_str, "DynamicImport");
     }
 
-    fn module_with_reference_paths(paths: &[ReferencePathId]) -> ModuleNode {
+    fn module_with_reference_paths(paths: &[Option<ReferencePathId>]) -> ModuleNode {
         ModuleNode {
             file_id: FileId(0),
             path: PathBuf::from("/project/source.ts"),
@@ -822,9 +870,15 @@ mod tests {
     #[test]
     fn reference_path_metadata_tracks_exact_depth_and_hop_bounds() {
         let mut interner = ReferencePathInterner::default();
-        let root = interner.direct(FileId(10), ModuleLoadMechanism::EsModule);
-        let lower = interner.extend(root, FileId(5), ModuleLoadMechanism::EsModule);
-        let upper = interner.extend(lower, FileId(20), ModuleLoadMechanism::EsModule);
+        let root = interner
+            .direct(FileId(10), ModuleLoadMechanism::EsModule)
+            .expect("tracked interner must return a path");
+        let lower = interner
+            .extend(Some(root), FileId(5), ModuleLoadMechanism::EsModule)
+            .expect("tracked interner must extend a path");
+        let upper = interner
+            .extend(Some(lower), FileId(20), ModuleLoadMechanism::EsModule)
+            .expect("tracked interner must extend a path");
 
         assert_eq!(interner.metadata[root.index()].depth, 0);
         assert_eq!(
@@ -837,8 +891,8 @@ mod tests {
             Some((FileId(5), FileId(20)))
         );
 
-        let repeated = interner.extend(upper, FileId(10), ModuleLoadMechanism::EsModule);
-        assert_eq!(repeated, upper);
+        let repeated = interner.extend(Some(upper), FileId(10), ModuleLoadMechanism::EsModule);
+        assert_eq!(repeated, Some(upper));
     }
 
     #[test]
@@ -946,7 +1000,7 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(42),
             kind: ReferenceKind::NamedImport,
-            path: ReferencePathId(0),
+            path: Some(ReferencePathId::from_index(0)),
             import_span: oxc_span::Span::new(10, 30),
         };
         assert_eq!(reference.from_file, FileId(42));
@@ -960,7 +1014,7 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(7),
             kind: ReferenceKind::ReExport,
-            path: ReferencePathId(0),
+            path: Some(ReferencePathId::from_index(0)),
             import_span: oxc_span::Span::new(5, 25),
         };
         let copied = reference;
@@ -1086,13 +1140,13 @@ mod tests {
                 SymbolReference {
                     from_file: FileId(1),
                     kind: ReferenceKind::NamedImport,
-                    path: ReferencePathId(0),
+                    path: Some(ReferencePathId::from_index(0)),
                     import_span: oxc_span::Span::new(0, 10),
                 },
                 SymbolReference {
                     from_file: FileId(2),
                     kind: ReferenceKind::ReExport,
-                    path: ReferencePathId(1),
+                    path: Some(ReferencePathId::from_index(1)),
                     import_span: oxc_span::Span::new(5, 15),
                 },
             ],

--- a/crates/graph/src/graph/types.rs
+++ b/crates/graph/src/graph/types.rs
@@ -1,5 +1,6 @@
 //! Shared graph types: module nodes, re-export edges, export symbols, and references.
 
+use std::cmp::Ordering;
 use std::ops::Range;
 use std::path::PathBuf;
 
@@ -205,15 +206,201 @@ pub struct SymbolReference {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ReferencePathId(pub(crate) u32);
 
-/// One target hop in an interned linked reference path.
+/// One conjunctive step in an interned export-reference route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ReferencePathNode {
-    /// Previous hop, or `None` for the consumer's direct module load.
-    pub(crate) parent: Option<ReferencePathId>,
-    /// Module loaded by this hop.
+pub(crate) enum ReferencePathNode {
+    /// One ordinary module-load hop.
+    Hop {
+        /// Previous conjunctive step, or `None` for a direct load.
+        parent: Option<ReferencePathId>,
+        /// Module loaded by this hop.
+        target: FileId,
+        /// Runtime mechanism used by this hop.
+        mechanism: ModuleLoadMechanism,
+    },
+    /// One existential traversal through a compact namespace transition graph.
+    Route {
+        /// Previous conjunctive step, used when a namespace route is followed
+        /// by another namespace segment.
+        parent: Option<ReferencePathId>,
+        /// Canonical transition graph containing `start` and `terminal`.
+        graph: ReferenceRouteGraphId,
+        /// Local graph node where traversal begins.
+        start: ReferenceRouteNodeId,
+        /// Local graph node that must be reachable.
+        terminal: ReferenceRouteNodeId,
+        /// Mechanism used by the consumer to load `start`. `None` means the
+        /// reference source already owns the start module (entry points and
+        /// concatenated route segments).
+        start_mechanism: Option<ModuleLoadMechanism>,
+    },
+}
+
+impl ReferencePathNode {
+    pub(crate) const fn parent(self) -> Option<ReferencePathId> {
+        match self {
+            Self::Hop { parent, .. } | Self::Route { parent, .. } => parent,
+        }
+    }
+
+    fn remap_parent(&mut self, remap: &[ReferencePathId]) {
+        match self {
+            Self::Hop { parent, .. } | Self::Route { parent, .. } => {
+                *parent = parent.map(|path| remap[path.index()]);
+            }
+        }
+    }
+}
+
+/// Build-time identifier for one compact namespace transition graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ReferenceRouteGraphId(pub(crate) u32);
+
+/// Node identifier local to one namespace transition graph.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub(crate) struct ReferenceRouteNodeId(pub(crate) u32);
+
+/// One canonical node in a build-time namespace transition graph.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ReferenceRouteNodeSpec {
+    target: FileId,
+    mechanism: ModuleLoadMechanism,
+    successors: Vec<ReferenceRouteNodeId>,
+}
+
+impl ReferenceRouteNodeSpec {
+    pub(crate) fn new(
+        target: FileId,
+        mechanism: ModuleLoadMechanism,
+        mut successors: Vec<ReferenceRouteNodeId>,
+    ) -> Self {
+        successors.sort_unstable_by_key(|successor| successor.0);
+        successors.dedup();
+        Self {
+            target,
+            mechanism,
+            successors,
+        }
+    }
+}
+
+/// Canonical build-time representation of one namespace transition graph.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ReferenceRouteGraphSpec {
+    nodes: Vec<ReferenceRouteNodeSpec>,
+}
+
+impl ReferenceRouteGraphSpec {
+    pub(crate) fn new(nodes: Vec<ReferenceRouteNodeSpec>) -> Self {
+        debug_assert!(nodes.iter().all(|node| {
+            node.successors
+                .iter()
+                .all(|successor| successor.0 < nodes.len() as u32)
+        }));
+        Self { nodes }
+    }
+}
+
+/// Persisted range for one canonical namespace transition graph.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ReferenceRouteGraph {
+    pub(crate) nodes: Range<u32>,
+}
+
+/// One persisted namespace transition node.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ReferenceRouteNode {
     pub(crate) target: FileId,
-    /// Runtime module mechanism used by this hop.
     pub(crate) mechanism: ModuleLoadMechanism,
+    pub(crate) successors: Range<u32>,
+}
+
+/// Cache-friendly persisted namespace transition graphs.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ReferenceRoutes {
+    pub(crate) graphs: Vec<ReferenceRouteGraph>,
+    pub(crate) nodes: Vec<ReferenceRouteNode>,
+    pub(crate) edges: Vec<ReferenceRouteNodeId>,
+}
+
+impl ReferenceRoutes {
+    #[cfg(test)]
+    pub(crate) fn canonical_hops(
+        &self,
+        graph_id: ReferenceRouteGraphId,
+        start: ReferenceRouteNodeId,
+        terminal: ReferenceRouteNodeId,
+        start_mechanism: Option<ModuleLoadMechanism>,
+    ) -> Vec<(FileId, ModuleLoadMechanism)> {
+        let Some(graph) = self.graphs.get(graph_id.0 as usize) else {
+            return Vec::new();
+        };
+        let node_count = graph.nodes.end.saturating_sub(graph.nodes.start) as usize;
+        let start_index = start.0 as usize;
+        let terminal_index = terminal.0 as usize;
+        if start_index >= node_count || terminal_index >= node_count {
+            return Vec::new();
+        }
+
+        let mut predecessor = vec![None; node_count];
+        let mut visited = vec![false; node_count];
+        let mut queue = std::collections::VecDeque::from([start_index]);
+        visited[start_index] = true;
+        while let Some(local_index) = queue.pop_front() {
+            if local_index == terminal_index {
+                break;
+            }
+            let Some(node) = self.nodes.get(graph.nodes.start as usize + local_index) else {
+                return Vec::new();
+            };
+            let Some(successors) = self
+                .edges
+                .get(node.successors.start as usize..node.successors.end as usize)
+            else {
+                return Vec::new();
+            };
+            for successor in successors {
+                let successor_index = successor.0 as usize;
+                if successor_index >= node_count || visited[successor_index] {
+                    continue;
+                }
+                visited[successor_index] = true;
+                predecessor[successor_index] = Some(local_index);
+                queue.push_back(successor_index);
+            }
+        }
+        if !visited[terminal_index] {
+            return Vec::new();
+        }
+
+        let mut hops = Vec::new();
+        let mut current = terminal_index;
+        loop {
+            let node = &self.nodes[graph.nodes.start as usize + current];
+            if current != start_index {
+                hops.push((node.target, node.mechanism));
+            } else {
+                if let Some(mechanism) = start_mechanism {
+                    hops.push((node.target, mechanism));
+                }
+                break;
+            }
+            let Some(parent) = predecessor[current] else {
+                return Vec::new();
+            };
+            current = parent;
+        }
+        hops
+    }
+}
+
+/// Finalized linear paths plus compact namespace transition graphs.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct FinalizedReferencePaths {
+    pub(crate) paths: Vec<ReferencePathNode>,
+    pub(crate) routes: ReferenceRoutes,
 }
 
 /// Build-time interner for shared linked reference paths.
@@ -221,6 +408,8 @@ pub(crate) struct ReferencePathNode {
 pub(crate) struct ReferencePathInterner {
     nodes: Vec<ReferencePathNode>,
     ids: FxHashMap<ReferencePathNode, ReferencePathId>,
+    route_graphs: Vec<ReferenceRouteGraphSpec>,
+    route_graph_ids: FxHashMap<ReferenceRouteGraphSpec, ReferenceRouteGraphId>,
 }
 
 impl ReferencePathInterner {
@@ -230,7 +419,7 @@ impl ReferencePathInterner {
         target: FileId,
         mechanism: ModuleLoadMechanism,
     ) -> ReferencePathId {
-        self.intern(ReferencePathNode {
+        self.intern(ReferencePathNode::Hop {
             parent: None,
             target,
             mechanism,
@@ -247,10 +436,42 @@ impl ReferencePathInterner {
         if self.contains_target(parent, target) {
             return parent;
         }
-        self.intern(ReferencePathNode {
+        self.intern(ReferencePathNode::Hop {
             parent: Some(parent),
             target,
             mechanism,
+        })
+    }
+
+    /// Intern one compact namespace transition graph.
+    pub(crate) fn intern_route_graph(
+        &mut self,
+        graph: ReferenceRouteGraphSpec,
+    ) -> ReferenceRouteGraphId {
+        if let Some(id) = self.route_graph_ids.get(&graph) {
+            return *id;
+        }
+        let id = ReferenceRouteGraphId(self.route_graphs.len() as u32);
+        self.route_graphs.push(graph.clone());
+        self.route_graph_ids.insert(graph, id);
+        id
+    }
+
+    /// Intern one existential traversal through a compact route graph.
+    pub(crate) fn route(
+        &mut self,
+        parent: Option<ReferencePathId>,
+        graph: ReferenceRouteGraphId,
+        start: ReferenceRouteNodeId,
+        terminal: ReferenceRouteNodeId,
+        start_mechanism: Option<ModuleLoadMechanism>,
+    ) -> ReferencePathId {
+        self.intern(ReferencePathNode::Route {
+            parent,
+            graph,
+            start,
+            terminal,
+            start_mechanism,
         })
     }
 
@@ -259,10 +480,14 @@ impl ReferencePathInterner {
             let Some(node) = self.nodes.get(path.index()) else {
                 return false;
             };
-            if node.target == target {
+            if let ReferencePathNode::Hop {
+                target: hop_target, ..
+            } = node
+                && *hop_target == target
+            {
                 return true;
             }
-            let Some(parent) = node.parent else {
+            let Some(parent) = node.parent() else {
                 return false;
             };
             path = parent;
@@ -288,11 +513,12 @@ impl ReferencePathInterner {
     /// Paths are ordered depth-by-depth so every parent already has its final
     /// ID before its children are sorted. This keeps serialized graphs stable
     /// when equivalent imports or re-exports are discovered in another order.
-    pub(crate) fn finalize(self, modules: &mut [ModuleNode]) -> Vec<ReferencePathNode> {
+    pub(crate) fn finalize(self, modules: &mut [ModuleNode]) -> FinalizedReferencePaths {
+        let (routes, route_remap) = finalize_route_graphs(&self.route_graphs);
         let mut depths = Vec::with_capacity(self.nodes.len());
         let mut max_depth = 0usize;
         for node in &self.nodes {
-            let depth = node.parent.map_or(0, |parent| depths[parent.index()] + 1);
+            let depth = node.parent().map_or(0, |parent| depths[parent.index()] + 1);
             max_depth = max_depth.max(depth);
             depths.push(depth);
         }
@@ -305,17 +531,15 @@ impl ReferencePathInterner {
         let mut remap = vec![ReferencePathId(0); self.nodes.len()];
         let mut finalized = Vec::with_capacity(self.nodes.len());
         for mut paths in paths_by_depth {
-            paths.sort_unstable_by_key(|&old_index| {
-                let node = self.nodes[old_index];
-                (
-                    node.parent.map(|parent| remap[parent.index()].0),
-                    node.target.0,
-                    node.mechanism as u8,
-                )
+            paths.sort_unstable_by(|&left, &right| {
+                compare_path_nodes(self.nodes[left], self.nodes[right], &remap, &route_remap)
             });
             for old_index in paths {
                 let mut node = self.nodes[old_index];
-                node.parent = node.parent.map(|parent| remap[parent.index()]);
+                node.remap_parent(&remap);
+                if let ReferencePathNode::Route { graph, .. } = &mut node {
+                    *graph = route_remap[graph.0 as usize];
+                }
                 let canonical = ReferencePathId(finalized.len() as u32);
                 remap[old_index] = canonical;
                 finalized.push(node);
@@ -330,40 +554,127 @@ impl ReferencePathInterner {
             reference.path = remap[reference.path.index()];
         }
 
-        finalized
+        FinalizedReferencePaths {
+            paths: finalized,
+            routes,
+        }
     }
+}
+
+fn compare_path_nodes(
+    left: ReferencePathNode,
+    right: ReferencePathNode,
+    path_remap: &[ReferencePathId],
+    route_remap: &[ReferenceRouteGraphId],
+) -> Ordering {
+    let left_parent = left.parent().map(|parent| path_remap[parent.index()].0);
+    let right_parent = right.parent().map(|parent| path_remap[parent.index()].0);
+    left_parent
+        .cmp(&right_parent)
+        .then_with(|| match (left, right) {
+            (
+                ReferencePathNode::Hop {
+                    target: left_target,
+                    mechanism: left_mechanism,
+                    ..
+                },
+                ReferencePathNode::Hop {
+                    target: right_target,
+                    mechanism: right_mechanism,
+                    ..
+                },
+            ) => {
+                (left_target.0, left_mechanism as u8).cmp(&(right_target.0, right_mechanism as u8))
+            }
+            (ReferencePathNode::Hop { .. }, ReferencePathNode::Route { .. }) => Ordering::Less,
+            (ReferencePathNode::Route { .. }, ReferencePathNode::Hop { .. }) => Ordering::Greater,
+            (
+                ReferencePathNode::Route {
+                    graph: left_graph,
+                    start: left_start,
+                    terminal: left_terminal,
+                    start_mechanism: left_mechanism,
+                    ..
+                },
+                ReferencePathNode::Route {
+                    graph: right_graph,
+                    start: right_start,
+                    terminal: right_terminal,
+                    start_mechanism: right_mechanism,
+                    ..
+                },
+            ) => (
+                route_remap[left_graph.0 as usize].0,
+                left_start.0,
+                left_terminal.0,
+                left_mechanism.map(|mechanism| mechanism as u8),
+            )
+                .cmp(&(
+                    route_remap[right_graph.0 as usize].0,
+                    right_start.0,
+                    right_terminal.0,
+                    right_mechanism.map(|mechanism| mechanism as u8),
+                )),
+        })
+}
+
+fn compare_route_graph_specs(
+    left: &ReferenceRouteGraphSpec,
+    right: &ReferenceRouteGraphSpec,
+) -> Ordering {
+    left.nodes.len().cmp(&right.nodes.len()).then_with(|| {
+        left.nodes
+            .iter()
+            .zip(&right.nodes)
+            .find_map(|(left_node, right_node)| {
+                let ordering = (
+                    left_node.target.0,
+                    left_node.mechanism as u8,
+                    &left_node.successors,
+                )
+                    .cmp(&(
+                        right_node.target.0,
+                        right_node.mechanism as u8,
+                        &right_node.successors,
+                    ));
+                (ordering != Ordering::Equal).then_some(ordering)
+            })
+            .unwrap_or(Ordering::Equal)
+    })
+}
+
+fn finalize_route_graphs(
+    graphs: &[ReferenceRouteGraphSpec],
+) -> (ReferenceRoutes, Vec<ReferenceRouteGraphId>) {
+    let mut order: Vec<usize> = (0..graphs.len()).collect();
+    order
+        .sort_unstable_by(|&left, &right| compare_route_graph_specs(&graphs[left], &graphs[right]));
+
+    let mut remap = vec![ReferenceRouteGraphId(0); graphs.len()];
+    let mut finalized = ReferenceRoutes::default();
+    for old_index in order {
+        let graph_id = ReferenceRouteGraphId(finalized.graphs.len() as u32);
+        remap[old_index] = graph_id;
+        let node_start = finalized.nodes.len() as u32;
+        for node in &graphs[old_index].nodes {
+            let edge_start = finalized.edges.len() as u32;
+            finalized.edges.extend_from_slice(&node.successors);
+            finalized.nodes.push(ReferenceRouteNode {
+                target: node.target,
+                mechanism: node.mechanism,
+                successors: edge_start..finalized.edges.len() as u32,
+            });
+        }
+        finalized.graphs.push(ReferenceRouteGraph {
+            nodes: node_start..finalized.nodes.len() as u32,
+        });
+    }
+    (finalized, remap)
 }
 
 impl ReferencePathId {
     pub(crate) const fn index(self) -> usize {
         self.0 as usize
-    }
-}
-
-/// Allocation-free iterator over a linked reference path, from final hop to first.
-#[derive(Clone)]
-pub(crate) struct ReferencePathIter<'a> {
-    nodes: &'a [ReferencePathNode],
-    next: Option<ReferencePathId>,
-}
-
-impl<'a> ReferencePathIter<'a> {
-    pub(crate) const fn new(nodes: &'a [ReferencePathNode], path: ReferencePathId) -> Self {
-        Self {
-            nodes,
-            next: Some(path),
-        }
-    }
-}
-
-impl Iterator for ReferencePathIter<'_> {
-    type Item = (FileId, ModuleLoadMechanism);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let path = self.next?;
-        let node = self.nodes.get(path.index())?;
-        self.next = node.parent;
-        Some((node.target, node.mechanism))
     }
 }
 
@@ -495,6 +806,76 @@ mod tests {
             .map(|reference| reference.path)
             .collect();
         assert_eq!(first_paths, second_paths);
+    }
+
+    fn two_hop_route(first: FileId, second: FileId) -> ReferenceRouteGraphSpec {
+        ReferenceRouteGraphSpec::new(vec![
+            ReferenceRouteNodeSpec::new(
+                first,
+                ModuleLoadMechanism::EsModule,
+                vec![ReferenceRouteNodeId(1)],
+            ),
+            ReferenceRouteNodeSpec::new(second, ModuleLoadMechanism::EsModule, Vec::new()),
+        ])
+    }
+
+    #[test]
+    fn finalized_reference_routes_are_independent_of_interning_order() {
+        let route_a = two_hop_route(FileId(1), FileId(2));
+        let route_b = two_hop_route(FileId(3), FileId(4));
+
+        let mut first = ReferencePathInterner::default();
+        let first_a = first.intern_route_graph(route_a.clone());
+        let first_b = first.intern_route_graph(route_b.clone());
+        let first_b_path = first.route(
+            None,
+            first_b,
+            ReferenceRouteNodeId(0),
+            ReferenceRouteNodeId(1),
+            Some(ModuleLoadMechanism::CommonJsRequire),
+        );
+        let first_a_path = first.route(
+            None,
+            first_a,
+            ReferenceRouteNodeId(0),
+            ReferenceRouteNodeId(1),
+            Some(ModuleLoadMechanism::EsModule),
+        );
+        let mut first_modules = vec![module_with_reference_paths(&[first_b_path, first_a_path])];
+        let first_paths = first.finalize(&mut first_modules);
+
+        let mut second = ReferencePathInterner::default();
+        let second_b = second.intern_route_graph(route_b);
+        let second_a = second.intern_route_graph(route_a);
+        let second_b_path = second.route(
+            None,
+            second_b,
+            ReferenceRouteNodeId(0),
+            ReferenceRouteNodeId(1),
+            Some(ModuleLoadMechanism::CommonJsRequire),
+        );
+        let second_a_path = second.route(
+            None,
+            second_a,
+            ReferenceRouteNodeId(0),
+            ReferenceRouteNodeId(1),
+            Some(ModuleLoadMechanism::EsModule),
+        );
+        let mut second_modules = vec![module_with_reference_paths(&[second_b_path, second_a_path])];
+        let second_paths = second.finalize(&mut second_modules);
+
+        assert_eq!(first_paths, second_paths);
+        let first_reference_paths: Vec<_> = first_modules[0].exports[0]
+            .references
+            .iter()
+            .map(|reference| reference.path)
+            .collect();
+        let second_reference_paths: Vec<_> = second_modules[0].exports[0]
+            .references
+            .iter()
+            .map(|reference| reference.path)
+            .collect();
+        assert_eq!(first_reference_paths, second_reference_paths);
     }
 
     #[test]

--- a/crates/graph/src/graph/types.rs
+++ b/crates/graph/src/graph/types.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use fallow_types::discover::FileId;
 use fallow_types::extract::{ExportName, ModuleLoadMechanism, VisibilityTag};
+use rustc_hash::FxHashMap;
 
 /// A single module in the graph.
 ///
@@ -192,25 +193,177 @@ pub struct SymbolReference {
     pub from_file: FileId,
     /// How the export is referenced.
     pub kind: ReferenceKind,
-    /// Runtime module mechanism used by the exact reference path.
-    ///
-    /// Re-export propagation records [`ModuleLoadMechanism::EsModule`] because
-    /// the final hop into the owning module is an ESM re-export even when the
-    /// original consumer loaded the barrel through CommonJS.
-    pub mechanism: ModuleLoadMechanism,
+    /// Interned linked path from `from_file` to the owning export.
+    pub(crate) path: ReferencePathId,
     /// Byte span of the import statement in the referencing file.
     /// Used by the LSP to locate references for Code Lens navigation.
     #[serde(with = "crate::cache::span_serde")]
     pub import_span: oxc_span::Span,
 }
 
-impl SymbolReference {
-    /// Carry a consumer reference through an ESM re-export edge.
-    pub(crate) const fn through_re_export(self) -> Self {
-        Self {
-            mechanism: ModuleLoadMechanism::EsModule,
-            ..self
+/// Compact identifier for an interned reference path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ReferencePathId(pub(crate) u32);
+
+/// One target hop in an interned linked reference path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ReferencePathNode {
+    /// Previous hop, or `None` for the consumer's direct module load.
+    pub(crate) parent: Option<ReferencePathId>,
+    /// Module loaded by this hop.
+    pub(crate) target: FileId,
+    /// Runtime module mechanism used by this hop.
+    pub(crate) mechanism: ModuleLoadMechanism,
+}
+
+/// Build-time interner for shared linked reference paths.
+#[derive(Default)]
+pub(crate) struct ReferencePathInterner {
+    nodes: Vec<ReferencePathNode>,
+    ids: FxHashMap<ReferencePathNode, ReferencePathId>,
+}
+
+impl ReferencePathInterner {
+    /// Intern a direct consumer-to-target path.
+    pub(crate) fn direct(
+        &mut self,
+        target: FileId,
+        mechanism: ModuleLoadMechanism,
+    ) -> ReferencePathId {
+        self.intern(ReferencePathNode {
+            parent: None,
+            target,
+            mechanism,
+        })
+    }
+
+    /// Append one typed hop to an existing path.
+    pub(crate) fn extend(
+        &mut self,
+        parent: ReferencePathId,
+        target: FileId,
+        mechanism: ModuleLoadMechanism,
+    ) -> ReferencePathId {
+        if self.contains_target(parent, target) {
+            return parent;
         }
+        self.intern(ReferencePathNode {
+            parent: Some(parent),
+            target,
+            mechanism,
+        })
+    }
+
+    fn contains_target(&self, mut path: ReferencePathId, target: FileId) -> bool {
+        loop {
+            let Some(node) = self.nodes.get(path.index()) else {
+                return false;
+            };
+            if node.target == target {
+                return true;
+            }
+            let Some(parent) = node.parent else {
+                return false;
+            };
+            path = parent;
+        }
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "a process cannot allocate more than u32::MAX reference path nodes"
+    )]
+    fn intern(&mut self, node: ReferencePathNode) -> ReferencePathId {
+        if let Some(path) = self.ids.get(&node) {
+            return *path;
+        }
+        let path = ReferencePathId(self.nodes.len() as u32);
+        self.nodes.push(node);
+        self.ids.insert(node, path);
+        path
+    }
+
+    /// Finalize cache-friendly storage and assign canonical IDs.
+    ///
+    /// Paths are ordered depth-by-depth so every parent already has its final
+    /// ID before its children are sorted. This keeps serialized graphs stable
+    /// when equivalent imports or re-exports are discovered in another order.
+    pub(crate) fn finalize(self, modules: &mut [ModuleNode]) -> Vec<ReferencePathNode> {
+        let mut depths = Vec::with_capacity(self.nodes.len());
+        let mut max_depth = 0usize;
+        for node in &self.nodes {
+            let depth = node.parent.map_or(0, |parent| depths[parent.index()] + 1);
+            max_depth = max_depth.max(depth);
+            depths.push(depth);
+        }
+
+        let mut paths_by_depth = vec![Vec::new(); max_depth.saturating_add(1)];
+        for (old_index, depth) in depths.into_iter().enumerate() {
+            paths_by_depth[depth].push(old_index);
+        }
+
+        let mut remap = vec![ReferencePathId(0); self.nodes.len()];
+        let mut finalized = Vec::with_capacity(self.nodes.len());
+        for mut paths in paths_by_depth {
+            paths.sort_unstable_by_key(|&old_index| {
+                let node = self.nodes[old_index];
+                (
+                    node.parent.map(|parent| remap[parent.index()].0),
+                    node.target.0,
+                    node.mechanism as u8,
+                )
+            });
+            for old_index in paths {
+                let mut node = self.nodes[old_index];
+                node.parent = node.parent.map(|parent| remap[parent.index()]);
+                let canonical = ReferencePathId(finalized.len() as u32);
+                remap[old_index] = canonical;
+                finalized.push(node);
+            }
+        }
+
+        for reference in modules
+            .iter_mut()
+            .flat_map(|module| &mut module.exports)
+            .flat_map(|export| &mut export.references)
+        {
+            reference.path = remap[reference.path.index()];
+        }
+
+        finalized
+    }
+}
+
+impl ReferencePathId {
+    pub(crate) const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// Allocation-free iterator over a linked reference path, from final hop to first.
+#[derive(Clone)]
+pub(crate) struct ReferencePathIter<'a> {
+    nodes: &'a [ReferencePathNode],
+    next: Option<ReferencePathId>,
+}
+
+impl<'a> ReferencePathIter<'a> {
+    pub(crate) const fn new(nodes: &'a [ReferencePathNode], path: ReferencePathId) -> Self {
+        Self {
+            nodes,
+            next: Some(path),
+        }
+    }
+}
+
+impl Iterator for ReferencePathIter<'_> {
+    type Item = (FileId, ModuleLoadMechanism);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let path = self.next?;
+        let node = self.nodes.get(path.index())?;
+        self.next = node.parent;
+        Some((node.target, node.mechanism))
     }
 }
 
@@ -234,7 +387,7 @@ pub enum ReferenceKind {
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<ExportSymbol>() == 112);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<SymbolReference>() == 16);
+const _: () = assert!(std::mem::size_of::<SymbolReference>() == 24);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<ReExportEdge>() == 64);
 #[cfg(all(target_pointer_width = "64", unix))]
@@ -285,12 +438,71 @@ mod tests {
         assert_eq!(debug_str, "DynamicImport");
     }
 
+    fn module_with_reference_paths(paths: &[ReferencePathId]) -> ModuleNode {
+        ModuleNode {
+            file_id: FileId(0),
+            path: PathBuf::from("/project/source.ts"),
+            edge_range: 0..0,
+            exports: vec![ExportSymbol {
+                name: ExportName::Named("value".to_string()),
+                is_type_only: false,
+                is_side_effect_used: false,
+                visibility: VisibilityTag::None,
+                expected_unused_reason: None,
+                span: oxc_span::Span::default(),
+                references: paths
+                    .iter()
+                    .copied()
+                    .map(|path| SymbolReference {
+                        from_file: FileId(0),
+                        kind: ReferenceKind::NamedImport,
+                        path,
+                        import_span: oxc_span::Span::default(),
+                    })
+                    .collect(),
+                members: Vec::new(),
+            }],
+            re_exports: Vec::new(),
+            flags: 0,
+        }
+    }
+
+    #[test]
+    fn finalized_reference_paths_are_independent_of_interning_order() {
+        let mut first = ReferencePathInterner::default();
+        let first_parent = first.direct(FileId(1), ModuleLoadMechanism::EsModule);
+        let first_direct = first.direct(FileId(2), ModuleLoadMechanism::CommonJsRequire);
+        let first_chain = first.extend(first_parent, FileId(3), ModuleLoadMechanism::EsModule);
+        let mut first_modules = vec![module_with_reference_paths(&[first_direct, first_chain])];
+        let first_nodes = first.finalize(&mut first_modules);
+
+        let mut second = ReferencePathInterner::default();
+        let second_direct = second.direct(FileId(2), ModuleLoadMechanism::CommonJsRequire);
+        let second_parent = second.direct(FileId(1), ModuleLoadMechanism::EsModule);
+        let second_chain = second.extend(second_parent, FileId(3), ModuleLoadMechanism::EsModule);
+        let mut second_modules = vec![module_with_reference_paths(&[second_direct, second_chain])];
+        let second_nodes = second.finalize(&mut second_modules);
+
+        assert_eq!(first_nodes, second_nodes);
+        let first_paths: Vec<_> = first_modules[0].exports[0]
+            .references
+            .iter()
+            .map(|reference| reference.path)
+            .collect();
+        let second_paths: Vec<_> = second_modules[0].exports[0]
+            .references
+            .iter()
+            .map(|reference| reference.path)
+            .collect();
+        assert_eq!(first_paths, second_paths);
+    }
+
     #[test]
     fn symbol_reference_construction() {
         let reference = SymbolReference {
             from_file: FileId(42),
             kind: ReferenceKind::NamedImport,
-            mechanism: ModuleLoadMechanism::EsModule,
+            path: ReferencePathId(0),
             import_span: oxc_span::Span::new(10, 30),
         };
         assert_eq!(reference.from_file, FileId(42));
@@ -304,7 +516,7 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(7),
             kind: ReferenceKind::ReExport,
-            mechanism: ModuleLoadMechanism::EsModule,
+            path: ReferencePathId(0),
             import_span: oxc_span::Span::new(5, 25),
         };
         let copied = reference;
@@ -430,13 +642,13 @@ mod tests {
                 SymbolReference {
                     from_file: FileId(1),
                     kind: ReferenceKind::NamedImport,
-                    mechanism: ModuleLoadMechanism::EsModule,
+                    path: ReferencePathId(0),
                     import_span: oxc_span::Span::new(0, 10),
                 },
                 SymbolReference {
                     from_file: FileId(2),
                     kind: ReferenceKind::ReExport,
-                    mechanism: ModuleLoadMechanism::EsModule,
+                    path: ReferencePathId(1),
                     import_span: oxc_span::Span::new(5, 15),
                 },
             ],

--- a/crates/graph/src/graph/types.rs
+++ b/crates/graph/src/graph/types.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use std::path::PathBuf;
 
 use fallow_types::discover::FileId;
-use fallow_types::extract::{ExportName, VisibilityTag};
+use fallow_types::extract::{ExportName, ModuleLoadMechanism, VisibilityTag};
 
 /// A single module in the graph.
 ///
@@ -192,10 +192,26 @@ pub struct SymbolReference {
     pub from_file: FileId,
     /// How the export is referenced.
     pub kind: ReferenceKind,
+    /// Runtime module mechanism used by the exact reference path.
+    ///
+    /// Re-export propagation records [`ModuleLoadMechanism::EsModule`] because
+    /// the final hop into the owning module is an ESM re-export even when the
+    /// original consumer loaded the barrel through CommonJS.
+    pub mechanism: ModuleLoadMechanism,
     /// Byte span of the import statement in the referencing file.
     /// Used by the LSP to locate references for Code Lens navigation.
     #[serde(with = "crate::cache::span_serde")]
     pub import_span: oxc_span::Span,
+}
+
+impl SymbolReference {
+    /// Carry a consumer reference through an ESM re-export edge.
+    pub(crate) const fn through_re_export(self) -> Self {
+        Self {
+            mechanism: ModuleLoadMechanism::EsModule,
+            ..self
+        }
+    }
 }
 
 /// How an export is referenced.
@@ -274,6 +290,7 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(42),
             kind: ReferenceKind::NamedImport,
+            mechanism: ModuleLoadMechanism::EsModule,
             import_span: oxc_span::Span::new(10, 30),
         };
         assert_eq!(reference.from_file, FileId(42));
@@ -287,6 +304,7 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(7),
             kind: ReferenceKind::ReExport,
+            mechanism: ModuleLoadMechanism::EsModule,
             import_span: oxc_span::Span::new(5, 25),
         };
         let copied = reference;
@@ -412,11 +430,13 @@ mod tests {
                 SymbolReference {
                     from_file: FileId(1),
                     kind: ReferenceKind::NamedImport,
+                    mechanism: ModuleLoadMechanism::EsModule,
                     import_span: oxc_span::Span::new(0, 10),
                 },
                 SymbolReference {
                     from_file: FileId(2),
                     kind: ReferenceKind::ReExport,
+                    mechanism: ModuleLoadMechanism::EsModule,
                     import_span: oxc_span::Span::new(5, 15),
                 },
             ],

--- a/crates/graph/src/resolve/fallbacks.rs
+++ b/crates/graph/src/resolve/fallbacks.rs
@@ -1114,6 +1114,7 @@ pub(super) fn make_glob_from_pattern(
 mod tests {
     use super::*;
     use crate::resolve::types::{CanonicalizeCache, TsconfigCache};
+    use fallow_types::extract::ModuleLoadMechanism;
     use rustc_hash::FxHashSet;
 
     fn with_package_map_ctx(
@@ -1860,6 +1861,7 @@ mod tests {
             prefix: "./locales/".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./locales/*");
     }
@@ -1870,6 +1872,7 @@ mod tests {
             prefix: "./locales/".to_string(),
             suffix: Some(".json".to_string()),
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./locales/*.json");
     }
@@ -1880,6 +1883,7 @@ mod tests {
             prefix: "./pages/**/*.tsx".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./pages/**/*.tsx");
     }
@@ -1890,6 +1894,7 @@ mod tests {
             prefix: "./i18n/{en,de,fr}.json".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./i18n/{en,de,fr}.json");
     }
@@ -1900,6 +1905,7 @@ mod tests {
             prefix: String::new(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "*");
     }
@@ -1910,6 +1916,7 @@ mod tests {
             prefix: String::new(),
             suffix: Some(".ts".to_string()),
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "*.ts");
     }
@@ -1920,6 +1927,7 @@ mod tests {
             prefix: "./pages/".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./pages/*");
     }
@@ -1930,6 +1938,7 @@ mod tests {
             prefix: "./locales/".to_string(),
             suffix: Some(".json".to_string()),
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./locales/*.json");
     }
@@ -1940,6 +1949,7 @@ mod tests {
             prefix: "./modules/".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./modules/*");
     }
@@ -1950,6 +1960,7 @@ mod tests {
             prefix: "./pages/".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./pages/*");
     }
@@ -1960,6 +1971,7 @@ mod tests {
             prefix: "./views/".to_string(),
             suffix: Some(".vue".to_string()),
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./views/*.vue");
     }
@@ -1970,6 +1982,7 @@ mod tests {
             prefix: "./components/**/*.vue".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(
             make_glob_from_pattern(&pattern),
@@ -1984,6 +1997,7 @@ mod tests {
             prefix: "./plugins/{auth,analytics}.ts".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(
             make_glob_from_pattern(&pattern),
@@ -1998,6 +2012,7 @@ mod tests {
             prefix: "./routes/**/*.{ts,tsx}".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(
             make_glob_from_pattern(&pattern),
@@ -2012,6 +2027,7 @@ mod tests {
             prefix: "./*.ts".to_string(),
             suffix: Some(".extra".to_string()),
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(
             make_glob_from_pattern(&pattern),
@@ -2026,6 +2042,7 @@ mod tests {
             prefix: "./".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./*");
     }
@@ -2036,6 +2053,7 @@ mod tests {
             prefix: "./config".to_string(),
             suffix: None,
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "./config*");
     }
@@ -2046,6 +2064,7 @@ mod tests {
             prefix: "../shared/".to_string(),
             suffix: Some(".ts".to_string()),
             span: oxc_span::Span::default(),
+            mechanism: ModuleLoadMechanism::EsModule,
         };
         assert_eq!(make_glob_from_pattern(&pattern), "../shared/*.ts");
     }

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -55,7 +55,7 @@ use require_imports::resolve_require_imports;
 use specifier::create_resolver;
 use static_imports::resolve_static_imports;
 use types::{PackageManifestInfo, ResolveContext};
-use upgrades::apply_specifier_upgrades;
+use upgrades::{ResolvedReplacementCandidate, apply_specifier_upgrades};
 
 /// Inputs used to resolve imports for a complete extracted project.
 pub struct ResolveAllImportsInput<'a> {
@@ -207,13 +207,13 @@ pub fn resolve_all_imports_with_session(
         })
         .collect();
     let mut resolved = Vec::with_capacity(resolved_outputs.len());
-    let mut replaced_module_targets = Vec::new();
+    let mut replacement_candidates = Vec::new();
     for output in resolved_outputs {
         resolved.push(output.module);
-        replaced_module_targets.extend(output.replaced_module_targets);
+        replacement_candidates.extend(output.replacement_candidates);
     }
 
-    apply_specifier_upgrades(&mut resolved);
+    apply_specifier_upgrades(&mut resolved, &mut replacement_candidates);
 
     synthesize_auto_import_edges(
         &mut resolved,
@@ -223,6 +223,15 @@ pub fn resolve_all_imports_with_session(
         &raw_path_to_id,
     );
 
+    let mut replaced_module_targets: Vec<_> = replacement_candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            Some(ResolvedReplacedModuleTarget {
+                source_file: candidate.source_file,
+                target_file: candidate.target.internal_file_id()?,
+            })
+        })
+        .collect();
     replaced_module_targets
         .sort_unstable_by_key(|target| (target.source_file.0, target.target_file.0));
     replaced_module_targets.dedup();
@@ -334,8 +343,8 @@ fn resolve_module_imports(
             .unwrap_or(file_path)
     };
 
-    let replaced_module_targets =
-        resolve_replaced_module_targets(module.file_id, &module.semantic_facts, ctx, file_path);
+    let replacement_candidates =
+        resolve_replacement_candidates(module.file_id, &module.semantic_facts, ctx, file_path);
     let module = build_resolved_module(ResolvedModuleBuildInput {
         module,
         ctx,
@@ -348,38 +357,37 @@ fn resolve_module_imports(
 
     Some(ResolvedModuleOutput {
         module,
-        replaced_module_targets,
+        replacement_candidates,
     })
 }
 
 struct ResolvedModuleOutput {
     module: ResolvedModule,
-    replaced_module_targets: Vec<ResolvedReplacedModuleTarget>,
+    replacement_candidates: Vec<ResolvedReplacementCandidate>,
 }
 
-fn resolve_replaced_module_targets(
+fn resolve_replacement_candidates(
     source_file: FileId,
     semantic_facts: &[SemanticFact],
     ctx: &ResolveContext<'_>,
     file_path: &Path,
-) -> Vec<ResolvedReplacedModuleTarget> {
-    let mut targets: Vec<_> = semantic_facts
+) -> Vec<ResolvedReplacementCandidate> {
+    let mut candidates: Vec<_> = semantic_facts
         .iter()
         .filter_map(|fact| {
             let SemanticFact::ReplacedModuleTarget(target) = fact else {
                 return None;
             };
-            let target_file = specifier::resolve_specifier(ctx, file_path, &target.source, false)
-                .internal_file_id()?;
-            Some(ResolvedReplacedModuleTarget {
+            Some(ResolvedReplacementCandidate {
                 source_file,
-                target_file,
+                source_specifier: target.source.clone(),
+                target: specifier::resolve_specifier(ctx, file_path, &target.source, false),
             })
         })
         .collect();
-    targets.sort_unstable_by_key(|target| target.target_file.0);
-    targets.dedup();
-    targets
+    candidates.sort_unstable_by(|left, right| left.source_specifier.cmp(&right.source_specifier));
+    candidates.dedup_by(|left, right| left.source_specifier == right.source_specifier);
+    candidates
 }
 
 struct ResolvedModuleBuildInput<'a> {

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -55,7 +55,7 @@ use require_imports::resolve_require_imports;
 use specifier::create_resolver;
 use static_imports::resolve_static_imports;
 use types::{PackageManifestInfo, ResolveContext};
-use upgrades::{ResolvedReplacementCandidate, apply_specifier_upgrades};
+use upgrades::{ResolvedVitestMockOperation, apply_specifier_upgrades};
 
 /// Inputs used to resolve imports for a complete extracted project.
 pub struct ResolveAllImportsInput<'a> {
@@ -207,13 +207,13 @@ pub fn resolve_all_imports_with_session(
         })
         .collect();
     let mut resolved = Vec::with_capacity(resolved_outputs.len());
-    let mut replacement_candidates = Vec::new();
+    let mut vitest_mock_operations = Vec::new();
     for output in resolved_outputs {
         resolved.push(output.module);
-        replacement_candidates.extend(output.replacement_candidates);
+        vitest_mock_operations.extend(output.vitest_mock_operations);
     }
 
-    apply_specifier_upgrades(&mut resolved, &mut replacement_candidates);
+    apply_specifier_upgrades(&mut resolved, &mut vitest_mock_operations);
 
     synthesize_auto_import_edges(
         &mut resolved,
@@ -223,18 +223,7 @@ pub fn resolve_all_imports_with_session(
         &raw_path_to_id,
     );
 
-    let mut replaced_module_targets: Vec<_> = replacement_candidates
-        .into_iter()
-        .filter_map(|candidate| {
-            Some(ResolvedReplacedModuleTarget {
-                source_file: candidate.source_file,
-                target_file: candidate.target.internal_file_id()?,
-            })
-        })
-        .collect();
-    replaced_module_targets
-        .sort_unstable_by_key(|target| (target.source_file.0, target.target_file.0));
-    replaced_module_targets.dedup();
+    let replaced_module_targets = final_replaced_module_targets(vitest_mock_operations);
 
     ResolvedProject {
         modules: resolved,
@@ -343,8 +332,8 @@ fn resolve_module_imports(
             .unwrap_or(file_path)
     };
 
-    let replacement_candidates =
-        resolve_replacement_candidates(module.file_id, &module.semantic_facts, ctx, file_path);
+    let vitest_mock_operations =
+        resolve_vitest_mock_operations(module.file_id, &module.semantic_facts, ctx, file_path);
     let module = build_resolved_module(ResolvedModuleBuildInput {
         module,
         ctx,
@@ -357,37 +346,76 @@ fn resolve_module_imports(
 
     Some(ResolvedModuleOutput {
         module,
-        replacement_candidates,
+        vitest_mock_operations,
     })
 }
 
 struct ResolvedModuleOutput {
     module: ResolvedModule,
-    replacement_candidates: Vec<ResolvedReplacementCandidate>,
+    vitest_mock_operations: Vec<ResolvedVitestMockOperation>,
 }
 
-fn resolve_replacement_candidates(
+fn resolve_vitest_mock_operations(
     source_file: FileId,
     semantic_facts: &[SemanticFact],
     ctx: &ResolveContext<'_>,
     file_path: &Path,
-) -> Vec<ResolvedReplacementCandidate> {
-    let mut candidates: Vec<_> = semantic_facts
+) -> Vec<ResolvedVitestMockOperation> {
+    let mut operations: Vec<_> = semantic_facts
         .iter()
         .filter_map(|fact| {
-            let SemanticFact::ReplacedModuleTarget(target) = fact else {
+            let SemanticFact::VitestModuleMockOperation(operation) = fact else {
                 return None;
             };
-            Some(ResolvedReplacementCandidate {
+            Some(ResolvedVitestMockOperation {
                 source_file,
-                source_specifier: target.source.clone(),
-                target: specifier::resolve_specifier(ctx, file_path, &target.source, false),
+                source_specifier: operation.source.clone(),
+                call_start: operation.call_start,
+                action: operation.action,
+                target: specifier::resolve_specifier(ctx, file_path, &operation.source, false),
             })
         })
         .collect();
-    candidates.sort_unstable_by(|left, right| left.source_specifier.cmp(&right.source_specifier));
-    candidates.dedup_by(|left, right| left.source_specifier == right.source_specifier);
-    candidates
+    operations.sort_unstable_by(|left, right| {
+        left.call_start
+            .cmp(&right.call_start)
+            .then_with(|| left.source_specifier.cmp(&right.source_specifier))
+    });
+    operations
+}
+
+fn final_replaced_module_targets(
+    mut operations: Vec<ResolvedVitestMockOperation>,
+) -> Vec<ResolvedReplacedModuleTarget> {
+    operations.sort_unstable_by(|left, right| {
+        left.source_file
+            .0
+            .cmp(&right.source_file.0)
+            .then_with(|| left.call_start.cmp(&right.call_start))
+            .then_with(|| left.source_specifier.cmp(&right.source_specifier))
+    });
+
+    let mut final_operations = FxHashMap::default();
+    for operation in operations {
+        let Some(target_file) = operation.target.internal_file_id() else {
+            continue;
+        };
+        final_operations.insert((operation.source_file, target_file), operation.action);
+    }
+
+    let mut targets: Vec<_> = final_operations
+        .into_iter()
+        .filter_map(|((source_file, target_file), action)| {
+            action
+                .replaces_original()
+                .then_some(ResolvedReplacedModuleTarget {
+                    source_file,
+                    target_file,
+                })
+        })
+        .collect();
+    targets.sort_unstable_by_key(|target| (target.source_file.0, target.target_file.0));
+    targets
 }
 
 struct ResolvedModuleBuildInput<'a> {

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -33,7 +33,8 @@ pub use path_info::{
     extract_package_name, is_bare_specifier, is_path_alias, is_valid_package_name,
 };
 pub use types::{
-    ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport, ResolvedSourceEdge,
+    ResolveResult, ResolvedImport, ResolvedModule, ResolvedProject, ResolvedReExport,
+    ResolvedReplacedModuleTarget, ResolvedSourceEdge,
 };
 
 use std::path::{Path, PathBuf};
@@ -44,7 +45,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_config::{AutoImportKind, AutoImportRule};
 use fallow_types::discover::{DiscoveredFile, FileId};
-use fallow_types::extract::{ImportInfo, ImportedName, ModuleInfo};
+use fallow_types::extract::{ImportInfo, ImportedName, ModuleInfo, SemanticFact};
 use oxc_span::Span;
 
 use dynamic_imports::{resolve_dynamic_imports, resolve_dynamic_patterns};
@@ -140,7 +141,7 @@ impl ResolverSession {
 
 /// Resolve all imports across all modules in parallel.
 #[must_use]
-pub fn resolve_all_imports(input: &ResolveAllImportsInput<'_>) -> Vec<ResolvedModule> {
+pub fn resolve_all_imports(input: &ResolveAllImportsInput<'_>) -> ResolvedProject {
     let session = ResolverSession::new(input);
     resolve_all_imports_with_session(input, &session)
 }
@@ -156,7 +157,7 @@ pub fn resolve_all_imports(input: &ResolveAllImportsInput<'_>) -> Vec<ResolvedMo
 pub fn resolve_all_imports_with_session(
     input: &ResolveAllImportsInput<'_>,
     session: &ResolverSession,
-) -> Vec<ResolvedModule> {
+) -> ResolvedProject {
     let root_is_canonical = session.root_is_canonical;
     let workspace_roots = build_workspace_roots(input.workspaces, &session.canonical_ws_roots);
     let canonical_paths = build_canonical_file_paths(input.files, root_is_canonical);
@@ -198,13 +199,19 @@ pub fn resolve_all_imports_with_session(
         canonicalize_cache: &canonicalize_cache,
     };
 
-    let mut resolved: Vec<ResolvedModule> = input
+    let resolved_outputs: Vec<ResolvedModuleOutput> = input
         .modules
         .par_iter()
         .filter_map(|module| {
             resolve_module_imports(module, &ctx, &file_paths, &canonical_paths, input.files)
         })
         .collect();
+    let mut resolved = Vec::with_capacity(resolved_outputs.len());
+    let mut replaced_module_targets = Vec::new();
+    for output in resolved_outputs {
+        resolved.push(output.module);
+        replaced_module_targets.extend(output.replaced_module_targets);
+    }
 
     apply_specifier_upgrades(&mut resolved);
 
@@ -216,7 +223,14 @@ pub fn resolve_all_imports_with_session(
         &raw_path_to_id,
     );
 
-    resolved
+    replaced_module_targets
+        .sort_unstable_by_key(|target| (target.source_file.0, target.target_file.0));
+    replaced_module_targets.dedup();
+
+    ResolvedProject {
+        modules: resolved,
+        replaced_module_targets,
+    }
 }
 
 fn build_workspace_roots<'a>(
@@ -295,7 +309,7 @@ fn resolve_module_imports(
     file_paths: &[&Path],
     canonical_paths: &[PathBuf],
     files: &[DiscoveredFile],
-) -> Option<ResolvedModule> {
+) -> Option<ResolvedModuleOutput> {
     let Some(file_path) = file_paths.get(module.file_id.0 as usize) else {
         tracing::warn!(
             file_id = module.file_id.0,
@@ -320,7 +334,9 @@ fn resolve_module_imports(
             .unwrap_or(file_path)
     };
 
-    Some(build_resolved_module(ResolvedModuleBuildInput {
+    let replaced_module_targets =
+        resolve_replaced_module_targets(module.file_id, &module.semantic_facts, ctx, file_path);
+    let module = build_resolved_module(ResolvedModuleBuildInput {
         module,
         ctx,
         file_path,
@@ -328,7 +344,42 @@ fn resolve_module_imports(
         canonical_paths,
         files,
         all_imports,
-    }))
+    });
+
+    Some(ResolvedModuleOutput {
+        module,
+        replaced_module_targets,
+    })
+}
+
+struct ResolvedModuleOutput {
+    module: ResolvedModule,
+    replaced_module_targets: Vec<ResolvedReplacedModuleTarget>,
+}
+
+fn resolve_replaced_module_targets(
+    source_file: FileId,
+    semantic_facts: &[SemanticFact],
+    ctx: &ResolveContext<'_>,
+    file_path: &Path,
+) -> Vec<ResolvedReplacedModuleTarget> {
+    let mut targets: Vec<_> = semantic_facts
+        .iter()
+        .filter_map(|fact| {
+            let SemanticFact::ReplacedModuleTarget(target) = fact else {
+                return None;
+            };
+            let target_file = specifier::resolve_specifier(ctx, file_path, &target.source, false)
+                .internal_file_id()?;
+            Some(ResolvedReplacedModuleTarget {
+                source_file,
+                target_file,
+            })
+        })
+        .collect();
+    targets.sort_unstable_by_key(|target| target.target_file.0);
+    targets.dedup();
+    targets
 }
 
 struct ResolvedModuleBuildInput<'a> {

--- a/crates/graph/src/resolve/require_imports.rs
+++ b/crates/graph/src/resolve/require_imports.rs
@@ -35,7 +35,7 @@ pub(super) fn resolve_single_require(
     file_path: &Path,
     req: &RequireCallInfo,
 ) -> Vec<ResolvedImport> {
-    let target = resolve_specifier(ctx, file_path, &req.source, false);
+    let target = resolve_specifier(ctx, file_path, &req.source, false).into_commonjs_require();
 
     if req.destructured_names.is_empty() {
         return vec![ResolvedImport {

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -694,7 +694,7 @@ fn require_imports_empty_list() {
 }
 
 #[test]
-fn specifier_upgrades_npm_to_internal() {
+fn specifier_upgrades_npm_to_internal_with_package_identity() {
     let mut modules = vec![
         make_resolved_module(
             0,
@@ -719,8 +719,15 @@ fn specifier_upgrades_npm_to_internal() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[1].resolved_imports[0].target,
+        modules[0].resolved_imports[0].target,
         ResolveResult::InternalModule(FileId(5))
+    ));
+    assert!(matches!(
+        &modules[1].resolved_imports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(5),
+            package_name,
+        } if package_name == "preact"
     ));
 }
 
@@ -823,8 +830,11 @@ fn specifier_upgrades_applies_to_dynamic_imports() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[1].resolved_dynamic_imports[0].target,
-        ResolveResult::InternalModule(FileId(5))
+        &modules[1].resolved_dynamic_imports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(5),
+            package_name,
+        } if package_name == "preact"
     ));
 }
 
@@ -854,8 +864,11 @@ fn specifier_upgrades_applies_to_re_exports() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[1].re_exports[0].target,
-        ResolveResult::InternalModule(FileId(5))
+        &modules[1].re_exports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(5),
+            package_name,
+        } if package_name == "preact"
     ));
 }
 
@@ -929,8 +942,11 @@ fn specifier_upgrades_first_internal_wins() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[2].resolved_imports[0].target,
-        ResolveResult::InternalModule(FileId(10))
+        &modules[2].resolved_imports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(10),
+            package_name,
+        } if package_name == "shared-lib"
     ));
 }
 
@@ -991,8 +1007,11 @@ fn specifier_upgrades_cross_import_and_re_export() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[1].re_exports[0].target,
-        ResolveResult::InternalModule(FileId(3))
+        &modules[1].re_exports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(3),
+            package_name,
+        } if package_name == "@myorg/utils"
     ));
 }
 
@@ -1199,8 +1218,11 @@ fn specifier_upgrades_re_export_triggers_import_upgrade() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[1].resolved_imports[0].target,
-        ResolveResult::InternalModule(FileId(5))
+        &modules[1].resolved_imports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(5),
+            package_name,
+        } if package_name == "@myorg/shared"
     ));
 }
 
@@ -1230,8 +1252,11 @@ fn specifier_upgrades_re_export_triggers_dynamic_import_upgrade() {
     apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
-        modules[1].resolved_dynamic_imports[0].target,
-        ResolveResult::InternalModule(FileId(7))
+        &modules[1].resolved_dynamic_imports[0].target,
+        ResolveResult::InternalPackageModule {
+            file_id: FileId(7),
+            package_name,
+        } if package_name == "my-workspace-pkg"
     ));
 }
 
@@ -1448,8 +1473,11 @@ fn specifier_upgrade_preserves_actual_require_mechanism() {
         apply_specifier_upgrades(&mut modules, &mut []);
 
         assert!(matches!(
-            modules[1].resolved_imports[0].target,
-            ResolveResult::CommonJsInternalModule(FileId(2))
+            &modules[1].resolved_imports[0].target,
+            ResolveResult::CommonJsInternalPackageModule {
+                file_id: FileId(2),
+                package_name,
+            } if package_name == "shared-package"
         ));
     });
 }

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -6,7 +6,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use fallow_types::discover::{DiscoveredFile, FileId};
 use fallow_types::extract::{
     DynamicImportInfo, DynamicImportPattern, ImportInfo, ImportedName, ModuleLoadMechanism,
-    ReExportInfo, ReplacedModuleTargetFact, RequireCallInfo, SemanticFact,
+    ReExportInfo, RequireCallInfo, SemanticFact, VitestModuleMockAction,
+    VitestModuleMockOperationFact,
 };
 
 use super::dynamic_imports::{
@@ -20,7 +21,8 @@ use super::static_imports::resolve_static_imports;
 use super::types::{CanonicalizeCache, ResolveContext, TsconfigCache};
 use super::upgrades::apply_specifier_upgrades;
 use super::{
-    ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport, resolve_replacement_candidates,
+    ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport, final_replaced_module_targets,
+    resolve_vitest_mock_operations,
 };
 
 fn dummy_span() -> Span {
@@ -92,6 +94,28 @@ fn make_re_export(source: &str, imported: &str, exported: &str) -> ReExportInfo 
         is_type_only: false,
         span: oxc_span::Span::default(),
     }
+}
+
+fn vitest_mock_fact(
+    source: &str,
+    call_start: u32,
+    factory_replaces_original: bool,
+) -> SemanticFact {
+    SemanticFact::VitestModuleMockOperation(VitestModuleMockOperationFact {
+        source: source.to_string(),
+        call_start,
+        action: VitestModuleMockAction::Mock {
+            factory_replaces_original,
+        },
+    })
+}
+
+fn vitest_unmock_fact(source: &str, call_start: u32) -> SemanticFact {
+    SemanticFact::VitestModuleMockOperation(VitestModuleMockOperationFact {
+        source: source.to_string(),
+        call_start,
+        action: VitestModuleMockAction::Unmock,
+    })
 }
 
 fn make_dynamic(
@@ -168,13 +192,18 @@ fn make_resolved_re_export(source: &str, target: ResolveResult) -> ResolvedReExp
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn replaced_module_targets_resolve_internal_files_and_abstain_on_missing_targets() {
+fn vitest_mock_operations_resolve_canonical_targets_and_abstain_on_missing() {
     let dir = tempfile::tempdir().expect("create temp dir");
     let root = dunce::canonicalize(dir.path()).expect("canonicalize temp dir");
     let test_file = root.join("wrapper.test.ts");
     let dependency_file = root.join("dependency.ts");
     std::fs::write(&test_file, "").expect("write test file");
     std::fs::write(&dependency_file, "export const value = 1;").expect("write dependency");
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["*"]}}}"#,
+    )
+    .expect("write tsconfig");
 
     let resolver = specifier::create_resolver(&[], &[]);
     let style_resolver = specifier::create_resolver(&[], &["style".to_string()]);
@@ -209,28 +238,13 @@ fn replaced_module_targets_resolve_internal_files_and_abstain_on_missing_targets
         canonicalize_cache: &canonicalize_cache,
     };
     let facts = [
-        SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
-            source: "./dependency".to_string(),
-        }),
-        SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
-            source: "./dependency".to_string(),
-        }),
-        SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
-            source: "./missing".to_string(),
-        }),
+        vitest_mock_fact("./dependency", 10, true),
+        vitest_mock_fact("./missing", 20, true),
     ];
 
-    let mut candidates = resolve_replacement_candidates(FileId(0), &facts, &ctx, &test_file);
-    apply_specifier_upgrades(&mut [], &mut candidates);
-    let targets: Vec<_> = candidates
-        .into_iter()
-        .filter_map(|candidate| {
-            Some(super::ResolvedReplacedModuleTarget {
-                source_file: candidate.source_file,
-                target_file: candidate.target.internal_file_id()?,
-            })
-        })
-        .collect();
+    let mut operations = resolve_vitest_mock_operations(FileId(0), &facts, &ctx, &test_file);
+    apply_specifier_upgrades(&mut [], &mut operations);
+    let targets = final_replaced_module_targets(operations);
 
     assert_eq!(
         targets,
@@ -238,6 +252,23 @@ fn replaced_module_targets_resolve_internal_files_and_abstain_on_missing_targets
             source_file: FileId(0),
             target_file: FileId(1),
         }]
+    );
+    let facts = [
+        vitest_mock_fact("@/dependency", 10, true),
+        vitest_unmock_fact("./dependency.ts", 20),
+    ];
+
+    let mut operations = resolve_vitest_mock_operations(FileId(0), &facts, &ctx, &test_file);
+    assert!(
+        operations
+            .iter()
+            .all(|operation| operation.target.internal_file_id() == Some(FileId(1))),
+        "alias and explicit-extension spellings should resolve to one canonical target: {operations:?}"
+    );
+    apply_specifier_upgrades(&mut [], &mut operations);
+    assert!(
+        final_replaced_module_targets(operations).is_empty(),
+        "the final unmock must clear an equivalent aliased mock target"
     );
 }
 
@@ -320,22 +351,18 @@ fn cross_tsconfig_bare_alias_upgrades_replacement_target() {
         ResolveResult::InternalModule(FileId(2))
     ));
 
-    let mut candidates = resolve_replacement_candidates(
+    let mut operations = resolve_vitest_mock_operations(
         FileId(1),
-        &[SemanticFact::ReplacedModuleTarget(
-            ReplacedModuleTargetFact {
-                source: "shared-alias".to_string(),
-            },
-        )],
+        &[vitest_mock_fact("shared-alias", 10, true)],
         &ctx,
         &test_file,
     );
-    assert!(matches!(candidates[0].target, ResolveResult::NpmPackage(_)));
+    assert!(matches!(operations[0].target, ResolveResult::NpmPackage(_)));
 
     let mut modules = vec![make_resolved_module(0, donor_imports, vec![], vec![])];
-    apply_specifier_upgrades(&mut modules, &mut candidates);
+    apply_specifier_upgrades(&mut modules, &mut operations);
 
-    assert_eq!(candidates[0].target.internal_file_id(), Some(FileId(2)));
+    assert_eq!(operations[0].target.internal_file_id(), Some(FileId(2)));
 }
 
 #[test]

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -20,8 +20,7 @@ use super::static_imports::resolve_static_imports;
 use super::types::{CanonicalizeCache, ResolveContext, TsconfigCache};
 use super::upgrades::apply_specifier_upgrades;
 use super::{
-    ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport,
-    resolve_replaced_module_targets,
+    ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport, resolve_replacement_candidates,
 };
 
 fn dummy_span() -> Span {
@@ -221,7 +220,17 @@ fn replaced_module_targets_resolve_internal_files_and_abstain_on_missing_targets
         }),
     ];
 
-    let targets = resolve_replaced_module_targets(FileId(0), &facts, &ctx, &test_file);
+    let mut candidates = resolve_replacement_candidates(FileId(0), &facts, &ctx, &test_file);
+    apply_specifier_upgrades(&mut [], &mut candidates);
+    let targets: Vec<_> = candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            Some(super::ResolvedReplacedModuleTarget {
+                source_file: candidate.source_file,
+                target_file: candidate.target.internal_file_id()?,
+            })
+        })
+        .collect();
 
     assert_eq!(
         targets,
@@ -230,6 +239,103 @@ fn replaced_module_targets_resolve_internal_files_and_abstain_on_missing_targets
             target_file: FileId(1),
         }]
     );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn cross_tsconfig_bare_alias_upgrades_replacement_target() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize temp dir");
+    let aliased_dir = root.join("packages/app");
+    let aliased_source = aliased_dir.join("src/source.ts");
+    let test_file = root.join("tests/example.test.ts");
+    let dependency_file = root.join("shared/dependency.ts");
+    std::fs::create_dir_all(aliased_source.parent().expect("source parent"))
+        .expect("create aliased source dir");
+    std::fs::create_dir_all(test_file.parent().expect("test parent"))
+        .expect("create test source dir");
+    std::fs::create_dir_all(dependency_file.parent().expect("dependency parent"))
+        .expect("create dependency dir");
+    std::fs::write(
+        aliased_dir.join("tsconfig.json"),
+        r#"{
+            "compilerOptions": {
+                "baseUrl": ".",
+                "paths": {
+                    "shared-alias": ["../../shared/dependency.ts"]
+                }
+            }
+        }"#,
+    )
+    .expect("write tsconfig");
+    std::fs::write(&aliased_source, "").expect("write aliased source");
+    std::fs::write(&test_file, "").expect("write test source");
+    std::fs::write(&dependency_file, "export const value = 1;").expect("write dependency");
+
+    let resolver = specifier::create_resolver(&[], &[]);
+    let style_resolver = specifier::create_resolver(&[], &["style".to_string()]);
+    let extensions = react_native::build_extensions(&[]);
+    let path_to_id = FxHashMap::from_iter([
+        (aliased_source.as_path(), FileId(0)),
+        (test_file.as_path(), FileId(1)),
+        (dependency_file.as_path(), FileId(2)),
+    ]);
+    let raw_path_to_id = path_to_id.clone();
+    let workspace_roots = FxHashMap::default();
+    let package_manifests = Vec::new();
+    let condition_names = react_native::build_condition_names(&[], &[]);
+    let tsconfig_warned = std::sync::Mutex::new(FxHashSet::default());
+    let tsconfig_cache = TsconfigCache::default();
+    let canonicalize_cache = CanonicalizeCache::default();
+    let ctx = ResolveContext {
+        resolver: &resolver,
+        style_resolver: &style_resolver,
+        extensions: &extensions,
+        path_to_id: &path_to_id,
+        raw_path_to_id: &raw_path_to_id,
+        workspace_roots: &workspace_roots,
+        package_manifests: &package_manifests,
+        condition_names: &condition_names,
+        path_aliases: &[],
+        scss_include_paths: &[],
+        static_dir_mappings: &[],
+        root: &root,
+        canonical_fallback: None,
+        tsconfig_warned: &tsconfig_warned,
+        tsconfig_cache: &tsconfig_cache,
+        canonicalize_cache: &canonicalize_cache,
+    };
+
+    let donor_imports = resolve_static_imports(
+        &ctx,
+        &aliased_source,
+        &[make_import(
+            "shared-alias",
+            ImportedName::Named("value".to_string()),
+            "value",
+        )],
+    );
+    assert!(matches!(
+        donor_imports[0].target,
+        ResolveResult::InternalModule(FileId(2))
+    ));
+
+    let mut candidates = resolve_replacement_candidates(
+        FileId(1),
+        &[SemanticFact::ReplacedModuleTarget(
+            ReplacedModuleTargetFact {
+                source: "shared-alias".to_string(),
+            },
+        )],
+        &ctx,
+        &test_file,
+    );
+    assert!(matches!(candidates[0].target, ResolveResult::NpmPackage(_)));
+
+    let mut modules = vec![make_resolved_module(0, donor_imports, vec![], vec![])];
+    apply_specifier_upgrades(&mut modules, &mut candidates);
+
+    assert_eq!(candidates[0].target.internal_file_id(), Some(FileId(2)));
 }
 
 #[test]
@@ -610,7 +716,7 @@ fn specifier_upgrades_npm_to_internal() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_imports[0].target,
@@ -641,7 +747,7 @@ fn specifier_upgrades_noop_when_no_internal() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[0].resolved_imports[0].target,
@@ -656,7 +762,7 @@ fn specifier_upgrades_noop_when_no_internal() {
 #[test]
 fn specifier_upgrades_empty_modules() {
     let mut modules: Vec<ResolvedModule> = vec![];
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
     assert!(modules.is_empty());
 }
 
@@ -683,7 +789,7 @@ fn specifier_upgrades_skips_relative_specifiers() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_imports[0].target,
@@ -714,7 +820,7 @@ fn specifier_upgrades_applies_to_dynamic_imports() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_dynamic_imports[0].target,
@@ -745,7 +851,7 @@ fn specifier_upgrades_applies_to_re_exports() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].re_exports[0].target,
@@ -776,7 +882,7 @@ fn specifier_upgrades_does_not_downgrade_internal() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[0].resolved_imports[0].target,
@@ -820,7 +926,7 @@ fn specifier_upgrades_first_internal_wins() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[2].resolved_imports[0].target,
@@ -851,7 +957,7 @@ fn specifier_upgrades_does_not_touch_unresolvable() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_imports[0].target,
@@ -882,7 +988,7 @@ fn specifier_upgrades_cross_import_and_re_export() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].re_exports[0].target,
@@ -1026,7 +1132,7 @@ fn static_import_bare_specifier_becomes_npm_package() {
 }
 
 #[test]
-fn require_bare_specifier_becomes_npm_package() {
+fn require_bare_specifier_retains_commonjs_provenance() {
     with_empty_ctx(|ctx| {
         let req = make_require("express", vec![], Some("express"));
         let file = Path::new("/project/src/app.js");
@@ -1035,7 +1141,7 @@ fn require_bare_specifier_becomes_npm_package() {
         assert_eq!(result.len(), 1);
         assert!(matches!(
             result[0].target,
-            ResolveResult::NpmPackage(ref pkg) if pkg == "express"
+            ResolveResult::CommonJsNpmPackage(ref pkg) if pkg == "express"
         ));
     });
 }
@@ -1087,7 +1193,7 @@ fn specifier_upgrades_re_export_triggers_import_upgrade() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_imports[0].target,
@@ -1118,7 +1224,7 @@ fn specifier_upgrades_re_export_triggers_dynamic_import_upgrade() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_dynamic_imports[0].target,
@@ -1151,7 +1257,7 @@ fn specifier_upgrades_does_not_upgrade_external_file() {
         ),
     ];
 
-    apply_specifier_upgrades(&mut modules);
+    apply_specifier_upgrades(&mut modules, &mut []);
 
     assert!(matches!(
         modules[1].resolved_imports[0].target,
@@ -1306,6 +1412,40 @@ fn dynamic_import_preserves_source_span() {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].info.span.start, 42);
         assert_eq!(result[0].info.span.end, 84);
+    });
+}
+
+#[test]
+fn specifier_upgrade_preserves_actual_require_mechanism() {
+    with_empty_ctx(|ctx| {
+        let require_imports = resolve_single_require(
+            ctx,
+            Path::new("/project/src/consumer.js"),
+            &make_require("shared-package", vec![], Some("shared")),
+        );
+        assert!(matches!(
+            require_imports[0].target,
+            ResolveResult::CommonJsNpmPackage(_)
+        ));
+
+        let mut modules = vec![
+            make_resolved_module(
+                0,
+                vec![make_resolved_import(
+                    "shared-package",
+                    ResolveResult::InternalModule(FileId(2)),
+                )],
+                vec![],
+                vec![],
+            ),
+            make_resolved_module(1, require_imports, vec![], vec![]),
+        ];
+        apply_specifier_upgrades(&mut modules, &mut []);
+
+        assert!(matches!(
+            modules[1].resolved_imports[0].target,
+            ResolveResult::CommonJsInternalModule(FileId(2))
+        ));
     });
 }
 

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -6,7 +6,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use fallow_types::discover::{DiscoveredFile, FileId};
 use fallow_types::extract::{
     DynamicImportInfo, DynamicImportPattern, ImportInfo, ImportedName, ReExportInfo,
-    RequireCallInfo,
+    ReplacedModuleTargetFact, RequireCallInfo, SemanticFact,
 };
 
 use super::dynamic_imports::{
@@ -19,7 +19,10 @@ use super::specifier;
 use super::static_imports::resolve_static_imports;
 use super::types::{CanonicalizeCache, ResolveContext, TsconfigCache};
 use super::upgrades::apply_specifier_upgrades;
-use super::{ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport};
+use super::{
+    ResolveResult, ResolvedImport, ResolvedModule, ResolvedReExport,
+    resolve_replaced_module_targets,
+};
 
 fn dummy_span() -> Span {
     Span::new(0, 0)
@@ -162,6 +165,71 @@ fn make_resolved_re_export(source: &str, target: ResolveResult) -> ResolvedReExp
         info: make_re_export(source, "x", "x"),
         target,
     }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn replaced_module_targets_resolve_internal_files_and_abstain_on_missing_targets() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let root = dunce::canonicalize(dir.path()).expect("canonicalize temp dir");
+    let test_file = root.join("wrapper.test.ts");
+    let dependency_file = root.join("dependency.ts");
+    std::fs::write(&test_file, "").expect("write test file");
+    std::fs::write(&dependency_file, "export const value = 1;").expect("write dependency");
+
+    let resolver = specifier::create_resolver(&[], &[]);
+    let style_resolver = specifier::create_resolver(&[], &["style".to_string()]);
+    let extensions = react_native::build_extensions(&[]);
+    let path_to_id = FxHashMap::from_iter([
+        (test_file.as_path(), FileId(0)),
+        (dependency_file.as_path(), FileId(1)),
+    ]);
+    let raw_path_to_id = path_to_id.clone();
+    let workspace_roots = FxHashMap::default();
+    let package_manifests = Vec::new();
+    let condition_names = react_native::build_condition_names(&[], &[]);
+    let tsconfig_warned = std::sync::Mutex::new(FxHashSet::default());
+    let tsconfig_cache = TsconfigCache::default();
+    let canonicalize_cache = CanonicalizeCache::default();
+    let ctx = ResolveContext {
+        resolver: &resolver,
+        style_resolver: &style_resolver,
+        extensions: &extensions,
+        path_to_id: &path_to_id,
+        raw_path_to_id: &raw_path_to_id,
+        workspace_roots: &workspace_roots,
+        package_manifests: &package_manifests,
+        condition_names: &condition_names,
+        path_aliases: &[],
+        scss_include_paths: &[],
+        static_dir_mappings: &[],
+        root: &root,
+        canonical_fallback: None,
+        tsconfig_warned: &tsconfig_warned,
+        tsconfig_cache: &tsconfig_cache,
+        canonicalize_cache: &canonicalize_cache,
+    };
+    let facts = [
+        SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+            source: "./dependency".to_string(),
+        }),
+        SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+            source: "./dependency".to_string(),
+        }),
+        SemanticFact::ReplacedModuleTarget(ReplacedModuleTargetFact {
+            source: "./missing".to_string(),
+        }),
+    ];
+
+    let targets = resolve_replaced_module_targets(FileId(0), &facts, &ctx, &test_file);
+
+    assert_eq!(
+        targets,
+        vec![super::ResolvedReplacedModuleTarget {
+            source_file: FileId(0),
+            target_file: FileId(1),
+        }]
+    );
 }
 
 #[test]

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -5,8 +5,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::discover::{DiscoveredFile, FileId};
 use fallow_types::extract::{
-    DynamicImportInfo, DynamicImportPattern, ImportInfo, ImportedName, ReExportInfo,
-    ReplacedModuleTargetFact, RequireCallInfo, SemanticFact,
+    DynamicImportInfo, DynamicImportPattern, ImportInfo, ImportedName, ModuleLoadMechanism,
+    ReExportInfo, ReplacedModuleTargetFact, RequireCallInfo, SemanticFact,
 };
 
 use super::dynamic_imports::{
@@ -1003,6 +1003,7 @@ fn dynamic_patterns_matches_files_in_dir() {
         prefix: "./locales/".into(),
         suffix: Some(".json".into()),
         span: dummy_span(),
+        mechanism: ModuleLoadMechanism::EsModule,
     }];
     let canonical_paths = vec![
         PathBuf::from("/project/src/locales/en.json"),
@@ -1042,6 +1043,7 @@ fn dynamic_patterns_no_matches_returns_empty() {
         prefix: "./locales/".into(),
         suffix: Some(".json".into()),
         span: dummy_span(),
+        mechanism: ModuleLoadMechanism::EsModule,
     }];
     let canonical_paths = vec![PathBuf::from("/project/src/utils.ts")];
     let files = vec![DiscoveredFile {
@@ -1076,6 +1078,7 @@ fn dynamic_patterns_glob_prefix_passthrough() {
         prefix: "./**/*.ts".into(),
         suffix: None,
         span: dummy_span(),
+        mechanism: ModuleLoadMechanism::EsModule,
     }];
     let canonical_paths = vec![
         PathBuf::from("/project/src/utils.ts"),
@@ -1272,6 +1275,7 @@ fn dynamic_patterns_prefix_without_suffix() {
         prefix: "./pages/".into(),
         suffix: None,
         span: dummy_span(),
+        mechanism: ModuleLoadMechanism::EsModule,
     }];
     let canonical_paths = vec![
         PathBuf::from("/project/src/pages/Home.tsx"),
@@ -1311,6 +1315,7 @@ fn dynamic_patterns_empty_canonical_paths() {
         prefix: "./locales/".into(),
         suffix: Some(".json".into()),
         span: dummy_span(),
+        mechanism: ModuleLoadMechanism::EsModule,
     }];
 
     let result = resolve_dynamic_patterns(from_dir, &patterns, &[], &[]);

--- a/crates/graph/src/resolve/types.rs
+++ b/crates/graph/src/resolve/types.rs
@@ -102,6 +102,24 @@ impl ResolveResult {
     }
 }
 
+/// Resolver output for one extracted project.
+#[derive(Debug, Default)]
+pub struct ResolvedProject {
+    /// Modules with every ordinary import and re-export resolved.
+    pub modules: Vec<ResolvedModule>,
+    /// Proven test-time replacements whose targets resolve inside the project.
+    pub replaced_module_targets: Vec<ResolvedReplacedModuleTarget>,
+}
+
+/// One project-internal module replacement resolved from its declaring source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedReplacedModuleTarget {
+    /// File that declares the replacement fact.
+    pub source_file: FileId,
+    /// Project file replaced for this source's test-root traversal.
+    pub target_file: FileId,
+}
+
 /// A resolved import with its target.
 #[derive(Debug, Clone)]
 pub struct ResolvedImport {

--- a/crates/graph/src/resolve/types.rs
+++ b/crates/graph/src/resolve/types.rs
@@ -14,6 +14,8 @@ use fallow_types::discover::FileId;
 pub enum ResolveResult {
     /// Resolved to a file within the project.
     InternalModule(FileId),
+    /// Resolved from a CommonJS `require()` to a file within the project.
+    CommonJsInternalModule(FileId),
     /// Resolved to a project file through a framework convention auto-import.
     SyntheticAutoImport(FileId),
     /// Resolved to a workspace or self package source file while preserving
@@ -22,6 +24,13 @@ pub enum ResolveResult {
         /// Internal source file reached by the package map.
         file_id: FileId,
         /// Package name that was used in the import specifier.
+        package_name: String,
+    },
+    /// Resolved from a CommonJS `require()` to workspace or self-package source.
+    CommonJsInternalPackageModule {
+        /// Internal source file reached by the package map.
+        file_id: FileId,
+        /// Package name used in the require specifier.
         package_name: String,
     },
     /// Resolved to a file outside the project (`node_modules`, `.json`, etc.).
@@ -38,8 +47,10 @@ impl ResolveResult {
     pub const fn internal_file_id(&self) -> Option<FileId> {
         match self {
             Self::InternalModule(file_id)
+            | Self::CommonJsInternalModule(file_id)
             | Self::SyntheticAutoImport(file_id)
-            | Self::InternalPackageModule { file_id, .. } => Some(*file_id),
+            | Self::InternalPackageModule { file_id, .. }
+            | Self::CommonJsInternalPackageModule { file_id, .. } => Some(*file_id),
             Self::ExternalFile(_) | Self::NpmPackage(_) | Self::Unresolvable(_) => None,
         }
     }
@@ -50,14 +61,40 @@ impl ResolveResult {
         matches!(self, Self::SyntheticAutoImport(_))
     }
 
+    /// Return whether this internal edge originated from CommonJS `require()`.
+    #[must_use]
+    pub const fn is_commonjs_require(&self) -> bool {
+        matches!(
+            self,
+            Self::CommonJsInternalModule(_) | Self::CommonJsInternalPackageModule { .. }
+        )
+    }
+
+    /// Retain CommonJS provenance on project-internal resolution results.
+    #[must_use]
+    pub fn into_commonjs_require(self) -> Self {
+        match self {
+            Self::InternalModule(file_id) => Self::CommonJsInternalModule(file_id),
+            Self::InternalPackageModule {
+                file_id,
+                package_name,
+            } => Self::CommonJsInternalPackageModule {
+                file_id,
+                package_name,
+            },
+            other => other,
+        }
+    }
+
     /// Return the package name that should receive dependency usage credit.
     #[must_use]
     pub fn package_usage_name(&self) -> Option<&str> {
         match self {
-            Self::InternalPackageModule { package_name, .. } | Self::NpmPackage(package_name) => {
-                Some(package_name)
-            }
+            Self::InternalPackageModule { package_name, .. }
+            | Self::CommonJsInternalPackageModule { package_name, .. }
+            | Self::NpmPackage(package_name) => Some(package_name),
             Self::InternalModule(_)
+            | Self::CommonJsInternalModule(_)
             | Self::SyntheticAutoImport(_)
             | Self::ExternalFile(_)
             | Self::Unresolvable(_) => None,
@@ -463,6 +500,29 @@ mod tests {
         assert!(fallback.get(Path::new("/nonexistent/file.ts")).is_none());
 
         let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn commonjs_provenance_wraps_internal_targets_only() {
+        assert!(matches!(
+            ResolveResult::InternalModule(FileId(4)).into_commonjs_require(),
+            ResolveResult::CommonJsInternalModule(FileId(4))
+        ));
+        assert!(matches!(
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(5),
+                package_name: "pkg".to_string(),
+            }
+            .into_commonjs_require(),
+            ResolveResult::CommonJsInternalPackageModule {
+                file_id: FileId(5),
+                package_name,
+            } if package_name == "pkg"
+        ));
+        assert!(matches!(
+            ResolveResult::NpmPackage("pkg".to_string()).into_commonjs_require(),
+            ResolveResult::NpmPackage(package_name) if package_name == "pkg"
+        ));
     }
 }
 

--- a/crates/graph/src/resolve/types.rs
+++ b/crates/graph/src/resolve/types.rs
@@ -37,6 +37,8 @@ pub enum ResolveResult {
     ExternalFile(PathBuf),
     /// Bare specifier — an npm package.
     NpmPackage(String),
+    /// Bare npm package referenced through CommonJS `require()`.
+    CommonJsNpmPackage(String),
     /// Could not resolve.
     Unresolvable(String),
 }
@@ -51,7 +53,10 @@ impl ResolveResult {
             | Self::SyntheticAutoImport(file_id)
             | Self::InternalPackageModule { file_id, .. }
             | Self::CommonJsInternalPackageModule { file_id, .. } => Some(*file_id),
-            Self::ExternalFile(_) | Self::NpmPackage(_) | Self::Unresolvable(_) => None,
+            Self::ExternalFile(_)
+            | Self::NpmPackage(_)
+            | Self::CommonJsNpmPackage(_)
+            | Self::Unresolvable(_) => None,
         }
     }
 
@@ -61,16 +66,24 @@ impl ResolveResult {
         matches!(self, Self::SyntheticAutoImport(_))
     }
 
-    /// Return whether this internal edge originated from CommonJS `require()`.
+    /// Return whether this edge originated from CommonJS `require()`.
     #[must_use]
     pub const fn is_commonjs_require(&self) -> bool {
         matches!(
             self,
-            Self::CommonJsInternalModule(_) | Self::CommonJsInternalPackageModule { .. }
+            Self::CommonJsInternalModule(_)
+                | Self::CommonJsInternalPackageModule { .. }
+                | Self::CommonJsNpmPackage(_)
         )
     }
 
-    /// Retain CommonJS provenance on project-internal resolution results.
+    /// Return whether this target is an unresolved bare package edge.
+    #[must_use]
+    pub const fn is_bare_package(&self) -> bool {
+        matches!(self, Self::NpmPackage(_) | Self::CommonJsNpmPackage(_))
+    }
+
+    /// Retain CommonJS provenance on targets that can participate in upgrades.
     #[must_use]
     pub fn into_commonjs_require(self) -> Self {
         match self {
@@ -82,6 +95,24 @@ impl ResolveResult {
                 file_id,
                 package_name,
             },
+            Self::NpmPackage(package_name) => Self::CommonJsNpmPackage(package_name),
+            other => other,
+        }
+    }
+
+    /// Remove CommonJS provenance while preserving the resolved destination.
+    #[must_use]
+    pub fn into_es_module(self) -> Self {
+        match self {
+            Self::CommonJsInternalModule(file_id) => Self::InternalModule(file_id),
+            Self::CommonJsInternalPackageModule {
+                file_id,
+                package_name,
+            } => Self::InternalPackageModule {
+                file_id,
+                package_name,
+            },
+            Self::CommonJsNpmPackage(package_name) => Self::NpmPackage(package_name),
             other => other,
         }
     }
@@ -92,7 +123,8 @@ impl ResolveResult {
         match self {
             Self::InternalPackageModule { package_name, .. }
             | Self::CommonJsInternalPackageModule { package_name, .. }
-            | Self::NpmPackage(package_name) => Some(package_name),
+            | Self::NpmPackage(package_name)
+            | Self::CommonJsNpmPackage(package_name) => Some(package_name),
             Self::InternalModule(_)
             | Self::CommonJsInternalModule(_)
             | Self::SyntheticAutoImport(_)
@@ -521,7 +553,7 @@ mod tests {
     }
 
     #[test]
-    fn commonjs_provenance_wraps_internal_targets_only() {
+    fn commonjs_provenance_wraps_internal_and_bare_package_targets() {
         assert!(matches!(
             ResolveResult::InternalModule(FileId(4)).into_commonjs_require(),
             ResolveResult::CommonJsInternalModule(FileId(4))
@@ -539,7 +571,7 @@ mod tests {
         ));
         assert!(matches!(
             ResolveResult::NpmPackage("pkg".to_string()).into_commonjs_require(),
-            ResolveResult::NpmPackage(package_name) if package_name == "pkg"
+            ResolveResult::CommonJsNpmPackage(package_name) if package_name == "pkg"
         ));
     }
 }

--- a/crates/graph/src/resolve/upgrades.rs
+++ b/crates/graph/src/resolve/upgrades.rs
@@ -287,8 +287,11 @@ mod tests {
         apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
-            resolved[1].re_exports[0].target,
-            ResolveResult::InternalModule(FileId(10))
+            &resolved[1].re_exports[0].target,
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                package_name,
+            } if package_name == "preact"
         ));
     }
 
@@ -317,8 +320,11 @@ mod tests {
             ResolveResult::InternalModule(FileId(10))
         ));
         assert!(matches!(
-            resolved[1].resolved_imports[1].target,
-            ResolveResult::InternalModule(FileId(10))
+            &resolved[1].resolved_imports[1].target,
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                package_name,
+            } if package_name == "preact"
         ));
     }
 
@@ -383,8 +389,11 @@ mod tests {
         apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
-            resolved[1].resolved_dynamic_imports[0].target,
-            ResolveResult::InternalModule(FileId(10))
+            &resolved[1].resolved_dynamic_imports[0].target,
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                package_name,
+            } if package_name == "preact"
         ));
     }
 
@@ -435,8 +444,11 @@ mod tests {
         apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
-            resolved[2].resolved_imports[0].target,
-            ResolveResult::InternalModule(FileId(10))
+            &resolved[2].resolved_imports[0].target,
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                package_name,
+            } if package_name == "preact"
         ));
     }
 
@@ -458,8 +470,11 @@ mod tests {
         apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
-            resolved[1].resolved_imports[0].target,
-            ResolveResult::InternalModule(FileId(10))
+            &resolved[1].resolved_imports[0].target,
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                package_name,
+            } if package_name == "preact"
         ));
     }
 

--- a/crates/graph/src/resolve/upgrades.rs
+++ b/crates/graph/src/resolve/upgrades.rs
@@ -22,14 +22,18 @@ use super::ResolvedModule;
 use super::path_info::is_bare_specifier;
 use super::types::ResolveResult;
 
-/// A replacement fact retaining enough resolution state for the global
-/// cross-tsconfig bare-specifier upgrade.
+/// A Vitest mock operation retaining enough resolution state for the global
+/// cross-tsconfig bare-specifier upgrade and canonical final-state selection.
 #[derive(Debug)]
-pub(super) struct ResolvedReplacementCandidate {
-    /// File that declared this replacement.
+pub(super) struct ResolvedVitestMockOperation {
+    /// File that declared this operation.
     pub(super) source_file: FileId,
-    /// Literal module specifier from the replacement call.
+    /// Literal module specifier from the mock API call.
     pub(super) source_specifier: String,
+    /// Source-order position of the call within `source_file`.
+    pub(super) call_start: u32,
+    /// Typed mock or unmock action.
+    pub(super) action: fallow_types::extract::VitestModuleMockAction,
     /// Per-file resolution result before the global upgrade.
     pub(super) target: ResolveResult,
 }
@@ -51,7 +55,7 @@ pub(super) struct ResolvedReplacementCandidate {
 /// imprecise for that edge case , both files get connected regardless.
 pub(super) fn apply_specifier_upgrades(
     resolved: &mut [ResolvedModule],
-    replacements: &mut [ResolvedReplacementCandidate],
+    mock_operations: &mut [ResolvedVitestMockOperation],
 ) {
     let mut specifier_upgrades: FxHashMap<String, ResolveResult> = FxHashMap::default();
     for module in resolved.iter() {
@@ -75,13 +79,13 @@ pub(super) fn apply_specifier_upgrades(
         }
     }
 
-    for replacement in replacements.iter() {
-        if is_bare_specifier(&replacement.source_specifier)
-            && replacement.target.internal_file_id().is_some()
+    for operation in mock_operations.iter() {
+        if is_bare_specifier(&operation.source_specifier)
+            && operation.target.internal_file_id().is_some()
         {
             specifier_upgrades
-                .entry(replacement.source_specifier.clone())
-                .or_insert_with(|| replacement.target.clone().into_es_module());
+                .entry(operation.source_specifier.clone())
+                .or_insert_with(|| operation.target.clone().into_es_module());
         }
     }
 
@@ -102,10 +106,10 @@ pub(super) fn apply_specifier_upgrades(
         }
     }
 
-    for replacement in replacements {
+    for operation in mock_operations {
         upgrade_bare_target(
-            &replacement.source_specifier,
-            &mut replacement.target,
+            &operation.source_specifier,
+            &mut operation.target,
             &specifier_upgrades,
         );
     }

--- a/crates/graph/src/resolve/upgrades.rs
+++ b/crates/graph/src/resolve/upgrades.rs
@@ -16,9 +16,23 @@
 
 use rustc_hash::FxHashMap;
 
+use fallow_types::discover::FileId;
+
 use super::ResolvedModule;
 use super::path_info::is_bare_specifier;
 use super::types::ResolveResult;
+
+/// A replacement fact retaining enough resolution state for the global
+/// cross-tsconfig bare-specifier upgrade.
+#[derive(Debug)]
+pub(super) struct ResolvedReplacementCandidate {
+    /// File that declared this replacement.
+    pub(super) source_file: FileId,
+    /// Literal module specifier from the replacement call.
+    pub(super) source_specifier: String,
+    /// Per-file resolution result before the global upgrade.
+    pub(super) target: ResolveResult,
+}
 
 /// Post-resolution pass: deterministic specifier upgrade.
 ///
@@ -35,7 +49,10 @@ use super::types::ResolveResult;
 /// Note: if two tsconfigs map the same specifier to different `FileId`s, the first one
 /// encountered (by module order = `FileId` order) wins. This is deterministic but may be
 /// imprecise for that edge case , both files get connected regardless.
-pub(super) fn apply_specifier_upgrades(resolved: &mut [ResolvedModule]) {
+pub(super) fn apply_specifier_upgrades(
+    resolved: &mut [ResolvedModule],
+    replacements: &mut [ResolvedReplacementCandidate],
+) {
     let mut specifier_upgrades: FxHashMap<String, ResolveResult> = FxHashMap::default();
     for module in resolved.iter() {
         for imp in module
@@ -46,15 +63,25 @@ pub(super) fn apply_specifier_upgrades(resolved: &mut [ResolvedModule]) {
             if is_bare_specifier(&imp.info.source) && imp.target.internal_file_id().is_some() {
                 specifier_upgrades
                     .entry(imp.info.source.clone())
-                    .or_insert_with(|| imp.target.clone());
+                    .or_insert_with(|| imp.target.clone().into_es_module());
             }
         }
         for re in &module.re_exports {
             if is_bare_specifier(&re.info.source) && re.target.internal_file_id().is_some() {
                 specifier_upgrades
                     .entry(re.info.source.clone())
-                    .or_insert_with(|| re.target.clone());
+                    .or_insert_with(|| re.target.clone().into_es_module());
             }
+        }
+    }
+
+    for replacement in replacements.iter() {
+        if is_bare_specifier(&replacement.source_specifier)
+            && replacement.target.internal_file_id().is_some()
+        {
+            specifier_upgrades
+                .entry(replacement.source_specifier.clone())
+                .or_insert_with(|| replacement.target.clone().into_es_module());
         }
     }
 
@@ -68,20 +95,40 @@ pub(super) fn apply_specifier_upgrades(resolved: &mut [ResolvedModule]) {
             .iter_mut()
             .chain(module.resolved_dynamic_imports.iter_mut())
         {
-            if matches!(imp.target, ResolveResult::NpmPackage(_))
-                && let Some(target) = specifier_upgrades.get(&imp.info.source)
-            {
-                imp.target = target.clone();
-            }
+            upgrade_bare_target(&imp.info.source, &mut imp.target, &specifier_upgrades);
         }
         for re in &mut module.re_exports {
-            if matches!(re.target, ResolveResult::NpmPackage(_))
-                && let Some(target) = specifier_upgrades.get(&re.info.source)
-            {
-                re.target = target.clone();
-            }
+            upgrade_bare_target(&re.info.source, &mut re.target, &specifier_upgrades);
         }
     }
+
+    for replacement in replacements {
+        upgrade_bare_target(
+            &replacement.source_specifier,
+            &mut replacement.target,
+            &specifier_upgrades,
+        );
+    }
+}
+
+fn upgrade_bare_target(
+    source_specifier: &str,
+    target: &mut ResolveResult,
+    specifier_upgrades: &FxHashMap<String, ResolveResult>,
+) {
+    if !target.is_bare_package() {
+        return;
+    }
+    let Some(upgraded_target) = specifier_upgrades.get(source_specifier) else {
+        return;
+    };
+
+    let is_commonjs_require = target.is_commonjs_require();
+    *target = if is_commonjs_require {
+        upgraded_target.clone().into_commonjs_require()
+    } else {
+        upgraded_target.clone().into_es_module()
+    };
 }
 
 #[cfg(test)]
@@ -155,7 +202,7 @@ mod tests {
     #[test]
     fn empty_modules_no_crash() {
         let mut resolved: Vec<ResolvedModule> = vec![];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
         assert!(resolved.is_empty());
     }
 
@@ -167,7 +214,7 @@ mod tests {
             make_import("preact", ResolveResult::InternalModule(FileId(2))),
         ];
         let mut resolved = vec![m];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[0].resolved_imports[0].target,
@@ -194,7 +241,7 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[0].resolved_imports[0].target,
@@ -221,7 +268,7 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[1].re_exports[0].target,
@@ -247,7 +294,7 @@ mod tests {
         ];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[1].resolved_imports[0].target,
@@ -267,7 +314,7 @@ mod tests {
             make_import("react", ResolveResult::NpmPackage("react".to_string())),
         ];
         let mut resolved = vec![m];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[0].resolved_imports[0].target,
@@ -294,7 +341,7 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[1].resolved_imports[0].target,
@@ -317,7 +364,7 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[1].resolved_dynamic_imports[0].target,
@@ -340,7 +387,7 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[1].resolved_imports[0].target,
@@ -369,7 +416,7 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1, m2];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[2].resolved_imports[0].target,
@@ -392,7 +439,51 @@ mod tests {
         )];
 
         let mut resolved = vec![m0, m1];
-        apply_specifier_upgrades(&mut resolved);
+        apply_specifier_upgrades(&mut resolved, &mut []);
+
+        assert!(matches!(
+            resolved[1].resolved_imports[0].target,
+            ResolveResult::InternalModule(FileId(10))
+        ));
+    }
+
+    #[test]
+    fn esm_donor_preserves_commonjs_recipient_mechanism() {
+        let mut esm_module = empty_module(FileId(0));
+        esm_module.resolved_imports = vec![make_import(
+            "shared-package",
+            ResolveResult::InternalModule(FileId(10)),
+        )];
+        let mut commonjs_module = empty_module(FileId(1));
+        commonjs_module.resolved_imports = vec![make_import(
+            "shared-package",
+            ResolveResult::CommonJsNpmPackage("shared-package".to_string()),
+        )];
+
+        let mut resolved = vec![esm_module, commonjs_module];
+        apply_specifier_upgrades(&mut resolved, &mut []);
+
+        assert!(matches!(
+            resolved[1].resolved_imports[0].target,
+            ResolveResult::CommonJsInternalModule(FileId(10))
+        ));
+    }
+
+    #[test]
+    fn commonjs_donor_does_not_contaminate_esm_recipient() {
+        let mut commonjs_module = empty_module(FileId(0));
+        commonjs_module.resolved_imports = vec![make_import(
+            "shared-package",
+            ResolveResult::CommonJsInternalModule(FileId(10)),
+        )];
+        let mut esm_module = empty_module(FileId(1));
+        esm_module.resolved_imports = vec![make_import(
+            "shared-package",
+            ResolveResult::NpmPackage("shared-package".to_string()),
+        )];
+
+        let mut resolved = vec![commonjs_module, esm_module];
+        apply_specifier_upgrades(&mut resolved, &mut []);
 
         assert!(matches!(
             resolved[1].resolved_imports[0].target,

--- a/crates/graph/src/resolve/upgrades.rs
+++ b/crates/graph/src/resolve/upgrades.rs
@@ -42,9 +42,9 @@ pub(super) struct ResolvedReplacementCandidate {
 /// makes the per-file result depend on which thread resolved first (non-deterministic).
 ///
 /// Scans all resolved imports/re-exports to find bare specifiers where ANY file resolved
-/// to `InternalModule`. For those specifiers, upgrades all `NpmPackage` results to
-/// `InternalModule`. This is correct because if any tsconfig context maps a specifier to
-/// a project source file, that source file IS the origin of the package.
+/// to a project-internal module. For those specifiers, upgrades all bare-package results
+/// to internal package results. This preserves both the canonical source destination and
+/// the package identity used by dependency diagnostics.
 ///
 /// Note: if two tsconfigs map the same specifier to different `FileId`s, the first one
 /// encountered (by module order = `FileId` order) wins. This is deterministic but may be
@@ -122,12 +122,25 @@ fn upgrade_bare_target(
     let Some(upgraded_target) = specifier_upgrades.get(source_specifier) else {
         return;
     };
+    let Some(file_id) = upgraded_target.internal_file_id() else {
+        return;
+    };
 
-    let is_commonjs_require = target.is_commonjs_require();
+    let (package_name, is_commonjs_require) = match target {
+        ResolveResult::NpmPackage(package_name) => (package_name.clone(), false),
+        ResolveResult::CommonJsNpmPackage(package_name) => (package_name.clone(), true),
+        _ => return,
+    };
     *target = if is_commonjs_require {
-        upgraded_target.clone().into_commonjs_require()
+        ResolveResult::CommonJsInternalPackageModule {
+            file_id,
+            package_name,
+        }
     } else {
-        upgraded_target.clone().into_es_module()
+        ResolveResult::InternalPackageModule {
+            file_id,
+            package_name,
+        }
     };
 }
 
@@ -249,7 +262,10 @@ mod tests {
         ));
         assert!(matches!(
             resolved[1].resolved_imports[0].target,
-            ResolveResult::InternalModule(FileId(10))
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                ref package_name,
+            } if package_name == "preact"
         ));
     }
 
@@ -465,7 +481,10 @@ mod tests {
 
         assert!(matches!(
             resolved[1].resolved_imports[0].target,
-            ResolveResult::CommonJsInternalModule(FileId(10))
+            ResolveResult::CommonJsInternalPackageModule {
+                file_id: FileId(10),
+                ref package_name,
+            } if package_name == "shared-package"
         ));
     }
 
@@ -487,7 +506,10 @@ mod tests {
 
         assert!(matches!(
             resolved[1].resolved_imports[0].target,
-            ResolveResult::InternalModule(FileId(10))
+            ResolveResult::InternalPackageModule {
+                file_id: FileId(10),
+                ref package_name,
+            } if package_name == "shared-package"
         ));
     }
 }

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1605,6 +1605,13 @@ pub enum SemanticFact {
     /// A whole-object use of `this.<field>...` tied to its exact enclosing class.
     /// Appended because bitcode encodes enum variants by ordinal.
     ClassThisWholeObjectUse(ClassThisWholeObjectUseFact),
+    /// A module target that an explicitly imported Vitest `vi.mock` factory
+    /// provably replaces without loading the original module.
+    ///
+    /// Appended because bitcode encodes enum variants by ordinal. The ordinary
+    /// dynamic-import fact for the same source remains authoritative for graph
+    /// reachability and unresolved-import diagnostics.
+    ReplacedModuleTarget(ReplacedModuleTargetFact),
 }
 
 /// Iterate Angular template member names from typed semantic facts.
@@ -2205,6 +2212,18 @@ pub struct InstanceExportBindingFact {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct DynamicCustomElementRenderFact;
+
+/// Static source target of a proven complete test-time module replacement.
+///
+/// The declaring [`ModuleInfo::file_id`] owns the test-root provenance. The
+/// resolver consumes `source` through its canonical specifier pipeline; this
+/// fact deliberately carries no resolved path or duplicate diagnostic span.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ReplacedModuleTargetFact {
+    /// Static module specifier passed to the replacement API.
+    pub source: String,
+}
 
 /// A `this`-rooted member access with exact enclosing-class provenance.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1241,9 +1241,9 @@ const _: () = assert!(std::mem::size_of::<FlagUse>() <= 96);
 )]
 #[repr(u8)]
 pub enum ModuleLoadMechanism {
-    /// ECMAScript module loading through `import()` or `import.meta.glob`.
+    /// ECMAScript module loading through imports, re-exports, or import globs.
     EsModule = 0,
-    /// CommonJS module loading through `require.context`.
+    /// CommonJS module loading through `require()` or `require.context`.
     CommonJsRequire = 1,
 }
 

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1226,6 +1226,27 @@ pub struct FlagUse {
 
 const _: () = assert!(std::mem::size_of::<FlagUse>() <= 96);
 
+/// The runtime mechanism used to load a module.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    bitcode::Encode,
+    bitcode::Decode,
+)]
+#[repr(u8)]
+pub enum ModuleLoadMechanism {
+    /// ECMAScript module loading through `import()` or `import.meta.glob`.
+    EsModule = 0,
+    /// CommonJS module loading through `require.context`.
+    CommonJsRequire = 1,
+}
+
 /// A dynamic import with a partially resolved pattern.
 #[derive(Debug, Clone)]
 pub struct DynamicImportPattern {
@@ -1235,6 +1256,8 @@ pub struct DynamicImportPattern {
     pub suffix: Option<String>,
     /// Source span in the original file.
     pub span: Span,
+    /// Runtime mechanism used to load modules matching this pattern.
+    pub mechanism: ModuleLoadMechanism,
 }
 
 /// Visibility tag from JSDoc/TSDoc comments that suppresses unused-export detection.
@@ -3149,6 +3172,7 @@ mod tests {
                 prefix: "./pages/".to_string(),
                 suffix: Some(".tsx".to_string()),
                 span: span(),
+                mechanism: ModuleLoadMechanism::EsModule,
             }],
             require_calls: vec![RequireCallInfo {
                 source: "./required".to_string(),

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1628,13 +1628,13 @@ pub enum SemanticFact {
     /// A whole-object use of `this.<field>...` tied to its exact enclosing class.
     /// Appended because bitcode encodes enum variants by ordinal.
     ClassThisWholeObjectUse(ClassThisWholeObjectUseFact),
-    /// A module target that an explicitly imported Vitest `vi.mock` factory
-    /// provably replaces without loading the original module.
+    /// An ordered Vitest module-mock operation with direct imported-`vi`
+    /// provenance.
     ///
     /// Appended because bitcode encodes enum variants by ordinal. The ordinary
     /// dynamic-import fact for the same source remains authoritative for graph
     /// reachability and unresolved-import diagnostics.
-    ReplacedModuleTarget(ReplacedModuleTargetFact),
+    VitestModuleMockOperation(VitestModuleMockOperationFact),
 }
 
 /// Iterate Angular template member names from typed semantic facts.
@@ -2236,16 +2236,48 @@ pub struct InstanceExportBindingFact {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct DynamicCustomElementRenderFact;
 
-/// Static source target of a proven complete test-time module replacement.
+/// The action performed by a Vitest module-mock operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum VitestModuleMockAction {
+    /// Register a mock. `factory_replaces_original` is true only when the
+    /// factory is structurally closed and cannot load the original module.
+    Mock {
+        /// Whether the factory provably replaces the original module.
+        factory_replaces_original: bool,
+    },
+    /// Remove a registered mock and restore the original module.
+    Unmock,
+}
+
+impl VitestModuleMockAction {
+    /// Whether this operation registers a proven complete replacement.
+    #[must_use]
+    pub const fn replaces_original(self) -> bool {
+        matches!(
+            self,
+            Self::Mock {
+                factory_replaces_original: true
+            }
+        )
+    }
+}
+
+/// Ordered Vitest module-mock operation with a static source target.
 ///
 /// The declaring [`ModuleInfo::file_id`] owns the test-root provenance. The
 /// resolver consumes `source` through its canonical specifier pipeline; this
 /// fact deliberately carries no resolved path or duplicate diagnostic span.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, bitcode::Encode, bitcode::Decode)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct ReplacedModuleTargetFact {
-    /// Static module specifier passed to the replacement API.
+pub struct VitestModuleMockOperationFact {
+    /// Static module specifier passed to `vi.mock` or `vi.unmock`.
     pub source: String,
+    /// Source-order position of the call within the declaring module.
+    pub call_start: u32,
+    /// Typed mock or unmock action.
+    pub action: VitestModuleMockAction,
 }
 
 /// A `this`-rooted member access with exact enclosing-class provenance.

--- a/tests/fixtures/issue-2031-mixed-test-reachability/package.json
+++ b/tests/fixtures/issue-2031-mixed-test-reachability/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-2031-mixed-test-reachability",
+  "private": true,
+  "type": "module",
+  "main": "src/entry.ts",
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}

--- a/tests/fixtures/issue-2031-mixed-test-reachability/src/dependency.test.ts
+++ b/tests/fixtures/issue-2031-mixed-test-reachability/src/dependency.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from "vitest";
+
+import { renderDependency } from "./dependency";
+
+it("uses the real dependency", () => {
+  expect(renderDependency()).toBe("real dependency");
+});

--- a/tests/fixtures/issue-2031-mixed-test-reachability/src/dependency.ts
+++ b/tests/fixtures/issue-2031-mixed-test-reachability/src/dependency.ts
@@ -1,0 +1,3 @@
+export function renderDependency(): string {
+  return "real dependency";
+}

--- a/tests/fixtures/issue-2031-mixed-test-reachability/src/entry.ts
+++ b/tests/fixtures/issue-2031-mixed-test-reachability/src/entry.ts
@@ -1,0 +1,5 @@
+import { renderWrapper } from "./wrapper";
+
+export function renderEntry(): string {
+  return renderWrapper();
+}

--- a/tests/fixtures/issue-2031-mixed-test-reachability/src/wrapper.test.ts
+++ b/tests/fixtures/issue-2031-mixed-test-reachability/src/wrapper.test.ts
@@ -1,0 +1,11 @@
+import { expect, it, vi } from "vitest";
+
+import { renderWrapper } from "./wrapper";
+
+vi.mock("./dependency", () => ({
+  renderDependency: vi.fn<() => string>(() => "mocked dependency"),
+}));
+
+it("uses the replacement", () => {
+  expect(renderWrapper()).toBe("mocked dependency");
+});

--- a/tests/fixtures/issue-2031-mixed-test-reachability/src/wrapper.ts
+++ b/tests/fixtures/issue-2031-mixed-test-reachability/src/wrapper.ts
@@ -1,0 +1,5 @@
+import { renderDependency } from "./dependency";
+
+export function renderWrapper(): string {
+  return renderDependency();
+}

--- a/tests/fixtures/issue-2031-mocked-test-reachability/package.json
+++ b/tests/fixtures/issue-2031-mocked-test-reachability/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-2031-mocked-test-reachability",
+  "private": true,
+  "type": "module",
+  "main": "src/entry.ts",
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}

--- a/tests/fixtures/issue-2031-mocked-test-reachability/src/dependency.ts
+++ b/tests/fixtures/issue-2031-mocked-test-reachability/src/dependency.ts
@@ -1,0 +1,3 @@
+export function renderDependency(): string {
+  return "real dependency";
+}

--- a/tests/fixtures/issue-2031-mocked-test-reachability/src/entry.ts
+++ b/tests/fixtures/issue-2031-mocked-test-reachability/src/entry.ts
@@ -1,0 +1,5 @@
+import { renderWrapper } from "./wrapper";
+
+export function renderEntry(): string {
+  return renderWrapper();
+}

--- a/tests/fixtures/issue-2031-mocked-test-reachability/src/wrapper.test.ts
+++ b/tests/fixtures/issue-2031-mocked-test-reachability/src/wrapper.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWrapper } from "./wrapper";
+
+vi.mock("./dependency", () => ({
+  renderDependency: vi.fn<() => string>(() => "mocked dependency"),
+}));
+
+describe("renderWrapper", () => {
+  it("uses the replacement", () => {
+    expect(renderWrapper()).toBe("mocked dependency");
+  });
+});

--- a/tests/fixtures/issue-2031-mocked-test-reachability/src/wrapper.ts
+++ b/tests/fixtures/issue-2031-mocked-test-reachability/src/wrapper.ts
@@ -1,0 +1,5 @@
+import { renderDependency } from "./dependency";
+
+export function renderWrapper(): string {
+  return renderDependency();
+}

--- a/tests/fixtures/issue-2031-unmocked-test-reachability/package.json
+++ b/tests/fixtures/issue-2031-unmocked-test-reachability/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-2031-unmocked-test-reachability",
+  "private": true,
+  "type": "module",
+  "main": "src/entry.ts",
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}

--- a/tests/fixtures/issue-2031-unmocked-test-reachability/src/dependency.ts
+++ b/tests/fixtures/issue-2031-unmocked-test-reachability/src/dependency.ts
@@ -1,0 +1,3 @@
+export function renderDependency(): string {
+  return "real dependency";
+}

--- a/tests/fixtures/issue-2031-unmocked-test-reachability/src/entry.ts
+++ b/tests/fixtures/issue-2031-unmocked-test-reachability/src/entry.ts
@@ -1,0 +1,5 @@
+import { renderWrapper } from "./wrapper";
+
+export function renderEntry(): string {
+  return renderWrapper();
+}

--- a/tests/fixtures/issue-2031-unmocked-test-reachability/src/wrapper.test.ts
+++ b/tests/fixtures/issue-2031-unmocked-test-reachability/src/wrapper.test.ts
@@ -5,7 +5,7 @@ import { renderWrapper } from "./wrapper";
 vi.mock("./dependency", () => ({
   renderDependency: vi.fn<() => string>(() => "mocked dependency"),
 }));
-vi.unmock("./dependency");
+vi.unmock("./dependency.ts");
 
 it("uses the restored dependency", () => {
   expect(renderWrapper()).toBe("real dependency");

--- a/tests/fixtures/issue-2031-unmocked-test-reachability/src/wrapper.test.ts
+++ b/tests/fixtures/issue-2031-unmocked-test-reachability/src/wrapper.test.ts
@@ -1,0 +1,12 @@
+import { expect, it, vi } from "vitest";
+
+import { renderWrapper } from "./wrapper";
+
+vi.mock("./dependency", () => ({
+  renderDependency: vi.fn<() => string>(() => "mocked dependency"),
+}));
+vi.unmock("./dependency");
+
+it("uses the restored dependency", () => {
+  expect(renderWrapper()).toBe("real dependency");
+});

--- a/tests/fixtures/issue-2031-unmocked-test-reachability/src/wrapper.ts
+++ b/tests/fixtures/issue-2031-unmocked-test-reachability/src/wrapper.ts
@@ -1,0 +1,5 @@
+import { renderDependency } from "./dependency";
+
+export function renderWrapper(): string {
+  return renderDependency();
+}


### PR DESCRIPTION
Fixes #2031.

Problem

Fallow treated the real module behind a proven Vitest replacement as statically test-covered. That hid coverage gaps and lowered estimated CRAP even though the test executed the mock instead.

Behavior

A test root with a proven vi.mock replacement no longer credits the replaced ESM target or exports reached through it. A final vi.unmock restores the real path. Another unmasked test root can still cover the same module, and CommonJS require paths remain active.

Design

Extraction records ordered typed mock and unmock operations only for the direct imported vi binding, a static target, and a factory proven not to load or depend on the original module. Resolution canonicalizes targets through the normal specifier pipeline and selects final state by test root and resolved file identity.

The graph groups roots with identical replacement masks, propagates profiles in one bit-parallel traversal, and retains exact compact reference provenance through named re-exports, namespace aliases, cycles, and diamonds. Health consumes one shared graph-owned coverage view for file gaps, export gaps, and estimated CRAP.

Safety and performance

Uncertain factories, aliases, dynamic targets, vi.importActual, importOriginal, and loader escapes abstain. Jest and vi.doMock are outside this change. Projects without proven replacements keep the ordinary single-BFS path and do not store reference provenance.

Verification

Focused extraction, resolution, graph, cache, coverage-gap, and CRAP regressions pass. The matrix covers final unmock state, equivalent specifiers, multiple test roots, ESM and CommonJS paths, cycles, diamonds, deterministic cache roundtrips, bounded many-profile and dense namespace cases, and deterministic Vitest smoke output. Full local repository verification and the hosted Miri, MSRV, cross-architecture, allocation, coverage, binary-size, editor, ecosystem, and CodSpeed gates pass.