### PR TITLE
fix(audit): compare semantic identities by compatibility, not equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fallow audit` with `typeAware.enabled` no longer degrades to syntactic
+  attribution on every diff that adds or removes a file.** The type-aware
+  comparison now decides base/head identity compatibility with
+  `incompatible_fields()` instead of raw equality: the deferred project-config
+  hash of a side that ran no semantic queries is compatible with any concrete
+  hash, a side that produced no semantic identity at all made no semantic
+  claims and no longer forces the fallback, and the semantic project-config
+  hash no longer includes the project's root file listing (base and head of a
+  diff naturally differ in file membership). The same compatibility check
+  applies to warm runs that rehydrate the cached base snapshot. Genuinely
+  incompatible identities, such as a tsconfig or compiler-options change
+  between base and head, still degrade with the existing warning. (Closes
+  [#2102](https://github.com/fallow-rs/fallow/issues/2102).)
+
 - **`fallow audit` attribution is now rename-aware.** New-vs-inherited
   attribution follows git rename detection when joining head findings against
   the base snapshot, so a pure `git mv` (a route rename, a directory

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -392,22 +392,27 @@ fn snapshot_from_results(
 /// When a reason is returned the audit does not fail; it falls back to the
 /// identity-independent syntactic key sets captured before refinement on each
 /// side, so `--gate new-only` keeps working with `typeAware.enabled` set even
-/// when base and head resolve different semantic identities (changed
-/// tsconfigs, one-sided sidecar availability, differing omissions).
+/// when base and head resolve incompatible semantic identities (changed
+/// tsconfigs or differing omissions). Compatibility is decided by
+/// `SemanticAnalysisIdentity::incompatible_fields`, not raw equality: the
+/// deferred project-config hash and a fully absent identity both mean a side
+/// ran no semantic queries, which is compatible with any concrete identity
+/// on the other side (#2102).
 fn type_aware_attribution_degrade_reason(
     base: Option<&AuditKeySnapshot>,
     head: Option<&fallow_types::envelope::TypeAwareMeta>,
 ) -> Option<&'static str> {
     let base = base?;
     let base_identity = base.type_aware_identity.as_ref();
-    if base_identity.is_some() != head.is_some() {
-        return Some("only one side produced a semantic analysis identity");
-    }
-    if let (Some(base_identity), Some(head_identity)) =
-        (base_identity, head.and_then(|meta| meta.identity.as_ref()))
-        && base_identity != head_identity
+    let head_identity = head.and_then(|meta| meta.identity.as_ref());
+    // Compatibility, not equality: `incompatible_fields` treats the deferred
+    // project-config hash (a side that ran no semantic queries) as compatible
+    // with any concrete hash, and a side with no identity at all made no
+    // semantic claims, so nothing can conflict (#2102).
+    if let (Some(base_identity), Some(head_identity)) = (base_identity, head_identity)
+        && !base_identity.incompatible_fields(head_identity).is_empty()
     {
-        return Some("their semantic analysis identities differ");
+        return Some("their semantic analysis identities are incompatible");
     }
     if let Some(head) = head
         && base.type_aware_gap_signature != type_aware_gap_signature(head)
@@ -1294,8 +1299,8 @@ fn assemble_audit_result(input: AuditAssemblyInput<'_>) -> Result<AuditResult, E
     if let Some(reason) = type_aware_degrade {
         let warning = format!(
             "audit compared base and head with syntactic attribution because {reason} \
-(usually a tsconfig change between base and head, or the sidecar being unavailable \
-on the base side); type-aware refinement still applies to head findings, and \
+(usually a tsconfig or compiler-options change between base and head); \
+type-aware refinement still applies to head findings, and \
 semantic-only findings stay out of the new-only gate for this run; set \
 audit.typeAware: false or pass --no-type-aware to keep the gate syntactic"
         );

--- a/crates/cli/src/audit_cache.rs
+++ b/crates/cli/src/audit_cache.rs
@@ -29,9 +29,11 @@ pub(super) struct CachedAuditKeySnapshot {
     pub(super) base_sha: String,
     /// JSON-serialized `SemanticAnalysisIdentity` of the base pass, `None`
     /// when the base ran without type-aware analysis. Persisted so a warm
-    /// cache hit still compares base and head identities instead of treating
-    /// every cached type-aware base as identity-less (which would spuriously
-    /// degrade the new-only gate to syntactic attribution).
+    /// cache hit still runs the identity compatibility check
+    /// (`incompatible_fields`, not raw equality; see #2102) against the head
+    /// identity: a genuinely incompatible cached base must keep degrading the
+    /// new-only gate to syntactic attribution, and an identity-less cached
+    /// base must not be mistaken for one that made semantic claims.
     pub(super) type_aware_identity: Option<String>,
     pub(super) type_aware_gap_signature: Vec<String>,
     /// Pre-refinement syntactic dead-code keys of the base pass, `None` when

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -1972,23 +1972,56 @@ fn degrade_reason_absent_for_fully_syntactic_comparison() {
     assert_eq!(type_aware_attribution_degrade_reason(None, None), None);
 }
 
+/// Regression test for #2102: a side without a semantic identity made no
+/// semantic claims (it legitimately ran no semantic queries), so the other
+/// side's identity cannot conflict with it and the comparison must not
+/// degrade.
 #[test]
-fn degrade_reason_when_only_one_side_has_type_aware_identity() {
+fn degrade_reason_absent_when_only_one_side_has_type_aware_identity() {
     let base = empty_snapshot_with_type_aware(Some(identity_with_hash("hash-a")), Vec::new());
-    assert!(type_aware_attribution_degrade_reason(Some(&base), None).is_some());
+    assert_eq!(
+        type_aware_attribution_degrade_reason(Some(&base), None),
+        None
+    );
 
     let base = empty_snapshot_with_type_aware(None, Vec::new());
     let head = meta_with_identity(identity_with_hash("hash-a"));
-    assert!(type_aware_attribution_degrade_reason(Some(&base), Some(&head)).is_some());
+    assert_eq!(
+        type_aware_attribution_degrade_reason(Some(&base), Some(&head)),
+        None
+    );
+}
+
+/// Regression test for #2102: the deferred project-config hash (a side that
+/// needed no semantic queries) is compatible with any concrete hash, so a
+/// diff that adds a file (deferred base, concrete head) must not degrade.
+#[test]
+fn degrade_reason_absent_for_deferred_vs_concrete_project_config_hash() {
+    let deferred = identity_with_hash(fallow_types::semantic::DEFERRED_PROJECT_CONFIG_HASH);
+    let concrete = identity_with_hash("sha256:concrete");
+
+    let base = empty_snapshot_with_type_aware(Some(deferred.clone()), Vec::new());
+    let head = meta_with_identity(concrete.clone());
+    assert_eq!(
+        type_aware_attribution_degrade_reason(Some(&base), Some(&head)),
+        None
+    );
+
+    let base = empty_snapshot_with_type_aware(Some(concrete), Vec::new());
+    let head = meta_with_identity(deferred);
+    assert_eq!(
+        type_aware_attribution_degrade_reason(Some(&base), Some(&head)),
+        None
+    );
 }
 
 #[test]
-fn degrade_reason_when_semantic_identities_differ() {
+fn degrade_reason_when_semantic_identities_are_incompatible() {
     let base = empty_snapshot_with_type_aware(Some(identity_with_hash("hash-a")), Vec::new());
     let head = meta_with_identity(identity_with_hash("hash-b"));
     assert_eq!(
         type_aware_attribution_degrade_reason(Some(&base), Some(&head)),
-        Some("their semantic analysis identities differ")
+        Some("their semantic analysis identities are incompatible")
     );
 }
 

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -4189,6 +4189,94 @@ fn audit_new_only_degrades_to_syntactic_attribution_on_type_aware_identity_misma
     );
 }
 
+/// Regression test for #2102: with `typeAware.enabled`, a diff that only adds
+/// a new zero-export file must keep type-aware attribution. The base pass
+/// needs no semantic queries (its project-config hash stays deferred) while
+/// the head pass runs at least one query (concrete hash); those identities
+/// are compatible by design, so the audit must not degrade to syntactic
+/// attribution or warn.
+#[test]
+fn audit_type_aware_new_file_keeps_type_aware_attribution() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name": "audit-type-aware-new-file", "main": "src/index.ts"}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("tsconfig.json"),
+        r#"{"compilerOptions": {"strict": true}}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join(".fallowrc.json"),
+        r#"{"typeAware": {"enabled": true}}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import { used } from './utils';\nused();\n",
+    )
+    .unwrap();
+    fs::write(dir.join("src/utils.ts"), "export const used = () => 42;\n").unwrap();
+    git(dir, &["init", "-b", "main"]);
+    commit_all(dir, "initial");
+    git(dir, &["checkout", "-b", "feature"]);
+
+    // The diff only adds a zero-export file; its contents do not matter.
+    fs::write(dir.join("src/newfile.ts"), "const x = 1;\nvoid x;\n").unwrap();
+    commit_all(dir, "add zero-export file");
+
+    let output = common::run_fallow_raw_with_type_aware_sidecar(&[
+        "audit",
+        "--root",
+        dir.to_str().unwrap(),
+        "--base",
+        "main",
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+
+    assert_ne!(
+        output.code, 2,
+        "compatible identities must not fail the audit. stdout: {}\nstderr: {}",
+        output.stdout, output.stderr
+    );
+    let json = parse_json(&output);
+    let warnings: Vec<String> = json["_meta"]["type_aware"]["warnings"]
+        .as_array()
+        .map(|warnings| {
+            warnings
+                .iter()
+                .filter_map(|warning| warning.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        !warnings
+            .iter()
+            .any(|warning| warning.contains("syntactic attribution")),
+        "a deferred base identity is compatible with a concrete head identity \
+and must keep the type-aware comparison: {warnings:#?}"
+    );
+    assert!(
+        json["_meta"]["type_aware"]["identity"].is_object(),
+        "head should report its semantic analysis identity"
+    );
+    let unused_files = json["dead_code"]["unused_files"]
+        .as_array()
+        .expect("dead_code.unused_files should be an array");
+    assert!(
+        unused_files
+            .iter()
+            .any(|finding| finding["path"] == "src/newfile.ts" && finding["introduced"] == true),
+        "the new file should be attributed as introduced: {unused_files:#?}"
+    );
+}
+
 /// Negative control for the audit base-snapshot cache under type-aware
 /// analysis (enabled via config, not a CLI flag): the same audit run twice
 /// must behave identically. The second run hits the cached base snapshot,
@@ -4229,11 +4317,10 @@ fn audit_type_aware_base_snapshot_cache_preserves_identity_comparison() {
     commit_all(dir, "initial");
     git(dir, &["checkout", "-b", "feature"]);
 
-    // Only existing files change: no tsconfig edit and no new file, so base
-    // and head resolve the same semantic identity (the project's root file
-    // set is part of it). A genuinely new unused export in an existing file
-    // keeps the new-only gate failing on both runs so attribution stays
-    // observable.
+    // Only existing files change: no tsconfig edit, so base and head resolve
+    // the same semantic identity. A genuinely new unused export in an
+    // existing file keeps the new-only gate failing on both runs so
+    // attribution stays observable.
     fs::write(
         dir.join("src/utils.ts"),
         "export const used = () => 42;\nexport const unusedBase = () => 0;\nexport const unusedNew = () => 2;\n",

--- a/tools/type-aware-sidecar/src/project-state.mjs
+++ b/tools/type-aware-sidecar/src/project-state.mjs
@@ -157,13 +157,16 @@ const configDocumentClosure = (root, configFileName, seen = new Set()) => {
   };
 };
 
+// The hash deliberately excludes the project's root file listing: base and
+// head of a diff naturally differ in file membership (added or deleted
+// files), and semantic evidence stays comparable as long as the
+// configuration that produced it is the same. Configuration changes are
+// covered by the compiler options and the config document closure
+// (https://github.com/fallow-rs/fallow/issues/2102).
 const effectiveProjectConfigHash = (root, project) => {
   const effective = {
     config: configPath(root, project),
     compiler_options: normalizedConfigValue(root, project.compilerOptions),
-    root_files: project.rootFiles
-      .map((fileName) => normalizedConfigValue(root, fileName))
-      .toSorted(compareText),
     config_document: configDocumentClosure(root, project.configFileName),
   };
   return `sha256:${createHash("sha256").update(JSON.stringify(effective)).digest("hex")}`;


### PR DESCRIPTION
With `typeAware.enabled`, `fallow audit` degraded to syntactic attribution with a warning on effectively every diff that adds or removes a file. Since #2095 this no longer exits 2, but the degrade and its warning still fired for identities that are compatible by design. Excellent source-level analysis by the reporter in the issue.

Two mechanisms produced the spurious degrade:

1. `type_aware_attribution_degrade_reason` compared the base and head `SemanticAnalysisIdentity` with raw `!=` plus an `is_some() != is_some()` gate, while `SemanticAnalysisIdentity::incompatible_fields()` deliberately treats the deferred project-config hash (`deferred:no-semantic-queries`) as compatible with any concrete hash.
2. The sidecar's effective project-config hash included the project's root file listing, so two sides that both ran semantic queries got different concrete hashes whenever the diff added or removed a file, even with an identical configuration.

Changes:

- Base the degrade decision on `incompatible_fields().is_empty()` instead of raw equality.
- Tolerate an absent identity on a side that ran no semantic queries: it made no semantic claims, so nothing can conflict.
- Drop `root_files` from the sidecar's effective project-config hash. Base and head of a diff naturally differ in file membership; configuration changes stay covered by the compiler options and the config document closure, so a tsconfig change between base and head still degrades with the existing warning (existing regression test for #2092 keeps covering this).
- The cached base snapshot path (audit_cache.rs) persists the identity and flows through the same compatibility check after rehydration; comments updated to state the compatibility semantics.

Tests:

- New integration test: a diff that only adds a zero-export `.ts` file with `typeAware` enabled produces no degrade warning and normal type-aware attribution (fails before the fix with the exact warning from the issue, verified by running it against the pre-fix code).
- New predicate-level unit tests: deferred-vs-concrete hash in both directions is compatible; a one-sided identity is compatible; two different concrete hashes still degrade.
- Existing controls: the #2092 tsconfig-change test still degrades with the warning; the warm-cache identity-preservation test still passes.
- Validated end to end on a repro project mirroring the issue: cold run, warm cached-base-snapshot run (no degrade), and a tsconfig-change control (degrades).

The macOS `/var` vs `/private/var` containment failure mentioned as a secondary observation in the issue was addressed by #2095 and is not part of this change.

Fixes #2102
