### PR TITLE
fix(health): explain override rows a reader could not act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unused shell pagination helper has been removed now that provider pagination
   is owned by the typed Rust posting path.
 
+### Changed
+
+- **Threshold override rows carry the measured span and read `stale` on
+  suppressed units.** `threshold_overrides[]` metrics gain an additive
+  `line_count` field on complexity rows (absent on CRAP and `<component>`
+  rollup rows, which never score unit size), so a
+  `still breaches: complexity` claim sits next to the number it was scored
+  on; human and compact output render it as `lines=N`, markdown as
+  `N lines`. A unit
+  hidden by an inline `fallow-ignore` comment now reports its matching
+  override as `stale` with position and metrics instead of `no_match`,
+  matching the existing CRAP-side behavior; a `maxUnitSize` ceiling still
+  scores suppressed units because suppression covers the finding, not the
+  large-function list. The human threshold-override section is now capped
+  like file scores: rows are prioritized by actionability (`no_match`,
+  `insufficient`, `active`, then `stale`), at most 10 are printed, and an
+  overflow line names what was hidden; JSON stays uncapped. No schema
+  version bump: the new field is additive.
+
 ## [3.15.0] - 2026-08-11
 
 ### Added

--- a/crates/api/src/compact_output.rs
+++ b/crates/api/src/compact_output.rs
@@ -616,9 +616,12 @@ fn push_threshold_overrides_compact(
             let crap = metrics
                 .crap
                 .map_or(String::new(), |value| format!(",crap={value:.1}"));
+            let line_count = metrics
+                .line_count
+                .map_or(String::new(), |value| format!(",lines={value}"));
             format!(
-                ",cyclomatic={},cognitive={}{}",
-                metrics.cyclomatic, metrics.cognitive, crap
+                ",cyclomatic={},cognitive={}{}{}",
+                metrics.cyclomatic, metrics.cognitive, line_count, crap
             )
         });
         let outstanding = if entry.outstanding.is_empty() {

--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -1783,9 +1783,12 @@ fn write_threshold_overrides_section(
                 let crap = metrics
                     .crap
                     .map_or(String::new(), |value| format!(", CRAP {value:.1}"));
+                let line_count = metrics
+                    .line_count
+                    .map_or(String::new(), |value| format!(", {value} lines"));
                 format!(
-                    "cyclomatic {}, cognitive {}{}",
-                    metrics.cyclomatic, metrics.cognitive, crap
+                    "cyclomatic {}, cognitive {}{}{}",
+                    metrics.cyclomatic, metrics.cognitive, line_count, crap
                 )
             },
         );

--- a/crates/cli/src/report/human/health.rs
+++ b/crates/cli/src/report/human/health.rs
@@ -2092,13 +2092,17 @@ fn render_threshold_overrides(
             .yellow()
             .bold()
     ));
