### PR TITLE
fix(health): handle inline Svelte await states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Svelte await-block complexity labels now match the source.** `{#await}`
   and `{:then}` contributions previously appeared as `if` in health JSON and
   the VS Code inline breakdown. They now use the explicit `await` and `then`
-  kinds, while `{:catch}` remains `catch` and metric totals are unchanged.
-  The standalone health schema is now version 8. Combined and audit output are
-  version 9 because they embed health; dead-code and unrelated output formats
-  keep their existing versions. JSON consumers must handle the two new values.
+  kinds, while `{:catch}` remains `catch`. Inline continuations such as
+  `{#await load() then value}` and `{#await load() catch error}` now count and
+  label both the await frame and its continuation, including when both labels
+  share one VS Code decoration and hover; explicit continuation totals are
+  unchanged. Standalone Svelte, Vue, and Astro template findings now also emit
+  a valid file-level HTML suppression instead of an Angular decorator hint.
+  Regex literals inside template expressions no longer hide the selected await
+  state or logical operators that follow the regex.
+  Standalone health, combined, and audit output are version 9; dead-code and
+  unrelated output formats keep their existing versions. JSON consumers must
+  handle the two new values.
 - **Complexity findings in framework templates now show which conditions
   caused them.** A `<template>` finding in Vue, Angular, Svelte, or Astro
   reported a cyclomatic and cognitive number with nothing behind it, so the

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -756,6 +756,102 @@ fn health_svelte_await_breakdown_uses_source_kinds() {
 }
 
 #[test]
