### PR TITLE
fix(benchmarks): collect Rust walltime results

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - codspeed-macro

--- a/.github/workflows/bench-rust-walltime.yml
+++ b/.github/workflows/bench-rust-walltime.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
+  RUSTFLAGS: "-C debuginfo=1 -C strip=none -g"
 
 jobs:
   benchmark:
@@ -88,6 +88,6 @@ jobs:
         with:
           mode: walltime
           run: >-
-            cargo codspeed run
+            cargo codspeed run -m walltime
             -p "$BENCH_PACKAGE"
             --bench "$BENCH_TARGET"

--- a/.github/workflows/bench-rust-walltime.yml
+++ b/.github/workflows/bench-rust-walltime.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   benchmark:
     name: CodSpeed walltime (${{ inputs.workload }})
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     permissions:
       contents: read
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,12 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
-name = "bpaf"
-version = "0.9.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b86829876e7e200161a5aa6ea688d46c32d64d70ee3100127790dde84688d6e"
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +454,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed-criterion-compat"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d31ae2e9ab23c29fa13bdfa06d012524176f5c0f4e25ec262cd829d947ebc5e"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored 2.2.0",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8605e40bab5114dcb0f76268e18880082b5798dec10757b5b58d2c3bbc7a1c"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,20 +647,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion2"
-version = "3.0.4"
+name = "criterion-plot"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b961b72d7eaf7444d1eb98d353d5c2aa08e2443d77fef6bff0e6e97064162482"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
- "bpaf",
  "cast",
