### PR TITLE
fix(resolve): probe aliased Sass partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Tsconfig aliases in Sass imports now resolve partial files after alias
+  expansion.** Imports such as `@use "@/styles/tokens"`, where `@/*` maps to
+  `src/*`, now probe `_tokens.scss`, `_tokens.sass`, and Sass directory-index
+  conventions at the expanded path. This also applies to style imports
+  extracted from SFCs, while JavaScript and TypeScript imports keep their
+  existing resolution behavior. (Closes
+  [#2075](https://github.com/fallow-rs/fallow/issues/2075).)
+
 - **A saved duplication baseline keeps matching after unrelated line shifts.**
   Baselines stored `path:start-end` pairs per clone group, so inserting a line
   above a clone made every instance in that group look new and the accepted

--- a/crates/core/tests/integration_test/scss_partials.rs
+++ b/crates/core/tests/integration_test/scss_partials.rs
@@ -1,6 +1,72 @@
 use super::common::{create_config, fixture_path};
 
 #[test]
+fn issue_2075_sass_partials_resolve_after_tsconfig_alias_expansion() {
+    let root = fixture_path("issue-2075-sass-alias-partial");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.unresolved_imports.is_empty(),
+        "all aliased Sass partials and controls should resolve: {:?}",
+        results.unresolved_imports
+    );
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .filter_map(|issue| issue.file.path.file_name())
+        .filter_map(|name| name.to_str())
+        .map(ToString::to_string)
+        .collect();
+    assert!(
+        !unused_file_names.contains(&"_tokens.scss".to_string()),
+        "the aliased SCSS partial should be reachable: {unused_file_names:?}"
+    );
+    assert!(
+        !unused_file_names.contains(&"_sfc-tokens.scss".to_string()),
+        "the partial imported from an SFC style block should be reachable: {unused_file_names:?}"
+    );
+    assert!(
+        !unused_file_names.contains(&"_sass-tokens.sass".to_string()),
+        "the aliased indented-Sass partial should be reachable: {unused_file_names:?}"
+    );
+    assert!(
+        !unused_file_names.contains(&"_index.scss".to_string()),
+        "the aliased Sass directory partial should be reachable: {unused_file_names:?}"
+    );
+    assert!(
+        !unused_file_names.contains(&"_precedence.scss".to_string()),
+        "SCSS partial candidates should be probed before the next extension: {unused_file_names:?}"
+    );
+    assert!(
+        unused_file_names.contains(&"precedence.sass".to_string()),
+        "the lower-precedence direct Sass candidate should remain unreachable: {unused_file_names:?}"
+    );
+}
+
+#[test]
+fn issue_2075_ts_imports_do_not_use_sass_partial_alias_fallback() {
+    let root = fixture_path("issue-2075-ts-alias-control");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results
+            .unresolved_imports
+            .iter()
+            .any(|issue| issue.import.specifier == "@/styles/tokens"),
+        "a JS/TS-context alias must not gain Sass partial resolution"
+    );
+    assert!(
+        results.unused_files.iter().any(|issue| {
+            issue.file.path.file_name().and_then(|name| name.to_str()) == Some("_tokens.scss")
+        }),
+        "the Sass partial must remain unreachable from a JS/TS-context alias"
+    );
+}
+
+#[test]
 fn scss_partial_files_resolved_via_underscore_convention() {
     let root = fixture_path("scss-partial-project");
     let config = create_config(root);

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -665,7 +665,12 @@ fn try_nearest_tsconfig_path_alias(
     ctx: &ResolveContext<'_>,
     from_file: &Path,
     specifier: &str,
+    from_style: bool,
 ) -> Option<ResolveResult> {
+    let style_context = from_style
+        || from_file
+            .extension()
+            .is_some_and(|extension| extension == "scss" || extension == "sass");
     let chain = local_tsconfig_chain(ctx, from_file);
     for tsconfig_path in &chain {
         let Some(json) = read_tsconfig_json_cached(ctx, tsconfig_path) else {
@@ -675,7 +680,9 @@ fn try_nearest_tsconfig_path_alias(
             .get("compilerOptions")
             .and_then(|compiler_options| compiler_options.get("paths"))
             .is_some();
-        if let Some(result) = try_tsconfig_paths_from_config(ctx, tsconfig_path, &json, specifier) {
+        if let Some(result) =
+            try_tsconfig_paths_from_config(ctx, tsconfig_path, &json, specifier, style_context)
+        {
             return Some(result);
         }
         if has_paths {
@@ -691,7 +698,7 @@ fn try_nearest_tsconfig_path_alias(
             .and_then(|compiler_options| compiler_options.get("baseUrl"))
             .is_some();
         if let Some(result) =
-            try_tsconfig_base_url_from_config(ctx, tsconfig_path, &json, specifier)
+            try_tsconfig_base_url_from_config(ctx, tsconfig_path, &json, specifier, style_context)
         {
             return Some(result);
         }
@@ -707,6 +714,7 @@ fn try_tsconfig_paths_from_config(
     tsconfig_path: &Path,
     json: &Value,
     specifier: &str,
+    style_context: bool,
 ) -> Option<ResolveResult> {
     let compiler_options = json.get("compilerOptions")?;
     let paths = compiler_options.get("paths")?.as_object()?;
@@ -751,7 +759,7 @@ fn try_tsconfig_paths_from_config(
             } else {
                 base_dir.join(target_path)
             };
-            if let Some(result) = try_tsconfig_alias_target(ctx, &absolute) {
+            if let Some(result) = try_tsconfig_alias_target(ctx, &absolute, style_context) {
                 return Some(result);
             }
         }
@@ -771,6 +779,7 @@ fn try_tsconfig_base_url_from_config(
     tsconfig_path: &Path,
     json: &Value,
     specifier: &str,
+    style_context: bool,
 ) -> Option<ResolveResult> {
     if specifier.starts_with('.') || Path::new(specifier).is_absolute() {
         return None;
@@ -784,10 +793,14 @@ fn try_tsconfig_base_url_from_config(
     } else {
         tsconfig_dir.join(base_url)
     };
-    try_tsconfig_alias_target(ctx, &base_dir.join(specifier))
+    try_tsconfig_alias_target(ctx, &base_dir.join(specifier), style_context)
 }
 
-fn try_tsconfig_alias_target(ctx: &ResolveContext<'_>, target: &Path) -> Option<ResolveResult> {
+fn try_tsconfig_alias_target(
+    ctx: &ResolveContext<'_>,
+    target: &Path,
+    style_context: bool,
+) -> Option<ResolveResult> {
     if let Some(result) = resolve_tsconfig_alias_candidate(ctx, target) {
         return Some(result);
     }
@@ -796,7 +809,11 @@ fn try_tsconfig_alias_target(ctx: &ResolveContext<'_>, target: &Path) -> Option<
         return Some(result);
     }
 
-    if let Some(result) = try_tsconfig_alias_directory(ctx, target) {
+    if style_context && let Some(result) = try_tsconfig_alias_sass_target(ctx, target) {
+        return Some(result);
+    }
+
+    if let Some(result) = try_tsconfig_alias_directory(ctx, target, style_context) {
         return Some(result);
     }
 
@@ -822,6 +839,70 @@ fn try_tsconfig_alias_target(ctx: &ResolveContext<'_>, target: &Path) -> Option<
     None
 }
 
+/// Probe Sass's extension, partial, and directory-index conventions against an
+/// already-expanded tsconfig alias target.
+///
+/// This must only be called for stylesheet edges. JavaScript and TypeScript
+/// imports may use the same alias text, but `_name.scss` is not a valid module
+/// candidate in those contexts.
+fn try_tsconfig_alias_sass_target(
+    ctx: &ResolveContext<'_>,
+    target: &Path,
+) -> Option<ResolveResult> {
+    let style_extension = target
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "css" | "scss" | "sass"));
+
+    let filename = target.file_name()?.to_str()?;
+    let partial =
+        (!filename.starts_with('_')).then(|| target.with_file_name(format!("_{filename}")));
+
+    if style_extension {
+        if let Some(partial) = partial
+            && let Some(result) = resolve_tsconfig_alias_candidate(ctx, &partial)
+        {
+            return Some(result);
+        }
+        return None;
+    }
+
+    // Match the established Sass fallback order: exhaust direct, partial, and
+    // directory-index candidates for one extension before trying the next.
+    for extension in [".scss", ".sass"] {
+        if let Some(result) =
+            resolve_tsconfig_alias_candidate(ctx, &with_appended_extension(target, extension))
+        {
+            return Some(result);
+        }
+        if let Some(partial) = &partial
+            && let Some(result) =
+                resolve_tsconfig_alias_candidate(ctx, &with_appended_extension(partial, extension))
+        {
+            return Some(result);
+        }
+        for index in ["_index", "index"] {
+            if let Some(result) = resolve_tsconfig_alias_candidate(
+                ctx,
+                &with_appended_extension(&target.join(index), extension),
+            ) {
+                return Some(result);
+            }
+        }
+    }
+
+    for candidate in [
+        with_appended_extension(target, ".css"),
+        target.join("index.css"),
+    ] {
+        if let Some(result) = resolve_tsconfig_alias_candidate(ctx, &candidate) {
+            return Some(result);
+        }
+    }
+
+    None
+}
+
 fn should_probe_extensions(ctx: &ResolveContext<'_>, target: &Path) -> bool {
     target
         .extension()
@@ -839,14 +920,19 @@ fn with_appended_extension(path: &Path, extension: &str) -> PathBuf {
     PathBuf::from(value)
 }
 
-fn try_tsconfig_alias_directory(ctx: &ResolveContext<'_>, target: &Path) -> Option<ResolveResult> {
+fn try_tsconfig_alias_directory(
+    ctx: &ResolveContext<'_>,
+    target: &Path,
+    style_context: bool,
+) -> Option<ResolveResult> {
     if !target.is_dir() {
         return None;
     }
     if let Some(package_json) = read_json_file(&target.join("package.json")) {
         for field in ["module", "main"] {
             if let Some(entry) = package_json.get(field).and_then(Value::as_str)
-                && let Some(result) = try_tsconfig_alias_target(ctx, &target.join(entry))
+                && let Some(result) =
+                    try_tsconfig_alias_target(ctx, &target.join(entry), style_context)
             {
                 return Some(result);
             }
@@ -1485,7 +1571,8 @@ fn resolve_resolved_specifier(
             return result;
         }
         if (flags.is_bare || flags.is_alias || flags.matches_plugin_alias)
-            && let Some(result) = try_nearest_tsconfig_path_alias(ctx, from_file, specifier)
+            && let Some(result) =
+                try_nearest_tsconfig_path_alias(ctx, from_file, specifier, from_style)
         {
             return result;
         }
@@ -1606,7 +1693,7 @@ fn try_failed_primary_fallbacks(
     }
 
     if (used_tsconfig_fallback || can_try_nearest_alias)
-        && let Some(result) = try_nearest_tsconfig_path_alias(ctx, from_file, specifier)
+        && let Some(result) = try_nearest_tsconfig_path_alias(ctx, from_file, specifier, from_style)
     {
         return Some(result);
     }
@@ -1709,7 +1796,7 @@ fn try_tsconfig_root_dirs(
             };
             for candidate_root in &roots {
                 let candidate = candidate_root.join(relative_dir).join(specifier);
-                if let Some(result) = try_tsconfig_alias_target(ctx, &candidate) {
+                if let Some(result) = try_tsconfig_alias_target(ctx, &candidate, false) {
                     return Some(result);
                 }
             }

--- a/tests/fixtures/issue-2075-sass-alias-partial/package.json
+++ b/tests/fixtures/issue-2075-sass-alias-partial/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-2075-sass-alias-partial",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/main.ts",
+  "dependencies": {
+    "vue": "3.0.0"
+  }
+}

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/App.vue
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/App.vue
@@ -1,0 +1,9 @@
+<template><div class="app" /></template>
+
+<style lang="scss">
+@use "@/styles/sfc-tokens";
+
+.app {
+  color: sfc-tokens.$color;
+}
+</style>

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/alias-partial-entry.sass
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/alias-partial-entry.sass
@@ -1,0 +1,4 @@
+@use "@/styles/sass-tokens"
+
+.alias-sass-partial
+  color: sass-tokens.$color

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/alias-partial-entry.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/alias-partial-entry.scss
@@ -1,0 +1,9 @@
+@use "@/styles/tokens";
+@use "@/styles/components";
+@use "@/styles/precedence";
+
+.alias-partial {
+  color: tokens.$color;
+  background: components.$background;
+  border-color: precedence.$color;
+}

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/alias-plain-entry.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/alias-plain-entry.scss
@@ -1,0 +1,5 @@
+@use "@/styles/plain";
+
+.alias-plain {
+  color: plain.$color;
+}

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/main.ts
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/main.ts
@@ -1,0 +1,7 @@
+import "./alias-partial-entry.scss";
+import "./alias-plain-entry.scss";
+import "./relative-partial-entry.scss";
+import "./alias-partial-entry.sass";
+import App from "./App.vue";
+
+export const app = App;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/relative-partial-entry.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/relative-partial-entry.scss
@@ -1,0 +1,5 @@
+@use "./styles/palette";
+
+.relative-partial {
+  color: palette.$color;
+}

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_palette.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_palette.scss
@@ -1,0 +1,1 @@
+$color: green;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_precedence.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_precedence.scss
@@ -1,0 +1,1 @@
+$color: teal;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_sass-tokens.sass
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_sass-tokens.sass
@@ -1,0 +1,1 @@
+$color: purple

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_sfc-tokens.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_sfc-tokens.scss
@@ -1,0 +1,1 @@
+$color: blue;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_tokens.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/_tokens.scss
@@ -1,0 +1,1 @@
+$color: red;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/components/_index.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/components/_index.scss
@@ -1,0 +1,1 @@
+$background: white;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/plain.scss
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/plain.scss
@@ -1,0 +1,1 @@
+$color: orange;

--- a/tests/fixtures/issue-2075-sass-alias-partial/src/styles/precedence.sass
+++ b/tests/fixtures/issue-2075-sass-alias-partial/src/styles/precedence.sass
@@ -1,0 +1,1 @@
+$color: pink

--- a/tests/fixtures/issue-2075-sass-alias-partial/tsconfig.json
+++ b/tests/fixtures/issue-2075-sass-alias-partial/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/issue-2075-ts-alias-control/package.json
+++ b/tests/fixtures/issue-2075-ts-alias-control/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "issue-2075-ts-alias-control",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/main.ts"
+}

--- a/tests/fixtures/issue-2075-ts-alias-control/src/main.ts
+++ b/tests/fixtures/issue-2075-ts-alias-control/src/main.ts
@@ -1,0 +1,3 @@
+import "@/styles/tokens";
+
+export const ready = true;

--- a/tests/fixtures/issue-2075-ts-alias-control/src/styles/_tokens.scss
+++ b/tests/fixtures/issue-2075-ts-alias-control/src/styles/_tokens.scss
@@ -1,0 +1,1 @@
+$color: red;

--- a/tests/fixtures/issue-2075-ts-alias-control/tsconfig.json
+++ b/tests/fixtures/issue-2075-ts-alias-control/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Fixes #2075.

Resolve Sass/SCSS partial and index candidates after `tsconfig` `paths` or `baseUrl` expansion, while keeping JavaScript and TypeScript resolution unchanged. This also covers Vue SFC style imports.

Regression coverage includes aliased partials, `.sass`, `_index`, ordinary alias and relative controls, an SFC style import, candidate precedence, and a TypeScript negative control.

Verification:
- `cargo test -p fallow-graph --lib`
- `cargo test -p fallow-core scss_partials`
- full `fallow-core` unit and integration suites
- `cargo clippy -p fallow-graph -p fallow-core --all-targets -- -D warnings`
- `cargo fmt --check`
- original issue repro with the rebuilt CLI