### PR TITLE
perf(engine): fuse duplicate rank preparation

### DIFF
--- a/crates/engine/src/duplication_detector/detect/concatenation.rs
+++ b/crates/engine/src/duplication_detector/detect/concatenation.rs
@@ -1,4 +1,62 @@
-//! Step 2: Text preparation, concatenate ranked token sequences with sentinels.
+//! Text preparation for suffix-array duplicate detection.
+
+use rustc_hash::FxHashMap;
+
+use super::FileData;
+
+pub(super) struct RankedText {
+    pub(super) text: Vec<i64>,
+    pub(super) file_of: Vec<usize>,
+    pub(super) file_offsets: Vec<usize>,
+    pub(super) unique_ranks: usize,
+}
+
+/// Rank token hashes and write the suffix-array text in one pass.
+///
+/// Ranks retain encounter order across files, while unique negative sentinels
+/// preserve file boundaries. Writing the final buffers directly avoids the
+/// intermediate per-file rank vectors used by the rolling detector.
+pub(super) fn rank_and_concatenate(files: &[FileData]) -> RankedText {
+    let token_count: usize = files.iter().map(|file| file.hashed_tokens.len()).sum();
+    let total_len = token_count + files.len().saturating_sub(1);
+    let mut hash_to_rank: FxHashMap<u64, u32> =
+        FxHashMap::with_capacity_and_hasher(token_count / 2, rustc_hash::FxBuildHasher);
+    let mut text = Vec::with_capacity(total_len);
+    let mut file_of = Vec::with_capacity(total_len);
+    let mut file_offsets = Vec::with_capacity(files.len());
+    let mut next_rank = 0_u32;
+    let mut sentinel = -1_i64;
+
+    for (file_id, file) in files.iter().enumerate() {
+        file_offsets.push(text.len());
+
+        for token in &file.hashed_tokens {
+            let rank = match hash_to_rank.entry(token.hash) {
+                std::collections::hash_map::Entry::Occupied(entry) => *entry.get(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let rank = next_rank;
+                    next_rank += 1;
+                    *entry.insert(rank)
+                }
+            };
+            text.push(i64::from(rank));
+            file_of.push(file_id);
+        }
+
+        if file_id + 1 < files.len() {
+            text.push(sentinel);
+            file_of.push(usize::MAX);
+            sentinel -= 1;
+        }
+    }
+
+    RankedText {
+        text,
+        file_of,
+        file_offsets,
+        unique_ranks: next_rank as usize,
+    }
+}
 
 /// Concatenate all ranked token sequences into a single `Vec<i64>`,
 /// inserting unique negative sentinel values between files.
@@ -9,6 +67,7 @@
 ///   (`usize::MAX` for sentinel positions)
 /// - `file_offsets[file_id]` is the starting position of file `file_id`
 ///   in `text`
+#[cfg(test)]
 pub(super) fn concatenate_with_sentinels(
     ranked_files: &[Vec<u32>],
 ) -> (Vec<i64>, Vec<usize>, Vec<usize>) {

--- a/crates/engine/src/duplication_detector/detect/mod.rs
+++ b/crates/engine/src/duplication_detector/detect/mod.rs
@@ -284,9 +284,8 @@ fn build_detection_inputs(
     (files, totals, focus_file_ids)
 }
 
-/// Run the clone-detection front half (steps 1-2: rank-reduce then concatenate
-/// with sentinels), returning the concatenated text, file index maps, and each
-/// step's elapsed time for the completion trace.
+/// Run the clone-detection front half, ranking tokens while writing the
+/// concatenated suffix-array text and file index maps.
 fn rank_and_concatenate(
     files: &[FileData],
 ) -> (
@@ -297,30 +296,29 @@ fn rank_and_concatenate(
     std::time::Duration,
 ) {
     let t0 = std::time::Instant::now();
-    let ranked_files = ranking::rank_reduce(files);
+    let ranked = concatenation::rank_and_concatenate(files);
     let rank_time = t0.elapsed();
-    let unique_ranks: usize = ranked_files
-        .iter()
-        .flat_map(|f| f.iter())
-        .copied()
-        .max()
-        .map_or(0, |m| m as usize + 1);
     tracing::debug!(
         elapsed_us = rank_time.as_micros(),
-        unique_ranks,
+        unique_ranks = ranked.unique_ranks,
         "step1_rank_reduce"
     );
-
-    let t0 = std::time::Instant::now();
-    let (text, file_of, file_offsets) = concatenation::concatenate_with_sentinels(&ranked_files);
-    let concat_time = t0.elapsed();
+    // Keep the established trace events stable. The fused pass is accounted
+    // in rank time because there is no longer a separately measurable copy.
+    let concat_time = std::time::Duration::ZERO;
     tracing::debug!(
         elapsed_us = concat_time.as_micros(),
-        concat_len = text.len(),
+        concat_len = ranked.text.len(),
         "step2_concatenate"
     );
 
-    (text, file_of, file_offsets, rank_time, concat_time)
+    (
+        ranked.text,
+        ranked.file_of,
+        ranked.file_offsets,
+        rank_time,
+        concat_time,
+    )
 }
 
 struct CloneDetectionTimings {

--- a/crates/engine/src/duplication_detector/detect/tests.rs
+++ b/crates/engine/src/duplication_detector/detect/tests.rs
@@ -740,6 +740,40 @@ fn concat_empty_file_in_middle() {
     assert_eq!(file_of[3], usize::MAX);
 }
 
+#[test]
+fn fused_rank_and_concatenate_matches_two_step_preparation() {
+    let files = vec![
+        FileData {
+            path: PathBuf::from("a.ts"),
+            hashed_tokens: make_hashed_tokens(&[30, 10, 30]),
+            file_tokens: make_file_tokens("a b a", 3),
+            atomic_invocation_spans: Vec::new(),
+        },
+        FileData {
+            path: PathBuf::from("empty.ts"),
+            hashed_tokens: Vec::new(),
+            file_tokens: make_file_tokens("", 0),
+            atomic_invocation_spans: Vec::new(),
+        },
+        FileData {
+            path: PathBuf::from("b.ts"),
+            hashed_tokens: make_hashed_tokens(&[10, 20]),
+            file_tokens: make_file_tokens("b c", 2),
+            atomic_invocation_spans: Vec::new(),
+        },
+    ];
+
+    let ranked_files = ranking::rank_reduce(&files);
+    let expected = concatenation::concatenate_with_sentinels(&ranked_files);
+    let actual = concatenation::rank_and_concatenate(&files);
+
+    assert_eq!(actual.text, expected.0);
+    assert_eq!(actual.file_of, expected.1);
+    assert_eq!(actual.file_offsets, expected.2);
+    assert_eq!(actual.text, vec![0, 1, 0, -1, -2, 1, 2]);
+    assert_eq!(actual.unique_ranks, 3);
+}
+
 fn make_file_data(path: &str, source: &str, num_tokens: usize) -> FileData {
     FileData {
         path: PathBuf::from(path),


### PR DESCRIPTION
## Summary

- rank token hashes directly into the suffix-array input buffers
- avoid intermediate per-file rank vectors and the second token copy
- keep the rolling detector on its existing rank-reduction path
- preserve encounter-order ranks, file offsets, and unique negative sentinels

## Verification

- focused duplicate-detector tests pass
- workspace strict clippy passes
- formatting and diff checks pass
- CodSpeed simulation harness builds locally
- CodSpeed comparison runs in CI because the simulation executor is not supported on macOS