-    for entry in &report.threshold_overrides {
-        let status = match entry.status {
-            fallow_output::ThresholdOverrideStatus::Active => "active",
-            fallow_output::ThresholdOverrideStatus::Stale => "stale",
-            fallow_output::ThresholdOverrideStatus::Insufficient => "insufficient",
-            fallow_output::ThresholdOverrideStatus::NoMatch => "no_match",
-        };
+    // Rows are prioritized by actionability before the cap: `no_match` and
+    // `insufficient` need a config or code change, `active` is confirmation,
+    // and `stale` is pure noise at volume. A wide glob produces one row per
+    // matched function, so an uncapped section drowned the actionable rows
+    // (issue #2163 follow-up). The stable sort preserves the engine's
+    // deterministic order within each status. JSON stays uncapped.
+    let mut display: Vec<&fallow_output::ThresholdOverrideState> =
+        report.threshold_overrides.iter().collect();
+    display.sort_by_key(|entry| threshold_override_status_display_rank(entry.status));
+    for entry in display.iter().take(MAX_FLAT_ITEMS) {
+        let status = threshold_override_status_label(entry.status);
         let dimension = threshold_override_dimension_label(entry.dimension);
         let outstanding = threshold_override_outstanding_suffix(&entry.outstanding);
         let target = entry.path.as_ref().map_or_else(
@@ -2109,9 +2113,12 @@ fn render_threshold_overrides(
             let crap = metrics
                 .crap
                 .map_or(String::new(), |value| format!(" crap={value:.1}"));
+            let line_count = metrics
+                .line_count
+                .map_or(String::new(), |value| format!(" lines={value}"));
             format!(
-                " cyclomatic={} cognitive={}{}",
-                metrics.cyclomatic, metrics.cognitive, crap
+                " cyclomatic={} cognitive={}{}{}",
+                metrics.cyclomatic, metrics.cognitive, line_count, crap
             )
         });
         lines.push(format!(
@@ -2119,7 +2126,57 @@ fn render_threshold_overrides(
             idx = entry.override_index
         ));
     }
+    push_threshold_overrides_overflow(lines, &display);
     lines.push(String::new());
+}
+
+fn threshold_override_status_label(status: fallow_output::ThresholdOverrideStatus) -> &'static str {
+    match status {
+        fallow_output::ThresholdOverrideStatus::Active => "active",
+        fallow_output::ThresholdOverrideStatus::Stale => "stale",
+        fallow_output::ThresholdOverrideStatus::Insufficient => "insufficient",
+        fallow_output::ThresholdOverrideStatus::NoMatch => "no_match",
+    }
+}
+
+fn threshold_override_status_display_rank(status: fallow_output::ThresholdOverrideStatus) -> u8 {
+    match status {
+        fallow_output::ThresholdOverrideStatus::NoMatch => 0,
+        fallow_output::ThresholdOverrideStatus::Insufficient => 1,
+        fallow_output::ThresholdOverrideStatus::Active => 2,
+        fallow_output::ThresholdOverrideStatus::Stale => 3,
+    }
+}
+
+fn push_threshold_overrides_overflow(
+    lines: &mut Vec<String>,
+    display: &[&fallow_output::ThresholdOverrideState],
+) {
+    if display.len() <= MAX_FLAT_ITEMS {
+        return;
+    }
+    let hidden = &display[MAX_FLAT_ITEMS..];
+    let mut counts: Vec<(&'static str, usize)> = Vec::new();
+    for entry in hidden {
+        let label = threshold_override_status_label(entry.status);
+        match counts.iter_mut().find(|(name, _)| *name == label) {
+            Some((_, count)) => *count += 1,
+            None => counts.push((label, 1)),
+        }
+    }
+    let breakdown = counts
+        .iter()
+        .map(|(name, count)| format!("{count} {name}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    lines.push(format!(
+        "    {}",
+        format!(
+            "... and {} more rows ({breakdown}) (--format json for full list)",
+            hidden.len()
+        )
+        .dimmed()
+    ));
 }
 
 fn threshold_override_dimension_label(
@@ -3051,6 +3108,7 @@ mod tests {
                 cyclomatic: 9,
                 cognitive: 21,
                 crap: None,
+                line_count: Some(100),
             }),
             reason: None,
         };
@@ -3061,6 +3119,7 @@ mod tests {
                 cyclomatic: 9,
                 cognitive: 21,
                 crap: Some(90.0),
+                line_count: None,
             }),
             ..base.clone()
         };
