### PR TITLE
fix(graph): drop speculative mock candidates that resolve to package space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unused shell pagination helper has been removed now that provider pagination
   is owned by the typed Rust posting path.
 
+- **Factory-less `jest.mock`/`vi.mock` of a scoped package no longer fabricates
+  a phantom `unlisted-dependency` finding**
+  (Closes [#2213](https://github.com/fallow-rs/fallow/issues/2213)). The
+  speculative `__mocks__` sibling candidate synthesized for automock calls
+  (`@scope/__mocks__/pkg`) could classify as an npm package and surface as an
+  unlisted dependency named `@scope/__mocks__`, blocking gated CI runs in Jest
+  projects. Speculative mock candidates that resolve to package space are now
+  dropped in the resolver; manual-mock discovery through relative and aliased
+  specifiers is unchanged.
+
 ### Changed
 
 - **Threshold override rows carry the measured span and read `stale` on
@@ -34,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `insufficient`, `active`, then `stale`), at most 10 are printed, and an
   overflow line names what was hidden; JSON stays uncapped. No schema
   version bump: the new field is additive.
-
 ## [3.15.0] - 2026-08-11
 
 ### Added

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -241,6 +241,8 @@ mod issue_1911_unlisted_alias;
 mod issue_2005_jsdom_optional_peer_canvas;
 #[path = "integration_test/issue_2006_cli_flag_value_dependency.rs"]
 mod issue_2006_cli_flag_value_dependency;
+#[path = "integration_test/issue_2213_jest_mock_phantom_package.rs"]
+mod issue_2213_jest_mock_phantom_package;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_2213_jest_mock_phantom_package.rs
+++ b/crates/core/tests/integration_test/issue_2213_jest_mock_phantom_package.rs
@@ -26,7 +26,10 @@ fn create_project(root: &Path) {
         r#"{
             "name": "issue-2213-repro",
             "private": true,
-            "dependencies": { "@bacons/apple-targets": "^5.0.0" },
+            "dependencies": {
+                "@bacons/apple-targets": "^5.0.0",
+                "@mockonly/kit": "^1.0.0"
+            },
             "devDependencies": { "jest": "^29.7.0" }
         }"#,
     );
@@ -47,6 +50,7 @@ fn create_project(root: &Path) {
         r#"import { ExtensionStorage } from "@bacons/apple-targets";
            import { helper } from "definitely-not-installed";
            jest.mock("@bacons/apple-targets");
+           jest.mock("@mockonly/kit");
            test("reads", () => {
              expect(ExtensionStorage.get()).toBe("mock");
              expect(helper).toBeDefined();
@@ -96,5 +100,17 @@ fn issue_2213_jest_mock_does_not_fabricate_phantom_unlisted_dependency() {
             .iter()
             .any(|specifier| specifier.contains("__mocks__")),
         "the speculative mock candidate must not surface as unresolved-import, got {unresolved:?}"
+    );
+
+    // Dropping the speculative sibling must not drop the package credit of the
+    // primary edge: `@mockonly/kit` is referenced only through `jest.mock`.
+    let unused: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unused.contains(&"@mockonly/kit"),
+        "a listed package referenced only via jest.mock must keep its usage credit, got {unused:?}"
     );
 }

--- a/crates/core/tests/integration_test/issue_2213_jest_mock_phantom_package.rs
+++ b/crates/core/tests/integration_test/issue_2213_jest_mock_phantom_package.rs
@@ -1,0 +1,100 @@
+//! Regression tests for issue #2213: `jest.mock('@scope/pkg')` without a
+//! factory synthesized the speculative `__mocks__` sibling candidate
+//! `@scope/__mocks__/pkg`. Bare specifiers classify as npm packages instead of
+//! `Unresolvable`, so the candidate bypassed the speculative drop guard and
+//! surfaced as a phantom `unlisted-dependency` finding for `@scope/__mocks__`,
+//! blocking CI in gated audits. The resolver now drops speculative candidates
+//! that land in package space; only internal manual-mock files count as hits.
+
+use std::path::Path;
+
+use super::common::create_config;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, contents).expect("write file");
+}
+
+/// The reporter's shape: a listed scoped dependency, a Jest manual mock under
+/// the root `__mocks__/` directory, and a test that both imports the real
+/// specifier and registers the factory-less automock.
+fn create_project(root: &Path) {
+    write(
+        root.join("package.json").as_path(),
+        r#"{
+            "name": "issue-2213-repro",
+            "private": true,
+            "dependencies": { "@bacons/apple-targets": "^5.0.0" },
+            "devDependencies": { "jest": "^29.7.0" }
+        }"#,
+    );
+    write(
+        root.join("__mocks__/@bacons/apple-targets.ts").as_path(),
+        r#"export const ExtensionStorage = { get: (): string => "mock" };"#,
+    );
+    write(
+        root.join("src/index.ts").as_path(),
+        r#"import { ExtensionStorage } from "@bacons/apple-targets";
+           export const read = (): string => ExtensionStorage.get();"#,
+    );
+    // The second import is the positive control: a genuinely unlisted package
+    // must keep surfacing, so a regression that suppresses every unlisted
+    // dependency cannot make this test pass.
+    write(
+        root.join("src/__tests__/widget.test.ts").as_path(),
+        r#"import { ExtensionStorage } from "@bacons/apple-targets";
+           import { helper } from "definitely-not-installed";
+           jest.mock("@bacons/apple-targets");
+           test("reads", () => {
+             expect(ExtensionStorage.get()).toBe("mock");
+             expect(helper).toBeDefined();
+           });"#,
+    );
+    let pkg = root.join("node_modules/@bacons/apple-targets");
+    write(
+        pkg.join("package.json").as_path(),
+        r#"{ "name": "@bacons/apple-targets", "version": "5.0.0", "main": "index.js" }"#,
+    );
+    write(
+        pkg.join("index.js").as_path(),
+        "module.exports = { ExtensionStorage: { get: () => 'real' } };",
+    );
+}
+
+#[test]
+fn issue_2213_jest_mock_does_not_fabricate_phantom_unlisted_dependency() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    create_project(dir.path());
+
+    let config = create_config(dir.path().to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unlisted: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unlisted.contains(&"@bacons/__mocks__"),
+        "factory-less jest.mock of a scoped package must not fabricate a \
+         phantom `@scope/__mocks__` unlisted dependency, got {unlisted:?}"
+    );
+    assert!(
+        unlisted.contains(&"definitely-not-installed"),
+        "a genuinely unlisted dependency must still be reported, got {unlisted:?}"
+    );
+
+    let unresolved: Vec<&str> = results
+        .unresolved_imports
+        .iter()
+        .map(|finding| finding.import.specifier.as_str())
+        .collect();
+    assert!(
+        !unresolved
+            .iter()
+            .any(|specifier| specifier.contains("__mocks__")),
+        "the speculative mock candidate must not surface as unresolved-import, got {unresolved:?}"
+    );
+}

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -57,7 +57,12 @@ pub use store::GraphCacheStore;
 /// Bumped to 20: cached re-export edges now carry the enclosing statement
 /// span and the source string-literal span used to anchor unresolved-import
 /// findings on the specifier. Warm 19 caches lack both spans.
