### PR TITLE
perf(core): cache default entry matchers

### DIFF
--- a/crates/core/src/discover/entry_points.rs
+++ b/crates/core/src/discover/entry_points.rs
@@ -484,6 +484,20 @@ const DEFAULT_INDEX_PATTERNS: &[&str] = &[
     "main.{ts,tsx,js,jsx}",
 ];
 
+/// Process-wide matcher for the compile-time default index patterns.
+fn default_index_matchers() -> &'static globset::GlobSet {
+    static MATCHERS: std::sync::OnceLock<globset::GlobSet> = std::sync::OnceLock::new();
+    MATCHERS.get_or_init(|| {
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in DEFAULT_INDEX_PATTERNS {
+            if let Ok(glob) = globset::Glob::new(pattern) {
+                builder.add(glob);
+            }
+        }
+        builder.build().unwrap_or_default()
+    })
+}
+
 /// Fall back to default index patterns if no entries were found.
 ///
 /// When `ws_filter` is `Some`, only files whose path starts with the given
@@ -493,10 +507,7 @@ fn apply_default_fallback(
     root: &Path,
     ws_filter: Option<&Path>,
 ) -> Vec<EntryPoint> {
-    let default_matchers: Vec<globset::GlobMatcher> = DEFAULT_INDEX_PATTERNS
-        .iter()
-        .filter_map(|p| globset::Glob::new(p).ok().map(|g| g.compile_matcher()))
-        .collect();
+    let default_matchers = default_index_matchers();
 
     let mut entries = Vec::new();
     for file in files {
@@ -507,10 +518,7 @@ fn apply_default_fallback(
         }
         let relative = file.path.strip_prefix(root).unwrap_or(&file.path);
         let relative_str = relative.to_string_lossy();
-        if default_matchers
-            .iter()
-            .any(|m| m.is_match(relative_str.as_ref()))
-        {
+        if default_matchers.is_match(relative_str.as_ref()) {
             entries.push(EntryPoint {
                 path: file.path.clone(),
                 source: EntryPointSource::DefaultIndex,
@@ -2832,6 +2840,52 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert!(entries[0].path.ends_with("src/index.ts"));
         assert!(matches!(entries[0].source, EntryPointSource::DefaultIndex));
+    }
+
+    #[test]
+    fn default_index_matchers_preserve_patterns_and_are_shared() {
+        let matchers = default_index_matchers();
+        for path in [
+            "src/index.ts",
+            "src/index.tsx",
+            "src/index.js",
+            "src/index.jsx",
+            "src/main.ts",
+            "src/main.tsx",
+            "src/main.js",
+            "src/main.jsx",
+            "index.ts",
+            "index.tsx",
+            "index.js",
+            "index.jsx",
+            "main.ts",
+            "main.tsx",
+            "main.js",
+            "main.jsx",
+        ] {
+            assert!(
+                matchers.is_match(path),
+                "default index did not match {path}"
+            );
+        }
+        for path in [
+            "src/index.mts",
+            "src/nested/index.ts",
+            "packages/app/src/index.ts",
+            "custom-entry.ts",
+        ] {
+            assert!(!matchers.is_match(path), "non-default index matched {path}");
+        }
+
+        std::thread::scope(|scope| {
+            let handles = std::iter::repeat_with(|| scope.spawn(default_index_matchers))
+                .take(4)
+                .collect::<Vec<_>>();
+            for handle in handles {
+                let from_thread = handle.join().expect("fallback matcher thread");
+                assert!(std::ptr::eq(matchers, from_thread));
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- cache the compile-time default entry-point matchers once per process
- keep user and external patterns out of global state
- preserve the existing default pattern, fallback, and concurrency behavior

## Performance

The retention gate is the official CodSpeed WallTime comparison from base run `6a7dd5272d121d0ea2fb627a` to head run `6a7dd5c4db29ba441074e99d`. `stable_editor_workspace_repeated_session_analysis` improved from 11.8 ms to 10.5 ms, a 12.88% gain. The complete programmatic-stable workload reported one improvement, three unchanged benchmarks, and no regressions. The corresponding GitHub Actions runs are `31708652563` and `31708898144`.

Fresh Simulation runs `6a7dd45f2d121d0ea2fb625b` and `6a7dd9056ec878e6410ac913` show the target improving from 12.5 ms to 11.1 ms, a 12.59% gain, while `stable_combined_workspace_programmatic_session_reuse` remains unchanged. CodSpeed reports different CPUs for these Simulation samples, so WallTime is the retention evidence and Simulation is supporting evidence.

The causal flamegraph isolates the intended change. `apply_default_fallback` falls from 1.1 ms, 8.90% of the target, to 9.8 us, 0.09%. Per-call `Glob::compile_matcher` work disappears from the hot path.

The current head is rebased onto docs-only commit `4a2c8cb05`. The intervening commit only changes `docs/development/quality-gates.md`; the product patch-id remains `5dfe1d9b`, so the measured product code is unchanged.

## Validation

- focused default matcher concurrency, entry-point, and full core tests pass
- strict core and workspace clippy, formatting, diff, and CodSpeed benchmark compilation pass
- exact-base RHC file inventory is identical after normalization (`38fd8adc...`)
- exact-base RHC dead-code JSON is identical after removing runtime metadata (`940af66f...`)
- independent Rust review approved the rebased patch
