### PR TITLE
ci: retry the image and template downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN set -eux; \
       exit 1; \
       ;; \
   esac; \
-  curl -fsSL "https://github.com/fallow-rs/fallow/releases/download/v${FALLOW_VERSION}/${asset}" -o /usr/local/bin/fallow; \
+  curl -fsSL --retry 5 --retry-connrefused --retry-delay 2 \
+    "https://github.com/fallow-rs/fallow/releases/download/v${FALLOW_VERSION}/${asset}" -o /usr/local/bin/fallow; \
   echo "${sha256}  /usr/local/bin/fallow" | sha256sum -c -; \
   chmod +x /usr/local/bin/fallow
 

--- a/ci/gitlab-ci.yml
+++ b/ci/gitlab-ci.yml
@@ -371,7 +371,7 @@ variables:
           echo "Downloading MR integration scripts pinned to ${FALLOW_SCRIPTS_REF}..."
 
           for f in comment.sh review.sh gitlab_common.sh; do
-            if curl -sf "${FALLOW_SCRIPTS_BASE}/ci/scripts/${f}" -o "${FALLOW_SCRIPTS_DIR}/${f}" 2>/dev/null; then
+            if curl -sf --retry 3 --retry-connrefused --retry-delay 2 "${FALLOW_SCRIPTS_BASE}/ci/scripts/${f}" -o "${FALLOW_SCRIPTS_DIR}/${f}" 2>/dev/null; then
               chmod +x "${FALLOW_SCRIPTS_DIR}/${f}"
             else
               echo "  WARNING: Failed to download ci/scripts/${f}"


### PR DESCRIPTION
The `Docker` job on main failed minutes after #2237 with:

```
curl: (22) The requested URL returned error: 503
```

Fetching the release asset inside the image build. A rerun cleared it, so main is green again, but the download itself had no retry.

#2237 covered the workflows and composite actions. These are the two fetches outside that scope:

- **`Dockerfile`** downloads the release binary and verifies its SHA-256 afterwards. Integrity was covered, availability was not. curl treats 5xx as transient, so `--retry` addresses exactly the failure above.
- **`ci/gitlab-ci.yml`** downloads the MR integration scripts. It already degrades with a per-script warning rather than failing, which is the right behaviour, but it degrades on the first blip. Retrying first means adopters see that warning far less often.

Neither change touches the pinned version or the checksums the release flow maintains.

Verified: `bash ci/tests/run.sh` passes, the template still parses as YAML, and a local image build ran the changed layer through to its `sha256sum -c` check with the new flags in place. The build was cut short by a local timeout on a later apt layer, so the full image was not produced here; CI builds it.