+fn health_svelte_await_then_shorthand_counts_both_states() {
+    let dir = tempdir().expect("create temp dir");
+    write_file(
+        &dir.path().join("package.json"),
+        r#"{"name":"svelte-await-shorthand-complexity","dependencies":{"svelte":"latest"}}"#,
+    );
+    write_file(
+        &dir.path().join("src/App.svelte"),
+        "{#await load() then value}\n<p>{value}</p>\n{/await}\n",
+    );
+
+    let output = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &[
+            "--complexity",
+            "--complexity-breakdown",
+            "--max-cyclomatic",
+            "1",
+            "--max-cognitive",
+            "1",
+            "--report-only",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr);
+
+    let json = parse_json(&output);
+    let template = json["findings"]
+        .as_array()
+        .and_then(|findings| {
+            findings
+                .iter()
+                .find(|finding| finding["name"] == "<template>")
+        })
+        .expect("Svelte template complexity finding");
+    let kinds: Vec<&str> = template["contributions"]
+        .as_array()
+        .expect("complexity contributions")
+        .iter()
+        .filter_map(|contribution| contribution["kind"].as_str())
+        .collect();
+
+    assert_eq!(kinds, vec!["await", "await", "then", "then"]);
+    assert_eq!(template["cyclomatic"], 3);
+    assert_eq!(template["cognitive"], 2);
+
+    let suppress = template["actions"]
+        .as_array()
+        .and_then(|actions| {
+            actions
+                .iter()
+                .find(|action| action["type"] == "suppress-file")
+        })
+        .expect("standalone Svelte template suppress action");
+    assert_eq!(
+        suppress["comment"],
+        "<!-- fallow-ignore-file complexity -->"
+    );
+    assert_eq!(suppress["placement"], "top-of-template");
+
+    write_file(
+        &dir.path().join("src/App.svelte"),
+        "<!-- fallow-ignore-file complexity -->\n{#await load() then value}\n<p>{value}</p>\n{/await}\n",
+    );
+    let suppressed = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &[
+            "--complexity",
+            "--max-cyclomatic",
+            "1",
+            "--max-cognitive",
+            "1",
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+        ],
+    );
+    assert_eq!(suppressed.code, 0, "stderr: {}", suppressed.stderr);
+    let suppressed_json = parse_json(&suppressed);
+    assert!(
+        suppressed_json["findings"]
+            .as_array()
+            .is_none_or(|findings| findings
+                .iter()
+                .all(|finding| finding["name"] != "<template>")),
+        "suppressed Svelte template should not emit a finding: {suppressed_json:#?}"
+    );
+}
+
+#[test]
 fn health_reports_angular_template_complexity() {
     let output = run_fallow(
         "health",

--- a/crates/cli/tests/snapshots/snapshot_tests__json_health_with_coverage_gaps.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_health_with_coverage_gaps.snap
@@ -4,7 +4,7 @@ expression: redact_version(&json_str)
 ---
 {
   "kind": "health",
-  "schema_version": 8,
+  "schema_version": 9,
   "version": "[VERSION]",
   "elapsed_ms": 0,
   "findings": [

--- a/crates/cli/tests/snapshots/snapshot_tests__json_health_with_coverage_intelligence.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_health_with_coverage_intelligence.snap
@@ -4,7 +4,7 @@ expression: redact_version(&json_str)
 ---
 {
   "kind": "health",
-  "schema_version": 8,
+  "schema_version": 9,
   "version": "[VERSION]",
   "elapsed_ms": 0,
   "findings": [

--- a/crates/cli/tests/snapshots/snapshot_tests__json_health_with_runtime_coverage.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_health_with_runtime_coverage.snap
@@ -4,7 +4,7 @@ expression: redact_version(&json_str)
 ---
 {
   "kind": "health",
-  "schema_version": 8,
+  "schema_version": 9,
   "version": "[VERSION]",
   "elapsed_ms": 0,
   "findings": [

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -870,7 +870,12 @@ use crate::MemberKind;
 /// Bumped to 254 for issue #2158: Svelte `{#await}` and `{:then}` complexity
 /// contributions now retain their source constructs instead of being cached as
 /// `If`.
-pub(super) const CACHE_VERSION: u32 = 254;
+///
+/// Bumped to 255 for issue #2158 follow-up: inline Svelte await continuations
+/// (`{#await promise then value}` / `{#await promise catch error}`) now retain
+/// their continuation contribution instead of being cached with only `Await`,
+/// and template-expression regex literals no longer hide later contributions.
+pub(super) const CACHE_VERSION: u32 = 255;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/template_complexity/engine.rs
+++ b/crates/extract/src/template_complexity/engine.rs
@@ -17,6 +17,81 @@ use fallow_types::extract::{ComplexityContributionKind, ComplexityMetric};
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ScanError;
 
+/// Minimal lexical state needed to distinguish a JavaScript regex literal
+/// from division. Reserved words only open an operand position when they are
+/// actual keywords, not property names such as `value.of`.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RegexContext {
+    can_start: bool,
+    after_property_access: bool,
+}
+
+impl RegexContext {
+    pub(super) const fn expression_start() -> Self {
+        Self {
+            can_start: true,
+            after_property_access: false,
+        }
+    }
+
+    pub(super) const fn can_start(self) -> bool {
+        self.can_start
+    }
+
+    pub(super) fn after_value(&mut self) {
+        self.can_start = false;
+        self.after_property_access = false;
+    }
+
+    pub(super) fn after_operator(&mut self) {
+        self.can_start = true;
+        self.after_property_access = false;
+    }
+
+    pub(super) fn after_property_access(&mut self) {
+        self.can_start = false;
+        self.after_property_access = true;
+    }
+
+    pub(super) fn after_identifier(&mut self, identifier: &str) {
+        self.can_start = !self.after_property_access && is_regex_prefix_keyword(identifier);
+        self.after_property_access = false;
+    }
+
+    pub(super) fn after_character(&mut self, character: char) {
+        if character.is_alphanumeric() {
+            self.after_value();
+        } else {
+            self.after_operator();
+        }
+    }
+
+    fn skip_markup(&mut self, slash: usize) -> usize {
+        self.after_operator();
+        slash + 1
+    }
+}
+
+fn is_regex_prefix_keyword(identifier: &str) -> bool {
+    matches!(
+        identifier,
+        "await"
+            | "case"
+            | "delete"
+            | "do"
+            | "else"
+            | "extends"
+            | "in"
+            | "instanceof"
+            | "new"
+            | "return"
+            | "throw"
+            | "typeof"
+            | "void"
+            | "yield"
+    )
+}
+
 /// Accumulator state captured before a fallible expression scan, so a scan that
 /// fails partway can be undone.
 #[derive(Debug, Clone, Copy)]
@@ -262,6 +337,17 @@ impl TemplateComplexity {
 struct ScanState {
     last_logical_operator: Option<LogicalOperator>,
     needs_rhs: bool,
+    regex: RegexContext,
+}
+
+impl ScanState {
+    fn new() -> Self {
+        Self {
+            last_logical_operator: None,
+            needs_rhs: false,
+            regex: RegexContext::expression_start(),
+        }
+    }
 }
 
 /// The expression slice currently being scanned, with everything needed to
@@ -279,10 +365,7 @@ struct ExprScope<'a> {
 impl TemplateComplexity {
     fn scan_expression_without_ternary(&mut self, scope: ExprScope<'_>) -> Result<(), ScanError> {
         let ExprScope { source, base, .. } = scope;
-        let mut state = ScanState {
-            last_logical_operator: None,
-            needs_rhs: false,
-        };
+        let mut state = ScanState::new();
         let mut offset = 0;
 
         while offset < source.len() {
@@ -291,6 +374,23 @@ impl TemplateComplexity {
                 b'\'' | b'"' | b'`' => {
                     offset = skip_quoted(source, offset)?;
                     state.needs_rhs = false;
+                    state.regex.after_value();
+                }
+                b'/' if is_tag_close(source, offset) => offset = state.regex.skip_markup(offset),
+                b'/' if source.as_bytes().get(offset + 1) == Some(&b'/') => {
+                    offset = skip_line_comment(source, offset);
+                }
+                b'/' if source.as_bytes().get(offset + 1) == Some(&b'*') => {
+                    offset = skip_block_comment(source, offset)?;
+                }
+                b'/' if state.regex.can_start() => {
+                    offset = skip_regex_literal(source, offset)?;
+                    state.needs_rhs = false;
+                    state.regex.after_value();
+                }
+                b'/' => {
+                    offset += usize::from(source.as_bytes().get(offset + 1) == Some(&b'=')) + 1;
+                    state.regex.after_operator();
                 }
                 b'(' | b'[' | b'{' => {
                     offset = self.scan_bracket_group(scope, offset, &mut state)?;
@@ -299,6 +399,7 @@ impl TemplateComplexity {
                 _ if source[offset..].starts_with("?.") => {
                     self.inc_cyclomatic(base + offset, ComplexityContributionKind::OptionalChain);
                     offset += 2;
+                    state.regex.after_property_access();
                 }
                 _ if source[offset..].starts_with("&&=")
                     || source[offset..].starts_with("||=")
@@ -310,6 +411,7 @@ impl TemplateComplexity {
                     );
                     state.last_logical_operator = None;
                     state.needs_rhs = true;
+                    state.regex.after_operator();
                     offset += 3;
                 }
                 _ if source[offset..].starts_with("&&")
@@ -323,11 +425,38 @@ impl TemplateComplexity {
                         return Err(ScanError);
                     }
                     state.last_logical_operator = None;
+                    state.regex.after_operator();
                     offset += 1;
+                }
+                byte if is_identifier_start(byte) => {
+                    let (identifier, end) = read_identifier(source, offset).ok_or(ScanError)?;
+                    state.needs_rhs = false;
+                    state.regex.after_identifier(identifier);
+                    offset = end;
+                }
+                byte if byte.is_ascii_digit() => {
+                    offset = skip_number_literal(source, offset);
+                    state.needs_rhs = false;
+                    state.regex.after_value();
+                }
+                b'.' if source[offset..].starts_with("...") => {
+                    offset += 3;
+                    state.regex.after_operator();
+                }
+                b'.' => {
+                    offset += 1;
+                    state.regex.after_property_access();
+                }
+                b'+' | b'-'
+                    if source.as_bytes().get(offset + 1) == Some(&source.as_bytes()[offset]) =>
+                {
+                    offset += 2;
                 }
                 _ => {
                     state.needs_rhs = false;
-                    offset += source[offset..].chars().next().map_or(1, char::len_utf8);
+                    let character = source[offset..].chars().next().ok_or(ScanError)?;
+                    offset += character.len_utf8();
+                    state.regex.after_character(character);
                 }
             }
         }
@@ -363,6 +492,7 @@ impl TemplateComplexity {
         )?;
         state.last_logical_operator = None;
         state.needs_rhs = false;
+        state.regex.after_value();
         Ok(end + 1)
     }
 
@@ -399,6 +529,7 @@ impl TemplateComplexity {
             state.last_logical_operator = Some(operator);
         }
         state.needs_rhs = true;
+        state.regex.after_operator();
         Ok(offset + 2)
     }
 }
@@ -408,13 +539,34 @@ fn find_top_level_ternary(source: &str) -> Result<Option<(usize, usize)>, ScanEr
     let mut depth = 0_u16;
     let mut nested_ternaries = 0_u16;
     let mut question = None;
+    let mut regex = RegexContext::expression_start();
 
     while offset < source.len() {
         match source.as_bytes()[offset] {
-            b'\'' | b'"' | b'`' => offset = skip_quoted(source, offset)?,
+            byte if byte.is_ascii_whitespace() => offset += 1,
+            b'\'' | b'"' | b'`' => {
+                offset = skip_quoted(source, offset)?;
+                regex.after_value();
+            }
+            b'/' if is_tag_close(source, offset) => offset = regex.skip_markup(offset),
+            b'/' if source.as_bytes().get(offset + 1) == Some(&b'/') => {
+                offset = skip_line_comment(source, offset);
+            }
+            b'/' if source.as_bytes().get(offset + 1) == Some(&b'*') => {
+                offset = skip_block_comment(source, offset)?;
+            }
+            b'/' if regex.can_start() => {
+                offset = skip_regex_literal(source, offset)?;
+                regex.after_value();
+            }
+            b'/' => {
+                offset += usize::from(source.as_bytes().get(offset + 1) == Some(&b'=')) + 1;
+                regex.after_operator();
+            }
             b'(' | b'[' | b'{' => {
                 depth = depth.saturating_add(1);
                 offset += 1;
+                regex.after_operator();
             }
             b')' | b']' | b'}' => {
                 if depth == 0 {
@@ -422,9 +574,15 @@ fn find_top_level_ternary(source: &str) -> Result<Option<(usize, usize)>, ScanEr
                 }
                 depth -= 1;
                 offset += 1;
+                regex.after_value();
             }
-            b'?' if source[offset..].starts_with("??") || source[offset..].starts_with("?.") => {
+            b'?' if source[offset..].starts_with("?.") => {
                 offset += 2;
+                regex.after_property_access();
+            }
+            b'?' if source[offset..].starts_with("??") => {
+                offset += 2;
+                regex.after_operator();
             }
             b'?' if depth == 0 => {
                 if question.is_none() {
@@ -433,18 +591,44 @@ fn find_top_level_ternary(source: &str) -> Result<Option<(usize, usize)>, ScanEr
                     nested_ternaries = nested_ternaries.saturating_add(1);
                 }
                 offset += 1;
+                regex.after_operator();
             }
             b':' if depth == 0 && question.is_some() => {
                 if nested_ternaries == 0 {
-                    if let Some(question) = question {
-                        return Ok(Some((question, offset)));
-                    }
-                    return Err(ScanError);
+                    let question = question.ok_or(ScanError)?;
+                    return Ok(Some((question, offset)));
                 }
                 nested_ternaries -= 1;
                 offset += 1;
+                regex.after_operator();
             }
-            _ => offset += source[offset..].chars().next().map_or(1, char::len_utf8),
+            byte if is_identifier_start(byte) => {
+                let (identifier, end) = read_identifier(source, offset).ok_or(ScanError)?;
+                regex.after_identifier(identifier);
+                offset = end;
+            }
+            byte if byte.is_ascii_digit() => {
+                offset = skip_number_literal(source, offset);
+                regex.after_value();
+            }
+            b'.' if source[offset..].starts_with("...") => {
+                offset += 3;
+                regex.after_operator();
+            }
+            b'.' => {
+                offset += 1;
+                regex.after_property_access();
+            }
+            b'+' | b'-'
+                if source.as_bytes().get(offset + 1) == Some(&source.as_bytes()[offset]) =>
+            {
+                offset += 2;
+            }
+            _ => {
+                let character = source[offset..].chars().next().ok_or(ScanError)?;
+                offset += character.len_utf8();
+                regex.after_character(character);
+            }
         }
     }
 
@@ -463,12 +647,33 @@ pub(super) fn find_matching_delimiter(
 ) -> Result<usize, ScanError> {
     let mut offset = open_offset + 1;
     let mut depth = 1_u16;
+    let mut regex = RegexContext::expression_start();
     while offset < source.len() {
         match source.as_bytes()[offset] {
-            b'\'' | b'"' | b'`' => offset = skip_quoted(source, offset)?,
+            byte if byte.is_ascii_whitespace() => offset += 1,
+            b'\'' | b'"' | b'`' => {
+                offset = skip_quoted(source, offset)?;
+                regex.after_value();
+            }
+            b'/' if is_tag_close(source, offset) => offset = regex.skip_markup(offset),
+            b'/' if source.as_bytes().get(offset + 1) == Some(&b'/') => {
+                offset = skip_line_comment(source, offset);
+            }
+            b'/' if source.as_bytes().get(offset + 1) == Some(&b'*') => {
+                offset = skip_block_comment(source, offset)?;
+            }
+            b'/' if regex.can_start() => {
+                offset = skip_regex_literal(source, offset)?;
+                regex.after_value();
+            }
+            b'/' => {
+                offset += usize::from(source.as_bytes().get(offset + 1) == Some(&b'=')) + 1;
+                regex.after_operator();
+            }
             byte if byte == open => {
                 depth = depth.saturating_add(1);
                 offset += 1;
+                regex.after_operator();
             }
             byte if byte == close => {
                 depth -= 1;
@@ -476,11 +681,83 @@ pub(super) fn find_matching_delimiter(
                     return Ok(offset);
                 }
                 offset += 1;
+                regex.after_value();
             }
-            _ => offset += source[offset..].chars().next().map_or(1, char::len_utf8),
+            b'(' | b'[' | b'{' => {
+                offset += 1;
+                regex.after_operator();
+            }
+            b')' | b']' | b'}' => {
+                offset += 1;
+                regex.after_value();
+            }
+            byte if is_identifier_start(byte) => {
+                let (identifier, end) = read_identifier(source, offset).ok_or(ScanError)?;
+                regex.after_identifier(identifier);
+                offset = end;
+            }
+            byte if byte.is_ascii_digit() => {
+                offset = skip_number_literal(source, offset);
+                regex.after_value();
+            }
+            _ if source[offset..].starts_with("?.") => {
+                offset += 2;
+                regex.after_property_access();
+            }
+            b'.' if source[offset..].starts_with("...") => {
+                offset += 3;
+                regex.after_operator();
+            }
+            b'.' => {
+                offset += 1;
+                regex.after_property_access();
+            }
+            b'+' | b'-'
+                if source.as_bytes().get(offset + 1) == Some(&source.as_bytes()[offset]) =>
+            {
+                offset += 2;
+            }
+            _ => {
+                let character = source[offset..].chars().next().ok_or(ScanError)?;
+                offset += character.len_utf8();
+                regex.after_character(character);
+            }
         }
     }
     Err(ScanError)
+}
+
+/// The shared delimiter matcher also walks JSX-like Astro markup nested inside
+/// `{ ... }`. Recognize only a complete closing tag here, while leaving an
+/// ambiguous sequence such as `value</li>/.test(input)` on the regex path.
+fn is_tag_close(source: &str, slash: usize) -> bool {
+    if slash == 0 || source.as_bytes()[slash - 1] != b'<' {
+        return false;
+    }
+
+    let bytes = source.as_bytes();
+    let mut offset = slash + 1;
+    if bytes.get(offset) == Some(&b'>') {
+        return bytes.get(offset + 1) != Some(&b'/');
+    }
+    if !bytes
+        .get(offset)
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$'))
+    {
+        return false;
+    }
+
+    offset += 1;
+    while bytes.get(offset).is_some_and(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$' | b'-' | b'.' | b':')
+    }) {
+        offset += 1;
+    }
+    while bytes.get(offset).is_some_and(u8::is_ascii_whitespace) {
+        offset += 1;
+    }
+
+    bytes.get(offset) == Some(&b'>') && bytes.get(offset + 1) != Some(&b'/')
 }
 
 fn matching_close_byte(open: u8) -> Option<u8> {
@@ -510,6 +787,63 @@ pub(super) fn skip_quoted(source: &str, quote_offset: usize) -> Result<usize, Sc
         }
     }
     Err(ScanError)
+}
+
+pub(super) fn skip_line_comment(source: &str, slash: usize) -> usize {
+    source[slash + 2..]
+        .find('\n')
+        .map_or(source.len(), |newline| slash + 2 + newline + 1)
+}
+
+pub(super) fn skip_block_comment(source: &str, slash: usize) -> Result<usize, ScanError> {
+    let close = source[slash + 2..].find("*/").ok_or(ScanError)?;
+    Ok(slash + close + 4)
+}
+
+/// Skip a JavaScript regex literal, including escaped characters, character
+/// classes, and trailing flags. The caller only enters here when the preceding
+/// token requires an operand, which keeps division on the ordinary scan path.
+pub(super) fn skip_regex_literal(source: &str, slash: usize) -> Result<usize, ScanError> {
+    let mut offset = slash + 1;
+    let mut in_character_class = false;
+    while offset < source.len() {
+        match source.as_bytes()[offset] {
+            b'\\' => {
+                offset += 1;
+                if offset < source.len() {
+                    offset += source[offset..].chars().next().map_or(0, char::len_utf8);
+                }
+            }
+            b'[' if !in_character_class => {
+                in_character_class = true;
+                offset += 1;
+            }
+            b']' if in_character_class => {
+                in_character_class = false;
+                offset += 1;
+            }
+            b'/' if !in_character_class => {
+                offset += 1;
+                while offset < source.len() && source.as_bytes()[offset].is_ascii_alphabetic() {
+                    offset += 1;
+                }
+                return Ok(offset);
+            }
+            b'\n' | b'\r' => return Err(ScanError),
+            _ => offset += source[offset..].chars().next().map_or(1, char::len_utf8),
+        }
+    }
+    Err(ScanError)
+}
+
+pub(super) fn skip_number_literal(source: &str, mut offset: usize) -> usize {
+    while offset < source.len()
+        && (source.as_bytes()[offset].is_ascii_alphanumeric()
+            || matches!(source.as_bytes()[offset], b'.' | b'_' | b'\''))
+    {
+        offset += 1;
+    }
+    offset
 }
 
 pub(super) fn skip_whitespace(source: &str, mut offset: usize) -> usize {
@@ -599,5 +933,27 @@ mod tests {
             .map(|contribution| contribution.offset)
             .collect();
         assert_eq!(offsets, vec![102, 107]);
+    }
+
+    #[test]
+    fn regex_contents_are_ignored_and_following_operators_are_scored() {
+        assert_eq!(
+            expression_metrics(r"/[?():{}&|]+/.test(input) && ready"),
+            Some((1, 1))
+        );
+        assert_eq!(
+            expression_metrics(r"(value</li>/.test(input)) && ready"),
+            Some((1, 1))
+        );
+    }
+
+    #[test]
+    fn markup_closing_tags_do_not_look_like_regex_literals() {
+        let source = "{show && items.map((item) => <li>{item}</li>)}";
+        let close = find_matching_delimiter(source, 0, b'{', b'}')
+            .expect("markup expression should have a matching brace");
+
+        assert_eq!(close, source.len() - 1);
+        assert_eq!(expression_metrics(&source[1..close]), Some((1, 1)));
     }
 }

--- a/crates/extract/src/template_complexity/svelte.rs
+++ b/crates/extract/src/template_complexity/svelte.rs
@@ -18,7 +18,10 @@ use std::sync::LazyLock;
 use fallow_types::extract::{ComplexityContributionKind, FunctionComplexity};
 
 use super::build_template_complexity;
-use super::engine::{ScanError, TemplateComplexity, skip_quoted};
+use super::engine::{
+    RegexContext, ScanError, TemplateComplexity, read_identifier, skip_block_comment,
+    skip_line_comment, skip_number_literal, skip_quoted, skip_regex_literal,
+};
 
 static MASK_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     crate::static_regex(
@@ -155,17 +158,35 @@ impl<'a> SvelteScanner<'a> {
         let (keyword, after) = split_keyword(rest);
         match keyword {
             // `{#if cond}` / `{#key expr}`: one branch each, whose whole
-            // remainder is the bound expression.
-            //
-            // `{#key}` still uses the closest shared control-flow vocabulary;
-            // `{#await}` has its own public kind because the editor renders it.
-            "if" | "key" | "await" => {
-                let kind = if keyword == "await" {
-                    ComplexityContributionKind::Await
-                } else {
-                    ComplexityContributionKind::If
-                };
-                self.add_control_flow_with_expr(after, inner_offset, kind)?;
+            // remainder is the bound expression. `{#key}` uses the closest
+            // shared control-flow vocabulary.
+            "if" | "key" => {
+                self.add_control_flow_with_expr(
+                    after,
+                    inner_offset,
+                    ComplexityContributionKind::If,
+                )?;
+                self.nesting = self.nesting.saturating_add(1);
+                Ok(())
+            }
+            // Await blocks can omit the pending branch with
+            // `{#await expression then binding}` or
+            // `{#await expression catch binding}`. Score the promise expression
+            // separately from the binding and record the selected state as the
+            // same flat continuation used by `{:then}` / `{:catch}`.
+            "await" => {
+                let shorthand = split_await_shorthand(after)?;
+                self.complexity.add_control_flow(
+                    inner_offset,
+                    ComplexityContributionKind::Await,
+                    self.nesting,
+                );
+                self.add_expr_slice(shorthand.expression)?;
+                if let Some(state) = shorthand.state {
+                    let state_offset = self.offset_of(state.keyword);
+                    self.complexity.inc_cyclomatic(state_offset, state.kind);
+                    self.complexity.inc_cognitive_flat(state_offset, state.kind);
+                }
                 self.nesting = self.nesting.saturating_add(1);
                 Ok(())
             }
@@ -298,17 +319,54 @@ impl<'a> SvelteScanner<'a> {
 }
 
 /// Find the `}` that closes the `{` at `open`, honoring nested `{ }`, quoted
-/// strings, and template literals so a `}` inside a string or nested object
-/// does not end the section early. Byte-safe over multibyte text.
+/// strings, template literals, comments, and regex literals. Byte-safe over
+/// multibyte text.
 fn find_matching_curly(source: &str, open: usize) -> Result<usize, ScanError> {
     let mut offset = open + 1;
     let mut depth = 1_u16;
+    let mut regex = RegexContext::expression_start();
+    let mut at_start = true;
+    let mut directive_keyword_pending = false;
     while offset < source.len() {
         match source.as_bytes()[offset] {
-            b'\'' | b'"' | b'`' => offset = skip_quoted(source, offset)?,
+            byte if byte.is_ascii_whitespace() => offset += 1,
+            b'#' | b':' | b'@' if at_start => {
+                at_start = false;
+                directive_keyword_pending = true;
+                regex.after_operator();
+                offset += 1;
+            }
+            b'/' if offset == open + 1 && starts_block_close(source, offset) => {
+                at_start = false;
+                regex.after_operator();
+                offset += 1;
+            }
+            b'\'' | b'"' | b'`' => {
+                at_start = false;
+                offset = skip_quoted(source, offset)?;
+                regex.after_value();
+            }
+            b'/' if source.as_bytes().get(offset + 1) == Some(&b'/') => {
+                offset = skip_line_comment(source, offset);
+            }
+            b'/' if source.as_bytes().get(offset + 1) == Some(&b'*') => {
+                offset = skip_block_comment(source, offset)?;
+            }
+            b'/' if regex.can_start() => {
+                at_start = false;
+                offset = skip_regex_literal(source, offset)?;
+                regex.after_value();
+            }
+            b'/' => {
+                at_start = false;
+                offset += usize::from(source.as_bytes().get(offset + 1) == Some(&b'=')) + 1;
+                regex.after_operator();
+            }
             b'{' => {
+                at_start = false;
                 depth = depth.saturating_add(1);
                 offset += 1;
+                regex.after_operator();
             }
             b'}' => {
                 depth -= 1;
@@ -316,11 +374,61 @@ fn find_matching_curly(source: &str, open: usize) -> Result<usize, ScanError> {
                     return Ok(offset);
                 }
                 offset += 1;
+                regex.after_value();
             }
-            _ => offset += source[offset..].chars().next().map_or(1, char::len_utf8),
+            byte if byte == b'_' || byte == b'$' || byte.is_ascii_alphabetic() => {
+                at_start = false;
+                let (identifier, end) = read_identifier(source, offset).ok_or(ScanError)?;
+                if directive_keyword_pending {
+                    directive_keyword_pending = identifier == "else";
+                    regex.after_operator();
+                } else {
+                    regex.after_identifier(identifier);
+                }
+                offset = end;
+            }
+            byte if byte.is_ascii_digit() => {
+                at_start = false;
+                offset = skip_number_literal(source, offset);
+                regex.after_value();
+            }
+            _ if source[offset..].starts_with("?.") => {
+                at_start = false;
+                offset += 2;
+                regex.after_property_access();
+            }
+            b'.' if source[offset..].starts_with("...") => {
+                at_start = false;
+                offset += 3;
+                regex.after_operator();
+            }
+            b'.' => {
+                at_start = false;
+                offset += 1;
+                regex.after_property_access();
+            }
+            b'+' | b'-'
+                if source.as_bytes().get(offset + 1) == Some(&source.as_bytes()[offset]) =>
+            {
+                at_start = false;
+                offset += 2;
+            }
+            _ => {
+                at_start = false;
+                let character = source[offset..].chars().next().ok_or(ScanError)?;
+                offset += character.len_utf8();
+                regex.after_character(character);
+            }
         }
     }
     Err(ScanError)
+}
+
+fn starts_block_close(source: &str, slash: usize) -> bool {
+    read_identifier(source, slash + 1).is_some_and(|(keyword, end)| {
+        matches!(keyword, "if" | "each" | "await" | "key" | "snippet")
+            && source.as_bytes().get(end) == Some(&b'}')
+    })
 }
 
 /// Split a block body into its leading keyword (`if`, `each`, `else`, ...) and
@@ -330,6 +438,125 @@ fn split_keyword(body: &str) -> (&str, &str) {
         Some(index) => (&body[..index], &body[index..]),
         None => (body, ""),
     }
+}
+
+/// Split an await body into its promise expression and optional shorthand
+/// state keyword. Svelte permits both `{#await expression then binding}` and
+/// `{#await expression catch binding}`. Only a top-level keyword begins the
+/// shorthand state, so nested calls, object literals, strings, and comments
+/// remain part of the promise expression.
+struct AwaitShorthand<'a> {
+    expression: &'a str,
+    state: Option<AwaitShorthandState<'a>>,
+}
+
+#[derive(Clone, Copy)]
+struct AwaitShorthandState<'a> {
+    keyword: &'a str,
+    kind: ComplexityContributionKind,
+}
+
+fn split_await_shorthand(after: &str) -> Result<AwaitShorthand<'_>, ScanError> {
+    let trimmed = after.trim_start();
+    let bytes = trimmed.as_bytes();
+    let mut index = 0;
+    let mut depth = 0_u16;
+    let mut regex = RegexContext::expression_start();
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' | b'`' => {
+                index = skip_quoted(trimmed, index)?;
+                regex.after_value();
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(trimmed, index);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(trimmed, index)?;
+            }
+            b'/' if regex.can_start() => {
+                index = skip_regex_literal(trimmed, index)?;
+                regex.after_value();
+            }
+            b'/' => {
+                index += usize::from(bytes.get(index + 1) == Some(&b'=')) + 1;
+                regex.after_operator();
+            }
+            b'(' | b'[' | b'{' => {
+                depth = depth.saturating_add(1);
+                index += 1;
+                regex.after_operator();
+            }
+            b')' | b']' | b'}' => {
+                depth = depth.saturating_sub(1);
+                index += 1;
+                regex.after_value();
+            }
+            byte if byte == b'_' || byte == b'$' || byte.is_ascii_alphabetic() => {
+                let Some((identifier, identifier_end)) = read_identifier(trimmed, index) else {
+                    return Err(ScanError);
+                };
+                let kind = match identifier {
+                    "then" => Some(ComplexityContributionKind::Then),
+                    "catch" => Some(ComplexityContributionKind::Catch),
+                    _ => None,
+                };
+                if depth == 0
+                    && let Some(kind) = kind
+                {
+                    let binding = trimmed[identifier_end..].trim_start();
+                    if before_is_boundary(trimmed, index)
+                        && after_is_boundary(trimmed, identifier_end)
+                        && starts_binding(binding)
+                    {
+                        return Ok(AwaitShorthand {
+                            expression: trimmed[..index].trim_end(),
+                            state: Some(AwaitShorthandState {
+                                keyword: identifier,
+                                kind,
+                            }),
+                        });
+                    }
+                }
+                regex.after_identifier(identifier);
+                index = identifier_end;
+            }
+            byte if byte.is_ascii_digit() => {
+                index = skip_number_literal(trimmed, index);
+                regex.after_value();
+            }
+            b'.' if trimmed[index..].starts_with("...") => {
+                index += 3;
+                regex.after_operator();
+            }
+            b'.' => {
+                index += 1;
+                regex.after_property_access();
+            }
+            b'+' | b'-' if bytes.get(index + 1) == Some(&bytes[index]) => {
+                index += 2;
+            }
+            byte if byte.is_ascii_whitespace() => index += 1,
+            _ => {
+                let character = trimmed[index..].chars().next().ok_or(ScanError)?;
+                index += character.len_utf8();
+                regex.after_character(character);
+            }
+        }
+    }
+
+    Ok(AwaitShorthand {
+        expression: trimmed,
+        state: None,
+    })
+}
+
+fn starts_binding(binding: &str) -> bool {
+    binding
+        .chars()
+        .next()
+        .is_some_and(|first| matches!(first, '{' | '[' | '_' | '$') || first.is_alphabetic())
 }
 
 /// Extract the iterable expression from an `{#each ...}` body remainder. The
@@ -455,6 +682,194 @@ mod tests {
     }
 
     #[test]
+    fn await_shorthand_counts_the_selected_state() {
+        for (source, state_kind) in [
+            (
+                "{#await import('./Component.svelte') then { default: Component }}<Component />{/await}",
+                ComplexityContributionKind::Then,
+            ),
+            (
+                "{#await load() catch error}<p>{error}</p>{/await}",
+                ComplexityContributionKind::Catch,
+            ),
+            (
+                "{#await load() then { value = choose('catch error') }}<p>{value}</p>{/await}",
+                ComplexityContributionKind::Then,
+            ),
+        ] {
+            let complexity = compute_svelte_template_complexity(source)
+                .expect("shorthand await block should have complexity");
+            assert_eq!(complexity.cyclomatic, 3, "{source}: {complexity:?}");
+            assert_eq!(complexity.cognitive, 2, "{source}: {complexity:?}");
+
+            for kind in [ComplexityContributionKind::Await, state_kind] {
+                let contributions: Vec<_> = complexity
+                    .contributions
+                    .iter()
+                    .filter(|contribution| contribution.kind == kind)
+                    .collect();
+                assert_eq!(contributions.len(), 2, "{source}: {complexity:?}");
+                assert!(
+                    contributions
+                        .iter()
+                        .all(|contribution| contribution.weight == 1),
+                    "{source}: {complexity:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn await_shorthand_splits_only_the_top_level_state_keyword() {
+        let complexity = compute_svelte_template_complexity(
+            r#"{#await resolve({ then: "catch" }).then(load) && ready then value}<p>{value}</p>{/await}"#,
+        )
+        .expect("shorthand await block should have complexity");
+
+        assert_eq!(complexity.cyclomatic, 4, "{complexity:?}");
+        assert_eq!(complexity.cognitive, 3, "{complexity:?}");
+        assert_eq!(
+            complexity
+                .contributions
+                .iter()
+                .filter(|contribution| contribution.kind == ComplexityContributionKind::Then)
+                .count(),
+            2,
+            "{complexity:?}"
+        );
+    }
+
+    #[test]
+    fn await_regex_contents_do_not_start_shorthand() {
+        for (source, state_kind, state_line) in [
+            (
+                "{#await / then value /.test(input)}\n<p>loading</p>\n{:then result}\n<p>{result}</p>\n{/await}",
+                ComplexityContributionKind::Then,
+                3,
+            ),
+            (
+                "{#await / catch error /.test(input)}\n<p>loading</p>\n{:catch error}\n<p>{error}</p>\n{/await}",
+                ComplexityContributionKind::Catch,
+                3,
+            ),
+        ] {
+            let complexity = compute_svelte_template_complexity(source)
+                .expect("regex await expression should have complexity");
+            assert_eq!(complexity.cyclomatic, 3, "{source}: {complexity:?}");
+            assert_eq!(complexity.cognitive, 2, "{source}: {complexity:?}");
+            assert!(
+                complexity
+                    .contributions
+                    .iter()
+                    .filter(|contribution| contribution.kind == state_kind)
+                    .all(|contribution| contribution.line == state_line),
+                "{source}: {complexity:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn await_regex_and_division_expressions_keep_real_shorthand() {
+        for (source, state_kind) in [
+            (
+                "{#await / then value /.test(input) then result}<p>{result}</p>{/await}",
+                ComplexityContributionKind::Then,
+            ),
+            (
+                "{#await / catch error /.test(input) catch error}<p>{error}</p>{/await}",
+                ComplexityContributionKind::Catch,
+            ),
+            (
+                "{#await total / divisor then result}<p>{result}</p>{/await}",
+                ComplexityContributionKind::Then,
+            ),
+            (
+                "{#await of / divisor then result}<p>{result}</p>{/await}",
+                ComplexityContributionKind::Then,
+            ),
+            (
+                "{#await values.of / divisor then result}<p>{result}</p>{/await}",
+                ComplexityContributionKind::Then,
+            ),
+        ] {
+            let complexity = compute_svelte_template_complexity(source)
+                .unwrap_or_else(|| panic!("await shorthand should have complexity: {source}"));
+            assert_eq!(complexity.cyclomatic, 3, "{source}: {complexity:?}");
+            assert_eq!(complexity.cognitive, 2, "{source}: {complexity:?}");
+            assert_eq!(
+                complexity
+                    .contributions
+                    .iter()
+                    .filter(|contribution| contribution.kind == state_kind)
+                    .count(),
+                2,
+                "{source}: {complexity:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn await_regex_after_return_scores_expression_and_real_shorthand() {
+        let source = "{#await (() => { return /[))] then fake/; })() && ready\nthen result}<p>{result}</p>{/await}";
+        let complexity = compute_svelte_template_complexity(source)
+            .expect("valid regex expression should preserve await complexity");
+
+        assert_eq!(complexity.cyclomatic, 4, "{complexity:?}");
+        assert_eq!(complexity.cognitive, 3, "{complexity:?}");
+        assert!(
+            complexity
+                .contributions
+                .iter()
+                .filter(|contribution| { contribution.kind == ComplexityContributionKind::Then })
+                .all(|contribution| contribution.line == 2),
+            "{complexity:?}"
+        );
+        assert_eq!(
+            complexity
+                .contributions
+                .iter()
+                .filter(|contribution| {
+                    contribution.kind == ComplexityContributionKind::LogicalAnd
+                })
+                .count(),
+            2,
+            "{complexity:?}"
+        );
+    }
+
+    #[test]
+    fn if_regex_contents_are_ignored_and_following_operators_are_scored() {
+        let source = "{#if /[?():{}&|]+/.test(input) && ready}<p>ready</p>{/if}";
+        let complexity = compute_svelte_template_complexity(source)
+            .expect("valid regex condition should preserve template complexity");
+
+        assert_eq!(complexity.cyclomatic, 3, "{complexity:?}");
+        assert_eq!(complexity.cognitive, 2, "{complexity:?}");
+        assert_eq!(
+            complexity
+                .contributions
+                .iter()
+                .filter(|contribution| {
+                    contribution.kind == ComplexityContributionKind::LogicalAnd
+                })
+                .count(),
+            2,
+            "{complexity:?}"
+        );
+    }
+
+    #[test]
+    fn await_bindingless_continuations_count() {
+        let complexity = compute_svelte_template_complexity(
+            "{#await load()}<p>loading</p>{:then}<p>done</p>{:catch}<p>failed</p>{/await}",
+        )
+        .expect("bindingless continuations should have complexity");
+
+        assert_eq!(complexity.cyclomatic, 4, "{complexity:?}");
+        assert_eq!(complexity.cognitive, 3, "{complexity:?}");
+    }
+
+    #[test]
     fn key_block_counts() {
         let complexity = compute_svelte_template_complexity("{#key selectedId}<Child />{/key}")
             .expect("template should have complexity");
@@ -498,6 +913,8 @@ for (const i of items) { use(i); }
         assert!(compute_svelte_template_complexity("{#if a && ").is_none());
         // Logical with no RHS inside an interpolation.
         assert!(compute_svelte_template_complexity("<p>{a && }</p>").is_none());
+        // Shorthand await expression with no logical RHS.
+        assert!(compute_svelte_template_complexity("{#await a && then value}{/await}").is_none());
         // Unterminated curly.
         assert!(compute_svelte_template_complexity("<p>{ a && b").is_none());
     }

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -1319,7 +1319,7 @@ mod tests {
             .expect("health should run through programmatic health boundary");
 
         assert_eq!(json["kind"], "health");
-        assert_eq!(json["schema_version"], 8);
+        assert_eq!(json["schema_version"], 9);
         assert!(json.get("health_score").is_some());
     }
 

--- a/crates/output/src/health.rs
+++ b/crates/output/src/health.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Current schema version for the standalone health JSON envelope.
-pub const HEALTH_SCHEMA_VERSION: u32 = 8;
+pub const HEALTH_SCHEMA_VERSION: u32 = 9;
 
 /// Exact schema version for [`HealthOutput`].
 #[cfg(feature = "schema")]

--- a/crates/output/src/health_findings.rs
+++ b/crates/output/src/health_findings.rs
@@ -254,12 +254,7 @@ fn build_suppress_action(
     is_template: bool,
     is_component: bool,
 ) -> HealthFindingAction {
-    if is_template
-        && violation
-            .path
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("html"))
-    {
+    if is_template && is_standalone_template_path(&violation.path) {
         return suppress_file_action(
             "Suppress with an HTML comment at the top of the template",
             "<!-- fallow-ignore-file complexity -->",
@@ -282,6 +277,16 @@ fn build_suppress_action(
         "Suppress with an inline comment above the function declaration",
         "above-function-declaration",
     )
+}
+
+fn is_standalone_template_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            ["html", "svelte", "vue", "astro"]
+                .iter()
+                .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+        })
 }
 
 fn suppress_file_action(description: &str, comment: &str, placement: &str) -> HealthFindingAction {

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -22455,7 +22455,7 @@
     },
     "HealthSchemaVersion": {
       "type": "integer",
-      "const": 8,
+      "const": 9,
       "description": "Exact schema version for [`HealthOutput`]."
     },
     "AuditSchemaVersion": {

--- a/editors/vscode/src/complexityDecorations.ts
+++ b/editors/vscode/src/complexityDecorations.ts
@@ -141,15 +141,33 @@ const dominantKind = (
   return best.kind;
 };
 
+const isContinuationKind = (kind: ComplexityContributionKind): boolean =>
+  kind === "then" || kind === "catch";
+
+const extraKindSuffix = (
+  kinds: ReadonlySet<ComplexityContributionKind>,
+  dominant: ComplexityContributionKind,
+): string => {
+  const secondary = [...kinds].filter((kind) => kind !== dominant);
+  if (secondary.length === 0) {
+    return "";
+  }
+  const continuation = secondary.find(isContinuationKind);
+  if (!continuation) {
+    return ` +${secondary.length}`;
+  }
+  const remaining = secondary.length - 1;
+  return ` + ${kindLabel(continuation)}${remaining > 0 ? ` +${remaining}` : ""}`;
+};
+
 const inlineToken = (aggregate: LineAggregate): string => {
   // Cognitive is the nesting-sensitive "how hard to follow" headline; fall back
   // to cyclomatic for lines that only add independent paths (a case label, a
   // logical-assignment, an optional-chain link).
   const headline = aggregate.cognitive > 0 ? aggregate.cognitive : aggregate.cyclomatic;
   const kinds = new Set(aggregate.contributions.map((c) => c.kind));
-  const label = kindLabel(dominantKind(aggregate.contributions));
-  const extra = kinds.size > 1 ? ` +${kinds.size - 1}` : "";
-  return `+${headline} ${label}${extra}`;
+  const dominant = dominantKind(aggregate.contributions);
+  return `+${headline} ${kindLabel(dominant)}${extraKindSuffix(kinds, dominant)}`;
 };
 
 const lineHover = (aggregate: LineAggregate): vscode.MarkdownString => {
@@ -193,19 +211,24 @@ export const complexityKey = (findingPath: string, line: number): string =>
 /**
  * The hover markdown for a 1-based source line: the function summary + CRAP
  * when the line is a complex function's signature, the per-kind contribution
- * list when it is a decision-point line, `undefined` otherwise. Pure (the
- * markdown type is the only VS Code dependency), so it is unit-testable
- * independently of an open editor.
+ * list when it is a decision-point line, or both when those are the same line.
+ * Returns `undefined` otherwise. Pure (the markdown type is the only VS Code
+ * dependency), so it is unit-testable independently of an open editor.
  */
 export const hoverForLine = (
   matched: readonly HealthFinding[],
   line1Based: number,
 ): vscode.MarkdownString | undefined => {
   const fn = matched.find((f) => f.line === line1Based);
+  const aggregate = aggregateByLine(matched).get(line1Based);
+  if (fn && aggregate) {
+    const md = functionHover(fn);
+    md.appendMarkdown(`\n${lineHover(aggregate).value}`);
+    return md;
+  }
   if (fn) {
     return functionHover(fn);
   }
-  const aggregate = aggregateByLine(matched).get(line1Based);
   if (aggregate) {
     return lineHover(aggregate);
   }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -806,7 +806,7 @@ export type LogicalGroupStatus = ("ok" | "empty" | "invalid_path")
 /**
  * Exact schema version for [`HealthOutput`].
  */
-export type HealthSchemaVersion = 8
+export type HealthSchemaVersion = 9
 /**
  * Resolver mode label for grouped envelopes (dead-code, dupes, health).
  *

--- a/editors/vscode/test/complexityDecorations.test.ts
+++ b/editors/vscode/test/complexityDecorations.test.ts
@@ -131,16 +131,18 @@ describe("buildComplexityDecorations", () => {
     expect(after).toContain("else if");
   });
 
-  it("renders Svelte await and then contributions with source labels", () => {
+  it("renders Svelte await, then, and catch contributions with source labels", () => {
     const f = finding({
       contributions: [
         contribution(8, "cognitive", "await", 1),
         contribution(10, "cognitive", "then", 1),
+        contribution(12, "cognitive", "catch", 1),
       ],
     });
     const result = buildComplexityDecorations([f], docPath, root, all);
     expect(result[0]?.afterText).toContain("await");
     expect(result[1]?.afterText).toContain("then");
+    expect(result[2]?.afterText).toContain("catch");
   });
 });
 
@@ -170,10 +172,15 @@ describe("hoverForLine", () => {
     expect(md?.value).toContain("for loop");
   });
 
-  it("uses the Svelte continuation label in the hover", () => {
-    const f = finding({ contributions: [contribution(12, "cognitive", "then", 1)] });
-    const md = hoverForLine([f], 12);
-    expect(md?.value).toContain("then · +1 cognitive");
+  it("uses the Svelte state labels in the hover", () => {
+    const f = finding({
+      contributions: [
+        contribution(12, "cognitive", "then", 1),
+        contribution(13, "cognitive", "catch", 1),
+      ],
+    });
+    expect(hoverForLine([f], 12)?.value).toContain("then · +1 cognitive");
+    expect(hoverForLine([f], 13)?.value).toContain("catch · +1 cognitive");
   });
 
   it("returns undefined on a line with neither a function nor a contribution", () => {

--- a/editors/vscode/test/complexityDecorations.test.ts
+++ b/editors/vscode/test/complexityDecorations.test.ts
@@ -131,19 +131,36 @@ describe("buildComplexityDecorations", () => {
     expect(after).toContain("else if");
   });
 
-  it("renders Svelte await, then, and catch contributions with source labels", () => {
+  it("keeps the compact extra-kind count for an ordinary mixed line", () => {
     const f = finding({
       contributions: [
-        contribution(8, "cognitive", "await", 1),
-        contribution(10, "cognitive", "then", 1),
-        contribution(12, "cognitive", "catch", 1),
+        contribution(8, "cognitive", "if", 1),
+        contribution(8, "cognitive", "logical-and", 1),
       ],
     });
     const result = buildComplexityDecorations([f], docPath, root, all);
-    expect(result[0]?.afterText).toContain("await");
-    expect(result[1]?.afterText).toContain("then");
-    expect(result[2]?.afterText).toContain("catch");
+    expect(result[0]?.afterText).toBe("+2 if +1");
   });
+
+  it.each(["then", "catch"] as const)(
+    "renders a same-line Svelte await + %s shorthand with both source labels",
+    (state) => {
+      const f = finding({
+        line: 8,
+        cyclomatic: 3,
+        cognitive: 2,
+        contributions: [
+          contribution(8, "cyclomatic", "await", 1),
+          contribution(8, "cognitive", "await", 1),
+          contribution(8, "cyclomatic", state, 1),
+          contribution(8, "cognitive", state, 1),
+        ],
+      });
+      const result = buildComplexityDecorations([f], docPath, root, all);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.afterText).toBe(`+2 await + ${state}`);
+    },
+  );
 });
 
 describe("hoverForLine", () => {
@@ -172,16 +189,27 @@ describe("hoverForLine", () => {
     expect(md?.value).toContain("for loop");
   });
 
-  it("uses the Svelte state labels in the hover", () => {
-    const f = finding({
-      contributions: [
-        contribution(12, "cognitive", "then", 1),
-        contribution(13, "cognitive", "catch", 1),
-      ],
-    });
-    expect(hoverForLine([f], 12)?.value).toContain("then · +1 cognitive");
-    expect(hoverForLine([f], 13)?.value).toContain("catch · +1 cognitive");
-  });
+  it.each(["then", "catch"] as const)(
+    "keeps the function summary and shows both same-line Svelte await + %s labels",
+    (state) => {
+      const f = finding({
+        line: 12,
+        cyclomatic: 3,
+        cognitive: 2,
+        contributions: [
+          contribution(12, "cyclomatic", "await", 1),
+          contribution(12, "cognitive", "await", 1),
+          contribution(12, "cyclomatic", state, 1),
+          contribution(12, "cognitive", state, 1),
+        ],
+      });
+      const value = hoverForLine([f], 12)?.value;
+      expect(value).toContain("parseArgs");
+      expect(value).toContain("Complexity contributions");
+      expect(value).toContain("await · +1 cognitive");
+      expect(value).toContain(`${state} · +1 cognitive`);
+    },
+  );
 
   it("returns undefined on a line with neither a function nor a contribution", () => {
     const f = finding({ line: 10, contributions: [contribution(12, "cyclomatic", "if", 1)] });

--- a/editors/vscode/test/generated-types.test.ts
+++ b/editors/vscode/test/generated-types.test.ts
@@ -39,7 +39,7 @@ describe("generated/output-contract.d.ts", () => {
     expectTypeOf<CombinedSchemaVersion>().toEqualTypeOf<9>();
     expectTypeOf<DupesSchemaVersion>().toEqualTypeOf<2 | 8>();
     expectTypeOf<FeatureFlagsSchemaVersion>().toEqualTypeOf<8>();
-    expectTypeOf<HealthSchemaVersion>().toEqualTypeOf<8>();
+    expectTypeOf<HealthSchemaVersion>().toEqualTypeOf<9>();
     expectTypeOf<TypeAwareStatusSchemaVersion>().toEqualTypeOf<8>();
   });
 

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -806,7 +806,7 @@ export type LogicalGroupStatus = ("ok" | "empty" | "invalid_path")
 /**
  * Exact schema version for [`HealthOutput`].
  */
-export type HealthSchemaVersion = 8
+export type HealthSchemaVersion = 9
 /**
  * Resolver mode label for grouped envelopes (dead-code, dupes, health).
  *


### PR DESCRIPTION
## Summary

- count and label inline Svelte await continuations, including `then` and `catch`
- make shared template-expression scanning regex-aware without confusing division or Astro closing tags
- expose same-line await continuation labels in VS Code decorations and hover
- move standalone health to schema 9, invalidate stale extraction caches, and regenerate public contracts
- emit valid file-level suppression actions for standalone framework templates

## Validation

- `npm run verify:full`
- generated-contract and public contract-surface checks
- focused VS Code unit, type, and lint checks
- public SvelteKit template smoke covering shorthand, nested control flow, regex expressions, action metadata, and schema version

Follow-up hardening for #2158.
