### PR TITLE
fix: repair dangling anchors in the CLI reference

### DIFF
--- a/.agents/skills/fallow/references/cli-reference.md
+++ b/.agents/skills/fallow/references/cli-reference.md
@@ -12,7 +12,7 @@ Complete command and flag specifications for all fallow CLI commands.
 - [`list`: Project Introspection](#list-project-introspection)
 - [`init`: Config Generation](#init-config-generation)
 - [`migrate`: Config Migration](#migrate-config-migration)
-- [`health`: Function Complexity Analysis](#health-function-complexity-analysis)
+- [`health`: Function Complexity and File Health Analysis](#health-function-complexity-and-file-health-analysis)
 - [`audit`: Changed-File Quality Gate](#audit-changed-file-quality-gate)
 - [`flags`: Feature Flag Detection](#flags-feature-flag-detection)
 - [`explain`: Rule Explanation](#explain-rule-explanation)
@@ -62,7 +62,7 @@ Analyzes the project for unused files, exports, dependencies, types, members, an
 | `--unused-files` | Unused files |
 | `--unused-exports` | Unused exports |
 | `--unused-types` | Unused types |
-| `--private-type-leaks` | Opt-in API hygiene check (default `off`) for exported signatures that reference same-file private types. Storybook `*.stories.*` story files and framework routing convention files (Next.js App + Pages Router, Gatsby, Remix v2, TanStack Router, Expo Router) are skipped to avoid noise. Enable via this flag or `private-type-leaks: "warn"` / `"error"` in [`rules`](#rules-configuration). |
+| `--private-type-leaks` | Opt-in API hygiene check (default `off`) for exported signatures that reference same-file private types. Storybook `*.stories.*` story files and framework routing convention files (Next.js App + Pages Router, Gatsby, Remix v2, TanStack Router, Expo Router) are skipped to avoid noise. Enable via this flag or `private-type-leaks: "warn"` / `"error"` in [`rules`](#configuration-file-format). |
 | `--unused-deps` | Unused dependencies, devDependencies, optionalDependencies, type-only production deps, and test-only production deps |
 | `--unused-enum-members` | Unused enum members |
 | `--unused-class-members` | Unused class members |
@@ -351,7 +351,7 @@ fallow migrate --from knip.jsonc
 
 ---
 
-## `health`: Function Complexity & File Health Analysis
+## `health`: Function Complexity and File Health Analysis
 
 Analyzes function complexity across the project using cyclomatic and cognitive complexity metrics. By default all sections are included (health score, complexity findings, file scores, hotspots, and refactoring targets). Use `--complexity`, `--file-scores`, `--hotspots`, `--targets`, or `--score` to show only specific sections.
 

--- a/.claude/skills/fallow/references/cli-reference.md
+++ b/.claude/skills/fallow/references/cli-reference.md
@@ -12,7 +12,7 @@ Complete command and flag specifications for all fallow CLI commands.
 - [`list`: Project Introspection](#list-project-introspection)
 - [`init`: Config Generation](#init-config-generation)
 - [`migrate`: Config Migration](#migrate-config-migration)
-- [`health`: Function Complexity Analysis](#health-function-complexity-analysis)
+- [`health`: Function Complexity and File Health Analysis](#health-function-complexity-and-file-health-analysis)
 - [`audit`: Changed-File Quality Gate](#audit-changed-file-quality-gate)
 - [`flags`: Feature Flag Detection](#flags-feature-flag-detection)
 - [`explain`: Rule Explanation](#explain-rule-explanation)
@@ -62,7 +62,7 @@ Analyzes the project for unused files, exports, dependencies, types, members, an
 | `--unused-files` | Unused files |
 | `--unused-exports` | Unused exports |
 | `--unused-types` | Unused types |
-| `--private-type-leaks` | Opt-in API hygiene check (default `off`) for exported signatures that reference same-file private types. Storybook `*.stories.*` story files and framework routing convention files (Next.js App + Pages Router, Gatsby, Remix v2, TanStack Router, Expo Router) are skipped to avoid noise. Enable via this flag or `private-type-leaks: "warn"` / `"error"` in [`rules`](#rules-configuration). |
+| `--private-type-leaks` | Opt-in API hygiene check (default `off`) for exported signatures that reference same-file private types. Storybook `*.stories.*` story files and framework routing convention files (Next.js App + Pages Router, Gatsby, Remix v2, TanStack Router, Expo Router) are skipped to avoid noise. Enable via this flag or `private-type-leaks: "warn"` / `"error"` in [`rules`](#configuration-file-format). |
 | `--unused-deps` | Unused dependencies, devDependencies, optionalDependencies, type-only production deps, and test-only production deps |
 | `--unused-enum-members` | Unused enum members |
 | `--unused-class-members` | Unused class members |
@@ -351,7 +351,7 @@ fallow migrate --from knip.jsonc
 
 ---
 
-## `health`: Function Complexity & File Health Analysis
+## `health`: Function Complexity and File Health Analysis
 
 Analyzes function complexity across the project using cyclomatic and cognitive complexity metrics. By default all sections are included (health score, complexity findings, file scores, hotspots, and refactoring targets). Use `--complexity`, `--file-scores`, `--hotspots`, `--targets`, or `--score` to show only specific sections.
 

--- a/npm/fallow/skills/fallow/references/cli-reference.md
+++ b/npm/fallow/skills/fallow/references/cli-reference.md
@@ -12,7 +12,7 @@ Complete command and flag specifications for all fallow CLI commands.
 - [`list`: Project Introspection](#list-project-introspection)
 - [`init`: Config Generation](#init-config-generation)
 - [`migrate`: Config Migration](#migrate-config-migration)
-- [`health`: Function Complexity Analysis](#health-function-complexity-analysis)
+- [`health`: Function Complexity and File Health Analysis](#health-function-complexity-and-file-health-analysis)
 - [`audit`: Changed-File Quality Gate](#audit-changed-file-quality-gate)
 - [`flags`: Feature Flag Detection](#flags-feature-flag-detection)
 - [`security`: Security Candidate Detection](#security-security-candidate-detection)
@@ -20,7 +20,7 @@ Complete command and flag specifications for all fallow CLI commands.
 - [`trace`: Symbol Call Chains](#trace-symbol-call-chains)
 - [`decision-surface`: Structural Decisions](#decision-surface-structural-decisions)
 - [`explain`: Rule Explanation](#explain-rule-explanation)
-- [`schema`: CLI Introspection](#schema-cli-introspection)
+- [`schema`: Capability Manifest](#schema-capability-manifest)
 - [`config-schema`: Config JSON Schema](#config-schema-config-json-schema)
 - [`plugin-schema`: Plugin JSON Schema](#plugin-schema-plugin-json-schema)
 - [`plugin-check`: Verify external plugins](#plugin-check-verify-external-plugins)
@@ -65,7 +65,7 @@ Common global flags for this command: [`--format`](#global-flags), [`--quiet`](#
 | `--unused-exports` | Unused exports |
 | `--unused-deps` | Unused dependencies, devDependencies, optionalDependencies, type-only production deps, and test-only production deps |
 | `--unused-types` | Unused types |
-| `--private-type-leaks` | Opt-in API hygiene check (default `off`) for exported signatures that reference same-file private types. Storybook `*.stories.*` story files and framework routing convention files (Next.js App + Pages Router, Gatsby, Remix v2, TanStack Router, Expo Router) are skipped to avoid noise. Enable via this flag or `private-type-leaks: "warn"` / `"error"` in [`rules`](#rules-configuration). |
+| `--private-type-leaks` | Opt-in API hygiene check (default `off`) for exported signatures that reference same-file private types. Storybook `*.stories.*` story files and framework routing convention files (Next.js App + Pages Router, Gatsby, Remix v2, TanStack Router, Expo Router) are skipped to avoid noise. Enable via this flag or `private-type-leaks: "warn"` / `"error"` in [`rules`](#configuration-file-format). |
 | `--unused-enum-members` | Unused enum members |
 | `--unused-class-members` | Unused class members |
 | `--unused-store-members` | Unused Pinia store members |
@@ -382,7 +382,7 @@ fallow migrate --from knip.jsonc
 
 ---
 
-## `health`: Function Complexity & File Health Analysis
+## `health`: Function Complexity and File Health Analysis
 
 Analyzes function complexity across the project using cyclomatic and cognitive complexity metrics. By default all sections are included (health score, complexity findings, file scores, hotspots, and refactoring targets). Use `--complexity`, `--file-scores`, `--hotspots`, `--targets`, or `--score` to show only specific sections.
 

--- a/scripts/agent-doc-anchors.test.mjs
+++ b/scripts/agent-doc-anchors.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Skill trees whose markdown ships to agents and to external linters. */
+const SKILL_ROOTS = [".agents/skills", ".claude/skills", "npm/fallow/skills"];
+
+const INLINE_LINK = /\[[^\]]*\]\((#[^)\s]+)\)/gu;
+const HEADING = /^#{1,6}\s+(.*)$/u;
+
+/** GitHub's heading slug: drop inline code fences and other punctuation, keep
+ * word characters and hyphens, then join the remaining words with hyphens.
+ * Markdown linters that flag MD051 resolve anchors the same way. */
+const slugFor = (heading) =>
+  heading
+    .replaceAll("`", "")
+    .toLowerCase()
+    .replaceAll(/[^\w\s-]/gu, "")
+    .trim()
+    .replaceAll(/\s/gu, "-");
+
+const markdownFilesUnder = (root) => {
+  const absolute = join(REPOSITORY_ROOT, root);
+  let entries;
+  try {
+    entries = readdirSync(absolute, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries.flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return markdownFilesUnder(path);
+    return entry.isFile() && entry.name.endsWith(".md") ? [path] : [];
+  });
+};
+
+const brokenAnchorsIn = (path) => {
+  const text = readFileSync(join(REPOSITORY_ROOT, path), "utf8");
+  const lines = text.split("\n");
+
+  const slugs = new Set();
+  for (const line of lines) {
+    const heading = HEADING.exec(line);
+    if (heading) slugs.add(slugFor(heading[1].trim()));
+  }
+
+  const broken = [];
+  for (const [index, line] of lines.entries()) {
+    for (const [, anchor] of line.matchAll(INLINE_LINK)) {
+      const slug = anchor.slice(1);
+      if (!slugs.has(slug)) broken.push(`${path}:${index + 1}: ${anchor}`);
+    }
+  }
+  return broken;
+};
+
+test("skill markdown carries no dangling in-document anchors", () => {
+  const files = SKILL_ROOTS.flatMap(markdownFilesUnder);
+  assert.ok(files.length > 0, "expected to find skill markdown to check");
+
+  const broken = files.flatMap(brokenAnchorsIn);
+  assert.deepEqual(
+    broken,
+    [],
+    `these links point at headings that do not exist:\n  ${broken.join("\n  ")}`,
+  );
+});
+
+test("slugFor matches the anchors GitHub generates", () => {
+  assert.equal(slugFor("`schema`: Capability Manifest"), "schema-capability-manifest");
+  assert.equal(slugFor("Global Flags"), "global-flags");
+  // An ampersand is dropped rather than replaced, which silently doubles the
+  // hyphen; headings should spell "and" instead.
+  assert.equal(slugFor("Complexity & Health"), "complexity--health");
+});


### PR DESCRIPTION
Three links in the CLI reference pointed at headings that no longer exist, so markdown linters flag them and readers of the skill land nowhere:

| Link | Heading it should reach |
|:-----|:------------------------|
| `#health-function-complexity-analysis` | `health`: Function Complexity and File Health Analysis |
| `#schema-cli-introspection` | `schema`: Capability Manifest |
| `#rules-configuration` | Configuration File Format |

The headings were renamed over time while the hand-written table of contents and one cross-reference in a flag description stayed behind.

The health heading spelled its conjunction as `&`. Slug generation drops the character rather than replacing it, which yields `#health-function-complexity--file-health-analysis` with a doubled hyphen: correct, but it reads as a typo and invites the next editor to "fix" it back into a broken link. It now spells the word out.

`scripts/agent-doc-anchors.test.mjs` walks every markdown file under the three skill trees and fails on any in-document link whose target heading is absent. Reintroducing any of the three anchors makes it fail, which is how the fix was checked.

Reported in fallow-rs/fallow-skills#6.

## Follow-up after merge

`fallow-skills` carries a copy of this tree verified against a pinned fallow commit, so its content and `source-lock.json` need the same update once this lands.