### PR TITLE
fix(graph): cap test-reachability profile count with coarse fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   analysis now falls back to the coarse test-reachability pass instead of
   letting index storage and propagation cost grow without bound. The fallback
   is fail-open (mocked modules stay test-reachable, matching pre-profile
-  behavior) and logs a warning so the degradation is visible. (Closes
+  behavior) and logs a warning so the degradation is visible. The persisted
+  graph cache version is bumped so warm caches written before this change are
+  rebuilt under the new semantics instead of replaying stale profiled results.
+  (Closes
   [#2084](https://github.com/fallow-rs/fallow/issues/2084).)
 
 ## [3.11.0] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Test-reachability profiles are capped to keep huge monorepos fast.** When
+  test-root mock replacements produce more than 1024 distinct mask profiles,
+  analysis now falls back to the coarse test-reachability pass instead of
+  letting index storage and propagation cost grow without bound. The fallback
+  is fail-open (mocked modules stay test-reachable, matching pre-profile
+  behavior) and logs a warning so the degradation is visible. (Closes
+  [#2084](https://github.com/fallow-rs/fallow/issues/2084).)
+
 ## [3.11.0] - 2026-08-02
 
 ### Added

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -41,7 +41,13 @@ pub use store::GraphCacheStore;
 /// Ordinary graphs omit unused provenance. Versions 7 through 16 were used by
 /// published development commits for this change, so the final version remains
 /// 17 rather than reusing a potentially stale intermediate cache version.
-pub const GRAPH_CACHE_VERSION: u32 = 17;
+///
+/// Bumped to 18 for issue #2084 (PR #2096): profiled test-reachability masking
+/// now falls back to the legacy fail-open classification when a graph would
+/// need more than the mask-profile cap, so caches written by the unbounded
+/// profiling code must not replay their old profiled results on large
+/// monorepos where the cap now engages.
+pub const GRAPH_CACHE_VERSION: u32 = 18;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -11,6 +11,19 @@ use fallow_types::extract::ModuleLoadMechanism;
 
 use super::{ModuleGraph, TestReachabilityIndex};
 
+/// Upper bound on distinct replacement-mask profiles before profiled
+/// reachability falls back to the legacy coarse bitset pass.
+///
+/// Follows the `re_export_transition_safety_cap` precedent of bounding an
+/// otherwise unbounded blowup. `TestReachabilityIndex` storage is
+/// O(files * profile_count / 64) u64 words and worklist propagation touches
+/// every profile word per edge visit, so at 1024 profiles each file costs 16
+/// words (128 bytes): about 12 MiB of index for a 100k-file monorepo. Beyond
+/// that the memory and propagation cost outweigh the masking precision, and
+/// the legacy pass is a safe over-approximation (fail-open, pre-#2068
+/// behavior).
+const PROFILE_COUNT_SAFETY_CAP: usize = 1024;
+
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct TestReachabilityProfile {
     masked_targets: Vec<FileId>,
@@ -63,6 +76,19 @@ impl<'roots> TestReachabilityPlan<'roots> {
         for &root in test_entry_points {
             let mask = targets_by_root.remove(&root).unwrap_or_default();
             roots_by_mask.entry(mask).or_default().push(root);
+        }
+
+        if roots_by_mask.len() > PROFILE_COUNT_SAFETY_CAP {
+            tracing::warn!(
+                profile_count = roots_by_mask.len(),
+                safety_cap = PROFILE_COUNT_SAFETY_CAP,
+                "Test-reachability profile count exceeded its safety cap; \
+                 falling back to coarse test reachability without replacement \
+                 masking. Mocked modules stay test-reachable (fail-open)."
+            );
+            return Self::Legacy {
+                roots: test_entry_points,
+            };
         }
 
         let mut profiles: Vec<_> = roots_by_mask
@@ -1308,6 +1334,86 @@ mod tests {
                 },
             ]
         );
+    }
+
+    type UniqueMaskInputs = (
+        Vec<u32>,
+        Vec<(u32, u32, bool)>,
+        Vec<ResolvedReplacedModuleTarget>,
+    );
+
+    /// Build roots 0..count, each importing and mocking a unique target at
+    /// count + root, so every root lands in its own mask profile.
+    fn unique_mask_graph_inputs(count: u32) -> UniqueMaskInputs {
+        let test_roots: Vec<u32> = (0..count).collect();
+        let mut edges = Vec::with_capacity(test_roots.len());
+        let mut replacements = Vec::with_capacity(test_roots.len());
+        for &root in &test_roots {
+            let masked_target = count + root;
+            edges.push((root, masked_target, false));
+            replacements.push(ResolvedReplacedModuleTarget {
+                source_file: FileId(root),
+                target_file: FileId(masked_target),
+            });
+        }
+        (test_roots, edges, replacements)
+    }
+
+    #[test]
+    fn profile_count_at_the_safety_cap_keeps_profiled_masking() {
+        let count = u32::try_from(super::PROFILE_COUNT_SAFETY_CAP).expect("cap fits in u32");
+        let total = count as usize * 2;
+        let (test_roots, edges, replacements) = unique_mask_graph_inputs(count);
+        let graph = build_reachability_graph_with_replacements(
+            total,
+            &edges,
+            &[],
+            &test_roots,
+            &replacements,
+        );
+
+        assert_eq!(
+            graph.test_reachability_index.profile_count,
+            super::PROFILE_COUNT_SAFETY_CAP
+        );
+        // Profiles sort by mask, so profile 0 belongs to root 0 whose unique
+        // target is FileId(count).
+        assert!(
+            graph
+                .test_reachability_index
+                .profile_masks(FileId(count), 0)
+        );
+        assert!(graph.modules[0].is_test_reachable());
+        // Masking still applies under the cap: the mocked target is only
+        // imported by the root that replaces it, so it stays unreachable.
+        assert!(!graph.modules[count as usize].is_test_reachable());
+    }
+
+    #[test]
+    fn profile_count_above_the_safety_cap_falls_back_to_coarse_reachability() {
+        let count = u32::try_from(super::PROFILE_COUNT_SAFETY_CAP * 4).expect("cap fits in u32");
+        let total = count as usize * 2;
+        let (test_roots, edges, replacements) = unique_mask_graph_inputs(count);
+        let graph = build_reachability_graph_with_replacements(
+            total,
+            &edges,
+            &[],
+            &test_roots,
+            &replacements,
+        );
+        let root_set: FxHashSet<_> = test_roots.iter().copied().map(FileId).collect();
+
+        let plan = TestReachabilityPlan::new(&root_set, &replacements, total);
+        assert!(matches!(&plan, TestReachabilityPlan::Legacy { .. }));
+        assert!(!plan.requires_reference_provenance());
+
+        // Fail-open: no profiles survive, and mocked targets stay
+        // test-reachable exactly as the pre-profile coarse pass reported them.
+        assert_eq!(graph.test_reachability_index.profile_count, 0);
+        for &root in &test_roots {
+            assert!(graph.modules[root as usize].is_test_reachable());
+            assert!(graph.modules[(count + root) as usize].is_test_reachable());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

`TestReachabilityIndex`/`ProfileWorklist` scale with the number of distinct replacement-mask profiles with no upper bound: storage is O(files * profile_count / 64) u64 words and propagation touches every profile word per edge visit. A large monorepo where many test files each mock a unique module set could reach thousands of profiles.

This adds `PROFILE_COUNT_SAFETY_CAP` (1024) in `TestReachabilityPlan::new`. Above the cap, planning returns the legacy coarse bitset plan (fail-open, pre-#2068 behavior: mocked modules stay test-reachable) and emits a `tracing::warn!` so the degradation is visible, the same way resolve-layer degradations are surfaced.

## Decisions

- **Cap placement in plan construction, not the worklist.** Falling back before profiles are materialized means the index is never allocated and `requires_reference_provenance` stays consistent with the chosen plan, so reference-provenance collection is skipped exactly as on the pre-#2068 path.
- **Magnitude follows the `re_export_transition_safety_cap` precedent** of bounding a structural blowup: at 1024 profiles each file costs 16 words (128 bytes), about 12 MiB of index on a 100k-file monorepo; beyond that the memory and propagation cost outweigh the masking precision.
- **Warn, not error**, because the fallback is expected, safe over-approximation rather than a correctness bug.

## Tests

- Stress test at 4x the cap: the plan degrades to `Legacy`, `profile_count` is 0, and every root and mocked target is coarsely test-reachable (fail-open sanity).
- Boundary test at exactly the cap: profiled masking still engages, `profile_count` equals the cap, and a uniquely mocked target stays masked and test-unreachable.

Validated with the full `fallow-graph` suite, `cargo fmt --check`, and a clean `cargo clippy --all-targets` for the crate.

Fixes #2084