### PR TITLE
refactor: harden duplication architecture

### DIFF
--- a/crates/engine/benches/dupes_detect.rs
+++ b/crates/engine/benches/dupes_detect.rs
@@ -293,6 +293,25 @@ fn clone_family_grouping_1000x3(c: &mut Criterion) {
     });
 }
 
+fn clone_group_spread_high_occurrence(c: &mut Criterion) {
+    let instances = (0..4_096)
+        .map(|index| CloneInstance {
+            file: PathBuf::from(format!("packages/{}/src/module-{index}.ts", index % 64)),
+            start_line: index * 300 + 1,
+            end_line: index * 300 + 40,
+            start_col: 0,
+            end_col: 0,
+            fragment: String::new(),
+        })
+        .collect::<Vec<_>>();
+
+    c.bench_function("clone_group_spread_high_occurrence", |bencher| {
+        bencher.iter(|| {
+            std::hint::black_box(fallow_types::duplicates::clone_group_spread(&instances))
+        });
+    });
+}
+
 criterion_group!(
     benches,
     dupe_detect_2x500_identical,
@@ -303,6 +322,7 @@ criterion_group!(
     dupe_detect_100x200_mixed_focused,
     dupe_detect_80x20x80_interval_pressure,
     dupe_detect_2x5000_identical,
-    clone_family_grouping_1000x3
+    clone_family_grouping_1000x3,
+    clone_group_spread_high_occurrence
 );
 criterion_main!(benches);

--- a/crates/engine/src/duplicates.rs
+++ b/crates/engine/src/duplicates.rs
@@ -22,6 +22,8 @@ pub use detector::{detect, normalize, tokenize};
 
 /// Engine alias for [`fallow_types::duplicates::CloneGroup`].
 pub type CloneGroup = fallow_types::duplicates::CloneGroup;
+/// Engine alias for [`fallow_types::duplicates::CloneGroupKind`].
+pub type CloneGroupKind = fallow_types::duplicates::CloneGroupKind;
 /// Engine alias for [`fallow_types::duplicates::CloneInstance`].
 pub type CloneInstance = fallow_types::duplicates::CloneInstance;
 /// Engine alias for [`fallow_types::duplicates::DefaultIgnoreSkips`].

--- a/crates/engine/src/duplication_detector/deepdive.rs
+++ b/crates/engine/src/duplication_detector/deepdive.rs
@@ -14,6 +14,9 @@ use fallow_config::DetectionMode;
 use rustc_hash::{FxHashMap, FxHashSet};
 use xxhash_rust::xxh3::{Xxh3, xxh3_64};
 
+use super::tokenize::{
+    FragmentTokenizationKind, FragmentTokenizationStrategy, fragment_tokenization_kind,
+};
 use super::types::{CloneGroup, CloneInstance, RefactoringKind, RefactoringSuggestion};
 
 /// Prefix marking a clone-group fingerprint addressable via `--trace`.
@@ -274,7 +277,10 @@ fn distinct_fragment_inputs(instances: &[CloneInstance]) -> Vec<(FragmentTokeniz
         .iter()
         .map(|instance| {
             (
-                fragment_tokenization_kind(&instance.file),
+                fragment_tokenization_kind(
+                    &instance.file,
+                    FragmentTokenizationStrategy::Fingerprint,
+                ),
                 instance.fragment.as_str(),
             )
         })
@@ -282,58 +288,6 @@ fn distinct_fragment_inputs(instances: &[CloneInstance]) -> Vec<(FragmentTokeniz
     fragments.sort_unstable();
     fragments.dedup();
     fragments
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum FragmentTokenizationKind {
-    JavaScript,
-    Jsx,
-    Mjs,
-    Cjs,
-    TypeScript,
-    Tsx,
-    Mts,
-    Cts,
-    Css,
-    Scss,
-    Sass,
-    Less,
-}
-
-impl FragmentTokenizationKind {
-    fn path(self) -> &'static Path {
-        Path::new(match self {
-            Self::JavaScript => "fragment.js",
-            Self::Jsx => "fragment.jsx",
-            Self::Mjs => "fragment.mjs",
-            Self::Cjs => "fragment.cjs",
-            Self::TypeScript => "fragment.ts",
-            Self::Tsx => "fragment.tsx",
-            Self::Mts => "fragment.mts",
-            Self::Cts => "fragment.cts",
-            Self::Css => "fragment.css",
-            Self::Scss => "fragment.scss",
-            Self::Sass => "fragment.sass",
-            Self::Less => "fragment.less",
-        })
-    }
-}
-
-fn fragment_tokenization_kind(path: &Path) -> FragmentTokenizationKind {
-    match path.extension().and_then(|extension| extension.to_str()) {
-        Some("js") => FragmentTokenizationKind::JavaScript,
-        Some("jsx") => FragmentTokenizationKind::Jsx,
-        Some("mjs") => FragmentTokenizationKind::Mjs,
-        Some("cjs") => FragmentTokenizationKind::Cjs,
-        Some("tsx") => FragmentTokenizationKind::Tsx,
-        Some("mts") => FragmentTokenizationKind::Mts,
-        Some("cts") => FragmentTokenizationKind::Cts,
-        Some("css") => FragmentTokenizationKind::Css,
-        Some("scss") => FragmentTokenizationKind::Scss,
-        Some("sass") => FragmentTokenizationKind::Sass,
-        Some("less") => FragmentTokenizationKind::Less,
-        _ => FragmentTokenizationKind::TypeScript,
-    }
 }
 
 fn normalized_fragment_sequence(path: &Path, fragment: &str) -> Vec<u64> {

--- a/crates/engine/src/duplication_detector/mod.rs
+++ b/crates/engine/src/duplication_detector/mod.rs
@@ -332,7 +332,12 @@ fn detect_and_postprocess(
 
     if let Some(result) = near_result.as_mut() {
         near::suppress_exact_covered_near_groups(&mut result.clone_groups, &report.clone_groups);
-        report.clone_groups.append(&mut result.clone_groups);
+        report.clone_groups.extend(
+            result
+                .clone_groups
+                .drain(..)
+                .map(near::NearCloneGroup::into_clone_group),
+        );
         report.stats.near_candidates_skipped = result.skipped_candidates;
         report.stats = crate::duplicates::recompute_stats(&report);
     }

--- a/crates/engine/src/duplication_detector/near.rs
+++ b/crates/engine/src/duplication_detector/near.rs
@@ -9,7 +9,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::TokenizedFile;
 use super::normalize::normalize_and_hash_resolved;
-use super::types::{CloneGroup, CloneInstance};
+use super::tokenize::{FragmentTokenizationStrategy, tokenize_fragment};
+use super::types::{CloneGroup, CloneGroupKind, CloneInstance};
 
 const SHINGLE_TOKENS: usize = 7;
 const SHINGLE_BASE: u64 = 1_000_003;
@@ -36,8 +37,27 @@ pub(super) struct NearDetectionInput<'a> {
 
 /// Bounded near-miss results plus visible truncation metadata.
 pub(super) struct NearDetectionResult {
-    pub(super) clone_groups: Vec<CloneGroup>,
+    pub(super) clone_groups: Vec<NearCloneGroup>,
     pub(super) skipped_candidates: usize,
+}
+
+/// Internal near-clone representation with a required similarity invariant.
+pub(super) struct NearCloneGroup {
+    instances: Vec<CloneInstance>,
+    token_count: usize,
+    line_count: usize,
+    similarity: f64,
+}
+
+impl NearCloneGroup {
+    pub(super) fn into_clone_group(self) -> CloneGroup {
+        CloneGroup {
+            instances: self.instances,
+            token_count: self.token_count,
+            line_count: self.line_count,
+            similarity: Some(self.similarity),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -505,7 +525,7 @@ fn complete_link_clusters(
 
 /// Recompute the derived metrics of a near group after instance filtering.
 pub(super) fn refresh_near_group_metrics(group: &mut CloneGroup) {
-    if group.similarity.is_none() || group.instances.len() < 2 {
+    if !matches!(group.kind(), CloneGroupKind::Near { .. }) || group.instances.len() < 2 {
         return;
     }
 
@@ -515,10 +535,10 @@ pub(super) fn refresh_near_group_metrics(group: &mut CloneGroup) {
         .instances
         .iter()
         .map(|instance| {
-            let tokens = super::tokenize::tokenize_file(
-                function_fragment_path(&instance.file),
+            let tokens = tokenize_fragment(
+                &instance.file,
                 &instance.fragment,
-                false,
+                FragmentTokenizationStrategy::Function,
             );
             normalize_and_hash_resolved(&tokens.tokens, semantic)
                 .into_iter()
@@ -554,15 +574,6 @@ pub(super) fn refresh_near_group_metrics(group: &mut CloneGroup) {
         .reduce(f64::min);
 }
 
-fn function_fragment_path(path: &Path) -> &'static Path {
-    match path.extension().and_then(|extension| extension.to_str()) {
-        Some("js" | "mjs" | "cjs") => Path::new("fragment.js"),
-        Some("jsx") => Path::new("fragment.jsx"),
-        Some("ts" | "mts" | "cts") => Path::new("fragment.ts"),
-        _ => Path::new("fragment.tsx"),
-    }
-}
-
 fn remove_nested_members(mut members: Vec<usize>, candidates: &[FunctionCandidate]) -> Vec<usize> {
     members.sort_by_key(|&id| (Reverse(candidates[id].semantic_tokens.len()), id));
     let mut kept = Vec::new();
@@ -583,7 +594,7 @@ fn build_clone_group(
     candidates: &[FunctionCandidate],
     similarities: &FxHashMap<(usize, usize), f64>,
     skip_local: bool,
-) -> Option<CloneGroup> {
+) -> Option<NearCloneGroup> {
     if skip_local {
         let directories = cluster
             .iter()
@@ -633,15 +644,15 @@ fn build_clone_group(
             }
         })
         .collect();
-    Some(CloneGroup {
+    Some(NearCloneGroup {
         instances,
         token_count,
         line_count,
-        similarity: Some(similarity),
+        similarity,
     })
 }
 
-fn sort_groups(groups: &mut [CloneGroup]) {
+fn sort_groups(groups: &mut [NearCloneGroup]) {
     groups.sort_by(
         |left, right| match (left.instances.first(), right.instances.first()) {
             (Some(left), Some(right)) => left
@@ -659,7 +670,7 @@ fn sort_groups(groups: &mut [CloneGroup]) {
 /// Remove near groups already represented by one exact group covering every
 /// near instance. Partial exact sub-clones do not suppress a gapped function.
 pub(super) fn suppress_exact_covered_near_groups(
-    near_groups: &mut Vec<CloneGroup>,
+    near_groups: &mut Vec<NearCloneGroup>,
     exact_groups: &[CloneGroup],
 ) {
     near_groups.retain(|near| {
@@ -740,11 +751,7 @@ mod tests {
         assert_eq!(result.clone_groups.len(), 1);
         let group = &result.clone_groups[0];
         assert_eq!(group.instances.len(), 2);
-        assert!(
-            group
-                .similarity
-                .is_some_and(|value| value >= MIN_SIMILARITY)
-        );
+        assert!(group.similarity >= MIN_SIMILARITY);
     }
 
     #[test]
@@ -927,11 +934,11 @@ mod tests {
             end_col: 20,
             fragment: String::new(),
         };
-        let near = CloneGroup {
+        let near = NearCloneGroup {
             instances: vec![instance("a.ts", 2, 8), instance("b.ts", 12, 18)],
             token_count: 30,
             line_count: 7,
-            similarity: Some(0.9),
+            similarity: 0.9,
         };
         let partial = CloneGroup {
             instances: vec![instance("a.ts", 2, 8), instance("b.ts", 13, 18)],

--- a/crates/engine/src/duplication_detector/tokenize/fragment.rs
+++ b/crates/engine/src/duplication_detector/tokenize/fragment.rs
@@ -1,0 +1,154 @@
+use std::path::Path;
+
+#[cfg(test)]
+use std::path::PathBuf;
+
+use super::{FileTokens, tokenize_file};
+
+/// Context in which an extracted fragment is tokenized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FragmentTokenizationStrategy {
+    /// Preserve the source extension when it affects stable fingerprint identity.
+    Fingerprint,
+    /// Parse an extracted function body with the closest JavaScript language mode.
+    Function,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FragmentTokenizationKind {
+    JavaScript,
+    Jsx,
+    Mjs,
+    Cjs,
+    TypeScript,
+    Tsx,
+    Mts,
+    Cts,
+    Css,
+    Scss,
+    Sass,
+    Less,
+}
+
+impl FragmentTokenizationKind {
+    pub fn path(self) -> &'static Path {
+        Path::new(match self {
+            Self::JavaScript => "fragment.js",
+            Self::Jsx => "fragment.jsx",
+            Self::Mjs => "fragment.mjs",
+            Self::Cjs => "fragment.cjs",
+            Self::TypeScript => "fragment.ts",
+            Self::Tsx => "fragment.tsx",
+            Self::Mts => "fragment.mts",
+            Self::Cts => "fragment.cts",
+            Self::Css => "fragment.css",
+            Self::Scss => "fragment.scss",
+            Self::Sass => "fragment.sass",
+            Self::Less => "fragment.less",
+        })
+    }
+}
+
+pub fn fragment_tokenization_kind(
+    path: &Path,
+    strategy: FragmentTokenizationStrategy,
+) -> FragmentTokenizationKind {
+    let extension = path.extension().and_then(|extension| extension.to_str());
+    match strategy {
+        FragmentTokenizationStrategy::Fingerprint => match extension {
+            Some("js") => FragmentTokenizationKind::JavaScript,
+            Some("jsx") => FragmentTokenizationKind::Jsx,
+            Some("mjs") => FragmentTokenizationKind::Mjs,
+            Some("cjs") => FragmentTokenizationKind::Cjs,
+            Some("tsx") => FragmentTokenizationKind::Tsx,
+            Some("mts") => FragmentTokenizationKind::Mts,
+            Some("cts") => FragmentTokenizationKind::Cts,
+            Some("css") => FragmentTokenizationKind::Css,
+            Some("scss") => FragmentTokenizationKind::Scss,
+            Some("sass") => FragmentTokenizationKind::Sass,
+            Some("less") => FragmentTokenizationKind::Less,
+            _ => FragmentTokenizationKind::TypeScript,
+        },
+        FragmentTokenizationStrategy::Function => match extension {
+            Some("js" | "mjs" | "cjs") => FragmentTokenizationKind::JavaScript,
+            Some("jsx") => FragmentTokenizationKind::Jsx,
+            Some("ts" | "mts" | "cts") => FragmentTokenizationKind::TypeScript,
+            _ => FragmentTokenizationKind::Tsx,
+        },
+    }
+}
+
+pub fn tokenize_fragment(
+    source_path: &Path,
+    fragment: &str,
+    strategy: FragmentTokenizationStrategy,
+) -> FileTokens {
+    let kind = fragment_tokenization_kind(source_path, strategy);
+    tokenize_file(kind.path(), fragment, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_strategy_preserves_existing_extension_mapping() {
+        let cases = [
+            ("a.js", FragmentTokenizationKind::JavaScript),
+            ("a.jsx", FragmentTokenizationKind::Jsx),
+            ("a.mjs", FragmentTokenizationKind::Mjs),
+            ("a.cjs", FragmentTokenizationKind::Cjs),
+            ("a.ts", FragmentTokenizationKind::TypeScript),
+            ("a.tsx", FragmentTokenizationKind::Tsx),
+            ("a.mts", FragmentTokenizationKind::Mts),
+            ("a.cts", FragmentTokenizationKind::Cts),
+            ("a.css", FragmentTokenizationKind::Css),
+            ("a.scss", FragmentTokenizationKind::Scss),
+            ("a.sass", FragmentTokenizationKind::Sass),
+            ("a.less", FragmentTokenizationKind::Less),
+            ("a.vue", FragmentTokenizationKind::TypeScript),
+            ("a.svelte", FragmentTokenizationKind::TypeScript),
+            ("a.astro", FragmentTokenizationKind::TypeScript),
+        ];
+
+        for (path, expected) in cases {
+            assert_eq!(
+                fragment_tokenization_kind(
+                    &PathBuf::from(path),
+                    FragmentTokenizationStrategy::Fingerprint
+                ),
+                expected,
+                "unexpected fingerprint mapping for {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn function_strategy_preserves_existing_parser_modes() {
+        let cases = [
+            ("a.js", FragmentTokenizationKind::JavaScript),
+            ("a.mjs", FragmentTokenizationKind::JavaScript),
+            ("a.cjs", FragmentTokenizationKind::JavaScript),
+            ("a.jsx", FragmentTokenizationKind::Jsx),
+            ("a.ts", FragmentTokenizationKind::TypeScript),
+            ("a.mts", FragmentTokenizationKind::TypeScript),
+            ("a.cts", FragmentTokenizationKind::TypeScript),
+            ("a.tsx", FragmentTokenizationKind::Tsx),
+            ("a.vue", FragmentTokenizationKind::Tsx),
+            ("a.svelte", FragmentTokenizationKind::Tsx),
+            ("a.astro", FragmentTokenizationKind::Tsx),
+            ("a.css", FragmentTokenizationKind::Tsx),
+        ];
+
+        for (path, expected) in cases {
+            assert_eq!(
+                fragment_tokenization_kind(
+                    &PathBuf::from(path),
+                    FragmentTokenizationStrategy::Function
+                ),
+                expected,
+                "unexpected function mapping for {path}"
+            );
+        }
+    }
+}

--- a/crates/engine/src/duplication_detector/tokenize/mod.rs
+++ b/crates/engine/src/duplication_detector/tokenize/mod.rs
@@ -5,7 +5,13 @@ use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::{SourceType, Span};
 
+mod fragment;
 mod lexical;
+
+pub(crate) use fragment::{
+    FragmentTokenizationKind, FragmentTokenizationStrategy, fragment_tokenization_kind,
+    tokenize_fragment,
+};
 
 #[cfg(test)]
 pub use super::token_types::KeywordType;

--- a/crates/engine/src/duplication_detector/types.rs
+++ b/crates/engine/src/duplication_detector/types.rs
@@ -2,8 +2,9 @@
 pub use fallow_config::DetectionMode;
 pub use fallow_config::DuplicatesConfig;
 pub use fallow_types::duplicates::{
-    CloneFamily, CloneGroup, CloneInstance, DefaultIgnoreSkipCount, DefaultIgnoreSkips,
-    DuplicationReport, DuplicationStats, MirroredDirectory, RefactoringKind, RefactoringSuggestion,
+    CloneFamily, CloneGroup, CloneGroupKind, CloneInstance, DefaultIgnoreSkipCount,
+    DefaultIgnoreSkips, DuplicationReport, DuplicationStats, MirroredDirectory, RefactoringKind,
+    RefactoringSuggestion,
 };
 
 #[cfg(test)]

--- a/crates/types/src/duplicates.rs
+++ b/crates/types/src/duplicates.rs
@@ -1,7 +1,7 @@
 //! Shared duplicate-code output contracts.
 
 use std::cmp::{Ordering, Reverse};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -44,7 +44,32 @@ pub struct CloneGroup {
     pub similarity: Option<f64>,
 }
 
+/// Whether a clone group is exact or a near-miss match.
+///
+/// This is derived from the serialized clone-group fields and does not add a
+/// separate discriminator to the output contract.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum CloneGroupKind {
+    /// An exact or normalization-equivalent clone group.
+    Exact,
+    /// A near-miss group and its lowest all-pairs similarity.
+    Near {
+        /// Lowest all-pairs similarity for the group.
+        similarity: f64,
+    },
+}
+
 impl CloneGroup {
+    /// Return the semantic kind represented by this clone group.
+    #[must_use]
+    pub fn kind(&self) -> CloneGroupKind {
+        self.similarity
+            .map_or(CloneGroupKind::Exact, |similarity| CloneGroupKind::Near {
+                similarity,
+            })
+    }
+
     /// Maximum directory-tree or same-file line distance between instances.
     #[must_use]
     pub fn spread(&self) -> usize {
@@ -73,13 +98,41 @@ const SPREAD_RANK_WEIGHTS: [u64; MAX_RANKED_SPREAD + 1] = [
 /// 250-line steps. The returned value is not capped; only ranking caps spread.
 #[must_use]
 pub fn clone_group_spread(instances: &[CloneInstance]) -> usize {
-    let mut spread = 0;
-    for (index, left) in instances.iter().enumerate() {
-        for right in &instances[index + 1..] {
-            spread = spread.max(instance_pair_spread(left, right));
-        }
+    if instances.len() < 2 {
+        return 0;
     }
-    spread
+
+    let mut by_file = instances.iter().collect::<Vec<_>>();
+    by_file.sort_unstable_by(|left, right| left.file.cmp(&right.file));
+
+    let mut same_file_max = 0;
+    let mut parent_components = Vec::new();
+    let mut start = 0;
+    while start < by_file.len() {
+        let mut end = start + 1;
+        while end < by_file.len() && by_file[end].file == by_file[start].file {
+            end += 1;
+        }
+
+        parent_components.push(path_parent_components(&by_file[start].file));
+        if end - start >= 2 {
+            let min_end = by_file[start..end]
+                .iter()
+                .map(|instance| instance.end_line)
+                .min()
+                .unwrap_or(0);
+            let max_start = by_file[start..end]
+                .iter()
+                .map(|instance| instance.start_line)
+                .max()
+                .unwrap_or(0);
+            let gap = max_start.saturating_sub(min_end).saturating_sub(1);
+            same_file_max = same_file_max.max(gap.div_ceil(SAME_FILE_SPREAD_STEP));
+        }
+        start = end;
+    }
+
+    same_file_max.max(directory_tree_diameter(&parent_components))
 }
 
 /// Compare clone groups in shared spread-aware priority order.
@@ -88,6 +141,7 @@ pub fn compare_clone_groups(left: &CloneGroup, right: &CloneGroup) -> Ordering {
     clone_group_rank_key(left).cmp(&clone_group_rank_key(right))
 }
 
+#[cfg(test)]
 fn instance_pair_spread(left: &CloneInstance, right: &CloneInstance) -> usize {
     if left.file == right.file {
         return same_file_spread(left, right);
@@ -95,6 +149,7 @@ fn instance_pair_spread(left: &CloneInstance, right: &CloneInstance) -> usize {
     directory_distance(&left.file, &right.file)
 }
 
+#[cfg(test)]
 fn same_file_spread(left: &CloneInstance, right: &CloneInstance) -> usize {
     let gap = if left.end_line < right.start_line {
         right
@@ -111,26 +166,48 @@ fn same_file_spread(left: &CloneInstance, right: &CloneInstance) -> usize {
     gap.div_ceil(SAME_FILE_SPREAD_STEP)
 }
 
-fn directory_distance(left: &Path, right: &Path) -> usize {
-    let left_components: Vec<_> = left
-        .parent()
+fn path_parent_components(path: &Path) -> Vec<Component<'_>> {
+    path.parent()
         .unwrap_or_else(|| Path::new(""))
         .components()
-        .collect();
-    let right_components: Vec<_> = right
-        .parent()
-        .unwrap_or_else(|| Path::new(""))
-        .components()
-        .collect();
-    let shared = left_components
+        .collect()
+}
+
+fn directory_tree_diameter(paths: &[Vec<Component<'_>>]) -> usize {
+    if paths.len() < 2 {
+        return 0;
+    }
+
+    let endpoint = farthest_path(paths, 0).0;
+    farthest_path(paths, endpoint).1
+}
+
+fn farthest_path(paths: &[Vec<Component<'_>>], origin: usize) -> (usize, usize) {
+    paths
         .iter()
-        .zip(&right_components)
+        .enumerate()
+        .map(|(index, path)| (index, component_distance(&paths[origin], path)))
+        .max_by_key(|&(index, distance)| (distance, index))
+        .unwrap_or((origin, 0))
+}
+
+fn component_distance(left: &[Component<'_>], right: &[Component<'_>]) -> usize {
+    let shared = left
+        .iter()
+        .zip(right)
         .take_while(|(left, right)| left == right)
         .count();
-    left_components
-        .len()
+    left.len()
         .saturating_sub(shared)
-        .saturating_add(right_components.len().saturating_sub(shared))
+        .saturating_add(right.len().saturating_sub(shared))
+}
+
+#[cfg(test)]
+fn directory_distance(left: &Path, right: &Path) -> usize {
+    component_distance(
+        &path_parent_components(left),
+        &path_parent_components(right),
+    )
 }
 
 type CloneGroupRankKey = (
@@ -340,6 +417,17 @@ const fn is_zero_usize(value: &usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    fn pairwise_clone_group_spread(instances: &[CloneInstance]) -> usize {
+        let mut spread = 0;
+        for (index, left) in instances.iter().enumerate() {
+            for right in &instances[index + 1..] {
+                spread = spread.max(instance_pair_spread(left, right));
+            }
+        }
+        spread
+    }
 
     fn instance(file: &str, start_line: usize, end_line: usize) -> CloneInstance {
         CloneInstance {
@@ -428,6 +516,74 @@ mod tests {
             20,
         );
         assert_eq!(clone.spread(), 0);
+    }
+
+    #[test]
+    fn directory_diameter_handles_ties_and_mixed_roots() {
+        let instances = vec![
+            instance("src/a.ts", 1, 10),
+            instance("packages/a/b.ts", 1, 10),
+            instance("packages/c/d.ts", 1, 10),
+            instance("/repo/src/e.ts", 1, 10),
+        ];
+
+        assert_eq!(
+            clone_group_spread(&instances),
+            pairwise_clone_group_spread(&instances)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn directory_diameter_handles_windows_prefixes() {
+        let instances = vec![
+            instance(r"C:\repo\src\a.ts", 1, 10),
+            instance(r"C:\repo\packages\b.ts", 1, 10),
+            instance(r"D:\other\c.ts", 1, 10),
+        ];
+
+        assert_eq!(
+            clone_group_spread(&instances),
+            pairwise_clone_group_spread(&instances)
+        );
+    }
+
+    #[test]
+    fn clone_group_kind_does_not_change_serialized_contract() {
+        let mut clone = group(vec![instance("src/a.ts", 1, 10)], 20, 10);
+        assert_eq!(clone.kind(), CloneGroupKind::Exact);
+        assert!(serde_json::to_value(&clone).unwrap()["similarity"].is_null());
+
+        clone.similarity = Some(0.85);
+        assert_eq!(clone.kind(), CloneGroupKind::Near { similarity: 0.85 });
+        assert_eq!(serde_json::to_value(&clone).unwrap()["similarity"], 0.85);
+    }
+
+    proptest! {
+        #[test]
+        fn optimized_spread_matches_pairwise_reference(
+            entries in prop::collection::vec((0_u8..8, 1_usize..4_000, 1_usize..500), 0..80)
+        ) {
+            let paths = [
+                "src/a.ts",
+                "src/b.ts",
+                "packages/a/src/c.ts",
+                "packages/b/src/d.ts",
+                "packages/b/test/e.ts",
+                "/repo/apps/web/f.ts",
+                "/repo/crates/core/g.ts",
+                "h.ts",
+            ];
+            let instances = entries
+                .into_iter()
+                .map(|(path, start, len)| instance(paths[usize::from(path)], start, start + len))
+                .collect::<Vec<_>>();
+
+            prop_assert_eq!(
+                clone_group_spread(&instances),
+                pairwise_clone_group_spread(&instances)
+            );
+        }
     }
 
     #[test]

--- a/crates/types/src/duplicates.rs
+++ b/crates/types/src/duplicates.rs
@@ -559,30 +559,34 @@ mod tests {
         assert_eq!(serde_json::to_value(&clone).unwrap()["similarity"], 0.85);
     }
 
-    proptest! {
-        #[test]
-        fn optimized_spread_matches_pairwise_reference(
-            entries in prop::collection::vec((0_u8..8, 1_usize..4_000, 1_usize..500), 0..80)
-        ) {
-            let paths = [
-                "src/a.ts",
-                "src/b.ts",
-                "packages/a/src/c.ts",
-                "packages/b/src/d.ts",
-                "packages/b/test/e.ts",
-                "/repo/apps/web/f.ts",
-                "/repo/crates/core/g.ts",
-                "h.ts",
-            ];
-            let instances = entries
-                .into_iter()
-                .map(|(path, start, len)| instance(paths[usize::from(path)], start, start + len))
-                .collect::<Vec<_>>();
+    mod proptests {
+        use super::*;
 
-            prop_assert_eq!(
-                clone_group_spread(&instances),
-                pairwise_clone_group_spread(&instances)
-            );
+        proptest! {
+            #[test]
+            fn optimized_spread_matches_pairwise_reference(
+                entries in prop::collection::vec((0_u8..8, 1_usize..4_000, 1_usize..500), 0..80)
+            ) {
+                let paths = [
+                    "src/a.ts",
+                    "src/b.ts",
+                    "packages/a/src/c.ts",
+                    "packages/b/src/d.ts",
+                    "packages/b/test/e.ts",
+                    "/repo/apps/web/f.ts",
+                    "/repo/crates/core/g.ts",
+                    "h.ts",
+                ];
+                let instances = entries
+                    .into_iter()
+                    .map(|(path, start, len)| instance(paths[usize::from(path)], start, start + len))
+                    .collect::<Vec<_>>();
+
+                prop_assert_eq!(
+                    clone_group_spread(&instances),
+                    pairwise_clone_group_spread(&instances)
+                );
+            }
         }
     }
 

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -74,6 +74,15 @@ error by suppressing a downstream detector.
   function-like spans with semantic shingles while retaining exact results from
   the configured mode. Candidate generation is deterministically bounded and
   reports skipped comparisons instead of hiding incomplete work.
+- Near groups carry a required similarity inside the engine and convert to the
+  shared output type only at the detector boundary. `CloneGroup::kind()` is the
+  canonical way to distinguish exact and near groups after that conversion.
+- Extracted-fragment language selection is centralized in the duplication
+  tokenizer. Fingerprints preserve extension-specific tokenization, while
+  function fragments use the closest JavaScript parser mode for their source.
+- Clone-group spread is the exact maximum of same-file interval distance and
+  lexical parent-directory tree distance. Its implementation must remain
+  equivalent to the pairwise definition without doing pairwise path work.
 - Clone fingerprints are based on normalized token sequences, not raw source
   text. Formatting, comments, and line endings therefore preserve identity.
   Reviewed clone keys append the surviving instance count so token changes and


### PR DESCRIPTION
Makes the duplication internals scale cleanly while preserving the existing output contract.

- replaces pairwise spread calculation with exact interval extrema and lexical tree diameter
- introduces an internal near-clone group with required similarity
- adds `CloneGroup::kind()` without changing serialized JSON or generated contracts
- centralizes fingerprint and function-fragment language selection
- adds pairwise parity properties, extension-mapping coverage, and a high-occurrence benchmark

Validation:
- exact and near JSON parity on a focused fixture and the public Fallow repository
- high-occurrence spread benchmark improved from about 817 ms to 1.36 ms
- `npm run verify:fast`
- `npm run verify:full`

Closes the architecture follow-ups from #2155.