### PR TITLE
fix(audit-cache): stop counting deregistered legacy entries as reclaimed

### DIFF
--- a/crates/cli/src/audit_cache_prune.rs
+++ b/crates/cli/src/audit_cache_prune.rs
@@ -86,6 +86,9 @@ struct PruneCounts {
     failed: usize,
     lock_only: usize,
     owner_live: usize,
+    /// Legacy pre-#1815 registrations cleared while the cache directory stayed
+    /// warm on disk; a subset of `kept`, and never part of `reclaimed_bytes`.
+    deregistered: usize,
     reclaimed_bytes: u64,
 }
 
@@ -99,6 +102,7 @@ impl PruneCounts {
             failed: 0,
             lock_only: 0,
             owner_live: 0,
+            deregistered: 0,
             reclaimed_bytes: 0,
         };
         for entry in entries {
@@ -116,6 +120,7 @@ impl PruneCounts {
             match entry.disposition.reason() {
                 "lock-only" => counts.lock_only += 1,
                 "owner-live" => counts.owner_live += 1,
+                "legacy-deregistered" => counts.deregistered += 1,
                 _ => {}
             }
         }
@@ -163,6 +168,7 @@ fn emit_prune_json(
         "kept": counts.kept,
         "skipped": counts.skipped,
         "failed": counts.failed,
+        "deregistered": counts.deregistered,
         "complete": counts.complete(),
         "reclaimed_bytes": counts.reclaimed_bytes,
     });
@@ -210,6 +216,18 @@ fn print_prune_human(
             counts.owner_live,
         );
     }
