### PR TITLE
fix(core): keep package tooling out of production reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Build and tooling scripts no longer make devDependencies look like
+  production dependencies.** Files referenced from package.json scripts stay
+  reachable for dead-code analysis, but only npm's
+  `start`/`prestart`/`poststart` lifecycle and scripts invoked from it contribute
+  production reachability. This prevents `dev-dependencies-in-production`
+  false positives from build pipelines such as Style Dictionary and SVGO while
+  preserving the rule for start-only services.
+
 ## [3.15.0] - 2026-08-11
 
 ### Added

--- a/crates/core/src/discover/entry_points.rs
+++ b/crates/core/src/discover/entry_points.rs
@@ -1,6 +1,5 @@
 use std::path::{Component, Path, PathBuf};
 
-use super::parse_scripts::extract_script_file_refs;
 use super::walk::SOURCE_EXTENSIONS;
 use fallow_config::{EntryPointRole, PackageJson, ResolvedConfig};
 use fallow_graph::resolve::OUTPUT_DIRS;
@@ -145,8 +144,19 @@ fn dedup_entry_paths(entries: &mut Vec<EntryPoint>) {
 
 #[derive(Debug, Default)]
 pub struct EntryPointDiscovery {
+    /// Runtime entry points declared by package metadata or inferred defaults.
     pub entries: Vec<EntryPoint>,
+    /// Tooling entry points referenced only from non-runtime package scripts.
+    pub support_entries: Vec<EntryPoint>,
     pub skipped_entries: FxHashMap<String, usize>,
+}
+
+impl EntryPointDiscovery {
+    fn into_all_entries(mut self) -> Vec<EntryPoint> {
+        self.entries.append(&mut self.support_entries);
+        dedup_entry_paths(&mut self.entries);
+        self.entries
+    }
 }
 
 /// Resolve a path relative to a base directory, with security check and extension fallback.
@@ -579,8 +589,10 @@ fn push_package_json_entries(
     let Some(scripts) = &pkg.scripts else {
         return;
     };
-    for script_value in scripts.values() {
-        for file_ref in extract_script_file_refs(script_value) {
+    let runtime_scripts = runtime_package_script_names(scripts);
+    for (script_name, script_value) in scripts {
+        let refs = package_script_refs(script_value);
+        for file_ref in refs.inheritable {
             if let Some(ep) = resolve_entry_path_with_tracking(
                 root,
                 &file_ref,
@@ -588,8 +600,181 @@ fn push_package_json_entries(
                 EntryPointSource::PackageJsonScript,
                 Some(&mut discovery.skipped_entries),
             ) {
-                discovery.entries.push(ep);
+                if runtime_scripts.contains(script_name) {
+                    discovery.entries.push(ep);
+                } else {
+                    discovery.support_entries.push(ep);
+                }
             }
+        }
+        for config_ref in refs.support {
+            if let Some(ep) = resolve_entry_path_with_tracking(
+                root,
+                &config_ref,
+                canonical_root,
+                EntryPointSource::PackageJsonScript,
+                Some(&mut discovery.skipped_entries),
+            ) {
+                discovery.support_entries.push(ep);
+            }
+        }
+    }
+}
+
+struct PackageScriptRefs {
+    inheritable: Vec<String>,
+    support: Vec<String>,
+}
+
+fn package_script_refs(script: &str) -> PackageScriptRefs {
+    let mut inheritable = Vec::new();
+    let mut support = Vec::new();
+    for command in crate::scripts::parse_script(script) {
+        inheritable.extend(command.file_args);
+        support.extend(command.config_args);
+    }
+    inheritable.extend(super::parse_scripts::extract_script_file_refs(script));
+    support.sort_unstable();
+    support.dedup();
+    inheritable.retain(|path| support.binary_search(path).is_err());
+    inheritable.sort_unstable();
+    inheritable.dedup();
+    PackageScriptRefs {
+        inheritable,
+        support,
+    }
+}
+
+/// npm's start lifecycle is a production execution surface. Other package
+/// scripts are conservatively treated as tooling: their files stay reachable,
+/// but do not prove that a devDependency ships with the application.
+#[expect(
+    clippy::disallowed_types,
+    reason = "API matches serde-deserialized package.json scripts map"
+)]
+fn runtime_package_script_names(
+    scripts: &std::collections::HashMap<String, String>,
+) -> FxHashSet<String> {
+    runtime_package_script_names_with_seeds(scripts, &FxHashSet::default())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "API matches serde-deserialized package.json scripts map"
+)]
+fn runtime_package_script_names_with_seeds(
+    scripts: &std::collections::HashMap<String, String>,
+    seeds: &FxHashSet<String>,
+) -> FxHashSet<String> {
+    let catalog = crate::scripts::ScriptCatalog::from_scripts(scripts);
+    let mut runtime = FxHashSet::default();
+    let mut pending = Vec::new();
+
+    enqueue_runtime_script("start", scripts, &mut runtime, &mut pending);
+    for seed in seeds {
+        enqueue_runtime_script(seed, scripts, &mut runtime, &mut pending);
+    }
+
+    while let Some(name) = pending.pop() {
+        let Some(body) = scripts.get(&name) else {
+            continue;
+        };
+        for referenced in crate::scripts::referenced_package_scripts(body, &catalog) {
+            enqueue_runtime_script(&referenced, scripts, &mut runtime, &mut pending);
+        }
+    }
+
+    runtime
+}
+
+pub fn workspace_runtime_script_seeds(
+    project_root: &Path,
+    root_pkg: Option<&PackageJson>,
+    workspace_pkgs: &[(fallow_config::WorkspaceInfo, PackageJson)],
+) -> FxHashMap<String, FxHashSet<String>> {
+    let mut seeds: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
+    let mut selectors = FxHashMap::default();
+    for (idx, (workspace, _)) in workspace_pkgs.iter().enumerate() {
+        selectors.insert(workspace.name.clone(), idx);
+        if let Ok(relative) = workspace.root.strip_prefix(project_root) {
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            selectors.insert(relative.clone(), idx);
+            selectors.insert(format!("./{relative}"), idx);
+        }
+    }
+
+    let mut pending = Vec::new();
+    if let Some(scripts) = root_pkg.and_then(|pkg| pkg.scripts.as_ref()) {
+        pending.extend(
+            runtime_package_script_names(scripts)
+                .into_iter()
+                .map(|name| (None, name)),
+        );
+    }
+    for (idx, (_, pkg)) in workspace_pkgs.iter().enumerate() {
+        if let Some(scripts) = pkg.scripts.as_ref() {
+            pending.extend(
+                runtime_package_script_names(scripts)
+                    .into_iter()
+                    .map(|name| (Some(idx), name)),
+            );
+        }
+    }
+
+    let mut visited = FxHashSet::default();
+    while let Some((source_idx, name)) = pending.pop() {
+        if !visited.insert((source_idx, name.clone())) {
+            continue;
+        }
+        let scripts = match source_idx {
+            Some(idx) => workspace_pkgs[idx].1.scripts.as_ref(),
+            None => root_pkg.and_then(|pkg| pkg.scripts.as_ref()),
+        };
+        let Some(body) = scripts.and_then(|scripts| scripts.get(&name)) else {
+            continue;
+        };
+        for (selector, script) in crate::scripts::referenced_workspace_scripts(body) {
+            let Some(&target_idx) = selectors.get(&selector) else {
+                continue;
+            };
+            let (workspace, target_pkg) = &workspace_pkgs[target_idx];
+            let Some(target_scripts) = target_pkg.scripts.as_ref() else {
+                continue;
+            };
+            let target_seeds = FxHashSet::from_iter([script]);
+            for runtime_name in
+                runtime_package_script_names_with_seeds(target_scripts, &target_seeds)
+            {
+                if seeds
+                    .entry(workspace.name.clone())
+                    .or_default()
+                    .insert(runtime_name.clone())
+                {
+                    pending.push((Some(target_idx), runtime_name));
+                }
+            }
+        }
+    }
+    seeds
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "API matches serde-deserialized package.json scripts map"
+)]
+fn enqueue_runtime_script(
+    name: &str,
+    scripts: &std::collections::HashMap<String, String>,
+    runtime: &mut FxHashSet<String>,
+    pending: &mut Vec<String>,
+) {
+    for candidate in [
+        format!("pre{name}"),
+        name.to_string(),
+        format!("post{name}"),
+    ] {
+        if scripts.contains_key(&candidate) && runtime.insert(candidate.clone()) {
+            pending.push(candidate);
         }
     }
 }
