### PR TITLE
refactor: keep one definition of each discovery constant

### DIFF
--- a/crates/cli/src/architecture_boundaries.rs
+++ b/crates/cli/src/architecture_boundaries.rs
@@ -1522,6 +1522,10 @@ fn core_backend_fallow_core_calls_are_explicitly_allowlisted() {
         "fallow_core::discover::discover_entry_points",
         "fallow_core::discover::discover_workspace_entry_points",
         "fallow_core::discover::discover_plugin_entry_points",
+        // Discovery vocabulary lives with the walk that consumes it.
+        "fallow_core::discover::ALLOWED_HIDDEN_DIRS",
+        "fallow_core::discover::PRODUCTION_EXCLUDE_PATTERNS",
+        "fallow_core::discover::SOURCE_EXTENSIONS",
     ];
 
     for line in core_backend.lines() {

--- a/crates/core/src/discover/entry_points.rs
+++ b/crates/core/src/discover/entry_points.rs
@@ -3,14 +3,11 @@ use std::path::{Component, Path, PathBuf};
 use super::parse_scripts::extract_script_file_refs;
 use super::walk::SOURCE_EXTENSIONS;
 use fallow_config::{EntryPointRole, PackageJson, ResolvedConfig};
+use fallow_graph::resolve::OUTPUT_DIRS;
 use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource};
 use fallow_types::path_util::is_absolute_path_any_platform;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-/// Known output directory names from exports maps.