+    if counts.deregistered > 0 {
+        let verb = if opts.dry_run {
+            "would deregister"
+        } else {
+            "deregistered"
+        };
+        let s = plural(counts.deregistered);
+        println!(
+            "  {verb} {} legacy git registration{s}; the cache stays warm on disk (not counted as reclaimed)",
+            counts.deregistered,
+        );
+    }
     let verb = if opts.dry_run {
         "would reclaim"
     } else {
@@ -251,12 +269,23 @@ fn header_line(scan_root: &Path, resolved: &ResolvedCacheMaxAge) -> String {
 }
 
 fn entry_row(entry: &SweepEntry, dry_run: bool) -> String {
-    let action = match (entry.disposition.decision(), dry_run) {
-        (SweepDecision::Removed, true) => "would remove",
-        (SweepDecision::Removed, false) => "removed",
-        (SweepDecision::Kept, _) => "kept",
-        (SweepDecision::Skipped, _) => "skipped",
-        (SweepDecision::Failed, _) => "failed",
+    // The legacy current-path case only clears the git registration; "kept"
+    // would hide the mutation and "removed" would claim one that never
+    // happens, so the action names the deregistration itself.
+    let action = if entry.disposition.reason() == "legacy-deregistered" {
+        if dry_run {
+            "would deregister"
+        } else {
+            "deregistered"
+        }
+    } else {
+        match (entry.disposition.decision(), dry_run) {
+            (SweepDecision::Removed, true) => "would remove",
+            (SweepDecision::Removed, false) => "removed",
+            (SweepDecision::Kept, _) => "kept",
+            (SweepDecision::Skipped, _) => "skipped",
+            (SweepDecision::Failed, _) => "failed",
+        }
     };
     let name = entry.path.file_name().map_or_else(
         || entry.path.display().to_string(),
@@ -277,6 +306,9 @@ fn entry_row(entry: &SweepEntry, dry_run: bool) -> String {
         }
         "orphaned-sidecars" => segments.push("orphaned sidecars".to_string()),
         "legacy-registered" => segments.push("legacy git registration".to_string()),
+        "legacy-deregistered" => {
+            segments.push("legacy git registration; cache stays warm on disk".to_string());
+        }
         "fresh" => push_age(&mut segments, entry),
         "owner-live" => push_owner(&mut segments, entry, "owner live"),
         "owner-unverifiable" => push_owner(&mut segments, entry, "owner unverifiable"),
@@ -345,6 +377,7 @@ mod tests {
             entry(SweepDisposition::KeptNotOwned, Some(7)),
             entry(SweepDisposition::KeptLockOnly, None),
             entry(SweepDisposition::KeptOwnerLive, Some(3)),
+            entry(SweepDisposition::KeptLegacyDeregistered, Some(64)),
             entry(SweepDisposition::SkippedLocked, Some(1)),
             entry(SweepDisposition::RemoveFailed, Some(2)),
         ];
@@ -355,12 +388,16 @@ mod tests {
             counts.found,
         );
         assert_eq!(counts.removed, 2);
-        assert_eq!(counts.kept, 4);
+        assert_eq!(counts.kept, 5);
         assert_eq!(counts.skipped, 1);
         assert_eq!(counts.failed, 1);
         assert_eq!(counts.lock_only, 1);
         assert_eq!(counts.owner_live, 1);
-        assert_eq!(counts.reclaimed_bytes, 10);
+        assert_eq!(counts.deregistered, 1);
+        assert_eq!(
+            counts.reclaimed_bytes, 10,
+            "a deregistered-but-kept legacy entry must not add its size to reclaimed bytes",
+        );
         assert!(!counts.complete());
         assert!(PruneCounts::tally(&[entry(SweepDisposition::KeptFresh, None)]).complete());
     }
@@ -381,6 +418,15 @@ mod tests {
         assert_eq!(
             entry_row(&seeded, false),
             "  kept         fallow-audit-base-cache-aa-root-bb  2 KiB  first seen, ages from now",
+        );
+        let deregistered = entry(SweepDisposition::KeptLegacyDeregistered, Some(2048));
+        assert_eq!(
+            entry_row(&deregistered, false),
+            "  deregistered fallow-audit-base-cache-aa-root-bb  2 KiB  legacy git registration; cache stays warm on disk",
+        );
+        assert_eq!(
+            entry_row(&deregistered, true),
+            "  would deregister fallow-audit-base-cache-aa-root-bb  2 KiB  legacy git registration; cache stays warm on disk",
         );
     }
 }

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -1049,9 +1049,9 @@ fn sweep_report_dry_run_lists_legacy_registered_without_deregistering() {
     assert!(
         report.entries.iter().any(|entry| {
             paths_equal(&entry.path, &cache_path)
-                && entry.disposition == SweepDisposition::ReclaimedLegacyRegistered
+                && entry.disposition == SweepDisposition::KeptLegacyDeregistered
         }),
-        "dry run must still enumerate and report the legacy registered pass",
+        "dry run must report the still-registered current path as deregistered-but-kept",
     );
     assert!(
         worktree_is_registered_with_git(&repo, &cache_path),
@@ -1066,6 +1066,76 @@ fn sweep_report_dry_run_lists_legacy_registered_without_deregistering() {
         "dry run must not seed a grace sidecar",
     );
     cleanup_reusable_worktree(&repo, &cache_path);
+}
+
+/// Pre-#1815 upgrade edge: a mixed-version registration at the CURRENT cache
+/// path is only deregistered and stays warm on disk, so it must report as
+/// kept (`legacy-deregistered`), while a released SHA-keyed registration is
+/// genuinely removed and stays a `legacy-registered` reclaim.
+#[test]
+fn sweep_report_apply_keeps_deregistered_current_path_and_removes_released_sha() {
+    let tmp = tempfile::TempDir::new().expect("temp dir should be created");
+    let repo = init_throwaway_repo(tmp.path(), "repo-report-legacy-apply");
+    let current_path = reusable_audit_worktree_path(&repo);
+    let released_path = legacy_reusable_audit_worktree_path(&repo, TEST_BASE_SHA)
+        .expect("legacy SHA path should resolve");
+    register_reusable_worktree(&repo, &current_path);
+    register_reusable_worktree(&repo, &released_path);
+
+    let report = sweep_reusable_caches_with_report(
+        &repo,
+        Some(Duration::from_hours(30 * 24)),
+        tmp.path(),
+        SweepMode::Apply,
+        SweepSizes::Measure,
+    );
+
+    // Match by entry NAME: the report echoes the canonical paths git prints,
+    // while a removed entry can no longer be canonicalized for `paths_equal`.
+    let find = |path: &Path| {
+        let name = path.file_name().expect("cache path should have a name");
+        report
+            .entries
+            .iter()
+            .find(|entry| entry.path.file_name() == Some(name))
+            .unwrap_or_else(|| panic!("entry for {} should be reported", path.display()))
+    };
+    let current = find(&current_path);
+    assert_eq!(
+        current.disposition,
+        SweepDisposition::KeptLegacyDeregistered
+    );
+    assert_eq!(current.disposition.decision(), SweepDecision::Kept);
+    assert_eq!(current.disposition.reason(), "legacy-deregistered");
+    assert!(
+        current.size_bytes.is_some_and(|size| size > 0),
+        "the kept-warm entry still reports what it occupies",
+    );
+    let released = find(&released_path);
+    assert_eq!(
+        released.disposition,
+        SweepDisposition::ReclaimedLegacyRegistered
+    );
+    assert_eq!(released.disposition.decision(), SweepDecision::Removed);
+
+    assert!(
+        current_path.is_dir(),
+        "the current-path cache must stay warm on disk",
+    );
+    assert!(
+        !worktree_is_registered_with_git(&repo, &current_path),
+        "the current-path cache must be deregistered from git",
+    );
+    assert!(
+        !released_path.is_dir(),
+        "the released SHA-keyed cache must be removed",
+    );
+    assert_eq!(
+        report.removed, 0,
+        "neither legacy outcome feeds the per-audit stderr summary counter",
+    );
+    cleanup_reusable_worktree(&repo, &current_path);
+    cleanup_reusable_worktree(&repo, &released_path);
 }
 
 #[test]
@@ -3142,6 +3212,26 @@ fn audit_new_only_does_not_gate_reshaped_clone_group_without_added_lines() {
     );
 
     assert_reshaped_demotion_observability(&result);
+}
+
+/// Issue #2220: each demotion diff-source state renders its user-facing
+/// label. `Shared` carries the source label recorded by the shared diff
+/// cache (`shared_diff_source_label()`) verbatim; the base ref only feeds
+/// the worktree fallback.
+#[test]
+fn dupe_demotion_diff_source_labels_cover_every_state() {
+    assert_eq!(
+        DupeDemotionDiffSource::Shared("--diff-file pr.diff".to_string()).label("main"),
+        "--diff-file pr.diff",
+    );
+    assert_eq!(
+        DupeDemotionDiffSource::Worktree.label("origin/main"),
+        "merge-base worktree diff vs origin/main",
+    );
+    assert_eq!(
+        DupeDemotionDiffSource::Skipped.label("main"),
+        "skipped: no diff available",
+    );
 }
 
 /// Issue #2220 assertions for the re-shaped-clone fixture: the demotion is

--- a/crates/cli/src/base_worktree.rs
+++ b/crates/cli/src/base_worktree.rs
@@ -735,10 +735,15 @@ pub enum SweepDisposition {
     ReclaimedOrphan,
     /// Entry aged past the effective threshold.
     ReclaimedAged,
-    /// Entry was still REGISTERED as a git worktree by pre-#1815 fallow; the
-    /// registration was reclaimed (released SHA-keyed directories are removed,
-    /// the current path stays warm after deregistration).
+    /// A released SHA-keyed directory still REGISTERED as a git worktree by
+    /// pre-#1815 fallow; the root-owned cache cannot reuse it, so it is
+    /// deregistered AND removed.
     ReclaimedLegacyRegistered,
+    /// The current cache path still REGISTERED as a git worktree by pre-#1815
+    /// fallow (a mixed-version registration); only the git registration is
+    /// reclaimed and the directory stays warm on disk, so its measured size
+    /// never counts as reclaimed bytes.
+    KeptLegacyDeregistered,
     /// Younger than the threshold.
     KeptFresh,
     /// Foreign entry whose recorded owner root still exists; that repo's own
@@ -775,7 +780,8 @@ impl SweepDisposition {
             Self::ReclaimedOrphan | Self::ReclaimedAged | Self::ReclaimedLegacyRegistered => {
                 SweepDecision::Removed
             }
-            Self::KeptFresh
+            Self::KeptLegacyDeregistered
+            | Self::KeptFresh
             | Self::KeptOwnerLive
             | Self::KeptOwnerUnverifiable(_)
             | Self::KeptAgeGcDisabled
@@ -796,6 +802,7 @@ impl SweepDisposition {
             Self::ReclaimedOrphan => "orphaned-sidecars",
             Self::ReclaimedAged => "aged-out",
             Self::ReclaimedLegacyRegistered => "legacy-registered",
+            Self::KeptLegacyDeregistered => "legacy-deregistered",
             Self::KeptFresh => "fresh",
             Self::KeptOwnerLive => "owner-live",
             Self::KeptOwnerUnverifiable(_) => "owner-unverifiable",
@@ -983,9 +990,11 @@ fn entry_probe_metadata(path: &Path, now: SystemTime) -> (Option<u64>, Option<Pa
 }
 
 /// Deregister reusable base-snapshot caches left REGISTERED by fallow versions
-/// before #1815. A mixed-version registration at the current path stays warm;
-/// released SHA-keyed paths are removed because the root-owned cache cannot
-/// reuse them. Under [`SweepMode::DryRun`] only the read-only halves run
+/// before #1815. A mixed-version registration at the current path stays warm
+/// and reports [`SweepDisposition::KeptLegacyDeregistered`] (only the git
+/// registration goes away, so nothing is reclaimed); released SHA-keyed paths
+/// are removed because the root-owned cache cannot reuse them. Under
+/// [`SweepMode::DryRun`] only the read-only halves run
 /// (`list_audit_worktrees`, `audit_worktree_is_registered`): registered
 /// entries are reported without locks, deregistration, removal, or the
 /// trailing `git worktree prune`.
@@ -1014,12 +1023,17 @@ fn legacy_registered_pass(
         };
         let (age_days, owner_root) = entry_probe_metadata(&path, now);
         let size_bytes = size_map.remove(&path).flatten();
+        let is_current_path = pass == SweepPass::Owned;
         let disposition = match mode {
             SweepMode::DryRun => {
                 if !audit_worktree_is_registered(repo_root, &path) {
                     continue;
                 }
-                SweepDisposition::ReclaimedLegacyRegistered
+                if is_current_path {
+                    SweepDisposition::KeptLegacyDeregistered
+                } else {
+                    SweepDisposition::ReclaimedLegacyRegistered
+                }
             }
             SweepMode::Apply => {
                 let Some(_lock) = ReusableWorktreeLock::try_acquire(
@@ -1039,7 +1053,6 @@ fn legacy_registered_pass(
                 if !audit_worktree_is_registered(repo_root, &path) {
                     continue;
                 }
-                let is_current_path = paths_equal(&path, &owned_path);
                 let head = is_current_path
                     .then(|| legacy_reusable_sha(&path))
                     .flatten();
@@ -1058,7 +1071,7 @@ fn legacy_registered_pass(
                     if let Some(head) = head {
                         let _ = write_reusable_sha(&path, &head);
                     }
-                    SweepDisposition::ReclaimedLegacyRegistered
+                    SweepDisposition::KeptLegacyDeregistered
                 } else if let Err(error) = remove_reusable_cache_entry_locked(repo_root, &path) {
                     tracing::warn!(
                         path = %path.display(),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1816,11 +1816,12 @@ enum AuditCacheCli {
     /// silently: orphaned-sidecar cleanup, age-based reclaim under the
     /// resolved threshold, and cross-repo reclaim of abandoned entries whose
     /// recorded owner root no longer exists. Entries owned by other live
-    /// projects are never touched. `--root` is optional and defaults to the
-    /// current directory. Reported sizes come from a full recursive walk of
-    /// each cache entry, which can take a few seconds on large caches. To
-    /// delete one project's caches unconditionally, use
-    /// `fallow audit-cache remove --root <path> --yes`.
+    /// projects are never touched. Use `--dry-run` to preview every decision
+    /// the policy would take without touching the filesystem. `--root` is
+    /// optional and defaults to the current directory. Reported sizes come
+    /// from a full recursive walk of each cache entry, which can take a few
+    /// seconds on large caches. To delete one project's caches
+    /// unconditionally, use `fallow audit-cache remove --root <path> --yes`.
     Prune {
         /// Preview decisions without touching the filesystem.
         #[arg(long)]

--- a/crates/cli/src/report/ci/diff_filter.rs
+++ b/crates/cli/src/report/ci/diff_filter.rs
@@ -680,6 +680,22 @@ mod tests {
         assert_eq!(loaded.index.added_line_count(), 0);
     }
 
+    /// The retained source label is what `shared_diff_source_label()` serves
+    /// to name the diff that decided a filtering or demotion outcome
+    /// (issue #2220).
+    #[test]
+    fn bounded_diff_reader_retains_the_source_label() {
+        let text = "diff --git a/src/a.ts b/src/a.ts\n\
+                    --- a/src/a.ts\n\
+                    +++ b/src/a.ts\n\
+                    @@ -0,0 +1,1 @@\n\
+                    +export const a = 1;\n";
+        let loaded =
+            load_diff_index_from_reader(Cursor::new(text), "--diff-file pr.diff", 1024, true)
+                .unwrap();
+        assert_eq!(loaded.source_label, "--diff-file pr.diff");
+    }
+
     #[test]
     fn filter_issues_from_path_skips_oversize_diff() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -599,6 +599,151 @@ fn audit_cache_prune_zero_max_age_reclaims_orphans_only() {
     );
 }
 
+/// Register pre-#1815-style git worktrees at both the CURRENT cache path and
+/// a released SHA-keyed path for `root` under `scan_root`, returning
+/// `(current_path, released_path)`.
+fn register_legacy_cache_worktrees(
+    root: &Path,
+    scan_root: &Path,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let base_sha = "0123456789abcdef0123456789abcdef01234567";
+    let (current_path, released_path) = audit_cache_paths_in(root, base_sha, scan_root);
+    for path in [&current_path, &released_path] {
+        git(
+            root,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                "--quiet",
+                path.to_str().expect("cache path should be utf-8"),
+                "HEAD",
+            ],
+        );
+    }
+    (current_path, released_path)
+}
+
+/// Pre-#1815 upgrade edge (issue #2255 follow-up), dry-run half: the row and
+/// summary must announce the pending deregistration without claiming removal,
+/// and preview mode must not touch either registered entry.
+#[test]
+fn audit_cache_prune_dry_run_previews_legacy_deregistration() {
+    let fixture = create_audit_fixture("cache-prune-legacy-dry-run");
+    let root = fixture.path();
+    let scan = TempDir::new().expect("scan root should be created");
+    let (current_path, released_path) = register_legacy_cache_worktrees(root, scan.path());
+
+    let dry_run = run_prune_with_scan_root(
+        &[
+            "audit-cache",
+            "prune",
+            "--dry-run",
+            "--root",
+            root.to_str().expect("root should be utf-8"),
+        ],
+        scan.path(),
+    );
+
+    assert_eq!(
+        dry_run.code, 0,
+        "prune dry-run should succeed: {}{}",
+        dry_run.stdout, dry_run.stderr
+    );
+    assert!(
+        dry_run.stdout.contains("would deregister")
+            && dry_run
+                .stdout
+                .contains("legacy git registration; cache stays warm on disk"),
+        "the dry-run row must announce deregistration without claiming removal: {}",
+        dry_run.stdout
+    );
+    assert!(
+        dry_run.stdout.contains(
+            "would deregister 1 legacy git registration; the cache stays warm on disk (not counted as reclaimed)"
+        ),
+        "the dry-run summary must carry the deregistered count: {}",
+        dry_run.stdout
+    );
+    assert!(
+        current_path.is_dir() && released_path.is_dir(),
+        "dry run must not touch either registered entry",
+    );
+}
+
+/// Pre-#1815 upgrade edge (issue #2255 follow-up): a mixed-version git
+/// registration at the CURRENT cache path is only deregistered and stays warm
+/// on disk, so its measured size must never inflate `reclaimed_bytes`; it
+/// surfaces as its own `deregistered` count instead. A released SHA-keyed
+/// registration is genuinely removed and stays counted.
+#[test]
+fn audit_cache_prune_excludes_deregistered_current_path_from_reclaimed_bytes() {
+    let fixture = create_audit_fixture("cache-prune-legacy-registered");
+    let root = fixture.path();
+    let scan = TempDir::new().expect("scan root should be created");
+    let (current_path, released_path) = register_legacy_cache_worktrees(root, scan.path());
+
+    let output = run_prune_with_scan_root(
+        &[
+            "audit-cache",
+            "prune",
+            "--root",
+            root.to_str().expect("root should be utf-8"),
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        scan.path(),
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "prune should succeed: {}{}",
+        output.stdout, output.stderr
+    );
+    let json = parse_json(&output);
+    assert_eq!(json["deregistered"], serde_json::json!(1));
+    assert_eq!(json["removed"], serde_json::json!(1));
+    let entries = json["entries"]
+        .as_array()
+        .expect("entries should be an array");
+    let by_reason = |reason: &str| {
+        entries
+            .iter()
+            .find(|entry| entry["reason"] == serde_json::json!(reason))
+            .unwrap_or_else(|| panic!("an entry with reason {reason} should be reported"))
+    };
+    let deregistered = by_reason("legacy-deregistered");
+    assert_eq!(deregistered["disposition"], serde_json::json!("kept"));
+    assert_eq!(deregistered["pass"], serde_json::json!("owned"));
+    assert!(
+        deregistered["size_bytes"]
+            .as_u64()
+            .is_some_and(|size| size > 0),
+        "the kept-warm entry still reports what it occupies: {deregistered}"
+    );
+    let removed = by_reason("legacy-registered");
+    assert_eq!(removed["disposition"], serde_json::json!("removed"));
+    assert_eq!(
+        json["reclaimed_bytes"], removed["size_bytes"],
+        "reclaimed_bytes must carry only the genuinely removed entry's size",
+    );
+
+    assert!(
+        current_path.is_dir(),
+        "the deregistered current-path cache must stay warm on disk",
+    );
+    assert_eq!(
+        fs::read_to_string(current_path.join(".git")).expect(".git stub should be readable"),
+        "gitdir: fallow-audit-unregistered\n",
+        "the current-path cache must be deregistered in place",
+    );
+    assert!(
+        !released_path.is_dir(),
+        "the released SHA-keyed cache must be removed",
+    );
+}
+
 #[test]
 fn audit_cache_prune_reports_lock_contention_with_exit_zero() {
     let fixture = create_audit_fixture("cache-prune-contended");
@@ -2077,6 +2222,269 @@ fn audit_new_only_inherits_shifted_duplicate_group() {
         }),
         "expected a clone group spanning fileA.ts and fileB.ts"
     );
+}
+
+const DEMOTION_HELPER: &str = "export function eq(xs: string[], ys: string[]): boolean {\n  if (xs.length !== ys.length) {\n    return false;\n  }\n  for (let index = 0; index < xs.length; index += 1) {\n    if (xs[index] !== ys[index]) {\n      return false;\n    }\n  }\n  return true;\n}\n";
+
+const DEMOTION_SCAFFOLDING: &str = "export function selfTest(): boolean {\n  const alpha = ['alpha', 'beta', 'gamma'];\n  const beta = ['alpha', 'beta', 'gamma'];\n  const gamma = ['delta', 'epsilon', 'zeta'];\n  const first = eq(alpha, beta);\n  const second = eq(alpha, gamma);\n  const third = eq(beta, gamma);\n  const outcomes = [first, !second, !third];\n  const labels = ['same', 'differs', 'differs'];\n  const combined = outcomes.map((outcome, index) => `${labels[index]}:${outcome}`);\n  return combined.length === outcomes.length && outcomes.every((outcome) => outcome === true);\n}\n";
+
+/// Repo whose working tree extracts an identical helper out of two committed
+/// modules (the issue #2164 refactor). The surviving scaffolding clone group
+/// contains no added line, so the new-only gate demotes it to inherited and
+/// the demotion diff source becomes observable (issue #2220).
+fn reshaped_clone_fixture() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name":"audit-demotion-reshape","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import { selfTest as a } from './a';\nimport { selfTest as b } from './b';\na();\nb();\n",
+    )
+    .unwrap();
+    let base_module = format!("{DEMOTION_HELPER}{DEMOTION_SCAFFOLDING}");
+    fs::write(dir.join("src/a.ts"), &base_module).unwrap();
+    fs::write(dir.join("src/b.ts"), &base_module).unwrap();
+
+    git(dir, &["init", "-b", "main"]);
+    // Pin LF so base-worktree checkouts on Windows keep the head fingerprints.
+    git(dir, &["config", "core.autocrlf", "false"]);
+    commit_all(dir, "initial");
+
+    let refactored = format!("import {{ eq }} from './lib';\n{DEMOTION_SCAFFOLDING}");
+    fs::write(dir.join("src/a.ts"), &refactored).unwrap();
+    fs::write(dir.join("src/b.ts"), &refactored).unwrap();
+    fs::write(dir.join("src/lib.ts"), DEMOTION_HELPER).unwrap();
+    tmp
+}
+
+/// Without an opt-in shared diff the merge-base worktree diff decides the
+/// demotion, and both the demotion note and the `--explain` detail must name
+/// it (issue #2220, `DupeDemotionDiffSource::Worktree`).
+#[test]
+fn audit_demotion_note_names_worktree_diff_source_under_explain() {
+    let fixture = reshaped_clone_fixture();
+    let root = fixture.path().to_str().unwrap();
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root,
+        "--base",
+        "HEAD",
+        "--gate",
+        "new-only",
+        "--no-cache",
+        "--explain",
+    ]);
+
+    assert_eq!(
+        output.code, 0,
+        "the demoted refactor must pass the gate. stdout: {}\nstderr: {}",
+        output.stdout, output.stderr
+    );
+    assert!(
+        output.stderr.contains(
+            "of which 1 clone group was reclassified as pre-existing: no duplicated line was added by this change (diff source: merge-base worktree diff vs HEAD)"
+        ),
+        "the demotion note must name the worktree diff source: {}",
+        output.stderr
+    );
+    assert!(
+        output.stdout.contains("demoted dup:")
+            && output.stdout.contains(
+                "no instance overlaps an added line (rule: no-added-lines, gate: new-only)"
+            ),
+        "--explain must list the demoted group: {}",
+        output.stdout
+    );
+    assert!(
+        output
+            .stdout
+            .contains("demotion diff source: merge-base worktree diff vs HEAD"),
+        "--explain must name the deciding diff source: {}",
+        output.stdout
+    );
+}
+
+/// An opt-in shared diff (`--diff-file`) must take precedence over the
+/// merge-base worktree diff for the demotion decision (issue #2220,
+/// `DupeDemotionDiffSource::Shared` via `shared_diff_source_label()`): a diff
+/// whose added lines fall inside a clone instance keeps the group gating as
+/// introduced, where the worktree diff alone would have demoted it.
+#[test]
+fn audit_demotion_shared_diff_source_takes_precedence_over_worktree_diff() {
+    let fixture = reshaped_clone_fixture();
+    let root = fixture.path().to_str().unwrap();
+
+    let control = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root,
+        "--base",
+        "HEAD",
+        "--gate",
+        "new-only",
+        "--no-cache",
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+    assert_eq!(
+        control.code, 0,
+        "control run should pass: {}{}",
+        control.stdout, control.stderr
+    );
+    let control_json = parse_json(&control);
+    assert_eq!(control_json["attribution"]["duplication_demoted"], 1);
+    assert_eq!(control_json["attribution"]["duplication_introduced"], 0);
+
+    // A shared diff claiming an added line INSIDE the scaffolding clone
+    // instance (src/a.ts spans lines 2-12 after the refactor). The worktree
+    // diff sees no added line there, so any behavior change below is the
+    // shared source deciding.
+    let diff_dir = TempDir::new().expect("diff dir should be created");
+    let diff_path = diff_dir.path().join("touch-instance.diff");
+    fs::write(
+        &diff_path,
+        "diff --git a/src/a.ts b/src/a.ts\n\
+         --- a/src/a.ts\n\
+         +++ b/src/a.ts\n\
+         @@ -4,0 +5,1 @@\n\
+         +  const injected = 'x';\n",
+    )
+    .unwrap();
+
+    let shared = run_fallow_raw(&[
+        "audit",
+        "--root",
+        root,
+        "--base",
+        "HEAD",
+        "--gate",
+        "new-only",
+        "--no-cache",
+        "--diff-file",
+        diff_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+    assert_eq!(
+        shared.code, 0,
+        "introduced duplication warns without failing by default: {}{}",
+        shared.stdout, shared.stderr
+    );
+    let shared_json = parse_json(&shared);
+    assert_eq!(
+        shared_json["attribution"]["duplication_demoted"], 0,
+        "a shared diff touching an instance must veto the demotion: {shared_json}"
+    );
+    assert_eq!(shared_json["attribution"]["duplication_introduced"], 1);
+    let groups = shared_json["duplication"]["clone_groups"]
+        .as_array()
+        .expect("clone groups array");
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0]["introduced"], true);
+    assert!(
+        groups[0].get("demotion_reason").is_none(),
+        "a non-demoted group must not carry the marker: {}",
+        groups[0]
+    );
+}
+
+/// When no diff can be obtained at all the demotion check is skipped, every
+/// introduced clone group keeps gating, and `--explain` says so (issue #2220,
+/// `DupeDemotionDiffSource::Skipped`). An unreadable untracked file makes the
+/// merge-base worktree diff fail while the rest of the audit still runs.
+#[cfg(unix)]
+#[test]
+fn audit_demotion_skipped_diff_source_prints_explain_line() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name":"audit-demotion-skipped","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join(".fallowrc.json"),
+        r#"{"duplicates":{"threshold":1.0}}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import { selfTest as a } from './a';\na();\n",
+    )
+    .unwrap();
+    let module = format!("{DEMOTION_HELPER}{DEMOTION_SCAFFOLDING}");
+    fs::write(dir.join("src/a.ts"), &module).unwrap();
+    git(dir, &["init", "-b", "main"]);
+    git(dir, &["config", "core.autocrlf", "false"]);
+    commit_all(dir, "initial");
+
+    // The paste: the new clone instance is all added lines, so it gates.
+    fs::write(dir.join("src/b.ts"), &module).unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import { selfTest as a } from './a';\nimport { selfTest as b } from './b';\na();\nb();\n",
+    )
+    .unwrap();
+    // An unreadable untracked file fails the worktree diff's untracked-file
+    // pass (`git diff --no-index`) without disturbing changed-file discovery.
+    let blocked = dir.join("blocked.txt");
+    fs::write(&blocked, "unreadable").unwrap();
+    fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let output = run_fallow_raw(&[
+        "audit",
+        "--root",
+        dir.to_str().unwrap(),
+        "--base",
+        "HEAD",
+        "--gate",
+        "new-only",
+        "--no-cache",
+        "--explain",
+    ]);
+
+    assert_eq!(
+        output.code, 1,
+        "the pasted clone must keep gating when the demotion check is skipped. stdout: {}\nstderr: {}",
+        output.stdout, output.stderr
+    );
+    assert!(
+        output
+            .stdout
+            .contains("demotion check skipped: no diff available"),
+        "--explain must surface the skipped demotion check: {}",
+        output.stdout
+    );
+
+    let json_run = run_fallow_raw(&[
+        "audit",
+        "--root",
+        dir.to_str().unwrap(),
+        "--base",
+        "HEAD",
+        "--gate",
+        "new-only",
+        "--no-cache",
+        "--format",
+        "json",
+        "--quiet",
+    ]);
+    assert_eq!(json_run.code, 1);
+    let json = parse_json(&json_run);
+    assert_eq!(json["attribution"]["duplication_demoted"], 0);
+    assert_eq!(json["attribution"]["duplication_introduced"], 1);
 }
 
 #[test]

--- a/docs/reference/cli-internals.md
+++ b/docs/reference/cli-internals.md
@@ -84,7 +84,13 @@ garbage-collects. Two subcommands with distinct semantics:
   of abandoned entries), report every considered entry with sizes, and exit
   0 whenever the command ran, including lock-contention skips and per-entry
   failures. Machine consumers gate on the envelope's `complete` field.
-  Defaults to the current directory as root.
+  Defaults to the current directory as root. A pre-#1815 registration at the
+  current cache path is only deregistered and stays warm on disk: it reports
+  as kept with reason `legacy-deregistered`, counts in the envelope's
+  additive `deregistered` field and the matching human summary line, and
+  never adds its size to `reclaimed_bytes`. Released SHA-keyed registrations
+  are genuinely removed (reason `legacy-registered`) and stay counted as
+  reclaimed.
 
 Shared invariants (`crates/cli/src/base_worktree.rs`):
 
@@ -94,8 +100,8 @@ Shared invariants (`crates/cli/src/base_worktree.rs`):
 - `--dry-run` performs zero filesystem mutation: no cache removal, no
   `.lock` sidecar creation (acquiring a lock would create one), no
   `.last-used` grace seeding, and no git worktree deregistration. The legacy
-  registered-cache pass is still enumerated read-only and reported with
-  reason `legacy-registered`.
+  registered-cache pass is still enumerated read-only with the same
+  `legacy-registered` / `legacy-deregistered` split an apply run reports.
 - `.lock` sidecars are permanent lock identities and are never deleted:
   removing an unlinked-but-still-flocked inode while a racer re-creates the
   path would split one lock across two inodes.


### PR DESCRIPTION
## What

Three accepted review follow-ups from #2255 and #2256, landed as one branch.

Refs #2221 and #2220.

### 1. Prune no longer counts deregistered-but-kept legacy entries as reclaimed (from the #2255 review)

A pre-#1815 registration at the CURRENT cache path is only deregistered and stays warm on disk, but the prune flow counted its measured size in `reclaimed_bytes` and the human reclaim total. Now:

- The current-path variant reports as `kept` with reason `legacy-deregistered` (new `SweepDisposition::KeptLegacyDeregistered`), in both apply and dry-run modes; released SHA-keyed registrations are genuinely removed and keep reason `legacy-registered` with their size counted.
- The JSON envelope gains an additive `deregistered` count; `reclaimed_bytes` carries only genuinely removed entries. The counts closing invariant (`removed + kept + skipped + failed == found`) is unchanged: `deregistered` is a subset of `kept`, like the existing `lock_only` and `owner_live` breakdowns.
- Human output: the row uses a dedicated `deregistered` / `would deregister` action with a "cache stays warm on disk" note, plus a summary line naming the deregistered count as not counted toward the reclaim total.
- `docs/reference/cli-internals.md` documents the split.

### 2. Demotion diff-source test coverage (from the #2256 review)

Only the `Worktree` state of `DupeDemotionDiffSource` had direct coverage. Added, as subprocess-style integration tests spawning the built binary against git fixtures (the process-global shared-diff cache makes in-process testing order-dependent):

- `Shared`: on the re-shaped-clone fixture, a control run demotes via the merge-base worktree diff (`duplication_demoted` 1), while the same fixture with a `--diff-file` whose added lines fall inside a clone instance keeps the group gating as introduced (`duplication_demoted` 0, no `demotion_reason` marker). The behavior flip pins that the shared diff index takes precedence over the worktree diff for the demotion decision.
- `Skipped`: an unreadable untracked file makes the merge-base worktree diff fail while the rest of the audit still runs; the pasted clone keeps gating (exit 1) and `--explain` prints the `demotion check skipped: no diff available` line. Unix-only (permission-based).
- `Worktree` note wording: the human demotion note and the `--explain` detail lines name `merge-base worktree diff vs <base>`.
- Unit tests: `DupeDemotionDiffSource::label()` for all three states, and the shared-diff loader retaining the user-facing source label that `shared_diff_source_label()` serves.

Note observed while writing these tests: with a shared diff active, a demotion with `duplication_demoted >= 1` is structurally unreachable on the CLI path, because the same diff index filters the head duplication report first (a group survives only when some instance overlaps an added line, which is exactly the demotion veto). The `Shared` label therefore currently never renders in output; the tests pin the decision precedence and the label plumbing separately.

### 3. Prune long help states that --dry-run previews the policy (from the #2255 review)

The `audit-cache prune` long help now says: "Use `--dry-run` to preview every decision the policy would take without touching the filesystem." No generated contract surface embeds nested subcommand help (the capability manifest carries the `audit-cache` group only), so the generators produce no drift.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --workspace --benches`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`: pass.
- `cargo test -p fallow-cli` (unit and integration suites, including all new tests): pass.
- `npm run generate:contracts:check` and `npm run check:agent-adapters`: pass, no drift.
- `typos`, hidden-unicode scan (staged), comment-quality scan (staged): pass.
- Manual replay with the built binary on scratch git fixtures: the pre-#1815 registered-cache case shows the deregistered row, the additive `deregistered` count, and `reclaimed_bytes` carrying only the removed SHA-keyed entry; the demotion fixtures reproduce the `Shared` precedence flip and the `Skipped` explain line before the tests were written.
