### PR TITLE
fix(action): bound installed binary verification

### DIFF
--- a/action/scripts/install.sh
+++ b/action/scripts/install.sh
@@ -220,10 +220,15 @@ npm install -g --ignore-scripts "$install_arg"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 action_root="${GITHUB_ACTION_PATH:-$(cd "$script_dir/../.." && pwd)}"
 verify_script="$action_root/npm/fallow/scripts/verify-binary.js"
+verify_runner="$action_root/action/scripts/verify-installed.mjs"
 global_root="$(npm root -g)"
 global_fallow_root="$global_root/fallow"
 if [ ! -f "$verify_script" ]; then
   echo "::error::Verifier script not found at ${verify_script}; cannot verify fallow binaries"
+  exit 1
+fi
+if [ ! -f "$verify_runner" ]; then
+  echo "::error::Verifier runner not found at ${verify_runner}; cannot verify fallow binaries"
   exit 1
 fi
 
@@ -237,33 +242,20 @@ fi
 installed_fallow_version="$(node -p "require('${global_fallow_root}/package.json').version" 2>/dev/null | tr -d '\r\n' || true)"
 [ -n "$installed_fallow_version" ] || installed_fallow_version="unknown"
 
-if ! ACTION_VERIFY_SCRIPT="$verify_script" FALLOW_VERIFY_RESOLVE_FROM="$global_fallow_root" node <<'NODE'
-(async () => {
-  const { verifyInstalled, SKIP_ENV } = require(process.env.ACTION_VERIFY_SCRIPT);
-  const result = await verifyInstalled({ resolveFrom: process.env.FALLOW_VERIFY_RESOLVE_FROM });
-  if (result.skipped) {
-    console.log('::warning::Binary verification skipped because ' + SKIP_ENV + ' is set. Only use this when deliberately replacing the published binary.');
-    process.exit(0);
-  }
-  if (!result.ok) {
-    const where = result.binary ? ' ' + result.binary : '';
-    console.error('::error::fallow binary verification failed' + where + ' (' + result.code + '): ' + result.message);
-    process.exit(1);
-  }
-  console.log('Verified Ed25519 signatures and SHA-256 digests on fallow binaries (package ' + result.package + '@' + result.version + ')');
-})().catch((err) => {
-  console.error('::error::fallow binary verification failed (internal-error): ' + err.message);
-  process.exit(1);
-});
-NODE
-then
+if ACTION_VERIFY_SCRIPT="$verify_script" FALLOW_VERIFY_RESOLVE_FROM="$global_fallow_root" node "$verify_runner"; then
+  :
+else
+  verify_status=$?
+  if [ "$verify_status" -eq 124 ]; then
+    exit "$verify_status"
+  fi
   # The verifier above printed the version-aware fix (bump the pin for a
   # pre-signing version, or treat a missing signature on a signed-era package
   # as tampering). Add the locate-the-knob context: which version was installed
   # and from where, since the Action ref is a different knob from the CLI
   # version. Neutral wording so it stays correct for both failure causes.
   echo "::error::Verification ran against fallow ${installed_fallow_version}, installed from ${version_source}. The Action ref (${GITHUB_ACTION_REF:-see your workflow}) selects the Action code, not the CLI version. Apply the recommended fix in the verification error above."
-  exit 1
+  exit "$verify_status"
 fi
 
 installed_version="$(fallow --version 2>/dev/null || echo 'unknown version')"

