### PR TITLE
build(scripts): fail loudly when node resolution escapes the checkout

### DIFF
--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -20,6 +20,33 @@ old, the sidecar exits with code 2 and a stderr message naming the conflict
 and the install command above; that failure is a missing install, not a code
 defect. CI installs the sidecar, so these tests pass there either way.
 
+## Local resolution invariant
+
+Every checkout runs the dependency versions it pins. Node resolves a bare
+specifier by walking ancestor directories until it finds a matching
+`node_modules` entry, and `npm run` extends `PATH` the same way, so a checkout
+nested inside another checkout (a git worktree placed inside the clone) borrows
+the outer install whenever it has none of its own. The tools then run at
+whatever version the outer checkout pinned, and the results do not describe the
+branch under test.
+
+Install into the checkout you are working in:
+
+```bash
+npm ci
+npm ci --prefix tools/type-aware-sidecar
+pnpm --dir editors/vscode install
+```
+
+`scripts/assert-local-resolution.mjs` enforces the invariant for the
+entrypoints that load third-party modules. It runs before the JavaScript lint
+and format scripts, and before contract generation reaches the extension
+codegen. When it fires it names the foreign path it resolved and the install
+command that fixes it. Entrypoints that import only `node:` builtins cannot
+escape and need no guard. The type-aware sidecar keeps its own preflight in
+`tools/type-aware-sidecar/src/backend-preflight.mjs` because it also checks the
+backend version.
+
 ## Canonical commands
 
 Run the smallest useful scope first:

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "test:type-aware-corpus": "node --test scripts/type-aware-corpus.test.mjs",
     "smoke:styling-corpus": "node scripts/styling-corpus-smoke.mjs",
     "smoke:styling-prs": "node scripts/styling-pr-smoke.mjs",
+    "prelint:js": "node scripts/assert-local-resolution.mjs oxlint",
     "lint:js": "oxlint --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs",
+    "prefmt:js": "node scripts/assert-local-resolution.mjs oxfmt",
     "fmt:js": "oxfmt --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs",
