### PR TITLE
ci(benchmarks): add output walltime suite

### DIFF
--- a/.github/workflows/bench-rust-walltime.yml
+++ b/.github/workflows/bench-rust-walltime.yml
@@ -15,6 +15,7 @@ on:
           - analysis
           - programmatic-stable
           - component-engine
+          - component-output
 
 permissions:
   contents: read
@@ -63,6 +64,10 @@ jobs:
             component-engine)
               echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
               echo "bench=component_engine" >> "$GITHUB_OUTPUT"
+              ;;
+            component-output)
+              echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
+              echo "bench=component_output" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Unsupported walltime workload: $WALLTIME_WORKLOAD" >&2

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -13,8 +13,8 @@ persistent-session reuse as distinct benchmarks.
 
 Rust walltime retain gates run through the separate, manual
 `.github/workflows/bench-rust-walltime.yml` workflow. Its fixed suite choices
-cover core analysis, stable programmatic sessions, and engine components
-without accepting arbitrary commands. Keeping it manual avoids adding
+cover core analysis, stable programmatic sessions, and engine and output
+components without accepting arbitrary commands. Keeping it manual avoids adding
 release-LTO builds to every pull request while preserving comparable Linux
 base/head evidence on CodSpeed's dedicated macro runners:
 

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -292,6 +292,8 @@ test("Rust walltime benchmarks use CodSpeed macro runners", () => {
   );
   assert.match(job, /tool: cargo-codspeed@4\.7\.0/);
   assert.match(job, /case "\$WALLTIME_WORKLOAD" in/);
+  assert.match(workflow, /- component-output/);
+  assert.match(job, /component-output\)[\s\S]*bench=component_output/);
   assert.doesNotMatch(job, /run:.*\$\{\{ inputs\.workload \}\}/);
 });
 


### PR DESCRIPTION
Adds `component-output` as a fixed Rust WallTime workload. This lets output optimizations use the same exact-base retain gate as the existing analysis, programmatic, and engine suites.

The workload remains allowlisted through the quoted `case` mapping and runs only `fallow-benchmarks --bench component_output`. Documentation and workflow-policy coverage are updated.

Validation:
- workflow policy tests pass
- actionlint passes
- zizmor passes