### PR TITLE
perf(graph): move reference provenance into a per-export side table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Per-reference memory is back to its pre-3.11 size for projects without
+  replacement mocks.** The reference provenance introduced for mock-aware
+  test reachability now lives in a per-export side table that is only
+  populated when a `vi.mock`-style replacement exists, restoring the compact
+  16-byte symbol reference for every other project in RAM and in the graph
+  cache. Masked-reachability behavior is unchanged, and the graph cache
+  version is bumped so older caches are rebuilt. (Closes
+  [#2083](https://github.com/fallow-rs/fallow/issues/2083).)
+
 ## [3.11.0] - 2026-08-02
 
 ### Added

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -3202,6 +3202,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: Span::new(10, 30),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             }];
 

--- a/crates/core/src/analyze/predicates/file.rs
+++ b/crates/core/src/analyze/predicates/file.rs
@@ -530,6 +530,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(10, 50),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         assert!(!is_barrel_with_reachable_sources(&graph.modules[1], &graph));
@@ -579,6 +580,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 0),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         assert!(is_barrel_with_reachable_sources(&graph.modules[1], &graph));

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -1475,6 +1475,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(span_start, span_end),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }
     }
@@ -1605,6 +1606,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(10, 20),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         graph.modules[2].set_reachable(true);
@@ -1616,6 +1618,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(10, 20),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         let suppressions = SuppressionContext::empty();
@@ -2073,6 +2076,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 10),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         };
 
@@ -2386,6 +2390,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(span_start, span_end),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }
     }
@@ -2472,6 +2477,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(10, 20),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         let config = test_config();
@@ -3148,6 +3154,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(10, 30),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         let config = test_config();
@@ -3182,6 +3189,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(10, 30),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         let config = test_config();
@@ -3216,6 +3224,7 @@ mod tests {
             expected_unused_reason: None,
             span: Span::new(10, 30),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         let config = test_config();

--- a/crates/engine/src/health/coverage_gaps.rs
+++ b/crates/engine/src/health/coverage_gaps.rs
@@ -65,10 +65,7 @@ fn collect_untested_exports(
             continue;
         }
 
-        let has_test_dependency = export
-            .references
-            .iter()
-            .any(|reference| test_coverage.covers_reference(reference));
+        let has_test_dependency = test_coverage.covers_any_reference(export);
         if has_test_dependency {
             continue;
         }

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -670,10 +670,7 @@ fn build_test_referenced_exports(
         if export.is_type_only {
             continue;
         }
-        let has_test_ref = export
-            .references
-            .iter()
-            .any(|reference| test_coverage.covers_reference(reference));
+        let has_test_ref = test_coverage.covers_any_reference(export);
         if has_test_ref {
             set.insert(export.name.to_string());
         }
@@ -1960,6 +1957,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::empty(0),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             },
             fallow_graph::graph::ExportSymbol {
@@ -1970,6 +1968,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::empty(0),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             },
             fallow_graph::graph::ExportSymbol {
@@ -1980,6 +1979,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::empty(0),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             },
             fallow_graph::graph::ExportSymbol {
@@ -1990,6 +1990,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::empty(0),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             },
         ];
@@ -2015,6 +2016,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::empty(0),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
         let unused_map = rustc_hash::FxHashMap::default();
@@ -2390,6 +2392,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::empty(0),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             },
             fallow_graph::graph::ExportSymbol {
@@ -2400,6 +2403,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::empty(0),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             },
         ];
@@ -2425,6 +2429,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::empty(0),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
 
@@ -2449,6 +2454,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::empty(0),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }];
 
@@ -4247,6 +4253,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::default(),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         }
     }

--- a/crates/engine/src/module_graph.rs
+++ b/crates/engine/src/module_graph.rs
@@ -106,8 +106,8 @@ impl<'a> StaticTestCoverage<'a> {
         self.graph.is_test_reachable(file_id)
     }
 
-    pub(crate) fn covers_reference(self, reference: &fallow_graph::graph::SymbolReference) -> bool {
-        self.graph.is_test_reference_covered(reference)
+    pub(crate) fn covers_any_reference(self, export: &fallow_graph::graph::ExportSymbol) -> bool {
+        self.graph.is_any_test_reference_covered(export)
     }
 }
 
@@ -272,10 +272,7 @@ pub fn module_value_exports(graph: &RetainedModuleGraph) -> Vec<ModuleValueExpor
                     file_id: node.file_id,
                     name: export.name.to_string(),
                     span_start: export.span.start,
-                    test_referenced: export
-                        .references
-                        .iter()
-                        .any(|reference| test_coverage.covers_reference(reference)),
+                    test_referenced: test_coverage.covers_any_reference(export),
                 })
         })
         .collect()

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -41,7 +41,11 @@ pub use store::GraphCacheStore;
 /// Ordinary graphs omit unused provenance. Versions 7 through 16 were used by
 /// published development commits for this change, so the final version remains
 /// 17 rather than reusing a potentially stale intermediate cache version.
-pub const GRAPH_CACHE_VERSION: u32 = 17;
+///
+/// Bumped to 18 for issue #2083: reference provenance moved out of
+/// `SymbolReference` into the per-export `reference_paths` side table, changing
+/// the persisted layout of every export's reference list.
+pub const GRAPH_CACHE_VERSION: u32 = 18;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -225,6 +225,7 @@ fn build_export_symbols(resolved: Option<&ResolvedModule>) -> Vec<ExportSymbol> 
                     expected_unused_reason: e.expected_unused_reason.clone(),
                     span: e.span,
                     references: Vec::new(),
+                    reference_paths: Vec::new(),
                     members: e.members.clone(),
                 })
                 .collect()
@@ -311,6 +312,7 @@ fn push_re_export_stub(
         expected_unused_reason: None,
         span: re_export.info.span,
         references: Vec::new(),
+        reference_paths: Vec::new(),
         members: Vec::new(),
     });
 }

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -33,7 +33,9 @@ pub use impact_closure::{
 };
 pub use partition_order::{PartitionOrder, PartitionOrderPaths, ReviewUnit, ReviewUnitPaths};
 pub use re_exports::GraphReExportCycle;
