### PR TITLE
fix(api): request api-surface capability only when private-type-leaks is active

### DIFF
--- a/crates/api/src/type_aware/mod.rs
+++ b/crates/api/src/type_aware/mod.rs
@@ -44,12 +44,10 @@ pub fn refine_programmatic_dead_code(
         return Ok(None);
     }
 
-    let include_all = !filters.any_active();
-    let include_symbol_use = include_all
-        || filters.unused_exports
-        || filters.unused_types
-        || filters.unused_class_members;
-    let include_api_surface = include_all || filters.private_type_leaks;
+    let DeadCodeCapabilityScope {
+        include_symbol_use,
+        include_api_surface,
+    } = dead_code_capability_scope(filters, &session.config().rules);
     let entry_points = fallow_engine::list_inventory::collect_entry_points(
         session.config(),
         session.files(),
@@ -122,12 +120,10 @@ pub fn refine_programmatic_dead_code_in_session(
     if !options.enabled {
         return Ok(None);
     }
-    let include_all = !filters.any_active();
-    let include_symbol_use = include_all
-        || filters.unused_exports
-        || filters.unused_types
-        || filters.unused_class_members;
-    let include_api_surface = include_all || filters.private_type_leaks;
+    let DeadCodeCapabilityScope {
+        include_symbol_use,
+        include_api_surface,
+    } = dead_code_capability_scope(filters, &session.config().rules);
     let entry_points = fallow_engine::list_inventory::collect_entry_points(
         session.config(),
         session.files(),
@@ -240,4 +236,97 @@ fn programmatic_semantic_error(error: &TypeAwareError) -> ProgrammaticError {
     ProgrammaticError::new(error.to_string(), 2)
         .with_code("FALLOW_TYPE_AWARE_FAILED")
         .with_context("analysis.typeAware")
+}
+
+/// Semantic capability families a programmatic dead-code refinement requests.
+struct DeadCodeCapabilityScope {
+    include_symbol_use: bool,
+    include_api_surface: bool,
+}
+
+/// Derive the capability families a refinement request needs.
+///
+/// With no filters active, `ApiSurface` follows the resolved
+/// `private-type-leaks` severity so a disabled rule never triggers sidecar
+/// API-surface work (issue #2218). With filters active, only the explicitly
+/// requested families are included; an explicit `private_type_leaks` filter
+/// requests `ApiSurface` regardless of severity because hosts activate the
+/// opt-in rule for that filter.
+fn dead_code_capability_scope(
+    filters: &DeadCodeFilters,
+    rules: &fallow_config::RulesConfig,
+) -> DeadCodeCapabilityScope {
+    let include_all = !filters.any_active();
+    DeadCodeCapabilityScope {
+        include_symbol_use: include_all
+            || filters.unused_exports
+            || filters.unused_types
+            || filters.unused_class_members,
+        include_api_surface: filters.private_type_leaks
+            || (include_all && rules.private_type_leaks != fallow_config::Severity::Off),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fallow_config::{RulesConfig, Severity};
+
+    use super::dead_code_capability_scope;
+    use crate::DeadCodeFilters;
+
+    #[test]
+    fn rule_off_without_filters_skips_api_surface() {
+        let filters = DeadCodeFilters::default();
+        let rules = RulesConfig::default();
+        assert_eq!(rules.private_type_leaks, Severity::Off);
+
+        let scope = dead_code_capability_scope(&filters, &rules);
+
+        assert!(scope.include_symbol_use);
+        assert!(!scope.include_api_surface);
+    }
+
+    #[test]
+    fn active_rule_without_filters_requests_api_surface() {
+        let filters = DeadCodeFilters::default();
+        let rules = RulesConfig {
+            private_type_leaks: Severity::Warn,
+            ..RulesConfig::default()
+        };
+
+        let scope = dead_code_capability_scope(&filters, &rules);
+
+        assert!(scope.include_symbol_use);
+        assert!(scope.include_api_surface);
+    }
+
+    #[test]
+    fn explicit_private_type_leaks_filter_requests_api_surface() {
+        let filters = DeadCodeFilters {
+            private_type_leaks: true,
+            ..DeadCodeFilters::default()
+        };
+        let rules = RulesConfig::default();
+
+        let scope = dead_code_capability_scope(&filters, &rules);
+
+        assert!(scope.include_api_surface);
+    }
+
+    #[test]
+    fn unrelated_filter_skips_api_surface_even_with_active_rule() {
+        let filters = DeadCodeFilters {
+            unused_exports: true,
+            ..DeadCodeFilters::default()
+        };
+        let rules = RulesConfig {
+            private_type_leaks: Severity::Warn,
+            ..RulesConfig::default()
+        };
+
+        let scope = dead_code_capability_scope(&filters, &rules);
+
+        assert!(scope.include_symbol_use);
+        assert!(!scope.include_api_surface);
+    }
 }

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -1758,6 +1758,46 @@ mod tests {
         assert_eq!(config.rules.private_type_leaks, Severity::Off);
     }
 
+    fn load_and_resolve_config_file(json: &str) -> ResolvedConfig {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join(".fallowrc.json");
+        std::fs::write(&config_path, json).expect("config file is written");
+        fallow_config::FallowConfig::load(&config_path)
+            .expect("config file loads")
+            .resolve(
+                dir.path().to_path_buf(),
+                OutputFormat::Json,
+                1,
+                true,
+                true,
+                None,
+            )
+    }
+
+    #[test]
+    fn loaded_explicit_private_type_leaks_off_survives_resolve_and_type_aware_default() {
+        let mut config = load_and_resolve_config_file(
+            r#"{"typeAware": {"enabled": true}, "rules": {"private-type-leaks": "off"}}"#,
+        );
+        assert!(config.type_aware.enabled);
+        assert!(config.rules.private_type_leaks_configured);
+
+        apply_type_aware_private_leak_default(&mut config, false);
+
+        assert_eq!(config.rules.private_type_leaks, Severity::Off);
+    }
+
+    #[test]
+    fn loaded_unset_private_type_leaks_defaults_on_after_resolve_under_type_aware() {
+        let mut config = load_and_resolve_config_file(r#"{"typeAware": {"enabled": true}}"#);
+        assert!(config.type_aware.enabled);
+        assert!(!config.rules.private_type_leaks_configured);
+
+        apply_type_aware_private_leak_default(&mut config, false);
+
+        assert_eq!(config.rules.private_type_leaks, Severity::Warn);
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "test fixture; linear setup/assert, length is not a maintainability concern"

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -1852,6 +1852,32 @@ unknown_field = true
         assert!(!config.rules.private_type_leaks_configured);
     }
 
+    /// The explicit-configuration flag is `serde(skip)`, so a serde round-trip
+    /// of a loaded config drops it and the type-aware `warn` default would
+    /// force the rule back on. No production path round-trips a
+    /// [`FallowConfig`] today; this test pins the hazard so introducing one
+    /// fails loudly instead of silently re-enabling an explicitly-off rule.
+    #[test]
+    fn serde_round_trip_drops_explicit_private_type_leaks_flag() {
+        let dir = test_dir("round-trip-private-type-leaks");
+        let config_path = dir.path().join(".fallowrc.json");
+        std::fs::write(&config_path, r#"{"rules": {"private-type-leaks": "off"}}"#).unwrap();
+
+        let config = FallowConfig::load(&config_path).unwrap();
+        assert!(config.rules.private_type_leaks_configured);
+
+        let serialized = serde_json::to_value(&config).unwrap();
+        let round_tripped: FallowConfig = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(round_tripped.rules.private_type_leaks, Severity::Off);
+        assert!(
+            !round_tripped.rules.private_type_leaks_configured,
+            "a serde round-trip drops the serde(skip) flag; any code path that \
+             round-trips a loaded FallowConfig must re-record it (see the field \
+             docs on RulesConfig::private_type_leaks_configured)"
+        );
+    }
+
     #[test]
     fn load_json_config_file_with_health_threshold_override() {
         let dir = test_dir("json-health-threshold-override");

--- a/crates/config/src/config/rules.rs
+++ b/crates/config/src/config/rules.rs
@@ -82,6 +82,13 @@ pub struct RulesConfig {
     /// loading, not by serde: type-aware hosts default this opt-in rule to
     /// `warn`, and this flag lets an explicit user `off` win over that
     /// default (issue #2170).
+    ///
+    /// Because the field is `serde(skip)`, any serialize/deserialize
+    /// round-trip of [`FallowConfig`](crate::FallowConfig) silently resets it
+    /// to `false`, which would re-enable the type-aware `warn` default for a
+    /// user who explicitly set the rule to `off`. Do not route configs through
+    /// a serde round-trip after [`FallowConfig::load`](crate::FallowConfig::load)
+    /// without re-recording this flag.
     #[serde(skip)]
     pub private_type_leaks_configured: bool,
     /// A declared `dependencies` entry never observed used. Defaults to

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,6 +6,13 @@
 //! [`ResolvedConfig`] the analysis crates consume. Also hosts workspace and
 //! `package.json` discovery, declarative external plugin definitions, rule
 //! packs, and the in-place config editing used by `fallow fix`.
+//!
+//! Config section structs such as [`RulesConfig`] are not `#[non_exhaustive]`
+//! and gain new public fields in minor releases as rules are added, so
+//! exhaustive struct literals in downstream code are source-breaking on
+//! upgrade. Construct them with struct update syntax, for example
+//! `RulesConfig { unused_files: Severity::Off, ..RulesConfig::default() }`,
+//! to stay source-compatible.
 
 #![warn(missing_docs)]
 #![cfg_attr(

--- a/crates/core/tests/integration_test/private_type_leaks.rs
+++ b/crates/core/tests/integration_test/private_type_leaks.rs
@@ -7,6 +7,24 @@ fn create_private_type_leak_config(root: std::path::PathBuf) -> fallow_config::R
 }
 
 #[test]
+fn rule_off_reports_no_private_type_leaks() {
+    let root = fixture_path("private-type-leaks");
+    let config = create_config(root);
+    assert_eq!(
+        config.rules.private_type_leaks,
+        fallow_config::Severity::Off
+    );
+
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.private_type_leaks.is_empty(),
+        "private-type-leaks off must suppress all findings, found: {:?}",
+        results.private_type_leaks
+    );
+}
+
+#[test]
 fn exported_signatures_report_same_file_private_types() {
     let root = fixture_path("private-type-leaks");
     let config = create_private_type_leak_config(root);

--- a/docs/type-aware-analysis.md
+++ b/docs/type-aware-analysis.md
@@ -194,7 +194,9 @@ the normal semver review described in
 Type-aware runs default the opt-in `private-type-leaks` rule to `warn` when the
 config leaves it unset, because semantic confirmation makes the findings
 trustworthy. An explicit `"private-type-leaks": "off"` in `rules` always wins
-and disables the findings entirely, type-aware or not.
+and disables the findings entirely, type-aware or not. When the rule is off,
+hosts also skip the API-surface semantic capability request, so the sidecar
+performs no API-surface work for a rule whose findings would be discarded.
 
 Private-type-leak
 reconciliation sends only Fallow's bounded candidate set and receives stable


### PR DESCRIPTION
## What

- The programmatic type-aware path (`refine_programmatic_dead_code` and its session variant) now derives the ApiSurface capability request from the resolved `private-type-leaks` severity. With no filters active and the rule off, the sidecar no longer receives an API-surface request whose findings would be discarded. An explicit private-type-leaks filter still requests the capability, and unrelated filters still scope it out. The derivation is extracted into a shared, unit-tested helper used by both call sites.
- End-to-end coverage for the explicit `private-type-leaks` config seam:
  - a real config file through `FallowConfig::load` -> `resolve` -> the CLI type-aware default keeps an explicit `off` off, and still defaults an unset rule to `warn`
  - a serde round-trip of a loaded `FallowConfig` drops the `serde(skip)` explicit-configuration flag; the hazard is now documented on the field and pinned by a regression test
  - the `fallow-config` crate docs note that rules structs are not `non_exhaustive` and gain public fields in minor releases, which is source-breaking for exhaustive downstream struct literals
  - a fixture test asserts that analysis with the rule off reports no private-type-leak findings

## Why

Follow-up to #2170. The CLI stopped force-enabling the rule under type-aware, but programmatic hosts (Node API, MCP, LSP) still requested the ApiSurface semantic capability when the rule was off, wasting sidecar work on results that were always discarded. The config seam (load -> resolve -> type-aware default) had no end-to-end test and could regress silently on a config refactor.

## Verification

- New unit tests on the capability derivation: rule off without filters skips the request, active rule requests it, explicit filter requests it, unrelated filters skip it
- New config-load seam tests, serde round-trip regression test, and rule-off fixture test: pass
- cargo fmt, cargo clippy (workspace, all targets, warnings denied), full workspace test suite, cargo doc with warnings denied, generated-contract drift check, knowledge-architecture check: pass
- docs/type-aware-analysis.md updated to state that hosts skip the API-surface capability request when the rule is off

Closes #2218
Closes #2219