+    "prefmt:js:check": "node scripts/assert-local-resolution.mjs oxfmt",
     "fmt:js:check": "oxfmt --check --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs"
   },
   "engines": {

--- a/scripts/assert-local-resolution.mjs
+++ b/scripts/assert-local-resolution.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Fail fast when Node module resolution escapes this checkout.
+ *
+ * Node resolves a bare specifier by walking ancestor directories until it
+ * finds a matching `node_modules` entry, and `npm run` extends `PATH` the same
+ * way. A checkout nested inside another checkout (for example a git worktree
+ * created inside the clone) therefore borrows the outer install when it has
+ * none of its own, silently running tool versions this checkout does not pin.
+ * This guard turns that into a named failure.
+ *
+ * Run: `node scripts/assert-local-resolution.mjs <dependency>...`
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { runCliMain } from "./cli-main.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_INSTALL_COMMAND = "npm ci";
+
+const realPath = (path) => {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+};
+
+const isInside = (root, path) =>
+  path === root || path.startsWith(root.endsWith(sep) ? root : root + sep);
+
+/**
+ * Walk ancestor `node_modules` directories the way Node does.
+ *
+ * @param {string} dependency Package name, optionally scoped.
+ * @param {string} startDirectory Directory to start the walk from.
+ * @returns {string | null} Installed package directory, or `null` when absent.
+ */
+const ancestorPackageDirectory = (dependency, startDirectory) => {
+  let directory = startDirectory;
+  for (;;) {
+    const candidate = join(directory, "node_modules", dependency);
+    if (existsSync(join(candidate, "package.json"))) {
+      return candidate;
+    }
+    const parent = dirname(directory);
+    if (parent === directory) {
+      return null;
+    }
+    directory = parent;
+  }
+};
+
+/**
+ * Locate the package directory Node would load for `dependency`.
+ *
+ * @param {string} dependency Package name, optionally scoped.
+ * @param {string} resolveFrom Absolute path of the file that imports it.
+ * @returns {string | null} Installed package directory, or `null` when absent.
+ */
+export const resolveDependencyDirectory = (dependency, resolveFrom) => {
+  try {
+    return dirname(createRequire(resolveFrom).resolve(`${dependency}/package.json`));
+  } catch {
+    // An `exports` map may hide `package.json`, so fall back to the walk.
+  }
+  return ancestorPackageDirectory(dependency, dirname(resolveFrom));
+};
+
+/**
+ * Assert that `dependency` resolves to an install inside this checkout.
+ *
+ * @param {object} options
+ * @param {string} options.dependency Package name, optionally scoped.
+ * @param {string} [options.resolveFrom] Absolute path of the importing file;
+ *   defaults to the repository manifest, which matches how `npm run` resolves
+ *   binaries declared in the root `package.json`.
+ * @param {string} [options.repoRoot] Checkout that must own the install.
+ * @param {string} [options.installCommand] Command that creates that install.
+ * @throws {Error} When the dependency is missing or resolves outside the
+ *   checkout, naming the foreign path and the install command.
+ */
+export const assertLocalResolution = ({
+  dependency,
+  resolveFrom = join(REPO_ROOT, "package.json"),
+  repoRoot = REPO_ROOT,
+  installCommand = DEFAULT_INSTALL_COMMAND,
+}) => {
+  const directory = resolveDependencyDirectory(dependency, resolveFrom);
+  if (directory === null) {
+    throw new Error(
+      `${dependency} is not installed anywhere Node can reach from ${resolveFrom}; ` +
+        `run \`${installCommand}\` in ${repoRoot}`,
+    );
+  }
+  if (isInside(repoRoot, directory) || isInside(realPath(repoRoot), realPath(directory))) {
+    return;
+  }
+  throw new Error(
+    `${dependency} resolves to ${directory}, which is outside this checkout (${repoRoot}). ` +
+      "Node walks ancestor node_modules directories, so a checkout nested inside another " +
+      "checkout runs the outer install and its versions instead of the pinned ones. " +
+      `Run \`${installCommand}\` in ${repoRoot}.`,
+  );
+};
+
+export const main = (args = process.argv.slice(2)) => {
+  if (args.length === 0) {
+    throw new Error("usage: node scripts/assert-local-resolution.mjs <dependency>...");
+  }
+  for (const dependency of args) {
+    assertLocalResolution({ dependency });
+  }
+  return 0;
+};
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runCliMain(main);
+}

