### PR TITLE
docs(release): name the two version-bearing manifests outside the bump

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -54,6 +54,24 @@ description: Prepare and publish a Fallow release with version, changelog, gener
 8. Apply version changes transactionally. Regenerate every public contract,
    adapter, packaged skill, and version-bearing artifact. Synchronize
    `fallow-docs` and `fallow-skills` from their canonical sources.
+
+   Two version-bearing manifests sit outside the workspace bump and follow
+   opposite rules. `scripts/sync-npm-versions.sh` rewrites both and is wired to
+   no workflow, so a release can skip it silently.
+
+   - `tools/type-aware-sidecar` bumps in lockstep with the CLI, inside the
+     release commit. The CLI refuses a companion whose version differs from the
+     binary, so a skipped bump turns `main` red on Windows validation rather
+     than at publish time.
+   - `crates/napi` and its `@fallow/*` platform manifests stay at the last
+     published version through the release commit, keeping any dependabot bump
+     that landed on top. Their platform packages do not exist on npm at the new
+     version until publish runs, so bumping them early leaves a lockfile with
+     unresolvable entries and `npm ci` fails. They sync in the post-publish
+     catch-up step.
+
+   Version-string assertions do not catch the second case. Verify a touched
+   lockfile with `cd crates/napi && rm -rf node_modules && npm ci`.
 9. Run package dry-runs, generated-contract checks, companion-repository
    checks, and the repository's full release gates. Review the exact staged
    paths before creating a signed release commit. Do not create the version tag

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -55,6 +55,24 @@ description: Prepare and publish a Fallow release with version, changelog, gener
 8. Apply version changes transactionally. Regenerate every public contract,
    adapter, packaged skill, and version-bearing artifact. Synchronize
    `fallow-docs` and `fallow-skills` from their canonical sources.
+
+   Two version-bearing manifests sit outside the workspace bump and follow
+   opposite rules. `scripts/sync-npm-versions.sh` rewrites both and is wired to
+   no workflow, so a release can skip it silently.
+
+   - `tools/type-aware-sidecar` bumps in lockstep with the CLI, inside the
+     release commit. The CLI refuses a companion whose version differs from the
+     binary, so a skipped bump turns `main` red on Windows validation rather
+     than at publish time.
+   - `crates/napi` and its `@fallow/*` platform manifests stay at the last
+     published version through the release commit, keeping any dependabot bump
+     that landed on top. Their platform packages do not exist on npm at the new
+     version until publish runs, so bumping them early leaves a lockfile with
+     unresolvable entries and `npm ci` fails. They sync in the post-publish
+     catch-up step.
+
+   Version-string assertions do not catch the second case. Verify a touched
+   lockfile with `cd crates/napi && rm -rf node_modules && npm ci`.
 9. Run package dry-runs, generated-contract checks, companion-repository
    checks, and the repository's full release gates. Review the exact staged
    paths before creating a signed release commit. Do not create the version tag


### PR DESCRIPTION
Step 8 said "every version-bearing artifact", which is true and useless: `tools/type-aware-sidecar` and `crates/napi` both sit outside the workspace bump and follow opposite rules, and the step named neither.

v3.15.0 left the sidecar at 3.14.0. The CLI refuses a companion whose version differs from the binary, so `main` went red on Windows validation. The repair then ran `scripts/sync-npm-versions.sh` whole, which also bumped `crates/napi` and its platform manifests. Those platform packages do not exist on npm at the new version until publish runs, so the regenerated lockfile referenced unresolvable entries and `npm ci` failed, and that half had to be reverted.

The script is documented as a cargo-release pre-release hook but is wired to no workflow, so a release can skip it without a word. Naming both manifests and their opposite rules is the part the skill can carry; wiring the sidecar half into the release flow is a separate question worth answering.

Version-string assertions do not catch the napi case, so the step names the lockfile check that does.