### PR TITLE
feat(scripts): extend CLI flag-value crediting with a convention table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI flag values that name packages by convention now credit the
+  dependency.** The eslint `--format` shorthand from
+  [#2006](https://github.com/fallow-rs/fallow/issues/2006) is now one row in
+  an embedded convention catalogue that also covers eslint `--plugin`, jest
+  `--testEnvironment` / `--runner` / `--reporters` / `--preset`, preload and
+  loader flags on node, tsx and ts-node (`-r`, `--require`, `--loader`,
+  `--experimental-loader`, `--import`, including subpaths like
+  `dotenv/config`), mocha `--reporter` and `--require`, prettier `--plugin`,
+  stylelint `--custom-syntax` and postcss `--use`. A package used only through
+  such a flag in a script or CI command is no longer reported as an unused
+  dependency; built-in values, paths and unlisted flags keep abstaining, and a
+  malformed catalogue row fails the parse loudly. (Closes
+  [#2019](https://github.com/fallow-rs/fallow/issues/2019).)
+
 ## [3.11.0] - 2026-08-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,24 @@ notes = "optional, human context only"
 - Do **not** turn this into "credit every optional peer of a used package". Vite alone declares twelve optional peers, so that rule would silently exempt all of them and hide genuinely unused dependencies. Every row needs a specific, config-observable reason the package is loaded.
 - Run `cargo test -p fallow-core config_value_credits` to validate the catalogue (it checks the TOML parses, rejects unknown surfaces and fields, empty values or credits, and duplicate rows).
 
+## Crediting a dependency named by a CLI flag value
+
+Some CLIs load an npm package because a flag value names it: `eslint --format gha` loads `eslint-formatter-gha`, `mocha --reporter mochawesome` loads `mochawesome`, `node -r dotenv/config` loads `dotenv`. Those conventions live in a third data-driven catalogue at `crates/core/data/cli_flag_credits.toml`, next to the other two and parsed the same way (embedded via `include_str!`, no regeneration step):
+
+```toml
+[[flag-credit]]
+binaries = ["mocha"]
+flags = ["--reporter", "-R"]
+resolution = "verbatim"
+builtins = ["spec", "dot", "json"]
+notes = "optional, human context only"
+```
+
+- `resolution` says how the tool maps the value to a package: `prefixed` (eslint's `normalizePackageName` expansion with the entry's `prefix`), `prefixed-then-bare` (jest-resolve tries the prefixed name and then the plain one, so both are credited), or `verbatim` (the value is the package, optionally with a subpath such as `dotenv/config`). The set is closed; a new resolution algorithm means a new enum variant in `crates/core/src/scripts/flag_credits.rs` in the same change.
+- `builtins` lists values the tool resolves internally; they credit nothing. List them whenever built-in names collide with real npm packages (mocha's `json`, `markdown` and `list` reporters do).
+- Do **not** add a generic "any bare token matching a declared dependency" rule. A wrong credit produces no signal anywhere, it just makes a real finding vanish, and values like `--platform node` and `--env production` collide with real package names. Every row needs a documented, tool-specific loading convention.
+- Run `cargo test -p fallow-core flag_credits` to validate the catalogue (it checks the TOML parses, rejects unknown resolutions and fields, malformed flags, prefix-contract violations, and duplicate `(binary, flag)` rows).
+
 ## Editing the JSON output contract
 
 Fallow's JSON output schema lives in `docs/output-schema.json` (JSON Schema draft-07) and is consumed by downstream tools (VS Code extension TypeScript codegen, GitHub Action jq scripts, AI agents using AJV validation).

--- a/crates/core/data/cli_flag_credits.toml
+++ b/crates/core/data/cli_flag_credits.toml
@@ -1,0 +1,191 @@
+# Community-maintainable catalogue of CLI flag-value dependency credits.
+#
+# Some CLIs load an npm package because a flag VALUE names it: `eslint --format
+# gha` loads `eslint-formatter-gha`, `mocha --reporter mochawesome` loads
+# `mochawesome`, `node -r dotenv/config` loads `dotenv`. A package used only
+# that way has no import, no config entry, and no binary invocation anywhere in
+# the project, so without a credit it is reported as an unused dependency.
+#
+# This file is the single source of truth for those rules: it is embedded into
+# the binary via `include_str!` and parsed once at startup (see
+# `crates/core/src/scripts/flag_credits.rs`). There is NO regeneration step. To
+# cover another flag of a listed tool, or another tool with a documented
+# value-to-package convention, add one entry below and open a PR.
+#
+# Each entry is `(binaries, flags) -> resolution`:
+#   - `binaries`: the CLI names the rule applies to, as they appear in a script
+#     or CI command after package-manager wrappers are stripped.
+#   - `flags`: the flag spellings that take the package-naming value. Both
+#     `--flag value` and `--flag=value` forms are matched, and comma-separated
+#     values credit each listed name.
+#   - `resolution`: how the tool maps the value to a package.
+#       `prefixed`         the tool expands a bare value with `prefix` the way
+#                          eslint's normalizePackageName does; scoped values are
+#                          always packages, unscoped values with a path
+#                          character are files and credit nothing.
+#       `prefixed-then-bare` the tool tries `prefix`-expanded first and the
+#                          plain name second (jest-resolve), so both candidates
+#                          are credited.
+#       `verbatim`         the value is the package name itself, optionally
+#                          with a subpath (`dotenv/config` credits `dotenv`).
+#   - `prefix`: required for the prefixed resolutions, forbidden for verbatim.
+#   - `builtins`: values the tool resolves internally; they never name an
+#     installable package, so they credit nothing.
+#   - `notes`: optional human context; does not affect matching.
+#
+# A credit only ever exempts an already-declared dependency from the unused
+# scan; it is never consulted by unlisted-dependency detection, so a wrong row
+# cannot invent a finding. It CAN make a real finding vanish, which is why
+# there is deliberately no generic "any bare token matching a declared
+# dependency" rule: values like `--platform node`, `--target html` and `--env
+# production` collide with real package names. Every row here is a documented,
+# tool-specific loading convention (issue #2019).
+
+# ── eslint ────────────────────────────────────────────────────────────────
+
+[[flag-credit]]
+binaries = ["eslint"]
+flags = ["--format", "-f"]
+resolution = "prefixed"
+prefix = "eslint-formatter"
+notes = """
+eslint expands `--format gha` to `eslint-formatter-gha` through a documented
+shorthand (issue #2006). Bundled formatter names are not filtered out: eslint
+resolves the npm package before falling back to its bundled one, so a declared
+`eslint-formatter-json` really is loaded.
+"""
+
+[[flag-credit]]
+binaries = ["eslint"]
+flags = ["--plugin"]
+resolution = "prefixed"
+prefix = "eslint-plugin"
+notes = """
+Same normalizePackageName expansion with the `eslint-plugin` prefix. There are
+no built-in plugins, so every resolvable value names an installable package.
+"""
+
+# ── jest ──────────────────────────────────────────────────────────────────
+
+[[flag-credit]]
+binaries = ["jest"]
+flags = ["--testEnvironment", "--test-environment", "--env"]
+resolution = "prefixed-then-bare"
+prefix = "jest-environment"
+builtins = ["node"]
+notes = """
+jest-resolve tries `jest-environment-<value>` and then the plain value, so
+both candidates are credited. `node` is the built-in environment.
+"""
+
+[[flag-credit]]
+binaries = ["jest"]
+flags = ["--runner"]
+resolution = "prefixed-then-bare"
+prefix = "jest-runner"
+notes = """
+Same jest-resolve lookup with the `jest-runner` prefix. The default `jest-runner`
+package ships with jest itself and is credited only when declared.
+"""
+
+[[flag-credit]]
+binaries = ["jest"]
+flags = ["--reporters"]
+resolution = "verbatim"
+builtins = ["default", "github-actions", "summary"]
+notes = """
+Reporter values name the module verbatim (`jest-junit`); the listed built-ins
+resolve inside jest and never name an installable package.
+"""
+
+[[flag-credit]]
+binaries = ["jest"]
+flags = ["--preset"]
+resolution = "verbatim"
+notes = """
+A preset value points at an npm module containing a jest-preset file
+(`ts-jest`, `react-native`); jest resolves the name verbatim.
+"""
+
+# ── node module preloading (node, tsx, ts-node) ───────────────────────────
+
+[[flag-credit]]
+binaries = ["node", "tsx", "ts-node"]
+flags = ["--require", "-r", "--loader", "--experimental-loader", "--import"]
+resolution = "verbatim"
+notes = """
+Preload and loader flags take a module specifier verbatim; subpath specifiers
+like `ts-node/register` and `dotenv/config` credit the owning package. Values
+starting with `.` or `/` are file paths and `node:` specifiers are built-in
+modules; both credit nothing.
+"""
+
+# ── mocha ─────────────────────────────────────────────────────────────────
+
+[[flag-credit]]
+binaries = ["mocha"]
+flags = ["--reporter", "-R"]
+resolution = "verbatim"
+builtins = [
+    "base",
+    "doc",
+    "dot",
+    "html",
+    "json",
+    "json-stream",
+    "landing",
+    "list",
+    "markdown",
+    "min",
+    "nyan",
+    "progress",
+    "spec",
+    "tap",
+    "xunit",
+]
+notes = """
+Third-party reporters are named verbatim (`mochawesome`). The built-in
+reporter names are excluded because mocha resolves them internally and several
+(`json`, `markdown`, `list`) collide with real npm packages.
+"""
+
+[[flag-credit]]
+binaries = ["mocha"]
+flags = ["--require", "-r"]
+resolution = "verbatim"
+notes = """
+Same preload semantics as node's `--require`, resolved verbatim.
+"""
+
+# ── prettier ──────────────────────────────────────────────────────────────
+
+[[flag-credit]]
+binaries = ["prettier"]
+flags = ["--plugin"]
+resolution = "verbatim"
+notes = """
+prettier does not auto-prefix plugin names; the value is the package itself
+(`prettier-plugin-tailwindcss`, `@prettier/plugin-xml`).
+"""
+
+# ── stylelint ─────────────────────────────────────────────────────────────
+
+[[flag-credit]]
+binaries = ["stylelint"]
+flags = ["--custom-syntax"]
+resolution = "verbatim"
+notes = """
+Custom syntaxes are named verbatim (`postcss-scss`). `--formatter` has no row
+on purpose: no `stylelint-formatter-*` naming convention exists.
+"""
+
+# ── postcss ───────────────────────────────────────────────────────────────
+
+[[flag-credit]]
+binaries = ["postcss"]
+flags = ["--use", "-u"]
+resolution = "verbatim"
+notes = """
+postcss-cli loads each `--use` value as a plugin package verbatim
+(`autoprefixer`, `postcss-preset-env`).
+"""

--- a/crates/core/src/scripts/flag_credits.rs
+++ b/crates/core/src/scripts/flag_credits.rs
@@ -313,8 +313,12 @@ fn prefixed_package(value: &str, prefix: &str) -> Option<String> {
 ///
 /// A subpath specifier credits the owning package: `dotenv/config` credits
 /// `dotenv`, `@scope/pkg/register` credits `@scope/pkg`. Relative and absolute
-/// paths credit nothing, and an unscoped first segment ending in a script
-/// extension is a file, not a package.
+/// paths credit nothing, an unscoped single segment ending in a script
+/// extension is a file, and an unscoped multi-segment value whose last segment
+/// ends in a script extension abstains: tools like mocha resolve an existing
+/// relative file such as `test/setup.js` before treating the value as a
+/// module, and `test`, `config`, and `tools` are all real npm package names,
+/// so crediting the first segment would silently delete genuine findings.
 fn verbatim_package(value: &str) -> Option<String> {
     if value.starts_with(['.', '/', '\\']) {
         return None;
@@ -325,10 +329,16 @@ fn verbatim_package(value: &str) -> Option<String> {
         let name = parts.next().filter(|s| !s.is_empty())?;
         return Some(format!("@{scope}/{name}"));
     }
-    let first = value.split('/').next()?;
+    let mut segments = value.split('/');
+    let first = segments.next()?;
     if first.is_empty()
         || first.contains('\\')
         || SCRIPT_EXTENSIONS.iter().any(|ext| first.ends_with(ext))
+    {
+        return None;
+    }
+    if let Some(last) = segments.next_back()
+        && SCRIPT_EXTENSIONS.iter().any(|ext| last.ends_with(ext))
     {
         return None;
     }
@@ -483,6 +493,19 @@ mod tests {
         assert!(credits("node", "-r ./setup.js").is_empty());
         assert!(credits("node", "-r setup.js").is_empty());
         assert!(credits("node", "--loader /abs/loader.mjs").is_empty());
+    }
+
+    /// mocha path-resolves an existing relative file before treating the value
+    /// as a module, so `test/setup.js` must not credit the `test` package.
+    #[test]
+    fn directory_relative_script_paths_credit_nothing() {
+        assert!(credits("mocha", "--require test/setup.js").is_empty());
+        assert!(credits("node", "-r config/env.js").is_empty());
+        assert!(credits("node", "-r scripts/register.js").is_empty());
+        assert!(credits("mocha", "--require tools/mocha-setup.cjs").is_empty());
+        // A package subpath whose file has a script extension abstains too;
+        // missing a credit is the safe direction, inventing one is not.
+        assert!(credits("node", "-r pkg/dist/index.js").is_empty());
     }
 
     #[test]

--- a/crates/core/src/scripts/flag_credits.rs
+++ b/crates/core/src/scripts/flag_credits.rs
@@ -1,0 +1,633 @@
+//! CLI flag-value dependency crediting.
+//!
+//! Some CLIs load an npm package because a flag value names it: `eslint
+//! --format gha` loads `eslint-formatter-gha`, `mocha --reporter mochawesome`
+//! loads `mochawesome`. A package used only that way has no import, no config
+//! entry, and no binary invocation anywhere in the project, so without a credit
+//! it is reported as an unused dependency (issues #2006 and #2019).
+//!
+//! The conventions are data, not code: the `(binary, flag) -> resolution` rows
+//! live in `crates/core/data/cli_flag_credits.toml`, embedded via
+//! `include_str!` and parsed once at startup. There is no regeneration step.
+//!
+//! A credit only ever exempts an already-declared dependency from the unused
+//! scan; it is never consulted by unlisted-dependency detection, so a
+//! synthesized name cannot invent a finding.
+
+use rustc_hash::FxHashMap;
+
+use super::strip_surrounding_quotes;
+
+/// Embedded catalogue source. Because it is `include_str!`-embedded at compile
+/// time, a green `catalogue_parses` test guarantees the released binary parses.
+const CATALOGUE_TOML: &str = include_str!("../../data/cli_flag_credits.toml");
+
+/// File extensions that mark an unscoped verbatim value as a file path rather
+/// than a package name.
+const SCRIPT_EXTENSIONS: &[&str] = &[
+    ".js", ".cjs", ".mjs", ".jsx", ".ts", ".cts", ".mts", ".tsx", ".json", ".node",
+];
+
+/// How a tool maps a flag value to the package it loads.
+///
+/// The set is closed on purpose: each variant encodes a documented resolution
+/// algorithm, so an unknown value in the TOML is a bug rather than a new rule.
+/// Serde rejects unknown variants, which makes the catalogue parse fail loudly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum Resolution {
+    /// The tool expands a bare value with the entry's prefix the way eslint's
+    /// `normalizePackageName` does; scoped values are always packages, unscoped
+    /// values with a path character are files.
+    Prefixed,
+    /// The tool tries the prefix-expanded name first and the plain name second
+    /// (jest-resolve), so both candidates are credited.
+    PrefixedThenBare,
+    /// The value is the package name itself, optionally with a subpath
+    /// (`dotenv/config` credits `dotenv`).
+    Verbatim,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogueFile {
+    #[serde(default, rename = "flag-credit")]
+    flag_credit: Vec<FlagCreditEntry>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FlagCreditEntry {
+    /// CLI names the rule applies to, after package-manager wrappers are
+    /// stripped.
+    binaries: Vec<String>,
+    /// Flag spellings that take the package-naming value.
+    flags: Vec<String>,
+    resolution: Resolution,
+    /// Required for the prefixed resolutions, forbidden for verbatim.
+    #[serde(default)]
+    prefix: Option<String>,
+    /// Values the tool resolves internally; they credit nothing.
+    #[serde(default)]
+    builtins: Vec<String>,
+    /// Optional human context; does not affect matching.
+    #[expect(
+        dead_code,
+        reason = "documentation field, surfaced via the catalogue source"
+    )]
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+/// One parsed convention shared by every `(binary, flag)` key it covers.
+#[derive(Debug)]
+struct FlagRule {
+    resolution: Resolution,
+    prefix: Option<String>,
+    builtins: Vec<String>,
+}
+
+#[derive(Debug)]
+struct Catalogue {
+    rules: Vec<FlagRule>,
+    /// `(binary, flag)` -> index into `rules`.
+    index: FxHashMap<(String, String), usize>,
+}
+
+impl Catalogue {
+    fn rule(&self, binary: &str, flag: &str) -> Option<&FlagRule> {
+        let key = (binary.to_string(), flag.to_string());
+        self.index.get(&key).map(|&idx| &self.rules[idx])
+    }
+}
+
+/// Parse and validate catalogue source.
+///
+/// # Errors
+///
+/// Returns a human-readable message when the TOML is malformed, an entry names
+/// an unknown resolution, a binary, flag, or builtin is blank, a flag does not
+/// start with `-`, the prefix contract for the resolution is violated, or two
+/// entries claim the same `(binary, flag)` key.
+fn parse(source: &str) -> Result<Catalogue, String> {
+    let parsed: CatalogueFile = toml::from_str(source).map_err(|e| e.to_string())?;
+    let mut rules = Vec::new();
+    let mut index = FxHashMap::default();
+
+    for entry in parsed.flag_credit {
+        let label = format!("{:?} / {:?}", entry.binaries, entry.flags);
+        if entry.binaries.is_empty() {
+            return Err(format!("flag-credit entry {label} lists no binaries"));
+        }
+        if entry.flags.is_empty() {
+            return Err(format!("flag-credit entry {label} lists no flags"));
+        }
+        if entry.binaries.iter().any(|b| b.trim().is_empty()) {
+            return Err(format!("flag-credit entry {label} has a blank binary"));
+        }
+        if let Some(flag) = entry
+            .flags
+            .iter()
+            .find(|f| !f.starts_with('-') || f.len() < 2)
+        {
+            return Err(format!(
+                "flag-credit entry {label} has a malformed flag {flag:?}"
+            ));
+        }
+        if entry.builtins.iter().any(|b| b.trim().is_empty()) {
+            return Err(format!("flag-credit entry {label} has a blank builtin"));
+        }
+        match entry.resolution {
+            Resolution::Prefixed | Resolution::PrefixedThenBare => {
+                if entry.prefix.as_deref().is_none_or(|p| p.trim().is_empty()) {
+                    return Err(format!(
+                        "flag-credit entry {label} needs a non-empty prefix for its resolution"
+                    ));
+                }
+            }
+            Resolution::Verbatim => {
+                if entry.prefix.is_some() {
+                    return Err(format!(
+                        "flag-credit entry {label} is verbatim and must not set a prefix"
+                    ));
+                }
+            }
+        }
+
+        let rule_idx = rules.len();
+        rules.push(FlagRule {
+            resolution: entry.resolution,
+            prefix: entry.prefix,
+            builtins: entry.builtins,
+        });
+        for binary in &entry.binaries {
+            for flag in &entry.flags {
+                let key = (binary.clone(), flag.clone());
+                if index.contains_key(&key) {
+                    return Err(format!("duplicate flag-credit entry: {key:?}"));
+                }
+                index.insert(key, rule_idx);
+            }
+        }
+    }
+
+    Ok(Catalogue { rules, index })
+}
+
+/// Parse and cache the embedded catalogue once. Panics with a clear message if
+/// the embedded TOML is invalid; this is unreachable in a released binary
+/// because the bytes are compile-time-embedded and gated by `catalogue_parses`.
+#[expect(
+    clippy::expect_used,
+    reason = "embedded flag-credit catalogue is compile-time data pinned by catalogue_parses"
+)]
+fn catalogue() -> &'static Catalogue {
+    static CATALOGUE: std::sync::OnceLock<Catalogue> = std::sync::OnceLock::new();
+    CATALOGUE.get_or_init(|| {
+        parse(CATALOGUE_TOML).expect(
+            "embedded crates/core/data/cli_flag_credits.toml must be valid; run \
+             `cargo test -p fallow-core flag_credits` to see the error",
+        )
+    })
+}
+
+/// Packages a CLI names through a flag value rather than a positional argument.
+///
+/// `args` are the tokens after the binary itself; scanning stops at `--`
+/// because everything past it belongs to another program.
+pub fn flag_referenced_packages(binary: &str, args: &[&str]) -> Vec<String> {
+    let catalogue = catalogue();
+    let mut packages = Vec::new();
+    let mut idx = 0;
+    while idx < args.len() {
+        let token = args[idx];
+        if token == "--" {
+            break;
+        }
+
+        let inline = token
+            .split_once('=')
+            .and_then(|(flag, value)| catalogue.rule(binary, flag).map(|rule| (rule, value)));
+        let (rule, value) = if let Some(found) = inline {
+            idx += 1;
+            found
+        } else if let Some(rule) = catalogue.rule(binary, token) {
+            idx += 2;
+            let Some(value) = args.get(idx - 1) else {
+                break;
+            };
+            (rule, *value)
+        } else {
+            idx += 1;
+            continue;
+        };
+
+        for piece in strip_surrounding_quotes(value).split(',') {
+            credit_value(rule, piece.trim(), &mut packages);
+        }
+    }
+    packages
+}
+
+fn credit_value(rule: &FlagRule, value: &str, out: &mut Vec<String>) {
+    // A leading dash is a flag, not a value; a colon marks node: built-ins,
+    // Windows drive paths, and URLs, none of which are npm packages.
+    if value.is_empty() || value.starts_with('-') || value.contains(':') {
+        return;
+    }
+    if rule.builtins.iter().any(|builtin| builtin == value) {
+        return;
+    }
+
+    let prefix = rule.prefix.as_deref();
+    match rule.resolution {
+        Resolution::Prefixed => {
+            if let Some(prefix) = prefix
+                && let Some(package) = prefixed_package(value, prefix)
+            {
+                push_unique(out, package);
+            }
+        }
+        Resolution::PrefixedThenBare => {
+            if value.starts_with('@') {
+                // jest-resolve's prefix expansion is not scope-aware; a scoped
+                // value only ever resolves to the scoped package itself.
+                if let Some(package) = verbatim_package(value) {
+                    push_unique(out, package);
+                }
+                return;
+            }
+            if let Some(prefix) = prefix
+                && let Some(package) = prefixed_package(value, prefix)
+            {
+                push_unique(out, package);
+            }
+            if let Some(package) = verbatim_package(value) {
+                push_unique(out, package);
+            }
+        }
+        Resolution::Verbatim => {
+            if let Some(package) = verbatim_package(value) {
+                push_unique(out, package);
+            }
+        }
+    }
+}
+
+fn push_unique(out: &mut Vec<String>, package: String) {
+    if !out.contains(&package) {
+        out.push(package);
+    }
+}
+
+/// Resolve a prefix-expanded flag value to the package the tool would load.
+///
+/// Mirrors eslint's `normalizePackageName(name, prefix)`: a value starting with
+/// `@` is always a package, never a path, so `@scope/sarif` with prefix
+/// `eslint-formatter` becomes `@scope/eslint-formatter-sarif` and an
+/// already-qualified name passes through. Only an unscoped value carrying a
+/// path separator or extension is a file path.
+fn prefixed_package(value: &str, prefix: &str) -> Option<String> {
+    if let Some(scoped) = value.strip_prefix('@') {
+        let mut parts = scoped.splitn(2, '/');
+        let scope = parts.next().filter(|s| !s.is_empty())?;
+        return Some(match parts.next().filter(|s| !s.is_empty()) {
+            None => format!("@{scope}/{prefix}"),
+            Some(name) if name.starts_with(prefix) => format!("@{scope}/{name}"),
+            Some(name) => format!("@{scope}/{prefix}-{name}"),
+        });
+    }
+
+    if value.contains(['/', '\\', '.']) {
+        return None;
+    }
+    if let Some(rest) = value.strip_prefix(prefix)
+        && rest.starts_with('-')
+    {
+        return Some(value.to_string());
+    }
+    Some(format!("{prefix}-{value}"))
+}
+
+/// Resolve a verbatim flag value to the package that owns the specifier.
+///
+/// A subpath specifier credits the owning package: `dotenv/config` credits
+/// `dotenv`, `@scope/pkg/register` credits `@scope/pkg`. Relative and absolute
+/// paths credit nothing, and an unscoped first segment ending in a script
+/// extension is a file, not a package.
+fn verbatim_package(value: &str) -> Option<String> {
+    if value.starts_with(['.', '/', '\\']) {
+        return None;
+    }
+    if let Some(scoped) = value.strip_prefix('@') {
+        let mut parts = scoped.split('/');
+        let scope = parts.next().filter(|s| !s.is_empty())?;
+        let name = parts.next().filter(|s| !s.is_empty())?;
+        return Some(format!("@{scope}/{name}"));
+    }
+    let first = value.split('/').next()?;
+    if first.is_empty()
+        || first.contains('\\')
+        || SCRIPT_EXTENSIONS.iter().any(|ext| first.ends_with(ext))
+    {
+        return None;
+    }
+    Some(first.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credits(binary: &str, command: &str) -> Vec<String> {
+        let tokens: Vec<&str> = command.split_whitespace().collect();
+        flag_referenced_packages(binary, &tokens)
+    }
+
+    fn formatter_packages(command: &str) -> Vec<String> {
+        credits("eslint", command)
+    }
+
+    #[test]
+    fn catalogue_parses() {
+        let cat = catalogue();
+        assert!(!cat.index.is_empty(), "catalogue must have entries");
+    }
+
+    #[test]
+    fn bare_formatter_shorthand_expands() {
+        assert_eq!(
+            formatter_packages("--format gha"),
+            vec!["eslint-formatter-gha"]
+        );
+        assert_eq!(formatter_packages("-f gha"), vec!["eslint-formatter-gha"]);
+        assert_eq!(
+            formatter_packages("--format=gha"),
+            vec!["eslint-formatter-gha"]
+        );
+    }
+
+    /// GitHub's own code-scanning starter workflow passes exactly this value.
+    #[test]
+    fn scoped_formatter_is_credited_verbatim() {
+        assert_eq!(
+            formatter_packages("--format @microsoft/eslint-formatter-sarif"),
+            vec!["@microsoft/eslint-formatter-sarif"]
+        );
+    }
+
+    #[test]
+    fn scoped_shorthand_formatter_expands() {
+        assert_eq!(
+            formatter_packages("--format @microsoft/sarif"),
+            vec!["@microsoft/eslint-formatter-sarif"]
+        );
+        assert_eq!(
+            formatter_packages("--format @scope"),
+            vec!["@scope/eslint-formatter"]
+        );
+    }
+
+    #[test]
+    fn already_prefixed_formatter_is_not_double_prefixed() {
+        assert_eq!(
+            formatter_packages("--format eslint-formatter-gha"),
+            vec!["eslint-formatter-gha"]
+        );
+    }
+
+    #[test]
+    fn unscoped_path_formatter_is_skipped() {
+        assert!(formatter_packages("--format ./tools/fmt.js").is_empty());
+        assert!(formatter_packages("--format node_modules/x/index.js").is_empty());
+    }
+
+    #[test]
+    fn tokens_after_double_dash_are_not_scanned() {
+        assert!(formatter_packages("--fix -- --format gha").is_empty());
+    }
+
+    #[test]
+    fn flag_value_starting_with_dash_credits_nothing() {
+        assert!(formatter_packages("--format --fix").is_empty());
+    }
+
+    #[test]
+    fn eslint_plugin_expands_with_plugin_prefix() {
+        assert_eq!(
+            credits("eslint", "--plugin import"),
+            vec!["eslint-plugin-import"]
+        );
+        assert_eq!(
+            credits("eslint", "--plugin import,unicorn"),
+            vec!["eslint-plugin-import", "eslint-plugin-unicorn"]
+        );
+    }
+
+    #[test]
+    fn jest_environment_credits_both_candidates() {
+        assert_eq!(
+            credits("jest", "--testEnvironment jsdom"),
+            vec!["jest-environment-jsdom", "jsdom"]
+        );
+        assert_eq!(
+            credits("jest", "--env=jsdom"),
+            vec!["jest-environment-jsdom", "jsdom"]
+        );
+    }
+
+    #[test]
+    fn jest_builtin_environment_credits_nothing() {
+        assert!(credits("jest", "--testEnvironment node").is_empty());
+    }
+
+    #[test]
+    fn jest_already_prefixed_environment_is_credited_once() {
+        assert_eq!(
+            credits("jest", "--testEnvironment jest-environment-jsdom"),
+            vec!["jest-environment-jsdom"]
+        );
+    }
+
+    #[test]
+    fn jest_scoped_environment_is_credited_verbatim() {
+        assert_eq!(
+            credits("jest", "--testEnvironment @happy-dom/jest-environment"),
+            vec!["@happy-dom/jest-environment"]
+        );
+    }
+
+    #[test]
+    fn jest_reporter_is_verbatim_and_builtins_abstain() {
+        assert_eq!(
+            credits("jest", "--reporters jest-junit"),
+            vec!["jest-junit"]
+        );
+        assert!(credits("jest", "--reporters default").is_empty());
+        assert!(credits("jest", "--reporters github-actions").is_empty());
+    }
+
+    #[test]
+    fn node_preload_subpath_credits_owning_package() {
+        assert_eq!(credits("node", "-r dotenv/config"), vec!["dotenv"]);
+        assert_eq!(
+            credits("node", "--require ts-node/register"),
+            vec!["ts-node"]
+        );
+        assert_eq!(credits("node", "--import tsx src/main.ts"), vec!["tsx"]);
+    }
+
+    #[test]
+    fn node_builtin_and_path_preloads_credit_nothing() {
+        assert!(credits("node", "-r node:assert").is_empty());
+        assert!(credits("node", "-r ./setup.js").is_empty());
+        assert!(credits("node", "-r setup.js").is_empty());
+        assert!(credits("node", "--loader /abs/loader.mjs").is_empty());
+    }
+
+    #[test]
+    fn mocha_reporter_is_verbatim_and_builtins_abstain() {
+        assert_eq!(
+            credits("mocha", "--reporter mochawesome"),
+            vec!["mochawesome"]
+        );
+        assert!(credits("mocha", "--reporter spec").is_empty());
+        assert!(
+            credits("mocha", "-R json").is_empty(),
+            "built-in colliding with a real npm package must abstain"
+        );
+    }
+
+    #[test]
+    fn prettier_stylelint_postcss_values_are_verbatim() {
+        assert_eq!(
+            credits("prettier", "--plugin prettier-plugin-tailwindcss"),
+            vec!["prettier-plugin-tailwindcss"]
+        );
+        assert_eq!(
+            credits("stylelint", "--custom-syntax postcss-scss"),
+            vec!["postcss-scss"]
+        );
+        assert_eq!(
+            credits("postcss", "--use autoprefixer"),
+            vec!["autoprefixer"]
+        );
+    }
+
+    #[test]
+    fn unlisted_binary_or_flag_credits_nothing() {
+        assert!(credits("prettier", "--format gha").is_empty());
+        assert!(credits("stylelint", "--formatter pretty").is_empty());
+        assert!(credits("nyc", "--reporter lcov").is_empty());
+    }
+
+    #[test]
+    fn unknown_resolution_is_rejected() {
+        let err = parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = ["--y"]
+resolution = "fuzzy"
+"#,
+        )
+        .expect_err("unknown resolution must fail");
+        assert!(err.contains("fuzzy"), "got: {err}");
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let err = parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = ["--y"]
+resolution = "verbatim"
+ecosystem = "css"
+"#,
+        )
+        .expect_err("unknown field must fail");
+        assert!(err.contains("ecosystem"), "got: {err}");
+    }
+
+    #[test]
+    fn prefixed_without_prefix_is_rejected() {
+        parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = ["--y"]
+resolution = "prefixed"
+"#,
+        )
+        .expect_err("prefixed resolution without prefix must fail");
+    }
+
+    #[test]
+    fn verbatim_with_prefix_is_rejected() {
+        parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = ["--y"]
+resolution = "verbatim"
+prefix = "x-plugin"
+"#,
+        )
+        .expect_err("verbatim resolution with prefix must fail");
+    }
+
+    #[test]
+    fn malformed_flag_is_rejected() {
+        parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = ["plugin"]
+resolution = "verbatim"
+"#,
+        )
+        .expect_err("flag without leading dash must fail");
+    }
+
+    #[test]
+    fn duplicate_binary_flag_pair_is_rejected() {
+        let err = parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = ["--y"]
+resolution = "verbatim"
+
+[[flag-credit]]
+binaries = ["x"]
+flags = ["--y", "-z"]
+resolution = "verbatim"
+"#,
+        )
+        .expect_err("duplicate (binary, flag) must fail");
+        assert!(err.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_binaries_or_flags_are_rejected() {
+        parse(
+            r#"
+[[flag-credit]]
+binaries = []
+flags = ["--y"]
+resolution = "verbatim"
+"#,
+        )
+        .expect_err("empty binaries must fail");
+        parse(
+            r#"
+[[flag-credit]]
+binaries = ["x"]
+flags = []
+resolution = "verbatim"
+"#,
+        )
+        .expect_err("empty flags must fail");
+    }
+}

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -10,6 +10,7 @@
 //! `ts-node`). Shell operators (`&&`, `||`, `;`, `|`, `&`) are split correctly.
 
 pub mod ci;
+mod flag_credits;
 mod resolve;
 mod shell;
 
@@ -938,7 +939,7 @@ fn parse_command_segment(
 
     let is_node_runner = NODE_RUNNERS.contains(&binary.as_str());
     let (file_args, config_args) = extract_args_for_binary(&tokens, idx + 1, is_node_runner);
-    let flag_packages = flag_referenced_packages(&binary, &tokens[idx + 1..]);
+    let flag_packages = flag_credits::flag_referenced_packages(&binary, &tokens[idx + 1..]);
 
     Some(SegmentOutcome::Command(ScriptCommand {
         binary,
@@ -956,86 +957,6 @@ fn forwarded_arguments(segment: &str, from_token: usize) -> String {
         .skip(from_token)
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-/// Packages a CLI names through a flag value rather than a positional argument.
-///
-/// eslint expands `--format gha` to the `eslint-formatter-gha` package using a
-/// documented shorthand, so a formatter invoked only from a CI command has no
-/// import, no config entry, and no binary invocation anywhere in the project and
-/// is reported as an unused dependency (issue #2006).
-///
-/// The synthesized name only ever exempts an already-declared dependency from
-/// the unused scan; it is not consulted by unlisted-dependency detection, so an
-/// undeclared formatter cannot turn into a new finding. That is also why the
-/// bundled formatter names are not filtered out: eslint resolves the npm package
-/// before falling back to its bundled one, so a declared `eslint-formatter-json`
-/// really is loaded, and an undeclared one credits nothing either way.
-fn flag_referenced_packages(binary: &str, args: &[&str]) -> Vec<String> {
-    if binary != "eslint" {
-        return Vec::new();
-    }
-
-    let mut packages = Vec::new();
-    let mut idx = 0;
-    while idx < args.len() {
-        let token = args[idx];
-        // Everything past `--` belongs to another program.
-        if token == "--" {
-            break;
-        }
-        let value = if let Some(value) = token
-            .strip_prefix("--format=")
-            .or_else(|| token.strip_prefix("-f="))
-        {
-            idx += 1;
-            value
-        } else if matches!(token, "--format" | "-f") {
-            idx += 2;
-            let Some(value) = args.get(idx - 1) else {
-                break;
-            };
-            value
-        } else {
-            idx += 1;
-            continue;
-        };
-
-        if let Some(package) = eslint_formatter_package(strip_surrounding_quotes(value)) {
-            packages.push(package);
-        }
-    }
-    packages
-}
-
-/// Resolve an eslint `--format` value to the package eslint would load.
-///
-/// Mirrors eslint's own `normalizePackageName(name, "eslint-formatter")`: a value
-/// starting with `@` is always a package, never a path, so `@scope/sarif` becomes
-/// `@scope/eslint-formatter-sarif` and an already-qualified name passes through.
-/// Only an unscoped value carrying a path separator or extension is a file path.
-fn eslint_formatter_package(value: &str) -> Option<String> {
-    if value.is_empty() || value.starts_with('-') {
-        return None;
-    }
-
-    if let Some(scoped) = value.strip_prefix('@') {
-        let mut parts = scoped.splitn(2, '/');
-        let scope = parts.next().filter(|s| !s.is_empty())?;
-        return Some(match parts.next().filter(|s| !s.is_empty()) {
-            None => format!("@{scope}/eslint-formatter"),
-            Some(name) if name.starts_with("eslint-formatter") => format!("@{scope}/{name}"),
-            Some(name) => format!("@{scope}/eslint-formatter-{name}"),
-        });
-    }
-
-    if value.contains(['/', '\\', '.']) {
-        return None;
-    }
-    if value.starts_with("eslint-formatter-") {
-        return Some(value.to_string());
-    }
-    Some(format!("eslint-formatter-{value}"))
 }
 
 /// Extract a config file path from a `--config` or `-c` flag.
@@ -1168,11 +1089,6 @@ mod tests {
         packages.iter().map(|pkg| (*pkg).to_string()).collect()
     }
 
-    fn formatter_packages(command: &str) -> Vec<String> {
-        let tokens: Vec<&str> = command.split_whitespace().collect();
-        flag_referenced_packages("eslint", &tokens)
-    }
-
     /// Analyze a CI-style command against a project whose package.json declares
     /// `scripts` and every package in `declared`.
     fn analyze_ci_command(
@@ -1192,69 +1108,6 @@ mod tests {
             &package_set(declared),
             &ScriptCatalog::from_scripts(&scripts),
         )
-    }
-
-    #[test]
-    fn bare_formatter_shorthand_expands() {
-        assert_eq!(
-            formatter_packages("--format gha"),
-            vec!["eslint-formatter-gha"]
-        );
-        assert_eq!(formatter_packages("-f gha"), vec!["eslint-formatter-gha"]);
-        assert_eq!(
-            formatter_packages("--format=gha"),
-            vec!["eslint-formatter-gha"]
-        );
-    }
-
-    /// GitHub's own code-scanning starter workflow passes exactly this value.
-    #[test]
-    fn scoped_formatter_is_credited_verbatim() {
-        assert_eq!(
-            formatter_packages("--format @microsoft/eslint-formatter-sarif"),
-            vec!["@microsoft/eslint-formatter-sarif"]
-        );
-    }
-
-    #[test]
-    fn scoped_shorthand_formatter_expands() {
-        assert_eq!(
-            formatter_packages("--format @microsoft/sarif"),
-            vec!["@microsoft/eslint-formatter-sarif"]
-        );
-        assert_eq!(
-            formatter_packages("--format @scope"),
-            vec!["@scope/eslint-formatter"]
-        );
-    }
-
-    #[test]
-    fn already_prefixed_formatter_is_not_double_prefixed() {
-        assert_eq!(
-            formatter_packages("--format eslint-formatter-gha"),
-            vec!["eslint-formatter-gha"]
-        );
-    }
-
-    #[test]
-    fn unscoped_path_formatter_is_skipped() {
-        assert!(formatter_packages("--format ./tools/fmt.js").is_empty());
-        assert!(formatter_packages("--format node_modules/x/index.js").is_empty());
-    }
-
-    #[test]
-    fn tokens_after_double_dash_are_not_scanned() {
-        assert!(formatter_packages("--fix -- --format gha").is_empty());
-    }
-
-    #[test]
-    fn flag_value_starting_with_dash_credits_nothing() {
-        assert!(formatter_packages("--format --fix").is_empty());
-    }
-
-    #[test]
-    fn non_eslint_binary_credits_nothing() {
-        assert!(flag_referenced_packages("prettier", &["--format", "gha"]).is_empty());
     }
 
     #[test]

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -287,6 +287,8 @@ mod issue_1301_bun_catalog;
 mod issue_1648_unused_prop_ignore_pattern;
 #[path = "integration_test/issue_195_non_source_entry_points.rs"]
 mod issue_195_non_source_entry_points;
+#[path = "integration_test/issue_2019_cli_flag_convention_table.rs"]
+mod issue_2019_cli_flag_convention_table;
 #[path = "integration_test/issue_2069_npm_overrides.rs"]
 mod issue_2069_npm_overrides;
 #[path = "integration_test/issue_317_namespace_barrel_ignore_exports.rs"]

--- a/crates/core/tests/integration_test/issue_2019_cli_flag_convention_table.rs
+++ b/crates/core/tests/integration_test/issue_2019_cli_flag_convention_table.rs
@@ -1,0 +1,124 @@
+//! Regression tests for issue #2019: the CLI flag-value convention table.
+//!
+//! #2006 credited packages named as eslint `--format` values. Other CLIs
+//! follow the same pattern, where a flag value names an npm package that has
+//! no other reference in the project: `mocha --reporter mochawesome`,
+//! `node -r dotenv/config`, `jest --testEnvironment jsdom`. The conventions
+//! live in `crates/core/data/cli_flag_credits.toml`; a (binary, flag) pair
+//! without a row must keep abstaining.
+
+use std::path::Path;
+
+use super::common::create_config;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, contents).expect("write file");
+}
+
+fn unused_dev_dependencies(results: &fallow_types::results::AnalysisResults) -> Vec<&str> {
+    results
+        .unused_dev_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect()
+}
+
+fn analyze(root: &Path) -> fallow_types::results::AnalysisResults {
+    let config = create_config(root.to_path_buf());
+    fallow_core::analyze(&config).expect("analysis should succeed")
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2019_convention_table_credits_flag_named_packages() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write(
+        &dir.path().join("package.json"),
+        r#"{
+            "name": "flag-convention-repro",
+            "private": true,
+            "main": "src/index.ts",
+            "scripts": {
+                "test": "mocha --reporter mochawesome",
+                "test:unit": "jest --testEnvironment jsdom",
+                "start": "node -r dotenv/config src/index.js"
+            },
+            "devDependencies": {
+                "mocha": "^10.0.0",
+                "jest": "^29.0.0",
+                "mochawesome": "^7.1.3",
+                "jest-environment-jsdom": "^29.0.0",
+                "dotenv": "^16.4.5",
+                "left-pad": "^1.3.0"
+            }
+        }"#,
+    );
+    write(&dir.path().join("src/index.ts"), r"export const value = 1;");
+    let results = analyze(dir.path());
+
+    let unused = unused_dev_dependencies(&results);
+    for credited in ["mochawesome", "jest-environment-jsdom", "dotenv"] {
+        assert!(
+            !unused.contains(&credited),
+            "{credited} is named by a flag value and must be credited, got {unused:?}"
+        );
+    }
+    assert!(
+        unused.contains(&"left-pad"),
+        "an unrelated unused devDependency must still be reported, got {unused:?}"
+    );
+}
+
+/// stylelint `--formatter` and nyc `--reporter` deliberately have no catalogue
+/// rows (no naming convention, unstable built-in set), so a package whose name
+/// only appears as such a flag value stays unused and no dependency is
+/// invented. `pretty` and `lcov` are real npm packages that collide with those
+/// values, which is exactly why a generic bare-token rule is refused.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn issue_2019_unlisted_convention_still_abstains() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    write(
+        &dir.path().join("package.json"),
+        r#"{
+            "name": "flag-convention-control",
+            "private": true,
+            "main": "src/index.ts",
+            "scripts": {
+                "lint:css": "stylelint --formatter pretty src/**/*.css",
+                "coverage": "nyc --reporter=lcov node src/index.js"
+            },
+            "devDependencies": {
+                "stylelint": "^16.0.0",
+                "nyc": "^17.0.0",
+                "pretty": "^2.0.0",
+                "lcov": "^1.16.0"
+            }
+        }"#,
+    );
+    write(&dir.path().join("src/index.ts"), r"export const value = 1;");
+    let results = analyze(dir.path());
+
+    let unused = unused_dev_dependencies(&results);
+    assert!(
+        unused.contains(&"pretty"),
+        "an unlisted convention must not credit the bare value, got {unused:?}"
+    );
+    assert!(
+        unused.contains(&"lcov"),
+        "an unlisted convention must not credit the bare value, got {unused:?}"
+    );
+
+    let unlisted: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    assert!(
+        unlisted.is_empty(),
+        "flag-value credit must never create an unlisted dependency, got {unlisted:?}"
+    );
+}

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -91,6 +91,31 @@ analyzes, so a production run cannot enter a body that script filtering skipped.
 A name declared with different bodies in several workspace packages keeps its
 name but permanently loses its body.
 
