### PR TITLE
fix(audit): keep --gate new-only from failing clone-removal refactors

### DIFF
--- a/crates/api/src/audit_keys.rs
+++ b/crates/api/src/audit_keys.rs
@@ -320,6 +320,18 @@ impl AuditDomainLedger {
     pub fn introduced(&self) -> impl ExactSizeIterator<Item = bool> + '_ {
         self.records.iter().map(|(_, introduced)| *introduced)
     }
+
+    /// Demote introduced findings whose keys are in `demote` to inherited
+    /// (advisory) status so they no longer fail the new-only gate.
+    pub fn demote_introductions(&mut self, demote: &FxHashSet<String>) {
+        for (key, introduced) in &mut self.records {
+            if *introduced && demote.contains(key) {
+                *introduced = false;
+                self.introduced_keys.remove(key);
+                self.inherited_keys.insert(key.clone());
+            }
+        }
+    }
 }
 
 /// One-pass audit comparison shared by attribution, verdict, and annotations.
@@ -3256,6 +3268,34 @@ pub fn dupe_group_key(group: &fallow_types::duplicates::CloneGroup, root: &Path)
     )
 }
 
+/// Keys of clone groups whose every instance lies entirely outside the diff's
+/// added lines: the duplicated text existed verbatim at base, and the group
+/// only became reportable (under a new attribution key) because the changeset
+/// removed code elsewhere; deduplicating one region can create or re-shape a
+/// clone group across files (issue #2164). New-only gating demotes these
+/// groups to inherited so a clone-removal refactor is not failed by the
+/// duplication it did not write. An instance whose path cannot be mapped into
+/// the diff's namespace is treated as touched, so its group keeps gating.
+pub fn preexisting_dupe_group_keys<'a>(
+    groups: impl IntoIterator<Item = &'a fallow_types::duplicates::CloneGroup>,
+    root: &Path,
+    diff: &fallow_output::DiffIndex,
+) -> FxHashSet<String> {
+    let instance_touched = |instance: &fallow_types::duplicates::CloneInstance| -> bool {
+        let Some(rel) = diff.key_for(&instance.file, root) else {
+            return true;
+        };
+        let start = u64::try_from(instance.start_line).unwrap_or(u64::MAX);
+        let end = u64::try_from(instance.end_line).unwrap_or(u64::MAX);
+        diff.range_overlaps_added(&rel, start, end)
+    };
+    groups
+        .into_iter()
+        .filter(|group| !group.instances.iter().any(instance_touched))
+        .map(|group| dupe_group_key(group, root))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
@@ -4329,6 +4369,44 @@ mod tests {
         assert!(key_ba.starts_with("dupe:src/a.ts|src/b.ts:"));
         // Same fragment => same hash.
         assert_eq!(key_ab, key_ba);
+    }
+
+    #[test]
+    fn preexisting_dupe_group_keys_collects_only_groups_outside_added_lines() {
+        let root = root();
+        let a = root.join("src/a.ts");
+        let b = root.join("src/b.ts");
+        let c = root.join("src/c.ts");
+        // Instances span lines 1..=5. The diff adds line 3 in src/c.ts only.
+        let untouched = make_clone_group(&[a.clone(), b], "shared scaffolding");
+        let touched = make_clone_group(&[a, c], "pasted block");
+        let diff = fallow_output::DiffIndex::from_unified_diff(
+            "diff --git a/src/c.ts b/src/c.ts\n--- a/src/c.ts\n+++ b/src/c.ts\n@@ -3,0 +3,1 @@\n+const added = 1;\n",
+        );
+
+        let demote = super::preexisting_dupe_group_keys([&untouched, &touched], &root, &diff);
+
+        assert!(demote.contains(&dupe_group_key(&untouched, &root)));
+        assert!(!demote.contains(&dupe_group_key(&touched, &root)));
+        assert_eq!(demote.len(), 1);
+    }
+
+    #[test]
+    fn demote_introductions_moves_introduced_keys_to_inherited() {
+        let base: FxHashSet<String> = std::iter::once("dupe:old".to_string()).collect();
+        let mut ledger = AuditDomainLedger::compare(
+            ["dupe:kept".to_string(), "dupe:demoted".to_string()],
+            Some(&base),
+        );
+        assert_eq!(ledger.introduced_count(), 2);
+
+        let demote: FxHashSet<String> = std::iter::once("dupe:demoted".to_string()).collect();
+        ledger.demote_introductions(&demote);
+
+        assert_eq!(ledger.introduced_count(), 1);
+        assert_eq!(ledger.inherited_count(), 1);
+        let introduced: Vec<bool> = ledger.introduced().collect();
+        assert_eq!(introduced, vec![true, false]);
     }
 
     #[test]

--- a/crates/api/src/audit_keys.rs
+++ b/crates/api/src/audit_keys.rs
@@ -3269,13 +3269,14 @@ pub fn dupe_group_key(group: &fallow_types::duplicates::CloneGroup, root: &Path)
 }
 
 /// Keys of clone groups whose every instance lies entirely outside the diff's
