### PR TITLE
fix(extract): report a complexity breakdown for framework templates

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -861,7 +861,12 @@ use crate::MemberKind;
 /// source string-literal span so unresolved-import findings anchor on the
 /// specifier and suppressions cover the whole statement. Warm 251 caches
 /// lack both spans.
-pub(super) const CACHE_VERSION: u32 = 252;
+///
+/// Bumped to 253 for issue #2150: synthetic `<template>` complexity now carries
+/// per-construct contributions for Angular, Vue, Svelte, and Astro. The metric
+/// totals are unchanged, but warm 252 caches hold an empty breakdown, so an
+/// unedited template would keep rendering a finding with no explanation.
+pub(super) const CACHE_VERSION: u32 = 253;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/template_complexity/astro.rs
+++ b/crates/extract/src/template_complexity/astro.rs
@@ -13,7 +13,7 @@
 
 use std::sync::LazyLock;
 
-use fallow_types::extract::FunctionComplexity;
+use fallow_types::extract::{ComplexityContributionKind, FunctionComplexity};
 
 use super::build_template_complexity;
 use super::engine::{ScanError, TemplateComplexity, find_matching_delimiter};
@@ -68,7 +68,11 @@ fn scan_markup_expressions(
         for needle in ITERATION_CALLS {
             let mut from = 0;
             while let Some(pos) = expr[from..].find(needle) {
-                complexity.add_control_flow(0);
+                complexity.add_control_flow(
+                    offset + 1 + from + pos,
+                    ComplexityContributionKind::ForOf,
+                    0,
+                );
                 from += pos + needle.len();
             }
         }
@@ -109,6 +113,16 @@ mod tests {
     #[test]
     fn malformed_brace_drops_entry() {
         let source = "---\n---\n<div>{a && b</div>\n";
+        assert!(compute_astro_template_complexity(source).is_none());
+    }
+
+    /// This scanner swallows a per-expression scan error on purpose, so a
+    /// half-scored expression must leave no increments behind. Otherwise a
+    /// dangling operator invents a synthetic `<template>` finding for a
+    /// template that has no complexity at all.
+    #[test]
+    fn expression_that_fails_to_tokenize_contributes_nothing() {
+        let source = "---\n---\n<div>{ show && }</div>\n";
         assert!(compute_astro_template_complexity(source).is_none());
     }
 }

--- a/crates/extract/src/template_complexity/engine.rs
+++ b/crates/extract/src/template_complexity/engine.rs
@@ -10,10 +10,34 @@
 //! scanners (sibling modules) own only the control-flow tokenization and feed
 //! their bound expressions through [`TemplateComplexity::add_expression`].
 
+use fallow_types::extract::{ComplexityContributionKind, ComplexityMetric};
+
 /// Internal scanner error. Carries no data: any malformed-template path
 /// just falls through and the caller drops the synthetic finding.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ScanError;
+
+/// Accumulator state captured before a fallible expression scan, so a scan that
+/// fails partway can be undone.
+#[derive(Debug, Clone, Copy)]
+struct Checkpoint {
+    cyclomatic: u16,
+    cognitive: u16,
+    first_offset: Option<usize>,
+    contributions: usize,
+}
+
+/// One recorded increment, still anchored at a byte offset into the template
+/// source. [`super::build_template_complexity`] resolves the offset to
+/// line/column once, against the original (unmasked) file.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RawContribution {
+    pub(super) offset: usize,
+    pub(super) metric: ComplexityMetric,
+    pub(super) kind: ComplexityContributionKind,
+    pub(super) weight: u16,
+    pub(super) nesting: u16,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LogicalOperator {
@@ -30,6 +54,7 @@ pub(super) struct TemplateComplexity {
     pub(super) cyclomatic: u16,
     pub(super) cognitive: u16,
     pub(super) first_offset: Option<usize>,
+    pub(super) contributions: Vec<RawContribution>,
 }
 
 impl Default for TemplateComplexity {
@@ -38,14 +63,61 @@ impl Default for TemplateComplexity {
             cyclomatic: 1,
             cognitive: 0,
             first_offset: None,
+            contributions: Vec::new(),
         }
     }
 }
 
 impl TemplateComplexity {
+    /// Record a cyclomatic `+1` at `offset`. Every cyclomatic increment in this
+    /// module goes through here so the breakdown can never drift from the
+    /// aggregate, mirroring the discipline in `crate::complexity`.
+    pub(super) fn inc_cyclomatic(&mut self, offset: usize, kind: ComplexityContributionKind) {
+        self.contributions.push(RawContribution {
+            offset,
+            metric: ComplexityMetric::Cyclomatic,
+            kind,
+            weight: 1,
+            nesting: 0,
+        });
+        self.cyclomatic = self.cyclomatic.saturating_add(1);
+    }
+
+    /// Record a cognitive increment of `1 + nesting` at `offset`.
+    pub(super) fn inc_cognitive(
+        &mut self,
+        offset: usize,
+        kind: ComplexityContributionKind,
+        nesting: u16,
+    ) {
+        let weight = 1_u16.saturating_add(nesting);
+        self.contributions.push(RawContribution {
+            offset,
+            metric: ComplexityMetric::Cognitive,
+            kind,
+            weight,
+            nesting,
+        });
+        self.cognitive = self.cognitive.saturating_add(weight);
+    }
+
+    /// Record a cognitive `+1` at `offset` with no nesting penalty (an `else` /
+    /// `v-else` continuation, an `else if` cascade).
+    pub(super) fn inc_cognitive_flat(&mut self, offset: usize, kind: ComplexityContributionKind) {
+        self.inc_cognitive(offset, kind, 0);
+    }
+
     /// Score one bound JS expression and fold its metrics in. `offset` is the
     /// byte offset of `source` within the original template, used to anchor the
-    /// synthetic finding at the first non-trivial expression.
+    /// synthetic finding at the first non-trivial expression and every
+    /// contribution recorded inside the expression.
+    ///
+    /// All-or-nothing: the scan records increments as it walks, so a malformed
+    /// expression is rolled back before returning. Most callers propagate the
+    /// error and drop the whole template, but the Astro scanner deliberately
+    /// swallows it (a benign non-boolean markup expression need not tokenize as
+    /// one), and half-scored metrics there would invent a synthetic finding for
+    /// a template that has none.
     pub(super) fn add_expression(
         &mut self,
         source: &str,
@@ -55,19 +127,35 @@ impl TemplateComplexity {
         let Some(trim_start) = source.find(|c: char| !c.is_whitespace()) else {
             return Ok(());
         };
+        let checkpoint = Checkpoint {
+            cyclomatic: self.cyclomatic,
+            cognitive: self.cognitive,
+            first_offset: self.first_offset,
+            contributions: self.contributions.len(),
+        };
         self.first_offset.get_or_insert(offset + trim_start);
-        let metrics = compute_expression_metrics(&source[trim_start..], nesting, 0)?;
-        self.cyclomatic = self.cyclomatic.saturating_add(metrics.cyclomatic);
-        self.cognitive = self.cognitive.saturating_add(metrics.cognitive);
-        Ok(())
+        let result = self.scan_expression(&source[trim_start..], offset + trim_start, nesting, 0);
+        if result.is_err() {
+            self.cyclomatic = checkpoint.cyclomatic;
+            self.cognitive = checkpoint.cognitive;
+            self.first_offset = checkpoint.first_offset;
+            self.contributions.truncate(checkpoint.contributions);
+        }
+        result
     }
 
     /// Account for one control-flow construct (an `@if`/`@for`, a `v-if`/`v-for`,
     /// a `{#if}`/`{#each}`): +1 cyclomatic and +1+nesting cognitive (the cognitive
-    /// nesting penalty mirrors Sonar's nesting model).
-    pub(super) fn add_control_flow(&mut self, nesting: u16) {
-        self.cyclomatic = self.cyclomatic.saturating_add(1);
-        self.cognitive = self.cognitive.saturating_add(1 + nesting);
+    /// nesting penalty mirrors Sonar's nesting model). `offset` anchors both
+    /// increments at the directive or block keyword that introduced them.
+    pub(super) fn add_control_flow(
+        &mut self,
+        offset: usize,
+        kind: ComplexityContributionKind,
+        nesting: u16,
+    ) {
+        self.inc_cyclomatic(offset, kind);
+        self.inc_cognitive(offset, kind, nesting);
     }
 }
 
@@ -107,19 +195,6 @@ pub(super) fn read_attribute_value(
     }
 }
 
-#[derive(Clone, Copy, Default)]
-struct ExpressionMetrics {
-    cyclomatic: u16,
-    cognitive: u16,
-}
-
-impl ExpressionMetrics {
-    fn add(&mut self, other: Self) {
-        self.cyclomatic = self.cyclomatic.saturating_add(other.cyclomatic);
-        self.cognitive = self.cognitive.saturating_add(other.cognitive);
-    }
-}
-
 /// Maximum bracket/ternary recursion depth for template-expression metric
 /// scoring. Real template expressions nest only 3-5 levels deep, so this cap is
 /// generous; past it a pathological input like `((((...))))` is treated as
@@ -129,159 +204,203 @@ impl ExpressionMetrics {
 /// `MAX_BINDING_PATH_DEPTH` bounded-work style. Issue #1843 follow-up.
 const MAX_TEMPLATE_EXPR_DEPTH: u16 = 64;
 
-fn compute_expression_metrics(
-    source: &str,
-    nesting: u16,
-    depth: u16,
-) -> Result<ExpressionMetrics, ScanError> {
-    if depth > MAX_TEMPLATE_EXPR_DEPTH {
-        return Err(ScanError);
-    }
-    let source = source.trim();
-    if source.is_empty() {
-        return Ok(ExpressionMetrics::default());
-    }
-    if let Some((question, colon)) = find_top_level_ternary(source)? {
-        let mut metrics = ExpressionMetrics::default();
-        metrics.add(compute_expression_metrics(
-            &source[..question],
+impl TemplateComplexity {
+    /// Score a JS expression, recording each increment at its absolute offset.
+    /// `base` is the byte offset of `source` within the original template, so a
+    /// recursive call into a sub-slice must advance it by the slice's start.
+    fn scan_expression(
+        &mut self,
+        source: &str,
+        base: usize,
+        nesting: u16,
+        depth: u16,
+    ) -> Result<(), ScanError> {
+        if depth > MAX_TEMPLATE_EXPR_DEPTH {
+            return Err(ScanError);
+        }
+        let leading = source.len() - source.trim_start().len();
+        let base = base + leading;
+        let source = source.trim();
+        if source.is_empty() {
+            return Ok(());
+        }
+        if let Some((question, colon)) = find_top_level_ternary(source)? {
+            self.scan_expression(&source[..question], base, nesting, depth + 1)?;
+            self.inc_cyclomatic(base + question, ComplexityContributionKind::Ternary);
+            self.inc_cognitive(
+                base + question,
+                ComplexityContributionKind::Ternary,
+                nesting,
+            );
+            self.scan_expression(
+                &source[question + 1..colon],
+                base + question + 1,
+                nesting.saturating_add(1),
+                depth + 1,
+            )?;
+            self.scan_expression(
+                &source[colon + 1..],
+                base + colon + 1,
+                nesting.saturating_add(1),
+                depth + 1,
+            )?;
+            return Ok(());
+        }
+        self.scan_expression_without_ternary(ExprScope {
+            source,
+            base,
             nesting,
-            depth + 1,
-        )?);
-        metrics.cyclomatic = metrics.cyclomatic.saturating_add(1);
-        metrics.cognitive = metrics.cognitive.saturating_add(1 + nesting);
-        metrics.add(compute_expression_metrics(
-            &source[question + 1..colon],
-            nesting.saturating_add(1),
-            depth + 1,
-        )?);
-        metrics.add(compute_expression_metrics(
-            &source[colon + 1..],
-            nesting.saturating_add(1),
-            depth + 1,
-        )?);
-        return Ok(metrics);
+            depth,
+        })
     }
-    scan_expression_without_ternary(source, nesting, depth)
 }
 
-/// Mutable scanning state shared across the [`scan_expression_without_ternary`]
-/// match arms.
+/// Mutable scanning state shared across the `scan_expression_without_ternary`
+/// match arms. The metric counters live on [`TemplateComplexity`]; what remains
+/// here is the operator-run bookkeeping that decides whether the NEXT logical
+/// operator earns a cognitive increment.
 struct ScanState {
-    metrics: ExpressionMetrics,
     last_logical_operator: Option<LogicalOperator>,
     needs_rhs: bool,
 }
 
-fn scan_expression_without_ternary(
-    source: &str,
+/// The expression slice currently being scanned, with everything needed to
+/// place a contribution: `base` is the slice's byte offset in the template,
+/// `nesting` the cognitive nesting penalty in force, `depth` the recursion
+/// guard.
+#[derive(Clone, Copy)]
+struct ExprScope<'a> {
+    source: &'a str,
+    base: usize,
     nesting: u16,
     depth: u16,
-) -> Result<ExpressionMetrics, ScanError> {
-    let mut state = ScanState {
-        metrics: ExpressionMetrics::default(),
-        last_logical_operator: None,
-        needs_rhs: false,
-    };
-    let mut offset = 0;
+}
 
-    while offset < source.len() {
-        match source.as_bytes()[offset] {
-            byte if byte.is_ascii_whitespace() => offset += 1,
-            b'\'' | b'"' | b'`' => {
-                offset = skip_quoted(source, offset)?;
-                state.needs_rhs = false;
-            }
-            b'(' | b'[' | b'{' => {
-                offset = scan_bracket_group(source, offset, nesting, depth, &mut state)?;
-            }
-            b')' | b']' | b'}' => return Err(ScanError),
-            _ if source[offset..].starts_with("?.") => {
-                state.metrics.cyclomatic = state.metrics.cyclomatic.saturating_add(1);
-                offset += 2;
-            }
-            _ if source[offset..].starts_with("&&=")
-                || source[offset..].starts_with("||=")
-                || source[offset..].starts_with("??=") =>
-            {
-                state.metrics.cyclomatic = state.metrics.cyclomatic.saturating_add(1);
-                state.last_logical_operator = None;
-                state.needs_rhs = true;
-                offset += 3;
-            }
-            _ if source[offset..].starts_with("&&")
-                || source[offset..].starts_with("||")
-                || source[offset..].starts_with("??") =>
-            {
-                offset = scan_logical_operator(source, offset, &mut state)?;
-            }
-            b',' | b';' => {
-                if state.needs_rhs {
-                    return Err(ScanError);
+impl TemplateComplexity {
+    fn scan_expression_without_ternary(&mut self, scope: ExprScope<'_>) -> Result<(), ScanError> {
+        let ExprScope { source, base, .. } = scope;
+        let mut state = ScanState {
+            last_logical_operator: None,
+            needs_rhs: false,
+        };
+        let mut offset = 0;
+
+        while offset < source.len() {
+            match source.as_bytes()[offset] {
+                byte if byte.is_ascii_whitespace() => offset += 1,
+                b'\'' | b'"' | b'`' => {
+                    offset = skip_quoted(source, offset)?;
+                    state.needs_rhs = false;
                 }
-                state.last_logical_operator = None;
-                offset += 1;
+                b'(' | b'[' | b'{' => {
+                    offset = self.scan_bracket_group(scope, offset, &mut state)?;
+                }
+                b')' | b']' | b'}' => return Err(ScanError),
+                _ if source[offset..].starts_with("?.") => {
+                    self.inc_cyclomatic(base + offset, ComplexityContributionKind::OptionalChain);
+                    offset += 2;
+                }
+                _ if source[offset..].starts_with("&&=")
+                    || source[offset..].starts_with("||=")
+                    || source[offset..].starts_with("??=") =>
+                {
+                    self.inc_cyclomatic(
+                        base + offset,
+                        ComplexityContributionKind::LogicalAssignment,
+                    );
+                    state.last_logical_operator = None;
+                    state.needs_rhs = true;
+                    offset += 3;
+                }
+                _ if source[offset..].starts_with("&&")
+                    || source[offset..].starts_with("||")
+                    || source[offset..].starts_with("??") =>
+                {
+                    offset = self.scan_logical_operator(source, base, offset, &mut state)?;
+                }
+                b',' | b';' => {
+                    if state.needs_rhs {
+                        return Err(ScanError);
+                    }
+                    state.last_logical_operator = None;
+                    offset += 1;
+                }
+                _ => {
+                    state.needs_rhs = false;
+                    offset += source[offset..].chars().next().map_or(1, char::len_utf8);
+                }
             }
-            _ => {
-                state.needs_rhs = false;
-                offset += source[offset..].chars().next().map_or(1, char::len_utf8);
-            }
+        }
+
+        if state.needs_rhs {
+            Err(ScanError)
+        } else {
+            Ok(())
         }
     }
 
-    if state.needs_rhs {
-        Err(ScanError)
-    } else {
-        Ok(state.metrics)
+    /// Recurse into a bracketed sub-expression `( [ {` at `offset`, recording its
+    /// contributions and returning the offset just past the closing bracket.
+    fn scan_bracket_group(
+        &mut self,
+        scope: ExprScope<'_>,
+        offset: usize,
+        state: &mut ScanState,
+    ) -> Result<usize, ScanError> {
+        let ExprScope {
+            source,
+            base,
+            nesting,
+            depth,
+        } = scope;
+        let close = matching_close_byte(source.as_bytes()[offset]).ok_or(ScanError)?;
+        let end = find_matching_delimiter(source, offset, source.as_bytes()[offset], close)?;
+        self.scan_expression(
+            &source[offset + 1..end],
+            base + offset + 1,
+            nesting,
+            depth + 1,
+        )?;
+        state.last_logical_operator = None;
+        state.needs_rhs = false;
+        Ok(end + 1)
     }
-}
 
-/// Recurse into a bracketed sub-expression `( [ {` at `offset`, folding its
-/// metrics into `state` and returning the offset just past the closing bracket.
-fn scan_bracket_group(
-    source: &str,
-    offset: usize,
-    nesting: u16,
-    depth: u16,
-    state: &mut ScanState,
-) -> Result<usize, ScanError> {
-    let close = matching_close_byte(source.as_bytes()[offset]).ok_or(ScanError)?;
-    let end = find_matching_delimiter(source, offset, source.as_bytes()[offset], close)?;
-    state.metrics.add(compute_expression_metrics(
-        &source[offset + 1..end],
-        nesting,
-        depth + 1,
-    )?);
-    state.last_logical_operator = None;
-    state.needs_rhs = false;
-    Ok(end + 1)
-}
-
-/// Score a 2-char logical operator (`&& || ??`) at `offset`, updating cyclomatic
-/// / cognitive counts and the logical-operator run state, and return the offset
-/// past the operator.
-fn scan_logical_operator(
-    source: &str,
-    offset: usize,
-    state: &mut ScanState,
-) -> Result<usize, ScanError> {
-    if state.needs_rhs {
-        return Err(ScanError);
+    /// Score a 2-char logical operator (`&& || ??`) at `offset`, updating the
+    /// counters and the logical-operator run state, and return the offset past
+    /// the operator. A run of the SAME operator earns one cognitive increment
+    /// for the run, so only the operator that opens the run records a cognitive
+    /// contribution; every operator records a cyclomatic one.
+    fn scan_logical_operator(
+        &mut self,
+        source: &str,
+        base: usize,
+        offset: usize,
+        state: &mut ScanState,
+    ) -> Result<usize, ScanError> {
+        if state.needs_rhs {
+            return Err(ScanError);
+        }
+        let operator = if source[offset..].starts_with("&&") {
+            LogicalOperator::And
+        } else if source[offset..].starts_with("||") {
+            LogicalOperator::Or
+        } else {
+            LogicalOperator::Nullish
+        };
+        let kind = match operator {
+            LogicalOperator::And => ComplexityContributionKind::LogicalAnd,
+            LogicalOperator::Or => ComplexityContributionKind::LogicalOr,
+            LogicalOperator::Nullish => ComplexityContributionKind::NullishCoalescing,
+        };
+        self.inc_cyclomatic(base + offset, kind);
+        if state.last_logical_operator != Some(operator) {
+            self.inc_cognitive_flat(base + offset, kind);
+            state.last_logical_operator = Some(operator);
+        }
+        state.needs_rhs = true;
+        Ok(offset + 2)
     }
-    let operator = if source[offset..].starts_with("&&") {
-        LogicalOperator::And
-    } else if source[offset..].starts_with("||") {
-        LogicalOperator::Or
-    } else {
-        LogicalOperator::Nullish
-    };
-    state.metrics.cyclomatic = state.metrics.cyclomatic.saturating_add(1);
-    if state.last_logical_operator != Some(operator) {
-        state.metrics.cognitive = state.metrics.cognitive.saturating_add(1);
-        state.last_logical_operator = Some(operator);
-    }
-    state.needs_rhs = true;
-    Ok(offset + 2)
 }
 
 fn find_top_level_ternary(source: &str) -> Result<Option<(usize, usize)>, ScanError> {
@@ -431,17 +550,20 @@ fn is_identifier_continue(byte: u8) -> bool {
 mod tests {
     use super::*;
 
+    /// Score one bare expression and return its own `(cyclomatic, cognitive)`
+    /// contribution, with the accumulator's implicit straight-line path removed.
+    fn expression_metrics(source: &str) -> Option<(u16, u16)> {
+        let mut complexity = TemplateComplexity::default();
+        complexity.add_expression(source, 0, 0).ok()?;
+        Some((complexity.cyclomatic - 1, complexity.cognitive))
+    }
+
     #[test]
     fn shallow_expression_metrics_are_stable() {
         // A normal 2-3 level nested expression scores by logical-operator and
         // ternary count; the depth guard never fires for it.
-        let ternary = compute_expression_metrics("(a && b) ? c : (d || e)", 0, 0).unwrap();
-        assert_eq!(ternary.cyclomatic, 3);
-        assert_eq!(ternary.cognitive, 3);
-
-        let bracketed = compute_expression_metrics("(a && b)", 0, 0).unwrap();
-        assert_eq!(bracketed.cyclomatic, 1);
-        assert_eq!(bracketed.cognitive, 1);
+        assert_eq!(expression_metrics("(a && b) ? c : (d || e)"), Some((3, 3)));
+        assert_eq!(expression_metrics("(a && b)"), Some((1, 1)));
     }
 
     #[test]
@@ -450,9 +572,7 @@ mod tests {
         // `a && b` in redundant parens yields the same metrics as the bare
         // expression.
         let source = format!("{}a && b{}", "(".repeat(10), ")".repeat(10));
-        let metrics = compute_expression_metrics(&source, 0, 0).unwrap();
-        assert_eq!(metrics.cyclomatic, 1);
-        assert_eq!(metrics.cognitive, 1);
+        assert_eq!(expression_metrics(&source), Some((1, 1)));
     }
 
     #[test]
@@ -462,10 +582,22 @@ mod tests {
         // past MAX_TEMPLATE_EXPR_DEPTH and the synthetic finding is dropped.
         let depth = 5000;
         let source = format!("{}a{}", "(".repeat(depth), ")".repeat(depth));
-        assert!(compute_expression_metrics(&source, 0, 0).is_err());
 
-        // The public entry point surfaces the same drop as a ScanError.
         let mut complexity = TemplateComplexity::default();
         assert!(complexity.add_expression(&source, 0, 0).is_err());
+    }
+
+    #[test]
+    fn expression_contributions_are_anchored_at_their_operator() {
+        let mut complexity = TemplateComplexity::default();
+        complexity.add_expression("a && b || c", 100, 0).unwrap();
+
+        let offsets: Vec<usize> = complexity
+            .contributions
+            .iter()
+            .filter(|contribution| contribution.metric == ComplexityMetric::Cyclomatic)
+            .map(|contribution| contribution.offset)
+            .collect();
+        assert_eq!(offsets, vec![102, 107]);
     }
 }

--- a/crates/extract/src/template_complexity/mod.rs
+++ b/crates/extract/src/template_complexity/mod.rs
@@ -11,7 +11,10 @@ mod engine;
 mod svelte;
 mod vue;
 
-use fallow_types::extract::{FunctionComplexity, byte_offset_to_line_col, compute_line_offsets};
+use fallow_types::extract::{
+    ComplexityContribution, ComplexityContributionKind, FunctionComplexity,
+    byte_offset_to_line_col, compute_line_offsets,
+};
 
 use engine::{
     ScanError, TemplateComplexity, find_matching_delimiter, find_tag_end, is_identifier_after,
@@ -122,7 +125,13 @@ impl<'a> TemplateScanner<'a> {
             "if" | "for" => {
                 let (expr_start, expr_end, after_paren) =
                     parse_parenthesized(self.source, after_keyword)?;
-                self.complexity.add_control_flow(self.block_depth);
+                let kind = if keyword == "for" {
+                    ComplexityContributionKind::ForOf
+                } else {
+                    ComplexityContributionKind::If
+                };
+                self.complexity
+                    .add_control_flow(offset, kind, self.block_depth);
                 self.complexity.add_expression(
                     &self.source[expr_start..expr_end],
                     expr_start,
@@ -130,14 +139,15 @@ impl<'a> TemplateScanner<'a> {
                 )?;
                 Ok(Some(after_paren))
             }
-            "else" => self.scan_else(after_keyword),
+            "else" => self.scan_else(offset, after_keyword),
             "switch" => {
                 let (expr_start, expr_end, after_paren) =
                     parse_parenthesized(self.source, after_keyword)?;
-                self.complexity.cognitive = self
-                    .complexity
-                    .cognitive
-                    .saturating_add(1 + self.block_depth);
+                self.complexity.inc_cognitive(
+                    offset,
+                    ComplexityContributionKind::Switch,
+                    self.block_depth,
+                );
                 self.complexity.add_expression(
                     &self.source[expr_start..expr_end],
                     expr_start,
@@ -148,7 +158,8 @@ impl<'a> TemplateScanner<'a> {
             "case" => {
                 let (expr_start, expr_end, after_paren) =
                     parse_parenthesized(self.source, after_keyword)?;
-                self.complexity.cyclomatic = self.complexity.cyclomatic.saturating_add(1);
+                self.complexity
+                    .inc_cyclomatic(offset, ComplexityContributionKind::Case);
                 self.complexity.add_expression(
                     &self.source[expr_start..expr_end],
                     expr_start,
@@ -157,21 +168,23 @@ impl<'a> TemplateScanner<'a> {
                 Ok(Some(after_paren))
             }
             "default" | "placeholder" | "loading" | "error" | "empty" => Ok(Some(after_keyword)),
-            "defer" => self.scan_defer(after_keyword),
+            "defer" => self.scan_defer(offset, after_keyword),
             "let" => self.scan_let(after_keyword),
             _ => Ok(None),
         }
     }
 
-    fn scan_else(&mut self, after_else: usize) -> Result<Option<usize>, ScanError> {
+    fn scan_else(&mut self, offset: usize, after_else: usize) -> Result<Option<usize>, ScanError> {
         let after_ws = skip_whitespace(self.source, after_else);
         if self.source[after_ws..].starts_with("if")
             && !is_identifier_after(self.source, after_ws + "if".len())
         {
             let after_if = after_ws + "if".len();
             let (expr_start, expr_end, after_paren) = parse_parenthesized(self.source, after_if)?;
-            self.complexity.cyclomatic = self.complexity.cyclomatic.saturating_add(1);
-            self.complexity.cognitive = self.complexity.cognitive.saturating_add(1);
+            self.complexity
+                .inc_cyclomatic(offset, ComplexityContributionKind::ElseIf);
+            self.complexity
+                .inc_cognitive_flat(offset, ComplexityContributionKind::ElseIf);
             self.complexity.add_expression(
                 &self.source[expr_start..expr_end],
                 expr_start,
@@ -179,12 +192,17 @@ impl<'a> TemplateScanner<'a> {
             )?;
             Ok(Some(after_paren))
         } else {
-            self.complexity.cognitive = self.complexity.cognitive.saturating_add(1);
+            self.complexity
+                .inc_cognitive_flat(offset, ComplexityContributionKind::Else);
             Ok(Some(after_else))
         }
     }
 
-    fn scan_defer(&mut self, after_defer: usize) -> Result<Option<usize>, ScanError> {
+    fn scan_defer(
+        &mut self,
+        offset: usize,
+        after_defer: usize,
+    ) -> Result<Option<usize>, ScanError> {
         let after_ws = skip_whitespace(self.source, after_defer);
         if !self.source[after_ws..].starts_with('(') {
             return Ok(Some(after_defer));
@@ -193,7 +211,11 @@ impl<'a> TemplateScanner<'a> {
         let expr = &self.source[expr_start..expr_end];
         if let Some(when_offset) = find_word(expr, "when") {
             let condition_offset = expr_start + when_offset + "when".len();
-            self.complexity.add_control_flow(self.block_depth);
+            self.complexity.add_control_flow(
+                offset,
+                ComplexityContributionKind::If,
+                self.block_depth,
+            );
             self.complexity.add_expression(
                 &self.source[condition_offset..expr_end],
                 condition_offset,
@@ -258,7 +280,7 @@ impl<'a> TemplateScanner<'a> {
             }
             offset = skip_whitespace(self.source, offset + 1);
             let (value_start, value_end, next_offset) = read_attribute_value(self.source, offset)?;
-            self.scan_attribute_value(name, value_start, value_end)?;
+            self.scan_attribute_value(name, name_start, value_start, value_end)?;
             offset = next_offset;
         }
         Ok(())
@@ -267,6 +289,7 @@ impl<'a> TemplateScanner<'a> {
     fn scan_attribute_value(
         &mut self,
         name: &str,
+        name_start: usize,
         value_start: usize,
         value_end: usize,
     ) -> Result<(), ScanError> {
@@ -275,7 +298,13 @@ impl<'a> TemplateScanner<'a> {
             name,
             "*ngIf" | "[ngIf]" | "*ngFor" | "*ngForOf" | "[ngFor]" | "[ngForOf]"
         ) {
-            self.complexity.add_control_flow(self.block_depth);
+            let kind = if name.contains("For") {
+                ComplexityContributionKind::ForOf
+            } else {
+                ComplexityContributionKind::If
+            };
+            self.complexity
+                .add_control_flow(name_start, kind, self.block_depth);
             self.complexity
                 .add_expression(value, value_start, self.block_depth)?;
         } else if is_bound_template_attribute(name) {
@@ -336,6 +365,29 @@ pub(in crate::template_complexity) fn build_template_complexity(
     let (line, col) = byte_offset_to_line_col(&line_offsets, first_offset);
     let line_count = u32::try_from(source.lines().count()).unwrap_or(u32::MAX);
 
+    // The scanners record in scan order, which is source order for the outer
+    // markup walk but not within an expression that recurses into brackets or
+    // ternary branches. Sort so the editor breakdown reads top to bottom.
+    let mut contributions: Vec<ComplexityContribution> = complexity
+        .contributions
+        .iter()
+        .map(|raw| {
+            let (line, col) = byte_offset_to_line_col(
+                &line_offsets,
+                u32::try_from(raw.offset).unwrap_or(u32::MAX),
+            );
+            ComplexityContribution {
+                line,
+                col,
+                metric: raw.metric,
+                kind: raw.kind,
+                weight: raw.weight,
+                nesting: raw.nesting,
+            }
+        })
+        .collect();
+    contributions.sort_by_key(|contribution| (contribution.line, contribution.col));
+
     Some(FunctionComplexity {
         name: "<template>".to_string(),
         line,
@@ -348,9 +400,7 @@ pub(in crate::template_complexity) fn build_template_complexity(
         react_jsx_max_depth: 0,
         react_prop_count: 0,
         source_hash: None,
-        // The hand-rolled template scanners emit only aggregate metrics;
-        // per-construct contributions are out of scope for the first cut.
-        contributions: Vec::new(),
+        contributions,
     })
 }
 
@@ -408,7 +458,104 @@ fn is_bound_template_attribute(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_angular_template_complexity;
+    use fallow_types::extract::{ComplexityMetric, FunctionComplexity};
+
+    use super::{
+        compute_angular_template_complexity, compute_astro_template_complexity,
+        compute_svelte_template_complexity, compute_vue_template_complexity,
+    };
+
+    /// Every scanner must fully attribute the numbers it reports: the recorded
+    /// weights per metric have to add up to the metric itself. `cyclomatic`
+    /// keeps the implicit straight-line path, which is not a contribution.
+    fn assert_breakdown_explains_totals(complexity: &FunctionComplexity, label: &str) {
+        let sum = |metric: ComplexityMetric| -> u16 {
+            complexity
+                .contributions
+                .iter()
+                .filter(|contribution| contribution.metric == metric)
+                .map(|contribution| contribution.weight)
+                .sum()
+        };
+        assert!(
+            !complexity.contributions.is_empty(),
+            "{label} reported {} / {} with no breakdown",
+            complexity.cyclomatic,
+            complexity.cognitive
+        );
+        assert_eq!(
+            sum(ComplexityMetric::Cyclomatic),
+            complexity.cyclomatic - 1,
+            "{label} cyclomatic breakdown"
+        );
+        assert_eq!(
+            sum(ComplexityMetric::Cognitive),
+            complexity.cognitive,
+            "{label} cognitive breakdown"
+        );
+    }
+
+    /// #2150 was reported against Vue, but the empty breakdown came from the
+    /// shared accumulator, so every framework scanner is held to the invariant.
+    #[test]
+    fn every_framework_scanner_explains_its_totals() {
+        let angular = compute_angular_template_complexity(
+            r"
+@if (user?.enabled && flags.on) {
+  @for (item of items; track item.id) { <li>{{ item.name }}</li> }
+} @else if (fallback) { <p /> } @else { <p /> }
+",
+        )
+        .expect("angular template should have complexity");
+        assert_breakdown_explains_totals(&angular, "angular");
+
+        let vue = compute_vue_template_complexity(
+            r#"<template><div v-if="a && b"><li v-for="i in items">{{ i }}</li></div><p v-else>n</p></template>"#,
+        )
+        .expect("vue template should have complexity");
+        assert_breakdown_explains_totals(&vue, "vue");
+
+        let svelte = compute_svelte_template_complexity(
+            r"
+{#if user?.enabled && flags.on}
+  {#each items as item}<li>{item.name}</li>{/each}
+{:else if fallback}
+  <p />
+{:else}
+  <p />
+{/if}
+",
+        )
+        .expect("svelte template should have complexity");
+        assert_breakdown_explains_totals(&svelte, "svelte");
+
+        let astro = compute_astro_template_complexity(
+            "---\nconst items = [];\n---\n<ul>{items.map((i) => <li>{i.a && i.b}</li>)}</ul>\n",
+        )
+        .expect("astro template should have complexity");
+        assert_breakdown_explains_totals(&astro, "astro");
+    }
+
+    /// A Svelte block's bound expression is reached through several trims and
+    /// keyword splits, so its contributions are anchored by the slice's real
+    /// position rather than a base offset threaded by hand.
+    #[test]
+    fn svelte_contributions_land_on_the_source_line() {
+        let complexity = compute_svelte_template_complexity(
+            r"<div>
+  {#if alpha && beta}
+    <p />
+  {/if}
+</div>
+",
+        )
+        .expect("svelte template should have complexity");
+
+        assert!(!complexity.contributions.is_empty());
+        for contribution in &complexity.contributions {
+            assert_eq!(contribution.line, 2, "{contribution:?}");
+        }
+    }
 
     #[test]
     fn counts_control_flow_and_expressions() {

--- a/crates/extract/src/template_complexity/svelte.rs
+++ b/crates/extract/src/template_complexity/svelte.rs
@@ -15,7 +15,7 @@
 
 use std::sync::LazyLock;
 
-use fallow_types::extract::FunctionComplexity;
+use fallow_types::extract::{ComplexityContributionKind, FunctionComplexity};
 
 use super::build_template_complexity;
 use super::engine::{ScanError, TemplateComplexity, skip_quoted};
@@ -95,7 +95,7 @@ impl<'a> SvelteScanner<'a> {
             match byte {
                 b'{' => {
                     let close = find_matching_curly(self.source, index)?;
-                    self.add_expr_slice(self.source[index + 1..close].trim(), index + 1)?;
+                    self.add_expr_slice(self.source[index + 1..close].trim())?;
                     index = close + 1;
                 }
                 b'\'' | b'"' => {
@@ -145,9 +145,10 @@ impl<'a> SvelteScanner<'a> {
         if let Some(rest) = inner.strip_prefix('@') {
             return self.scan_at_directive(rest, inner_offset);
         }
-        // Plain `{ expr }` text interpolation.
-        self.complexity
-            .add_expression(inner, inner_offset, self.nesting)
+        // Plain `{ expr }` text interpolation. `inner` is already trimmed, so
+        // it anchors its own contributions; `inner_offset` still points at the
+        // pre-trim `{`.
+        self.add_expr_slice(inner)
     }
 
     fn scan_block_open(&mut self, rest: &str, inner_offset: usize) -> Result<(), ScanError> {
@@ -164,8 +165,12 @@ impl<'a> SvelteScanner<'a> {
                 // `{#each <iterable> as <binding> (<key>)}`: score the iterable
                 // but not the binding pattern.
                 let iterable = each_iterable(after);
-                self.complexity.add_control_flow(self.nesting);
-                self.add_expr_slice(iterable, inner_offset)?;
+                self.complexity.add_control_flow(
+                    inner_offset,
+                    ComplexityContributionKind::ForOf,
+                    self.nesting,
+                );
+                self.add_expr_slice(iterable)?;
                 self.nesting = self.nesting.saturating_add(1);
                 Ok(())
             }
@@ -190,13 +195,16 @@ impl<'a> SvelteScanner<'a> {
                 if let Some(condition) = after_trim.strip_prefix("if") {
                     // `{:else if cond}`: a new branch. Match Angular's `@else if`:
                     // cyclomatic +1, cognitive +1 (flat, not nesting-weighted).
-                    self.complexity.cyclomatic = self.complexity.cyclomatic.saturating_add(1);
-                    self.complexity.cognitive = self.complexity.cognitive.saturating_add(1);
-                    self.add_expr_slice(condition.trim(), inner_offset)?;
+                    self.complexity
+                        .inc_cyclomatic(inner_offset, ComplexityContributionKind::ElseIf);
+                    self.complexity
+                        .inc_cognitive_flat(inner_offset, ComplexityContributionKind::ElseIf);
+                    self.add_expr_slice(condition.trim())?;
                 } else {
                     // Bare `{:else}`: continuation. Match Angular's bare `@else`:
                     // cognitive +1, no cyclomatic increment.
-                    self.complexity.cognitive = self.complexity.cognitive.saturating_add(1);
+                    self.complexity
+                        .inc_cognitive_flat(inner_offset, ComplexityContributionKind::Else);
                 }
                 Ok(())
             }
@@ -204,8 +212,13 @@ impl<'a> SvelteScanner<'a> {
             // path. Flat cognitive +1 (the await frame already supplied the
             // nesting weight), mirroring the else-if branch treatment.
             "then" | "catch" => {
-                self.complexity.cyclomatic = self.complexity.cyclomatic.saturating_add(1);
-                self.complexity.cognitive = self.complexity.cognitive.saturating_add(1);
+                let kind = if keyword == "catch" {
+                    ComplexityContributionKind::Catch
+                } else {
+                    ComplexityContributionKind::If
+                };
+                self.complexity.inc_cyclomatic(inner_offset, kind);
+                self.complexity.inc_cognitive_flat(inner_offset, kind);
                 Ok(())
             }
             _ => Ok(()),
@@ -225,7 +238,7 @@ impl<'a> SvelteScanner<'a> {
                 }
                 Ok(())
             }
-            "html" | "render" | "debug" => self.add_expr_slice(after.trim(), inner_offset),
+            "html" | "render" | "debug" => self.add_expr_slice(after.trim()),
             _ => Ok(()),
         }
     }
@@ -237,20 +250,44 @@ impl<'a> SvelteScanner<'a> {
         expr: &str,
         inner_offset: usize,
     ) -> Result<(), ScanError> {
-        self.complexity.add_control_flow(self.nesting);
-        self.add_expr_slice(expr.trim(), inner_offset)
+        self.complexity.add_control_flow(
+            inner_offset,
+            ComplexityContributionKind::If,
+            self.nesting,
+        );
+        self.add_expr_slice(expr.trim())
     }
 
-    /// Score `slice` as a bound expression. The `inner_offset` (the block-open
-    /// position) is a coarse anchor for the synthetic finding's line/col, which
-    /// is all `first_offset` needs: the precise expression column is not
-    /// surfaced for the aggregate `<template>` entry.
-    fn add_expr_slice(&mut self, slice: &str, inner_offset: usize) -> Result<(), ScanError> {
+    /// Score `slice` as a bound expression, anchored at its true position.
+    fn add_expr_slice(&mut self, slice: &str) -> Result<(), ScanError> {
         if slice.is_empty() {
             return Ok(());
         }
-        self.complexity
-            .add_expression(slice, inner_offset, self.nesting)
+        let offset = self.offset_of(slice);
+        self.complexity.add_expression(slice, offset, self.nesting)
+    }
+
+    /// Byte offset of `slice` within the scanned markup.
+    ///
+    /// Every slice that reaches this scanner is a subslice of `self.source`
+    /// (produced by splitting and trimming it), so the pointer delta is its
+    /// exact offset, and masking preserves offsets against the original file.
+    /// Recovering the offset this way keeps the block keyword parsing free of a
+    /// base offset threaded through every `split_keyword` and `trim` step, where
+    /// one missed adjustment would silently misplace a breakdown entry.
+    ///
+    /// Passing a slice from anywhere else (an owned `String`, a literal) would
+    /// saturate to `0` and anchor the whole breakdown at line 1, so the
+    /// subslice precondition is asserted in debug builds rather than left to
+    /// produce quietly wrong output.
+    fn offset_of(&self, slice: &str) -> usize {
+        let base = self.source.as_ptr().addr();
+        let start = slice.as_ptr().addr();
+        debug_assert!(
+            start >= base && start + slice.len() <= base + self.source.len(),
+            "offset_of expects a subslice of the scanned markup"
+        );
+        start.saturating_sub(base)
     }
 }
 

--- a/crates/extract/src/template_complexity/vue.rs
+++ b/crates/extract/src/template_complexity/vue.rs
@@ -16,7 +16,7 @@
 
 use std::sync::LazyLock;
 
-use fallow_types::extract::FunctionComplexity;
+use fallow_types::extract::{ComplexityContributionKind, FunctionComplexity};
 
 use super::build_template_complexity;
 use super::engine::{
@@ -177,12 +177,13 @@ impl<'a> VueScanner<'a> {
             offset = skip_whitespace(self.source, offset);
             if offset >= tag_end || self.source.as_bytes()[offset] != b'=' {
                 // Valueless attribute (`disabled`, bare `v-else`).
-                has_control_flow |= self.scan_valueless_attr(name);
+                has_control_flow |= self.scan_valueless_attr(name, name_start);
                 continue;
             }
             offset = skip_whitespace(self.source, offset + 1);
             let (value_start, value_end, next_offset) = read_attribute_value(self.source, offset)?;
-            has_control_flow |= self.scan_attribute_value(name, value_start, value_end)?;
+            has_control_flow |=
+                self.scan_attribute_value(name, name_start, value_start, value_end)?;
             offset = next_offset;
         }
         Ok(has_control_flow)
@@ -192,9 +193,10 @@ impl<'a> VueScanner<'a> {
     /// control-flow continuation). Mirrors Angular's bare `@else`: cognitive
     /// +1, no cyclomatic increment (the new branch path is owned by the paired
     /// `v-if`). Returns `true` for `v-else` so its element opens a nesting level.
-    fn scan_valueless_attr(&mut self, name: &str) -> bool {
+    fn scan_valueless_attr(&mut self, name: &str, name_start: usize) -> bool {
         if name == "v-else" {
-            self.complexity.cognitive = self.complexity.cognitive.saturating_add(1);
+            self.complexity
+                .inc_cognitive_flat(name_start, ComplexityContributionKind::Else);
             return true;
         }
         false
@@ -207,12 +209,14 @@ impl<'a> VueScanner<'a> {
     fn scan_attribute_value(
         &mut self,
         name: &str,
+        name_start: usize,
         value_start: usize,
         value_end: usize,
     ) -> Result<bool, ScanError> {
         let value = &self.source[value_start..value_end];
         if is_control_flow_directive(name) {
-            self.complexity.add_control_flow(self.nesting);
+            self.complexity
+                .add_control_flow(name_start, control_flow_kind(name), self.nesting);
             self.complexity
                 .add_expression(value, value_start, self.nesting)?;
             return Ok(true);
@@ -228,6 +232,17 @@ impl<'a> VueScanner<'a> {
 /// `v-if` / `v-else-if` / `v-for` / `v-show` each introduce a branch / loop.
 fn is_control_flow_directive(name: &str) -> bool {
     matches!(name, "v-if" | "v-else-if" | "v-for" | "v-show")
+}
+
+/// The breakdown kind for a control-flow directive. `v-else-if` maps to
+/// `ElseIf` rather than `If` so a cascade reads the way the source does.
+/// `v-show` is a conditional render toggle, so it reports as a plain `If`.
+fn control_flow_kind(name: &str) -> ComplexityContributionKind {
+    match name {
+        "v-else-if" => ComplexityContributionKind::ElseIf,
+        "v-for" => ComplexityContributionKind::ForOf,
+        _ => ComplexityContributionKind::If,
+    }
 }
 
 /// Any directive whose value is a bound JS expression worth scoring for
@@ -264,7 +279,122 @@ fn is_void_tag(tag_name: &str) -> bool {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
+    use fallow_types::extract::{ComplexityContributionKind, ComplexityMetric};
+
     use super::compute_vue_template_complexity;
+
+    /// The reporter's shape in #2150: a `v-if` / `v-else` pair must arrive with a
+    /// breakdown, not just a total. Before the shared engine recorded
+    /// contributions this returned an empty vec for every template, so the
+    /// editor had nothing to render next to the finding.
+    #[test]
+    fn v_if_else_reports_its_decision_points() {
+        let complexity = compute_vue_template_complexity(
+            r#"<template>
+  <p v-if="a">1</p>
+  <p v-else-if="b">2</p>
+  <p v-else>3</p>
+</template>
+"#,
+        )
+        .expect("template should have complexity");
+
+        let kinds: Vec<ComplexityContributionKind> = complexity
+            .contributions
+            .iter()
+            .map(|contribution| contribution.kind)
+            .collect();
+        assert!(
+            kinds.contains(&ComplexityContributionKind::If)
+                && kinds.contains(&ComplexityContributionKind::ElseIf)
+                && kinds.contains(&ComplexityContributionKind::Else),
+            "{kinds:?}"
+        );
+
+        // Each directive is reported on the line it is written on.
+        let lines: Vec<u32> = complexity
+            .contributions
+            .iter()
+            .map(|contribution| contribution.line)
+            .collect();
+        assert_eq!(*lines.iter().min().expect("contributions"), 2);
+        assert_eq!(*lines.iter().max().expect("contributions"), 4);
+    }
+
+    /// The breakdown must always explain the whole number. `cyclomatic` carries
+    /// the implicit straight-line path that is not a contribution; `cognitive`
+    /// starts at zero, so it must be fully attributed.
+    #[test]
+    fn contribution_weights_sum_to_the_reported_metrics() {
+        let complexity = compute_vue_template_complexity(
+            r#"<template>
+  <div v-if="user?.enabled && flags.dashboard">
+    <li v-for="item in items" :key="item.id">
+      <badge :color="item.level > 3 ? 'red' : 'green'" />
+    </li>
+  </div>
+  <p v-else>none</p>
+</template>
+"#,
+        )
+        .expect("template should have complexity");
+
+        let sum = |metric: ComplexityMetric| -> u16 {
+            complexity
+                .contributions
+                .iter()
+                .filter(|contribution| contribution.metric == metric)
+                .map(|contribution| contribution.weight)
+                .sum()
+        };
+        assert_eq!(sum(ComplexityMetric::Cyclomatic), complexity.cyclomatic - 1);
+        assert_eq!(sum(ComplexityMetric::Cognitive), complexity.cognitive);
+    }
+
+    /// Offsets are recorded against the masked markup, which preserves byte
+    /// offsets, so a `<script>` block above the template must not shift the
+    /// reported lines.
+    #[test]
+    fn contributions_are_anchored_past_a_leading_script_block() {
+        let complexity = compute_vue_template_complexity(
+            r#"<script setup>
+const a = 1;
+const b = 2;
+</script>
+
+<template>
+  <p v-if="a && b">x</p>
+</template>
+"#,
+        )
+        .expect("template should have complexity");
+
+        assert!(!complexity.contributions.is_empty());
+        for contribution in &complexity.contributions {
+            assert_eq!(contribution.line, 7, "{contribution:?}");
+        }
+    }
+
+    /// A nested control-flow construct carries the nesting penalty in its own
+    /// weight, so a consumer can explain a `+2` as "+1 base, +1 nesting".
+    #[test]
+    fn nested_control_flow_records_its_nesting_penalty() {
+        let complexity = compute_vue_template_complexity(
+            r#"<template><div v-if="a"><li v-for="i in items">{{ i }}</li></div></template>"#,
+        )
+        .expect("template should have complexity");
+
+        let nested = complexity
+            .contributions
+            .iter()
+            .find(|contribution| {
+                contribution.metric == ComplexityMetric::Cognitive
+                    && contribution.kind == ComplexityContributionKind::ForOf
+            })
+            .expect("nested v-for contribution");
+        assert_eq!(nested.nesting, 1, "{nested:?}");
+        assert_eq!(nested.weight, 2, "{nested:?}");
+    }
 
     #[test]
     fn nested_v_for_in_v_if_with_ternary_binding_counts() {

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -12,6 +12,8 @@ and parse-cache changes.
   member, call, and framework facts.
 - `crates/extract/src/cache/`: cache types, conversion, storage, and tests.
 - `crates/extract/src/complexity.rs`: JavaScript and TypeScript complexity.
+- `crates/extract/src/template_complexity/`: synthetic `<template>` complexity
+  for Angular, Vue, Svelte, and Astro, over a shared JS-expression engine.
 - `crates/extract/src/sfc.rs`, `astro.rs`, `glimmer.rs`, `mdx.rs`, and
   `graphql.rs`: component and embedded-language extraction.
 - `crates/extract/src/sfc_template/`: template-visible usage for supported


### PR DESCRIPTION
Closes #2150. Thanks @Ericlm for the report and the ready-to-run repro repo, which made this a five-minute diagnosis.

## What was wrong

`build_template_complexity` hard-coded the breakdown away:

```rust
// The hand-rolled template scanners emit only aggregate metrics;
// per-construct contributions are out of scope for the first cut.
contributions: Vec::new(),
```

The shared accumulator behind every template scanner carried only the two totals, so this was never Vue-specific. Angular, Vue, Svelte, and Astro all reported a complexity number with nothing to explain it. The VS Code extension already passes `--complexity-breakdown` and already renders `contributions` per line, so it was only ever missing data.

## What changed

The accumulator records each increment at its byte offset, and every counter mutation goes through one helper that records as it counts, so the breakdown cannot drift from the total. The expression engine threads a base offset through its bracket and ternary recursion, so `&&`, `??`, `?:`, and `?.` are attributed at their own columns instead of being folded into the enclosing directive.

Metric totals are unchanged for every scanner. `CACHE_VERSION` goes 252 -> 253 because warm caches hold an empty breakdown, and an unedited template would otherwise keep rendering a finding with no explanation.

## Verification

Reporter's repro repo, `fallow health --complexity-breakdown`:

```
src/App.vue <template> cyclo=21 cog=21 contributions=41
   line 9   col 7   cyclomatic if
   line 9   col 7   cognitive  if
   line 10  col 7   cyclomatic else-if
   ...
   line 29  col 7   cognitive  else
   sums: cyclomatic 20 (+1 baseline = 21), cognitive 21
```

Lines 9 to 29 match the source exactly, and the weights reconcile to the reported totals.

- Repro test fails without the fix (verified by reverting just the emit: 3 of the 4 new Vue tests fail).
- A cross-framework test asserts the weights per metric sum back to the reported figures for Angular, Vue, Svelte, and Astro, so a future scanner change cannot silently drop provenance.
- The existing scanner tests were left untouched and still pass, which is what pins "totals did not move".
- Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --all-features`, `cargo check --workspace --benches`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `npm run generate:contracts:check`, `check:agent-adapters`, `check:knowledge-architecture`, `check:contract-surfaces`, `check:crate-boundaries`, `lint:js`, `fmt:js:check`.

## Note on scope

The issue is filed against Vue, and the fix covers all four template scanners. They share one accumulator, so fixing Vue alone would have meant duplicating it.