--- a/action/scripts/verify-installed.mjs
+++ b/action/scripts/verify-installed.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const VERIFY_CHILD_ARG = "--verify-child";
+const VERIFY_TIMEOUT_MS = 60_000;
+const TERMINATE_GRACE_MS = 1_000;
+const HARD_EXIT_GRACE_MS = 1_000;
+const TIMEOUT_EXIT_CODE = 124;
+const SIGNAL_EXIT_CODES = new Map([
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]);
+
+const cleanMessage = (value) => String(value).replace(/[\r\n]+/g, " ");
+
+const runVerification = async () => {
+  const require = createRequire(import.meta.url);
+  const { verifyInstalled, SKIP_ENV } = require(process.env.ACTION_VERIFY_SCRIPT);
+  const result = await verifyInstalled({ resolveFrom: process.env.FALLOW_VERIFY_RESOLVE_FROM });
+
+  if (result.skipped) {
+    console.log(
+      `::warning::Binary verification skipped because ${SKIP_ENV} is set. Only use this when deliberately replacing the published binary.`,
+    );
+    return 0;
+  }
+  if (!result.ok) {
+    const where = result.binary ? ` ${result.binary}` : "";
+    console.error(
+      `::error::fallow binary verification failed${where} (${result.code}): ${cleanMessage(result.message)}`,
+    );
+    return 1;
+  }
+
+  console.log(
+    `Verified Ed25519 signatures and SHA-256 digests on fallow binaries (package ${result.package}@${result.version})`,
+  );
+  return 0;
+};
+
+const configuredTimeoutMs = () => {
+  if (process.env.NODE_ENV !== "test") return VERIFY_TIMEOUT_MS;
+
+  const override = Number(process.env.FALLOW_ACTION_VERIFY_TIMEOUT_MS);
+  if (Number.isSafeInteger(override) && override > 0) return Math.min(override, VERIFY_TIMEOUT_MS);
+  return VERIFY_TIMEOUT_MS;
+};
+
+const superviseVerification = async () => {
+  const entryPath = fileURLToPath(import.meta.url);
+  const timeoutMs = configuredTimeoutMs();
+  const child = spawn(process.execPath, [entryPath, VERIFY_CHILD_ARG], {
+    env: process.env,
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  let forceTimer;
+  let hardExitTimer;
+  let forwardedSignal;
+  let timedOut = false;
+  let resolveHardExit;
+  const hardExit = new Promise((resolve) => {
+    resolveHardExit = resolve;
+  });
+
+  const terminate = (signal, exitCode) => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    child.kill(signal);
+    if (forceTimer) return;
+    forceTimer = setTimeout(() => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill("SIGKILL");
+      hardExitTimer = setTimeout(() => {
+        child.unref();
+        resolveHardExit([exitCode, null]);
+      }, HARD_EXIT_GRACE_MS);
+    }, TERMINATE_GRACE_MS);
+  };
+
+  const signalHandlers = new Map();
+  for (const signal of SIGNAL_EXIT_CODES.keys()) {
+    const handler = () => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      forwardedSignal ??= signal;
+      terminate(signal, SIGNAL_EXIT_CODES.get(forwardedSignal) ?? 1);
+    };
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  const timeout = setTimeout(() => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    timedOut = true;
+    console.error(
+      `::error::fallow binary verification timed out after ${timeoutMs}ms; the verifier process was terminated`,
+    );
+    terminate("SIGTERM", TIMEOUT_EXIT_CODE);
+  }, timeoutMs);
+
+  try {
+    const [code, signal] = await Promise.race([once(child, "exit"), hardExit]);
+    if (timedOut) return TIMEOUT_EXIT_CODE;
+    if (forwardedSignal) return SIGNAL_EXIT_CODES.get(forwardedSignal) ?? 1;
+    if (signal) {
+      console.error(
+        `::error::fallow binary verification stopped unexpectedly (${cleanMessage(signal)})`,
+      );
+      return 1;
+    }
+    return code ?? 1;
+  } catch (error) {
+    console.error(
+      `::error::fallow binary verification failed to start (internal-error): ${cleanMessage(error.message)}`,
+    );
+    return 1;
+  } finally {
+    clearTimeout(timeout);
+    if (forceTimer) clearTimeout(forceTimer);
+    if (hardExitTimer) clearTimeout(hardExitTimer);
+    for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
+  }
+};
+
+const main = async () => {
+  if (process.argv[2] === VERIFY_CHILD_ARG) return runVerification();
+  return superviseVerification();
+};
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(
+    `::error::fallow binary verification failed (internal-error): ${cleanMessage(error.message)}`,
+  );
+  process.exitCode = 1;
+}