@@ -616,10 +801,14 @@ fn discover_entry_points_with_warnings_impl(
         let exports_dirs = root_pkg
             .map(PackageJson::exports_subdirectories)
             .unwrap_or_default();
+        let mut nested_entries = PackageEntryBuckets {
+            runtime: &mut discovery.entries,
+            support: &mut discovery.support_entries,
+        };
         discover_nested_package_entries(
             &config.root,
             files,
-            &mut discovery.entries,
+            &mut nested_entries,
             &canonical_root,
             &exports_dirs,
             &mut discovery.skipped_entries,
@@ -632,6 +821,10 @@ fn discover_entry_points_with_warnings_impl(
 
     discovery.entries.sort_by(|a, b| a.path.cmp(&b.path));
     discovery.entries.dedup_by(|a, b| a.path == b.path);
+    discovery
+        .support_entries
+        .sort_by(|a, b| a.path.cmp(&b.path));
+    discovery.support_entries.dedup_by(|a, b| a.path == b.path);
 
     discovery
 }
@@ -661,7 +854,7 @@ pub fn discover_entry_points_with_warnings(
 pub fn discover_entry_points(config: &ResolvedConfig, files: &[DiscoveredFile]) -> Vec<EntryPoint> {
     let discovery = discover_entry_points_with_warnings(config, files);
     warn_skipped_entry_summary(&discovery.skipped_entries);
-    discovery.entries
+    discovery.into_all_entries()
 }
 
 /// Discover entry points from nested package.json files in subdirectories.
@@ -673,10 +866,15 @@ pub fn discover_entry_points(config: &ResolvedConfig, files: &[DiscoveredFile]) 
 ///
 /// For each discovered sub-package with a `package.json`, the `main`, `module`,
 /// `source`, `exports`, and `bin` fields are treated as entry points.
+struct PackageEntryBuckets<'a> {
+    runtime: &'a mut Vec<EntryPoint>,
+    support: &'a mut Vec<EntryPoint>,
+}
+
 fn discover_nested_package_entries(
     root: &Path,
     _files: &[DiscoveredFile],
-    entries: &mut Vec<EntryPoint>,
+    entries: &mut PackageEntryBuckets<'_>,
     canonical_root: &Path,
     exports_subdirectories: &[String],
     skipped_entries: &mut FxHashMap<String, usize>,
@@ -697,7 +895,13 @@ fn discover_nested_package_entries(
         for entry in read_dir.flatten() {
             let pkg_dir = entry.path();
             if visited.insert(pkg_dir.clone()) {
-                collect_nested_package_entries(&pkg_dir, entries, canonical_root, skipped_entries);
+                collect_nested_package_entries(
+                    &pkg_dir,
+                    entries.runtime,
+                    entries.support,
+                    canonical_root,
+                    skipped_entries,
+                );
             }
         }
     }
@@ -705,7 +909,13 @@ fn discover_nested_package_entries(
     for dir_name in exports_subdirectories {
         let pkg_dir = root.join(dir_name);
         if pkg_dir.is_dir() && visited.insert(pkg_dir.clone()) {
-            collect_nested_package_entries(&pkg_dir, entries, canonical_root, skipped_entries);
+            collect_nested_package_entries(
+                &pkg_dir,
+                entries.runtime,
+                entries.support,
+                canonical_root,
+                skipped_entries,
+            );
         }
     }
 }
@@ -714,6 +924,7 @@ fn discover_nested_package_entries(
 fn collect_nested_package_entries(
     pkg_dir: &Path,
     entries: &mut Vec<EntryPoint>,
+    support_entries: &mut Vec<EntryPoint>,
     canonical_root: &Path,
     skipped_entries: &mut FxHashMap<String, usize>,
 ) {
@@ -734,8 +945,10 @@ fn collect_nested_package_entries(
         }
     }
     if let Some(scripts) = &pkg.scripts {
-        for script_value in scripts.values() {
-            for file_ref in extract_script_file_refs(script_value) {
+        let runtime_scripts = runtime_package_script_names(scripts);
+        for (script_name, script_value) in scripts {
+            let refs = package_script_refs(script_value);
+            for file_ref in refs.inheritable {
                 if let Some(ep) = resolve_entry_path_with_tracking(
                     pkg_dir,
                     &file_ref,
@@ -743,7 +956,22 @@ fn collect_nested_package_entries(
                     EntryPointSource::PackageJsonScript,
                     Some(&mut *skipped_entries),
                 ) {
-                    entries.push(ep);
+                    if runtime_scripts.contains(script_name) {
+                        entries.push(ep);
+                    } else {
+                        support_entries.push(ep);
+                    }
+                }
+            }
+            for config_ref in refs.support {
+                if let Some(ep) = resolve_entry_path_with_tracking(
+                    pkg_dir,
+                    &config_ref,
+                    canonical_root,
+                    EntryPointSource::PackageJsonScript,
+                    Some(&mut *skipped_entries),
+                ) {
+                    support_entries.push(ep);
                 }
             }
         }
@@ -786,6 +1014,7 @@ fn discover_workspace_entry_points_with_warnings_impl(
     ws_root: &Path,
     all_files: &[DiscoveredFile],
     pkg: Option<&PackageJson>,
+    runtime_script_seeds: &FxHashSet<String>,
 ) -> EntryPointDiscovery {
     let mut discovery = EntryPointDiscovery::default();
 
@@ -812,8 +1041,11 @@ fn discover_workspace_entry_points_with_warnings_impl(
         }
 
         if let Some(scripts) = &pkg.scripts {
-            for script_value in scripts.values() {
-                for file_ref in extract_script_file_refs(script_value) {
+            let runtime_scripts =
+                runtime_package_script_names_with_seeds(scripts, runtime_script_seeds);
+            for (script_name, script_value) in scripts {
+                let refs = package_script_refs(script_value);
+                for file_ref in refs.inheritable {
                     if let Some(ep) = resolve_entry_path_with_tracking(
                         ws_root,
                         &file_ref,
@@ -821,7 +1053,22 @@ fn discover_workspace_entry_points_with_warnings_impl(
                         EntryPointSource::PackageJsonScript,
                         Some(&mut discovery.skipped_entries),
                     ) {
-                        discovery.entries.push(ep);
+                        if runtime_scripts.contains(script_name) {
+                            discovery.entries.push(ep);
+                        } else {
+                            discovery.support_entries.push(ep);
+                        }
+                    }
+                }
+                for config_ref in refs.support {
+                    if let Some(ep) = resolve_entry_path_with_tracking(
+                        ws_root,
+                        &config_ref,
+                        &canonical_ws_root,
+                        EntryPointSource::PackageJsonScript,
+                        Some(&mut discovery.skipped_entries),
+                    ) {
+                        discovery.support_entries.push(ep);
                     }
                 }
             }
@@ -835,14 +1082,24 @@ fn discover_workspace_entry_points_with_warnings_impl(
     discovery.entries.sort_by(|a, b| a.path.cmp(&b.path));
     discovery.entries.dedup_by(|a, b| a.path == b.path);
     discovery
+        .support_entries
+        .sort_by(|a, b| a.path.cmp(&b.path));
+    discovery.support_entries.dedup_by(|a, b| a.path == b.path);
+    discovery
 }
 
-pub fn discover_workspace_entry_points_with_warnings_from_pkg(
+pub fn discover_workspace_entry_points_with_runtime_scripts(
     ws_root: &Path,
     all_files: &[DiscoveredFile],
     pkg: Option<&PackageJson>,
+    runtime_script_seeds: &FxHashSet<String>,
 ) -> EntryPointDiscovery {
-    discover_workspace_entry_points_with_warnings_impl(ws_root, all_files, pkg)
+    discover_workspace_entry_points_with_warnings_impl(
+        ws_root,
+        all_files,
+        pkg,
+        runtime_script_seeds,
+    )
 }
 
 #[must_use]
@@ -852,7 +1109,12 @@ pub fn discover_workspace_entry_points_with_warnings(
     all_files: &[DiscoveredFile],
 ) -> EntryPointDiscovery {
     let pkg = fallow_config::load_dir_package_json(ws_root);
-    discover_workspace_entry_points_with_warnings_impl(ws_root, all_files, pkg.as_ref())
+    discover_workspace_entry_points_with_warnings_impl(
+        ws_root,
+        all_files,
+        pkg.as_ref(),
+        &FxHashSet::default(),
+    )
 }
 
 #[must_use]
@@ -863,7 +1125,7 @@ pub fn discover_workspace_entry_points(
 ) -> Vec<EntryPoint> {
     let discovery = discover_workspace_entry_points_with_warnings(ws_root, config, all_files);
     warn_skipped_entry_summary(&discovery.skipped_entries);
-    discovery.entries
+    discovery.into_all_entries()
 }
 
 /// Discover entry points from plugin results (dynamic config parsing).
@@ -2231,6 +2493,329 @@ mod tests {
             entries[0].source,
             EntryPointSource::PackageJsonScript
         ));
+    }
+
+    #[test]
+    fn build_script_is_support_while_default_index_stays_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("scripts")).expect("scripts dir");
+        std::fs::create_dir_all(root.join("src")).expect("src dir");
+        std::fs::write(root.join("scripts/build.ts"), "export const build = true;")
+            .expect("script file");
+        std::fs::write(root.join("src/index.ts"), "export const app = true;").expect("index file");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"scripts":{"build":"tsx scripts/build.ts"}}"#,
+        )
+        .expect("package file");
+        let config = config_for(root);
+        let files = [
+            discovered(root, "scripts/build.ts", 0),
+            discovered(root, "src/index.ts", 1),
+        ];
+
+        let discovery = discover_entry_points_with_warnings(&config, &files);
+
+        assert_eq!(discovery.entries.len(), 1);
+        assert!(discovery.entries[0].path.ends_with("src/index.ts"));
+        assert_eq!(discovery.support_entries.len(), 1);
+        assert!(
+            discovery.support_entries[0]
+                .path
+                .ends_with("scripts/build.ts")
+        );
+    }
+
+    #[test]
+    fn indirect_quoted_start_script_stays_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).expect("src dir");
+        std::fs::write(root.join("src/server.ts"), "export const server = true;")
+            .expect("server file");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"scripts":{"start":"npm run serve","serve":"node 'src/server.ts'"}}"#,
+        )
+        .expect("package file");
+        let config = config_for(root);
+        let files = [discovered(root, "src/server.ts", 0)];
+
+        let discovery = discover_entry_points_with_warnings(&config, &files);
+
+        assert_eq!(discovery.entries.len(), 1);
+        assert!(discovery.entries[0].path.ends_with("src/server.ts"));
+        assert!(discovery.support_entries.is_empty());
+    }
+
+    #[test]
+    fn indirect_start_script_includes_its_lifecycle_hooks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).expect("src dir");
+        for file in ["pre.ts", "server.ts", "post.ts"] {
+            std::fs::write(root.join("src").join(file), "export const value = true;")
+                .expect("runtime file");
+        }
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"scripts":{"start":"npm run serve","preserve":"node src/pre.ts","serve":"node src/server.ts","postserve":"node src/post.ts"}}"#,
+        )
+        .expect("package file");
+        let config = config_for(root);
+        let files = [
+            discovered(root, "src/pre.ts", 0),
+            discovered(root, "src/server.ts", 1),
+            discovered(root, "src/post.ts", 2),
+        ];
+
+        let discovery = discover_entry_points_with_warnings(&config, &files);
+
+        assert_eq!(discovery.entries.len(), 3);
+        assert!(discovery.support_entries.is_empty());
+    }
+
+    #[test]
+    #[expect(
+        clippy::disallowed_types,
+        reason = "test input matches the serde-deserialized package.json scripts map"
+    )]
+    fn start_does_not_recursively_invent_hooks_for_lifecycle_hooks() {
+        let scripts = std::collections::HashMap::from([
+            ("preprestart".to_string(), "node src/tool.ts".to_string()),
+            ("prestart".to_string(), "node src/pre.ts".to_string()),
+            ("start".to_string(), "node src/server.ts".to_string()),
+            ("poststart".to_string(), "node src/post.ts".to_string()),
+            ("postpoststart".to_string(), "node src/tool.ts".to_string()),
+        ]);
+
+        let runtime = runtime_package_script_names(&scripts);
+
+        assert_eq!(
+            runtime,
+            FxHashSet::from_iter([
+                "prestart".to_string(),
+                "start".to_string(),
+                "poststart".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn bun_build_script_remains_support_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("scripts")).expect("scripts dir");
+        std::fs::write(root.join("scripts/build.ts"), "export const build = true;")
+            .expect("build file");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"scripts":{"build":"bun scripts/build.ts"}}"#,
+        )
+        .expect("package file");
+        let config = config_for(root);
+        let files = [discovered(root, "scripts/build.ts", 0)];
+
+        let discovery = discover_entry_points_with_warnings(&config, &files);
+
+        assert!(discovery.entries.is_empty());
+        assert_eq!(discovery.support_entries.len(), 1);
+    }
+
+    #[test]
+    fn start_script_config_remains_support_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("vite.config.ts"), "export default {};").expect("config file");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"scripts":{"start":"vite --config vite.config.ts"}}"#,
+        )
+        .expect("package file");
+        let config = config_for(root);
+        let files = [discovered(root, "vite.config.ts", 0)];
+
+        let discovery = discover_entry_points_with_warnings(&config, &files);
+
+        assert!(discovery.entries.is_empty());
+        assert_eq!(discovery.support_entries.len(), 1);
+        assert!(
+            discovery.support_entries[0]
+                .path
+                .ends_with("vite.config.ts")
+        );
+    }
+
+    #[test]
+    fn manifest_entry_remains_runtime_when_build_script_references_same_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).expect("src dir");
+        std::fs::write(root.join("src/index.ts"), "export const app = true;").expect("index file");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"main":"src/index.ts","scripts":{"build":"tsx src/index.ts"}}"#,
+        )
+        .expect("package file");
+        let config = config_for(root);
+        let files = [discovered(root, "src/index.ts", 0)];
+
+        let discovery = discover_entry_points_with_warnings(&config, &files);
+
+        assert_eq!(discovery.entries.len(), 1);
+        assert!(discovery.entries[0].path.ends_with("src/index.ts"));
+    }
+
+    #[test]
+    fn workspace_build_script_is_support_with_runtime_fallback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let workspace = root.join("packages/app");
+        std::fs::create_dir_all(workspace.join("scripts")).expect("scripts dir");
+        std::fs::create_dir_all(workspace.join("src")).expect("src dir");
+        std::fs::write(
+            workspace.join("scripts/build.ts"),
+            "export const build = true;",
+        )
+        .expect("script file");
+        std::fs::write(workspace.join("src/index.ts"), "export const app = true;")
+            .expect("index file");
+        std::fs::write(
+            workspace.join("package.json"),
+            r#"{"name":"app","scripts":{"build":"tsx scripts/build.ts"}}"#,
+        )
+        .expect("package file");
+        let files = [
+            discovered(root, "packages/app/scripts/build.ts", 0),
+            discovered(root, "packages/app/src/index.ts", 1),
+        ];
+
+        let discovery =
+            discover_workspace_entry_points_with_warnings(&workspace, &config_for(root), &files);
+
+        assert_eq!(discovery.entries.len(), 1);
+        assert!(discovery.entries[0].path.ends_with("src/index.ts"));
+        assert_eq!(discovery.support_entries.len(), 1);
+        assert!(
+            discovery.support_entries[0]
+                .path
+                .ends_with("scripts/build.ts")
+        );
+    }
+
+    #[test]
+    fn workspace_script_selected_by_root_start_is_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let workspace = root.join("packages/api");
+        std::fs::create_dir_all(workspace.join("src")).expect("src dir");
+        std::fs::write(workspace.join("src/server.ts"), "export const app = true;")
+            .expect("server file");
+        let workspace_pkg: PackageJson = serde_json::from_str(
+            r#"{"name":"@scope/api","scripts":{"serve":"node src/server.ts"}}"#,
+        )
+        .expect("workspace package");
+        let files = [discovered(root, "packages/api/src/server.ts", 0)];
+        let seeds = FxHashSet::from_iter(["serve".to_string()]);
+
+        let discovery = discover_workspace_entry_points_with_runtime_scripts(
+            &workspace,
+            &files,
+            Some(&workspace_pkg),
+            &seeds,
+        );
+
+        assert_eq!(discovery.entries.len(), 1);
+        assert!(discovery.entries[0].path.ends_with("src/server.ts"));
+        assert!(discovery.support_entries.is_empty());
+    }
+
+    #[test]
+    fn workspace_script_selection_does_not_promote_same_named_root_script() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let root_pkg: PackageJson = serde_json::from_str(
+            r#"{
+                "scripts": {
+                    "start": "pnpm --filter=@scope/api run serve",
+                    "serve": "node src/unrelated.ts"
+                }
+            }"#,
+        )
+        .expect("root package");
+        let api_pkg: PackageJson = serde_json::from_str(
+            r#"{"name":"@scope/api","scripts":{"serve":"node src/server.ts"}}"#,
+        )
+        .expect("api package");
+        let workspace_pkgs = vec![(
+            fallow_config::WorkspaceInfo {
+                root: root.join("packages/api"),
+                name: "@scope/api".to_string(),
+                is_internal_dependency: false,
+            },
+            api_pkg,
+        )];
+        let scripts = root_pkg.scripts.as_ref().expect("root scripts");
+
+        let runtime = runtime_package_script_names(scripts);
+        let workspace_seeds =
+            workspace_runtime_script_seeds(root, Some(&root_pkg), &workspace_pkgs);
+
+        assert_eq!(runtime, FxHashSet::from_iter(["start".to_string()]));
+        assert_eq!(
+            workspace_seeds.get("@scope/api"),
+            Some(&FxHashSet::from_iter(["serve".to_string()]))
+        );
+    }
+
+    #[test]
+    fn workspace_runtime_script_seeds_follow_transitive_workspace_calls() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let root_pkg: PackageJson =
+            serde_json::from_str(r#"{"scripts":{"start":"pnpm --filter @scope/api run serve"}}"#)
+                .expect("root package");
+        let api_pkg: PackageJson = serde_json::from_str(
+            r#"{"name":"@scope/api","scripts":{"serve":"npm --workspace packages/worker run work"}}"#,
+        )
+        .expect("api package");
+        let worker_pkg: PackageJson = serde_json::from_str(
+            r#"{"name":"@scope/worker","scripts":{"prework":"node pre.ts","work":"node worker.ts"}}"#,
+        )
+        .expect("worker package");
+        let workspace_pkgs = vec![
+            (
+                fallow_config::WorkspaceInfo {
+                    root: root.join("packages/api"),
+                    name: "@scope/api".to_string(),
+                    is_internal_dependency: false,
+                },
+                api_pkg,
+            ),
+            (
+                fallow_config::WorkspaceInfo {
+                    root: root.join("packages/worker"),
+                    name: "@scope/worker".to_string(),
+                    is_internal_dependency: false,
+                },
+                worker_pkg,
+            ),
+        ];
+
+        let seeds = workspace_runtime_script_seeds(root, Some(&root_pkg), &workspace_pkgs);
+
+        assert_eq!(
+            seeds.get("@scope/api"),
+            Some(&FxHashSet::from_iter(["serve".to_string()]))
+        );
+        assert_eq!(
+            seeds.get("@scope/worker"),
+            Some(&FxHashSet::from_iter([
+                "prework".to_string(),
+                "work".to_string(),
+            ]))
+        );
     }
 
     #[test]

