### PR TITLE
ci: gate the release on the type-aware companion version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,44 @@ jobs:
             exit 1
           fi
 
+          # The type-aware companion is version-locked to the binary at runtime:
+          # the CLI refuses a companion whose version differs, so a release
+          # commit that bumped the workspace without bumping the companion
+          # ships a CLI that cannot run type-aware analysis. Catch it here,
+          # before anything is built, tagged or published, rather than in the
+          # Windows validation job or in the audit tests on main.
+          #
+          # crates/napi is deliberately NOT checked here. Its platform packages
+          # do not exist on the registry until this workflow publishes them, so
+          # the committed manifests stay at the last published version until the
+          # post-release catch-up. Bumping them early breaks the publish tree.
+          WORKSPACE_VERSION="$workspace_version" python3 - <<'PY'
+          import json, os, sys
+
+          expected = os.environ["WORKSPACE_VERSION"]
+          root = "tools/type-aware-sidecar"
+          manifest = json.load(open(f"{root}/package.json"))
+          lock = json.load(open(f"{root}/package-lock.json"))
+
+          found = {
+              f"{root}/package.json": manifest["version"],
+              f"{root}/package-lock.json version": lock["version"],
+              f'{root}/package-lock.json packages[""]': lock["packages"][""]["version"],
+          }
+          stale = {path: value for path, value in found.items() if value != expected}
+          if stale:
+              for path, value in stale.items():
+                  print(f"::error::{path} is {value}, expected {expected}")
+              print(
+                  "::error::bump the type-aware companion to "
+                  f"{expected} in the release commit. Set the version in those "
+                  "files directly; do not run scripts/sync-npm-versions.sh "
+                  "during a release, it also moves crates/napi ahead of publish."
+              )
+              sys.exit(1)
+          print(f"type-aware companion matches the workspace at {expected}")
+          PY
+
       # Release immutability is verified in the maintainer release flow, not
       # here. `repos/{owner}/{repo}/immutable-releases` requires the
       # Administration read permission, which is not a grantable GITHUB_TOKEN


### PR DESCRIPTION
v3.15.0 lost a release run to this: the release commit moved the workspace to 3.15.0 while `tools/type-aware-sidecar` stayed at 3.14.0. The CLI refuses a companion whose version differs from the binary, so the Windows validation job failed, and once the commit was on main the audit tests and the repository policy test failed there too.

Nothing automated caught it before the run started. This adds the check to the step that already verifies the tag against the workspace version, so it fails within seconds of dispatch, before any build, tag or publish, and before a version number is burned.

The error names each stale file with its found and expected value, and says how to fix it: set the version in those two files directly, and explicitly **not** by running `scripts/sync-npm-versions.sh`, because that also moves `crates/napi` ahead of publish. That is the second half of the same incident, where a well-meant repair broke the npm publish tree.

`crates/napi` is deliberately outside the gate, with the reason in a comment beside it: its platform packages do not exist on the registry until the release publishes them, so those manifests stay at the last published version until the post-release catch-up.

The release skill gains the same rule in step 8, stating both directions, so the instruction and the gate agree.

Verified against the real tree: it passes on current main at 3.15.0, and with the companion set back to 3.14.0 it reports all three stale locations and exits 1. Adapter regeneration, the knowledge-architecture check and the script tests are green.