### PR TITLE
ci(benchmarks): add round five walltime suites

### DIFF
--- a/.github/workflows/bench-rust-walltime.yml
+++ b/.github/workflows/bench-rust-walltime.yml
@@ -16,6 +16,8 @@ on:
           - programmatic-stable
           - component-engine
           - component-output
+          - dupes-detect
+          - representative-sources
 
 permissions:
   contents: read
@@ -68,6 +70,14 @@ jobs:
             component-output)
               echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
               echo "bench=component_output" >> "$GITHUB_OUTPUT"
+              ;;
+            dupes-detect)
+              echo "package=fallow-engine" >> "$GITHUB_OUTPUT"
+              echo "bench=dupes_detect" >> "$GITHUB_OUTPUT"
+              ;;
+            representative-sources)
+              echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
+              echo "bench=representative_sources" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Unsupported walltime workload: $WALLTIME_WORKLOAD" >&2

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -13,10 +13,11 @@ persistent-session reuse as distinct benchmarks.
 
 Rust walltime retain gates run through the separate, manual
 `.github/workflows/bench-rust-walltime.yml` workflow. Its fixed suite choices
-cover core analysis, stable programmatic sessions, and engine and output
-components without accepting arbitrary commands. Keeping it manual avoids adding
-release-LTO builds to every pull request while preserving comparable Linux
-base/head evidence on CodSpeed's dedicated macro runners:
+cover core analysis, stable programmatic sessions, duplicate detection, focused
+source extraction, and engine and output components without accepting arbitrary
+commands. Keeping it manual avoids adding release-LTO builds to every pull
+request while preserving comparable Linux base/head evidence on CodSpeed's
+dedicated macro runners:
 
 ```bash
 gh workflow run bench-rust-walltime.yml \

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -294,6 +294,13 @@ test("Rust walltime benchmarks use CodSpeed macro runners", () => {
   assert.match(job, /case "\$WALLTIME_WORKLOAD" in/);
   assert.match(workflow, /- component-output/);
   assert.match(job, /component-output\)[\s\S]*bench=component_output/);
+  assert.match(workflow, /- dupes-detect/);
+  assert.match(job, /dupes-detect\)[\s\S]*package=fallow-engine[\s\S]*bench=dupes_detect/);
+  assert.match(workflow, /- representative-sources/);
+  assert.match(
+    job,
+    /representative-sources\)[\s\S]*package=fallow-benchmarks[\s\S]*bench=representative_sources/,
+  );
   assert.doesNotMatch(job, /run:.*\$\{\{ inputs\.workload \}\}/);
 });
 


### PR DESCRIPTION
Adds fixed WallTime workload choices for the existing dupes_detect and representative_sources benchmark suites.

The workload input remains a strict choice mapped through a quoted case to constant package and benchmark names. No user input reaches a command.

Validation:
- workflow policy test
- actionlint
- zizmor
- both benchmark targets compile with CodSpeed enabled