-/// When an entry point path is inside one of these directories, we also try
-/// the `src/` equivalent to find the tracked source file.
-const OUTPUT_DIRS: &[&str] = &["dist", "build", "out", "esm", "cjs"];
 const SKIPPED_ENTRY_WARNING_PREVIEW: usize = 5;
 
 fn format_skipped_entry_warning(skipped_entries: &FxHashMap<String, usize>) -> Option<String> {

--- a/crates/core/src/discover/mod.rs
+++ b/crates/core/src/discover/mod.rs
@@ -132,7 +132,7 @@ pub fn discover_files_with_plugin_scopes(config: &ResolvedConfig) -> Vec<Discove
 /// - `.well-known` — Standard web convention directory
 /// - `.changeset` — Changesets configuration
 /// - `.github` — GitHub workflows and CI scripts
-const ALLOWED_HIDDEN_DIRS: &[&str] = &[
+pub const ALLOWED_HIDDEN_DIRS: &[&str] = &[
     ".storybook",
     ".vitepress",
     ".well-known",

--- a/crates/core/src/discover/walk.rs
+++ b/crates/core/src/discover/walk.rs
@@ -453,6 +453,7 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for FileVisitorBuilder<'s> {
     }
 }
 
+/// File extensions discovery treats as analyzable source files.
 pub const SOURCE_EXTENSIONS: &[&str] = &[
     "ts", "tsx", "mts", "cts", "gts", "js", "jsx", "mjs", "cjs", "gjs", "vue", "svelte", "astro",
     "mdx", "css", "scss", "sass", "less", "html", "graphql", "gql",

--- a/crates/engine/src/core_backend.rs
+++ b/crates/engine/src/core_backend.rs
@@ -25,6 +25,12 @@ pub use fallow_core::plugins::manifest_entries::{
 };
 pub use fallow_core::plugins::registry::is_external_plugin_active;
 
+// Discovery vocabulary owned by the surviving core walk, re-exported so the
+// engine boundary keeps one definition per constant.
+pub use fallow_core::discover::ALLOWED_HIDDEN_DIRS;
+pub use fallow_core::discover::PRODUCTION_EXCLUDE_PATTERNS;
+pub use fallow_core::discover::SOURCE_EXTENSIONS;
+
 #[derive(Debug, Clone, Copy)]
 pub struct ParseMetrics {
     pub parse_ms: f64,

--- a/crates/engine/src/discover.rs
+++ b/crates/engine/src/discover.rs
@@ -9,48 +9,17 @@ use fallow_config::{
     find_undeclared_workspaces_with_ignores,
 };
 pub use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
+
+/// Discovery vocabulary shared with the analysis backend: file extensions,
+/// production-exclusion globs, and the hidden directories traversal allows.
+pub use crate::core_backend::{
+    ALLOWED_HIDDEN_DIRS, PRODUCTION_EXCLUDE_PATTERNS, SOURCE_EXTENSIONS,
+};
 use rustc_hash::FxHashSet;
 
 use crate::{EngineError, EngineResult, plugins::PluginRegistry};
 
 const UNDECLARED_WORKSPACE_WARNING_PREVIEW: usize = 5;
-
-/// File extensions discovery treats as analyzable source files.
-pub const SOURCE_EXTENSIONS: &[&str] = &[
-    "ts", "tsx", "mts", "cts", "gts", "js", "jsx", "mjs", "cjs", "gjs", "vue", "svelte", "astro",
-    "mdx", "css", "scss", "sass", "less", "html", "graphql", "gql",
-];
-
-/// Glob patterns for test/dev/story files excluded in production mode.
-pub const PRODUCTION_EXCLUDE_PATTERNS: &[&str] = &[
-    "**/*.test.*",
-    "**/*.spec.*",
-    "**/*.e2e.*",
-    "**/*.e2e-spec.*",
-    "**/*.bench.*",
-    "**/*.fixture.*",
-    "**/*.stories.*",
-    "**/*.story.*",
-    "**/__tests__/**",
-    "**/__mocks__/**",
-    "**/__snapshots__/**",
-    "**/__fixtures__/**",
-    "**/test/**",
-    "**/tests/**",
-    "*.config.*",
-    "**/.*.js",
-    "**/.*.ts",
-    "**/.*.mjs",
-    "**/.*.cjs",
-];
-
-const ALLOWED_HIDDEN_DIRS: &[&str] = &[
-    ".storybook",
-    ".vitepress",
-    ".well-known",
-    ".changeset",
-    ".github",
-];
 
 const SCRIPT_SCOPE_DENYLIST: &[&str] = &[
     ".git",

--- a/crates/engine/src/public_api.rs
+++ b/crates/engine/src/public_api.rs
@@ -6,12 +6,12 @@ use fallow_config::{PackageJson, ResolvedConfig, WorkspaceInfo};
 use fallow_types::discover::FileId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use fallow_graph::resolve::OUTPUT_DIRS;
+
 use crate::{
     discover::{EntryPoint, EntryPointSource, SOURCE_EXTENSIONS},
     module_graph::RetainedModuleGraph,
 };
-
-const OUTPUT_DIRS: &[&str] = &["dist", "build", "out", "esm", "cjs"];
 
 /// Compute the exports-aware public API entry-point set for a project graph.
 #[must_use]

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -33,7 +33,7 @@ pub use path_info::{
     extract_package_name, is_bare_specifier, is_path_alias, is_valid_package_name,
 };
 pub use types::{
-    ResolveResult, ResolvedImport, ResolvedModule, ResolvedProject, ResolvedReExport,
+    OUTPUT_DIRS, ResolveResult, ResolvedImport, ResolvedModule, ResolvedProject, ResolvedReExport,
     ResolvedReplacedModuleTarget, ResolvedSourceEdge,
 };
 


### PR DESCRIPTION
Four constants that describe what discovery considers source code had copies on both sides of the engine boundary, the last mechanical duplication left by the discovery consolidation.

- `SOURCE_EXTENSIONS`, `PRODUCTION_EXCLUDE_PATTERNS`, and `ALLOWED_HIDDEN_DIRS` were byte-identical in `crates/engine/src/discover.rs` and the core walk that consumes them. The engine now re-exports the core definitions through the backend adapter, so the public paths (`fallow_engine::discover::SOURCE_EXTENSIONS`, used by the watch command) are unchanged.
- `OUTPUT_DIRS` had three copies (engine, core, graph). It moves to `fallow-graph`, the lowest crate both other sides already depend on, so core and engine import it directly with no adapter hop and no new boundary exception.

Verification: byte-identical `check` and `list` JSON on two real projects (a plugin-heavy Vue component library and a Next.js site) against a release binary built from a pristine worktree at the parent commit, normalizing only the run id and timings. Full workspace suite, clippy, and the architecture boundary tests are green; the three adapter re-exports carry narrow allowlist entries.