--- a/action/tests/install-verification-timeout.test.mjs
+++ b/action/tests/install-verification-timeout.test.mjs
@@ -1,0 +1,221 @@
+import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const ACTION_DIR = resolve(TEST_DIR, "..");
+const INSTALL_SCRIPT = process.env.INSTALL_SCRIPT_UNDER_TEST
+  ? resolve(process.cwd(), process.env.INSTALL_SCRIPT_UNDER_TEST)
+  : join(ACTION_DIR, "scripts", "install.sh");
+const VERIFY_RUNNER = join(ACTION_DIR, "scripts", "verify-installed.mjs");
+const HANG_VERIFY_TIMEOUT_MS = 50;
+const NORMAL_VERIFY_TIMEOUT_MS = 5_000;
+const HARD_WATCHDOG_MS = 8_000;
+const MOCK_VERSION = "9.9.9";
+
+const writeExecutable = async (path, contents) => {
+  await writeFile(path, contents, { mode: 0o755 });
+};
+
+const createHarness = async (verifyModule) => {
+  const root = await mkdtemp(join(tmpdir(), "fallow-action-verify-"));
+  const actionRoot = join(root, "action-root");
+  const binDir = join(root, "bin");
+  const globalRoot = join(root, "global", "node_modules");
+  const projectRoot = join(root, "project");
+  const verifyScript = join(actionRoot, "npm", "fallow", "scripts", "verify-binary.js");
+  const verifyRunner = join(actionRoot, "action", "scripts", "verify-installed.mjs");
+
+  await Promise.all([
+    mkdir(dirname(verifyScript), { recursive: true }),
+    mkdir(dirname(verifyRunner), { recursive: true }),
+    mkdir(join(globalRoot, "fallow"), { recursive: true }),
+    mkdir(projectRoot, { recursive: true }),
+    mkdir(binDir, { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(verifyScript, verifyModule),
+    writeFile(
+      join(globalRoot, "fallow", "package.json"),
+      `${JSON.stringify({ name: "fallow", version: MOCK_VERSION })}\n`,
+    ),
+    writeExecutable(
+      join(binDir, "npm"),
+      `#!/bin/sh
+if [ "$1" = "root" ] && [ "$2" = "-g" ]; then
+  printf '%s\\n' "$MOCK_GLOBAL_ROOT"
+  exit 0
+fi
+if [ "$1" = "install" ]; then
+  exit 0
+fi
+printf 'unexpected npm invocation: %s\\n' "$*" >&2
+exit 1
+`,
+    ),
+    writeExecutable(
+      join(binDir, "fallow"),
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf 'fallow ${MOCK_VERSION}\\n'
+  exit 0
+fi
+printf 'unexpected fallow invocation: %s\\n' "$*" >&2
+exit 1
+`,
+    ),
+  ]);
+
+  // origin/main has no runner yet and ignores this path. The fixed install
+  // script requires the production runner, so copy it when it exists.
+  try {
+    await copyFile(VERIFY_RUNNER, verifyRunner);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+
+  return { actionRoot, binDir, globalRoot, projectRoot, root };
+};
+
+const killProcessGroup = (child) => {
+  if (child.pid === undefined) return;
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    child.kill("SIGKILL");
+  }
+};
+
+const runInstall = (harness, verifyTimeoutMs = NORMAL_VERIFY_TIMEOUT_MS) =>
+  new Promise((resolveRun, rejectRun) => {
+    const child = spawn("bash", [INSTALL_SCRIPT], {
+      detached: true,
+      env: {
+        ...process.env,
+        FALLOW_ACTION_VERIFY_TIMEOUT_MS: String(verifyTimeoutMs),
+        FALLOW_VERSION: MOCK_VERSION,
+        GITHUB_ACTION_PATH: harness.actionRoot,
+        INPUT_ROOT: harness.projectRoot,
+        INPUT_TYPE_AWARE: "false",
+        MOCK_GLOBAL_ROOT: harness.globalRoot,
+        NODE_ENV: "test",
+        PATH: `${harness.binDir}:${process.env.PATH ?? ""}`,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let watchdogFired = false;
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    const watchdog = setTimeout(() => {
+      watchdogFired = true;
+      killProcessGroup(child);
+    }, HARD_WATCHDOG_MS);
+
+    child.once("error", (error) => {
+      clearTimeout(watchdog);
+      rejectRun(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(watchdog);
+      resolveRun({ code, signal, stderr, stdout, watchdogFired });
+    });
+  });
+
+const assertWatchdogDidNotFire = (result) => {
+  assert.equal(
+    result.watchdogFired,
+    false,
+    `install.sh exceeded its ${HARD_WATCHDOG_MS}ms test watchdog; the verifier may be unsupervised\n${result.stdout}\n${result.stderr}`,
+  );
+};
+
+test("install.sh bounds a verifier that never settles", async (context) => {
+  const harness = await createHarness(`
+const SKIP_ENV = "FALLOW_SKIP_BINARY_VERIFY";
+process.on("SIGTERM", () => {});
+const verifyInstalled = () => new Promise(() => {
+  setInterval(() => {}, 1_000);
+});
+module.exports = { SKIP_ENV, verifyInstalled };
+`);
+  context.after(() => rm(harness.root, { force: true, recursive: true }));
+
+  const result = await runInstall(harness, HANG_VERIFY_TIMEOUT_MS);
+  assertWatchdogDidNotFire(result);
+  assert.equal(result.code, 124, `${result.stdout}\n${result.stderr}`);
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /::error::fallow binary verification timed out after 50ms; the verifier process was terminated/,
+  );
+});
+
+test("install.sh keeps the successful verification path at status zero", async (context) => {
+  const harness = await createHarness(`
+const SKIP_ENV = "FALLOW_SKIP_BINARY_VERIFY";
+const verifyInstalled = async () => ({
+  ok: true,
+  package: "fallow-test-binary",
+  skipped: false,
+  version: "${MOCK_VERSION}",
+});
+module.exports = { SKIP_ENV, verifyInstalled };
+`);
+  context.after(() => rm(harness.root, { force: true, recursive: true }));
+
+  const result = await runInstall(harness);
+  assertWatchdogDidNotFire(result);
+  assert.equal(result.code, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /Verified Ed25519 signatures and SHA-256 digests on fallow binaries/);
+  assert.match(result.stdout, /Installed fallow fallow 9\.9\.9/);
+});
+
+test("install.sh keeps the skipped verification path at status zero", async (context) => {
+  const harness = await createHarness(`
+const SKIP_ENV = "FALLOW_SKIP_BINARY_VERIFY";
+const verifyInstalled = async () => ({ ok: true, skipped: true });
+module.exports = { SKIP_ENV, verifyInstalled };
+`);
+  context.after(() => rm(harness.root, { force: true, recursive: true }));
+
+  const result = await runInstall(harness);
+  assertWatchdogDidNotFire(result);
+  assert.equal(result.code, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /::warning::Binary verification skipped because/);
+});
+
+test("install.sh preserves a verifier failure", async (context) => {
+  const harness = await createHarness(`
+const SKIP_ENV = "FALLOW_SKIP_BINARY_VERIFY";
+const verifyInstalled = async () => ({
+  binary: "/tmp/fallow",
+  code: "sig-invalid",
+  message: "test signature mismatch",
+  ok: false,
+});
+module.exports = { SKIP_ENV, verifyInstalled };
+`);
+  context.after(() => rm(harness.root, { force: true, recursive: true }));
+
+  const result = await runInstall(harness);
+  assertWatchdogDidNotFire(result);
+  assert.equal(result.code, 1, `${result.stdout}\n${result.stderr}`);
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /::error::fallow binary verification failed \/tmp\/fallow \(sig-invalid\): test signature mismatch/,
+  );
+  assert.match(result.stdout, /Verification ran against fallow 9\.9\.9/);
+});

--- a/action/tests/run.sh
+++ b/action/tests/run.sh
@@ -220,6 +220,12 @@ fi
 echo ""
 echo "=== Install script ==="
 
+if node --test "$DIR/install-verification-timeout.test.mjs"; then
+  pass "install: binary verification is supervised"
+else
+  fail "install: binary verification is supervised" "regression test failed"
+fi
+
 INSTALL_TMP=$(mktemp -d)
 trap 'rm -rf "$INSTALL_TMP"' EXIT
 mkdir -p "$INSTALL_TMP/pinned" "$INSTALL_TMP/range" "$INSTALL_TMP/unsafe" "$INSTALL_TMP/empty"


### PR DESCRIPTION
Runs Action binary verification from a file-based Node entry point supervised by a separate parent process. This avoids the stdin heredoc boundary reported on self-hosted macOS runners and gives the complete verifier invocation a hard wall-clock deadline.

The supervisor forwards cancellation signals, escalates from SIGTERM to SIGKILL, preserves normal verifier exit statuses, and returns 124 with one focused workflow error on timeout.

Thanks @Jonathangadeaharder for the detailed trace and isolated probes.

## Verification

- The regression harness exceeds its watchdog on `origin/main` and exits with status 124 on this branch.
- Success, skipped verification, structured verification failure, timeout, forced termination, and cleanup paths pass.
- The GitHub Action suite passes.
- `npm run verify:full` passes.
- An isolated macOS ARM64 install of the published package verifies its Ed25519 signature and SHA-256 digest, then produces valid JSON while analyzing the public Vite repository.

The reporter's self-hosted runner remains the final environment-specific confirmation after this commit is available.

Fixes #2273