### PR TITLE
fix(security): stop treating "use server" as a server-only marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Importing a Server Action from a client component is no longer flagged as
+  a server-only import.** The `server-only-import` category of the
+  `client-server-leak` rule treated a `"use server"` directive as a server-only
+  marker, so every Server Action call site in a Next.js App Router project was
+  reported as a leak even though the bundler replaces that import with an
+  action reference and the action body never enters the client bundle. A
+  `"use server"` module now becomes a sink only through what it imports:
+  reaching `server-only`, `next/headers`, `next/server`, or Node server
+  modules such as `node:fs` / `node:child_process` (directly or through
+  re-export chains) is still reported, including from a `"use server"` file
+  that leaks such an import through a non-action export. The evidence and
+  SARIF rule text no longer name `"use server"` as a server-only marker.
+  (Closes [#2074](https://github.com/fallow-rs/fallow/issues/2074).)
+
 - **Tests that mock a module no longer count as statically covering the real
   module.** A test root with a proven `vi.mock` replacement executes the mock,
   yet the replaced module and everything reached only through it were still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `"use server"` module now becomes a sink only through what it imports:
   reaching `server-only`, `next/headers`, `next/server`, or Node server
   modules such as `node:fs` / `node:child_process` (directly or through
-  re-export chains) is still reported, including from a `"use server"` file
-  that leaks such an import through a non-action export. The evidence and
-  SARIF rule text no longer name `"use server"` as a server-only marker.
+  re-export chains) is still reported, including from a `"use server"` file.
+  The sink predicate stays module-level: it does not tell action exports apart
+  from value exports, so a `"use server"` module that imports server-only code
+  is still reported even when every export is an async action. For that shape
+  the evidence, human remediation hint, and SARIF rule text now carry the
+  deciding question: only a non-action export (a top-level const, a re-export,
+  or a default value) carries the server-only import into the client bundle,
+  and a module whose exports are all async actions is a false positive. The
+  texts no longer name `"use server"` as a server-only marker.
   (Closes [#2074](https://github.com/fallow-rs/fallow/issues/2074).)
 
 - **Tests that mock a module no longer count as statically covering the real

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -2322,7 +2322,11 @@ fn push_human_next_step(out: &mut String, finding: &SecurityFinding) {
         out.push_str(
             "    Next: check whether this server-only code is meant to run on the client. \
              If it is pulled in only through next/dynamic(..., { ssr: false }), type-only, \
-             or removed at build time, mark it as a false positive.\n",
+             or removed at build time, mark it as a false positive. If the sink is a \
+             \"use server\" Server Action module, decide by export shape: only a \
+             non-action export (a top-level const, a re-export, or a default value) \
+             carries the server-only import into the client bundle; if every export is \
+             an async action, mark it as a false positive.\n",
         );
     } else if matches!(finding.kind, SecurityFindingKind::ClientServerLeak) {
         out.push_str(
@@ -2618,7 +2622,11 @@ fn sarif_rule_def_server_only_leak(rule_id: &str) -> serde_json::Value {
              code such as server-only, next/headers, \
              next/server, or node:fs / node:child_process). fallow does not prove this \
              code runs on the client; a module pulled in only through \
-             next/dynamic(..., { ssr: false }) is a false positive." },
+             next/dynamic(..., { ssr: false }) is a false positive. For a \"use server\" \
+             Server Action module the deciding question is export shape: only a \
+             non-action export (a top-level const, a re-export, or a default value) \
+             carries the server-only import into the client bundle; a module whose \
+             exports are all async actions is a false positive." },
         "help": {
             "text": security_help_text(title),
             "markdown": security_help_markdown(title)

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -2614,8 +2614,8 @@ fn sarif_rule_def_server_only_leak(rule_id: &str) -> serde_json::Value {
         "shortDescription": { "text": "Client imports server-only code candidate (unverified)" },
         "fullDescription": { "text":
             "Unverified candidate, requires verification: a \"use client\" file \
-             transitively imports a server-only module (one carrying a \"use server\" \
-             directive or importing server-only code such as server-only, next/headers, \
+             transitively imports a server-only module (one importing server-only \
+             code such as server-only, next/headers, \
              next/server, or node:fs / node:child_process). fallow does not prove this \
              code runs on the client; a module pulled in only through \
              next/dynamic(..., { ssr: false }) is a false positive." },

--- a/crates/core/src/analyze/security/mod.rs
+++ b/crates/core/src/analyze/security/mod.rs
@@ -13,7 +13,13 @@
 //!    server-only marker here: a Server Action module imported from a
 //!    `"use client"` file is the framework's sanctioned mutation pattern (the
 //!    bundler swaps the import for an action reference), so only its server-only
-//!    IMPORTS count, and those still surface through re-export chains.
+//!    IMPORTS count, and those still surface through re-export chains. The sink
+//!    predicate is MODULE-LEVEL: it does not tell action exports apart from
+//!    value exports, so a `"use server"` module that imports server-only code
+//!    is still reported even when every export is an async action (the shape
+//!    the bundler exonerates). The remediation text carries the deciding
+//!    question (does a non-action export leak the import into the client
+//!    bundle) because fallow has no export-shape signal to gate on.
 //!
 //! fallow emits the structural import-hop trace; it does not prove the path is
 //! exploitable.
@@ -622,7 +628,11 @@ fn build_server_only_finding(
          node:fs / node:child_process; see the sink hop in the trace). Candidate for \
          verification: confirm whether this server-only code is meant to run on the client. \
          If it is pulled in only through next/dynamic(..., { ssr: false }), it is the \
-         sanctioned client-only escape hatch and is a false positive."
+         sanctioned client-only escape hatch and is a false positive. If the sink is a \
+         Server Action module, decide by export shape: only a non-action export (a \
+         top-level const, a re-export, or a default value) carries the server-only \
+         import into the client bundle; if every export is an async action, the bundler \
+         replaces the import with an action reference and it is a false positive."
         .to_owned();
 
     let candidate = client_leak_candidate(

--- a/crates/core/src/analyze/security/mod.rs
+++ b/crates/core/src/analyze/security/mod.rs
@@ -7,9 +7,13 @@
 //! 1. The cone reaches a module that reads a non-public env secret
 //!    (`category: None`, the original finding).
 //! 2. The cone reaches a SERVER-ONLY module (`category: Some("server-only-import")`):
-//!    a module carrying `"use server"`, importing the `server-only` poison
-//!    package, or importing a server-only Next.js / Node API (see the shared
-//!    `is_server_only_module` predicate in `analyze::server_only`).
+//!    a module importing the `server-only` poison package or a server-only
+//!    Next.js / Node API (see the shared `imports_server_only_code` predicate in
+//!    `analyze::server_only`). A `"use server"` directive is deliberately NOT a
+//!    server-only marker here: a Server Action module imported from a
+//!    `"use client"` file is the framework's sanctioned mutation pattern (the
+//!    bundler swaps the import for an action reference), so only its server-only
+//!    IMPORTS count, and those still surface through re-export chains.
 //!
 //! fallow emits the structural import-hop trace; it does not prove the path is
 //! exploitable.
@@ -198,18 +202,19 @@ fn compute_secret_source_set(
     sources
 }
 
-/// Set of file ids whose module is a SERVER-ONLY sink: it carries a `"use server"`
-/// directive, imports a server-only package, or imports a server-only named API
-/// from `next/headers`. Delegates to the shared
-/// [`is_server_only_module`](super::server_only::is_server_only_module) predicate
-/// so the server-only definition is identical to the
-/// `mixed_client_server_barrel` detector's.
+/// Set of file ids whose module is a SERVER-ONLY sink: it imports a server-only
+/// package or a server-only named API from `next/headers`. Delegates to the
+/// shared
+/// [`imports_server_only_code`](super::server_only::imports_server_only_code)
+/// predicate. A bare `"use server"` directive does NOT qualify: a Server Action
+/// module is meant to be imported by client components, so only its server-only
+/// imports make it a sink.
 fn compute_server_only_source_set(
     modules_by_id: &FxHashMap<FileId, &ModuleInfo>,
 ) -> FxHashSet<FileId> {
     let mut server_only: FxHashSet<FileId> = FxHashSet::default();
     for (&file_id, module) in modules_by_id {
-        if super::server_only::is_server_only_module(module) {
+        if super::server_only::imports_server_only_code(module) {
             server_only.insert(file_id);
         }
     }
@@ -428,8 +433,8 @@ fn emit_direct_client_file_leaks(
     }
 
     // Direct server-only case: the client file itself IS a server-only sink
-    // (carries "use server", imports a server-only package, or imports a
-    // server-only next/headers API). The most direct server-only leak; no
+    // (imports a server-only package or a server-only next/headers
+    // API). The most direct server-only leak; no
     // import hop needed. The transitive server-only emit below is gated so a
     // file that is both a direct AND a transitive sink is flagged once.
     if scan.server_only_sources.contains(&client_id) {
@@ -585,8 +590,8 @@ fn build_leak_finding(
 }
 
 /// Build a finding for the SERVER-ONLY sink: a `"use client"` file whose
-/// transitive static-import cone reaches a server-only module (one carrying
-/// `"use server"` or importing a server-only package). Same rule, same suppress
+/// transitive static-import cone reaches a server-only module (one importing a
+/// server-only package or API). Same rule, same suppress
 /// kind, same `SecurityFinding` shape as the secret leak; distinguished by
 /// `category: Some("server-only-import")` so consumers can tell the two apart.
 /// The terminal trace hop carries the `Sink` role (the server-only module is the
@@ -613,12 +618,11 @@ fn build_server_only_finding(
     // the absolute path here would leak it past relativization and make output
     // environment-dependent.
     let evidence = "This \"use client\" file transitively imports a SERVER-ONLY module \
-         (it carries a \"use server\" directive or imports server-only code such as \
-         server-only, next/headers, next/server, or node:fs / node:child_process; see the \
-         sink hop in the trace). Candidate for verification: confirm whether this server-only \
-         code is meant to run on the client. If it is pulled in only through \
-         next/dynamic(..., { ssr: false }), it is the sanctioned client-only escape hatch and \
-         is a false positive."
+         (it imports server-only code such as server-only, next/headers, next/server, or \
+         node:fs / node:child_process; see the sink hop in the trace). Candidate for \
+         verification: confirm whether this server-only code is meant to run on the client. \
+         If it is pulled in only through next/dynamic(..., { ssr: false }), it is the \
+         sanctioned client-only escape hatch and is a false positive."
         .to_owned();
 
     let candidate = client_leak_candidate(
@@ -688,17 +692,17 @@ fn build_direct_finding(
 }
 
 /// Build a finding for the direct SERVER-ONLY case: a `"use client"` file that is
-/// itself a server-only sink (carries `"use server"`, imports a server-only
-/// package, or imports a server-only `next/headers` API). No import hop is needed,
+/// itself a server-only sink (imports a server-only package or a server-only
+/// `next/headers` API). No import hop is needed,
 /// so the trace is a single self-hop on the client file, which is both the client
 /// boundary and the server-only sink. Mirrors [`build_direct_finding`] for the
 /// secret case; distinguished by `category: Some("server-only-import")`.
 fn build_direct_server_only_finding(graph: &ModuleGraph, client_id: FileId) -> SecurityFinding {
     let path = graph.modules[client_id.0 as usize].path.clone();
     let evidence = "This \"use client\" file directly imports SERVER-ONLY code \
-         (it carries a \"use server\" directive or imports server-only code such as \
-         server-only, next/headers, next/server, or node:fs / node:child_process). Candidate \
-         for verification: confirm whether this server-only code is meant to run on the client."
+         (server-only code such as server-only, next/headers, next/server, or \
+         node:fs / node:child_process). Candidate for verification: confirm whether this \
+         server-only code is meant to run on the client."
         .to_owned();
     let candidate =
         client_leak_candidate(path.clone(), 1, 0, Some(SERVER_ONLY_CATEGORY.to_owned()));

--- a/crates/core/src/analyze/server_only.rs
+++ b/crates/core/src/analyze/server_only.rs
@@ -74,9 +74,11 @@ pub fn is_server_only_module(module: &ModuleInfo) -> bool {
 /// a Node server runtime module, `next/server`, or a named server-only API from
 /// `next/headers`. Deliberately excludes the `"use server"` directive: a Server
 /// Action module is MEANT to be imported by client components, so the directive
-/// alone is not a server-only signal for the client/server-leak rule. A
-/// `"use server"` module that also imports one of these packages still matches
-/// (a non-action export can leak that import into the client bundle).
+/// alone is not a server-only signal for the client/server-leak rule. The
+/// predicate is module-level and does not inspect export shape: a `"use server"`
+/// module that also imports one of these packages still matches even when every
+/// export is an async action, because only a non-action export can leak the
+/// import into the client bundle and fallow cannot tell the two apart here.
 #[must_use]
 pub fn imports_server_only_code(module: &ModuleInfo) -> bool {
     module.imports.iter().any(|import| {

--- a/crates/core/src/analyze/server_only.rs
+++ b/crates/core/src/analyze/server_only.rs
@@ -7,10 +7,15 @@
 //! client" or any package-name guess is NOT here, because there is no clean
 //! syntactic sink for it.
 //!
-//! This single predicate is shared between the `security` client/server-leak
-//! detector and the `mixed_client_server_barrel` detector so the server-only
-//! definition (the [`SERVER_ONLY_PACKAGES`] list, `next/headers` named-import
-//! handling, and the `"use server"` directive check) never drifts.
+//! The import-based half ([`imports_server_only_code`]) is shared between the
+//! `security` client/server-leak detector and the `mixed_client_server_barrel`
+//! detector so the server-only definition (the [`SERVER_ONLY_PACKAGES`] list
+//! and `next/headers` named-import handling) never drifts. The `"use server"`
+//! directive is NOT a server-only marker for the security detector: a
+//! `"use server"` module imported from a `"use client"` file is the sanctioned
+//! Server Action pattern (the bundler replaces the import with an action
+//! reference; the body never enters the client bundle), so only
+//! [`is_server_only_module`] (used by the barrel detector) includes it.
 
 use fallow_types::extract::{ImportedName, ModuleInfo};
 
@@ -55,14 +60,27 @@ const NEXT_HEADERS_SERVER_NAMES: &[&str] = &["cookies", "headers", "draftMode"];
 /// `"use server"` directive, an import of a known server-only package, or a
 /// named server-only API from `next/headers`. The package check matches the
 /// import specifier directly, so `node:fs` and bare `fs` both count.
+///
+/// Includes the directive check, so it is the right predicate for the barrel
+/// detector; the security client/server-leak detector uses
+/// [`imports_server_only_code`] instead (a `"use server"` import from a client
+/// is the sanctioned Server Action boundary, not a leak).
 #[must_use]
 pub fn is_server_only_module(module: &ModuleInfo) -> bool {
-    // 1. A "use server" directive (Server Actions / server-only module).
-    if module.directives.iter().any(|d| d == USE_SERVER) {
-        return true;
-    }
+    module.directives.iter().any(|d| d == USE_SERVER) || imports_server_only_code(module)
+}
+
+/// Whether a module IMPORTS server-only code: the `server-only` poison package,
+/// a Node server runtime module, `next/server`, or a named server-only API from
+/// `next/headers`. Deliberately excludes the `"use server"` directive: a Server
+/// Action module is MEANT to be imported by client components, so the directive
+/// alone is not a server-only signal for the client/server-leak rule. A
+/// `"use server"` module that also imports one of these packages still matches
+/// (a non-action export can leak that import into the client bundle).
+#[must_use]
+pub fn imports_server_only_code(module: &ModuleInfo) -> bool {
     module.imports.iter().any(|import| {
-        // 2/3. An import of the `server-only` poison package, a Node server
+        // An import of the `server-only` poison package, a Node server
         // runtime module, or `next/server`. The specifier is matched directly
         // so both the `node:` and bare forms count.
         if SERVER_ONLY_PACKAGES.contains(&import.source.as_str()) {
@@ -194,6 +212,20 @@ mod tests {
         let mut module = empty_module();
         module.directives.push(USE_SERVER.to_string());
         assert!(is_server_only_module(&module));
+    }
+
+    #[test]
+    fn use_server_directive_alone_does_not_import_server_only_code() {
+        let mut module = empty_module();
+        module.directives.push(USE_SERVER.to_string());
+        assert!(!imports_server_only_code(&module));
+    }
+
+    #[test]
+    fn use_server_module_importing_node_fs_still_imports_server_only_code() {
+        let mut module = module_with_import("node:fs", ImportedName::Named("readFile".to_string()));
+        module.directives.push(USE_SERVER.to_string());
+        assert!(imports_server_only_code(&module));
     }
 
     #[test]

--- a/crates/core/tests/integration_test/security_client_server_leak.rs
+++ b/crates/core/tests/integration_test/security_client_server_leak.rs
@@ -462,9 +462,11 @@ fn server_action_import_is_not_a_server_only_sink() {
 
 #[test]
 fn use_server_module_importing_node_fs_is_still_a_sink() {
-    // Issue #2074 control: a "use server" module that ALSO imports node:fs and
-    // exposes it through a non-action export stays a server-only sink; the
-    // directive does not shield the server-only import.
+    // Issue #2074 control: a "use server" module that ALSO imports node:fs
+    // stays a server-only sink. The sink predicate is module-level (no
+    // action-vs-value export distinction), so the server-only import alone
+    // keeps the module a sink; the fixture's non-action export is the leak
+    // shape that makes such a report real.
     let results = analyze_with_security();
     assert_eq!(
         server_only_findings_on(&results, "src/fs-action-client.tsx"),
@@ -493,6 +495,12 @@ fn use_server_module_importing_node_fs_is_still_a_sink() {
     assert!(
         !finding.evidence.contains("use server"),
         "the evidence must not name \"use server\" as a server-only marker: {}",
+        finding.evidence
+    );
+    assert!(
+        finding.evidence.contains("non-action export"),
+        "the evidence must carry the export-shape triage question for Server Action \
+         sinks: {}",
         finding.evidence
     );
 }

--- a/crates/core/tests/integration_test/security_client_server_leak.rs
+++ b/crates/core/tests/integration_test/security_client_server_leak.rs
@@ -276,12 +276,14 @@ fn exactly_ten_findings_reported() {
     // (transitive import.meta.env), and vite-direct-client.tsx (direct
     // import.meta.env). Plus FIVE server-only-import findings: server-only-client.tsx
     // -> headers-util (next/headers cookies, transitive); direct-fs-client.tsx
-    // (direct node:fs); use-server-client.tsx -> use-server-mod ("use server");
+    // (direct node:fs); fs-action-client.tsx -> fs-action-mod ("use server"
+    // module that imports node:fs);
     // server-only-pkg-client.tsx -> server-only-pkg-mod (server-only package);
     // child-process-client.tsx -> child-process-mod (node:child_process).
     // public-client / vite-public-client / plain / dyn-client /
     // conditional-client / suppressed-client / shared-util-client (plain util,
     // no sink) / ssr-false-client (server reached only via next/dynamic ssr:false)
+    // / save-button (Server Action import, the sanctioned boundary)
     // must NOT produce findings.
     let results = analyze_with_security();
     assert_eq!(
@@ -435,14 +437,40 @@ fn direct_server_only_import_in_client_file_is_reported_once() {
 }
 
 #[test]
-fn use_server_directive_module_is_a_server_only_sink() {
-    // Fix 5: a "use client" file whose cone reaches a "use server"-directive
-    // module reports a server-only-import finding.
+fn server_action_import_is_not_a_server_only_sink() {
+    // Issue #2074: a "use client" file importing a "use server" Server Action
+    // module (with no server-only imports) is the framework's sanctioned
+    // mutation pattern, NOT a leak. No finding of any category may anchor on
+    // the client, and the action module must not appear as a sink anywhere.
+    let results = analyze_with_security();
+    assert!(
+        !anchored_on(&results, "src/save-button.tsx"),
+        "a client importing a Server Action must not be flagged"
+    );
+    assert!(
+        !results.security_findings.iter().any(|f| {
+            f.trace.iter().any(|h| {
+                h.path
+                    .to_string_lossy()
+                    .replace('\\', "/")
+                    .ends_with("src/actions/save.ts")
+            })
+        }),
+        "the Server Action module must not appear in any trace"
+    );
+}
+
+#[test]
+fn use_server_module_importing_node_fs_is_still_a_sink() {
+    // Issue #2074 control: a "use server" module that ALSO imports node:fs and
+    // exposes it through a non-action export stays a server-only sink; the
+    // directive does not shield the server-only import.
     let results = analyze_with_security();
     assert_eq!(
-        server_only_findings_on(&results, "src/use-server-client.tsx"),
+        server_only_findings_on(&results, "src/fs-action-client.tsx"),
         1,
-        "a client reaching a \"use server\" module must report one server-only-import finding"
+        "a client reaching a \"use server\" module that imports node:fs must report one \
+         server-only-import finding"
     );
     let finding = results
         .security_findings
@@ -451,16 +479,21 @@ fn use_server_directive_module_is_a_server_only_sink() {
             f.path
                 .to_string_lossy()
                 .replace('\\', "/")
-                .ends_with("src/use-server-client.tsx")
+                .ends_with("src/fs-action-client.tsx")
         })
-        .expect("use-server-client.tsx should be flagged");
+        .expect("fs-action-client.tsx should be flagged");
     let last = finding.trace.last().expect("trace must have hops");
     assert!(matches!(last.role, TraceHopRole::Sink));
     assert!(
         last.path
             .to_string_lossy()
             .replace('\\', "/")
-            .ends_with("src/use-server-mod.ts")
+            .ends_with("src/fs-action-mod.ts")
+    );
+    assert!(
+        !finding.evidence.contains("use server"),
+        "the evidence must not name \"use server\" as a server-only marker: {}",
+        finding.evidence
     );
 }
 

--- a/tests/fixtures/security-client-server-leak/src/actions/save.ts
+++ b/tests/fixtures/security-client-server-leak/src/actions/save.ts
@@ -1,0 +1,7 @@
+"use server";
+// A Server Action module with no server-only imports: importing it from a
+// "use client" file is the framework's sanctioned mutation pattern and must
+// NOT be a server-only sink (issue #2074).
+export async function save(input: unknown): Promise<unknown> {
+  return input;
+}

--- a/tests/fixtures/security-client-server-leak/src/fs-action-client.tsx
+++ b/tests/fixtures/security-client-server-leak/src/fs-action-client.tsx
@@ -1,0 +1,6 @@
+"use client";
+import { auditTemplate } from "./fs-action-mod";
+
+export function AuditView() {
+  return <pre>{auditTemplate}</pre>;
+}

--- a/tests/fixtures/security-client-server-leak/src/fs-action-mod.ts
+++ b/tests/fixtures/security-client-server-leak/src/fs-action-mod.ts
@@ -1,9 +1,10 @@
 "use server";
 import { readFileSync } from "node:fs";
 
-// Control for issue #2074: a "use server" file that ALSO imports node:fs and
-// leaks it through a non-action export. The directive does not shield the
-// server-only IMPORT, so this module stays a server-only sink.
+// Control for issue #2074: a "use server" file that ALSO imports node:fs.
+// The sink predicate is module-level (it does not inspect export shape), so
+// the server-only import keeps this module a sink no matter what it exports.
+// The non-action export below is the leak shape that makes such a report real.
 export async function saveAudit(entry: string): Promise<string> {
   return entry;
 }

--- a/tests/fixtures/security-client-server-leak/src/fs-action-mod.ts
+++ b/tests/fixtures/security-client-server-leak/src/fs-action-mod.ts
@@ -1,0 +1,11 @@
+"use server";
+import { readFileSync } from "node:fs";
+
+// Control for issue #2074: a "use server" file that ALSO imports node:fs and
+// leaks it through a non-action export. The directive does not shield the
+// server-only IMPORT, so this module stays a server-only sink.
+export async function saveAudit(entry: string): Promise<string> {
+  return entry;
+}
+
+export const auditTemplate = readFileSync("/etc/audit.tmpl", "utf8");

--- a/tests/fixtures/security-client-server-leak/src/save-button.tsx
+++ b/tests/fixtures/security-client-server-leak/src/save-button.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { save } from "./actions/save";
+
+// Issue #2074 repro: a client component calling a Server Action. The bundler
+// replaces the import with an action reference, so no server code enters the
+// client bundle and no finding may be reported.
+export function SaveButton() {
+  return <button onClick={() => save({})}>Save</button>;
+}

--- a/tests/fixtures/security-client-server-leak/src/use-server-client.tsx
+++ b/tests/fixtures/security-client-server-leak/src/use-server-client.tsx
@@ -1,5 +1,0 @@
-"use client";
-import { saveRecord } from "./use-server-mod";
-export function SaveView() {
-  return saveRecord("x");
-}

--- a/tests/fixtures/security-client-server-leak/src/use-server-mod.ts
+++ b/tests/fixtures/security-client-server-leak/src/use-server-mod.ts
@@ -1,5 +1,0 @@
-"use server";
-// A Server Action module: the "use server" directive marks it server-only.
-export async function saveRecord(value: string): Promise<string> {
-  return value.trim();
-}


### PR DESCRIPTION
The server-only-import category of the client-server-leak rule treated a "use server" directive as a server-only marker, the same class as server-only, next/headers, next/server, and node:fs / node:child_process. Those markers mean opposite things: a "use server" module imported from a "use client" file is the Server Action boundary the framework tells you to use (the bundler swaps the import for an action reference; the body never enters the client bundle). The result was a high-severity false positive on every Server Action call site in a Next.js App Router project.

## Fix

- `analyze::server_only` now exposes an imports-only predicate, `imports_server_only_code`, that checks only server-only imports (the `server-only` poison package, `next/headers` server APIs, `next/server`, Node server modules). `is_server_only_module` keeps the directive check for the mixed-client-server-barrel detector, whose semantics are unchanged.
- The security detector computes its sink set from `imports_server_only_code`, so a bare "use server" Server Action module is no longer a sink, while a "use server" module that imports node:fs (and can leak it through a non-action export) still is, including through re-export chains the BFS already follows.
- Evidence strings (direct and transitive) and the SARIF rule description no longer name "use server" as a server-only marker.

## Fixture coverage

- Issue repro: `src/actions/save.ts` (Server Action, no server-only imports) imported by `src/save-button.tsx` ("use client") produces no finding, and the action module appears in no trace.
- Control: `src/fs-action-mod.ts` ("use server" plus a node:fs import leaked through a non-action export) imported by `src/fs-action-client.tsx` still produces exactly one server-only-import finding with the sink hop on the module, and its evidence no longer mentions "use server".
- Unit tests on the split predicate: a bare directive fails the imports-only check; directive plus node:fs passes.

All existing server-only sink paths (next/headers cookies, direct node:fs, `server-only` package, node:child_process, ssr:false escape hatch, suppression) keep their previous behavior.

Validation: fallow-core suite green, CLI security tests green, fmt, clippy, and cargo doc clean for the touched crates.

Fixes #2074