### PR TITLE
perf(graph): reserve named export index capacity

### DIFF
--- a/crates/graph/src/graph/re_exports/propagate.rs
+++ b/crates/graph/src/graph/re_exports/propagate.rs
@@ -3,7 +3,7 @@
 //! Handles both star (`export * from`) and named (`export { foo } from`) re-exports,
 //! including entry-point special cases where exports are consumed externally.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 #[cfg(test)]
 use std::cell::Cell;
@@ -164,7 +164,8 @@ pub(in crate::graph) fn propagate_star_re_export(input: StarReExportPropagation<
 /// need to appear in a later name's lookup. The result is therefore byte-identical
 /// to the exact-`ExportName::Named`-match, ascending-index scan it replaces.
 fn build_named_export_index(source: &ModuleNode) -> FxHashMap<String, Vec<usize>> {
-    let mut index: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut index: FxHashMap<String, Vec<usize>> =
+        FxHashMap::with_capacity_and_hasher(source.exports.len(), FxBuildHasher);
     for (idx, export) in source.exports.iter().enumerate() {
         if let ExportName::Named(name) = &export.name {
             index.entry(name.clone()).or_default().push(idx);


### PR DESCRIPTION
## Summary

- reserve the transient named-export index from the source module's export count
- avoid repeated hash-table growth while preserving export ordering and lookup behavior

## Performance

Target benchmark:
`crates/core/benches/analysis.rs::benches::effective_export_ambiguous_star_fan_in_build::effective_export_ambiguous_star_fan_in_build`

- WallTime: 4.441 ms to 4.085 ms, 8.02% faster
- Simulation: 14.738 ms to 14.086 ms, 4.43% faster
- WallTime comparison: no regressions
- Simulation comparison: no regressions

CodSpeed runs:

- WallTime base: `6a7e309f94aa99e21603e217`
- WallTime head: `6a7e316994aa99e21603e22e`
- Simulation base: `6a7e190b339a59bb8b8371dc`
- Simulation head: `6a7e2d48ceb83ca09096b2f4`

The Simulation flamegraph reduces `ModuleGraph::propagate_re_export_entry` from 4.8 ms to 4.1 ms. Its hash-map entry path drops from 1.6 ms to 277 us.

## Validation

- focused named-export reference-scan test passed
- re-export tests passed
- full `fallow-graph` tests passed
- strict workspace Clippy passed
- formatting and diff checks passed
- analysis benchmark target compiled with CodSpeed
- normalized RHC analysis output matched the exact base
- independent Rust review approved the bounded allocation and semantic preservation
