### PR TITLE
perf(extract): skip irrelevant package scans

### DIFF
--- a/crates/extract/src/visitor/visit_impl_security_controls.rs
+++ b/crates/extract/src/visitor/visit_impl_security_controls.rs
@@ -161,16 +161,16 @@ impl ModuleInfoExtractor {
         let Some(callee_path) = flatten_callee_path(&expr.callee) else {
             return;
         };
-        if self.has_package_evidence("@nestjs/common")
-            && callee_path.rsplit('.').next() == Some("ValidationPipe")
+        if callee_path.rsplit('.').next() == Some("ValidationPipe")
+            && self.has_package_evidence("@nestjs/common")
         {
             self.record_validation_control_site("nestjs.validation-pipe", expr.span);
         }
     }
 
     fn is_elysia_validation_route(&self, callee_path: &str, expr: &CallExpression<'_>) -> bool {
-        self.has_package_evidence("elysia")
-            && route_method_leaf(callee_path).is_some()
+        route_method_leaf(callee_path).is_some()
+            && self.has_package_evidence("elysia")
             && expr
                 .arguments
                 .iter()
@@ -180,8 +180,8 @@ impl ModuleInfoExtractor {
     }
 
     fn is_fastify_validation_route(&self, callee_path: &str, expr: &CallExpression<'_>) -> bool {
-        self.has_package_evidence("fastify")
-            && route_method_leaf(callee_path).is_some()
+        route_method_leaf(callee_path).is_some()
+            && self.has_package_evidence("fastify")
             && expr
                 .arguments
                 .iter()
@@ -190,39 +190,40 @@ impl ModuleInfoExtractor {
     }
 
     fn is_trpc_input_control(&self, callee_path: &str, expr: &CallExpression<'_>) -> bool {
-        let lower = callee_path.to_ascii_lowercase();
-        self.has_package_evidence("@trpc/server")
-            && callee_path
+        if expr.arguments.is_empty()
+            || !callee_path
                 .rsplit('.')
                 .next()
                 .is_some_and(|leaf| leaf.eq_ignore_ascii_case("input"))
-            && lower.contains("procedure")
-            && !expr.arguments.is_empty()
+        {
+            return false;
+        }
+
+        callee_path.to_ascii_lowercase().contains("procedure")
+            && self.has_package_evidence("@trpc/server")
     }
 
     fn is_hono_validation_middleware(&self, callee_path: &str, expr: &CallExpression<'_>) -> bool {
-        (self.has_package_evidence("hono") || self.has_package_evidence("@hono/zod-validator"))
-            && matches!(
-                callee_path.rsplit('.').next(),
-                Some("validator" | "zValidator")
-            )
-            && !expr.arguments.is_empty()
+        matches!(
+            callee_path.rsplit('.').next(),
+            Some("validator" | "zValidator")
+        ) && !expr.arguments.is_empty()
+            && (self.has_package_evidence("hono")
+                || self.has_package_evidence("@hono/zod-validator"))
     }
 
     fn is_nest_validation_pipe_call(&self, callee_path: &str) -> bool {
-        self.has_package_evidence("@nestjs/common")
-            && matches!(
-                callee_path.rsplit('.').next(),
-                Some("UsePipes" | "ValidationPipe")
-            )
+        matches!(
+            callee_path.rsplit('.').next(),
+            Some("UsePipes" | "ValidationPipe")
+        ) && self.has_package_evidence("@nestjs/common")
     }
 
     fn is_express_validator_control(&self, callee_path: &str, expr: &CallExpression<'_>) -> bool {
-        self.has_package_evidence("express-validator")
-            && matches!(
-                callee_path.rsplit('.').next(),
-                Some("body" | "param" | "query" | "check")
-            )
-            && !expr.arguments.is_empty()
+        matches!(
+            callee_path.rsplit('.').next(),
+            Some("body" | "param" | "query" | "check")
+        ) && !expr.arguments.is_empty()
+            && self.has_package_evidence("express-validator")
     }
 }

--- a/crates/extract/tests/security_control_predicate_order.rs
+++ b/crates/extract/tests/security_control_predicate_order.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use fallow_extract::parse_from_content;
+use fallow_types::discover::FileId;
+
+#[test]
+fn skips_unrelated_calls_with_framework_evidence() {
+    let module = parse_from_content(
+        FileId(0),
+        Path::new("src/app.ts"),
+        r#"
+        import "elysia";
+        import "fastify";
+        import "@trpc/server";
+        import "hono";
+        import "@nestjs/common";
+        import "express-validator";
+        console.log("ready");
+        metrics.record("request");
+        new OtherPipe();
+        "#,
+    );
+
+    assert!(!module.security_control_sites.iter().any(|control| {
+        matches!(
+            control.callee_path.as_str(),
+            "elysia.route.validation"
+                | "fastify.route.schema"
+                | "trpc.procedure.input"
+                | "hono.validator"
+                | "nestjs.validation-pipe"
+                | "express-validator.middleware"
+        )
+    }));
+}


### PR DESCRIPTION
## Summary

- check cheap security-control callee and argument predicates before scanning package evidence
- avoid lowercase tRPC path allocation for unrelated calls
- cover unrelated calls in files that import supported frameworks

## Verification

- full `fallow-extract` test suite
- strict workspace clippy and rustfmt
- normalized JSON parity on Rijkshuisstijl Community against exact main
- native Rust review approved with no remaining findings

## Performance

Exact CodSpeed comparison against source-identical scaling code at `13bfa07f`:

- `scaling_full_pipeline_2000_files`: 990.9 ms to 602.9 ms, 64.36% faster
- `full_pipeline_1000_files`: 403.1 ms to 306 ms, 31.71% faster on matching runners
- the scaling result reproduced in two exact-base comparisons with runner directions reversed
- all other compared identities unchanged
- no regressions

Current base `f86dc174` only changes `crates/output/src/ci_output.rs`. The scaling benchmark calls `fallow_core::analyze`, `fallow-core` has no dependency on `fallow-output`, and the CodSpeed callgraph contains neither `escape_md` nor `render_pr_comment`.
