### PR TITLE
test(api): signal sidecar readiness after the start window

### DIFF
--- a/crates/api/src/type_aware/transport/mod.rs
+++ b/crates/api/src/type_aware/transport/mod.rs
@@ -580,9 +580,13 @@ mod tests {
         let root = tempfile::tempdir().expect("temporary sidecar root");
         let sidecar = root.path().join("blocking-sidecar.sh");
         let ready = root.path().join("sidecar-ready");
+        // The transport writes the request only after its post-spawn
+        // termination-epoch re-check passed, so signaling readiness after
+        // consuming stdin guarantees termination lands past the start window
+        // and surfaces the exit status instead of start cancellation (#2231).
         fs::write(
             &sidecar,
-            "#!/bin/sh\nprintf ready > sidecar-ready\nexec sleep 30\n",
+            "#!/bin/sh\nread request\nprintf ready > sidecar-ready\nexec sleep 30\n",
         )
         .expect("write sidecar");
         let mut permissions = fs::metadata(&sidecar)


### PR DESCRIPTION
## What

The `active_sidecar_termination_interrupts_blocking_request` fixture now signals readiness only after it consumes the request from stdin, instead of before. A comment records why the ordering matters.

## Why

The transport re-checks the termination epoch after spawning the sidecar and only then writes the request. The old fixture wrote its ready file as its first action, so on a slow runner the test could call `terminate_active_type_aware_sidecars()` while the transport was still inside that start window; the request then legitimately failed with "type-aware sidecar start was cancelled during shutdown" and the narrow "exited with status" assertion panicked. Gating readiness on the stdin read makes the ready file prove the transport is past the start window, because the request write happens strictly after the epoch re-check passes. Termination then deterministically surfaces the exit status, so the race is closed rather than the assertion widened, and the test stays pinned to the post-start-window behavior.

## Verification

- Reproduced the CI failure deterministically: with a temporary 500ms delay injected inside the start window, the old fixture fails with exactly "unexpected termination error: type-aware sidecar start was cancelled during shutdown", while the new fixture passes under that same injected delay. The delay was removed afterwards; the shipped diff is test-only.
- Stability: 300 consecutive runs of the test pass, plus 100 further runs under eight busy-loop CPU load processes as a slow-runner approximation, all passing.
- `cargo test -p fallow-api --lib` passes.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` are clean.

Closes #2231