### PR TITLE
test(conformance): pin the knip version in the comparison runners

### DIFF
--- a/tests/conformance/run-all.sh
+++ b/tests/conformance/run-all.sh
@@ -165,7 +165,7 @@ run_single_project() {
     # Run knip
     echo "    Running knip..." >&2
     local knip_exit=0
-    (cd "${dir}" && timeout_cmd "${TIMEOUT}" npx --yes knip --reporter json \
+    (cd "${dir}" && timeout_cmd "${TIMEOUT}" npx --yes "knip@${KNIP_VERSION:-6.32.0}" --reporter json \
         > "${knip_out}" 2>/dev/null) || knip_exit=$?
 
     if [[ ${knip_exit} -eq 124 ]]; then

--- a/tests/conformance/run.sh
+++ b/tests/conformance/run.sh
@@ -92,6 +92,9 @@ trap 'rm -rf "${TMPDIR_CONFORM}"' EXIT
 FALLOW_OUT="${TMPDIR_CONFORM}/fallow.json"
 KNIP_OUT="${TMPDIR_CONFORM}/knip.json"
 
+# knip is pinned so the tracked agreement trend measures fallow changes,
+# not knip releases; bump KNIP_VERSION deliberately and note it in the run.
+
 # Install knip locally in the project if needed (for npx to find it)
 # We use npx which will auto-download if needed
 echo "Running fallow..." >&2
@@ -118,7 +121,7 @@ if [[ ! -d "node_modules" ]]; then
     npm install --ignore-scripts --no-audit --no-fund >/dev/null 2>/dev/null || true
 fi
 
-npx --yes knip --reporter json > "${KNIP_OUT}" 2>/dev/null || KNIP_EXIT=$?
+npx --yes "knip@${KNIP_VERSION:-6.32.0}" --reporter json > "${KNIP_OUT}" 2>/dev/null || KNIP_EXIT=$?
 
 # knip exits 1 when issues are found (expected), 2 on error
 if [[ ${KNIP_EXIT} -eq 2 ]]; then


### PR DESCRIPTION
An unpinned npx knip made the tracked agreement trend move on knip releases: knip 6.32.0 (released this morning) shifted the zod datapoint from 2.8% to 1.9% and tripped the benchmark alert, while fallow output was verified byte-identical across the compared commits (both binaries rebuilt and rerun locally). Pins knip at 6.32.0 in both conformance runners, overridable via KNIP_VERSION for deliberate bumps.