@@ -3071,6 +3130,129 @@ mod tests {
         assert!(text.contains("#0 complexity active"), "{text}");
         assert!(text.contains("#0 crap active"), "{text}");
         assert!(text.contains("(still breaches: CRAP)"), "{text}");
+    }
+
+    /// The measured span renders only when the engine attached one: complexity
+    /// rows carry it, CRAP rows never do, so a CRAP-breach claim is never
+    /// juxtaposed with an unrelated unit-size number (issue #2163 follow-up).
+    #[test]
+    fn threshold_override_row_shows_line_count_only_when_present() {
+        let root = PathBuf::from("/project");
+        let mut report = disclosure_report(vec![disclosure_violation(
+            root.join("src/Widget.svelte"),
+            "<template>",
+            fallow_output::ExceededThreshold::Crap,
+        )]);
+        report.threshold_overrides = vec![
+            threshold_override_row(
+                0,
+                fallow_output::ThresholdOverrideStatus::Active,
+                fallow_output::ThresholdOverrideDimension::Complexity,
+                "src/Widget.svelte",
+            ),
+            threshold_override_row(
+                0,
+                fallow_output::ThresholdOverrideStatus::Active,
+                fallow_output::ThresholdOverrideDimension::Crap,
+                "src/Widget.svelte",
+            ),
+        ];
+
+        let text = plain(&build_health_human_lines(&report, &root));
+        assert!(
+            text.contains("#0 complexity active src/Widget.svelte:7:<template> cyclomatic=9 cognitive=21 lines=100"),
+            "{text}"
+        );
+        assert!(
+            text.contains(
+                "#0 crap active src/Widget.svelte:7:<template> cyclomatic=9 cognitive=21 crap=90.0"
+            ),
+            "{text}"
+        );
+    }
+
+    fn threshold_override_row(
+        override_index: usize,
+        status: fallow_output::ThresholdOverrideStatus,
+        dimension: fallow_output::ThresholdOverrideDimension,
+        path: &str,
+    ) -> fallow_output::ThresholdOverrideState {
+        let no_match = matches!(status, fallow_output::ThresholdOverrideStatus::NoMatch);
+        let is_crap = matches!(dimension, fallow_output::ThresholdOverrideDimension::Crap);
+        fallow_output::ThresholdOverrideState {
+            status,
+            override_index,
+            dimension,
+            outstanding: Vec::new(),
+            path: (!no_match).then(|| PathBuf::from(path)),
+            function: (!no_match).then(|| "<template>".to_string()),
+            line: (!no_match).then_some(7),
+            col: (!no_match).then_some(0),
+            configured_thresholds: fallow_output::HealthConfiguredThresholds {
+                max_cyclomatic: Some(500),
+                max_cognitive: Some(500),
+                max_crap: None,
+                max_unit_size: None,
+            },
+            effective_thresholds: OVERRIDE_THRESHOLDS,
+            metrics: (!no_match).then(|| fallow_output::ThresholdOverrideMetrics {
+                cyclomatic: 9,
+                cognitive: 21,
+                crap: is_crap.then_some(90.0),
+                line_count: (!is_crap).then_some(100),
+            }),
+            reason: None,
+        }
+    }
+
+    /// A wide glob emits one row per matched function, so the section is capped
+    /// like file scores and large functions. Actionable statuses survive the
+    /// cap ahead of `stale`, the header keeps counting configured entries, and
+    /// the overflow line names what was hidden (issue #2163 follow-up).
+    #[test]
+    fn threshold_override_section_caps_rows_and_keeps_actionable_statuses() {
+        let root = PathBuf::from("/project");
+        let mut report = disclosure_report(vec![disclosure_violation(
+            root.join("src/Widget.svelte"),
+            "<template>",
+            fallow_output::ExceededThreshold::Crap,
+        )]);
+        let mut rows = Vec::new();
+        for index in 0..12 {
+            rows.push(threshold_override_row(
+                0,
+                fallow_output::ThresholdOverrideStatus::Stale,
+                fallow_output::ThresholdOverrideDimension::Complexity,
+                &format!("src/stale{index}.spec.ts"),
+            ));
+        }
+        rows.push(threshold_override_row(
+            1,
+            fallow_output::ThresholdOverrideStatus::NoMatch,
+            fallow_output::ThresholdOverrideDimension::Complexity,
+            "",
+        ));
+        rows.push(threshold_override_row(
+            0,
+            fallow_output::ThresholdOverrideStatus::Insufficient,
+            fallow_output::ThresholdOverrideDimension::Complexity,
+            "src/big.spec.ts",
+        ));
+        report.threshold_overrides = rows;
+
+        let text = plain(&build_health_human_lines(&report, &root));
+        assert!(text.contains("Health threshold overrides (2)"), "{text}");
+        let row_count = text
+            .lines()
+            .filter(|line| line.trim_start().starts_with('#'))
+            .count();
+        assert_eq!(row_count, MAX_FLAT_ITEMS, "{text}");
+        assert!(text.contains("#1 complexity no_match"), "{text}");
+        assert!(text.contains("#0 complexity insufficient"), "{text}");
+        assert!(
+            text.contains("... and 4 more rows (4 stale) (--format json for full list)"),
+            "{text}"
+        );
     }
 
     #[test]

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -360,6 +360,114 @@ fn health_threshold_override_uses_local_ceiling() {
     assert_eq!(state["status"].as_str(), Some("active"));
     assert_eq!(state["function"].as_str(), Some("legacyFlow"));
     assert_eq!(state["reason"].as_str(), Some("legacy migration"));
+    assert!(
+        state["metrics"]["line_count"]
+            .as_u64()
+            .is_some_and(|n| n > 0),
+        "complexity rows must carry the measured span: {state:#?}"
+    );
+}
+
+/// An inline suppression already hides the finding, so the override is not
+/// what keeps the unit quiet: the row must read `stale`, not `no_match`,
+/// which claimed the glob matched nothing (issue #2163 follow-up).
+#[test]
+fn health_threshold_override_reports_stale_for_suppressed_function() {
+    let dir = tempdir().expect("create temp dir");
+    write_threshold_override_fixture(
+        dir.path(),
+        r#"{
+  "health": {
+    "thresholdOverrides": [
+      {
+        "files": ["src/legacy.ts"],
+        "functions": ["legacyFlow"],
+        "maxCyclomatic": 20
+      }
+    ]
+  }
+}
+"#,
+        &format!(
+            "// fallow-ignore-next-line complexity\n{}",
+            complex_threshold_override_source()
+        ),
+    );
+
+    let output = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &[
+            "--complexity",
+            "--max-cyclomatic",
+            "3",
+            "--max-cognitive",
+            "9999",
+            "--max-crap",
+            "10000",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+    );
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr);
+    let json = parse_json(&output);
+    let states = json["threshold_overrides"]
+        .as_array()
+        .expect("threshold_overrides array");
+    assert_eq!(states.len(), 1, "{states:#?}");
+    assert_eq!(states[0]["status"].as_str(), Some("stale"));
+    assert_eq!(states[0]["function"].as_str(), Some("legacyFlow"));
+}
+
+/// The human section is capped for scanability, but JSON is the machine
+/// surface and must keep every row (issue #2163 follow-up).
+#[test]
+fn health_threshold_override_json_keeps_every_row_when_human_section_caps() {
+    let dir = tempdir().expect("create temp dir");
+    let root = dir.path();
+    write_file(
+        &root.join("package.json"),
+        r#"{"name":"override-volume-fixture","type":"module","main":"src/many.spec.ts"}"#,
+    );
+    let mut source = String::new();
+    for i in 0..12 {
+        let _ = writeln!(
+            source,
+            "export function helper{i}(input: number): number {{\n  return input + {i};\n}}"
+        );
+    }
+    write_file(&root.join("src/many.spec.ts"), &source);
+    write_file(
+        &root.join(".fallowrc.json"),
+        r#"{"health":{"thresholdOverrides":[{"files":["src/*.spec.ts"],"maxCyclomatic":20}]}}"#,
+    );
+
+    let json_output = run_fallow_in_root(
+        "health",
+        root,
+        &["--complexity", "--format", "json", "--quiet"],
+    );
+    let json = parse_json(&json_output);
+    let states = json["threshold_overrides"]
+        .as_array()
+        .expect("threshold_overrides array");
+    assert_eq!(states.len(), 12, "one row per matched function, uncapped");
+
+    let human = run_fallow_in_root("health", root, &["--complexity", "--quiet"]);
+    let row_count = human
+        .stdout
+        .lines()
+        .filter(|line| line.trim_start().starts_with("#0 complexity"))
+        .count();
+    assert_eq!(row_count, 10, "{}", human.stdout);
+    assert!(
+        human
+            .stdout
+            .contains("... and 2 more rows (2 stale) (--format json for full list)"),
+        "{}",
+        human.stdout
+    );
 }
 
 /// A single low-complexity function whose body spans `body_lines` lines, so it