--- a/scripts/assert-local-resolution.test.mjs
+++ b/scripts/assert-local-resolution.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { assertLocalResolution, resolveDependencyDirectory } from "./assert-local-resolution.mjs";
+
+const DEPENDENCY = "fixture-dependency";
+
+const installPackage = (root, manifest = {}) => {
+  const directory = join(root, "node_modules", DEPENDENCY);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, "package.json"),
+    `${JSON.stringify({ name: DEPENDENCY, version: "1.0.0", ...manifest })}\n`,
+  );
+  writeFileSync(join(directory, "index.js"), "module.exports = {};\n");
+  return directory;
+};
+
+/**
+ * Build the escape layout: an outer checkout that owns the install and a
+ * nested checkout that does not, mirroring a worktree inside a clone.
+ */
+const nestedCheckout = () => {
+  const outer = mkdtempSync(join(tmpdir(), "fallow-resolution-"));
+  const checkout = join(outer, ".git-worktrees", "nested");
+  mkdirSync(join(checkout, "scripts"), { recursive: true });
+  return { outer, checkout, entrypoint: join(checkout, "scripts", "entrypoint.mjs") };
+};
+
+test("resolution escaping the checkout names the foreign path and the install command", () => {
+  const { outer, checkout, entrypoint } = nestedCheckout();
+  const foreign = installPackage(outer);
+  try {
+    assert.throws(
+      () =>
+        assertLocalResolution({
+          dependency: DEPENDENCY,
+          resolveFrom: entrypoint,
+          repoRoot: checkout,
+          installCommand: "npm ci",
+        }),
+      (error) =>
+        error.message.includes(foreign) &&
+        error.message.includes(checkout) &&
+        error.message.includes("npm ci"),
+    );
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a local install alongside an ancestor install passes silently", () => {
+  const { outer, checkout, entrypoint } = nestedCheckout();
+  installPackage(outer);
+  installPackage(checkout);
+  try {
+    assert.doesNotThrow(() =>
+      assertLocalResolution({
+        dependency: DEPENDENCY,
+        resolveFrom: entrypoint,
+        repoRoot: checkout,
+        installCommand: "npm ci",
+      }),
+    );
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a dependency hiding package.json behind exports still resolves", () => {
+  const { outer, checkout, entrypoint } = nestedCheckout();
+  const local = installPackage(checkout, { exports: { ".": "./index.js" } });
+  try {
+    assert.equal(resolveDependencyDirectory(DEPENDENCY, entrypoint), local);
+    assert.doesNotThrow(() =>
+      assertLocalResolution({
+        dependency: DEPENDENCY,
+        resolveFrom: entrypoint,
+        repoRoot: checkout,
+        installCommand: "npm ci",
+      }),
+    );
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a dependency missing everywhere reports the install command", () => {
+  const { outer, checkout, entrypoint } = nestedCheckout();
+  try {
+    assert.equal(resolveDependencyDirectory(DEPENDENCY, entrypoint), null);
+    assert.throws(
+      () =>
+        assertLocalResolution({
+          dependency: DEPENDENCY,
+          resolveFrom: entrypoint,
+          repoRoot: checkout,
+          installCommand: "pnpm --dir editors/vscode install",
+        }),
+      /is not installed anywhere Node can reach.*pnpm --dir editors\/vscode install/su,
+    );
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("the repository pins resolve inside this checkout", () => {
+  assert.doesNotThrow(() => assertLocalResolution({ dependency: "oxlint" }));
+  assert.doesNotThrow(() => assertLocalResolution({ dependency: "oxfmt" }));
+});

--- a/scripts/generate-all.mjs
+++ b/scripts/generate-all.mjs
@@ -13,6 +13,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { assertLocalResolution } from "./assert-local-resolution.mjs";
 import {
   checkSummaryRowFiles,
   formatSummaryRowProblems,
@@ -29,6 +30,7 @@ const OUTPUT_SCHEMA_PATH = "docs/output-schema.json";
 const AGENT_DOCS_TARGET = "npm/fallow/skills/fallow";
 const TYPE_AWARE_MANIFEST_PATH = "crates/api/type-aware-protocol.json";
 const TYPE_AWARE_MODULE_PATH = "tools/type-aware-sidecar/src/generated-protocol.mjs";
+const EXTENSION_CODEGEN_PATH = "editors/vscode/scripts/codegen-contracts.mjs";
 
 const run = (cmd, args, options = {}) =>
   execFileSync(cmd, args, {
@@ -112,7 +114,12 @@ const generateSchemaFiles = (stagingRoot) => {
 };
 
 const generateExtensionContracts = (stagingRoot) => {
-  run("node", ["editors/vscode/scripts/codegen-contracts.mjs"], {
+  assertLocalResolution({
+    dependency: "json-schema-to-typescript",
+    resolveFrom: join(REPO_ROOT, EXTENSION_CODEGEN_PATH),
+    installCommand: "pnpm --dir editors/vscode install",
+  });
+  run("node", [EXTENSION_CODEGEN_PATH], {
     env: {
       FALLOW_CODEGEN_CAPABILITY_SCHEMA: join(stagingRoot, CAPABILITY_SCHEMA_PATH),
       FALLOW_CODEGEN_OUTPUT_SCHEMA: join(stagingRoot, OUTPUT_SCHEMA_PATH),


### PR DESCRIPTION
## Problem

Node resolves a bare specifier by walking ancestor directories until it finds a matching `node_modules` entry, and `npm run` extends `PATH` the same way. A checkout nested inside another checkout (a git worktree created inside the clone) therefore borrows the outer install whenever it has none of its own.

Observed while working on #2246: a worktree with no local install resolved `typescript` from the outer checkout, so the type-aware sidecar ran against a version this branch does not pin. The sidecar preflight now detects and names that case, but the same escape was still silent for the repository's other Node entrypoints.

## Triage

Enumerated every Node entrypoint reachable from the root `package.json` scripts, `scripts/*.mjs`, `.github/scripts/*.mjs`, `crates/napi/scripts/`, and `editors/vscode/scripts/`, and split them by whether they resolve third-party modules at all:

| Entrypoint | Third-party resolution | Exposed |
|---|---|---|
| `scripts/*.mjs` (generators, checks, docs, corpus, smoke) | `node:` builtins and relative imports only | No |
| `.github/scripts/*.mjs`, `crates/napi/scripts/write-dts-entry.mjs` | `node:` builtins and relative imports only | No |
| `lint:js`, `fmt:js`, `fmt:js:check` | `oxlint` / `oxfmt` binaries found through the same ancestor walk | Yes |
| `generate:contracts[:check]` reaching `editors/vscode/scripts/codegen-contracts.mjs` | `json-schema-to-typescript` | Yes |
| `tools/type-aware-sidecar/` | `typescript` | Already guarded by its own preflight |
| `npm/fallow/scripts/*.js`, `crates/napi/index.js` | published wrapper code resolved at end-user install time | Out of scope |

The `commit-msg` hook already fails on an explicit `node_modules/.bin/commitlint` path check, so it cannot escape either.

## Fix

`scripts/assert-local-resolution.mjs` locates the package directory Node would actually load (`require.resolve`, falling back to the ancestor `node_modules` walk when an `exports` map hides `package.json`), compares its real path against this checkout's root, and throws when the install lives outside. The message names the foreign path, the checkout that should own the install, and the install command.

Wiring keeps the churn small:

- `prelint:js`, `prefmt:js`, and `prefmt:js:check` npm pre-scripts guard the `oxlint` and `oxfmt` binaries. The existing script strings are untouched, so the lint and format scope parsing in the repository policy test keeps working.
- `scripts/generate-all.mjs` asserts `json-schema-to-typescript` resolves inside the checkout before spawning the extension codegen, replacing a bare `ERR_MODULE_NOT_FOUND` (or a silent foreign resolution) with an actionable message.
- Builtins-only entrypoints get nothing.

The invariant is documented once, in `docs/development/quality-gates.md`, next to the existing sidecar install note.

## Verification

- New unit tests cover the fabricated nested-checkout layout in a temp dir: the guard fires and names both the foreign path and the install command; a local install alongside an ancestor install passes silently; a dependency whose `exports` map hides `package.json` still resolves; a dependency missing everywhere reports the install command; and the repository's own pins resolve inside the checkout.
- Real escape, reproduced in a worktree by hiding its local install and running `npm run lint:js`:

  ```
  > prelint:js
  > node scripts/assert-local-resolution.mjs oxlint

  oxlint resolves to /Users/user/fallow/node_modules/oxlint, which is outside this checkout
  (/Users/user/fallow/<worktree>). Node walks ancestor node_modules directories, so a checkout
  nested inside another checkout runs the outer install and its versions instead of the pinned
  ones. Run `npm ci` in /Users/user/fallow/<worktree>.
  ```

  `oxlint` never ran, exit code 1. After restoring the local install, `npm run lint:js` and `npm run fmt:js:check` pass with the guard silent.
- Same check against the extension codegen path reports `json-schema-to-typescript is not installed anywhere Node can reach from .../editors/vscode/scripts/codegen-contracts.mjs; run \`pnpm --dir editors/vscode install\``.

## Gates

`npm run lint:js`, `npm run fmt:js:check`, `node --test scripts/*.test.mjs`, `npm run check:knowledge-architecture`, `npm run check:agent-adapters`, `node scripts/check-comment-quality.mjs --staged`, `python3 scripts/scan-hidden-unicode.py --mode committed --staged`, and `typos` all pass. No Rust surfaces are touched, so the cargo gates do not apply.

`npm run generate:contracts:check` was not run end to end here: it needs a cargo build plus a `pnpm --dir editors/vscode install`, and this checkout has neither. The added guard is exercised directly instead, as shown above.

Refs #2246
