### PR TITLE
perf(graph): skip side-effect export indexes

### DIFF
--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -434,12 +434,20 @@ impl ModuleGraph {
         let mut export_indices: FxHashMap<usize, ExportNameIndex> = FxHashMap::default();
         for edge_idx in 0..self.edges.len() {
             let source_id = self.edges[edge_idx].source;
-            let target_idx = self.edges[edge_idx].target.0 as usize;
+            let target_id = self.edges[edge_idx].target;
+            let target_idx = target_id.0 as usize;
             if target_idx >= self.modules.len() {
                 continue;
             }
             for sym_idx in 0..self.edges[edge_idx].symbols.len() {
                 let sym = &self.edges[edge_idx].symbols[sym_idx];
+                if matches!(sym.imported_name, ImportedName::SideEffect) {
+                    // Preserve the direct path interned by `attach_symbol_reference`.
+                    // Side-effect imports affect reachability but never reference an
+                    // export, so building the target's name index cannot change output.
+                    let _ = reference_paths.direct(target_id, sym.mechanism);
+                    continue;
+                }
                 let module = &mut self.modules[target_idx];
                 let export_index = export_indices
                     .entry(target_idx)

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -2287,11 +2287,18 @@ mod tests {
         let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
         assert_eq!(graph.edge_count(), 1);
         let styles = &graph.modules[1];
+        assert!(styles.is_reachable());
         let export = &styles.exports[0];
         assert!(
             export.references.is_empty(),
             "side-effect import should not reference named exports"
         );
+
+        let encoded = postcard::to_allocvec(&graph).expect("encode graph");
+        let decoded: ModuleGraph = postcard::from_bytes(&encoded).expect("decode graph");
+        assert_eq!(decoded.edge_count(), 1);
+        assert!(decoded.modules[1].is_reachable());
+        assert!(decoded.modules[1].exports[0].references.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- skip building target export-name indexes for side-effect-only imports
- preserve direct reference-path interning, reachability, and cache round trips
- extend the side-effect import regression coverage through graph serialization

## Performance

CodSpeed WallTime against exact current main `e5bf4e24f` showed:

- `effective_export_ambiguous_star_fan_in_build`: +43.88%
- `reverse_re_export_chain[256]`: +15.67%
- `resolve_re_export_chains`: +13.69%
- `reverse_re_export_chain[64]`: +13.11%

The complete WallTime comparison reported no regressions across the measured analysis benchmarks. Exact runs: base `6a7dc47c313a53723c201699`, head `6a7dc53e2d121d0ea2fb60e5`. CodSpeed Simulation also reported improvements without regressions before the rebase.

## Validation

- focused side-effect, reachability, reference-path, and cache tests
- full graph suite
- strict workspace Clippy
- workspace benchmark compilation
- normalized Rijkshuisstijl Community dead-code JSON parity against exact current main
- correctness review approved with no findings
