### PR TITLE
perf(engine): use unstable clone family sort

### DIFF
--- a/crates/engine/src/duplication_detector/families.rs
+++ b/crates/engine/src/duplication_detector/families.rs
@@ -49,7 +49,7 @@ pub fn group_into_families(clone_groups: &[CloneGroup], root: &Path) -> Vec<Clon
         })
         .collect();
 
-    families.sort_by(|a, b| {
+    families.sort_unstable_by(|a, b| {
         b.total_duplicated_lines
             .cmp(&a.total_duplicated_lines)
             .then(b.groups.len().cmp(&a.groups.len()))


### PR DESCRIPTION
The clone-family comparator already defines a deterministic total order through its file-set tie-breaker. Use the allocation-free unstable sort path while preserving serialized ordering.\n\nValidation:\n- focused clone-family behavior tests\n- strict Clippy for the benchmark target\n- scoped CodSpeed instrumentation build and run\n\nThe exact-base GitHub CodSpeed result is the keep-or-close gate.