### PR TITLE
fix(analyze): align jest/vitest __mocks__ manual-mock semantics

### DIFF
--- a/.agents/rules/plugins.md
+++ b/.agents/rules/plugins.md
@@ -37,7 +37,7 @@ paths:
 ## Plugin trait extensions
 - `path_aliases()` for framework-specific alias resolution (Nuxt `~/`, Next.js `@/`)
 - `virtual_module_prefixes()` for framework virtual modules (Docusaurus `@theme/`, `@docusaurus/`)
-- `virtual_package_suffixes()` for framework virtual package conventions (Vitest `/__mocks__`). Matches as `ends_with` on the extracted package name, suppressing `unlisted-dependency` reports for non-npm specifiers like `@aws-sdk/__mocks__`.
+- `virtual_package_suffixes()` for framework virtual package conventions. Matches as `ends_with` on the extracted package name, suppressing `unlisted-dependency` reports for matching specifiers. No built-in plugin declares a suffix since issue #2226 (Vitest dropped `/__mocks__`, so a literal `X/__mocks__` import reports as unlisted under both Jest and Vitest); the capability stays available to external plugins.
 
 ## External plugins
 Standalone definitions in JSONC/JSON/TOML or inline via `framework` config field. Discovered from `plugins` config, `.fallow/plugins/`, and `fallow-plugin-*` files. See `docs/plugin-authoring.md`.

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -603,10 +603,12 @@ fn dynamic_import_unlisted_dep_has_import_site() {
     assert_eq!(unlisted[0].imported_from[0].col, 2);
 }
 
+/// The generic suffix mechanism stays available to external plugins even
+/// though no built-in plugin declares `/__mocks__` anymore (issue #2226).
 #[test]