+### CLI flag-value crediting
+
+Some CLIs load an npm package because a flag value names it: `eslint --format
+gha` loads `eslint-formatter-gha`, `mocha --reporter mochawesome` loads
+`mochawesome`, `node -r dotenv/config` loads `dotenv`. Fallow credits these
+packages from a closed convention table of `(binary, flag)` pairs;
+`crates/core/data/cli_flag_credits.toml` is the authoritative list of covered
+binaries, flags, resolution rules, and tool built-ins. This is why a package
+used only through such a flag (mochawesome, dotenv, a SARIF formatter in CI) is
+not reported as an unused dependency.
+
+Two invariants matter to users:
+
+- A credit can only remove an unused-dependency finding for a dependency the
+  project already declares.
+- The table is never consulted by unlisted-dependency detection, so a
+  synthesized name can never invent a finding.
+
+Values that name files rather than packages abstain: relative and absolute
+paths, and any unscoped value whose final path segment ends in a script
+extension (`mocha --require test/setup.js` credits nothing, because tools
+resolve an existing relative file before treating the value as a module).
+Built-in values listed per tool (`mocha --reporter spec`, `jest --reporters
+default`) also credit nothing.
+
 Expansion is bounded twice. `MAX_SCRIPT_INDIRECTION_DEPTH` caps the depth of a
 single chain, and `MAX_SCRIPT_EXPANSIONS` caps the total number of bodies
 expanded for one command, because the cycle guard only rejects names on the


