### PR TITLE
chore(ci): batch GitHub Actions dependency bumps

### DIFF
--- a/.github/workflows/bench-type-aware.yml
+++ b/.github/workflows/bench-type-aware.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: tools/type-aware-sidecar
 
       - name: Run type-aware benchmarks
-        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
+        uses: CodSpeedHQ/action@f22792bfac16f3e14eb9fbea76f4a48e9cc22b93 # v4.19.1
         with:
           mode: walltime
           run: npm run bench --prefix tools/type-aware-sidecar

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -103,7 +103,7 @@ jobs:
           cache-key: bench-${{ matrix.cache_key }}
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-codspeed@4.7.0
 
@@ -112,7 +112,7 @@ jobs:
         run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }} --features codspeed
 
       - name: Run benchmark shard
-        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
+        uses: CodSpeedHQ/action@f22792bfac16f3e14eb9fbea76f4a48e9cc22b93 # v4.19.1
         with:
           mode: simulation
           run: cargo codspeed run -p ${{ matrix.package }} --bench ${{ matrix.bench }}
@@ -152,7 +152,7 @@ jobs:
           cache-key: bench-${{ matrix.cache_key }}
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-codspeed@4.7.0
 
@@ -161,7 +161,7 @@ jobs:
         run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }} --features codspeed
 
       - name: Run full benchmark shard
-        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
+        uses: CodSpeedHQ/action@f22792bfac16f3e14eb9fbea76f4a48e9cc22b93 # v4.19.1
         with:
           mode: simulation
           run: cargo codspeed run -p ${{ matrix.package }} --bench ${{ matrix.bench }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
           path: .companion/fallow-skills
           persist-credentials: false
       - name: Documentation discoverability
-        uses: Hedde/trigger_tree@78a801629f0b11f403737e0ae9e5c2bfa827a6bb # v1.23.2
+        uses: Hedde/trigger_tree@a5b8ae9f99100f92be620be2f1cd8526df5f932e # v1.27.2
         with:
           min-score: "100"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -771,7 +771,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+      - uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-audit
       # RUSTSEC-2026-0097: `rand` 0.9.2 unsoundness with a custom logger via
@@ -804,7 +804,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+      - uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-shear
       - run: cargo shear
@@ -819,7 +819,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
       # Scope to repo's own workflows + composite action. tests/fixtures/ contains

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install cargo-llvm-cov
         if: steps.coverage_policy.outputs.run == 'true'
-        uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -68,7 +68,7 @@ jobs:
           key: fuzz-smoke-nightly-2026-07-20-cargo-fuzz-0.13.2
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-fuzz@0.13.2
           fallback: cargo-install

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Batches the open GitHub Actions dependabot updates into one PR. Every bump copies the exact pinned SHA and version comment from the corresponding dependabot diff, so the SHA-pin style is preserved throughout.

## Bumps

| Action | From | To | Files |
| --- | --- | --- | --- |
| CodSpeedHQ/action | 4.18.5 | 4.19.1 (`f22792b`) | bench.yml, bench-type-aware.yml |
| Hedde/trigger_tree | 1.23.2 | 1.27.2 (`a5b8ae9`) | ci.yml |
| ossf/scorecard-action | 2.4.3 | 2.4.4 (`2d11466`) | scorecard.yml |
| taiki-e/install-action | 2.84.0 | 2.85.3 (`18b1216`) | bench.yml, ci.yml, coverage.yml, fuzz-smoke.yml |
| astral-sh/setup-uv | 8.3.2 | 9.0.0 (`c771a70`) | ci.yml |

## Major bump reasoning: setup-uv v9

The only breaking change in setup-uv 9.0.0 flips the `prune-cache` default to `false`. Our single usage (the actionlint/zizmor job in ci.yml) sets `enable-cache: false`, so no cache exists to prune and the default flip has no effect. No workflow adaptation needed.

## Notes

- taiki-e/install-action steps keep their pinned tool tags (`cargo-codspeed@4.7.0`, `cargo-fuzz@0.13.2`, plus untagged `cargo-audit` and `cargo-shear`) exactly as before; only the action SHA moved, matching dependabot's diff.
- The trigger_tree bump covers the workflow action only. The client-side plugin pin (`.claude/settings.json` ref v1.23.2 and `.trigger-tree/README.md`) is a separate surface with its own install mechanics and is deliberately left unchanged.

## Validation

- actionlint on all six touched workflows: clean
- zizmor on `.github/workflows`: identical finding counts to the origin/main baseline (no new medium+ findings)
- `node --test scripts/workflow-policy.test.mjs scripts/repository-policy.test.mjs`: all pass
- grep confirms none of the five old SHAs remain in any workflow

Closes #2127
Closes #2126
Closes #2125
Closes #2123
Closes #2045
