### PR TITLE
chore(deps): bump CodSpeedHQ/action to v5.0.3

### DIFF
--- a/.github/workflows/bench-type-aware.yml
+++ b/.github/workflows/bench-type-aware.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: tools/type-aware-sidecar
 
       - name: Run type-aware benchmarks
-        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: walltime
           run: npm run bench --prefix tools/type-aware-sidecar

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -112,7 +112,7 @@ jobs:
         run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }} --features codspeed
 
       - name: Run benchmark shard
-        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: simulation
           run: cargo codspeed run -p ${{ matrix.package }} --bench ${{ matrix.bench }}
@@ -161,7 +161,7 @@ jobs:
         run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }} --features codspeed
 
       - name: Run full benchmark shard
-        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: simulation
           run: cargo codspeed run -p ${{ matrix.package }} --bench ${{ matrix.bench }}


### PR DESCRIPTION
All three benchmark-carrying repositories sat on v5.0.2 while v5.0.3 has been out since 7 August. This brings fallow to it; `srcmap` and `oxc-coverage-instrument` are on the same pin as of today.

v5.0.3 is a patch over the v5 measurement change that already landed, so there is no second baseline reset. It retries pinned binary downloads and accepts `--exclude-allocations` and `--cycle-estimation` without a value.

Both workflows that reference the action are updated, three call sites in total.