### PR TITLE
test(vscode): pin combined and health envelopes at schema 10

### DIFF
--- a/editors/vscode/test/generated-types.test.ts
+++ b/editors/vscode/test/generated-types.test.ts
@@ -36,10 +36,10 @@ describe("generated/output-contract.d.ts", () => {
     expectTypeOf<SchemaVersion>().toEqualTypeOf<8>();
     expectTypeOf<AuditSchemaVersion>().toEqualTypeOf<9>();
     expectTypeOf<CheckSchemaVersion>().toEqualTypeOf<8>();
-    expectTypeOf<CombinedSchemaVersion>().toEqualTypeOf<9>();
+    expectTypeOf<CombinedSchemaVersion>().toEqualTypeOf<10>();
     expectTypeOf<DupesSchemaVersion>().toEqualTypeOf<2 | 8>();
     expectTypeOf<FeatureFlagsSchemaVersion>().toEqualTypeOf<8>();
-    expectTypeOf<HealthSchemaVersion>().toEqualTypeOf<9>();
+    expectTypeOf<HealthSchemaVersion>().toEqualTypeOf<10>();
     expectTypeOf<TypeAwareStatusSchemaVersion>().toEqualTypeOf<8>();
   });
 
@@ -70,7 +70,7 @@ describe("generated/output-contract.d.ts", () => {
 
   it("exposes CombinedOutput with optional check/dupes/health branches", () => {
     const sample: CombinedOutput = {
-      schema_version: 9,
+      schema_version: 10,
       version: "0.0.0-test",
       elapsed_ms: 0,
     };


### PR DESCRIPTION
The generated-types type test still pinned CombinedSchemaVersion and HealthSchemaVersion at 9; both envelopes moved to 10 with the SFC threshold-override change, which turned the VS Code Extension job red on main.