--- a/crates/core/src/discover/mod.rs
+++ b/crates/core/src/discover/mod.rs
@@ -15,8 +15,8 @@ pub use entry_points::{
 };
 pub(crate) use entry_points::{
     EntryPointDiscovery, discover_entry_points_with_warnings_from_pkg,
-    discover_workspace_entry_points_with_warnings_from_pkg, resolve_entry_path,
-    warn_skipped_entry_summary,
+    discover_workspace_entry_points_with_runtime_scripts, resolve_entry_path,
+    warn_skipped_entry_summary, workspace_runtime_script_seeds,
 };
 pub use fallow_types::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
 pub(crate) use infrastructure::discover_infrastructure_entry_points;

--- a/crates/core/src/discover/parse_scripts.rs
+++ b/crates/core/src/discover/parse_scripts.rs
@@ -11,7 +11,7 @@
 pub fn extract_script_file_refs(script: &str) -> Vec<String> {
     let mut refs = Vec::new();
 
-    const RUNNERS: &[&str] = &["node", "ts-node", "tsx", "babel-node"];
+    const RUNNERS: &[&str] = &["node", "bun", "ts-node", "tsx", "babel-node"];
 
     for segment in script.split(&['&', '|', ';'][..]) {
         let segment = segment.trim();
@@ -114,6 +114,12 @@ mod tests {
     fn script_tsx_runner() {
         let refs = extract_script_file_refs("tsx scripts/migrate.ts");
         assert_eq!(refs, vec!["scripts/migrate.ts"]);
+    }
+
+    #[test]
+    fn script_bun_runner() {
+        let refs = extract_script_file_refs("bun scripts/build.ts");
+        assert_eq!(refs, vec!["scripts/build.ts"]);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2037,33 +2037,47 @@ fn discover_all_entry_points(
         .iter()
         .map(|(ws, pkg)| (ws.root.clone(), pkg))
         .collect();
+    let workspace_script_seeds = discover::workspace_runtime_script_seeds(
+        &input.config.root,
+        input.root_pkg,
+        input.workspace_pkgs,
+    );
 
     let workspace_discovery: Vec<discover::EntryPointDiscovery> = input
         .workspaces
         .par_iter()
         .map(|ws| {
             let pkg = workspace_pkg_by_root.get(&ws.root).copied();
-            discover::discover_workspace_entry_points_with_warnings_from_pkg(
+            let seeds = workspace_script_seeds
+                .get(&ws.name)
+                .cloned()
+                .unwrap_or_default();
+            discover::discover_workspace_entry_points_with_runtime_scripts(
                 &ws.root,
                 input.files,
                 pkg,
+                &seeds,
             )
         })
         .collect();
     let mut skipped_entries = rustc_hash::FxHashMap::default();
     entry_points.extend_runtime(root_discovery.entries);
+    entry_points.extend_support(root_discovery.support_entries);
     for (path, count) in root_discovery.skipped_entries {
         *skipped_entries.entry(path).or_insert(0) += count;
     }
     let mut ws_entries = Vec::new();
+    let mut ws_support_entries = Vec::new();
     for workspace in workspace_discovery {
         ws_entries.extend(workspace.entries);
+        ws_support_entries.extend(workspace.support_entries);
         for (path, count) in workspace.skipped_entries {
             *skipped_entries.entry(path).or_insert(0) += count;
         }
     }
     discover::warn_skipped_entry_summary(&skipped_entries);
     entry_points.extend_runtime(ws_entries);
+    entry_points.extend_support(ws_support_entries);
 
     let plugin_entries =
         discover::discover_plugin_entry_point_sets(input.plugin_result, input.config, input.files);

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -622,6 +622,129 @@ pub fn parse_script(script: &str) -> Vec<ScriptCommand> {
     commands
 }
 
+/// Return declared package scripts invoked by `command` through npm, pnpm,
+/// yarn, or bun. Used by entry-point discovery to propagate lifecycle roles
+/// through script indirection without expanding or executing script bodies.
+pub fn referenced_package_scripts(command: &str, catalog: &ScriptCatalog) -> FxHashSet<String> {
+    let mut names = FxHashSet::default();
+
+    for segment in shell::split_shell_operators(command) {
+        let tokens: Vec<&str> = segment
+            .split_whitespace()
+            .map(strip_surrounding_quotes)
+            .collect();
+        let Some(idx) = shell::skip_initial_wrappers(&tokens, 0) else {
+            continue;
+        };
+        if parse_workspace_script_invocation(&tokens, idx).is_some() {
+            continue;
+        }
+        if let Some(binary) = tokens.get(idx).copied()
+            && SCRIPT_MULTIPLEXERS.contains(&binary)
+        {
+            let mut skip_next = false;
+            for token in &tokens[idx + 1..] {
+                if skip_next {
+                    skip_next = false;
+                    continue;
+                }
+                if matches!(*token, "--names" | "--prefix" | "--max-parallel") {
+                    skip_next = true;
+                    continue;
+                }
+                let name = token.strip_prefix("npm:").unwrap_or(token);
+                if !name.starts_with('-') && catalog.contains(name) {
+                    names.insert(name.to_string());
+                }
+            }
+            continue;
+        }
+        if let Some(invocation) = declared_script_invocation(&tokens, idx, catalog) {
+            names.insert(invocation.name.to_string());
+        }
+    }
+
+    names
+}
+
+/// Return package-qualified script calls such as
+/// `pnpm --filter @scope/api run serve` from one command.
+pub fn referenced_workspace_scripts(command: &str) -> Vec<(String, String)> {
+    let mut references = Vec::new();
+    for segment in shell::split_shell_operators(command) {
+        let tokens: Vec<&str> = segment
+            .split_whitespace()
+            .map(strip_surrounding_quotes)
+            .collect();
+        let Some(idx) = shell::skip_initial_wrappers(&tokens, 0) else {
+            continue;
+        };
+        if let Some(reference) = parse_workspace_script_invocation(&tokens, idx) {
+            references.push(reference);
+        }
+    }
+    references.sort_unstable();
+    references.dedup();
+    references
+}
+
+fn parse_workspace_script_invocation(tokens: &[&str], idx: usize) -> Option<(String, String)> {
+    match tokens.get(idx).copied()? {
+        "pnpm" => parse_pnpm_workspace_script(tokens, idx),
+        "npm" => parse_npm_workspace_script(tokens, idx),
+        "yarn" => parse_yarn_workspace_script(tokens, idx),
+        _ => None,
+    }
+}
+
+fn parse_pnpm_workspace_script(tokens: &[&str], idx: usize) -> Option<(String, String)> {
+    let mut next = idx + 1;
+    while tokens
+        .get(next)
+        .is_some_and(|token| PNPM_IMPLICIT_EXEC_FLAGS.contains(token))
+    {
+        next += 1;
+    }
+    let selector = if tokens.get(next) == Some(&"--filter") {
+        let selector = *tokens.get(next + 1)?;
+        next += 2;
+        selector
+    } else {
+        let selector = tokens.get(next)?.strip_prefix("--filter=")?;
+        next += 1;
+        selector
+    };
+    if !matches!(tokens.get(next), Some(&"run" | &"run-script")) {
+        return None;
+    }
+    Some((selector.to_string(), (*tokens.get(next + 1)?).to_string()))
+}
+
+fn parse_npm_workspace_script(tokens: &[&str], idx: usize) -> Option<(String, String)> {
+    let flag = *tokens.get(idx + 1)?;
+    let (selector, next) = if matches!(flag, "--workspace" | "-w") {
+        (*tokens.get(idx + 2)?, idx + 3)
+    } else {
+        (flag.strip_prefix("--workspace=")?, idx + 2)
+    };
+    if !matches!(tokens.get(next), Some(&"run" | &"run-script")) {
+        return None;
+    }
+    Some((selector.to_string(), (*tokens.get(next + 1)?).to_string()))
+}
+
+fn parse_yarn_workspace_script(tokens: &[&str], idx: usize) -> Option<(String, String)> {
+    if tokens.get(idx + 1) != Some(&"workspace") {
+        return None;
+    }
+    let selector = *tokens.get(idx + 2)?;
+    let mut next = idx + 3;
+    if matches!(tokens.get(next), Some(&"run" | &"run-script")) {
+        next += 1;
+    }
+    Some((selector.to_string(), (*tokens.get(next)?).to_string()))
+}
+
 fn parse_script_with_context(
     script: &str,
     root: &Path,
@@ -846,6 +969,34 @@ fn script_invocation_target(
     idx: usize,
     context: &ScriptCommandContext<'_>,
 ) -> Option<PackageManagerTarget> {
+    let invocation = declared_script_invocation(tokens, idx, context.scripts)?;
+    let mut extra_args_from = invocation.name_idx + 1;
+    if tokens.get(extra_args_from) == Some(&"--") {
+        extra_args_from += 1;
+    } else if invocation.requires_double_dash && extra_args_from < tokens.len() {
+        return None;
+    }
+
+    Some(PackageManagerTarget::Script {
+        name: invocation.name.to_string(),
+        extra_args_from,
+    })
+}
+
+struct DeclaredScriptInvocation<'a> {
+    name: &'a str,
+    name_idx: usize,
+    requires_double_dash: bool,
+}
+
+fn declared_script_invocation<'a>(
+    tokens: &'a [&'a str],
+    idx: usize,
+    catalog: &ScriptCatalog,
+) -> Option<DeclaredScriptInvocation<'a>> {
+    if parse_workspace_script_invocation(tokens, idx).is_some() {
+        return None;
+    }
     let manager = tokens[idx];
     if !matches!(manager, "npm" | "pnpm" | "yarn" | "bun") {
         return None;
@@ -856,12 +1007,17 @@ fn script_invocation_target(
         while next < tokens.len() && PNPM_IMPLICIT_EXEC_FLAGS.contains(&tokens[next]) {
             next += 1;
         }
+        if tokens.get(next) == Some(&"--filter") {
+            next += 2;
+        }
+    } else if manager == "npm" && tokens.get(next) == Some(&"--silent") {
+        next += 1;
     }
     let subcmd = *tokens.get(next)?;
 
     let (name_idx, requires_double_dash) = if matches!(subcmd, "run" | "run-script") {
         (next + 1, manager == "npm")
-    } else if matches!(manager, "yarn" | "pnpm")
+    } else if matches!(manager, "yarn" | "pnpm" | "bun")
         && !subcmd.starts_with('-')
         && !PACKAGE_MANAGER_BUILTIN_COMMANDS.contains(&subcmd)
     {
@@ -871,20 +1027,14 @@ fn script_invocation_target(
     };
 
     let name = *tokens.get(name_idx)?;
-    if !context.scripts.contains(name) {
+    if !catalog.contains(name) {
         return None;
     }
 
-    let mut extra_args_from = name_idx + 1;
-    if tokens.get(extra_args_from) == Some(&"--") {
-        extra_args_from += 1;
-    } else if requires_double_dash {
-        return None;
-    }
-
-    Some(PackageManagerTarget::Script {
-        name: name.to_string(),
-        extra_args_from,
+    Some(DeclaredScriptInvocation {
+        name,
+        name_idx,
+        requires_double_dash,
     })
 }
 
@@ -2458,6 +2608,128 @@ mod tests {
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0].binary, "node");
         assert!(cmds[0].file_args.contains(&"src/**/*.test.ts".to_string()));
+    }
+
+    #[test]
+    fn referenced_scripts_include_plain_npm_run_without_forwarded_args() {
+        let scripts = HashMap::from([
+            ("start".to_string(), "npm run serve".to_string()),
+            ("serve".to_string(), "node src/server.ts".to_string()),
+        ]);
+        let catalog = ScriptCatalog::from_scripts(&scripts);
+
+        let referenced = referenced_package_scripts(&scripts["start"], &catalog);
+
+        assert_eq!(referenced, FxHashSet::from_iter(["serve".to_string()]));
+    }
+
+    #[test]
+    fn referenced_scripts_honor_pnpm_silent_shorthand() {
+        let scripts = HashMap::from([
+            ("start".to_string(), "pnpm -s serve".to_string()),
+            ("serve".to_string(), "node src/server.ts".to_string()),
+        ]);
+        let catalog = ScriptCatalog::from_scripts(&scripts);
+
+        let referenced = referenced_package_scripts(&scripts["start"], &catalog);
+
+        assert_eq!(referenced, FxHashSet::from_iter(["serve".to_string()]));
+    }
+
+    #[test]
+    fn referenced_scripts_honor_package_manager_options() {
+        let scripts = HashMap::from([
+            ("start".to_string(), "npm --silent run serve".to_string()),
+            ("serve".to_string(), "node src/server.ts".to_string()),
+        ]);
+        let catalog = ScriptCatalog::from_scripts(&scripts);
+        assert_eq!(
+            referenced_package_scripts(&scripts["start"], &catalog),
+            FxHashSet::from_iter(["serve".to_string()])
+        );
+
+        let command = "pnpm --filter app run serve";
+        assert_eq!(
+            referenced_package_scripts(command, &catalog),
+            FxHashSet::default(),
+            "workspace-qualified calls must not promote a same-named local script"
+        );
+    }
+
+    #[test]
+    fn referenced_scripts_include_multiplexer_targets() {
+        let scripts = HashMap::from([
+            (
+                "start".to_string(),
+                "run-p serve worker && concurrently \"npm:monitor\"".to_string(),
+            ),
+            ("serve".to_string(), "node src/server.ts".to_string()),
+            ("worker".to_string(), "node src/worker.ts".to_string()),
+            ("monitor".to_string(), "node src/monitor.ts".to_string()),
+        ]);
+        let catalog = ScriptCatalog::from_scripts(&scripts);
+
+        let referenced = referenced_package_scripts(&scripts["start"], &catalog);
+
+        assert_eq!(
+            referenced,
+            FxHashSet::from_iter([
+                "serve".to_string(),
+                "worker".to_string(),
+                "monitor".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn referenced_scripts_skip_multiplexer_option_values() {
+        let scripts = HashMap::from([
+            (
+                "start".to_string(),
+                "concurrently --names serve npm:worker npm:api".to_string(),
+            ),
+            ("serve".to_string(), "node src/server.ts".to_string()),
+            ("worker".to_string(), "node src/worker.ts".to_string()),
+            ("api".to_string(), "node src/api.ts".to_string()),
+        ]);
+        let catalog = ScriptCatalog::from_scripts(&scripts);
+
+        let referenced = referenced_package_scripts(&scripts["start"], &catalog);
+
+        assert_eq!(
+            referenced,
+            FxHashSet::from_iter(["worker".to_string(), "api".to_string()])
+        );
+    }
+
+    #[test]
+    fn referenced_scripts_include_bun_implicit_target() {
+        let scripts = HashMap::from([
+            ("start".to_string(), "bun serve".to_string()),
+            ("serve".to_string(), "bun src/server.ts".to_string()),
+        ]);
+        let catalog = ScriptCatalog::from_scripts(&scripts);
+
+        let referenced = referenced_package_scripts(&scripts["start"], &catalog);
+
+        assert_eq!(referenced, FxHashSet::from_iter(["serve".to_string()]));
+    }
+
+    #[test]
+    fn referenced_workspace_scripts_preserve_package_identity() {
+        for command in [
+            "pnpm --filter @scope/api run serve",
+            "pnpm --filter=@scope/api run serve",
+            "npm --workspace @scope/api run serve",
+            "npm --workspace=@scope/api run serve",
+            "yarn workspace @scope/api serve",
+        ] {
+            assert_eq!(
+                referenced_workspace_scripts(command),
+                vec![("@scope/api".to_string(), "serve".to_string())],
+                "failed to parse {command}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/tests/integration_test/dev_dep_in_prod.rs
+++ b/crates/core/tests/integration_test/dev_dep_in_prod.rs
@@ -20,6 +20,24 @@ fn dev_dependency_used_in_production_detected() {
         "yaml is value-imported from a production file and should be flagged, found: {flagged:?}"
     );
 
+    assert!(
+        flagged.contains(&"runtime-helper"),
+        "a devDependency reached through an indirect npm start script should be flagged, found: {flagged:?}"
+    );
+
+    assert!(
+        !flagged.contains(&"svgo"),
+        "a devDependency imported only by build tooling must not be flagged, found: {flagged:?}"
+    );
+
+    assert!(
+        !results
+            .unused_files
+            .iter()
+            .any(|finding| finding.file.path.ends_with("scripts/build.ts")),
+        "build tooling referenced from package.json must remain reachable for dead-code analysis"
+    );
+
     // type-fest is imported from production code but ONLY via `import type`,
     // which is erased at build time, so it must NOT be flagged.
     assert!(

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -156,6 +156,14 @@ analyzes, so a production run cannot enter a body that script filtering skipped.
 A name declared with different bodies in several workspace packages keeps its
 name but permanently loses its body.
 
+Script-referenced files are support roots by default: they stay reachable for
+dead-code analysis without contributing production reachability to dependency,
+health, or security analysis. The npm `start`, `prestart`, and `poststart`
+lifecycle is the narrow runtime exception, including declared scripts reached
+through package-manager indirection. Projects deployed through a custom script
+name should declare the deployed file in `entry` when no manifest, framework,
+or infrastructure entry already identifies it as runtime code.
+
 ### CLI flag-value crediting
 
 Some CLIs load an npm package because a flag value names it: `eslint --format

--- a/tests/fixtures/dev-dep-in-prod/package.json
+++ b/tests/fixtures/dev-dep-in-prod/package.json
@@ -1,11 +1,18 @@
 {
   "name": "dev-dep-in-prod",
   "main": "src/index.ts",
+  "scripts": {
+    "build": "tsx scripts/build.ts",
+    "start": "npm run serve",
+    "serve": "node 'src/server.ts'"
+  },
   "dependencies": {
     "left-pad": "^1.0.0"
   },
   "devDependencies": {
     "yaml": "^2.0.0",
+    "runtime-helper": "^1.0.0",
+    "svgo": "^4.0.0",
     "type-fest": "^4.0.0",
     "vitest": "^1.0.0"
   }

--- a/tests/fixtures/dev-dep-in-prod/scripts/build.ts
+++ b/tests/fixtures/dev-dep-in-prod/scripts/build.ts
@@ -1,0 +1,5 @@
+// Package-script tooling stays reachable for dead-code analysis, but its
+// imports do not prove that a devDependency ships with the application.
+import { optimize } from "svgo";
+
+export const build = (source: string): string => optimize(source).data;

--- a/tests/fixtures/dev-dep-in-prod/src/server.ts
+++ b/tests/fixtures/dev-dep-in-prod/src/server.ts
@@ -1,0 +1,5 @@
+// npm's start lifecycle reaches this file through the `serve` script. The
+// quoted path and script indirection must preserve production reachability.
+import { run } from "runtime-helper";
+
+run();


### PR DESCRIPTION
## Summary

- classify files referenced only by package build and tooling scripts as support roots
- preserve production reachability for the npm start lifecycle, local script indirection, and transitive workspace-qualified calls
- keep tooling files reachable for dead-code analysis and add focused detector and discovery regressions

## Why

Package scripts were previously treated as production entry points. That made devDependencies imported only by build tooling appear in dev-dependencies-in-production findings. The graph now keeps those support surfaces reachable without treating them as shipped runtime code.

## Validation

- npm run verify:full
- 2,588 fallow-core library tests
- 989 fallow-core integration tests
- focused package-script role, lifecycle, Bun, config, collision, and workspace-closure regressions
- three independent adversarial review passes: approved with no remaining blockers