### PR TITLE
perf(core): cache built-in plugin matchers

### DIFF
--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -1,8 +1,9 @@
 //! Plugin registry: discovers active plugins, collects patterns, parses configs.
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use fallow_config::{
     AutoImportRule, EntryPointRole, ExternalPluginDef, PackageJson, UsedClassMemberRule,
@@ -62,23 +63,47 @@ fn must_parse_workspace_config_when_root_active(plugin_name: &str) -> bool {
 fn compile_config_matchers<'a>(
     active: &[&'a dyn Plugin],
 ) -> Vec<(&'a dyn Plugin, Vec<globset::GlobMatcher>)> {
+    let cached = builtin_config_matchers();
     active
         .iter()
         .filter(|plugin| !plugin.config_patterns().is_empty())
         .map(|plugin| {
-            let matchers = plugin
-                .config_patterns()
-                .iter()
-                .filter_map(|pattern| {
-                    let prepared = prepare_config_pattern(pattern);
-                    globset::Glob::new(&prepared)
-                        .ok()
-                        .map(|glob| glob.compile_matcher())
-                })
-                .collect();
-            (*plugin, matchers)
+            (
+                *plugin,
+                cached
+                    .get(plugin.name())
+                    .cloned()
+                    .unwrap_or_else(|| compile_plugin_config_matchers(*plugin)),
+            )
         })
         .collect()
+}
+
+fn compile_plugin_config_matchers(plugin: &dyn Plugin) -> Vec<globset::GlobMatcher> {
+    plugin
+        .config_patterns()
+        .iter()
+        .filter_map(|pattern| {
+            let prepared = prepare_config_pattern(pattern);
+            globset::Glob::new(&prepared)
+                .ok()
+                .map(|glob| glob.compile_matcher())
+        })
+        .collect()
+}
+
+fn builtin_config_matchers() -> &'static FxHashMap<&'static str, Vec<globset::GlobMatcher>> {
+    static MATCHERS: OnceLock<FxHashMap<&'static str, Vec<globset::GlobMatcher>>> = OnceLock::new();
+    MATCHERS.get_or_init(|| {
+        builtin::create_builtin_plugins()
+            .into_iter()
+            .filter(|plugin| !plugin.config_patterns().is_empty())
+            .map(|plugin| {
+                let matchers = compile_plugin_config_matchers(plugin.as_ref());
+                (plugin.name(), matchers)
+            })
+            .collect()
+    })
 }
 
 /// Emit one info-level line naming every active plugin.
@@ -638,21 +663,18 @@ impl PluginRegistry {
     pub(crate) fn precompile_config_matchers(
         &self,
     ) -> Vec<(&dyn Plugin, Vec<globset::GlobMatcher>)> {
+        let cached = builtin_config_matchers();
         self.plugins
             .iter()
             .filter(|p| !p.config_patterns().is_empty())
             .map(|p| {
-                let matchers: Vec<globset::GlobMatcher> = p
-                    .config_patterns()
-                    .iter()
-                    .filter_map(|pat| {
-                        let prepared = prepare_config_pattern(pat);
-                        globset::Glob::new(&prepared)
-                            .ok()
-                            .map(|g| g.compile_matcher())
-                    })
-                    .collect();
-                (p.as_ref(), matchers)
+                (
+                    p.as_ref(),
+                    cached
+                        .get(p.name())
+                        .cloned()
+                        .unwrap_or_else(|| compile_plugin_config_matchers(p.as_ref())),
+                )
             })
             .collect()
     }

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -3,7 +3,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
 use fallow_config::{
     AutoImportRule, EntryPointRole, ExternalPluginDef, PackageJson, UsedClassMemberRule,
@@ -63,19 +63,10 @@ fn must_parse_workspace_config_when_root_active(plugin_name: &str) -> bool {
 fn compile_config_matchers<'a>(
     active: &[&'a dyn Plugin],
 ) -> Vec<(&'a dyn Plugin, Vec<globset::GlobMatcher>)> {
-    let cached = builtin_config_matchers();
     active
         .iter()
         .filter(|plugin| !plugin.config_patterns().is_empty())
-        .map(|plugin| {
-            (
-                *plugin,
-                cached
-                    .get(plugin.name())
-                    .cloned()
-                    .unwrap_or_else(|| compile_plugin_config_matchers(*plugin)),
-            )
-        })
+        .map(|plugin| (*plugin, cached_plugin_config_matchers(*plugin)))
         .collect()
 }
 
@@ -92,18 +83,59 @@ fn compile_plugin_config_matchers(plugin: &dyn Plugin) -> Vec<globset::GlobMatch
         .collect()
 }
 
-fn builtin_config_matchers() -> &'static FxHashMap<&'static str, Vec<globset::GlobMatcher>> {
-    static MATCHERS: OnceLock<FxHashMap<&'static str, Vec<globset::GlobMatcher>>> = OnceLock::new();
-    MATCHERS.get_or_init(|| {
-        builtin::create_builtin_plugins()
-            .into_iter()
-            .filter(|plugin| !plugin.config_patterns().is_empty())
-            .map(|plugin| {
-                let matchers = compile_plugin_config_matchers(plugin.as_ref());
-                (plugin.name(), matchers)
-            })
-            .collect()
-    })
+struct CachedPluginConfigMatchers {
+    patterns: &'static [&'static str],
+    matchers: Vec<globset::GlobMatcher>,
+}
+
+#[derive(Default)]
+struct PluginConfigMatcherCache {
+    by_name: RwLock<FxHashMap<&'static str, Vec<CachedPluginConfigMatchers>>>,
+}
+
+impl PluginConfigMatcherCache {
+    fn get_or_compile(&self, plugin: &dyn Plugin) -> Vec<globset::GlobMatcher> {
+        let patterns = plugin.config_patterns();
+        let cached = self
+            .by_name
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(plugin.name())
+            .and_then(|variants| {
+                variants
+                    .iter()
+                    .find(|entry| entry.patterns == patterns)
+                    .map(|entry| entry.matchers.clone())
+            });
+        if let Some(matchers) = cached {
+            return matchers;
+        }
+
+        let matchers = compile_plugin_config_matchers(plugin);
+        {
+            let mut by_name = self
+                .by_name
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let variants = by_name.entry(plugin.name()).or_default();
+            if let Some(entry) = variants.iter().find(|entry| entry.patterns == patterns) {
+                return entry.matchers.clone();
+            }
+            variants.push(CachedPluginConfigMatchers {
+                patterns,
+                matchers: matchers.clone(),
+            });
+            drop(by_name);
+        }
+        matchers
+    }
+}
+
+fn cached_plugin_config_matchers(plugin: &dyn Plugin) -> Vec<globset::GlobMatcher> {
+    static MATCHERS: OnceLock<PluginConfigMatcherCache> = OnceLock::new();
+    MATCHERS
+        .get_or_init(PluginConfigMatcherCache::default)
+        .get_or_compile(plugin)
 }
 
 /// Emit one info-level line naming every active plugin.
@@ -663,19 +695,10 @@ impl PluginRegistry {
     pub(crate) fn precompile_config_matchers(
         &self,
     ) -> Vec<(&dyn Plugin, Vec<globset::GlobMatcher>)> {
-        let cached = builtin_config_matchers();
         self.plugins
             .iter()
             .filter(|p| !p.config_patterns().is_empty())
-            .map(|p| {
-                (
-                    p.as_ref(),
-                    cached
-                        .get(p.name())
-                        .cloned()
-                        .unwrap_or_else(|| compile_plugin_config_matchers(p.as_ref())),
-                )
-            })
+            .map(|p| (p.as_ref(), cached_plugin_config_matchers(p.as_ref())))
             .collect()
     }
 }

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -2968,6 +2968,69 @@ fn precompile_config_matchers_match_nested_source_ext_configs() {
     );
 }
 
+struct ConfigPatternPlugin {
+    name: &'static str,
+    patterns: &'static [&'static str],
+}
+
+impl Plugin for ConfigPatternPlugin {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn config_patterns(&self) -> &'static [&'static str] {
+        self.patterns
+    }
+}
+
+#[test]
+fn config_matcher_cache_compiles_plugins_lazily_and_keeps_pattern_variants_distinct() {
+    let cache = PluginConfigMatcherCache::default();
+    let first = ConfigPatternPlugin {
+        name: "test-config-cache",
+        patterns: &["first.config.ts"],
+    };
+    let other = ConfigPatternPlugin {
+        name: "other-config-cache",
+        patterns: &["other.config.ts"],
+    };
+
+    let first_matchers = cache.get_or_compile(&first);
+    assert!(
+        first_matchers
+            .iter()
+            .any(|matcher| matcher.is_match("first.config.ts"))
+    );
+    let cached = cache
+        .by_name
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(
+        cached.len(),
+        1,
+        "only the requested plugin should be cached"
+    );
+    assert!(!cached.contains_key(other.name()));
+    drop(cached);
+
+    let same_name_other_patterns = ConfigPatternPlugin {
+        name: first.name(),
+        patterns: &["second.config.ts"],
+    };
+    let second_matchers = cache.get_or_compile(&same_name_other_patterns);
+    assert!(
+        second_matchers
+            .iter()
+            .any(|matcher| matcher.is_match("second.config.ts"))
+    );
+    assert!(
+        second_matchers
+            .iter()
+            .all(|matcher| !matcher.is_match("first.config.ts")),
+        "a same-name plugin with different patterns must not reuse stale matchers"
+    );
+}
+
 #[test]
 fn run_with_jest_config_extracts_setup_and_transform() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Cache compiled config glob matchers per built-in plugin name and clone the cheap compiled matcher handles for each analysis. Non-built-in or test plugins retain the existing compile path, so custom matcher semantics stay unchanged.\n\nValidation:\n- plugin registry behavior tests\n- strict Clippy for fallow-core\n- scoped CodSpeed instrumentation and repeated-session run\n\nExact-base GitHub CodSpeed remains the keep-or-close gate.