--- a/crates/engine/src/health/component_rollup.rs
+++ b/crates/engine/src/health/component_rollup.rs
@@ -223,11 +223,12 @@ fn build_component_rollup(
             col: worst.col,
             cyclomatic: rollup_cyc,
             cognitive: rollup_cog,
-            // Zero, not the rollup's own span: the rollup is never measured
+            // None, not the rollup's own span: the rollup is never measured
             // against `maxUnitSize` and never enters the large-function list, so
             // scoring a unit-size term here would let a row read `insufficient`
             // over a breach no other part of the report can show.
-            line_count: 0,
+            line_count: None,
+            suppressed: false,
         },
         &matches,
         resolver.global,

--- a/crates/engine/src/health/execute_tests.rs
+++ b/crates/engine/src/health/execute_tests.rs
@@ -2308,7 +2308,8 @@ fn override_row_names_crap_as_the_outstanding_dimension() {
             col: 0,
             cyclomatic: 9,
             cognitive: 21,
-            line_count: 30,
+            line_count: Some(30),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -2407,7 +2408,8 @@ fn override_configuring_every_ceiling_reports_nothing_outstanding() {
             col: 0,
             cyclomatic: 9,
             cognitive: 21,
-            line_count: 30,
+            line_count: Some(30),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -2523,7 +2525,8 @@ fn a_partly_configured_complexity_override_still_reports_the_surviving_dimension
             col: 0,
             cyclomatic: 25,
             cognitive: 21,
-            line_count: 30,
+            line_count: Some(30),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -2597,7 +2600,8 @@ fn a_superseded_override_row_reports_the_resolved_ceiling_not_its_own() {
             col: 0,
             cyclomatic: 30,
             cognitive: 29,
-            line_count: 30,
+            line_count: Some(30),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -2670,6 +2674,167 @@ fn a_suppressed_unit_reports_a_stale_crap_row_and_still_counts_as_matched() {
     assert!(states[0].outstanding.is_empty());
 }
 
+/// The complexity twin of the suppressed-CRAP case: an inline suppression
+/// already hides the complexity finding, so a cyclomatic/cognitive-scoped
+/// override buys nothing and the row reads `stale`, never `active`. The entry
+/// still counts as matched, so it must not fall through to a `no_match` row
+/// (issue #2163 follow-up).
+#[test]
+fn a_suppressed_unit_reports_a_stale_complexity_row_and_still_counts_as_matched() {
+    let resolver = threshold_resolver(&[fallow_config::HealthThresholdOverride {
+        files: vec!["src/supp.ts".to_string()],
+        functions: vec!["gnarly".to_string()],
+        max_cyclomatic: Some(40),
+        max_cognitive: None,
+        max_crap: None,
+        max_unit_size: None,
+        reason: None,
+    }]);
+    let (applied, matches) = resolver.resolve(Path::new("src/supp.ts"), "gnarly");
+    let mut tracker = ThresholdOverrideStateTracker::default();
+    tracker.record_complexity(
+        ComplexityFunctionContext {
+            path: Path::new("/project/src/supp.ts"),
+            function: "gnarly",
+            line: 2,
+            col: 0,
+            cyclomatic: 30,
+            cognitive: 12,
+            line_count: Some(40),
+            suppressed: true,
+        },
+        &matches,
+        issue_2163_globals(),
+        applied.effective,
+    );
+    tracker.record_no_match_entries(&resolver, true);
+
+    annotate_outstanding_dimensions(&mut tracker, &[]);
+
+    let states = tracker.into_states();
+    assert_eq!(states.len(), 1, "one stale row, and not a `no_match` one");
+    assert!(
+        matches!(
+            states[0].status,
+            fallow_output::ThresholdOverrideStatus::Stale
+        ),
+        "the suppression, not the raised ceiling, keeps the unit quiet: {:#?}",
+        states[0]
+    );
+    assert!(states[0].outstanding.is_empty());
+}
+
+/// Suppression covers the complexity finding only, never the large-function
+/// list, so a `maxUnitSize`-scoped entry keeps real unit-size scoring on a
+/// suppressed unit (issue #2163 follow-up).
+#[test]
+fn a_max_unit_size_override_still_scores_a_suppressed_unit() {
+    let resolver = threshold_resolver(&[fallow_config::HealthThresholdOverride {
+        files: vec!["src/supp.ts".to_string()],
+        functions: Vec::new(),
+        max_cyclomatic: None,
+        max_cognitive: None,
+        max_crap: None,
+        max_unit_size: Some(500),
+        reason: None,
+    }]);
+    let (applied, matches) = resolver.resolve(Path::new("src/supp.ts"), "gnarly");
+    let mut tracker = ThresholdOverrideStateTracker::default();
+    tracker.record_complexity(
+        ComplexityFunctionContext {
+            path: Path::new("/project/src/supp.ts"),
+            function: "gnarly",
+            line: 2,
+            col: 0,
+            cyclomatic: 5,
+            cognitive: 4,
+            line_count: Some(100),
+            suppressed: true,
+        },
+        &matches,
+        issue_2163_globals(),
+        applied.effective,
+    );
+
+    let states = tracker.into_states();
+    assert_eq!(states.len(), 1);
+    assert!(
+        matches!(
+            states[0].status,
+            fallow_output::ThresholdOverrideStatus::Active
+        ),
+        "100 lines exceed the global 60 and clear the raised 500: {:#?}",
+        states[0]
+    );
+}
+
+/// Complexity rows carry the measured span so a `still breaches: complexity`
+/// claim sits next to the number it was scored on; CRAP rows never score unit
+/// size, so the field stays absent there (issue #2163 follow-up).
+#[test]
+fn threshold_override_metrics_carry_line_count_on_complexity_rows_only() {
+    let resolver = threshold_resolver(&[fallow_config::HealthThresholdOverride {
+        files: vec!["src/Widget.svelte".to_string()],
+        functions: Vec::new(),
+        max_cyclomatic: Some(500),
+        max_cognitive: Some(500),
+        max_crap: Some(500.0),
+        max_unit_size: None,
+        reason: None,
+    }]);
+    let absolute = Path::new("/project/src/Widget.svelte");
+    let (applied, matches) = resolver.resolve(Path::new("src/Widget.svelte"), "<template>");
+    let mut tracker = ThresholdOverrideStateTracker::default();
+    tracker.record_complexity(
+        ComplexityFunctionContext {
+            path: absolute,
+            function: "<template>",
+            line: 1,
+            col: 0,
+            cyclomatic: 9,
+            cognitive: 21,
+            line_count: Some(100),
+            suppressed: false,
+        },
+        &matches,
+        issue_2163_globals(),
+        applied.effective,
+    );
+    tracker.record_crap(
+        CrapFunctionContext {
+            path: absolute,
+            function: "<template>",
+            line: 1,
+            col: 0,
+            suppressed: false,
+        },
+        MeasuredThresholdMetrics {
+            cyclomatic: 9,
+            cognitive: 21,
+            crap: 90.0,
+        },
+        &matches,
+        issue_2163_globals(),
+        applied.effective,
+    );
+
+    let states = tracker.into_states();
+    assert_eq!(states.len(), 2);
+    let complexity_row = states
+        .iter()
+        .find(|state| state.dimension == fallow_output::ThresholdOverrideDimension::Complexity)
+        .expect("complexity row");
+    assert_eq!(
+        complexity_row.metrics.expect("metrics").line_count,
+        Some(100)
+    );
+    let crap_row = states
+        .iter()
+        .find(|state| state.dimension == fallow_output::ThresholdOverrideDimension::Crap)
+        .expect("crap row");
+    assert!(crap_row.metrics.expect("metrics").line_count.is_none());
+}
+
 /// Two units in one file share the name `handler`. The row keyed to the
 /// high-complexity unit must take that unit's `exceeded`, not the other's.
 #[test]
@@ -2696,7 +2861,8 @@ fn same_named_units_do_not_steal_each_others_outstanding_dimensions() {
                 col: 2,
                 cyclomatic,
                 cognitive,
-                line_count: 30,
+                line_count: Some(30),
+                suppressed: false,
             },
             &matches,
             issue_2163_globals(),
@@ -3064,6 +3230,10 @@ fn a_component_rollup_row_does_not_score_a_unit_size_term() {
         states[0]
     );
     assert!(states[0].outstanding.is_empty(), "{:#?}", states[0]);
+    assert!(
+        states[0].metrics.expect("metrics").line_count.is_none(),
+        "the rollup's synthetic span must not surface as a measured unit size"
+    );
 }
 
 /// `maxUnitSize` is part of the complexity dimension, so a matching unit-size
@@ -3092,7 +3262,8 @@ fn a_unit_size_only_override_reports_a_complexity_row_when_it_matches() {
             col: 0,
             cyclomatic: 9,
             cognitive: 10,
-            line_count: 320,
+            line_count: Some(320),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -3143,7 +3314,8 @@ fn a_unit_size_only_override_that_is_still_breached_reports_insufficient() {
             col: 0,
             cyclomatic: 9,
             cognitive: 10,
-            line_count: 320,
+            line_count: Some(320),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -3187,7 +3359,8 @@ fn a_unit_size_breach_and_a_complexity_finding_name_one_outstanding_dimension() 
             col: 0,
             cyclomatic: 30,
             cognitive: 10,
-            line_count: 320,
+            line_count: Some(320),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -3234,7 +3407,8 @@ fn a_cyclomatic_only_override_is_insufficient_when_cognitive_still_breaches() {
             col: 0,
             cyclomatic: 25,
             cognitive: 22,
-            line_count: 30,
+            line_count: Some(30),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),
@@ -3289,7 +3463,8 @@ fn a_unit_size_only_override_is_not_stale_while_complexity_still_fires() {
             col: 0,
             cyclomatic: 25,
             cognitive: 21,
-            line_count: 32,
+            line_count: Some(32),
+            suppressed: false,
         },
         &matches,
         issue_2163_globals(),

--- a/crates/engine/src/health/findings.rs
+++ b/crates/engine/src/health/findings.rs
@@ -94,6 +94,29 @@ pub(super) fn collect_findings_with_resolver(
                 fc.line,
                 crate::suppress::IssueKind::Complexity,
             ) {
+                // Recorded before the skip, mirroring `record_crap`: the
+                // tracker is what registers the entry as matched, so skipping
+                // it here turned a glob that did match a suppressed unit into
+                // a `no_match` row (issue #2163 follow-up). The `is_empty`
+                // guard keeps the common no-override run at zero extra work.
+                if !input.threshold_resolver.is_empty() {
+                    let (applied, matched) = input.threshold_resolver.resolve(relative, &fc.name);
+                    input.threshold_state_tracker.record_complexity(
+                        ComplexityFunctionContext {
+                            path,
+                            function: &fc.name,
+                            line: fc.line,
+                            col: fc.col,
+                            cyclomatic: fc.cyclomatic,
+                            cognitive: fc.cognitive,
+                            line_count: Some(fc.line_count),
+                            suppressed: true,
+                        },
+                        &matched,
+                        input.threshold_resolver.global,
+                        applied.effective,
+                    );
+                }
                 continue;
             }
             let react_hook_profile = hook_profiles.get(fc_idx).cloned().flatten();
@@ -147,7 +170,8 @@ fn collect_complexity_finding(
             col: fc.col,
             cyclomatic: fc.cyclomatic,
             cognitive: fc.cognitive,
-            line_count: fc.line_count,
+            line_count: Some(fc.line_count),
+            suppressed: false,
         },
         &matched_overrides,
         input.threshold_resolver.global,

--- a/crates/engine/src/health/threshold_overrides.rs
+++ b/crates/engine/src/health/threshold_overrides.rs
@@ -148,6 +148,14 @@ impl ThresholdOverrideResolver {
     fn entries(&self) -> &[CompiledThresholdOverride] {
         &self.entries
     }
+
+    /// True when no `thresholdOverrides` entries are configured. Lets callers
+    /// on cold paths (suppressed functions) skip `resolve` entirely, so the
+    /// common no-override run does zero extra work per suppressed unit.
+    #[must_use]
+    pub(super) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -219,6 +227,7 @@ impl ThresholdOverrideStateTracker {
             cyclomatic,
             cognitive,
             line_count,
+            suppressed,
         } = function;
         for matched in matches {
             let configured = matched.entry.configured;
@@ -255,10 +264,17 @@ impl ThresholdOverrideStateTracker {
             // finding, so folding an unrelated long function into the predicate
             // would flip a cyclomatic-only override to `insufficient` with
             // nothing outstanding to point at.
+            //
+            // Suppression neutralizes only the finding-driven terms: an inline
+            // `fallow-ignore` comment hides the complexity finding, so a raised
+            // cyclomatic/cognitive ceiling buys nothing there and the row reads
+            // `stale`, mirroring `record_crap`. The unit-size term keeps real
+            // scoring because suppression covers the finding only, never the
+            // large-function list, so a raised `maxUnitSize` still has effect
+            // on a suppressed unit (issue #2163 follow-up).
             let breaches = |max_cyclomatic: u16, max_cognitive: u16, max_unit_size: u32| {
-                cyclomatic > max_cyclomatic
-                    || cognitive > max_cognitive
-                    || (touches_unit_size && line_count > max_unit_size)
+                (!suppressed && (cyclomatic > max_cyclomatic || cognitive > max_cognitive))
+                    || (touches_unit_size && line_count.is_some_and(|lc| lc > max_unit_size))
             };
             let global_exceeded = breaches(global.cyclomatic, global.cognitive, global.unit_size);
             let local_exceeded = breaches(
@@ -279,11 +295,12 @@ impl ThresholdOverrideStateTracker {
             // unit-size-only entry that raised the ceiling without clearing it
             // read `insufficient` with an empty `outstanding`, the one
             // contradiction a CI gate cannot detect (issue #2163).
-            let outstanding = if touches_unit_size && line_count > effective.max_unit_size {
-                vec![ThresholdOverrideDimension::Complexity]
-            } else {
-                Vec::new()
-            };
+            let outstanding =
+                if touches_unit_size && line_count.is_some_and(|lc| lc > effective.max_unit_size) {
+                    vec![ThresholdOverrideDimension::Complexity]
+                } else {
+                    Vec::new()
+                };
             self.push_state(ThresholdOverrideStateInput {
                 status,
                 override_index: matched.entry.index,
@@ -298,6 +315,7 @@ impl ThresholdOverrideStateTracker {
                     cyclomatic,
                     cognitive,
                     crap: None,
+                    line_count,
                 }),
                 reason: matched.entry.reason.clone(),
                 dimension: ThresholdOverrideDimension::Complexity,
@@ -350,6 +368,9 @@ impl ThresholdOverrideStateTracker {
                     cyclomatic: metrics.cyclomatic,
                     cognitive: metrics.cognitive,
                     crap: Some(metrics.crap),
+                    // The CRAP dimension never scores unit size, so an absent
+                    // field keeps the row honest next to a CRAP-breach claim.
+                    line_count: None,
                 }),
                 reason: matched.entry.reason.clone(),
                 dimension: ThresholdOverrideDimension::Crap,
@@ -466,7 +487,14 @@ impl ThresholdOverrideStateTracker {
 ///
 /// `line_count` is here because `maxUnitSize` is part of the complexity
 /// dimension: without it a unit-size-only entry has nothing to score its row
-/// against.
+/// against. `None` means the caller has no unit-size-scorable span: the
+/// `<component>` rollup is never measured against `maxUnitSize`, so a `Some`
+/// there would let a row read `insufficient` over a breach no other part of
+/// the report can show.
+///
+/// `suppressed` mirrors [`CrapFunctionContext`]: an inline `fallow-ignore`
+/// comment hides the complexity finding, so the row must read `stale` instead
+/// of falling through to `no_match` (issue #2163 follow-up).
 #[derive(Clone, Copy)]
 pub(super) struct ComplexityFunctionContext<'a> {
     pub(super) path: &'a Path,
@@ -475,7 +503,8 @@ pub(super) struct ComplexityFunctionContext<'a> {
     pub(super) col: u32,
     pub(super) cyclomatic: u16,
     pub(super) cognitive: u16,
-    pub(super) line_count: u32,
+    pub(super) line_count: Option<u32>,
+    pub(super) suppressed: bool,
 }
 
 /// One function's identity and suppression state for the CRAP recorder.

--- a/crates/output/src/health_scores.rs
+++ b/crates/output/src/health_scores.rs
@@ -583,6 +583,11 @@ pub struct ThresholdOverrideMetrics {
     /// Current CRAP score, when coverage data exists.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crap: Option<f64>,
+    /// Measured line count of the matched unit. Present on complexity rows,
+    /// where `maxUnitSize` participates in the dimension; absent on CRAP rows
+    /// and `<component>` rollup rows, which are never scored on unit size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_count: Option<u32>,
 }
 
 /// Report entry describing whether a threshold override is active, stale, or

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -14353,6 +14353,13 @@
             "null"
           ],
           "description": "Current CRAP score, when coverage data exists."
+        },
+        "line_count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Measured line count of the matched unit. Present on complexity rows,\nwhere `maxUnitSize` participates in the dimension; absent on CRAP rows\nand `<component>` rollup rows, which are never scored on unit size."
         }
       },
       "required": [

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -5759,6 +5759,12 @@ cognitive: number
  * Current CRAP score, when coverage data exists.
  */
 crap?: (number | null)
+/**
+ * Measured line count of the matched unit. Present on complexity rows,
+ * where `maxUnitSize` participates in the dimension; absent on CRAP rows
+ * and `<component>` rollup rows, which are never scored on unit size.
+ */
+line_count?: (number | null)
 }
 /**
  * Project-wide vital signs: a fixed set of metrics for trend tracking.

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -5759,6 +5759,12 @@ cognitive: number
  * Current CRAP score, when coverage data exists.
  */
 crap?: (number | null)
+/**
+ * Measured line count of the matched unit. Present on complexity rows,
+ * where `maxUnitSize` participates in the dimension; absent on CRAP rows
+ * and `<component>` rollup rows, which are never scored on unit size.
+ */
+line_count?: (number | null)
 }
 /**
  * Project-wide vital signs: a fixed set of metrics for trend tracking.


### PR DESCRIPTION
Three leftovers from the #2163 reviews.

A `maxUnitSize`-only override that still breached rendered `cyclomatic=1 cognitive=0 (still breaches: complexity)`: a complexity claim next to metrics far below both complexity ceilings, with the measured span nowhere on the row. Override metrics now carry an optional `line_count`, filled on complexity rows and absent on CRAP and `<component>` rollup rows. Additive optional field; the health schema stays at version 10 under the compatibility policy's additive-field exemption.

One `maxUnitSize`-only entry on a large file produced a row per matched function, printed uncapped: 134 rows, 124 of them stale confirmations. The human section now shows the ten most actionable rows (`no_match` and `insufficient` ahead of `active` ahead of `stale`, stable within status) with an overflow line naming what was elided. JSON, compact and markdown stay complete.

A complexity override scoped to a suppressed function read `no_match`, the same silent inversion the CRAP side fixed in #2207: the suppression guard skipped the function before the tracker saw it. The row is now recorded with the suppressed-implies-stale semantics `record_crap` already uses, at no extra cost on the zero-override path.

Pre-ship review verdict: SHIP. Every new test demonstrated red-before-green; contracts regenerated byte-identical; only the known typescript 6.0.3 sidecar failures.

Refs #2163