### PR TITLE
ci: retry the ecosystem project clone

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -80,18 +80,41 @@ jobs:
           PROJECT_REF: ${{ matrix.project.ref }}
           PROJECT_SPARSE: ${{ matrix.project.sparse }}
         run: |
+          # Five third-party repositories are cloned per run, which makes
+          # transient network and TLS errors the dominant failure mode. The
+          # analysis step below is deliberately non-gating, so a blip while
+          # fetching someone else's repository should not be the one thing
+          # that turns this workflow red.
+          clone_project() {
+            if [ -n "$PROJECT_SPARSE" ]; then
+              git clone --depth 1 --filter=blob:none --sparse \
+                --branch "$PROJECT_REF" \
+                "https://github.com/$PROJECT_REPO.git" \
+                ecosystem-project
+            else
+              git clone --depth 1 \
+                --branch "$PROJECT_REF" \
+                "https://github.com/$PROJECT_REPO.git" \
+                ecosystem-project
+            fi
+          }
+
+          for attempt in 1 2 3; do
+            if clone_project; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::could not clone $PROJECT_REPO after $attempt attempts"
+              exit 1
+            fi
+            echo "clone attempt $attempt failed, retrying"
+            rm -rf ecosystem-project
+            sleep "$((attempt * 15))"
+          done
+
           if [ -n "$PROJECT_SPARSE" ]; then
-            git clone --depth 1 --filter=blob:none --sparse \
-              --branch "$PROJECT_REF" \
-              "https://github.com/$PROJECT_REPO.git" \
-              ecosystem-project
             cd ecosystem-project
             git sparse-checkout set "$PROJECT_SPARSE"
-          else
-            git clone --depth 1 \
-              --branch "$PROJECT_REF" \
-              "https://github.com/$PROJECT_REPO.git" \
-              ecosystem-project
           fi
 
       - name: Run fallow dead-code


### PR DESCRIPTION
`Ecosystem (next.js-with-typescript)` went red on #2181 with:

```
fatal: unable to access 'https://github.com/vercel/next.js.git/':
server certificate verification failed. CAfile: none CRLfile: none
```

A transient TLS failure fetching someone else's repository, not anything in that PR. The same job passed on main immediately before and after.

The workflow already treats its own analysis as non-gating (`continue-on-error: true`, "this is for monitoring, not gating"), but the clone that feeds it had no retry, so one network blip while cloning any of the five third-party projects fails the run.

This retries the clone three times with a growing pause. A repository that has genuinely moved or been renamed still fails, loudly, with an `::error::` naming it.

Verified the shell against a stub `git`: a persistent failure exits 1 after three attempts, and a first-attempt flake recovers and still runs the sparse checkout afterwards. Touching this workflow triggers it, so the PR exercises the changed path.