-pub use types::{ExportSymbol, ModuleNode, ReExportEdge, ReferenceKind, SymbolReference};
+pub use types::{
+    ExportSymbol, ModuleNode, ReExportEdge, ReferenceKind, ReferencePathId, SymbolReference,
+};
 
 /// True when the path's final component looks like a TypeScript declaration
 /// file (`.d.ts`, `.d.mts`, `.d.cts`). Used to seed declaration files as
@@ -614,19 +616,23 @@ impl ModuleGraph {
             .is_some_and(ModuleNode::is_test_reachable)
     }
 
-    /// Return whether one test-root traversal covers this exact export reference.
+    /// Return whether one test-root traversal covers the export reference at
+    /// `reference_index` on `export`.
     ///
     /// Coverage requires one profile that reaches the referencing file and
     /// every target hop. ESM hops also require that profile not to replace the
     /// hop target; CommonJS hops remain active because Vitest replacement mocks
     /// do not intercept `require()`.
     #[must_use]
-    pub fn is_test_reference_covered(&self, reference: &SymbolReference) -> bool {
+    pub fn is_test_reference_covered(&self, export: &ExportSymbol, reference_index: usize) -> bool {
+        let Some(reference) = export.references.get(reference_index) else {
+            return false;
+        };
         if self.test_reachability_index.profile_count == 0 {
             return self.is_test_reachable(reference.from_file);
         }
 
-        let Some(path) = reference.path else {
+        let Some(path) = export.reference_path(reference_index) else {
             return false;
         };
 
@@ -638,13 +644,22 @@ impl ModuleGraph {
         )
     }
 
+    /// Return whether any reference on `export` is covered by a test-root
+    /// traversal.
+    #[must_use]
+    pub fn is_any_test_reference_covered(&self, export: &ExportSymbol) -> bool {
+        (0..export.references.len())
+            .any(|reference_index| self.is_test_reference_covered(export, reference_index))
+    }
+
     #[cfg(test)]
     fn reference_path_hops(
         &self,
-        reference: &SymbolReference,
+        export: &ExportSymbol,
+        reference_index: usize,
     ) -> Vec<(FileId, ModuleLoadMechanism)> {
         let mut hops = Vec::new();
-        let mut next = reference.path;
+        let mut next = export.reference_path(reference_index);
         while let Some(path_id) = next {
             let Some(node) = self.reference_paths.get(path_id.index()) else {
                 return Vec::new();

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -544,32 +544,32 @@ mod tests {
     #[test]
     fn mocked_namespace_barrel_stays_uncovered_when_target_has_an_alternate_route() {
         let graph = namespace_coverage_graph(false);
-        let reference = &graph.modules[2].exports[0].references[0];
+        let export = &graph.modules[2].exports[0];
 
         assert!(graph.modules[2].is_test_reachable());
         assert_eq!(
-            graph.reference_path_hops(reference),
+            graph.reference_path_hops(export, 0),
             vec![
                 (FileId(2), ModuleLoadMechanism::EsModule),
                 (FileId(1), ModuleLoadMechanism::EsModule),
             ]
         );
-        assert!(!graph.is_test_reference_covered(reference));
+        assert!(!graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
     fn commonjs_namespace_consumer_retains_its_exact_load_path() {
         let graph = namespace_coverage_graph(true);
-        let reference = &graph.modules[2].exports[0].references[0];
+        let export = &graph.modules[2].exports[0];
 
         assert_eq!(
-            graph.reference_path_hops(reference),
+            graph.reference_path_hops(export, 0),
             vec![
                 (FileId(2), ModuleLoadMechanism::EsModule),
                 (FileId(1), ModuleLoadMechanism::CommonJsRequire),
             ]
         );
-        assert!(graph.is_test_reference_covered(reference));
+        assert!(graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
@@ -578,16 +578,16 @@ mod tests {
         let encoded = postcard::to_allocvec(&graph).expect("encode namespace route graph");
         let decoded: ModuleGraph =
             postcard::from_bytes(&encoded).expect("decode namespace route graph");
-        let reference = &decoded.modules[2].exports[0].references[0];
+        let export = &decoded.modules[2].exports[0];
 
         assert_eq!(
-            decoded.reference_path_hops(reference),
+            decoded.reference_path_hops(export, 0),
             vec![
                 (FileId(2), ModuleLoadMechanism::EsModule),
                 (FileId(1), ModuleLoadMechanism::EsModule),
             ]
         );
-        assert!(!decoded.is_test_reference_covered(reference));
+        assert!(!decoded.is_test_reference_covered(export, 0));
         assert_eq!(decoded.reference_routes.graphs.len(), 1);
         assert_eq!(decoded.reference_routes.nodes.len(), 2);
     }
@@ -595,20 +595,20 @@ mod tests {
     #[test]
     fn namespace_diamond_is_covered_when_one_route_remains_active() {
         let graph = namespace_diamond_graph(false);
-        let references = &graph.modules[5].exports[0].references;
+        let export = &graph.modules[5].exports[0];
 
-        assert_eq!(references.len(), 1);
-        assert!(graph.is_test_reference_covered(&references[0]));
+        assert_eq!(export.references.len(), 1);
+        assert!(graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
     fn namespace_diamond_is_uncovered_when_every_route_is_masked() {
         let graph = namespace_diamond_graph(true);
-        let references = &graph.modules[5].exports[0].references;
+        let export = &graph.modules[5].exports[0];
 
         assert!(graph.modules[5].is_test_reachable());
-        assert_eq!(references.len(), 1);
-        assert!(!graph.is_test_reference_covered(&references[0]));
+        assert_eq!(export.references.len(), 1);
+        assert!(!graph.is_test_reference_covered(export, 0));
     }
 
     #[test]

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -128,17 +128,15 @@ pub(super) fn mark_all_exports_referenced_at_site(
 }
 
 fn attach_reference(export: &mut ExportSymbol, site: ReferenceSite, kind: ReferenceKind) {
-    let already_referenced = export
-        .references
-        .iter()
-        .any(|reference| reference.from_file == site.from_file && reference.path == site.path);
-    if !already_referenced {
-        export.references.push(SymbolReference {
-            from_file: site.from_file,
-            kind,
-            path: site.path,
-            import_span: site.import_span,
-        });
+    if !export.has_reference_from(site.from_file, site.path) {
+        export.push_reference(
+            SymbolReference {
+                from_file: site.from_file,
+                kind,
+                import_span: site.import_span,
+            },
+            site.path,
+        );
     }
 }
 
@@ -227,9 +225,9 @@ pub(super) fn create_synthetic_exports_for_star_re_exports_at_site(
             references: vec![SymbolReference {
                 from_file: site.from_file,
                 kind: ReferenceKind::NamespaceImport,
-                path: site.path,
                 import_span: site.import_span,
             }],
+            reference_paths: site.path.map(|path| vec![Some(path)]).unwrap_or_default(),
             members: Vec::new(),
         });
     }
@@ -638,6 +636,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::new(0, 5),
                 references: Vec::new(),
+                reference_paths: Vec::new(),
                 members: Vec::new(),
             },
             ExportSymbol {
@@ -648,6 +647,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::new(10, 15),
                 references: Vec::new(),
+                reference_paths: Vec::new(),
                 members: Vec::new(),
             },
         ];
@@ -674,9 +674,9 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(5),
                 kind: ReferenceKind::NamedImport,
-                path: reference_paths.direct(FileId(9), ModuleLoadMechanism::EsModule),
                 import_span: oxc_span::Span::new(0, 10),
             }],
+            reference_paths: vec![reference_paths.direct(FileId(9), ModuleLoadMechanism::EsModule)],
             members: Vec::new(),
         }];
         mark_all_exports_referenced(
@@ -697,6 +697,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 5),
             references: Vec::new(),
+            reference_paths: Vec::new(),
             members: Vec::new(),
         };
 
@@ -728,6 +729,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::new(0, 5),
                 references: Vec::new(),
+                reference_paths: Vec::new(),
                 members: Vec::new(),
             },
             ExportSymbol {
@@ -738,6 +740,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::new(10, 15),
                 references: Vec::new(),
+                reference_paths: Vec::new(),
                 members: Vec::new(),
             },
         ];
@@ -766,6 +769,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 5),
             references: Vec::new(),
+            reference_paths: Vec::new(),
             members: Vec::new(),
         }];
         let re_exports = vec![ReExportEdge {
@@ -1327,6 +1331,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 5),
             references: Vec::new(),
+            reference_paths: Vec::new(),
             members: Vec::new(),
         }];
         let accessed = vec!["default".to_string()];
