### PR TITLE
ci: retry the remaining third-party fetches

### DIFF
--- a/.github/workflows/hawk.yml
+++ b/.github/workflows/hawk.yml
@@ -43,6 +43,7 @@ jobs:
           install_root="${RUNNER_TEMP}/cargo-hawk"
           mkdir -p "${install_root}"
           curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            --retry 5 --retry-connrefused --retry-delay 2 \
             --output "${RUNNER_TEMP}/${HAWK_ARCHIVE}" \
             "${archive_url}"
           printf '%s *%s\n' "${HAWK_SHA256}" "${RUNNER_TEMP}/${HAWK_ARCHIVE}" \

--- a/tests/ecosystem/run.sh
+++ b/tests/ecosystem/run.sh
@@ -105,8 +105,18 @@ clone_project() {
         return 0
     fi
 
-    git clone --depth 1 --branch "$branch" --single-branch \
-        "https://github.com/$repo.git" "$dest" 2>/dev/null
+    # Cloning third-party repositories makes transient network and TLS errors
+    # the dominant failure mode here, so one blip should not fail the run.
+    local attempt
+    for attempt in 1 2 3; do
+        if git clone --depth 1 --branch "$branch" --single-branch \
+            "https://github.com/$repo.git" "$dest" 2>/dev/null; then
+            return 0
+        fi
+        rm -rf "$dest"
+        [[ "$attempt" -eq 3 ]] && return 1
+        sleep "$((attempt * 5))"
+    done
 }
 
 install_deps() {


### PR DESCRIPTION
Follow-up to #2206, which retried the clone in `ecosystem.yml`. Two more places reach a third-party host once and give up.

**`tests/ecosystem/run.sh`** drives the full ecosystem job and clones the same third-party repositories, so it carried the identical exposure the workflow-level fix addressed. It now retries three times with a growing pause, removing the partial destination between attempts, and still returns non-zero if the repository is genuinely gone.

**`.github/workflows/hawk.yml`** downloads a release archive with `--fail --location` and no retry. It verifies the SHA-256 afterwards, so integrity was covered and availability was not. It now carries `--retry 5 --retry-connrefused --retry-delay 2`, matching the rustup install elsewhere in this repository.

Nothing else needs it: no other unretried `curl`, `wget` or `git clone` remains in the workflows or composite actions.

Motivation, all on 2026-08-12: `Ecosystem (next.js-with-typescript)` died on `server certificate verification failed` while cloning next.js, a `Commit messages` checkout hit the same TLS error, and the CodSpeed runner failed to fetch its pinned valgrind build after five retries of its own. The first was addressed in #2206; these close the rest of our own surface.

Verified the retry logic against a stub `git`: a first-attempt failure recovers and returns 0, a persistent failure returns 1 after three attempts.
