### PR TITLE
perf(extract): deduplicate local type declarations once

### DIFF
--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -14,6 +14,42 @@ fn parse_sfc_with_complexity(source: &str, filename: &str) -> ModuleInfo {
 }
 
 #[test]
+fn vue_scripts_stably_deduplicate_local_type_declarations() {
+    let source = r#"
+<script lang="ts">
+interface Shared {}
+namespace Scope {}
+type Alias = string;
+</script>
+<script setup lang="ts">
+interface Shared { value: string }
+namespace Scope { export const value = 1 }
+type Alias = number;
+</script>
+"#;
+    let info = parse_sfc(source, "Merged.vue");
+
+    let declarations: Vec<(&str, Option<usize>)> = info
+        .local_type_declarations
+        .iter()
+        .map(|declaration| {
+            (
+                declaration.name.as_str(),
+                usize::try_from(declaration.span.start).ok(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        declarations,
+        [
+            ("Shared", source.find("Shared")),
+            ("Scope", source.find("Scope")),
+            ("Alias", source.find("Alias")),
+        ]
+    );
+}
+
+#[test]
 fn extracts_vue_script_imports() {
     let info = parse_sfc(
         r#"

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -2635,6 +2635,7 @@ impl ModuleInfoExtractor {
         let exported_factory_return_object_shapes =
             self.collect_exported_factory_return_object_shapes();
         let type_member_types = self.collect_type_member_types();
+        Self::deduplicate_local_type_declarations(&mut self.local_type_declarations);
         ModuleInfo {
             file_id,
             exports: self.exports.into(),
@@ -2795,6 +2796,7 @@ impl ModuleInfoExtractor {
         info.injection_tokens.append(&mut self.injection_tokens);
         info.local_type_declarations
             .append(&mut self.local_type_declarations);
+        Self::deduplicate_local_type_declarations(&mut info.local_type_declarations);
         info.public_signature_type_references
             .append(&mut self.public_signature_type_references);
         info.namespace_object_aliases

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -21,6 +21,38 @@ fn into_module_info_transfers_exports() {
     assert_eq!(info.file_id, FileId(0));
 }
 
+#[test]
+fn local_type_declarations_stably_deduplicate_merged_declarations() {
+    let source = r"
+        interface Shared {}
+        interface Shared { value: string }
+        namespace Scope {}
+        namespace Scope { export const value = 1 }
+        type Alias = string;
+        type Alias = number;
+    ";
+    let info = parse(source);
+
+    let declarations: Vec<(&str, Option<usize>)> = info
+        .local_type_declarations
+        .iter()
+        .map(|declaration| {
+            (
+                declaration.name.as_str(),
+                usize::try_from(declaration.span.start).ok(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        declarations,
+        [
+            ("Shared", source.find("Shared")),
+            ("Scope", source.find("Scope")),
+            ("Alias", source.find("Alias")),
+        ]
+    );
+}
+
 fn store_member_names(info: &crate::ModuleInfo, export: &str) -> Vec<String> {
     info.exports
         .iter()

--- a/crates/extract/src/visitor/visit_impl_signature.rs
+++ b/crates/extract/src/visitor/visit_impl_signature.rs
@@ -181,17 +181,27 @@ impl ModuleInfoExtractor {
     }
 
     pub(super) fn record_local_type_declaration(&mut self, name: &str, span: Span) {
-        if self
-            .local_type_declarations
-            .iter()
-            .any(|decl| decl.name == name)
-        {
-            return;
-        }
         self.local_type_declarations.push(LocalTypeDeclaration {
             name: name.to_string(),
             span,
         });
+    }
+
+    /// Keep the first declaration and source order while avoiding a growing
+    /// linear scan for every declaration visited in large type-heavy modules.
+    pub(crate) fn deduplicate_local_type_declarations(
+        declarations: &mut Vec<LocalTypeDeclaration>,
+    ) {
+        let keep = {
+            let mut seen = FxHashSet::default();
+            seen.reserve(declarations.len());
+            declarations
+                .iter()
+                .map(|declaration| seen.insert(declaration.name.as_str()))
+                .collect::<Vec<_>>()
+        };
+        let mut keep = keep.into_iter();
+        declarations.retain(|_| keep.next().unwrap_or(false));
     }
 
     pub(super) fn record_local_signature_refs(


### PR DESCRIPTION
## What changed

- defer local type-declaration deduplication to ModuleInfo emission
- preserve first declaration span and source order in direct and SFC merge paths
- use borrowed names plus a keep mask, avoiding a second owned String per declaration
- cover duplicate interface, namespace, and type declarations in TypeScript and Vue scripts

## Performance

Exact representative-sources WallTime comparison from base f66e6e8d to head 304330be:

- signature_reference_mapping_500_exports minimum: 14.264651 ms to 13.386511 ms, 6.16% faster
- median: 14.323576 ms to 13.443669 ms, 6.14% faster
- mean: 14.324229 ms to 13.445066 ms, 6.14% faster
- 100 rounds per revision, with non-overlapping distributions
- both representative control benchmarks unchanged, with no regressions

CodSpeed's default comparison threshold classifies all three benchmarks as unchanged. The exact WallTime distributions above consistently clear the repository's 5% retain threshold.

## Validation

- formatting, full extract and core suites, and strict all-target/all-feature clippy pass
- representative benchmark compiles and runs successfully
- RHC list output is raw byte-identical between exact base and head binaries
- RHC dead-code output is identical after removing only elapsed_ms and the analysis run id; exits and finding summaries match