-/// added lines: the duplicated text existed verbatim at base, and the group
-/// only became reportable (under a new attribution key) because the changeset
-/// removed code elsewhere; deduplicating one region can create or re-shape a
-/// clone group across files (issue #2164). New-only gating demotes these
-/// groups to inherited so a clone-removal refactor is not failed by the
-/// duplication it did not write. An instance whose path cannot be mapped into
-/// the diff's namespace is treated as touched, so its group keeps gating.
+/// added lines: no instance range contains an added line, so the changeset did
+/// not write the duplicated text, and the group only became reportable (under
+/// a new attribution key) because the changeset removed code elsewhere;
+/// deduplicating one region can create or re-shape a clone group across files
+/// (issue #2164). New-only gating demotes these groups to inherited so a
+/// clone-removal refactor is not failed by the duplication it did not write.
+/// An instance whose path cannot be mapped into the diff's namespace is
+/// treated as touched, so its group keeps gating.
 pub fn preexisting_dupe_group_keys<'a>(
     groups: impl IntoIterator<Item = &'a fallow_types::duplicates::CloneGroup>,
     root: &Path,

--- a/crates/api/src/runtime/audit.rs
+++ b/crates/api/src/runtime/audit.rs
@@ -62,8 +62,9 @@ pub fn run_audit(options: &AuditOptions) -> ProgrammaticResult<AuditProgrammatic
         None
     };
     let config = load_programmatic_audit_config(&resolved)?;
-    let comparison =
+    let mut comparison =
         build_programmatic_audit_comparison(&head, &config, runtime_base_snapshot.as_ref());
+    demote_preexisting_dupe_introductions(&mut comparison, &head, &resolved_base.git_ref);
     let summary = build_programmatic_audit_summary(&head, &comparison);
     let attribution =
         comparison_attribution(options.gate, &comparison, runtime_base_snapshot.is_some());
@@ -595,6 +596,38 @@ fn build_programmatic_audit_comparison(
         base_dupes: base.map(|snapshot| &snapshot.public.dupes),
         base_styling: base.map(|snapshot| &snapshot.styling),
     })
+}
+
+/// Demote introduced clone groups whose instances contain no added lines from
+/// the merge-base worktree diff: their duplicated text existed verbatim at
+/// base and only the group's attribution key changed because the changeset
+/// removed code elsewhere. Keeps the new-only gate from failing a
+/// clone-removal refactor on duplication it did not write (issue #2164).
+fn demote_preexisting_dupe_introductions(
+    comparison: &mut crate::audit_keys::AuditComparison,
+    analyses: &AuditSubanalyses,
+    base_ref: &str,
+) {
+    if comparison.dupes.introduced_count() == 0 {
+        return;
+    }
+    let root = &analyses.duplication.root;
+    let Ok(diff) = fallow_engine::changed_files::try_get_changed_diff(root, base_ref) else {
+        return;
+    };
+    let index = fallow_output::DiffIndex::from_unified_diff(&diff);
+    let demote = crate::audit_keys::preexisting_dupe_group_keys(
+        analyses
+            .duplication
+            .output
+            .report
+            .clone_groups
+            .iter()
+            .map(|group| &group.group),
+        root,
+        &index,
+    );
+    comparison.dupes.demote_introductions(&demote);
 }
 
 fn build_programmatic_audit_summary(

--- a/crates/api/src/runtime/audit.rs
+++ b/crates/api/src/runtime/audit.rs
@@ -599,8 +599,9 @@ fn build_programmatic_audit_comparison(
 }
 
 /// Demote introduced clone groups whose instances contain no added lines from
-/// the merge-base worktree diff: their duplicated text existed verbatim at
-/// base and only the group's attribution key changed because the changeset
+/// the merge-base worktree diff: no instance range contains an added line, so
+/// the changeset did not write the duplicated text and only the group's
+/// attribution key changed because the changeset
 /// removed code elsewhere. Keeps the new-only gate from failing a
 /// clone-removal refactor on duplication it did not write (issue #2164).
 fn demote_preexisting_dupe_introductions(

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1993,8 +1993,9 @@ fn build_cli_audit_comparison(
 }
 
 /// Demote introduced clone groups whose instances contain no added lines from
-/// the run's diff: their duplicated text existed verbatim at base and only the
-/// group's attribution key changed (membership or extent shifted because the
+/// the run's diff: no instance range contains an added line, so the changeset
+/// did not write the duplicated text and only the group's attribution key
+/// changed (membership or extent shifted because the
 /// changeset removed code elsewhere). Without this, the only safe sequence for
 /// a clone-removal refactor fails the new-only gate on duplication it did not
 /// write (issue #2164). Uses the same diff source as the rest of the run: the

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -1354,12 +1354,18 @@ audit.typeAware: false or pass --no-type-aware to keep the gate syntactic"
         }
     }
     drop_check_shared_parse(&mut check_result);