-fn vitest_mocks_package_not_reported_as_unlisted_via_suffix() {
+fn scoped_mocks_package_not_reported_as_unlisted_via_declared_suffix() {
     let (graph, resolved_modules) = build_graph_with_npm_imports(&[("@aws-sdk/__mocks__", false)]);
-    let pkg = make_pkg(&[], &["vitest"], &[]);
+    let pkg = make_pkg(&[], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
     let line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
 

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -680,16 +680,17 @@ fn fumadocs_contributes_virtual_module_prefixes() {
     );
 }
 
+/// Issue #2226: literal `X/__mocks__` imports carry no runner semantics, so
+/// Vitest must not suppress them and stays in parity with Jest.
 #[test]
-fn vitest_contributes_mocks_virtual_package_suffix() {
+fn vitest_contributes_no_virtual_package_suffixes() {
     let registry = PluginRegistry::default();
     let pkg = make_pkg_dev(&["vitest"]);
     let result = registry.run(&pkg, Path::new("/project"), &[]);
     assert!(
-        result
-            .virtual_package_suffixes
-            .contains(&"/__mocks__".to_string()),
-        "vitest should contribute '/__mocks__' virtual package suffix"
+        result.virtual_package_suffixes.is_empty(),
+        "vitest must not contribute virtual package suffixes, got: {:?}",
+        result.virtual_package_suffixes
     );
 }
 

--- a/crates/core/src/plugins/vitest.rs
+++ b/crates/core/src/plugins/vitest.rs
@@ -46,14 +46,6 @@ const FIXTURE_PATTERNS: &[&str] = &[
     "**/fixtures/**/*.{ts,tsx,js,jsx,json}",
 ];
 
-/// Package name suffixes that identify Vitest manual-mock virtual paths.
-///
-/// Vitest's manual-mock convention places mock factories at `<package>/__mocks__/<module>.ts`
-/// and test setups sometimes import from `@<scope>/__mocks__` paths (via package.json `imports`
-/// aliases or workspace virtual paths). These specifiers do not exist on npm and must not be
-/// flagged as unlisted dependencies.
-const VIRTUAL_PACKAGE_SUFFIXES: &[&str] = &["/__mocks__"];
-
 /// Built-in Vitest reporter names that should not be treated as dependencies.
 const BUILTIN_REPORTERS: &[&str] = &[
     "default",
@@ -133,10 +125,6 @@ impl Plugin for VitestPlugin {
 
     fn fixture_glob_patterns(&self) -> &'static [&'static str] {
         FIXTURE_PATTERNS
-    }
-
-    fn virtual_package_suffixes(&self) -> &'static [&'static str] {
-        VIRTUAL_PACKAGE_SUFFIXES
     }
 
     fn resolve_config(&self, config_path: &Path, source: &str, root: &Path) -> PluginResult {
@@ -329,51 +317,15 @@ mod tests {
         )
     }
 
+    /// Issue #2226: neither runner gives literal `X/__mocks__` imports special
+    /// meaning, so Vitest declares no virtual package suffixes and a literal
+    /// import of such a package is reported as unlisted, matching Jest.
     #[test]
-    fn mocks_path_suffix_is_present() {
-        let suffixes = VitestPlugin.virtual_package_suffixes();
+    fn no_virtual_package_suffixes_declared() {
         assert!(
-            suffixes.contains(&"/__mocks__"),
-            "VitestPlugin should declare /__mocks__ as a virtual package suffix"
+            VitestPlugin.virtual_package_suffixes().is_empty(),
+            "VitestPlugin must not suppress /__mocks__ package names"
         );
-    }
-
-    #[test]
-    fn scoped_mocks_package_matches_suffix() {
-        let suffixes = VitestPlugin.virtual_package_suffixes();
-        let candidates = [
-            "@aws-sdk/__mocks__",
-            "@sentry/__mocks__",
-            "@supabase/__mocks__",
-            "@mapbox/__mocks__",
-            "@ai-sdk/__mocks__",
-            "some-pkg/__mocks__",
-        ];
-        for candidate in &candidates {
-            assert!(
-                suffixes.iter().any(|s| candidate.ends_with(s)),
-                "{candidate} should be matched by a virtual package suffix"
-            );
-        }
-    }
-
-    #[test]
-    fn non_mocks_package_does_not_match_suffix() {
-        let suffixes = VitestPlugin.virtual_package_suffixes();
-        let non_mocks = [
-            "@aws-sdk/client-s3",
-            "vitest",
-            "@vitest/coverage-v8",
-            "__mocks__-helper",
-            "my__mocks__pkg",
-            "@scope/__mocks__-utils",
-        ];
-        for candidate in &non_mocks {
-            assert!(
-                !suffixes.iter().any(|s| candidate.ends_with(s)),
-                "{candidate} should NOT be matched by a virtual package suffix"
-            );
-        }
     }
 
     #[test]

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -247,6 +247,8 @@ mod issue_2005_jsdom_optional_peer_canvas;
 mod issue_2006_cli_flag_value_dependency;
 #[path = "integration_test/issue_2213_jest_mock_phantom_package.rs"]
 mod issue_2213_jest_mock_phantom_package;
+#[path = "integration_test/issue_2225_root_manual_mocks.rs"]
+mod issue_2225_root_manual_mocks;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/dependencies.rs
+++ b/crates/core/tests/integration_test/dependencies.rs
@@ -4,8 +4,11 @@ use fallow_config::{FallowConfig, OutputFormat, RulesConfig};
 
 use super::common::{create_config, fixture_path};
 
+/// Issue #2226: a user-written literal import of an `X/__mocks__` package
+/// carries no runner semantics, so it is reported as an unlisted dependency
+/// under Vitest, exactly as under Jest.
 #[test]
-fn vitest_mocks_specifiers_not_flagged_as_unlisted_dep() {
+fn vitest_literal_mocks_import_flagged_as_unlisted_dep() {
     let root = fixture_path("vitest-mocks-virtual");
     let config = create_config(root);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
@@ -17,13 +20,35 @@ fn vitest_mocks_specifiers_not_flagged_as_unlisted_dep() {
         .collect();
 
     assert!(
-        !unlisted_names.contains(&"@aws-sdk/__mocks__"),
-        "@aws-sdk/__mocks__ should not be flagged as an unlisted dependency, got: {unlisted_names:?}"
+        unlisted_names.contains(&"@aws-sdk/__mocks__"),
+        "literal @aws-sdk/__mocks__ import should be flagged as an unlisted dependency, got: {unlisted_names:?}"
     );
 }
 
+/// Jest side of the issue #2226 parity matrix: the same literal import is
+/// flagged in a Jest project too.
 #[test]
-fn vitest_mocks_scoped_specifiers_not_flagged_in_workspace_monorepo() {
+fn jest_literal_mocks_import_flagged_as_unlisted_dep() {
+    let root = fixture_path("issue-2226-jest-mocks-literal");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unlisted_names: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|d| d.dep.package_name.as_str())
+        .collect();
+
+    assert!(
+        unlisted_names.contains(&"@aws-sdk/__mocks__"),
+        "literal @aws-sdk/__mocks__ import should be flagged as an unlisted dependency, got: {unlisted_names:?}"
+    );
+}
+
+/// Issue #2226: literal `X/__mocks__` imports are flagged in workspace
+/// monorepos too; the removed suffix suppression no longer masks them.
+#[test]
+fn vitest_literal_mocks_imports_flagged_in_workspace_monorepo() {
     let root = fixture_path("vitest-mocks-workspace");
     let config = create_config(root);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
@@ -40,8 +65,8 @@ fn vitest_mocks_scoped_specifiers_not_flagged_in_workspace_monorepo() {
         "@sentry/__mocks__",
     ] {
         assert!(
-            !unlisted_names.contains(specifier),
-            "{specifier} should not be flagged as an unlisted dependency in workspace monorepo, got: {unlisted_names:?}"
+            unlisted_names.contains(specifier),
+            "{specifier} should be flagged as an unlisted dependency in workspace monorepo, got: {unlisted_names:?}"
         );
     }
 }

--- a/crates/core/tests/integration_test/issue_2225_root_manual_mocks.rs
+++ b/crates/core/tests/integration_test/issue_2225_root_manual_mocks.rs
@@ -1,0 +1,92 @@
+//! Regression tests for issue #2225: root-level `__mocks__/` manual mocks for
+//! node modules. Vitest resolves a factory-less `vi.mock('pkg')` /
+//! `vi.mock('@scope/pkg')` to `__mocks__/<specifier>` at the project root, but
+//! Fallow had no crediting path for bare specifiers (the speculative sibling
+//! of issue #251 needs a `/` in the specifier, and the package-space sibling
+//! is dropped by design since issue #2213), so those mock files surfaced as
+//! unused files. The parity matrix with Jest:
+//!
+//! - root mock with a matching factory-less mock call: used under both.
+//! - root mock without any mock call: unused under Vitest (manual mocks apply
+//!   only through `vi.mock`), used under Jest (node-module manual mocks are
+//!   applied automatically; the jest plugin declares `__mocks__` entry
+//!   patterns).
+
+use std::path::PathBuf;
+
+use super::common::{create_config, fixture_path};
+
+fn unused_files(root: &PathBuf, results: &fallow_core::results::AnalysisResults) -> Vec<String> {
+    results
+        .unused_files
+        .iter()
+        .map(|f| {
+            f.file
+                .path
+                .strip_prefix(root)
+                .unwrap_or(&f.file.path)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect()
+}
+
+#[test]
+fn vitest_root_manual_mocks_credited_by_factory_less_vi_mock() {
+    let root = fixture_path("issue-2225-vitest-root-mocks");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused = unused_files(&root, &results);
+    assert!(
+        !unused.contains(&"__mocks__/lodash.ts".to_string()),
+        "root manual mock of an unscoped node module should be credited by vi.mock, unused files: {unused:?}"
+    );
+    assert!(
+        !unused.contains(&"__mocks__/@bacons/apple-targets.ts".to_string()),
+        "root manual mock of a scoped node module should be credited by vi.mock, unused files: {unused:?}"
+    );
+    assert!(
+        unused.contains(&"__mocks__/unmatched-pkg.ts".to_string()),
+        "a root mock without any vi.mock call is never applied by vitest and must stay reported, unused files: {unused:?}"
+    );
+
+    let unlisted: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|d| d.dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unlisted.iter().any(|name| name.contains("__mocks__")),
+        "root-mock crediting must not fabricate phantom __mocks__ packages, got: {unlisted:?}"
+    );
+
+    let unused_deps: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|d| d.dep.package_name.as_str())
+        .collect();
+    assert!(
+        !unused_deps.contains(&"@bacons/apple-targets"),
+        "the mocked package keeps its usage credit from the vi.mock target edge, got: {unused_deps:?}"
+    );
+}
+
+#[test]
+fn jest_root_manual_mocks_stay_used_with_and_without_mock_calls() {
+    let root = fixture_path("issue-2225-jest-root-mocks");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused = unused_files(&root, &results);
+    for mock in [
+        "__mocks__/lodash.ts",
+        "__mocks__/@bacons/apple-targets.ts",
+        "__mocks__/unmatched-pkg.ts",
+    ] {
+        assert!(
+            !unused.contains(&mock.to_string()),
+            "jest applies root node-module manual mocks automatically, so {mock} must not be reported unused, unused files: {unused:?}"
+        );
+    }
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -924,7 +924,12 @@ use crate::MemberKind;
 /// Bumped to 269: a class's own lexical type binding now retains member accesses
 /// against that class while generic and nested type shadows still fail closed.
 /// Warm 268 caches can omit self-typed class member uses.
-pub(super) const CACHE_VERSION: u32 = 269;
+///
+/// Bumped to 270 for issue #2225: factory-less `vi.mock` / `jest.mock` calls
+/// with a bare package specifier now synthesize a speculative root-level
+/// `__mocks__/<specifier>` candidate. Warm 269 caches lack the candidate, so a
+/// root manual mock would stay reported as an unused file.
+pub(super) const CACHE_VERSION: u32 = 270;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/visit_impl_helpers.rs
+++ b/crates/extract/src/visitor/visit_impl_helpers.rs
@@ -346,6 +346,28 @@ pub(super) fn vitest_auto_mock_source(source: &str) -> Option<String> {
     Some(format!("{dir}/__mocks__/{file_name}"))
 }
 
+/// Root-level manual-mock candidate for a factory-less mock of a bare
+/// package specifier (`vi.mock('lodash')`, `jest.mock('@scope/pkg')`).
+///
+/// Both runners resolve such mocks to `__mocks__/<specifier>` at the project
+/// root: Jest applies node-module manual mocks automatically, Vitest only for
+/// registered `vi.mock` calls (issue #2225). The candidate stays root-relative
+/// because the extractor does not know the project root; the resolver probes
+/// it against ancestor `__mocks__` directories and drops it when no such file
+/// exists. Relative, absolute, `#`-alias, and URL-shaped sources are not bare
+/// package specifiers and get no root candidate.
+pub(super) fn root_manual_mock_source(source: &str) -> Option<String> {
+    let bare_package_shaped = !source.is_empty()
+        && !source.starts_with('.')
+        && !source.starts_with('/')
+        && !source.starts_with('#')
+        && !source.contains("://")
+        && !source.starts_with("data:")
+        && !source.ends_with('/')
+        && !source.split('/').any(|segment| segment == "__mocks__");
+    bare_package_shaped.then(|| format!("__mocks__/{source}"))
+}
+
 pub(super) fn pino_factory_callee_name(callee: &Expression<'_>) -> Option<String> {
     match unwrap_static_expr(callee) {
         Expression::Identifier(ident) => Some(ident.name.to_string()),
@@ -1536,6 +1558,52 @@ mod tests {
     fn vitest_auto_mock_source_nested_path_synthesizes_mocks_sibling() {
         let result = vitest_auto_mock_source("../utils/format");
         assert_eq!(result.as_deref(), Some("../utils/__mocks__/format"));
+    }
+
+    // -------------------------------------------------------------------------
+    // root_manual_mock_source
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn root_manual_mock_source_bare_package_synthesizes_root_candidate() {
+        assert_eq!(
+            root_manual_mock_source("lodash").as_deref(),
+            Some("__mocks__/lodash")
+        );
+    }
+
+    #[test]
+    fn root_manual_mock_source_scoped_package_synthesizes_root_candidate() {
+        assert_eq!(
+            root_manual_mock_source("@bacons/apple-targets").as_deref(),
+            Some("__mocks__/@bacons/apple-targets")
+        );
+    }
+
+    #[test]
+    fn root_manual_mock_source_package_subpath_synthesizes_root_candidate() {
+        assert_eq!(
+            root_manual_mock_source("lodash/merge").as_deref(),
+            Some("__mocks__/lodash/merge")
+        );
+    }
+
+    #[test]
+    fn root_manual_mock_source_non_bare_shapes_return_none() {
+        assert!(root_manual_mock_source("").is_none());
+        assert!(root_manual_mock_source("./services/api").is_none());
+        assert!(root_manual_mock_source("../utils/format").is_none());
+        assert!(root_manual_mock_source("/abs/path").is_none());
+        assert!(root_manual_mock_source("#internal/alias").is_none());
+        assert!(root_manual_mock_source("https://example.com/mod").is_none());
+        assert!(root_manual_mock_source("data:text/plain,foo").is_none());
+        assert!(root_manual_mock_source("pkg/").is_none());
+    }
+
+    #[test]
+    fn root_manual_mock_source_mocks_segment_returns_none() {
+        assert!(root_manual_mock_source("__mocks__/lodash").is_none());
+        assert!(root_manual_mock_source("@scope/__mocks__").is_none());
     }
 
     // -------------------------------------------------------------------------

--- a/crates/extract/src/visitor/visit_impl_playwright.rs
+++ b/crates/extract/src/visitor/visit_impl_playwright.rs
@@ -13,8 +13,8 @@ use super::super::{
 use super::visit_helpers::{
     collect_fixture_type_bindings_from_members, collect_fixture_type_bindings_from_type,
     mock_method_object_span, mock_object_is_literal_global, mock_replacement_candidate,
-    mock_static_target_source, playwright_extend_base_name, vi_mock_has_factory,
-    vitest_auto_mock_source,
+    mock_static_target_source, playwright_extend_base_name, root_manual_mock_source,
+    vi_mock_has_factory, vitest_auto_mock_source,
 };
 use crate::parse::MockApiReferenceSpans;
 
@@ -324,7 +324,23 @@ impl ModuleInfoExtractor {
             is_speculative: false,
         });
 
-        if !has_factory && let Some(mock_source) = vitest_auto_mock_source(target_source) {
+        if has_factory {
+            return;
+        }
+        // Two candidate conventions: the `__mocks__` sibling next to the
+        // mocked module (relative and alias-shaped specifiers, issue #251) and
+        // the root-level `__mocks__/<specifier>` manual mock for bare package
+        // specifiers (issue #2225). A slash-bearing bare source gets both: for
+        // an aliased user module the sibling resolves internally and the root
+        // candidate misses, while for a real package the sibling is dropped in
+        // package space and the root candidate probes the runner convention.
+        for mock_source in [
+            vitest_auto_mock_source(target_source),
+            root_manual_mock_source(target_source),
+        ]
+        .into_iter()
+        .flatten()
+        {
             self.dynamic_imports.push(DynamicImportInfo {
                 source: mock_source,
                 span,

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -102,7 +102,12 @@ pub use store::GraphCacheStore;
 /// namespace re-export surfaces. Warm 31 payloads neither describe the same
 /// structure nor carry those external bindings, so a consumed barrel export
 /// could be falsely reported as unused.
-pub const GRAPH_CACHE_VERSION: u32 = 32;
+///
+/// Bumped to 33 for issue #2225: speculative root-level `__mocks__/<specifier>`
+/// candidates from factory-less bare-specifier mocks now resolve to project
+/// files. Warm 32 caches lack those edges, so root manual mocks would stay
+/// reported as unused files.
+pub const GRAPH_CACHE_VERSION: u32 = 33;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/resolve/dynamic_imports.rs
+++ b/crates/graph/src/resolve/dynamic_imports.rs
@@ -47,16 +47,26 @@ pub(super) fn resolve_single_dynamic_import(
 ) -> Vec<ResolvedImport> {
     let target = resolve_specifier(ctx, file_path, &imp.source, false);
 
-    // Speculative candidates (the `__mocks__` sibling synthesized for
-    // factory-less `vi.mock`/`jest.mock` calls) exist solely to discover an
-    // internal manual-mock file. A package-space result means the specifier
-    // stayed bare after alias substitution; `pkg/__mocks__/...` is not a
-    // runner convention, so treating it as a hit would fabricate a phantom
-    // package name (`@scope/__mocks__`, issue #2213) for the
-    // unlisted-dependency analysis.
+    // Speculative candidates (the `__mocks__` sibling and root-level
+    // candidates synthesized for factory-less `vi.mock`/`jest.mock` calls)
+    // exist solely to discover an internal manual-mock file. A package-space
+    // result means the specifier stayed bare after alias substitution;
+    // `pkg/__mocks__/...` is not a runner convention, so treating it as a hit
+    // would fabricate a phantom package name (`@scope/__mocks__`, issue #2213)
+    // for the unlisted-dependency analysis. Before dropping, a root-relative
+    // `__mocks__/<specifier>` candidate gets one last chance against the
+    // runner's root-level manual-mock convention (issue #2225).
     if imp.is_speculative
         && (target.is_bare_package() || matches!(target, ResolveResult::Unresolvable(_)))
     {
+        if let Some(file_id) = resolve_root_manual_mock(ctx, file_path, &imp.source) {
+            return vec![dynamic_import_with(
+                imp,
+                ImportedName::Namespace,
+                imp.local_name.clone().unwrap_or_default(),
+                ResolveResult::SyntheticAutoImport(file_id),
+            )];
+        }
         return Vec::new();
     }
 
@@ -79,6 +89,56 @@ pub(super) fn resolve_single_dynamic_import(
         String::new(),
         target,
     )]
+}
+
+/// Resolve a root-level manual-mock candidate (`__mocks__/<specifier>`) to a
+/// project file.
+///
+/// A factory-less `vi.mock` / `jest.mock` of a bare package specifier loads
+/// its manual mock from the `__mocks__` directory at the runner's project
+/// root: Jest applies node-module manual mocks automatically, Vitest only for
+/// registered `vi.mock` calls (issue #2225). The extractor synthesizes the
+/// candidate with a root-relative `__mocks__/` source that always classifies
+/// as package space, so this probe is its only resolution path. Ancestors of
+/// the importing file are probed up to the analysis root so workspace members
+/// with their own runner root are covered.
+fn resolve_root_manual_mock(
+    ctx: &ResolveContext<'_>,
+    file_path: &Path,
+    source: &str,
+) -> Option<FileId> {
+    let candidate = source.strip_prefix("__mocks__/")?;
+    if candidate.is_empty() {
+        return None;
+    }
+    let mut dir = file_path.parent();
+    while let Some(current) = dir {
+        let base = current.join("__mocks__").join(candidate);
+        for ext in ctx.extensions {
+            let mut with_ext = base.clone().into_os_string();
+            with_ext.push(ext);
+            if let Some(file_id) = project_file_id(ctx, Path::new(&with_ext)) {
+                return Some(file_id);
+            }
+            let index = base.join(format!("index{ext}"));
+            if let Some(file_id) = project_file_id(ctx, &index) {
+                return Some(file_id);
+            }
+        }
+        if current == ctx.root {
+            break;
+        }
+        dir = current.parent();
+    }
+    None
+}
+
+/// Look up a constructed candidate path in the discovered-file indexes.
+fn project_file_id(ctx: &ResolveContext<'_>, path: &Path) -> Option<FileId> {
+    ctx.raw_path_to_id
+        .get(path)
+        .or_else(|| ctx.path_to_id.get(path))
+        .copied()
 }
 
 /// Expand a destructured-await dynamic import into one named/default import per

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -131,12 +131,19 @@ target must be a static string (string literal, expressionless template
 literal, or `import('...')` with a string-literal source); a templated
 ``vi.doMock(`./adapters/${name}`)`` credits nothing. The speculative `__mocks__`
 sibling is synthesized only for path-shaped specifiers containing a `/`
-(`./services/api` credits `./services/__mocks__/api`); a bare package
-specifier (`vi.mock('axios')`) credits the package itself but gets no
-root-level `__mocks__/axios.ts` sibling edge, so a root manual mock referenced
-only through a bare-specifier mock can still surface as an unused file.
-"Anything unproven keeps coverage credit" describes masking abstention only;
-it does not imply a credit edge exists.
+(`./services/api` credits `./services/__mocks__/api`); a sibling that stays in
+package space after alias substitution is dropped so it cannot fabricate a
+phantom `@scope/__mocks__` package (issue #2213). A bare package specifier
+(`vi.mock('axios')`, `jest.mock('@scope/pkg')`) additionally synthesizes a
+root-level `__mocks__/<specifier>` candidate; the resolver probes ancestor
+`__mocks__` directories of the test file up to the analysis root and credits
+the manual mock file when it exists, so root-level node-module mocks do not
+surface as unused files (issue #2225). A root mock with no matching
+factory-less mock call keeps surfacing under Vitest, which applies manual
+mocks only through `vi.mock`; under Jest the plugin's `__mocks__` entry
+patterns keep every manual mock used, matching Jest's automatic node-module
+mocking. "Anything unproven keeps coverage credit" describes masking
+abstention only; it does not imply a credit edge exists.
 
 ## Script indirection crediting
 

--- a/tests/fixtures/issue-2225-jest-root-mocks/__mocks__/@bacons/apple-targets.ts
+++ b/tests/fixtures/issue-2225-jest-root-mocks/__mocks__/@bacons/apple-targets.ts
@@ -1,0 +1,1 @@
+export const ExtensionStorage = { get: (): string => 'mock' };

--- a/tests/fixtures/issue-2225-jest-root-mocks/__mocks__/lodash.ts
+++ b/tests/fixtures/issue-2225-jest-root-mocks/__mocks__/lodash.ts
@@ -1,0 +1,1 @@
+export const merge = (): Record<string, never> => ({});

--- a/tests/fixtures/issue-2225-jest-root-mocks/__mocks__/unmatched-pkg.ts
+++ b/tests/fixtures/issue-2225-jest-root-mocks/__mocks__/unmatched-pkg.ts
@@ -1,0 +1,1 @@
+export const stale = (): string => 'auto-applied by jest for node modules';

--- a/tests/fixtures/issue-2225-jest-root-mocks/package.json
+++ b/tests/fixtures/issue-2225-jest-root-mocks/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "issue-2225-jest-root-mocks",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@bacons/apple-targets": "^5.0.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/fixtures/issue-2225-jest-root-mocks/src/app.test.ts
+++ b/tests/fixtures/issue-2225-jest-root-mocks/src/app.test.ts
@@ -1,0 +1,12 @@
+import { ExtensionStorage } from '@bacons/apple-targets';
+import { combine } from './index';
+
+jest.mock('lodash');
+jest.mock('@bacons/apple-targets');
+
+describe('app', () => {
+  it('uses the root-level manual mocks', () => {
+    expect(combine()).toEqual({});
+    expect(ExtensionStorage.get()).toBe('mock');
+  });
+});

--- a/tests/fixtures/issue-2225-jest-root-mocks/src/index.ts
+++ b/tests/fixtures/issue-2225-jest-root-mocks/src/index.ts
@@ -1,0 +1,3 @@
+import { merge } from 'lodash';
+
+export const combine = (): Record<string, never> => merge();

--- a/tests/fixtures/issue-2225-vitest-root-mocks/__mocks__/@bacons/apple-targets.ts
+++ b/tests/fixtures/issue-2225-vitest-root-mocks/__mocks__/@bacons/apple-targets.ts
@@ -1,0 +1,1 @@
+export const ExtensionStorage = { get: (): string => 'mock' };

--- a/tests/fixtures/issue-2225-vitest-root-mocks/__mocks__/lodash.ts
+++ b/tests/fixtures/issue-2225-vitest-root-mocks/__mocks__/lodash.ts
@@ -1,0 +1,1 @@
+export const merge = (): Record<string, never> => ({});

--- a/tests/fixtures/issue-2225-vitest-root-mocks/__mocks__/unmatched-pkg.ts
+++ b/tests/fixtures/issue-2225-vitest-root-mocks/__mocks__/unmatched-pkg.ts
@@ -1,0 +1,1 @@
+export const stale = (): string => 'never applied without vi.mock';

--- a/tests/fixtures/issue-2225-vitest-root-mocks/package.json
+++ b/tests/fixtures/issue-2225-vitest-root-mocks/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "issue-2225-vitest-root-mocks",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@bacons/apple-targets": "^5.0.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/tests/fixtures/issue-2225-vitest-root-mocks/src/app.test.ts
+++ b/tests/fixtures/issue-2225-vitest-root-mocks/src/app.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ExtensionStorage } from '@bacons/apple-targets';
+import { combine } from './index';
+
+vi.mock('lodash');
+vi.mock('@bacons/apple-targets');
+
+describe('app', () => {
+  it('uses the root-level manual mocks', () => {
+    expect(combine()).toEqual({});
+    expect(ExtensionStorage.get()).toBe('mock');
+  });
+});

--- a/tests/fixtures/issue-2225-vitest-root-mocks/src/index.ts
+++ b/tests/fixtures/issue-2225-vitest-root-mocks/src/index.ts
@@ -1,0 +1,3 @@
+import { merge } from 'lodash';
+
+export const combine = (): Record<string, never> => merge();

--- a/tests/fixtures/issue-2226-jest-mocks-literal/package.json
+++ b/tests/fixtures/issue-2226-jest-mocks-literal/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "issue-2226-jest-mocks-literal",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/fixtures/issue-2226-jest-mocks-literal/src/index.ts
+++ b/tests/fixtures/issue-2226-jest-mocks-literal/src/index.ts
@@ -1,0 +1,1 @@
+export const appName = 'issue-2226-jest-mocks-literal';

--- a/tests/fixtures/issue-2226-jest-mocks-literal/src/upload.test.ts
+++ b/tests/fixtures/issue-2226-jest-mocks-literal/src/upload.test.ts
@@ -1,0 +1,7 @@
+import { mockS3Send } from '@aws-sdk/__mocks__';
+
+describe('upload', () => {
+  it('uses the manual mock', () => {
+    expect(mockS3Send).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Aligns manual-mock (`__mocks__`) detection with each test runner's actual semantics, in both directions:

- **Root-level manual mocks for node modules (vitest false positive):** a factory-less `vi.mock('pkg')` / `jest.mock('@scope/pkg')` now synthesizes a speculative root-level `__mocks__/<specifier>` candidate during extraction. The resolver probes ancestor `__mocks__` directories of the test file (up to the analysis root, so workspace members are covered) and credits the manual mock file when it exists. Root-level node-module mocks such as `__mocks__/lodash.ts` and `__mocks__/@scope/pkg.ts` no longer surface as unused files in vitest projects. A root mock with no matching mock call keeps surfacing under vitest, which applies manual mocks only through `vi.mock`; jest keeps its `__mocks__` entry patterns, matching its automatic node-module mocking.
- **Literal `X/__mocks__` imports (jest/vitest divergence):** the vitest plugin no longer declares the `/__mocks__` virtual package suffix. Neither runner gives a user-written literal import of an `X/__mocks__` package special meaning, so it is now reported as an unlisted dependency under both runners. This is a deliberate narrowing: the synthesized-candidate source of these names was already removed in #2213, so the suppression only masked real user-written imports. The generic `virtual_package_suffixes` plugin capability itself is unchanged and remains available to external plugins.

Candidates that resolve nowhere are still dropped before any package-space classification, so the #2213 phantom-package guarantee is preserved (covered by the existing regression test).

Extract and graph cache versions are bumped because extraction output and resolution behavior changed; warm caches would otherwise keep replaying the old edges.

## Parity matrix

| Case | vitest | jest |
|---|---|---|
| Root mock with matching factory-less mock call | used | used |
| Root mock without any mock call | unused (applied only via `vi.mock`) | used (auto-applied for node modules) |
| Literal `X/__mocks__` import of an uninstalled package | unlisted dependency | unlisted dependency |
| Speculative `@scope/__mocks__` candidate | never surfaces | never surfaces |

## Verification

- New fixtures `tests/fixtures/issue-2225-vitest-root-mocks`, `issue-2225-jest-root-mocks`, and `issue-2226-jest-mocks-literal`, plus integration tests covering the full matrix above; the flipped expectations for `vitest-mocks-virtual` and `vitest-mocks-workspace` pin the new unlisted behavior deliberately.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (all suites pass; one pre-existing flaky sidecar-cancellation test in `crates/api` failed once and passed on rerun, unrelated to this change), `cargo check --workspace --benches`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`: all pass.
- End-to-end CLI runs on all four fixtures confirm the matrix, and a smoke run on a real vitest frontend project reports no mock-related findings and no regressions.

Closes #2225
Closes #2226
