### PR TITLE
feat(health): extend mock-aware test reachability to aliased vi, vitest namespaces, and jest.mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mock-aware test reachability covers aliased `vi` imports, `vitest`
+  namespace imports, and `jest.mock`.** The mock masking that shipped for the
+  literal `import { vi } from "vitest"` binding now also proves
+  `import { vi as v }` aliases, `import * as vitest` namespace access
+  (`vitest.vi.mock`), and `jest.mock` through the `jest` global or a
+  `@jest/globals` import (any alias), so a module whose only test-side use is
+  a proven complete replacement no longer keeps test-coverage credit in Jest
+  projects or under the wider Vitest idioms. Provenance stays span-exact and
+  factories abstain toward the old covered behavior unless they are
+  statically closed; `vi.doMock` and automock remain out of scope. (Refs
+  [#2082](https://github.com/fallow-rs/fallow/issues/2082).)
+
 ## [3.11.0] - 2026-08-02
 
 ### Added

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -2262,6 +2262,75 @@ fn health_coverage_gaps_exclude_vitest_replacement_targets() {
 }
 
 #[test]
+fn health_coverage_gaps_exclude_jest_replacement_targets() {
+    let output = run_fallow(
+        "health",
+        "issue-2082-jest-mocked-test-reachability",
+        &[
+            "--coverage-gaps",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(
+        output.code, 0,
+        "coverage gaps default to warn severity: {}",
+        output.stderr
+    );
+
+    let json = parse_json(&output);
+    let coverage = json["coverage_gaps"]
+        .as_object()
+        .expect("coverage_gaps should be an object");
+    let summary = coverage["summary"]
+        .as_object()
+        .expect("coverage_gaps.summary should be an object");
+    assert_eq!(summary["runtime_files"].as_u64(), Some(3));
+    assert_eq!(
+        summary["covered_files"].as_u64(),
+        Some(1),
+        "only the real wrapper executes through the jest test root"
+    );
+
+    let file_names: Vec<_> = coverage["files"]
+        .as_array()
+        .expect("coverage_gaps.files should be an array")
+        .iter()
+        .filter_map(|item| item["path"].as_str())
+        .map(|path| path.replace('\\', "/"))
+        .collect();
+    assert!(
+        file_names
+            .iter()
+            .any(|path| path.ends_with("src/dependency.ts")),
+        "the jest.mock replaced dependency should remain an untested runtime file: {file_names:?}"
+    );
+    assert!(
+        !file_names
+            .iter()
+            .any(|path| path.ends_with("src/wrapper.ts")),
+        "the wrapper itself should remain test-covered: {file_names:?}"
+    );
+
+    let export_names: Vec<_> = coverage["exports"]
+        .as_array()
+        .expect("coverage_gaps.exports should be an array")
+        .iter()
+        .filter_map(|item| item["export_name"].as_str())
+        .collect();
+    assert!(
+        export_names.contains(&"renderDependency"),
+        "the jest.mock replacement must not cover the real dependency export: {export_names:?}"
+    );
+    assert!(
+        !export_names.contains(&"renderWrapper"),
+        "the directly tested wrapper export should remain covered: {export_names:?}"
+    );
+}
+
+#[test]
 fn health_crap_estimation_excludes_vitest_replacement_targets() {
     let output = run_fallow(
         "health",

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -856,7 +856,7 @@ use crate::MemberKind;
 /// encodes literal-string indexed-access fixture types
 /// (`Factory["getter"]`) as bindings. Warm 248 caches lack those facts and
 /// keep the getter-typed fixture's target class members uncredited.
-pub(super) const CACHE_VERSION: u32 = 249;
+pub(super) const CACHE_VERSION: u32 = 250;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -237,7 +237,7 @@ fn build_primary_extractor(
         collect_glimmer_template_into_extractor(&mut extractor, path, source);
     let semantic_usage =
         compute_semantic_usage(program, &extractor.imports, &template_used_imports);
-    extractor.resolve_vitest_mock_operations(&semantic_usage.vitest_vi_reference_spans);
+    extractor.resolve_vitest_mock_operations(&semantic_usage.mock_api_reference_spans);
     (extractor, semantic_usage)
 }
 
@@ -381,7 +381,7 @@ fn parse_with_jsx_retry(input: &JsxRetryInput<'_>) -> Option<JsxRetryParse> {
         &extractor.imports,
         &template_used_imports,
     );
-    extractor.resolve_vitest_mock_operations(&semantic_usage.vitest_vi_reference_spans);
+    extractor.resolve_vitest_mock_operations(&semantic_usage.mock_api_reference_spans);
     let complexity = retry_complexity(
         input.need_complexity,
         &retry_return.program,
@@ -1085,11 +1085,25 @@ pub struct ImportBindingUsage {
     pub value_referenced: Vec<String>,
 }
 
+/// Reference spans proving module-mock API provenance (issue #2068 / #2082).
+///
+/// `mock_bindings` holds spans of references that resolve to a mock-API value
+/// binding: a named `vi` import from `vitest` (any local alias), a named
+/// `jest` import from `@jest/globals` (any local alias), or the unresolved
+/// `jest` global that the Jest test environment injects. `vitest_namespaces`
+/// holds spans of references to a `import * as ns from "vitest"` binding, so
+/// `ns.vi.mock(...)` can be proven through the namespace identifier.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct MockApiReferenceSpans {
+    pub(crate) mock_bindings: rustc_hash::FxHashSet<Span>,
+    pub(crate) vitest_namespaces: rustc_hash::FxHashSet<Span>,
+}
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SemanticUsage {
     pub import_binding_usage: ImportBindingUsage,
     pub auto_import_candidates: Vec<String>,
-    pub(crate) vitest_vi_reference_spans: rustc_hash::FxHashSet<Span>,
+    pub(crate) mock_api_reference_spans: MockApiReferenceSpans,
 }
 
 pub fn compute_semantic_usage(
@@ -1148,8 +1162,7 @@ pub fn compute_semantic_usage(
     let mut value_referenced_bindings: Vec<String> =
         value_referenced_bindings.into_iter().collect();
     value_referenced_bindings.sort_unstable();
-    let vitest_vi_reference_spans =
-        compute_vitest_vi_reference_spans(&semantic, imports, root_scope);
+    let mock_api_reference_spans = compute_mock_api_reference_spans(&semantic, imports, root_scope);
 
     SemanticUsage {
         import_binding_usage: ImportBindingUsage {
@@ -1158,41 +1171,83 @@ pub fn compute_semantic_usage(
             value_referenced: value_referenced_bindings,
         },
         auto_import_candidates: compute_auto_import_candidates_from_semantic(scoping),
-        vitest_vi_reference_spans,
+        mock_api_reference_spans,
     }
 }
 
-fn compute_vitest_vi_reference_spans(
+fn compute_mock_api_reference_spans(
     semantic: &oxc_semantic::Semantic<'_>,
     imports: &[ImportInfo],
     root_scope: oxc_semantic::ScopeId,
-) -> rustc_hash::FxHashSet<Span> {
-    let has_direct_vitest_import = imports.iter().any(|import| {
-        import.source == "vitest"
-            && import.local_name == "vi"
-            && !import.is_type_only
-            && matches!(&import.imported_name, ImportedName::Named(name) if name == "vi")
-    });
-    if !has_direct_vitest_import {
-        return rustc_hash::FxHashSet::default();
-    }
-
+) -> MockApiReferenceSpans {
     let scoping = semantic.scoping();
-    let Some(symbol_id) = scoping.get_binding(root_scope, oxc_str::Ident::from("vi")) else {
-        return rustc_hash::FxHashSet::default();
+    let mut spans = MockApiReferenceSpans::default();
+
+    let collect_binding_spans = |local_name: &str, out: &mut rustc_hash::FxHashSet<Span>| {
+        let Some(symbol_id) = scoping.get_binding(root_scope, oxc_str::Ident::from(local_name))
+        else {
+            return;
+        };
+        out.extend(
+            scoping
+                .get_resolved_references(symbol_id)
+                .filter_map(|reference| {
+                    let AstKind::IdentifierReference(identifier) =
+                        semantic.nodes().kind(reference.node_id())
+                    else {
+                        return None;
+                    };
+                    Some(identifier.span)
+                }),
+        );
     };
 
-    scoping
-        .get_resolved_references(symbol_id)
-        .filter_map(|reference| {
-            let AstKind::IdentifierReference(identifier) =
-                semantic.nodes().kind(reference.node_id())
-            else {
-                return None;
-            };
-            Some(identifier.span)
-        })
-        .collect()
+    for import in imports {
+        if import.is_type_only || import.local_name.is_empty() {
+            continue;
+        }
+        let is_vi_binding = import.source == "vitest"
+            && matches!(&import.imported_name, ImportedName::Named(name) if name == "vi");
+        let is_jest_binding = import.source == "@jest/globals"
+            && matches!(&import.imported_name, ImportedName::Named(name) if name == "jest");
+        let is_vitest_namespace =
+            import.source == "vitest" && matches!(&import.imported_name, ImportedName::Namespace);
+
+        if is_vi_binding || is_jest_binding {
+            collect_binding_spans(&import.local_name, &mut spans.mock_bindings);
+        } else if is_vitest_namespace {
+            collect_binding_spans(&import.local_name, &mut spans.vitest_namespaces);
+        }
+    }
+
+    // The Jest test environment injects `jest` as a global, so unresolved
+    // value references named `jest` count as mock-API provenance. Masking only
+    // ever applies to files the plugin layer classified as test entry points,
+    // which grounds this in the existing Jest test-root detection. Unresolved
+    // `vi` stays unproven on purpose (unchanged from #2068): Vitest exposes
+    // `vi` as a global only under `globals: true`, and without reading that
+    // config the safe direction is to abstain.
+    for (name, reference_ids) in scoping.root_unresolved_references() {
+        if name.as_str() != "jest" {
+            continue;
+        }
+        spans
+            .mock_bindings
+            .extend(reference_ids.iter().filter_map(|reference_id| {
+                let reference = scoping.get_reference(*reference_id);
+                if !reference.is_value() {
+                    return None;
+                }
+                let AstKind::IdentifierReference(identifier) =
+                    semantic.nodes().kind(reference.node_id())
+                else {
+                    return None;
+                };
+                Some(identifier.span)
+            }));
+    }
+
+    spans
 }
 
 pub fn compute_auto_import_candidates(program: &Program<'_>) -> Vec<String> {

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -436,6 +436,242 @@ fn shadowed_vitest_operations_do_not_change_imported_vi_state() {
 }
 
 #[test]
+fn aliased_vi_import_replacement_records_typed_target() {
+    let info = parse_source(
+        r#"
+        import { vi as v } from "vitest";
+        v.mock("./services/api", () => ({ request: v.fn() }));
+        "#,
+    );
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+    let sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    assert!(
+        sources.contains(&"./services/api"),
+        "aliased mock target must be credited once provenance is proven, got {sources:?}"
+    );
+}
+
+#[test]
+fn aliased_vi_import_without_factory_synthesizes_auto_mock_sibling() {
+    let info = parse_source(
+        r#"
+        import { vi as v } from "vitest";
+        v.mock("./services/api");
+        "#,
+    );
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(sources, vec!["./services/__mocks__/api", "./services/api"]);
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![(
+            "./services/api",
+            VitestModuleMockAction::Mock {
+                factory_replaces_original: false,
+            },
+        )]
+    );
+}
+
+#[test]
+fn aliased_vi_import_unmock_records_action() {
+    let info = parse_source(
+        r#"
+        import { vi as v } from "vitest";
+        v.mock("./dep", () => ({ request: v.fn() }));
+        v.unmock("./dep");
+        "#,
+    );
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![
+            (
+                "./dep",
+                VitestModuleMockAction::Mock {
+                    factory_replaces_original: true,
+                },
+            ),
+            ("./dep", VitestModuleMockAction::Unmock),
+        ]
+    );
+}
+
+#[test]
+fn aliased_vi_shadowed_or_unimported_binding_abstains() {
+    for source in [
+        r#"import { vi as v } from "vitest"; function f(v) { v.mock("./dep", () => ({})); }"#,
+        r#"const v = mockApi; v.mock("./dep", () => ({}));"#,
+        r#"import { v } from "not-vitest"; v.mock("./dep", () => ({}));"#,
+        r#"import type { vi as v } from "vitest"; v.mock("./dep", () => ({}));"#,
+    ] {
+        let info = parse_source(source);
+        assert!(
+            vitest_mock_actions(&info).is_empty(),
+            "unproven alias must not record mock operations: {source}"
+        );
+        assert!(
+            info.dynamic_imports.is_empty(),
+            "unproven alias must not credit files: {source}"
+        );
+    }
+}
+
+#[test]
+fn aliased_vi_factory_depending_on_outer_value_abstains_to_unproven() {
+    let info = parse_source(
+        r#"
+        import { vi as v } from "vitest";
+        const stub = () => 1;
+        v.mock("./dep", () => ({ request: stub }));
+        "#,
+    );
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![(
+            "./dep",
+            VitestModuleMockAction::Mock {
+                factory_replaces_original: false,
+            },
+        )]
+    );
+}
+
+#[test]
+fn vitest_namespace_import_replacement_records_typed_target() {
+    let info = parse_source(
+        r#"
+        import * as vitest from "vitest";
+        vitest.vi.mock("./services/api", () => ({ request: vitest.vi.fn() }));
+        "#,
+    );
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+}
+
+#[test]
+fn vitest_namespace_unmock_records_action() {
+    let info = parse_source(
+        r#"
+        import * as vitest from "vitest";
+        vitest.vi.unmock("./dep");
+        "#,
+    );
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![("./dep", VitestModuleMockAction::Unmock)]
+    );
+}
+
+#[test]
+fn vitest_namespace_abstain_controls() {
+    for source in [
+        // `.mock` directly on the namespace is not the Vitest API.
+        r#"import * as vitest from "vitest"; vitest.mock("./dep", () => ({}));"#,
+        // A namespace of another module must not prove `ns.vi.mock`.
+        r#"import * as other from "not-vitest"; other.vi.mock("./dep", () => ({}));"#,
+        // A local object named like a namespace must not prove.
+        r#"const vitest = { vi: mockApi }; vitest.vi.mock("./dep", () => ({}));"#,
+    ] {
+        let info = parse_source(source);
+        assert!(
+            vitest_mock_actions(&info).is_empty(),
+            "unproven namespace form must not record mock operations: {source}"
+        );
+    }
+}
+
+#[test]
+fn vitest_namespace_factory_using_unproven_bare_vi_abstains_to_unproven() {
+    let info = parse_source(
+        r#"
+        import * as vitest from "vitest";
+        vitest.vi.mock("./dep", () => ({ request: vi.fn() }));
+        "#,
+    );
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![(
+            "./dep",
+            VitestModuleMockAction::Mock {
+                factory_replaces_original: false,
+            },
+        )]
+    );
+}
+
+#[test]
+fn jest_global_replacement_records_typed_target() {
+    let info = parse_source(r#"jest.mock("./services/api", () => ({ request: jest.fn() }));"#);
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+}
+
+#[test]
+fn jest_global_mock_records_target_and_auto_mock_sibling() {
+    let info = parse_source(r#"jest.mock("./services/api");"#);
+    let mut sources: Vec<&str> = info
+        .dynamic_imports
+        .iter()
+        .map(|imp| imp.source.as_str())
+        .collect();
+    sources.sort_unstable();
+    assert_eq!(sources, vec!["./services/__mocks__/api", "./services/api"]);
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![(
+            "./services/api",
+            VitestModuleMockAction::Mock {
+                factory_replaces_original: false,
+            },
+        )]
+    );
+}
+
+#[test]
+fn jest_globals_import_aliased_replacement_records_typed_target() {
+    let info = parse_source(
+        r#"
+        import { jest as j } from "@jest/globals";
+        j.mock("./services/api", () => ({ request: j.fn() }));
+        "#,
+    );
+    assert_eq!(replaced_module_targets(&info), vec!["./services/api"]);
+}
+
+#[test]
+fn jest_unmock_records_action() {
+    let info = parse_source(r#"jest.unmock("./dep");"#);
+    assert_eq!(
+        vitest_mock_actions(&info),
+        vec![("./dep", VitestModuleMockAction::Unmock)]
+    );
+}
+
+#[test]
+fn jest_abstain_controls() {
+    for source in [
+        // A shadowing local `jest` binding removes global provenance.
+        r#"const jest = fakeApi; jest.mock("./dep", () => ({}));"#,
+        r#"import { jest } from "not-jest"; jest.mock("./dep", () => ({}));"#,
+        // `requireActual` loads the original module, poisoning the proof.
+        r#"jest.mock("./dep", () => jest.requireActual("./dep"));"#,
+        r#"jest.mock("./dep", () => { const { requireActual } = jest; return requireActual("./dep"); });"#,
+    ] {
+        let info = parse_source(source);
+        assert!(
+            replaced_module_targets(&info).is_empty(),
+            "unproven or original-loading jest form must abstain: {source}"
+        );
+    }
+}
+
+#[test]
 fn dynamic_import_await_captures_local_name() {
     let info = parse_source(
         "async function f() { const mod = await import('./service'); mod.doStuff(); }",

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -243,17 +243,42 @@ struct LitCustomElementCandidate {
     span_start: u32,
 }
 
+/// How a pending mock operation's recorded object span must be proven before
+/// the operation is trusted (issue #2082).
+///
+/// `Binding` covers `X.mock(...)` where `X` is an identifier: the span must
+/// resolve to a `vi` import from `vitest` (any local alias), a `jest` import
+/// from `@jest/globals` (any local alias), or the unresolved `jest` global.
+/// `VitestNamespace` covers `ns.vi.mock(...)`: the span must resolve to a
+/// namespace import of `vitest`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MockObjectProvenance {
+    Binding,
+    VitestNamespace,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct PendingVitestMockOperation {
     source: String,
-    vi_reference_span: Span,
-    call_start: u32,
+    /// Span of the identifier whose provenance the semantic pass must confirm
+    /// (the `vi`/`jest`/alias object, or the namespace in `ns.vi.mock`).
+    object_span: Span,
+    provenance: MockObjectProvenance,
+    call_span: Span,
+    has_factory: bool,
+    /// Aliased and namespace forms defer their dynamic-import credit edges to
+    /// `resolve_vitest_mock_operations`, where provenance is proven; literal
+    /// `vi`/`jest` objects push edges eagerly (they may be injected globals).
+    needs_deferred_edges: bool,
     proof: PendingVitestMockProof,
 }
 
 #[derive(Debug, Clone)]
 pub(super) enum PendingVitestMockProof {
-    ClosedFactory { vi_reference_spans: Vec<Span> },
+    ClosedFactory {
+        binding_requirement_spans: Vec<Span>,
+        namespace_requirement_spans: Vec<Span>,
+    },
     UnprovenMock,
     Unmock,
 }

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -192,17 +192,9 @@ pub(super) fn is_private_member_key(key: &PropertyKey<'_>) -> bool {
     matches!(key, PropertyKey::PrivateIdentifier(_))
 }
 
-pub(super) fn vitest_mock_source(call: &CallExpression<'_>) -> Option<String> {
-    vitest_method_object_span(call, "mock")?;
-    vitest_static_target_source(call)
-}
+use super::super::MockObjectProvenance;
 
-pub(super) fn vitest_unmock_source(call: &CallExpression<'_>) -> Option<String> {
-    vitest_method_object_span(call, "unmock")?;
-    vitest_static_target_source(call)
-}
-
-fn vitest_static_target_source(call: &CallExpression<'_>) -> Option<String> {
+pub(super) fn mock_static_target_source(call: &CallExpression<'_>) -> Option<String> {
     call.arguments.first().and_then(|argument| match argument {
         Argument::StringLiteral(value) => Some(value.value.to_string()),
         Argument::TemplateLiteral(value) if value.expressions.is_empty() => value
@@ -217,29 +209,44 @@ fn vitest_static_target_source(call: &CallExpression<'_>) -> Option<String> {
     })
 }
 
-pub(super) fn vitest_mock_object_span(call: &CallExpression<'_>) -> Option<Span> {
-    vitest_method_object_span(call, "mock")
-}
-
-pub(super) fn vitest_unmock_object_span(call: &CallExpression<'_>) -> Option<Span> {
-    vitest_method_object_span(call, "unmock")
-}
-
-fn vitest_method_object_span(call: &CallExpression<'_>, expected_method: &str) -> Option<Span> {
+/// Shape-match `X.<method>(...)` or `ns.vi.<method>(...)` and return the span
+/// whose provenance the semantic pass must later confirm. No name gating here:
+/// the span-provenance filter in `resolve_vitest_mock_operations` is the
+/// authority, so an unproven identifier simply drops out there.
+pub(super) fn mock_method_object_span(
+    call: &CallExpression<'_>,
+    expected_method: &str,
+) -> Option<(Span, MockObjectProvenance)> {
     let Expression::StaticMemberExpression(member) = &call.callee else {
         return None;
     };
     if member.property.name != expected_method {
         return None;
     }
-    let Expression::Identifier(object) = &member.object else {
-        return None;
-    };
-    if object.name != "vi" {
-        return None;
+    match &member.object {
+        Expression::Identifier(object) => Some((object.span, MockObjectProvenance::Binding)),
+        Expression::StaticMemberExpression(inner) if inner.property.name == "vi" => {
+            let Expression::Identifier(namespace) = &inner.object else {
+                return None;
+            };
+            Some((namespace.span, MockObjectProvenance::VitestNamespace))
+        }
+        _ => None,
     }
+}
 
-    Some(object.span)
+/// Whether the mock call object is the literal `vi` or `jest` identifier.
+///
+/// These two names may be injected globals (Vitest `globals: true`, the Jest
+/// test environment), so their dynamic-import credit edges are pushed eagerly
+/// at record time even when no import exists to prove provenance. Aliased and
+/// namespace forms always have an import, so their edges wait for the
+/// provenance check.
+pub(super) fn mock_object_is_literal_global(call: &CallExpression<'_>) -> bool {
+    let Expression::StaticMemberExpression(member) = &call.callee else {
+        return false;
+    };
+    matches!(&member.object, Expression::Identifier(object) if object.name == "vi" || object.name == "jest")
 }
 
 pub(super) fn vitest_auto_mock_source(source: &str) -> Option<String> {
@@ -372,8 +379,13 @@ pub(super) fn vi_mock_has_factory(call: &CallExpression<'_>) -> bool {
 }
 
 #[derive(Debug)]
-pub(super) struct VitestReplacementCandidate {
-    pub(super) factory_vi_reference_spans: Vec<Span>,
+pub(super) struct MockReplacementCandidate {
+    /// Identifier-reference spans that must later prove to be mock-API binding
+    /// references (`vi` / `jest` imports or the `jest` global).
+    pub(super) binding_requirement_spans: Vec<Span>,
+    /// Identifier-reference spans that must later prove to be `vitest`
+    /// namespace-import references (the `ns` in `ns.vi.fn()`).
+    pub(super) namespace_requirement_spans: Vec<Span>,
 }
 
 fn vitest_factory_has_no_parameters(argument: &Argument<'_>) -> Option<bool> {
@@ -398,36 +410,63 @@ fn vitest_factory_has_no_parameters(argument: &Argument<'_>) -> Option<bool> {
     }
 }
 
-#[derive(Default)]
-struct VitestFactoryProofVisitor {
-    unsafe_escape: bool,
-    vi_reference_spans: Vec<Span>,
+/// Property names that load the original module and therefore poison a
+/// factory proof regardless of the receiver (`vi.importActual`,
+/// `jest.requireActual`, or any alias of either).
+const MOCK_ORIGINAL_LOADER_PROPERTIES: &[&str] = &["importActual", "requireActual"];
+
+fn is_original_loader_property(name: &str) -> bool {
+    MOCK_ORIGINAL_LOADER_PROPERTIES.contains(&name)
 }
 
-impl<'a> Visit<'a> for VitestFactoryProofVisitor {
+#[derive(Default)]
+struct MockFactoryProofVisitor {
+    unsafe_escape: bool,
+    binding_requirement_spans: Vec<Span>,
+    namespace_requirement_spans: Vec<Span>,
+}
+
+impl<'a> Visit<'a> for MockFactoryProofVisitor {
     fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        // The only calls a closed factory may make are stub constructors:
+        // `X.fn()` (where `X` must later prove to be a `vi`/`jest` binding) or
+        // `ns.vi.fn()` (where `ns` must prove to be the `vitest` namespace).
+        // The callee is consumed here rather than walked, so its identifier
+        // lands in exactly one requirement bucket; arguments are still walked.
         let Expression::StaticMemberExpression(member) = &call.callee else {
             self.unsafe_escape = true;
             return;
         };
-        let Expression::Identifier(object) = &member.object else {
-            self.unsafe_escape = true;
-            return;
-        };
-        if object.name != "vi" || member.property.name != "fn" {
+        if member.property.name != "fn" {
             self.unsafe_escape = true;
             return;
         }
-
-        walk::walk_call_expression(self, call);
+        match &member.object {
+            Expression::Identifier(object) => {
+                self.binding_requirement_spans.push(object.span);
+            }
+            Expression::StaticMemberExpression(inner) if inner.property.name == "vi" => {
+                let Expression::Identifier(namespace) = &inner.object else {
+                    self.unsafe_escape = true;
+                    return;
+                };
+                self.namespace_requirement_spans.push(namespace.span);
+            }
+            _ => {
+                self.unsafe_escape = true;
+                return;
+            }
+        }
+        for argument in &call.arguments {
+            self.visit_argument(argument);
+        }
     }
 
     fn visit_identifier_reference(&mut self, identifier: &IdentifierReference<'a>) {
-        if identifier.name == "vi" {
-            self.vi_reference_spans.push(identifier.span);
-        } else {
-            self.unsafe_escape = true;
-        }
+        // Every free identifier must later prove to be a mock-API binding
+        // reference; anything else (locals, other imports, globals) fails the
+        // resolve-time check and the factory abstains.
+        self.binding_requirement_spans.push(identifier.span);
     }
 
     fn visit_import_expression(&mut self, _expression: &ImportExpression<'a>) {
@@ -443,9 +482,7 @@ impl<'a> Visit<'a> for VitestFactoryProofVisitor {
     }
 
     fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'a>) {
-        if member.property.name == "importActual"
-            && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
-        {
+        if is_original_loader_property(member.property.name.as_str()) {
             self.unsafe_escape = true;
             return;
         }
@@ -455,8 +492,7 @@ impl<'a> Visit<'a> for VitestFactoryProofVisitor {
     fn visit_computed_member_expression(&mut self, member: &ComputedMemberExpression<'a>) {
         if member
             .static_property_name()
-            .is_some_and(|name| name == "importActual")
-            && matches!(&member.object, Expression::Identifier(object) if object.name == "vi")
+            .is_some_and(|name| is_original_loader_property(&name))
         {
             self.unsafe_escape = true;
             return;
@@ -465,14 +501,12 @@ impl<'a> Visit<'a> for VitestFactoryProofVisitor {
     }
 
     fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
-        if let (BindingPattern::ObjectPattern(pattern), Some(Expression::Identifier(object))) =
-            (&declarator.id, &declarator.init)
-            && object.name == "vi"
+        if let BindingPattern::ObjectPattern(pattern) = &declarator.id
             && pattern.properties.iter().any(|property| {
                 property
                     .key
                     .static_name()
-                    .is_some_and(|name| name == "importActual")
+                    .is_some_and(|name| is_original_loader_property(&name))
             })
         {
             self.unsafe_escape = true;
@@ -482,24 +516,23 @@ impl<'a> Visit<'a> for VitestFactoryProofVisitor {
     }
 }
 
-/// Return a Vitest mock whose factory provably replaces the original module
+/// Return a module mock whose factory provably replaces the original module
 /// without loading it.
 ///
-/// Import provenance is checked by the caller. This helper stays conservative:
-/// factories with parameters can receive `importOriginal`; zero-argument
-/// factories abstain when they depend on any value other than the imported
-/// `vi`, construct values, dynamically import code, invoke an unproven helper,
-/// or call an original-module loader.
-pub(super) fn vitest_replacement_candidate(
+/// Import provenance is checked by the caller through span requirements. This
+/// helper stays conservative: factories with parameters can receive
+/// `importOriginal`; zero-argument factories abstain when they depend on any
+/// value other than a proven mock-API binding, construct values, dynamically
+/// import code, invoke an unproven helper, or call an original-module loader.
+pub(super) fn mock_replacement_candidate(
     call: &CallExpression<'_>,
-) -> Option<VitestReplacementCandidate> {
-    vitest_mock_source(call)?;
+) -> Option<MockReplacementCandidate> {
     let factory = call.arguments.get(1)?;
     if vitest_factory_has_no_parameters(factory) != Some(true) {
         return None;
     }
 
-    let mut proof = VitestFactoryProofVisitor::default();
+    let mut proof = MockFactoryProofVisitor::default();
     match factory {
         Argument::ArrowFunctionExpression(factory) => {
             proof.visit_arrow_function_expression(factory);
@@ -512,8 +545,9 @@ pub(super) fn vitest_replacement_candidate(
         }
         _ => return None,
     }
-    (!proof.unsafe_escape).then_some(VitestReplacementCandidate {
-        factory_vi_reference_spans: proof.vi_reference_spans,
+    (!proof.unsafe_escape).then_some(MockReplacementCandidate {
+        binding_requirement_spans: proof.binding_requirement_spans,
+        namespace_requirement_spans: proof.namespace_requirement_spans,
     })
 }
 

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -7,15 +7,16 @@ use crate::{
 };
 
 use super::super::{
-    ModuleInfoExtractor, PendingPlaywrightFactory, PendingVitestMockOperation,
-    PendingVitestMockProof,
+    MockObjectProvenance, ModuleInfoExtractor, PendingPlaywrightFactory,
+    PendingVitestMockOperation, PendingVitestMockProof,
 };
 use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
-    playwright_extend_base_name, vi_mock_has_factory, vitest_auto_mock_source,
-    vitest_mock_object_span, vitest_mock_source, vitest_replacement_candidate,
-    vitest_unmock_object_span, vitest_unmock_source,
+    mock_method_object_span, mock_object_is_literal_global, mock_replacement_candidate,
+    mock_static_target_source, playwright_extend_base_name, vi_mock_has_factory,
+    vitest_auto_mock_source,
 };
+use crate::parse::MockApiReferenceSpans;
 
 impl ModuleInfoExtractor {
     fn collect_playwright_fixture_type_bindings(&self, ty: &TSType<'_>) -> Vec<(String, String)> {
@@ -233,82 +234,136 @@ impl ModuleInfoExtractor {
     }
 
     pub(super) fn record_vitest_mock_imports(&mut self, expr: &CallExpression<'_>) {
-        let Some(target_source) = vitest_mock_source(expr) else {
+        let Some((object_span, provenance)) = mock_method_object_span(expr, "mock") else {
+            return;
+        };
+        let Some(target_source) = mock_static_target_source(expr) else {
             return;
         };
 
+        let has_factory = vi_mock_has_factory(expr);
+        // Literal `vi`/`jest` objects may be injected globals with no import to
+        // prove provenance against, so their credit edges are pushed eagerly.
+        // Aliased and namespace forms always come from an import; their edges
+        // wait for the span-provenance check in
+        // `resolve_vitest_mock_operations` so an unrelated `x.mock("./y")`
+        // never credits a file.
+        let literal_global = mock_object_is_literal_global(expr);
+        if literal_global {
+            self.push_mock_credit_edges(&target_source, expr.span, has_factory);
+        }
+
+        let proof = mock_replacement_candidate(expr).map_or(
+            PendingVitestMockProof::UnprovenMock,
+            |candidate| PendingVitestMockProof::ClosedFactory {
+                binding_requirement_spans: candidate.binding_requirement_spans,
+                namespace_requirement_spans: candidate.namespace_requirement_spans,
+            },
+        );
+        self.pending_vitest_mock_operations
+            .push(PendingVitestMockOperation {
+                source: target_source,
+                object_span,
+                provenance,
+                call_span: expr.span,
+                has_factory,
+                needs_deferred_edges: !literal_global,
+                proof,
+            });
+    }
+
+    fn push_mock_credit_edges(
+        &mut self,
+        target_source: &str,
+        span: oxc_span::Span,
+        has_factory: bool,
+    ) {
         self.dynamic_imports.push(DynamicImportInfo {
-            source: target_source.clone(),
-            span: expr.span,
+            source: target_source.to_string(),
+            span,
             destructured_names: Vec::new(),
             local_name: None,
             is_speculative: false,
         });
 
-        if !vi_mock_has_factory(expr)
-            && let Some(mock_source) = vitest_auto_mock_source(&target_source)
-        {
+        if !has_factory && let Some(mock_source) = vitest_auto_mock_source(target_source) {
             self.dynamic_imports.push(DynamicImportInfo {
                 source: mock_source,
-                span: expr.span,
+                span,
                 destructured_names: Vec::new(),
                 local_name: Some(String::new()),
                 is_speculative: true,
             });
         }
-
-        if let Some(vi_reference_span) = vitest_mock_object_span(expr) {
-            let proof = vitest_replacement_candidate(expr).map_or(
-                PendingVitestMockProof::UnprovenMock,
-                |candidate| PendingVitestMockProof::ClosedFactory {
-                    vi_reference_spans: candidate.factory_vi_reference_spans,
-                },
-            );
-            self.pending_vitest_mock_operations
-                .push(PendingVitestMockOperation {
-                    source: target_source,
-                    vi_reference_span,
-                    call_start: expr.span.start,
-                    proof,
-                });
-        }
     }
 
     pub(super) fn record_vitest_unmock(&mut self, expr: &CallExpression<'_>) {
-        if let Some(source) = vitest_unmock_source(expr)
-            && let Some(vi_reference_span) = vitest_unmock_object_span(expr)
+        if let Some((object_span, provenance)) = mock_method_object_span(expr, "unmock")
+            && let Some(source) = mock_static_target_source(expr)
         {
             self.pending_vitest_mock_operations
                 .push(PendingVitestMockOperation {
                     source,
-                    vi_reference_span,
-                    call_start: expr.span.start,
+                    object_span,
+                    provenance,
+                    call_span: expr.span,
+                    has_factory: false,
+                    needs_deferred_edges: false,
                     proof: PendingVitestMockProof::Unmock,
                 });
         }
     }
 
-    pub(crate) fn resolve_vitest_mock_operations(
-        &mut self,
-        vitest_vi_reference_spans: &rustc_hash::FxHashSet<oxc_span::Span>,
-    ) {
+    pub(crate) fn resolve_vitest_mock_operations(&mut self, spans: &MockApiReferenceSpans) {
         let mut operations: Vec<_> = self
             .pending_vitest_mock_operations
             .drain(..)
-            .filter(|operation| vitest_vi_reference_spans.contains(&operation.vi_reference_span))
+            .filter(|operation| match operation.provenance {
+                MockObjectProvenance::Binding => {
+                    spans.mock_bindings.contains(&operation.object_span)
+                }
+                MockObjectProvenance::VitestNamespace => {
+                    spans.vitest_namespaces.contains(&operation.object_span)
+                }
+            })
             .collect();
-        operations.sort_unstable_by_key(|operation| operation.call_start);
+        operations.sort_unstable_by_key(|operation| operation.call_span.start);
+
+        // Provenance is proven now, so push the deferred credit edges for
+        // aliased and namespace mock registrations (the literal `vi`/`jest`
+        // forms already pushed theirs at record time).
+        let deferred_edges: Vec<(String, oxc_span::Span, bool)> = operations
+            .iter()
+            .filter(|operation| {
+                operation.needs_deferred_edges
+                    && !matches!(operation.proof, PendingVitestMockProof::Unmock)
+            })
+            .map(|operation| {
+                (
+                    operation.source.clone(),
+                    operation.call_span,
+                    operation.has_factory,
+                )
+            })
+            .collect();
+        for (source, span, has_factory) in deferred_edges {
+            self.push_mock_credit_edges(&source, span, has_factory);
+        }
 
         self.semantic_facts
             .extend(operations.into_iter().map(|operation| {
                 let action = match operation.proof {
-                    PendingVitestMockProof::ClosedFactory { vi_reference_spans } => {
-                        VitestModuleMockAction::Mock {
-                            factory_replaces_original: vi_reference_spans
+                    PendingVitestMockProof::ClosedFactory {
+                        binding_requirement_spans,
+                        namespace_requirement_spans,
+                    } => VitestModuleMockAction::Mock {
+                        factory_replaces_original: binding_requirement_spans
+                            .iter()
+                            .all(|span| spans.mock_bindings.contains(span))
+                            && namespace_requirement_spans
                                 .iter()
-                                .all(|span| vitest_vi_reference_spans.contains(span)),
-                        }
-                    }
+                                .all(|span| spans.vitest_namespaces.contains(span)),
+                    },
                     PendingVitestMockProof::UnprovenMock => VitestModuleMockAction::Mock {
                         factory_replaces_original: false,
                     },
@@ -316,7 +371,7 @@ impl ModuleInfoExtractor {
                 };
                 SemanticFact::VitestModuleMockOperation(VitestModuleMockOperationFact {
                     source: operation.source,
-                    call_start: operation.call_start,
+                    call_start: operation.call_span.start,
                     action,
                 })
             }));

--- a/tests/fixtures/issue-2082-jest-mocked-test-reachability/package.json
+++ b/tests/fixtures/issue-2082-jest-mocked-test-reachability/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-2082-jest-mocked-test-reachability",
+  "private": true,
+  "type": "module",
+  "main": "src/entry.ts",
+  "devDependencies": {
+    "jest": "^30.0.0"
+  }
+}

--- a/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/dependency.ts
+++ b/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/dependency.ts
@@ -1,0 +1,3 @@
+export function renderDependency(): string {
+  return "real dependency";
+}

--- a/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/entry.ts
+++ b/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/entry.ts
@@ -1,0 +1,5 @@
+import { renderWrapper } from "./wrapper";
+
+export function renderEntry(): string {
+  return renderWrapper();
+}

--- a/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/wrapper.test.ts
+++ b/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/wrapper.test.ts
@@ -1,0 +1,11 @@
+import { renderWrapper } from "./wrapper";
+
+jest.mock("./dependency", () => ({
+  renderDependency: jest.fn(() => "mocked dependency"),
+}));
+
+describe("renderWrapper", () => {
+  it("uses the replacement", () => {
+    expect(renderWrapper()).toBe("mocked dependency");
+  });
+});

--- a/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/wrapper.ts
+++ b/tests/fixtures/issue-2082-jest-mocked-test-reachability/src/wrapper.ts
@@ -1,0 +1,5 @@
+import { renderDependency } from "./dependency";
+
+export function renderWrapper(): string {
+  return renderDependency();
+}


### PR DESCRIPTION
Extends the mock-aware static test reachability from #2068 (literal `import { vi } from "vitest"` only) to the wider mocking idioms listed in #2082, reusing the same span-provenance binding check and the abstain-by-default factory proof.

## What's covered now

- **Aliased named imports**: `import { vi as v } from "vitest"; v.mock(...)`. The semantic pass collects reference spans for any non-type named `vi` import from `vitest` regardless of local alias, so the existing span filter proves aliases with no new syntax-side guessing.
- **Namespace imports**: `import * as vitest from "vitest"; vitest.vi.mock(...)`. The shape matcher accepts `ns.vi.mock` / `ns.vi.unmock` and records the namespace identifier span, proven against a separate set of `vitest` namespace-import reference spans. The two span sets are deliberately kept apart so `vitest.mock(...)` (not the Vitest API) can never be proven by a namespace reference, and `v.mock(...)` can never be proven by one either.
- **`jest.mock` / `jest.unmock`**: proven through either a named `jest` import from `@jest/globals` (any alias) or the unresolved `jest` global that the Jest test environment injects. The masking side is unchanged and only ever applies to test entry points, so the global-`jest` path is grounded in the existing Jest plugin test-root detection (`enablers: ["jest"]` plus its test entry patterns): a stray `jest.mock` outside a recognized test root can register a fact but never mask anything.

## Design decisions

- **Shape first, provenance second.** The visitor now accepts any identifier object for `X.mock(...)` and records its span; the resolve pass drops every operation whose span is not a proven mock-API reference. This is the same principle #2068 used for shadowing, extended to be the single authority for all idioms.
- **Credit edges: eager for literal `vi`/`jest`, deferred otherwise.** The literal names may be injected globals with no import to prove against, so their dynamic-import credit edges (mock target plus speculative `__mocks__` sibling) stay eager, exactly as shipped for `vi`. Aliased and namespace forms always have an import, so their edges are pushed only after provenance is proven; an unrelated `foo.mock("./x")` never credits a file. `jest.mock('./x')` without a factory synthesizes the `__mocks__` sibling edge, which matches Jest's manual-mock convention directly.
- **Factory proof generalization.** The closed-factory visitor no longer hardcodes the name `vi`. It collects every free identifier reference as a *binding requirement* and every `ns.vi.fn()` namespace as a *namespace requirement*; the resolve pass accepts the factory only when all requirements land in the corresponding proven span sets. Anything unproven degrades to `factory_replaces_original: false` (keeps coverage credit), never the other direction. `requireActual` joins `importActual` as a proof poison on any receiver, including the alias/destructure escape hatches.
- **`ns.vi.fn()` is allowed inside factories** so the namespace idiom can actually prove replacement (`vitest.vi.mock("./dep", () => ({ f: vitest.vi.fn() }))`).

## Explicitly out of scope (kept listed in #2082)

- **`vi.doMock` / `jest.doMock`**: unhoisted and order-sensitive relative to imports in the same file; a sound masking treatment needs its own semantics decision (a `doMock` after the import has no effect on that import), so treating it like `mock` would over-mask.
- **Automock (`vi.mock` without factory) and `{ spy: true }`**: Vitest still evaluates the original module for shape, so masking it would produce false uncovered findings; it keeps crediting coverage as before. Deciding otherwise is a semantics call, not a detection gap.
- **Unresolved bare `vi` (Vitest `globals: true`)**: unchanged from #2068; without reading the Vitest config the safe direction remains abstention. (The eager credit edges for literal `vi.mock` are unaffected.)

## Mechanics

- `CACHE_VERSION` bumped (extraction emits more mock facts and credit edges).
- No graph or types changes: the mask plumbing and `VitestModuleMockOperationFact` are idiom-agnostic; test-root gating already covers Jest via the jest plugin.
- Tests: positive fixtures plus abstain controls per idiom in the extract crate (shadowed alias, foreign-module alias, type-only import, non-`vitest` namespace, local `jest`, `requireActual` poison, cross-idiom bare-`vi`-in-namespace-factory), and an end-to-end `fallow health --coverage-gaps` test on a new Jest fixture proving the replaced dependency loses coverage credit through a Jest test root while the wrapper keeps it.

Refs #2082