### PR DESCRIPTION
## What

Extends the flag-value dependency crediting from #2006 (eslint `--format`) into a data-driven convention table. The rows live in a new embedded catalogue, `crates/core/data/cli_flag_credits.toml`, in the same family as `tooling.toml` and `config_value_credits.toml`: `include_str!`-embedded, parsed once at startup, no regeneration step, and any malformed row (unknown resolution, unknown field, flag without a leading dash, prefix-contract violation, blank or duplicate entries) fails the parse loudly.

## Conventions included (for panel review)

Each row is a documented, tool-specific value-to-package convention:

- **eslint `--format` / `-f`** (migrated from the hardcoded #2006 implementation, behavior unchanged): `prefixed` with `eslint-formatter`, mirroring eslint's `normalizePackageName`.
- **eslint `--plugin`**: `prefixed` with `eslint-plugin`. No built-ins exist, so this is the safest row of the set.
- **jest `--testEnvironment` / `--test-environment` / `--env`**: `prefixed-then-bare` with `jest-environment`, because jest-resolve tries the prefixed name and then the plain one, so both candidates are credited. Built-in: `node`.
- **jest `--runner`**: `prefixed-then-bare` with `jest-runner`.
- **jest `--reporters`**: `verbatim`, built-ins `default`, `github-actions`, `summary`.
- **jest `--preset`**: `verbatim` (a preset names the npm module containing the jest-preset file).
- **node / tsx / ts-node `-r` / `--require` / `--loader` / `--experimental-loader` / `--import`**: `verbatim`. Subpath specifiers credit the owning package (`dotenv/config` credits `dotenv`, `ts-node/register` credits `ts-node`); values starting with `.` or `/` are paths and any value containing `:` (covers `node:` built-ins, Windows drives, URLs) credits nothing.
- **mocha `--reporter` / `-R`**: `verbatim`, with the full built-in reporter list excluded because several built-in names (`json`, `markdown`, `list`) collide with real npm packages.
- **mocha `--require` / `-r`**: `verbatim`.
- **prettier `--plugin`**: `verbatim` (prettier does not auto-prefix).
- **stylelint `--custom-syntax`**: `verbatim`.
- **postcss `--use` / `-u`**: `verbatim`.

Deliberately excluded, matching the issue: eslint `--rulesdir` and `--resolve-plugins-relative-to` (paths), stylelint `--formatter` (no naming convention), nyc / c8 `--reporter` (unstable built-in set), semantic-release and commitlint `--extends` (config-parsed already), and any generic bare-token rule.

## Surface naming decisions

- The catalogue keys are `(binary, flag)` pairs rather than an abstract surface enum: every convention is observable directly from the command line, so the binary name plus flag spelling IS the surface. Entries group multiple binaries and flag spellings that share one convention.
- `resolution` is a closed enum (`prefixed`, `prefixed-then-bare`, `verbatim`); a new resolution algorithm requires a new variant plus code in the same PR, same policy as `CreditSurface` in the config-value catalogue.
- Both `--flag value` and `--flag=value` forms match, comma-separated values credit each name, scanning stops at `--`, and jest's scoped values skip the (non-scope-aware) prefix expansion and credit only the scoped package.

## Safety

A credit only ever exempts an already-declared dependency from the unused-dependency scan; it is never consulted by unlisted-dependency detection, so a synthesized name cannot invent a finding. Built-in values, path values, and unlisted (binary, flag) pairs keep abstaining.

## Tests

- Unit tests in `flag_credits.rs`: all migrated #2006 eslint cases (unchanged assertions), each new convention, built-in abstention including the `json`/`lcov`-style collisions, subpath crediting, and every parse-loudly failure mode.
- Integration tests in `issue_2019_cli_flag_convention_table.rs`: a positive fixture where packages named only through script flag values (`mochawesome`, `jest-environment-jsdom`, `dotenv`) are credited while an unrelated dep stays reported, and a control proving unlisted conventions (`stylelint --formatter`, `nyc --reporter`) still abstain and invent no dependency.
- `CONTRIBUTING.md` documents the new catalogue next to the other two; CHANGELOG entry added.

Note on #2016: package-manager indirection into script bodies landed in #2063, so these rows apply through `npm run <script> -- --flag` forms as well.

Fixes #2019