-    let comparison = build_cli_audit_comparison(
+    let mut comparison = build_cli_audit_comparison(
         check_result.as_ref(),
         dupes_result.as_ref(),
         health_result.as_ref(),
         base_snapshot.as_ref(),
         type_aware_degrade.is_some(),
+    );
+    demote_preexisting_dupe_introductions(
+        &mut comparison,
+        dupes_result.as_ref(),
+        opts.root,
+        &input.base_ref,
     );
     let (attribution, verdict, summary) = compute_comparison_audit_outcome(
         opts.gate,
@@ -1984,6 +1990,42 @@ fn build_cli_audit_comparison(
         dupes: dupes_ledger,
         styling,
     }
+}
+
+/// Demote introduced clone groups whose instances contain no added lines from
+/// the run's diff: their duplicated text existed verbatim at base and only the
+/// group's attribution key changed (membership or extent shifted because the
+/// changeset removed code elsewhere). Without this, the only safe sequence for
+/// a clone-removal refactor fails the new-only gate on duplication it did not
+/// write (issue #2164). Uses the same diff source as the rest of the run: the
+/// opt-in shared diff when present, else the merge-base worktree diff.
+fn demote_preexisting_dupe_introductions(
+    comparison: &mut keys::AuditComparison,
+    dupes: Option<&DupesResult>,
+    root: &Path,
+    base_ref: &str,
+) {
+    if comparison.dupes.introduced_count() == 0 {
+        return;
+    }
+    let Some(dupes) = dupes else {
+        return;
+    };
+    let fallback_index;
+    let index = if let Some(shared) = crate::report::ci::diff_filter::shared_diff_index() {
+        shared
+    } else if let Ok(diff) = fallow_engine::changed_files::try_get_changed_diff(root, base_ref) {
+        fallback_index = fallow_output::DiffIndex::from_unified_diff(&diff);
+        &fallback_index
+    } else {
+        return;
+    };
+    let demote = keys::preexisting_dupe_group_keys(
+        dupes.report.clone_groups.iter(),
+        &dupes.config.root,
+        index,
+    );
+    comparison.dupes.demote_introductions(&demote);
 }
 
 fn compute_comparison_audit_outcome(

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -2647,6 +2647,116 @@ fn audit_reuses_dead_code_parse_for_health_when_production_matches() {
     );
 }
 
+/// Issue #2164: a clone-removal refactor may re-shape a clone group (here the
+/// shared helper is extracted, leaving the surrounding scaffolding as a new,
+/// smaller group with a new attribution key) without writing any duplicated
+/// line. The new-only gate must classify that group as inherited, not
+/// introduced.
+#[test]
+fn audit_new_only_does_not_gate_reshaped_clone_group_without_added_lines() {
+    let helper = "export function eq(xs: string[], ys: string[]): boolean {\n  if (xs.length !== ys.length) {\n    return false;\n  }\n  for (let index = 0; index < xs.length; index += 1) {\n    if (xs[index] !== ys[index]) {\n      return false;\n    }\n  }\n  return true;\n}\n";
+    let scaffolding = "export function selfTest(): boolean {\n  const alpha = ['alpha', 'beta', 'gamma'];\n  const beta = ['alpha', 'beta', 'gamma'];\n  const gamma = ['delta', 'epsilon', 'zeta'];\n  const first = eq(alpha, beta);\n  const second = eq(alpha, gamma);\n  const third = eq(beta, gamma);\n  const outcomes = [first, !second, !third];\n  const labels = ['same', 'differs', 'differs'];\n  const combined = outcomes.map((outcome, index) => `${labels[index]}:${outcome}`);\n  return combined.length === outcomes.length && outcomes.every((outcome) => outcome === true);\n}\n";
+
+    let tmp = tempfile::TempDir::new().expect("temp dir should be created");
+    let root = &tmp
+        .path()
+        .canonicalize()
+        .expect("temp dir should canonicalize");
+    fs::create_dir_all(root.join("src")).expect("src dir should be created");
+    fs::write(
+        root.join("package.json"),
+        r#"{"name":"audit-dupes-reshape","main":"src/index.ts"}"#,
+    )
+    .expect("package.json should be written");
+    fs::write(
+        root.join("src/index.ts"),
+        "import { selfTest as a } from './a';\nimport { selfTest as b } from './b';\na();\nb();\n",
+    )
+    .expect("index should be written");
+    let base_module = format!("{helper}{scaffolding}");
+    fs::write(root.join("src/a.ts"), &base_module).expect("a should be written");
+    fs::write(root.join("src/b.ts"), &base_module).expect("b should be written");
+
+    git(root, &["init", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(
+        root,
+        &["-c", "commit.gpgsign=false", "commit", "-m", "initial"],
+    );
+
+    // The refactor: extract the identical helper to a shared lib. The
+    // scaffolding lines are untouched in both files.
+    let refactored = format!("import {{ eq }} from './lib';\n{scaffolding}");
+    fs::write(root.join("src/a.ts"), &refactored).expect("a should be rewritten");
+    fs::write(root.join("src/b.ts"), &refactored).expect("b should be rewritten");
+    fs::write(root.join("src/lib.ts"), helper).expect("lib should be written");
+
+    let config_path = None;
+    let cache_root = root.join(".fallow");
+    let opts = AuditOptions {
+        root,
+        cache_dir: &cache_root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        no_cache: true,
+        threads: 1,
+        quiet: true,
+        allow_remote_extends: false,
+        changed_since: Some("HEAD"),
+        production: false,
+        production_dead_code: None,
+        production_health: None,
+        production_dupes: None,
+        workspace: None,
+        changed_workspaces: None,
+        explain: false,
+        explain_skipped: false,
+        performance: false,
+        group_by: None,
+        dead_code_baseline: None,
+        health_baseline: None,
+        dupes_baseline: None,
+        health_baseline_mode: fallow_engine::baseline::HealthBaselineMode::default(),
+        max_crap: None,
+        coverage: None,
+        coverage_root: None,
+        gate: AuditGate::NewOnly,
+        include_entry_exports: false,
+        css: false,
+        css_deep: false,
+        runtime_coverage: None,
+        min_invocations_hot: 100,
+        brief: false,
+        max_decisions: 4,
+        walkthrough_guide: false,
+        walkthrough: false,
+        mark_viewed: &[],
+        show_cleared: false,
+        walkthrough_file: None,
+        show_deprioritized: false,
+    };
+
+    let result = execute_audit(&opts).expect("audit should execute");
+    let dupes = result.dupes.as_ref().expect("dupes should run");
+    assert!(
+        !dupes.report.clone_groups.is_empty(),
+        "the scaffolding clone group should still be reported"
+    );
+    assert!(
+        !result.base_snapshot_skipped,
+        "base snapshot should be computed for attribution"
+    );
+    assert_eq!(
+        result.attribution.duplication_introduced, 0,
+        "a re-shaped clone group with no added lines must not gate as introduced"
+    );
+    assert!(
+        result.attribution.duplication_inherited >= 1,
+        "the pre-existing duplication should be reported as inherited"
+    );
+}
+
 #[test]
 fn audit_dupes_falls_back_to_own_discovery_when_health_off() {
     let tmp = tempfile::TempDir::new().expect("temp dir should be created");

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -2757,6 +2757,136 @@ fn audit_new_only_does_not_gate_reshaped_clone_group_without_added_lines() {
     );
 }
 
+/// Repo whose working tree pastes a whole module into a new file on top of a
+/// committed base, with a duplication threshold so the pasted clone can fail
+/// the gate.
+fn pasted_clone_audit_repo() -> tempfile::TempDir {
+    let helper = "export function eq(xs: string[], ys: string[]): boolean {\n  if (xs.length !== ys.length) {\n    return false;\n  }\n  for (let index = 0; index < xs.length; index += 1) {\n    if (xs[index] !== ys[index]) {\n      return false;\n    }\n  }\n  return true;\n}\n";
+    let scaffolding = "export function selfTest(): boolean {\n  const alpha = ['alpha', 'beta', 'gamma'];\n  const beta = ['alpha', 'beta', 'gamma'];\n  const gamma = ['delta', 'epsilon', 'zeta'];\n  const first = eq(alpha, beta);\n  const second = eq(alpha, gamma);\n  const third = eq(beta, gamma);\n  const outcomes = [first, !second, !third];\n  const labels = ['same', 'differs', 'differs'];\n  const combined = outcomes.map((outcome, index) => `${labels[index]}:${outcome}`);\n  return combined.length === outcomes.length && outcomes.every((outcome) => outcome === true);\n}\n";
+
+    let tmp = tempfile::TempDir::new().expect("temp dir should be created");
+    let root = &tmp
+        .path()
+        .canonicalize()
+        .expect("temp dir should canonicalize");
+    fs::create_dir_all(root.join("src")).expect("src dir should be created");
+    fs::write(
+        root.join("package.json"),
+        r#"{"name":"audit-dupes-paste","main":"src/index.ts"}"#,
+    )
+    .expect("package.json should be written");
+    fs::write(
+        root.join(".fallowrc.json"),
+        r#"{"duplicates":{"threshold":1.0}}"#,
+    )
+    .expect("config should be written");
+    fs::write(
+        root.join("src/index.ts"),
+        "import { selfTest as a } from './a';\na();\n",
+    )
+    .expect("index should be written");
+    let module = format!("{helper}{scaffolding}");
+    fs::write(root.join("src/a.ts"), &module).expect("a should be written");
+
+    git(root, &["init", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(
+        root,
+        &["-c", "commit.gpgsign=false", "commit", "-m", "initial"],
+    );
+
+    // The paste: copy the whole module into a new file. Every line of the new
+    // clone instance is an added line, so the group must keep gating.
+    fs::write(root.join("src/b.ts"), &module).expect("b should be written");
+    fs::write(
+        root.join("src/index.ts"),
+        "import { selfTest as a } from './a';\nimport { selfTest as b } from './b';\na();\nb();\n",
+    )
+    .expect("index should be rewritten");
+
+    tmp
+}
+
+/// Strict-side pin for the issue #2164 fix: the touched-instance guard must
+/// only demote re-shaped groups. A genuinely pasted clone (whole module copied
+/// into a new file) contains added lines, so it must still gate as introduced
+/// and fail the new-only gate.
+#[test]
+fn audit_new_only_still_gates_pasted_clone_as_introduced() {
+    let tmp = pasted_clone_audit_repo();
+    let root_buf = tmp
+        .path()
+        .canonicalize()
+        .expect("temp root should canonicalize");
+    let root = root_buf.as_path();
+
+    let config_path = None;
+    let cache_root = root.join(".fallow");
+    let opts = AuditOptions {
+        root,
+        cache_dir: &cache_root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        no_cache: true,
+        threads: 1,
+        quiet: true,
+        allow_remote_extends: false,
+        changed_since: Some("HEAD"),
+        production: false,
+        production_dead_code: None,
+        production_health: None,
+        production_dupes: None,
+        workspace: None,
+        changed_workspaces: None,
+        explain: false,
+        explain_skipped: false,
+        performance: false,
+        group_by: None,
+        dead_code_baseline: None,
+        health_baseline: None,
+        dupes_baseline: None,
+        health_baseline_mode: fallow_engine::baseline::HealthBaselineMode::default(),
+        max_crap: None,
+        coverage: None,
+        coverage_root: None,
+        gate: AuditGate::NewOnly,
+        include_entry_exports: false,
+        css: false,
+        css_deep: false,
+        runtime_coverage: None,
+        min_invocations_hot: 100,
+        brief: false,
+        max_decisions: 4,
+        walkthrough_guide: false,
+        walkthrough: false,
+        mark_viewed: &[],
+        show_cleared: false,
+        walkthrough_file: None,
+        show_deprioritized: false,
+    };
+
+    let result = execute_audit(&opts).expect("audit should execute");
+    let dupes = result.dupes.as_ref().expect("dupes should run");
+    assert!(
+        !dupes.report.clone_groups.is_empty(),
+        "the pasted clone group should be reported"
+    );
+    assert!(
+        !result.base_snapshot_skipped,
+        "base snapshot should be computed for attribution"
+    );
+    assert!(
+        result.attribution.duplication_introduced >= 1,
+        "a pasted clone contains added lines and must gate as introduced"
+    );
+    assert_eq!(
+        result.verdict,
+        AuditVerdict::Fail,
+        "introduced duplication above the threshold must fail the new-only gate"
+    );
+}
+
 #[test]
 fn audit_dupes_falls_back_to_own_discovery_when_health_off() {
     let tmp = tempfile::TempDir::new().expect("temp dir should be created");

--- a/crates/types/src/envelope.rs
+++ b/crates/types/src/envelope.rs
@@ -69,7 +69,10 @@ pub struct ElapsedMs(pub u64);
 /// Audit-mode marker emitted on each finding when `fallow audit --format json`
 /// runs with a base ref. `true` means the finding's structural key was not
 /// present at the base ref (introduced by the current changeset); `false`
-/// means it was inherited.
+/// means it was inherited. Duplication findings carry one carve-out: a clone
+/// group whose structural key is new but whose instances contain no added line
+/// from the diff (a group re-shaped by removing duplication elsewhere) is
+/// demoted to inherited and serializes `false` (issue #2164).
 ///
 /// Outside of audit sub-results the field is omitted, so call sites typically
 /// hold `Option<AuditIntroduced>`. Renders to the JSON wire as a bare boolean.

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -217,7 +217,7 @@
     },
     "AuditIntroduced": {
       "type": "boolean",
-      "description": "Audit-mode marker emitted on each finding when `fallow audit --format json`\nruns with a base ref. `true` means the finding's structural key was not\npresent at the base ref (introduced by the current changeset); `false`\nmeans it was inherited.\n\nOutside of audit sub-results the field is omitted, so call sites typically\nhold `Option<AuditIntroduced>`. Renders to the JSON wire as a bare boolean."
+      "description": "Audit-mode marker emitted on each finding when `fallow audit --format json`\nruns with a base ref. `true` means the finding's structural key was not\npresent at the base ref (introduced by the current changeset); `false`\nmeans it was inherited. Duplication findings carry one carve-out: a clone\ngroup whose structural key is new but whose instances contain no added line\nfrom the diff (a group re-shaped by removing duplication elsewhere) is\ndemoted to inherited and serializes `false` (issue #2164).\n\nOutside of audit sub-results the field is omitted, so call sites typically\nhold `Option<AuditIntroduced>`. Renders to the JSON wire as a bare boolean."
     },
     "ExplainOutput": {
       "type": "object",

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -270,7 +270,10 @@ export type AddToConfigValue = (string | IgnoreExportsRule[] | {
  * Audit-mode marker emitted on each finding when `fallow audit --format json`
  * runs with a base ref. `true` means the finding's structural key was not
  * present at the base ref (introduced by the current changeset); `false`
- * means it was inherited.
+ * means it was inherited. Duplication findings carry one carve-out: a clone
+ * group whose structural key is new but whose instances contain no added line
+ * from the diff (a group re-shaped by removing duplication elsewhere) is
+ * demoted to inherited and serializes `false` (issue #2164).
  *
  * Outside of audit sub-results the field is omitted, so call sites typically
  * hold `Option<AuditIntroduced>`. Renders to the JSON wire as a bare boolean.

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -270,7 +270,10 @@ export type AddToConfigValue = (string | IgnoreExportsRule[] | {
  * Audit-mode marker emitted on each finding when `fallow audit --format json`
  * runs with a base ref. `true` means the finding's structural key was not
  * present at the base ref (introduced by the current changeset); `false`
- * means it was inherited.
+ * means it was inherited. Duplication findings carry one carve-out: a clone
+ * group whose structural key is new but whose instances contain no added line
+ * from the diff (a group re-shaped by removing duplication elsewhere) is
+ * demoted to inherited and serializes `false` (issue #2164).
  *
  * Outside of audit sub-results the field is omitted, so call sites typically
  * hold `Option<AuditIntroduced>`. Renders to the JSON wire as a bare boolean.


### PR DESCRIPTION
The audit dupes attribution key changes whenever a clone group's membership or extent shifts, so a clone-removal refactor (extracting a shared helper and deleting instances) produced a "new" structural key and `--gate new-only` failed the only safe sequence for removing duplication.

Clone groups whose instance ranges contain no added line from the diff are now demoted to inherited instead of introduced. A strict-side integration test pins that a genuinely pasted clone still gates with `duplication_introduced >= 1` and a failing verdict, and the AuditIntroduced / preexisting_dupe_group_keys contract docs now describe the actual semantics (generated contracts regenerated).

Fixes #2164