### PR TITLE
perf(engine): build styling token candidates lazily

### DIFF
--- a/crates/engine/src/health/css_analytics/cva.rs
+++ b/crates/engine/src/health/css_analytics/cva.rs
@@ -63,14 +63,15 @@ pub(super) fn scan_cva_duplicate_variant_blocks(
 pub(super) fn scan_cva_variant_token_drifts(
     files: &[fallow_types::discover::DiscoveredFile],
     ctx: HealthScanCtx<'_>,
-    token_candidates: &[ComparableThemeTokenCandidate],
+    token_candidates: &StylingTokenCandidateCache<'_>,
 ) -> Vec<fallow_output::CvaVariantTokenDrift> {
-    if token_candidates.is_empty() {
+    if token_candidates.is_definitely_empty() {
         return Vec::new();
     }
     let mut out = Vec::new();
     let mut seen: rustc_hash::FxHashSet<(String, u32, String, String)> =
         rustc_hash::FxHashSet::default();
+    let mut candidates = None;
     for file in files {
         let Some((rel, source)) = read_js_style_scan_source(file, ctx) else {
             continue;
@@ -78,7 +79,11 @@ pub(super) fn scan_cva_variant_token_drifts(
         if !source_contains_cva_variants(&source) {
             continue;
         }
-        collect_cva_file_token_drifts(&mut out, &mut seen, &rel, &source, token_candidates);
+        let candidates = candidates.get_or_insert_with(|| token_candidates.get());
+        if candidates.is_empty() {
+            return Vec::new();
+        }
+        collect_cva_file_token_drifts(&mut out, &mut seen, &rel, &source, candidates);
     }
     out.sort_by(|a, b| {
         a.path

--- a/crates/engine/src/health/css_analytics/markup_scan.rs
+++ b/crates/engine/src/health/css_analytics/markup_scan.rs
@@ -45,7 +45,7 @@ pub(super) struct MarkupCssCandidateInput<'a> {
     pub(super) css_deep: bool,
     pub(super) ws_roots: Option<&'a [std::path::PathBuf]>,
     pub(super) styling_artifacts: Option<&'a StylingAnalysisArtifacts>,
-    pub(super) token_candidates: &'a [ComparableThemeTokenCandidate],
+    pub(super) token_candidates: &'a StylingTokenCandidateCache<'a>,
     pub(super) summary: &'a mut fallow_output::CssAnalyticsSummary,
 }
 

--- a/crates/engine/src/health/css_analytics/mod.rs
+++ b/crates/engine/src/health/css_analytics/mod.rs
@@ -1032,8 +1032,13 @@ pub(super) fn compute_css_analytics_report_with_artifacts(
     let mut summary = walk_ref.summary.clone();
     let mut raw_style_values = walk_ref.tokens.raw_style_values.clone();
     let styling_token_candidates =
-        css_report_token_candidates(&walk_ref.tokens, config, css_in_js_definers.as_ref());
-    annotate_raw_style_value_nearest_tokens(&mut raw_style_values, &styling_token_candidates);
+        StylingTokenCandidateCache::new(&walk_ref.tokens, config, css_in_js_definers.as_ref());
+    if !raw_style_values.is_empty() {
+        annotate_raw_style_value_nearest_tokens(
+            &mut raw_style_values,
+            styling_token_candidates.get(),
+        );
+    }
     let metrics =
         finalize_css_token_metrics(&walk_ref.tokens, &mut summary, files, config, ignore_set);
     let candidates = scan_markup_css_candidates(&mut MarkupCssCandidateInput {
@@ -1120,6 +1125,46 @@ fn css_report_token_candidates(
     candidates.extend(comparable_project_vocabulary_candidates(tokens));
     candidates.sort_by(|a, b| theme_token_sort_key(a).cmp(&theme_token_sort_key(b)));
     candidates
+}
+
+struct StylingTokenCandidateCache<'a> {
+    candidates: std::cell::OnceCell<Vec<ComparableThemeTokenCandidate>>,
+    tokens: &'a CssTokenSets,
+    config: &'a ResolvedConfig,
+    css_in_js_definers: Option<&'a CssInJsDefiners>,
+}
+
+impl<'a> StylingTokenCandidateCache<'a> {
+    fn new(
+        tokens: &'a CssTokenSets,
+        config: &'a ResolvedConfig,
+        css_in_js_definers: Option<&'a CssInJsDefiners>,
+    ) -> Self {
+        Self {
+            candidates: std::cell::OnceCell::new(),
+            tokens,
+            config,
+            css_in_js_definers,
+        }
+    }
+
+    fn get(&self) -> &[ComparableThemeTokenCandidate] {
+        self.candidates.get_or_init(|| {
+            css_report_token_candidates(self.tokens, self.config, self.css_in_js_definers)
+        })
+    }
+
+    fn is_definitely_empty(&self) -> bool {
+        if let Some(candidates) = self.candidates.get() {
+            return candidates.is_empty();
+        }
+        self.tokens.theme_token_definers.is_empty()
+            && self.tokens.custom_property_definers.is_empty()
+            && self.tokens.raw_style_values.len() < 2
+            && self
+                .css_in_js_definers
+                .is_none_or(|definers| definers.entries.iter().all(|entry| entry.leaves.is_empty()))
+    }
 }
 
 fn css_report_token_consumers(

--- a/crates/engine/src/health/css_analytics/token_consumer_tests.rs
+++ b/crates/engine/src/health/css_analytics/token_consumer_tests.rs
@@ -425,6 +425,100 @@ fn cva_duplicate_variant_blocks_surface_as_css_copy_paste() {
     assert_eq!(blocks[0].occurrences[0].path, "src/button.ts");
 }
 
+#[test]
+fn lazy_styling_candidates_preserve_raw_style_annotations() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"dependencies":{"tailwindcss":"4.0.0"}}"#,
+    )
+    .unwrap();
+    let styles = write_file(
+        root,
+        0,
+        "src/styles.css",
+        "@theme { --color-brand: #f05a28; }\n.card { color: #f05a29; }\n",
+    );
+
+    let computation = css_computation(root, &[styles]).expect("raw CSS keeps report");
+    let raw = computation
+        .report
+        .raw_style_values
+        .iter()
+        .find(|raw| raw.value == "#f05a29")
+        .expect("raw style value is reported");
+    assert_eq!(
+        raw.nearest_token.as_ref().map(|token| token.name.as_str()),
+        Some("--color-brand")
+    );
+}
+
+#[test]
+fn lazy_styling_candidates_preserve_cva_variant_drift() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"dependencies":{"class-variance-authority":"0.7.0","tailwindcss":"4.0.0"}}"#,
+    )
+    .unwrap();
+    let theme = write_file(
+        root,
+        0,
+        "src/theme.css",
+        "@theme {\n  --color-brand: #f05a28;\n}\n",
+    );
+    let button = write_file(
+        root,
+        1,
+        "src/button.ts",
+        "import { cva } from 'class-variance-authority';\n\
+         export const button = cva('inline-flex', {\n\
+           variants: {\n\
+             tone: {\n\
+               primary: 'px-3 py-2 text-sm font-medium bg-[#f05a28]',\n\
+               secondary: 'px-3 py-2 text-sm font-medium bg-[#f05a28]',\n\
+             },\n\
+           },\n\
+         });\n",
+    );
+
+    let computation = css_computation(root, &[theme, button]).expect("CVA drift keeps report");
+    let drift = computation
+        .report
+        .cva_variant_token_drifts
+        .first()
+        .expect("CVA arbitrary value points at a theme token");
+    assert_eq!(drift.class_token, "bg-[#f05a28]");
+    assert_eq!(drift.nearest_token.name, "--color-brand");
+}
+
+#[test]
+fn lazy_styling_candidates_preserve_css_deep_near_duplicates() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"dependencies":{"tailwindcss":"4.0.0"}}"#,
+    )
+    .unwrap();
+    let theme = write_file(
+        root,
+        0,
+        "src/theme.css",
+        "@theme {\n  --color-zbrand: #f05a28;\n  --color-abrand: rgb(240 90 41);\n}\n",
+    );
+    let mut changed = rustc_hash::FxHashSet::default();
+    changed.insert(theme.path.clone());
+
+    let computation = css_computation_3d_with_output_changed_files(root, &[theme], Some(&changed));
+    let near_duplicates = &computation.report.near_duplicate_theme_tokens;
+    assert!(near_duplicates.iter().any(|candidate| {
+        candidate.token == "--color-abrand" && candidate.nearest_token.name == "--color-zbrand"
+    }));
+}
+
 // --- CSS program Phase 3d: CSS-in-JS design-token blast-radius ---
 
 /// Like [`css_computation`] but parses each file into a `ModuleInfo` so the


### PR DESCRIPTION
## Summary

- construct comparable styling token candidates only when raw-style annotations or CVA drift analysis consumes them
- share the lazy result across both consumer paths
- preserve CSS-deep near-duplicate analysis and the merged CSS class inventory reuse

## Validation

- npm run verify:full
- focused CSS analytics tests for raw values, CVA drift, and CSS-deep near-duplicates
- Rijkshuisstijl Community stable health JSON is byte-identical to exact base 32b6a0104 after removing analysis_run_id and elapsed_ms

## Performance

CodSpeed will compare the existing benchmark identities against exact base 32b6a0104. No benchmark workload changed.