### PR TITLE
fix: sync the npm package versions with the 3.15.0 workspace

### DIFF
--- a/crates/napi/index.js
+++ b/crates/napi/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-android-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-android-arm64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-android-arm-eabi')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-x64-gnu')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-x64-msvc')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-ia32-msvc')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-win32-arm64-msvc')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@fallow-cli/fallow-node-darwin-universal')
       const bindingPackageVersion = require('@fallow-cli/fallow-node-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-darwin-x64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-darwin-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-freebsd-x64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-freebsd-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-x64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-x64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm-musleabihf')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-loong64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-loong64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-riscv64-musl')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@fallow-cli/fallow-node-linux-riscv64-gnu')
           const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-linux-ppc64-gnu')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-linux-s390x-gnu')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-openharmony-arm64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-openharmony-x64')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@fallow-cli/fallow-node-openharmony-arm')
         const bindingPackageVersion = require('@fallow-cli/fallow-node-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '3.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 3.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '3.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 3.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/crates/napi/package-lock.json
+++ b/crates/napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fallow-cli/fallow-node",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fallow-cli/fallow-node",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "3.8.2"
@@ -15,15 +15,15 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@fallow-cli/fallow-node-darwin-arm64": "3.14.0",
-        "@fallow-cli/fallow-node-darwin-x64": "3.14.0",
-        "@fallow-cli/fallow-node-linux-arm64-gnu": "3.14.0",
-        "@fallow-cli/fallow-node-linux-arm64-musl": "3.14.0",
-        "@fallow-cli/fallow-node-linux-x64-gnu": "3.14.0",
-        "@fallow-cli/fallow-node-linux-x64-musl": "3.14.0",
-        "@fallow-cli/fallow-node-win32-arm64-msvc": "3.14.0",
-        "@fallow-cli/fallow-node-win32-x64-msvc": "3.14.0",
-        "fallow-type-aware": "3.14.0"
+        "@fallow-cli/fallow-node-darwin-arm64": "3.15.0",
+        "@fallow-cli/fallow-node-darwin-x64": "3.15.0",
+        "@fallow-cli/fallow-node-linux-arm64-gnu": "3.15.0",
+        "@fallow-cli/fallow-node-linux-arm64-musl": "3.15.0",
+        "@fallow-cli/fallow-node-linux-x64-gnu": "3.15.0",
+        "@fallow-cli/fallow-node-linux-x64-musl": "3.15.0",
+        "@fallow-cli/fallow-node-win32-arm64-msvc": "3.15.0",
+        "@fallow-cli/fallow-node-win32-x64-msvc": "3.15.0",
+        "fallow-type-aware": "3.15.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/crates/napi/package.json
+++ b/crates/napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fallow-cli/fallow-node",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Native Node.js bindings for fallow, codebase intelligence for TypeScript and JavaScript. Finds unused code, duplication, circular dependencies, complexity hotspots, architecture drift, and design-system styling drift. Optional runtime intelligence layer (Fallow Runtime) adds production execution evidence.",
   "main": "loader.js",
   "types": "index.d.ts",
@@ -67,14 +67,14 @@
     "@napi-rs/cli": "3.8.2"
   },
   "optionalDependencies": {
-    "@fallow-cli/fallow-node-darwin-arm64": "3.14.0",
-    "@fallow-cli/fallow-node-darwin-x64": "3.14.0",
-    "@fallow-cli/fallow-node-linux-arm64-gnu": "3.14.0",
-    "@fallow-cli/fallow-node-linux-arm64-musl": "3.14.0",
-    "@fallow-cli/fallow-node-linux-x64-gnu": "3.14.0",
-    "@fallow-cli/fallow-node-linux-x64-musl": "3.14.0",
-    "@fallow-cli/fallow-node-win32-arm64-msvc": "3.14.0",
-    "@fallow-cli/fallow-node-win32-x64-msvc": "3.14.0",
-    "fallow-type-aware": "3.14.0"
+    "@fallow-cli/fallow-node-darwin-arm64": "3.15.0",
+    "@fallow-cli/fallow-node-darwin-x64": "3.15.0",
+    "@fallow-cli/fallow-node-linux-arm64-gnu": "3.15.0",
+    "@fallow-cli/fallow-node-linux-arm64-musl": "3.15.0",
+    "@fallow-cli/fallow-node-linux-x64-gnu": "3.15.0",
+    "@fallow-cli/fallow-node-linux-x64-musl": "3.15.0",
+    "@fallow-cli/fallow-node-win32-arm64-msvc": "3.15.0",
+    "@fallow-cli/fallow-node-win32-x64-msvc": "3.15.0",
+    "fallow-type-aware": "3.15.0"
   }
 }

--- a/tools/type-aware-sidecar/package-lock.json
+++ b/tools/type-aware-sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fallow-type-aware",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fallow-type-aware",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "license": "MIT",
       "dependencies": {
         "typescript": "7.0.2"

--- a/tools/type-aware-sidecar/package.json
+++ b/tools/type-aware-sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fallow-type-aware",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Optional TypeScript-Go semantic refinement sidecar for Fallow",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
main is red, and this is why.

The v3.15.0 release moved the Rust workspace to 3.15.0 but did not run `scripts/sync-npm-versions.sh`, so the npm side stayed at 3.14.0. The CLI refuses a type-aware companion whose version does not match the binary:

```
Type-aware analysis failed: type-aware companion version 3.14.0 does not
match Fallow 3.15.0. Install fallow-type-aware@3.15.0
```

That fails three audit tests in `Check`, and `scripts/repository-policy.test.mjs` asserts the same equality directly, which fails `JS Lint and Format`. Both are red on `eaaeb4a54` on main right now, so every open PR inherits it.

This is the output of the sync script itself, run for 3.14.0 to 3.15.0, not a hand edit. It covers the type-aware companion, the node bindings and their platform packages.

The script is documented as a cargo-release pre-release hook but is not wired into any workflow, so nothing catches a release that skips it. Worth a follow-up: either invoke it from the release flow or assert the equality in a gate that runs on the release commit.