### PR TITLE
test(mcp): harden Windows process-tree lifecycle tests against slow runners

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -17,6 +17,17 @@ mod params;
 mod server;
 mod tools;
 
+#[cfg(all(test, windows))]
+pub(crate) mod test_support {
+    /// Serializes the Windows process-tree lifecycle tests. Each one spawns a
+    /// nested PowerShell tree; running them concurrently on a loaded CI runner
+    /// multiplies process-spawn latency past the fixture timeouts and they
+    /// contend on the shared kill-target registry (issue #2112). A tokio mutex
+    /// is used so async tests can hold the guard across await points.
+    pub(crate) static PROCESS_TREE_TEST_LOCK: tokio::sync::Mutex<()> =
+        tokio::sync::Mutex::const_new(());
+}
+
 /// Run the MCP stdio server and return the process exit code.
 ///
 /// The standalone `fallow-mcp` binary and the multicall `fallow mcp-server`

--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -3,8 +3,18 @@ use rmcp::model::*;
 #[cfg(any(unix, windows))]
 use std::time::Duration;
 
+/// Ceiling for a PowerShell fixture that is expected to complete. The
+/// subprocess wait early-exits on completion, so this only bounds the failure
+/// path; generous headroom absorbs slow CI runner spawning (issue #2112).
 #[cfg(windows)]
-const WINDOWS_FIXTURE_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
+const WINDOWS_FIXTURE_COMPLETION_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// Timeout that must actually fire for the reap test, so its full duration is
+/// paid on every run. It still needs enough headroom for the fixture to start
+/// and write its PID files on a loaded runner before the job is terminated
+/// (issue #2112); the fixture sleeps must stay well above this value.
+#[cfg(windows)]
+const WINDOWS_FIXTURE_FIRED_TIMEOUT: Duration = Duration::from_mins(1);
 
 use crate::tools::run_fallow;
 #[cfg(any(unix, windows))]
