### PR TITLE
ci: add manual Rust walltime benchmarks

### DIFF
--- a/.github/workflows/bench-rust-walltime.yml
+++ b/.github/workflows/bench-rust-walltime.yml
@@ -1,0 +1,93 @@
+name: Rust Walltime Benchmarks
+
+# Keep walltime in a separate run from simulation so CodSpeed can assemble
+# both reports reliably. This workflow is manual because release-LTO walltime
+# builds are intentionally reserved for retain-gate validation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      workload:
+        description: Fixed Rust workload to measure
+        required: true
+        type: choice
+        options:
+          - analysis
+          - programmatic-stable
+          - component-engine
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
+
+jobs:
+  benchmark:
+    name: CodSpeed walltime (${{ inputs.workload }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: rust-walltime-${{ inputs.workload }}
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+        with:
+          tool: cargo-codspeed@4.7.0
+
+      - name: Select fixed workload
+        id: workload
+        env:
+          WALLTIME_WORKLOAD: ${{ inputs.workload }}
+        run: |
+          set -euo pipefail
+          case "$WALLTIME_WORKLOAD" in
+            analysis)
+              echo "package=fallow-core" >> "$GITHUB_OUTPUT"
+              echo "bench=analysis" >> "$GITHUB_OUTPUT"
+              ;;
+            programmatic-stable)
+              echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
+              echo "bench=programmatic_stable" >> "$GITHUB_OUTPUT"
+              ;;
+            component-engine)
+              echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
+              echo "bench=component_engine" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unsupported walltime workload: $WALLTIME_WORKLOAD" >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Build benchmark workload
+        env:
+          BENCH_PACKAGE: ${{ steps.workload.outputs.package }}
+          BENCH_TARGET: ${{ steps.workload.outputs.bench }}
+        run: >-
+          cargo codspeed build -m walltime
+          -p "$BENCH_PACKAGE"
+          --bench "$BENCH_TARGET"
+          --features codspeed
+
+      - name: Run benchmark workload
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        env:
+          BENCH_PACKAGE: ${{ steps.workload.outputs.package }}
+          BENCH_TARGET: ${{ steps.workload.outputs.bench }}
+        with:
+          mode: walltime
+          run: >-
+            cargo codspeed run
+            -p "$BENCH_PACKAGE"
+            --bench "$BENCH_TARGET"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -11,6 +11,22 @@ its child process, so `tools/type-aware-sidecar/bench/session.mjs` uses the
 supported Tinybench integration to track cold Program construction and warm
 persistent-session reuse as distinct benchmarks.
 
+Rust walltime retain gates run through the separate, manual
+`.github/workflows/bench-rust-walltime.yml` workflow. Its fixed suite choices
+cover core analysis, stable programmatic sessions, and engine components
+without accepting arbitrary commands. Keeping it manual avoids adding
+release-LTO builds to every pull request while preserving comparable Linux
+base/head evidence:
+
+```bash
+gh workflow run bench-rust-walltime.yml \
+  --ref <commit-or-branch> \
+  -f workload=analysis
+```
+
+Use the same workload on the exact base and head refs, then compare those two
+walltime runs in CodSpeed. Do not compare values across workload choices.
+
 Fast PR shards are selected by `.github/scripts/generate-benchmark-matrix.mjs`.
 Like Oxc's benchmark workflow, this keeps the tracked surface broad while only
 running the shards affected by a given change. Manual and merge-queue runs use


### PR DESCRIPTION
Adds a manual CodSpeed walltime workflow for three fixed Rust benchmark workloads.

The workflow keeps walltime separate from simulation, accepts no arbitrary command input, and does not run on normal pushes or pull requests. Maintainer documentation includes the exact dispatch flow.

Validation:
- benchmark harness
- benchmark matrix tests
- actionlint
- repository formatting
- fast repository verification