-pub const GRAPH_CACHE_VERSION: u32 = 20;
+///
+/// Bumped to 21 for issue #2213: speculative `__mocks__` sibling candidates
+/// that resolve to package space are no longer emitted, so warm 20 caches
+/// would keep replaying the phantom `@scope/__mocks__` package edges the
+/// resolver no longer produces.
+pub const GRAPH_CACHE_VERSION: u32 = 21;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/resolve/dynamic_imports.rs
+++ b/crates/graph/src/resolve/dynamic_imports.rs
@@ -55,12 +55,7 @@ pub(super) fn resolve_single_dynamic_import(
     // package name (`@scope/__mocks__`, issue #2213) for the
     // unlisted-dependency analysis.
     if imp.is_speculative
-        && matches!(
-            target,
-            ResolveResult::Unresolvable(_)
-                | ResolveResult::NpmPackage(_)
-                | ResolveResult::CommonJsNpmPackage(_)
-        )
+        && (target.is_bare_package() || matches!(target, ResolveResult::Unresolvable(_)))
     {
         return Vec::new();
     }

--- a/crates/graph/src/resolve/dynamic_imports.rs
+++ b/crates/graph/src/resolve/dynamic_imports.rs
@@ -47,7 +47,21 @@ pub(super) fn resolve_single_dynamic_import(
 ) -> Vec<ResolvedImport> {
     let target = resolve_specifier(ctx, file_path, &imp.source, false);
 
-    if imp.is_speculative && matches!(target, ResolveResult::Unresolvable(_)) {
+    // Speculative candidates (the `__mocks__` sibling synthesized for
+    // factory-less `vi.mock`/`jest.mock` calls) exist solely to discover an
+    // internal manual-mock file. A package-space result means the specifier
+    // stayed bare after alias substitution; `pkg/__mocks__/...` is not a
+    // runner convention, so treating it as a hit would fabricate a phantom
+    // package name (`@scope/__mocks__`, issue #2213) for the
+    // unlisted-dependency analysis.
+    if imp.is_speculative
+        && matches!(
+            target,
+            ResolveResult::Unresolvable(_)
+                | ResolveResult::NpmPackage(_)
+                | ResolveResult::CommonJsNpmPackage(_)
+        )
+    {
         return Vec::new();
     }
 

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -1476,6 +1476,46 @@ fn speculative_dynamic_import_drops_when_unresolvable() {
 }
 
 #[test]
+fn speculative_dynamic_import_drops_when_package_space() {
+    with_empty_ctx(|ctx| {
+        // `jest.mock('@bacons/apple-targets')` synthesizes the sibling
+        // candidate `@bacons/__mocks__/apple-targets`. Bare specifiers are
+        // never Unresolvable, so without the package-space drop this would
+        // surface as phantom package `@bacons/__mocks__` (issue #2213).
+        let imp = DynamicImportInfo {
+            source: "@bacons/__mocks__/apple-targets".into(),
+            span: dummy_span(),
+            destructured_names: vec![],
+            local_name: Some(String::new()),
+            is_speculative: true,
+        };
+        let file = Path::new("/project/src/app.test.ts");
+        let result = resolve_single_dynamic_import(ctx, file, &imp);
+        assert!(
+            result.is_empty(),
+            "speculative imports landing in package space must be dropped, got: {result:?}"
+        );
+    });
+}
+
+#[test]
+fn non_speculative_dynamic_import_keeps_package_entry() {
+    with_empty_ctx(|ctx| {
+        let imp = DynamicImportInfo {
+            source: "@bacons/apple-targets".into(),
+            span: dummy_span(),
+            destructured_names: vec![],
+            local_name: None,
+            is_speculative: false,
+        };
+        let file = Path::new("/project/src/app.test.ts");
+        let result = resolve_single_dynamic_import(ctx, file, &imp);
+        assert_eq!(result.len(), 1);
+        assert!(matches!(result[0].target, ResolveResult::NpmPackage(_)));
+    });
+}
+
+#[test]
 fn non_speculative_dynamic_import_keeps_unresolvable_entry() {
     with_empty_ctx(|ctx| {
         let imp = DynamicImportInfo {


### PR DESCRIPTION
## Summary

`jest.mock('@scope/pkg')` (and `vi.mock`) without a factory makes the extractor synthesize a speculative `__mocks__` sibling candidate, `{dir}/__mocks__/{file}`. For a bare scoped specifier that becomes `@scope/__mocks__/pkg`, and since bare specifiers classify as `NpmPackage` rather than `Unresolvable`, the candidate slipped past the speculative drop guard and surfaced as a phantom `unlisted-dependency` finding for `@scope/__mocks__`. In gated audits this blocks CI, which is how the reporter hit it.

The resolver now drops speculative dynamic-import candidates that land in package space (`NpmPackage` / `CommonJsNpmPackage`), alongside the existing `Unresolvable` drop. The sibling candidate exists solely to discover an internal manual-mock file; a package-space result means the specifier stayed bare after alias substitution, and `pkg/__mocks__/...` is not a runner convention.

Resolve is the earliest layer that can decide this: at extract time `@scope/pkg` and `@/alias` are indistinguishable, and aliased specifiers legitimately produce internal sibling hits that must keep their edge. Vitest projects never saw the phantom because the Vitest plugin suppresses `/__mocks__`-suffixed package names at the analysis layer; that suppression stays as defense in depth, but Jest projects are now fixed at the source.

Cached resolver output persists these edges and cache validity is keyed on `GRAPH_CACHE_VERSION` alone, so without a bump a warm cache written by an older version keeps replaying the phantom after upgrade (measured); the version moves to 21.

Note: the issue title attributes the phantom to Jest `moduleNameMapper`; isolation shows the mapper is irrelevant. A fixture without the mapper still reproduces, a fixture without `jest.mock` does not.

The one other producer of speculative dynamic imports, extensionless `new URL(spec, import.meta.url)` credit edges, is unaffected: it only accepts `./` and `../` specifiers, which can never classify as bare packages.

## Verification

- New resolver unit test (`speculative_dynamic_import_drops_when_package_space`) and integration test (`issue_2213_jest_mock_phantom_package`, reporter's shape including a genuinely-unlisted positive control and a listed package referenced only via `jest.mock` that must keep its usage credit) both fail without the fix and pass with it.
- All four mock registration forms verified phantom-free on a fixture: hoisted `jest.mock`, `jest.doMock`, and both through an aliased `@jest/globals` binding; `jest.mock('lodash')` (no subpath) and unscoped-with-subpath (`lodash/debounce`) shapes keep their dependency credit.
- Warm-cache upgrade path: cache written by the old binary, fixed binary run on top, phantom gone via the version bump (was still reported without it).
- Real-consumer diff runs with cleared caches (old main binary vs fixed binary, normalized JSON): identical output on a vitest OSS project with scoped `vi.mock` calls, on viz-frontend, and on a large private vitest app. These prove the drop costs nothing; the user-visible delta is Jest-only and covered by the fixtures above.
- `fallow-graph` unit suite and the `fallow-core` integration suite (including the vi.mock selectivity controls) green; full local verification (`npm run verify:full`) green.

Follow-ups filed separately rather than widened into this PR: vitest root-level `__mocks__/<pkg>` manual mocks are reported as unused files (pre-existing, jest has an entry pattern for this, vitest does not), and jest lacks the `/__mocks__` virtual-package suffix suppression for user-written literal imports that vitest has.

Closes #2213