- "ciborium",
- "codspeed",
- "colored 3.1.1",
- "num-traits",
- "oorandom",
- "serde",
- "serde_json",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1003,7 +1034,7 @@ dependencies = [
 name = "fallow-benchmarks"
 version = "3.15.0"
 dependencies = [
- "criterion2",
+ "codspeed-criterion-compat",
  "fallow-api",
  "fallow-config",
  "fallow-engine",
@@ -1102,7 +1133,7 @@ dependencies = [
 name = "fallow-core"
 version = "3.15.0"
 dependencies = [
- "criterion2",
+ "codspeed-criterion-compat",
  "dhat",
  "dunce",
  "fallow-config",
@@ -1151,8 +1182,8 @@ name = "fallow-engine"
 version = "3.15.0"
 dependencies = [
  "bitcode",
+ "codspeed-criterion-compat",
  "colored 3.1.1",
- "criterion2",
  "dunce",
  "fallow-config",
  "fallow-core",
@@ -1689,6 +1720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,6 +1970,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4156,6 +4204,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ notify = "8"
 open = "5"
 
 # Testing
-criterion2 = { version = "3.0.3", default-features = false }
+criterion = { package = "codspeed-criterion-compat", version = "=4.7.0", default-features = false }
 dhat = "0.3"
 insta = { version = "1", features = ["yaml"] }
 jsonschema = { version = "0.49", default-features = false }

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -38,7 +38,7 @@ name = "component_output"
 harness = false
 
 [dev-dependencies]
-criterion2 = { workspace = true }
+criterion = { workspace = true }
 fallow-api = { workspace = true }
 fallow-config = { workspace = true }
 fallow-engine = { workspace = true }
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-codspeed = ["criterion2/codspeed"]
+codspeed = []
 
 [lints]
 workspace = true

--- a/crates/benchmarks/benches/component_config.rs
+++ b/crates/benchmarks/benches/component_config.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/benchmarks/benches/component_engine.rs
+++ b/crates/benchmarks/benches/component_engine.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::fmt::Write as _;
 use std::fs;

--- a/crates/benchmarks/benches/component_graph.rs
+++ b/crates/benchmarks/benches/component_graph.rs
@@ -2,6 +2,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::path::{Path, PathBuf};
 

--- a/crates/benchmarks/benches/component_output.rs
+++ b/crates/benchmarks/benches/component_output.rs
@@ -2,6 +2,10 @@
     clippy::unwrap_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use fallow_output::{

--- a/crates/benchmarks/benches/programmatic_commands.rs
+++ b/crates/benchmarks/benches/programmatic_commands.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::fmt::Write as _;
 use std::fs;

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::fmt::Write as _;
 use std::fs;

--- a/crates/benchmarks/benches/representative_sources.rs
+++ b/crates/benchmarks/benches/representative_sources.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::fmt::Write as _;
 use std::hint::black_box;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -58,11 +58,11 @@ indicatif = { workspace = true }
 tracing = { workspace = true }
 
 [features]
-codspeed = ["criterion2/codspeed"]
+codspeed = []
 schema = ["fallow-types/schema"]
 
 [dev-dependencies]
-criterion2 = { workspace = true }
+criterion = { workspace = true }
 proptest = { workspace = true }
 dhat = { workspace = true }
 postcard = { workspace = true }

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "tests and benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 #![expect(
     deprecated,
     reason = "Core-internal policy: benchmark exercises the workspace path-dep fallow_core::analyze surface"

--- a/crates/core/benches/large_analysis.rs
+++ b/crates/core/benches/large_analysis.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "tests and benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 #![expect(
     deprecated,
     reason = "Core-internal policy: benchmark exercises the workspace path-dep fallow_core::analyze surface"

--- a/crates/core/benches/scaling_analysis.rs
+++ b/crates/core/benches/scaling_analysis.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 #![expect(
     deprecated,
     reason = "Core-internal policy: benchmark exercises the workspace path-dep fallow_core::analyze surface"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -44,11 +44,11 @@ tracing = { workspace = true }
 xxhash-rust = { workspace = true }
 
 [features]
-codspeed = ["criterion2/codspeed"]
+codspeed = []
 schema = ["fallow-output/schema", "fallow-types/schema"]
 
 [dev-dependencies]
-criterion2 = { workspace = true }
+criterion = { workspace = true }
 proptest = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/engine/benches/dupes_detect.rs
+++ b/crates/engine/benches/dupes_detect.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "tests and benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::path::PathBuf;
 

--- a/crates/engine/benches/dupes_pipeline.rs
+++ b/crates/engine/benches/dupes_pipeline.rs
@@ -3,6 +3,10 @@
     clippy::expect_used,
     reason = "tests and benches use unwrap and expect to keep fixture setup concise"
 )]
+#![allow(
+    clippy::significant_drop_tightening,
+    reason = "the external Criterion macro owns the benchmark lifecycle"
+)]
 
 use std::fmt::Write as _;
 use std::path::PathBuf;

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -16,7 +16,7 @@ Rust walltime retain gates run through the separate, manual
 cover core analysis, stable programmatic sessions, and engine components
 without accepting arbitrary commands. Keeping it manual avoids adding
 release-LTO builds to every pull request while preserving comparable Linux
-base/head evidence:
+base/head evidence on CodSpeed's dedicated macro runners:
 
 ```bash
 gh workflow run bench-rust-walltime.yml \

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -24,6 +24,10 @@ gh workflow run bench-rust-walltime.yml \
   -f workload=analysis
 ```
 
+The Rust benchmark crates use CodSpeed's official Criterion compatibility
+layer. Keep its major version aligned with `cargo-codspeed` so both simulation
+and walltime result collection remain available.
+
 Use the same workload on the exact base and head refs, then compare those two
 walltime runs in CodSpeed. Do not compare values across workload choices.
 

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -273,6 +273,20 @@ test("MSRV CI forces Rust 1.92 despite the repository toolchain override", () =>
   assert.match(msrvJob, /run: cargo check --workspace/);
 });
 
+test("Rust walltime benchmarks use CodSpeed macro runners", () => {
+  const workflow = readWorkflow(".github/workflows/bench-rust-walltime.yml");
+  const job = indentedBlock(workflow, "benchmark", 2);
+
+  assert.match(workflow, /^  workflow_dispatch:/m);
+  assert.doesNotMatch(workflow, /^  (push|pull_request|schedule):/m);
+  assert.match(job, /runs-on: codspeed-macro/);
+  assert.match(job, /permissions:\n\s+contents: read\n\s+id-token: write/);
+  assert.match(job, /cargo codspeed build -m walltime/);
+  assert.match(job, /mode: walltime/);
+  assert.match(job, /case "\$WALLTIME_WORKLOAD" in/);
+  assert.doesNotMatch(job, /run:.*\$\{\{ inputs\.workload \}\}/);
+});
+
 test("release runs Windows correctness and lifecycle verification without credentials", () => {
   const releaseWorkflow = readWorkflow(".github/workflows/release.yml");
   const validationWorkflow = readWorkflow(".github/workflows/release-validation.yml");

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -275,6 +275,7 @@ test("MSRV CI forces Rust 1.92 despite the repository toolchain override", () =>
 
 test("Rust walltime benchmarks use CodSpeed macro runners", () => {
   const workflow = readWorkflow(".github/workflows/bench-rust-walltime.yml");
+  const cargoManifest = readFileSync("Cargo.toml", "utf8");
   const job = indentedBlock(workflow, "benchmark", 2);
 
   assert.match(workflow, /^  workflow_dispatch:/m);
@@ -282,7 +283,14 @@ test("Rust walltime benchmarks use CodSpeed macro runners", () => {
   assert.match(job, /runs-on: codspeed-macro/);
   assert.match(job, /permissions:\n\s+contents: read\n\s+id-token: write/);
   assert.match(job, /cargo codspeed build -m walltime/);
+  assert.match(job, /cargo codspeed run -m walltime/);
   assert.match(job, /mode: walltime/);
+  assert.doesNotMatch(workflow, /--cfg codspeed/);
+  assert.match(
+    cargoManifest,
+    /criterion = \{ package = "codspeed-criterion-compat", version = "=4\.7\.0"/,
+  );
+  assert.match(job, /tool: cargo-codspeed@4\.7\.0/);
   assert.match(job, /case "\$WALLTIME_WORKLOAD" in/);
   assert.doesNotMatch(job, /run:.*\$\{\{ inputs\.workload \}\}/);
 });


### PR DESCRIPTION
Rust WallTime benchmarks now run on CodSpeed bare-metal macro runners and use CodSpeed's official Criterion compatibility layer. The compatibility layer and `cargo-codspeed` stay pinned to the same major version so both simulation and WallTime result collection work.

The manual workflow remains restricted to fixed Rust benchmark suites. It lets `cargo-codspeed` select the correct harness per measurement mode, and a policy test locks the runner, permissions, version alignment, WallTime commands, and bounded workload selection.

Validation:
- actionlint and zizmor pass
- benchmark harness and workflow policy tests pass
- all benchmark targets compile
- fast repository verification passes
- organization macro-runner access is enabled and live WallTime validation is running on the corrected integration
