### PR TITLE
fix(type-aware): keep the root typescript install sidecar-compatible

### DIFF
--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -11,12 +11,14 @@ The type-aware CLI tests launch the real sidecar from
 npm --prefix tools/type-aware-sidecar install
 ```
 
-Without it, `type_aware_class_method_impact_uses_exact_owner_identity`,
-`type_aware_framework_contract_requires_package_provenance`, and
-`type_aware_refines_ambiguous_unused_exports_without_unsafe_fixes` fail with an
-exit code of 2 and empty stderr. That failure looks like a code defect but is a
-missing install; CI installs the sidecar, so these pass there either way. Check
-this first before investigating those three.
+Without it, the sidecar falls back to whatever `typescript` ancestor
+`node_modules` directories provide. The root install pins the same
+`typescript` version as the sidecar (kept in lockstep through the root
+`package.json` `overrides` entry), so the type-aware CLI tests still pass
+after a root-only `npm ci`. When the resolvable `typescript` is missing or too
+old, the sidecar exits with code 2 and a stderr message naming the conflict
+and the install command above; that failure is a missing install, not a code
+defect. CI installs the sidecar, so these tests pass there either way.
 
 ## Canonical commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,6 +1032,346 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1690,18 +2030,39 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "overrides": {
+    "typescript": "7.0.2"
+  },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
     "@commitlint/config-conventional": "21.2.0",

--- a/tools/type-aware-sidecar/fallow-type-aware.mjs
+++ b/tools/type-aware-sidecar/fallow-type-aware.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-import { run } from "./src/cli.mjs";
+import { assertTypescriptBackendResolvable } from "./src/backend-preflight.mjs";
 
 try {
+  assertTypescriptBackendResolvable();
+  const { run } = await import("./src/cli.mjs");
   await run({ input: process.stdin, output: process.stdout, args: process.argv.slice(2) });
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);

--- a/tools/type-aware-sidecar/src/backend-preflight.mjs
+++ b/tools/type-aware-sidecar/src/backend-preflight.mjs
@@ -1,0 +1,42 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { BACKEND_VERSION } from "./generated-protocol.mjs";
+
+const REQUIRED_MAJOR = Number.parseInt(BACKEND_VERSION, 10);
+const INSTALL_HINT =
+  "run `npm ci` in tools/type-aware-sidecar so the sidecar resolves its own typescript install";
+
+/**
+ * Verify that module resolution hands the sidecar a typescript install that
+ * provides the `typescript/unstable/sync` backend entry point.
+ *
+ * The semantic modules import that entry point statically, so an incompatible
+ * resolution (for example a typescript 6 hoisted into an ancestor
+ * `node_modules`) fails at link time with a bare module path instead of the
+ * version conflict that caused it. This preflight runs before those imports
+ * and names the resolved version, its location, and the fix. Exact
+ * backend-version parity stays enforced in `protocol.mjs`.
+ *
+ * @param {string | URL} resolveFrom Module URL or file path to resolve from;
+ *   defaults to this module so the check mirrors the semantic imports.
+ */
+export const assertTypescriptBackendResolvable = (resolveFrom = import.meta.url) => {
+  const sidecarRequire = createRequire(resolveFrom);
+  let manifestPath;
+  try {
+    manifestPath = sidecarRequire.resolve("typescript/package.json");
+  } catch {
+    throw new Error(`typescript is not installed; ${INSTALL_HINT}`);
+  }
+  const { version } = sidecarRequire(manifestPath);
+  const major = Number.parseInt(version, 10);
+  if (Number.isFinite(major) && major >= REQUIRED_MAJOR) {
+    return;
+  }
+  throw new Error(
+    `resolved typescript ${version} from ${path.dirname(manifestPath)}, which lacks the ` +
+      `typescript/unstable/sync backend; fallow-type-aware needs typescript ${BACKEND_VERSION}; ` +
+      INSTALL_HINT,
+  );
+};

--- a/tools/type-aware-sidecar/test/backend-preflight.test.mjs
+++ b/tools/type-aware-sidecar/test/backend-preflight.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { assertTypescriptBackendResolvable } from "../src/backend-preflight.mjs";
+import { BACKEND_VERSION } from "../src/generated-protocol.mjs";
+
+const sidecarRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+const makeTree = () => mkdtempSync(path.join(tmpdir(), "fallow-preflight-"));
+
+const writeFakeTypescript = (root, version) => {
+  const packageDir = path.join(root, "node_modules", "typescript");
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({ name: "typescript", version }),
+  );
+  return packageDir;
+};
+
+test("preflight accepts the sidecar's own typescript install", () => {
+  assertTypescriptBackendResolvable();
+});
+
+test("root npm install stays in typescript lockstep with the sidecar", () => {
+  const readManifest = (manifestPath) => JSON.parse(readFileSync(manifestPath, "utf8"));
+  const repoManifest = readManifest(path.join(sidecarRoot, "..", "..", "package.json"));
+  const sidecarManifest = readManifest(path.join(sidecarRoot, "package.json"));
+  assert.equal(
+    repoManifest.overrides?.typescript,
+    sidecarManifest.dependencies.typescript,
+    "the repository root overrides typescript so a root-only npm ci resolves a sidecar-compatible install",
+  );
+});
+
+test("preflight names the version conflict when typescript is too old", () => {
+  const root = makeTree();
+  try {
+    const packageDir = writeFakeTypescript(root, "6.0.3");
+    assert.throws(
+      () => assertTypescriptBackendResolvable(path.join(root, "probe.mjs")),
+      (error) => {
+        assert.match(error.message, /resolved typescript 6\.0\.3/);
+        assert.ok(error.message.includes(packageDir));
+        assert.ok(error.message.includes(BACKEND_VERSION));
+        assert.match(error.message, /npm ci/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("preflight reports a missing typescript install", () => {
+  const root = makeTree();
+  try {
+    assert.throws(
+      () => assertTypescriptBackendResolvable(path.join(root, "probe.mjs")),
+      (error) => {
+        assert.match(error.message, /typescript is not installed/);
+        assert.match(error.message, /npm ci/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("executable exits 2 with an actionable message when only an old typescript resolves", () => {
+  const root = makeTree();
+  try {
+    cpSync(
+      path.join(sidecarRoot, "fallow-type-aware.mjs"),
+      path.join(root, "fallow-type-aware.mjs"),
+    );
+    cpSync(path.join(sidecarRoot, "src"), path.join(root, "src"), { recursive: true });
+    writeFakeTypescript(root, "6.0.3");
+    const result = spawnSync(
+      process.execPath,
+      [path.join(root, "fallow-type-aware.mjs"), "--status"],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 2, result.stderr);
+    assert.match(result.stderr, /fallow-type-aware: resolved typescript 6\.0\.3/);
+    assert.match(result.stderr, /npm ci/);
+    assert.doesNotMatch(result.stderr, /ERR_MODULE_NOT_FOUND/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

- Pins the root `typescript` to 7.0.2 via a `package.json` `overrides` entry, kept in lockstep with the `tools/type-aware-sidecar` dependency, and regenerates the root lockfile.
- Adds a preflight to the sidecar executable that runs before the static `typescript/unstable/sync` imports; when the resolvable typescript is missing or predates that entry point, the sidecar exits with code 2 and a message naming the resolved version, its location, and the install command.
- Updates the quality gates note that described the local failure mode.

## Why

The sidecar needs `typescript/unstable/sync` (typescript 7), while the root lockfile carried typescript 6.0.3 as an auto-installed peer of the commitlint chain; nothing at the root uses the typescript API. On a checkout where only the root `npm ci` ran, Node resolution walked up from the sidecar to the 6.0.3 copy and died at link time with a bare `ERR_MODULE_NOT_FOUND`, failing the type-aware CLI tests and hiding the version conflict that caused the break.

Exact backend-version parity (7.0.2) stays enforced in `protocol.mjs`; the preflight only converts the link-time resolution failure into an actionable diagnostic. The VS Code extension bundles its own typescript 7.0.2 next to the packaged sidecar and is unaffected.

## Verification

- Reproduced the reported failure first: with only the root install present, the sidecar failed with `ERR_MODULE_NOT_FOUND` for `typescript/unstable/sync`.
- After the change, with only the root install present (sidecar `node_modules` absent), the previously failing type-aware tests in `audit_tests`, `check_tests`, and `schema_conformance` pass.
- With no compatible install resolvable at all, the sidecar exits 2 with a message naming the resolved typescript version, its path, and the fix.
- Full sidecar suite passes (`node --test`), including new preflight coverage and a lockstep test tying the root override to the sidecar dependency.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` pass.
- `npm run lint:js`, `npm run fmt:js:check`, and `npm run generate:contracts:check` pass; `generated-protocol.mjs` is untouched.
- The root lockfile diff contains only the typescript 7.0.2 swap and its platform packages; the tarball integrity matches the sidecar lockfile entry.

Closes #2236