@@ -1353,9 +1358,9 @@ mod tests {
             references: vec![SymbolReference {
                 from_file: FileId(0),
                 kind: ReferenceKind::NamedImport,
-                path: reference_paths.direct(FileId(9), ModuleLoadMechanism::EsModule),
                 import_span: oxc_span::Span::new(0, 10),
             }],
+            reference_paths: vec![reference_paths.direct(FileId(9), ModuleLoadMechanism::EsModule)],
             members: Vec::new(),
         }];
         let accessed = vec!["foo".to_string()];
@@ -1380,6 +1385,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 5),
             references: Vec::new(),
+            reference_paths: Vec::new(),
             members: Vec::new(),
         }];
         let accessed: Vec<String> = vec![];

--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -13,7 +13,7 @@ use fallow_types::extract::{ExportName, ModuleLoadMechanism, VisibilityTag};
 
 use crate::graph::types::{
     ExportSymbol, ModuleNode, ReferenceKind, ReferencePathId, ReferencePathInterner,
-    SymbolReference,
+    RoutedReference, SymbolReference,
 };
 use crate::graph::{Edge, ImportedName};
 use crate::resolve::ResolvedModule;
@@ -227,11 +227,13 @@ fn named_refs_for_edge(
             Some((
                 name.clone(),
                 StarReference {
-                    reference: SymbolReference {
-                        from_file: edge.source,
-                        kind: ReferenceKind::NamedImport,
+                    routed: RoutedReference {
+                        reference: SymbolReference {
+                            from_file: edge.source,
+                            kind: ReferenceKind::NamedImport,
+                            import_span: sym.import_span,
+                        },
                         path: reference_paths.direct(edge.target, sym.mechanism),
-                        import_span: sym.import_span,
                     },
                     origin: StarReferenceOrigin::NamedImport {
                         local_name: sym.local_name.clone(),
@@ -254,12 +256,10 @@ fn barrel_star_refs(
         .map(|export| {
             let name = export.name.to_string();
             let refs = export
-                .references
-                .iter()
-                .copied()
-                .map(|reference| {
+                .routed_references()
+                .map(|routed| {
                     barrel_star_ref(
-                        reference,
+                        routed,
                         &name,
                         export.is_type_only,
                         named_import_origin_index,
@@ -272,15 +272,15 @@ fn barrel_star_refs(
 }
 
 fn barrel_star_ref(
-    reference: SymbolReference,
+    routed: RoutedReference,
     name: &str,
     is_type_only: bool,
     named_import_origin_index: &NamedImportOriginIndex,
 ) -> StarReference {
     StarReference {
-        reference,
+        routed,
         origin: named_import_origin_index
-            .get(reference, name)
+            .get(routed.reference, name)
             .cloned()
             .unwrap_or(StarReferenceOrigin::BarrelExport { is_type_only }),
     }
@@ -333,7 +333,7 @@ impl NamedImportOriginIndex {
 
 #[derive(Clone)]
 struct StarReference {
-    reference: SymbolReference,
+    routed: RoutedReference,
     origin: StarReferenceOrigin,
 }
 
@@ -655,12 +655,12 @@ fn attach_matching_star_refs(input: AttachMatchingStarRefs<'_>) -> bool {
             !exports.value_indices.is_empty(),
             triggering_is_type_only,
         );
-        let reference = through_re_export(star_ref.reference, source_id, reference_paths);
+        let routed = through_re_export(star_ref.routed, source_id, reference_paths);
         if attach_type_exports {
-            type_refs.push(reference);
+            type_refs.push(routed);
         }
         if attach_value_exports {
-            value_refs.push(reference);
+            value_refs.push(routed);
         }
     }
 
@@ -718,12 +718,12 @@ fn create_synthetic_exports_for_refs(input: CreateSyntheticExports<'_>) -> bool 
             !triggering_is_type_only,
             triggering_is_type_only,
         );
-        let reference = through_re_export(star_ref.reference, source_id, reference_paths);
+        let routed = through_re_export(star_ref.routed, source_id, reference_paths);
         if attach_type_exports {
-            type_refs.push(reference);
+            type_refs.push(routed);
         }
         if attach_value_exports {
-            value_refs.push(reference);
+            value_refs.push(routed);
         }
     }
 
@@ -782,7 +782,7 @@ struct CreateSyntheticExport<'a> {
     name: &'a str,
     export_name: ExportName,
     is_type_only: bool,
-    references: Vec<SymbolReference>,
+    references: Vec<RoutedReference>,
     synthetic_stubs: &'a mut FxHashSet<(FileId, String, bool)>,
 }
 
@@ -801,23 +801,28 @@ fn create_synthetic_export(input: CreateSyntheticExport<'_>) -> bool {
         return false;
     }
 
-    source.exports.push(ExportSymbol {
+    let mut export = ExportSymbol {
         name: export_name,
         is_type_only,
         is_side_effect_used: false,
         visibility: VisibilityTag::None,
         expected_unused_reason: None,
         span: oxc_span::Span::new(0, 0),
-        references,
+        references: Vec::new(),
+        reference_paths: Vec::new(),
         members: Vec::new(),
-    });
+    };
+    for routed in references {
+        export.push_reference(routed.reference, routed.path);
+    }
+    source.exports.push(export);
     true
 }
 
 fn attach_star_refs_to_exports(
     source: &mut ModuleNode,
     export_indices: &[usize],
-    references: &[SymbolReference],
+    references: &[RoutedReference],
     existing_references: &mut FxHashSet<(FileId, Option<ReferencePathId>)>,
 ) -> bool {
     let mut changed = false;
@@ -828,13 +833,12 @@ fn attach_star_refs_to_exports(
         existing_references.clear();
         existing_references.extend(
             source.exports[*export_idx]
-                .references
-                .iter()
-                .map(|reference| (reference.from_file, reference.path)),
+                .routed_references()
+                .map(|routed| (routed.reference.from_file, routed.path)),
         );
-        for reference in references {
-            if existing_references.insert((reference.from_file, reference.path)) {
-                source.exports[*export_idx].references.push(*reference);
+        for routed in references {
+            if existing_references.insert((routed.reference.from_file, routed.path)) {
+                source.exports[*export_idx].push_reference(routed.reference, routed.path);
                 changed = true;
             }
         }
@@ -843,13 +847,13 @@ fn attach_star_refs_to_exports(
 }
 
 fn through_re_export(
-    reference: SymbolReference,
+    routed: RoutedReference,
     target: FileId,
     reference_paths: &mut ReferencePathInterner,
-) -> SymbolReference {
-    SymbolReference {
-        path: reference_paths.extend(reference.path, target, ModuleLoadMechanism::EsModule),
-        ..reference
+) -> RoutedReference {
+    RoutedReference {
+        reference: routed.reference,
+        path: reference_paths.extend(routed.path, target, ModuleLoadMechanism::EsModule),
     }
 }
 
@@ -870,7 +874,7 @@ impl StarReference {
                 local_name,
                 is_type_only,
             } => decide_named_import_attach_targets(
-                module_by_id.get(&self.reference.from_file),
+                module_by_id.get(&self.routed.reference.from_file),
                 local_name,
                 *is_type_only,
                 has_type_exports,
@@ -964,17 +968,15 @@ fn propagate_entry_point_star(
         if matches!(export.name, ExportName::Default) {
             continue;
         }
-        if export
-            .references
-            .iter()
-            .all(|reference| reference.from_file != barrel_id || reference.path != path)
-        {
-            export.references.push(SymbolReference {
-                from_file: barrel_id,
-                kind: ReferenceKind::ReExport,
+        if !export.has_reference_from(barrel_id, path) {
+            export.push_reference(
+                SymbolReference {
+                    from_file: barrel_id,
+                    kind: ReferenceKind::ReExport,
+                    import_span: oxc_span::Span::new(0, 0),
+                },
                 path,
-                import_span: oxc_span::Span::new(0, 0),
-            });
+            );
             changed = true;
         }
     }
@@ -1008,11 +1010,11 @@ pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagatio
         reference_paths,
     } = input;
 
-    let refs_on_barrel: Vec<SymbolReference> = modules[barrel_idx]
+    let refs_on_barrel: Vec<RoutedReference> = modules[barrel_idx]
         .exports
         .iter()
         .filter(|e| e.name.matches_str(exported_name))
-        .flat_map(|e| e.references.iter().copied())
+        .flat_map(ExportSymbol::routed_references)
         .collect();
 
     if refs_on_barrel.is_empty() {
@@ -1042,14 +1044,13 @@ pub(in crate::graph) fn propagate_named_re_export(input: NamedReExportPropagatio
         existing_refs.clear();
         existing_refs.extend(
             source.exports[export_idx]
-                .references
-                .iter()
-                .map(|reference| (reference.from_file, reference.path)),
+                .routed_references()
+                .map(|routed| (routed.reference.from_file, routed.path)),
         );
         for ref_item in &refs_on_barrel {
-            let reference = through_re_export(*ref_item, source.file_id, reference_paths);
-            if existing_refs.insert((reference.from_file, reference.path)) {
-                source.exports[export_idx].references.push(reference);
+            let routed = through_re_export(*ref_item, source.file_id, reference_paths);
+            if existing_refs.insert((routed.reference.from_file, routed.path)) {
+                source.exports[export_idx].push_reference(routed.reference, routed.path);
                 changed = true;
             }
         }
@@ -1070,9 +1071,9 @@ fn propagate_entry_point_named(
     let synthetic_ref = SymbolReference {
         from_file: barrel_id,
         kind: ReferenceKind::ReExport,
-        path: reference_paths.direct(source_id, ModuleLoadMechanism::EsModule),
         import_span: oxc_span::Span::new(0, 0),
     };
+    let synthetic_path = reference_paths.direct(source_id, ModuleLoadMechanism::EsModule);
     let mut changed = false;
     let source = &mut modules[source_idx];
     let target_exports: Vec<usize> = source
@@ -1083,14 +1084,8 @@ fn propagate_entry_point_named(
         .map(|(i, _)| i)
         .collect();
     for export_idx in target_exports {
-        if source.exports[export_idx]
-            .references
-            .iter()
-            .all(|reference| {
-                reference.from_file != barrel_id || reference.path != synthetic_ref.path
-            })
-        {
-            source.exports[export_idx].references.push(synthetic_ref);
+        if !source.exports[export_idx].has_reference_from(barrel_id, synthetic_path) {
+            source.exports[export_idx].push_reference(synthetic_ref, synthetic_path);
             changed = true;
         }
     }
@@ -1115,6 +1110,7 @@ mod star_index_tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 0),
             references: Vec::new(),
+            reference_paths: Vec::new(),
             members: Vec::new(),
         }
     }

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -977,65 +977,64 @@ mod tests {
     fn replacement_masks_a_target_behind_an_esm_re_export() {
         let graph = build_masked_re_export_graph(false, false);
         let target_export = &graph.modules[2].exports[0];
-        let reference = target_export
-            .references
-            .first()
-            .expect("barrel consumer reference should propagate");
+        assert!(
+            !target_export.references.is_empty(),
+            "barrel consumer reference should propagate"
+        );
 
         assert!(graph.modules[1].is_test_reachable());
         assert!(!graph.modules[2].is_test_reachable());
         assert_eq!(
-            graph.reference_path_hops(reference)[0].1,
+            graph.reference_path_hops(target_export, 0)[0].1,
             ModuleLoadMechanism::EsModule
         );
-        assert!(!graph.is_test_reference_covered(reference));
+        assert!(!graph.is_test_reference_covered(target_export, 0));
     }
 
     #[test]
     fn commonjs_loaded_barrel_does_not_bypass_its_esm_re_export() {
         let graph = build_masked_re_export_graph(true, false);
         let target_export = &graph.modules[2].exports[0];
-        let reference = target_export
-            .references
-            .first()
-            .expect("barrel consumer reference should propagate");
+        assert!(
+            !target_export.references.is_empty(),
+            "barrel consumer reference should propagate"
+        );
 
         assert!(graph.modules[1].is_test_reachable());
         assert!(!graph.modules[2].is_test_reachable());
         assert_eq!(
-            graph.reference_path_hops(reference)[0].1,
+            graph.reference_path_hops(target_export, 0)[0].1,
             ModuleLoadMechanism::EsModule
         );
-        assert!(!graph.is_test_reference_covered(reference));
+        assert!(!graph.is_test_reference_covered(target_export, 0));
     }
 
     #[test]
     fn direct_commonjs_and_esm_re_export_retain_distinct_coverage() {
         let graph = build_masked_re_export_graph(false, true);
-        let references = &graph.modules[2].exports[0].references;
+        let export = &graph.modules[2].exports[0];
 
-        assert_eq!(references.len(), 2);
-        let esm = references
-            .iter()
-            .find(|reference| {
-                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::EsModule
+        assert_eq!(export.references.len(), 2);
+        let esm = (0..export.references.len())
+            .find(|&index| {
+                graph.reference_path_hops(export, index)[0].1 == ModuleLoadMechanism::EsModule
             })
             .expect("ESM re-export reference");
-        let commonjs = references
-            .iter()
-            .find(|reference| {
-                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::CommonJsRequire
+        let commonjs = (0..export.references.len())
+            .find(|&index| {
+                graph.reference_path_hops(export, index)[0].1
+                    == ModuleLoadMechanism::CommonJsRequire
             })
             .expect("direct CommonJS reference");
-        assert!(!graph.is_test_reference_covered(esm));
-        assert!(graph.is_test_reference_covered(commonjs));
+        assert!(!graph.is_test_reference_covered(export, esm));
+        assert!(graph.is_test_reference_covered(export, commonjs));
     }
 
     #[test]
     fn mocked_intermediate_barrel_blocks_a_reference_despite_an_alternate_target_route() {
         let graph = build_intermediate_replacement_graph(false, false, false);
-        let reference = &graph.modules[2].exports[0].references[0];
-        let hops = graph.reference_path_hops(reference);
+        let export = &graph.modules[2].exports[0];
+        let hops = graph.reference_path_hops(export, 0);
 
         assert!(graph.modules[2].is_test_reachable());
         assert_eq!(
@@ -1045,13 +1044,13 @@ mod tests {
                 (FileId(1), ModuleLoadMechanism::EsModule),
             ]
         );
-        assert!(!graph.is_test_reference_covered(reference));
+        assert!(!graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
     fn mocked_re_export_cycle_member_blocks_the_cyclic_reference_path() {
         let graph = build_intermediate_replacement_graph(false, true, false);
-        let reference = &graph.modules[2].exports[0].references[0];
+        let export = &graph.modules[2].exports[0];
 
         assert!(
             graph
@@ -1060,30 +1059,30 @@ mod tests {
                 .any(|cycle| cycle.file_ids == vec![FileId(1), FileId(2)])
         );
         assert!(graph.modules[2].is_test_reachable());
-        assert!(!graph.is_test_reference_covered(reference));
+        assert!(!graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
     fn commonjs_barrel_hop_bypasses_only_its_own_replacement() {
         let graph = build_intermediate_replacement_graph(true, false, false);
-        let reference = &graph.modules[2].exports[0].references[0];
+        let export = &graph.modules[2].exports[0];
 
         assert_eq!(
-            graph.reference_path_hops(reference),
+            graph.reference_path_hops(export, 0),
             vec![
                 (FileId(2), ModuleLoadMechanism::EsModule),
                 (FileId(1), ModuleLoadMechanism::CommonJsRequire),
             ]
         );
-        assert!(graph.is_test_reference_covered(reference));
+        assert!(graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
     fn commonjs_barrel_hop_does_not_bypass_a_replaced_esm_target() {
         let graph = build_intermediate_replacement_graph(true, false, true);
-        let reference = &graph.modules[2].exports[0].references[0];
+        let export = &graph.modules[2].exports[0];
 
-        assert!(!graph.is_test_reference_covered(reference));
+        assert!(!graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
@@ -1091,29 +1090,29 @@ mod tests {
         let graph = build_intermediate_replacement_graph(false, false, false);
         let encoded = postcard::to_allocvec(&graph).expect("encode graph");
         let decoded: ModuleGraph = postcard::from_bytes(&encoded).expect("decode graph");
-        let reference = &decoded.modules[2].exports[0].references[0];
+        let export = &decoded.modules[2].exports[0];
 
         assert_eq!(
-            decoded.reference_path_hops(reference),
+            decoded.reference_path_hops(export, 0),
             vec![
                 (FileId(2), ModuleLoadMechanism::EsModule),
                 (FileId(1), ModuleLoadMechanism::EsModule),
             ]
         );
-        assert!(!decoded.is_test_reference_covered(reference));
+        assert!(!decoded.is_test_reference_covered(export, 0));
     }
 
     #[test]
     fn require_context_keeps_a_replaced_target_covered() {
         let graph = build_masked_pattern_graph(&[ModuleLoadMechanism::CommonJsRequire]);
-        let reference = &graph.modules[1].exports[0].references[0];
+        let export = &graph.modules[1].exports[0];
 
         assert!(graph.modules[1].is_test_reachable());
         assert_eq!(
-            graph.reference_path_hops(reference)[0].1,
+            graph.reference_path_hops(export, 0)[0].1,
             ModuleLoadMechanism::CommonJsRequire
         );
-        assert!(graph.is_test_reference_covered(reference));
+        assert!(graph.is_test_reference_covered(export, 0));
     }
 
     #[test]
@@ -1122,24 +1121,23 @@ mod tests {
             ModuleLoadMechanism::EsModule,
             ModuleLoadMechanism::CommonJsRequire,
         ]);
-        let references = &graph.modules[1].exports[0].references;
+        let export = &graph.modules[1].exports[0];
 
         assert!(graph.modules[1].is_test_reachable());
-        assert_eq!(references.len(), 2);
-        let esm = references
-            .iter()
-            .find(|reference| {
-                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::EsModule
+        assert_eq!(export.references.len(), 2);
+        let esm = (0..export.references.len())
+            .find(|&index| {
+                graph.reference_path_hops(export, index)[0].1 == ModuleLoadMechanism::EsModule
             })
             .expect("ESM pattern reference");
-        let commonjs = references
-            .iter()
-            .find(|reference| {
-                graph.reference_path_hops(reference)[0].1 == ModuleLoadMechanism::CommonJsRequire
+        let commonjs = (0..export.references.len())
+            .find(|&index| {
+                graph.reference_path_hops(export, index)[0].1
+                    == ModuleLoadMechanism::CommonJsRequire
             })
             .expect("CommonJS pattern reference");
-        assert!(!graph.is_test_reference_covered(esm));
-        assert!(graph.is_test_reference_covered(commonjs));
+        assert!(!graph.is_test_reference_covered(export, esm));
+        assert!(graph.is_test_reference_covered(export, commonjs));
     }
 
     #[test]
@@ -1574,12 +1572,15 @@ mod tests {
             &test_entry_points,
             &files,
         );
-        let reference = &graph.modules[CHAIN_LENGTH as usize].exports[0].references[0];
+        let export = &graph.modules[CHAIN_LENGTH as usize].exports[0];
 
         assert_eq!(graph.test_reachability_index.profile_count, 0);
-        assert!(reference.path.is_none());
+        assert!(
+            export.reference_paths.is_empty(),
+            "the provenance side table must stay unallocated on the fast path"
+        );
         assert!(graph.reference_paths.is_empty());
-        assert!(graph.is_test_reference_covered(reference));
+        assert!(graph.is_test_reference_covered(export, 0));
     }
 
     #[test]

--- a/crates/graph/src/graph/types.rs
+++ b/crates/graph/src/graph/types.rs
@@ -178,6 +178,16 @@ pub struct ExportSymbol {
     pub span: oxc_span::Span,
     /// Which files reference this export.
     pub references: Vec<SymbolReference>,
+    /// Interned provenance paths parallel to `references`, keyed by reference
+    /// index (issue #2083).
+    ///
+    /// Only populated when the test-reachability plan requires reference
+    /// provenance (a replacement mock exists). It stays empty for every other
+    /// project so the reference list itself remains 16 bytes per entry and the
+    /// side table allocates nothing. Entries can be `None` even when populated:
+    /// legacy reachability stores no path, profiled reachability always does.
+    #[serde(default)]
+    pub reference_paths: Vec<Option<ReferencePathId>>,
     /// Members of this export (enum members, class members).
     ///
     /// `MemberInfo` is a shared `fallow-types` struct whose serde shape is
@@ -195,11 +205,6 @@ pub struct SymbolReference {
     pub from_file: FileId,
     /// How the export is referenced.
     pub kind: ReferenceKind,
-    /// Interned linked path from `from_file` to the owning export.
-    ///
-    /// Legacy reachability does not need root-specific provenance and stores
-    /// `None`; profiled reachability always stores an exact path.
-    pub(crate) path: Option<ReferencePathId>,
     /// Byte span of the import statement in the referencing file.
     /// Used by the LSP to locate references for Code Lens navigation.
     #[serde(with = "crate::cache::span_serde")]
@@ -207,8 +212,69 @@ pub struct SymbolReference {
 }
 
 /// Compact identifier for an interned reference path.
+///
+/// Opaque outside the graph crate; it only appears in the public API as the
+/// element type of [`ExportSymbol::reference_paths`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ReferencePathId(NonZeroU32);
+pub struct ReferencePathId(NonZeroU32);
+
+/// A symbol reference paired with its optional provenance path while build
+/// passes route it between exports, before it lands in a reference list plus
+/// its provenance side table.
+#[derive(Clone, Copy)]
+pub(crate) struct RoutedReference {
+    pub(crate) reference: SymbolReference,
+    pub(crate) path: Option<ReferencePathId>,
+}
+
+impl ExportSymbol {
+    /// Provenance path recorded for the reference at `index`, when tracked.
+    pub(crate) fn reference_path(&self, index: usize) -> Option<ReferencePathId> {
+        self.reference_paths.get(index).copied().flatten()
+    }
+
+    /// Whether a reference from `from_file` with this exact provenance path is
+    /// already attached.
+    pub(crate) fn has_reference_from(
+        &self,
+        from_file: FileId,
+        path: Option<ReferencePathId>,
+    ) -> bool {
+        self.references
+            .iter()
+            .enumerate()
+            .any(|(index, reference)| {
+                reference.from_file == from_file && self.reference_path(index) == path
+            })
+    }
+
+    /// Attach `reference`, recording `path` in the provenance side table.
+    ///
+    /// The side table stays untouched until the first tracked path arrives, so
+    /// projects without replacement mocks never allocate it.
+    pub(crate) fn push_reference(
+        &mut self,
+        reference: SymbolReference,
+        path: Option<ReferencePathId>,
+    ) {
+        if path.is_some() || !self.reference_paths.is_empty() {
+            self.reference_paths.resize(self.references.len(), None);
+            self.reference_paths.push(path);
+        }
+        self.references.push(reference);
+    }
+
+    /// Iterate references together with their recorded provenance paths.
+    pub(crate) fn routed_references(&self) -> impl Iterator<Item = RoutedReference> + '_ {
+        self.references
+            .iter()
+            .enumerate()
+            .map(|(index, reference)| RoutedReference {
+                reference: *reference,
+                path: self.reference_path(index),
+            })
+    }
+}
 
 /// One conjunctive step in an interned export-reference route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -622,13 +688,13 @@ impl ReferencePathInterner {
             }
         }
 
-        for reference in modules
+        for path in modules
             .iter_mut()
             .flat_map(|module| &mut module.exports)
-            .flat_map(|export| &mut export.references)
+            .flat_map(|export| &mut export.reference_paths)
         {
-            if let Some(path) = reference.path {
-                reference.path = Some(remap[path.index()]);
+            if let Some(existing) = *path {
+                *path = Some(remap[existing.index()]);
             }
         }
 
@@ -785,9 +851,9 @@ pub enum ReferenceKind {
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<ExportSymbol>() == 112);
+const _: () = assert!(std::mem::size_of::<ExportSymbol>() == 136);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<SymbolReference>() == 24);
+const _: () = assert!(std::mem::size_of::<SymbolReference>() == 16);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<ReExportEdge>() == 64);
 #[cfg(all(target_pointer_width = "64", unix))]
@@ -852,14 +918,13 @@ mod tests {
                 span: oxc_span::Span::default(),
                 references: paths
                     .iter()
-                    .copied()
-                    .map(|path| SymbolReference {
+                    .map(|_| SymbolReference {
                         from_file: FileId(0),
                         kind: ReferenceKind::NamedImport,
-                        path,
                         import_span: oxc_span::Span::default(),
                     })
                     .collect(),
+                reference_paths: paths.to_vec(),
                 members: Vec::new(),
             }],
             re_exports: Vec::new(),
@@ -912,17 +977,10 @@ mod tests {
         let second_nodes = second.finalize(&mut second_modules);
 
         assert_eq!(first_nodes, second_nodes);
-        let first_paths: Vec<_> = first_modules[0].exports[0]
-            .references
-            .iter()
-            .map(|reference| reference.path)
-            .collect();
-        let second_paths: Vec<_> = second_modules[0].exports[0]
-            .references
-            .iter()
-            .map(|reference| reference.path)
-            .collect();
-        assert_eq!(first_paths, second_paths);
+        assert_eq!(
+            first_modules[0].exports[0].reference_paths,
+            second_modules[0].exports[0].reference_paths
+        );
     }
 
     fn two_hop_route(first: FileId, second: FileId) -> ReferenceRouteGraphSpec {
@@ -982,17 +1040,10 @@ mod tests {
         let second_paths = second.finalize(&mut second_modules);
 
         assert_eq!(first_paths, second_paths);
-        let first_reference_paths: Vec<_> = first_modules[0].exports[0]
-            .references
-            .iter()
-            .map(|reference| reference.path)
-            .collect();
-        let second_reference_paths: Vec<_> = second_modules[0].exports[0]
-            .references
-            .iter()
-            .map(|reference| reference.path)
-            .collect();
-        assert_eq!(first_reference_paths, second_reference_paths);
+        assert_eq!(
+            first_modules[0].exports[0].reference_paths,
+            second_modules[0].exports[0].reference_paths
+        );
     }
 
     #[test]
@@ -1000,7 +1051,6 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(42),
             kind: ReferenceKind::NamedImport,
-            path: Some(ReferencePathId::from_index(0)),
             import_span: oxc_span::Span::new(10, 30),
         };
         assert_eq!(reference.from_file, FileId(42));
@@ -1014,7 +1064,6 @@ mod tests {
         let reference = SymbolReference {
             from_file: FileId(7),
             kind: ReferenceKind::ReExport,
-            path: Some(ReferencePathId::from_index(0)),
             import_span: oxc_span::Span::new(5, 25),
         };
         let copied = reference;
@@ -1075,6 +1124,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 50),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         };
         assert!(matches!(sym.name, ExportName::Named(ref n) if n == "myFunction"));
@@ -1092,6 +1142,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 20),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         };
         assert!(matches!(sym.name, ExportName::Default));
@@ -1107,6 +1158,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 10),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         };
         assert_eq!(sym.visibility, VisibilityTag::Public);
@@ -1122,6 +1174,7 @@ mod tests {
             expected_unused_reason: None,
             span: oxc_span::Span::new(0, 30),
             references: vec![],
+            reference_paths: Vec::new(),
             members: vec![],
         };
         assert!(sym.is_type_only);
@@ -1140,21 +1193,84 @@ mod tests {
                 SymbolReference {
                     from_file: FileId(1),
                     kind: ReferenceKind::NamedImport,
-                    path: Some(ReferencePathId::from_index(0)),
                     import_span: oxc_span::Span::new(0, 10),
                 },
                 SymbolReference {
                     from_file: FileId(2),
                     kind: ReferenceKind::ReExport,
-                    path: Some(ReferencePathId::from_index(1)),
                     import_span: oxc_span::Span::new(5, 15),
                 },
+            ],
+            reference_paths: vec![
+                Some(ReferencePathId::from_index(0)),
+                Some(ReferencePathId::from_index(1)),
             ],
             members: vec![],
         };
         assert_eq!(sym.references.len(), 2);
         assert_eq!(sym.references[0].from_file, FileId(1));
         assert_eq!(sym.references[1].kind, ReferenceKind::ReExport);
+    }
+
+    #[test]
+    fn push_reference_without_paths_never_allocates_the_side_table() {
+        let mut export = ExportSymbol {
+            name: ExportName::Named("value".to_string()),
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: oxc_span::Span::default(),
+            references: Vec::new(),
+            reference_paths: Vec::new(),
+            members: Vec::new(),
+        };
+        for id in 0..3 {
+            export.push_reference(
+                SymbolReference {
+                    from_file: FileId(id),
+                    kind: ReferenceKind::NamedImport,
+                    import_span: oxc_span::Span::default(),
+                },
+                None,
+            );
+        }
+        assert_eq!(export.references.len(), 3);
+        assert!(export.reference_paths.is_empty());
+        assert_eq!(export.reference_paths.capacity(), 0);
+        assert_eq!(export.reference_path(1), None);
+        assert!(export.has_reference_from(FileId(1), None));
+        assert!(!export.has_reference_from(FileId(9), None));
+    }
+
+    #[test]
+    fn push_reference_backfills_the_side_table_on_the_first_tracked_path() {
+        let mut export = ExportSymbol {
+            name: ExportName::Named("value".to_string()),
+            is_type_only: false,
+            is_side_effect_used: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: oxc_span::Span::default(),
+            references: Vec::new(),
+            reference_paths: Vec::new(),
+            members: Vec::new(),
+        };
+        let reference = SymbolReference {
+            from_file: FileId(0),
+            kind: ReferenceKind::NamedImport,
+            import_span: oxc_span::Span::default(),
+        };
+        export.push_reference(reference, None);
+        let tracked = ReferencePathId::from_index(4);
+        export.push_reference(reference, Some(tracked));
+        export.push_reference(reference, None);
+
+        assert_eq!(export.reference_paths, vec![None, Some(tracked), None]);
+        assert_eq!(export.reference_path(0), None);
+        assert_eq!(export.reference_path(1), Some(tracked));
+        assert!(export.has_reference_from(FileId(0), Some(tracked)));
+        assert!(!export.has_reference_from(FileId(0), Some(ReferencePathId::from_index(7))));
     }
 
     #[test]
@@ -1224,6 +1340,7 @@ mod tests {
                 expected_unused_reason: None,
                 span: oxc_span::Span::new(0, 20),
                 references: vec![],
+                reference_paths: Vec::new(),
                 members: vec![],
             }],
             re_exports: vec![ReExportEdge {


### PR DESCRIPTION
Restores the 16-byte `SymbolReference` that #2068 grew to 24 bytes by adding an inline `path: Option<ReferencePathId>` per reference.

## What changed

- `SymbolReference` drops the `path` field; the size assertion in `crates/graph/src/graph/types.rs` is restored to 16 bytes and acts as the regression gate.
- Reference provenance now lives in a sparse `reference_paths` side table on `ExportSymbol`, parallel to `references` and keyed by reference index. `push_reference` backfills the table with `None` entries only when the first tracked path arrives, so with the interner disabled (`requires_reference_provenance()` false, the overwhelmingly common case) the vector stays empty and never allocates. A unit test asserts `capacity() == 0` after pushes on the fast path.
- Build passes (star and named re-export propagation, narrowing, namespace crediting) route the pair through a crate-internal `RoutedReference`; dedup keys `(from_file, path)` and `finalize()` remapping read the side table instead of the inline field.
- The coverage API becomes `is_test_reference_covered(export, reference_index)` plus `is_any_test_reference_covered(export)`; the engine's per-export `.any()` call sites use the latter.
- `GRAPH_CACHE_VERSION` is bumped 17 to 18 because the persisted export layout changes; the version doc records the reason.

## Decisions

- The side table lives on `ExportSymbol` (growing it 112 to 136 bytes) rather than on a graph-level map: references are appended across several fixpoint passes that only hold `&mut ExportSymbol`, so a per-export parallel vector keeps every dedup and remap site local without threading module/export indices through the propagation pipeline. Exports are far outnumbered by references, so the trade is strictly favorable, and the empty vector costs nothing on the heap.
- `ReferencePathId` becomes an opaque `pub` type because it appears in the public field; its constructor stays crate-private.

## Validation

- `cargo test -p fallow-graph -p fallow-engine -p fallow-core`: pass, including the #2068 masked-reachability regression tests (unchanged semantics, updated to the index-based API).
- Full workspace check, clippy, and `cargo doc` with `-D warnings`: clean. The only failing workspace tests are the pre-existing type-aware sidecar tests that resolve `typescript/unstable/sync` from the environment, unrelated to this change.
- Real-project run (Vue 3 component library): cold run and cache-loaded rerun produce byte-identical results apart from run id and timing, confirming the version-18 cache round-trips.

Fixes #2083