### PR TITLE
perf(config): memoize member manifest loads during workspace discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Workspace discovery loads each member manifest once per run.** Directories
+  matched by more than one workspace source (identical globs in `package.json`
+  and `pnpm-workspace.yaml`, tsconfig references overlapping npm workspaces)
+  previously re-read and re-parsed `package.json` and re-probed
+  `deno.json` / `deno.jsonc` on every visit; a per-discovery memo now replays
+  the first outcome. Module resolution also probes each package's Deno config
+  once instead of twice (manifest load plus import-map load). Local criterion
+  runs of `component_config_workspace_discovery` and
+  `component_config_workspace_diagnostics` improved by about 7% and 12%.
+
 ## [3.13.0] - 2026-08-03
 
 ### Fixed

--- a/crates/config/src/workspace/deno_json.rs
+++ b/crates/config/src/workspace/deno_json.rs
@@ -130,22 +130,64 @@ pub fn dir_has_package_manifest(dir: &Path) -> bool {
 pub fn load_member_package_manifest(
     dir: &Path,
 ) -> Result<Option<(String, PackageJson, Vec<String>)>, String> {
+    manifest_from_probe(dir, DenoJson::load_from_dir(dir))
+}
+
+/// Project a pre-loaded Deno probe plus `package.json` into the
+/// [`load_member_package_manifest`] result shape. Shared so combined probes
+/// pay the `deno.json` / `deno.jsonc` filesystem probe only once.
+fn manifest_from_probe(
+    dir: &Path,
+    deno: Result<Option<(PathBuf, DenoJson)>, (PathBuf, String)>,
+) -> Result<Option<(String, PackageJson, Vec<String>)>, String> {
     let pkg_path = dir.join("package.json");
     if pkg_path.is_file() {
         let pkg = PackageJson::load(&pkg_path)?;
-        DenoJson::load_from_dir(dir).map_err(|(_path, error)| error)?;
+        deno.map_err(|(_path, error)| error)?;
         let deps = pkg.all_dependency_names();
         let name = pkg.name.clone().unwrap_or_else(|| dir_name_fallback(dir));
         return Ok(Some((name, pkg, deps)));
     }
 
-    match DenoJson::load_from_dir(dir).map_err(|(_path, error)| error)? {
+    match deno.map_err(|(_path, error)| error)? {
         Some((_path, deno)) => {
             let pkg = deno.to_package_json();
             let name = pkg.name.clone().unwrap_or_else(|| dir_name_fallback(dir));
             Ok(Some((name, pkg, Vec::new())))
         }
         None => Ok(None),
+    }
+}
+
+/// A directory's package-manifest outcome plus its Deno import map, produced
+/// from a single `deno.json` / `deno.jsonc` filesystem probe.
+///
+/// The two fields keep the independent error semantics of the separate
+/// loaders: `manifest` matches [`load_member_package_manifest`] exactly, and
+/// `deno_import_map` matches the success case of [`load_deno_import_map`]
+/// (absent when no Deno config exists or it fails to parse). A malformed
+/// `package.json` therefore does not discard a valid colocated import map.
+#[derive(Debug)]
+pub struct DirManifestProbe {
+    /// `(name, package_json_view, dependency_names)` or the manifest parse error.
+    pub manifest: Result<Option<(String, PackageJson, Vec<String>)>, String>,
+    /// Declaring config path and sorted `(specifier, target)` import-map entries.
+    pub deno_import_map: Option<(PathBuf, Vec<(String, String)>)>,
+}
+
+/// Load a directory's package manifest and Deno import map together, probing
+/// and parsing `deno.json` / `deno.jsonc` once instead of once per consumer.
+#[must_use]
+pub fn probe_dir_manifest(dir: &Path) -> DirManifestProbe {
+    let deno = DenoJson::load_from_dir(dir);
+    let deno_import_map = match &deno {
+        Ok(Some((path, config))) => Some((path.clone(), config.import_map_entries())),
+        _ => None,
+    };
+    let manifest = manifest_from_probe(dir, deno);
+    DirManifestProbe {
+        manifest,
+        deno_import_map,
     }
 }
 

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -8,13 +8,14 @@ mod pnpm_overrides;
 
 use std::path::{Path, PathBuf};
 
+use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub use deno_json::{
-    dir_has_deno_json, dir_has_package_manifest, is_deno_without_node_modules,
+    DirManifestProbe, dir_has_deno_json, dir_has_package_manifest, is_deno_without_node_modules,
     load_deno_import_map, load_dir_package_json, load_member_package_manifest,
-    load_root_deno_workspace_patterns,
+    load_root_deno_workspace_patterns, probe_dir_manifest,
 };
 #[cfg(test)]
 pub use diagnostics::capture_workspace_warnings;
@@ -149,6 +150,7 @@ fn collect_workspaces_and_diagnostics(
     let mut diagnostics = Vec::new();
     let patterns = collect_workspace_patterns(root)?;
     let canonical_root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut manifest_cache = ManifestCache::default();
 
     let mut workspaces = expand_patterns_to_workspaces(
         root,
@@ -156,15 +158,21 @@ fn collect_workspaces_and_diagnostics(
         &canonical_root,
         ignore_patterns,
         &mut diagnostics,
+        &mut manifest_cache,
     );
     workspaces.extend(collect_tsconfig_workspaces(
         root,
         &canonical_root,
         ignore_patterns,
         &mut diagnostics,
+        &mut manifest_cache,
     ));
     if patterns.is_empty() {
-        workspaces.extend(collect_shallow_package_workspaces(root, &canonical_root));
+        workspaces.extend(collect_shallow_package_workspaces(
+            root,
+            &canonical_root,
+            &mut manifest_cache,
+        ));
     }
 
     if !workspaces.is_empty() {
@@ -352,6 +360,29 @@ fn collect_workspace_patterns(root: &Path) -> Result<Vec<String>, WorkspaceLoadE
     Ok(patterns)
 }
 
+/// Memoized [`load_member_package_manifest`] outcomes for one discovery run.
+///
+/// The same directory is commonly matched by more than one workspace source
+/// (identical globs in `package.json` and `pnpm-workspace.yaml`, tsconfig
+/// references overlapping npm workspaces). Each manifest load costs a
+/// `package.json` read plus Deno `deno.json` / `deno.jsonc` probes, so repeat
+/// visits replay the memoized outcome instead of touching the filesystem again.
+type ManifestCache = FxHashMap<PathBuf, Result<Option<(String, PackageJson, Vec<String>)>, String>>;
+
+/// Load a member manifest through the per-discovery memo, preserving the
+/// exact per-call outcome (including errors) on repeat visits.
+fn load_member_package_manifest_cached(
+    dir: &Path,
+    cache: &mut ManifestCache,
+) -> Result<Option<(String, PackageJson, Vec<String>)>, String> {
+    if let Some(cached) = cache.get(dir) {
+        return cached.clone();
+    }
+    let outcome = load_member_package_manifest(dir);
+    cache.insert(dir.to_path_buf(), outcome.clone());
+    outcome
+}
+
 /// Expand workspace glob patterns to discover workspace directories.
 ///
 /// Handles positive/negated pattern splitting, glob matching, and package.json
@@ -362,6 +393,7 @@ fn expand_patterns_to_workspaces(
     canonical_root: &Path,
     ignore_patterns: &globset::GlobSet,
     diagnostics: &mut Vec<WorkspaceDiagnostic>,
+    manifest_cache: &mut ManifestCache,
 ) -> Vec<(WorkspaceInfo, Vec<String>)> {
     if patterns.is_empty() {
         return Vec::new();
@@ -403,7 +435,7 @@ fn expand_patterns_to_workspaces(
             if matches_negation(root, &dir, &negation_matchers) {
                 continue;
             }
-            register_matched_workspace(root, dir, &mut workspaces, diagnostics);
+            register_matched_workspace(root, dir, &mut workspaces, diagnostics, manifest_cache);
         }
     }
 
@@ -427,8 +459,9 @@ fn register_matched_workspace(
     dir: PathBuf,
     workspaces: &mut Vec<(WorkspaceInfo, Vec<String>)>,
     diagnostics: &mut Vec<WorkspaceDiagnostic>,
+    manifest_cache: &mut ManifestCache,
 ) {
-    match load_member_package_manifest(&dir) {
+    match load_member_package_manifest_cached(&dir, manifest_cache) {
         Ok(Some((name, _pkg, dep_names))) => {
             workspaces.push((
                 WorkspaceInfo {
@@ -460,11 +493,13 @@ fn collect_tsconfig_workspaces(
     canonical_root: &Path,
     ignore_patterns: &globset::GlobSet,
     diagnostics: &mut Vec<WorkspaceDiagnostic>,
+    manifest_cache: &mut ManifestCache,
 ) -> Vec<(WorkspaceInfo, Vec<String>)> {
     let mut workspaces = Vec::new();
 
     for dir in parse_tsconfig_references_with_diagnostics(root, ignore_patterns, diagnostics) {
-        if let Some(workspace) = tsconfig_workspace_from_dir(root, dir, canonical_root, diagnostics)
+        if let Some(workspace) =
+            tsconfig_workspace_from_dir(root, dir, canonical_root, diagnostics, manifest_cache)
         {
             workspaces.push(workspace);
         }
@@ -478,13 +513,15 @@ fn tsconfig_workspace_from_dir(
     dir: PathBuf,
     canonical_root: &Path,
     diagnostics: &mut Vec<WorkspaceDiagnostic>,
+    manifest_cache: &mut ManifestCache,
 ) -> Option<(WorkspaceInfo, Vec<String>)> {
     let canonical_dir = dunce::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
     if canonical_dir == *canonical_root || !canonical_dir.starts_with(canonical_root) {
         return None;
     }
 
-    let (name, dep_names) = load_tsconfig_workspace_package(root, &dir, diagnostics);
+    let (name, dep_names) =
+        load_tsconfig_workspace_package(root, &dir, diagnostics, manifest_cache);
     Some((
         WorkspaceInfo {
             root: dir,
@@ -499,8 +536,9 @@ fn load_tsconfig_workspace_package(
     root: &Path,
     dir: &Path,
     diagnostics: &mut Vec<WorkspaceDiagnostic>,
+    manifest_cache: &mut ManifestCache,
 ) -> (String, Vec<String>) {
-    match load_member_package_manifest(dir) {
+    match load_member_package_manifest_cached(dir, manifest_cache) {
         Ok(Some((name, _pkg, deps))) => (name, deps),
         Ok(None) => (dir_name(dir), Vec::new()),
         Err(error) => {
@@ -524,6 +562,7 @@ fn load_tsconfig_workspace_package(
 fn collect_shallow_package_workspaces(
     root: &Path,
     canonical_root: &Path,
+    manifest_cache: &mut ManifestCache,
 ) -> Vec<(WorkspaceInfo, Vec<String>)> {
     let mut workspaces = Vec::new();
     let Ok(top_entries) = std::fs::read_dir(root) else {
@@ -536,8 +575,8 @@ fn collect_shallow_package_workspaces(
             continue;
         }
 
-        collect_shallow_workspace_candidate(&path, canonical_root, &mut workspaces);
-        collect_shallow_child_workspaces(&path, canonical_root, &mut workspaces);
+        collect_shallow_workspace_candidate(&path, canonical_root, &mut workspaces, manifest_cache);
+        collect_shallow_child_workspaces(&path, canonical_root, &mut workspaces, manifest_cache);
     }
 
     workspaces
@@ -547,6 +586,7 @@ fn collect_shallow_child_workspaces(
     parent: &Path,
     canonical_root: &Path,
     workspaces: &mut Vec<(WorkspaceInfo, Vec<String>)>,
+    manifest_cache: &mut ManifestCache,
 ) {
     let Ok(child_entries) = std::fs::read_dir(parent) else {
         return;
@@ -559,7 +599,12 @@ fn collect_shallow_child_workspaces(
             continue;
         }
 
-        collect_shallow_workspace_candidate(&child_path, canonical_root, workspaces);
+        collect_shallow_workspace_candidate(
+            &child_path,
+            canonical_root,
+            workspaces,
+            manifest_cache,
+        );
     }
 }
 
@@ -567,13 +612,16 @@ fn collect_shallow_workspace_candidate(
     dir: &Path,
     canonical_root: &Path,
     workspaces: &mut Vec<(WorkspaceInfo, Vec<String>)>,
+    manifest_cache: &mut ManifestCache,
 ) {
     let canonical_dir = dunce::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
     if canonical_dir == *canonical_root || !canonical_dir.starts_with(canonical_root) {
         return;
     }
 
-    let Ok(Some((name, _pkg, dep_names))) = load_member_package_manifest(dir) else {
+    let Ok(Some((name, _pkg, dep_names))) =
+        load_member_package_manifest_cached(dir, manifest_cache)
+    else {
         return;
     };
 

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -273,11 +273,10 @@ fn build_package_manifests(
 ) -> Vec<PackageManifestInfo> {
     let root_canonical =
         dunce::canonicalize(input.root).unwrap_or_else(|_| input.root.to_path_buf());
-    let root_import_map = merge_deno_import_maps(&[], input.root);
+    let root_probe = fallow_config::probe_dir_manifest(input.root);
+    let root_import_map = merge_deno_import_maps(&[], input.root, root_probe.deno_import_map);
     let mut package_manifests = Vec::new();
-    if let Ok(Some((_name, package_json, _deps))) =
-        fallow_config::load_member_package_manifest(input.root)
-    {
+    if let Ok(Some((_name, package_json, _deps))) = root_probe.manifest {
         package_manifests.push(PackageManifestInfo {
             root: input.root.to_path_buf(),
             canonical_root: root_canonical,
@@ -287,15 +286,18 @@ fn build_package_manifests(
         });
     }
     for (ws, canonical_root) in input.workspaces.iter().zip(canonical_ws_roots.iter()) {
-        if let Ok(Some((_name, package_json, _deps))) =
-            fallow_config::load_member_package_manifest(&ws.root)
-        {
+        let ws_probe = fallow_config::probe_dir_manifest(&ws.root);
+        if let Ok(Some((_name, package_json, _deps))) = ws_probe.manifest {
             package_manifests.push(PackageManifestInfo {
                 root: ws.root.clone(),
                 canonical_root: canonical_root.clone(),
                 name: package_json.name.clone().or_else(|| Some(ws.name.clone())),
                 package_json,
-                deno_import_map: merge_deno_import_maps(&root_import_map, &ws.root),
+                deno_import_map: merge_deno_import_maps(
+                    &root_import_map,
+                    &ws.root,
+                    ws_probe.deno_import_map,
+                ),
             });
         }
     }
@@ -304,10 +306,13 @@ fn build_package_manifests(
 
 /// Merge inherited and package-local Deno import maps once per resolver
 /// session. Equal local keys replace inherited keys while retaining the
-/// declaring directory needed for relative target resolution.
+/// declaring directory needed for relative target resolution. The local map
+/// comes from the caller's single-probe manifest load so the Deno config is
+/// not read and parsed a second time.
 fn merge_deno_import_maps(
     inherited: &[DenoImportMapEntry],
     package_root: &Path,
+    local: Option<(PathBuf, Vec<(String, String)>)>,
 ) -> Vec<DenoImportMapEntry> {
     let mut entries: FxHashMap<String, DenoImportMapEntry> = inherited
         .iter()
@@ -315,9 +320,7 @@ fn merge_deno_import_maps(
         .map(|entry| (entry.key.clone(), entry))
         .collect();
 
-    if let Ok(Some((config_path, local_entries))) =
-        fallow_config::load_deno_import_map(package_root)
-    {
+    if let Some((config_path, local_entries)) = local {
         let declaring_dir = config_path.parent().unwrap_or(package_root).to_path_buf();
         for (key, target) in local_entries {
             entries.insert(


### PR DESCRIPTION
Recovers the ~11% CodSpeed regression on `component_config_workspace_discovery` / `component_config_workspace_diagnostics` introduced with Deno workspace support (#2080/#2091 window).

## What the scan was doing per workspace

- Every `load_member_package_manifest` call now probes `deno.json` and `deno.jsonc` (two extra stats) even when `package.json` is present, in pure-npm projects.
- Discovery visits the same member directory once per workspace source: `package.json` `workspaces` plus `pnpm-workspace.yaml` declaring the same globs (the benchmark fixture does exactly this), and tsconfig references overlapping npm workspaces. Each repeat visit re-read and re-parsed `package.json` and re-probed the Deno config.
- `build_package_manifests` in the resolver parsed each package's Deno config twice: once inside the manifest load, once via `load_deno_import_map` (flagged as optional cleanup in the #2080 review).

## Fix

- A per-discovery memo (`ManifestCache`) replays the first `load_member_package_manifest` outcome for a directory, including parse errors, so diagnostic multiplicity and all outcomes are unchanged; only repeated filesystem work is skipped.
- `probe_dir_manifest` loads the manifest and the Deno import map from a single `deno.json` / `deno.jsonc` probe; `build_package_manifests` uses it for the root and each workspace. Manifest and import-map error semantics stay independent, matching the old separate loaders.

No behavior change. The public `load_member_package_manifest` / `load_deno_import_map` APIs are untouched.

## Measurements

Criterion, local (M-series macOS), `--save-baseline pre` on the parent commit of this branch, then compare:

| benchmark | before | after | change |
|---|---|---|---|
| `component_config_workspace_discovery` | 1.3115 ms | 1.2249 ms | -6.6% (p = 0.00) |
| `component_config_workspace_diagnostics` | 1.3142 ms | 1.1580 ms | -11.9% (p = 0.00) |

Hyperfine, `fallow dead-code` on a generated 50-member npm monorepo, cold cache (`--prepare 'rm -rf .fallow'`, 15 runs):

| binary | mean ± σ |
|---|---|
| main (a99fb67) | 57.1 ms ± 0.9 ms |
| this branch | 55.9 ms ± 1.7 ms |

End-to-end the discovery slice is small, so the CLI-level delta is within noise (1.02 ± 0.03 times faster); the component benchmarks are the meaningful signal.

## Validation

- `cargo test -p fallow-config` and `-p fallow-graph`: pass
- `cargo test -p fallow-core` (full suite, including the deno-workspace fixture tests): pass
- `cargo fmt --check`, `cargo clippy --all-targets` on touched crates: clean
