### PR TITLE
perf(graph): recover the alias-loop regression from the provenance side table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Faster namespace-alias propagation during graph build.** The
+  cross-package namespace alias pass no longer formats a lookup string per
+  consumer import or builds the chained re-export state machine when the
+  alias target has no `export * as` edge, cutting allocations in the hot
+  loop. The `namespace_object_alias_propagation` benchmark improves by about
+  11% locally (883 us to 780 us), recovering the regression introduced by the
+  provenance side table in 3.13.0. Analysis output is unchanged.
+
 ## [3.13.0] - 2026-08-03
 
 ### Fixed

--- a/crates/graph/src/graph/namespace_aliases.rs
+++ b/crates/graph/src/graph/namespace_aliases.rs
@@ -66,7 +66,7 @@ pub(super) fn propagate_cross_package_aliases(
     reference_paths: &mut ReferencePathInterner,
 ) {
     let pending = collect_pending_credits(graph, module_by_id, indexes, reference_paths);
-    apply_pending_credits(graph, &pending);
+    apply_pending_credits(graph, pending);
 }
 
 fn collect_pending_credits(
@@ -230,9 +230,13 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
     if consumer_local.is_empty() {
         return;
     }
-    let expected_object = format!("{consumer_local}{prefix_match}");
     for access in &consumer.member_accesses {
-        if access.object != expected_object {
+        // Zero-allocation equivalent of `access.object == format!("{consumer_local}{prefix_match}")`.
+        let object_matches = access
+            .object
+            .strip_prefix(consumer_local)
+            .is_some_and(|rest| rest == prefix_match);
+        if !object_matches {
             continue;
         }
         pending.push(PendingCredit {
@@ -242,6 +246,19 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
             import_span: import.info.span,
             path,
         });
+        // The chain walker only produces credits when the alias target has an
+        // `export * as <member>` edge, so skip building its state machine (and
+        // formatting the accessor prefix) for the common leaf-target case.
+        let target_has_chained_re_export =
+            graph.modules.get(target_module_idx).is_some_and(|barrel| {
+                barrel
+                    .re_exports
+                    .iter()
+                    .any(|edge| edge.imported_name == "*" && edge.exported_name == access.member)
+            });
+        if !target_has_chained_re_export {
+            continue;
+        }
         let mut ctx = ChainWalkContext {
             graph,
             consumer,
@@ -253,7 +270,7 @@ fn collect_credits_for_consumer_import(input: &mut ConsumerCreditInput<'_>) {
             &mut ctx,
             target_module_idx,
             &access.member,
-            &format!("{expected_object}.{}", access.member),
+            &format!("{consumer_local}{prefix_match}.{}", access.member),
             path,
         );
     }
@@ -490,7 +507,7 @@ fn collect_chained_re_export_credits(
 /// namespace target is a star barrel (`export * from './bar'`): missing
 /// member exports are stubbed so Phase 4 chain resolution can propagate the
 /// reference to the real defining file.
-fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
+fn apply_pending_credits(graph: &mut ModuleGraph, pending: Vec<PendingCredit>) {
     type GroupKey = (usize, FileId, oxc_span::Span, Option<ReferencePathId>);
 
     let mut groups: FxHashMap<GroupKey, Vec<String>> = FxHashMap::default();
@@ -503,7 +520,7 @@ fn apply_pending_credits(graph: &mut ModuleGraph, pending: &[PendingCredit]) {
                 credit.path,
             ))
             .or_default()
-            .push(credit.member.clone());
+            .push(credit.member);
     }
 
     for ((target_module_idx, consumer_file_id, import_span, path), members) in groups {


### PR DESCRIPTION
## Summary

Recovers the CodSpeed regressions #2101 introduced in `crates/graph` (namespace_object_alias_propagation about -10.8% vs v3.10.0). Three allocation cuts in `propagate_cross_package_aliases`, no behavior change:

- Match consumer member accesses with a zero-allocation prefix comparison instead of `format!("{consumer_local}{prefix_match}")` per consumer import.
- Build the `AliasChain` state machine (root key strings, FxHashMap, VecDeque, member clones) and its accessor-prefix string only when the alias target actually has a chained `export * as <member>` edge; the walker produces no credits otherwise, so skipping is exactly equivalent.
- Move pending credit members into the grouping map in `apply_pending_credits` instead of cloning each member a second time.

Also audited fix direction 3: the #2096 `MaskedTestProfiles` rows are only built inside the `Profiled` reachability arm, so builds without replacements already pay nothing; no gating needed.

## Measurements (criterion, local, `--baseline pre` = current main)

| benchmark | v3.10.0 | main (pre) | this branch | delta vs pre |
|---|---|---|---|---|
| namespace_object_alias_propagation | 820.60 us | 883.45 us | 780.16 us | -11.0% |
| named_re_export_stub_build_9 | 356.72 ns | 345.20 ns | 343.96 ns | no change (p = 0.26) |

The alias bench is now 4.9% faster than the v3.10.0 anchor, fully recovering the regression. The stub_9 CodSpeed regression does not reproduce locally (main already measures about 3% faster than v3.10.0 on this machine); its residual on CodSpeed traces to the deliberate +24-byte `ExportSymbol` growth from the #2101 side table, which is not worth another cache-shape change for a 345 ns microbenchmark.

## Validation

- `cargo test -p fallow-graph` green (includes the #2068/#2101 masked-reachability gates)
- `cargo test -p fallow-core` green
- `cargo fmt` and `cargo clippy -p fallow-graph --all-targets` clean

Refs #2101, #2096.