@@ -113,26 +123,34 @@ fn process_exists(pid: u32) -> bool {
 
 #[cfg(any(unix, windows))]
 async fn read_pid(path: &std::path::Path) -> u32 {
-    for _ in 0..50 {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
         if let Ok(pid) = std::fs::read_to_string(path)
             && let Ok(pid) = pid.trim().parse()
         {
             return pid;
         }
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for PID file {}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
-    panic!("timed out waiting for PID file {}", path.display());
 }
 
 #[cfg(any(unix, windows))]
 async fn wait_for_process_exit(pid: u32) -> bool {
-    for _ in 0..200 {
+    let deadline = std::time::Instant::now() + Duration::from_mins(1);
+    loop {
         if !process_exists(pid) {
             return true;
         }
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
-    false
 }
 
 #[cfg(unix)]
@@ -737,13 +755,15 @@ async fn run_fallow_completed_child_cleanup_closes_inherited_pipes_without_timeo
 
 #[cfg(windows)]
 #[tokio::test]
+#[cfg_attr(miri, ignore = "spawns real subprocesses, unsupported under Miri")]
 async fn run_fallow_completed_success_cleans_descendant_process_tree_windows_job() {
+    let _serial = crate::test_support::PROCESS_TREE_TEST_LOCK.lock().await;
     let temp = tempfile::tempdir().expect("temp directory");
     let descendant_pid_path = temp.path().join("descendant.pid");
     let script_path = temp.path().join("completed-process-tree-fixture.ps1");
     let script = r"
 param([Parameter(Mandatory = $true)][string]$DescendantPidPath)
-$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' -PassThru
+$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 600' -PassThru
 $child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
 Write-Output '{}'
 ";
@@ -761,7 +781,7 @@ Write-Output '{}'
             "-DescendantPidPath".to_string(),
             descendant_pid_path.to_string_lossy().into_owned(),
         ],
-        WINDOWS_FIXTURE_STARTUP_TIMEOUT,
+        WINDOWS_FIXTURE_COMPLETION_TIMEOUT,
     )
     .await
     .expect("completed subprocess should stay a tool result");
@@ -882,7 +902,9 @@ async fn run_fallow_timeout_is_not_held_open_by_escaped_pipe_writer() {
 
 #[cfg(windows)]
 #[tokio::test]
+#[cfg_attr(miri, ignore = "spawns real subprocesses, unsupported under Miri")]
 async fn run_fallow_timeout_terminates_and_reaps_windows_job_tree() {
+    let _serial = crate::test_support::PROCESS_TREE_TEST_LOCK.lock().await;
     let temp = tempfile::tempdir().expect("temp directory");
     let direct_pid_path = temp.path().join("direct.pid");
     let descendant_pid_path = temp.path().join("descendant.pid");
@@ -893,9 +915,9 @@ param(
     [Parameter(Mandatory = $true)][string]$DescendantPidPath
 )
 $PID | Set-Content -NoNewline -LiteralPath $DirectPidPath
-$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' -PassThru
+$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 600' -PassThru
 $child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
-Start-Sleep -Seconds 30
+Start-Sleep -Seconds 600
 ";
     std::fs::write(&script_path, script).expect("PowerShell fixture script");
 
@@ -913,7 +935,7 @@ Start-Sleep -Seconds 30
             "-DescendantPidPath".to_string(),
             descendant_pid_path.to_string_lossy().into_owned(),
         ],
-        WINDOWS_FIXTURE_STARTUP_TIMEOUT,
+        WINDOWS_FIXTURE_FIRED_TIMEOUT,
     )
     .await
     .expect("timeout should stay a tool result");

--- a/crates/mcp/src/tools/code_mode_subprocess.rs
+++ b/crates/mcp/src/tools/code_mode_subprocess.rs
@@ -336,6 +336,11 @@ mod tests {
 mod windows_tests {
     use super::*;
 
+    /// Generous ceiling for PowerShell fixture startup on loaded CI runners;
+    /// the 10ms completion poll keeps the happy path fast (issue #2112).
+    const FIXTURE_COMPLETION_TIMEOUT: Duration = Duration::from_mins(2);
+    const PROCESS_EXIT_WAIT: Duration = Duration::from_mins(1);
+
     struct ProcessCleanup(u32);
 
     impl Drop for ProcessCleanup {
@@ -363,17 +368,22 @@ mod windows_tests {
     }
 
     fn wait_for_process_exit(pid: u32) -> bool {
-        for _ in 0..200 {
+        let deadline = Instant::now() + PROCESS_EXIT_WAIT;
+        loop {
             if !process_exists(pid) {
                 return true;
             }
-            thread::sleep(Duration::from_millis(10));
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(25));
         }
-        false
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "spawns real subprocesses, unsupported under Miri")]
     fn completed_success_cleans_descendant_process_tree() {
+        let _serial = crate::test_support::PROCESS_TREE_TEST_LOCK.blocking_lock();
         let temp = tempfile::tempdir().expect("temp directory");
         let descendant_pid_path = temp.path().join("descendant.pid");
         let script_path = temp.path().join("process-tree-fixture.ps1");
@@ -381,7 +391,7 @@ mod windows_tests {
 param(
     [Parameter(Mandatory = $true)][string]$DescendantPidPath
 )
-$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 30' -PassThru
+$child = Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 600' -PassThru
 $child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
 [Console]::Out.Write('{}')
 ";
@@ -401,7 +411,7 @@ $child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
             "powershell.exe",
             "test",
             &args,
-            Instant::now() + Duration::from_secs(5),
+            Instant::now() + FIXTURE_COMPLETION_TIMEOUT,
             1024,
         )
         .expect("completed subprocess should preserve successful output");


### PR DESCRIPTION
## Summary

Three Windows process-tree lifecycle tests in crates/mcp intermittently timed out on GitHub runners (three independent hits in one week, always passing on rerun): fixed timeouts raced PowerShell fixture startup on loaded runners. This hardens them without weakening any assertion and without retries.

- **Raised completion ceilings with early-exit polling.** The completed-tree fixtures now get a 2-minute ceiling (was 5s in `code_mode_subprocess` and 15s in `server/tests/run.rs`); the subprocess wait polls/awaits exit, so the happy path stays as fast as before. The fired-timeout test's timeout goes 15s -> 60s; its full duration is paid by design, so it stays lower than the completion ceiling.
- **Deadline polling instead of count-based waits.** `read_pid` (was 50 x 10ms) and `wait_for_process_exit` (was 200 x 10ms / 2s) now poll against generous deadlines (10s / 60s) with early exit.
- **Assertion strength preserved.** Fixture sleeps go 30s -> 600s so a descendant can never expire on its own inside the raised wait windows, and the fired-timeout fixture can never complete before the timeout fires (with the old 30s sleep a 60s timeout would have inverted that test).
- **Serialized the three tests** behind a shared `tokio::sync::Mutex` in a `cfg(all(test, windows))` `test_support` module, following the repo's static test-lock pattern: each test spawns a nested PowerShell tree and they contend on process spawning and the shared kill-target registry in `fallow-process`.
- **Miri-gated** the three tests (`#[cfg_attr(miri, ignore = ...)]`); they spawn real processes.

## Validation

- `cargo test -p fallow-mcp`: all pass on macOS (the shared `read_pid` / `wait_for_process_exit` helpers are exercised by the unix twins).
- `cargo fmt --check` and `cargo clippy -p fallow-mcp --all-targets -- -D warnings`: clean.
- `cargo check --target x86_64-pc-windows-msvc` was attempted but fails in `ring`'s C build script under macOS cross-compilation (missing MSVC headers), before reaching this crate; the `windows-rust` CI job's `cargo clippy -p fallow-mcp --all-targets` on windows-latest is the compile gate for the `cfg(windows)` code.
- No CHANGELOG entry: test-only change, no user-facing behavior.

Note: the fired-timeout test now takes ~60s (up from ~15s) wherever the full Windows suite runs; the filtered `windows-rust` PR job does not run it.

Fixes #2112
