### PR TITLE
fix: close analysis and audit follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,10 @@ jobs:
           FALLOW_DOCS_DIR: ${{ github.workspace }}/.companion/fallow-docs
           FALLOW_SKILLS_DIR: ${{ github.workspace }}/.companion/fallow-skills
         run: python3 scripts/check_telemetry_doc_sync.py
+      - name: Audit schema documentation parity
+        env:
+          FALLOW_DOCS_DIR: ${{ github.workspace }}/.companion/fallow-docs
+        run: node scripts/check-audit-schema-doc-sync.mjs
       - name: Agent adapter drift
         run: npm run check:agent-adapters
 

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -2409,13 +2409,10 @@ fn audit_demotion_shared_diff_source_takes_precedence_over_worktree_diff() {
 
 /// When no diff can be obtained at all the demotion check is skipped, every
 /// introduced clone group keeps gating, and `--explain` says so (issue #2220,
-/// `DupeDemotionDiffSource::Skipped`). An unreadable untracked file makes the
-/// merge-base worktree diff fail while the rest of the audit still runs.
-#[cfg(unix)]
+/// `DupeDemotionDiffSource::Skipped`). A missing external diff command makes
+/// the merge-base worktree diff fail while changed-file discovery still runs.
 #[test]
 fn audit_demotion_skipped_diff_source_prints_explain_line() {
-    use std::os::unix::fs::PermissionsExt as _;
-
     let tmp = TempDir::new().expect("failed to create temp dir");
     let dir = tmp.path();
     fs::create_dir_all(dir.join("src")).unwrap();
@@ -2447,23 +2444,25 @@ fn audit_demotion_skipped_diff_source_prints_explain_line() {
         "import { selfTest as a } from './a';\nimport { selfTest as b } from './b';\na();\nb();\n",
     )
     .unwrap();
-    // An unreadable untracked file fails the worktree diff's untracked-file
-    // pass (`git diff --no-index`) without disturbing changed-file discovery.
-    let blocked = dir.join("blocked.txt");
-    fs::write(&blocked, "unreadable").unwrap();
-    fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000)).unwrap();
+    // `--name-only` does not invoke an external diff, so changed-file
+    // discovery succeeds. Reading the actual diff does invoke it and fails.
+    let missing_external_diff = dir.join("missing-external-diff");
+    let diff_env = [("GIT_EXTERNAL_DIFF", missing_external_diff.as_path())];
 
-    let output = run_fallow_raw(&[
-        "audit",
-        "--root",
-        dir.to_str().unwrap(),
-        "--base",
-        "HEAD",
-        "--gate",
-        "new-only",
-        "--no-cache",
-        "--explain",
-    ]);
+    let output = run_fallow_raw_with_env(
+        &[
+            "audit",
+            "--root",
+            dir.to_str().unwrap(),
+            "--base",
+            "HEAD",
+            "--gate",
+            "new-only",
+            "--no-cache",
+            "--explain",
+        ],
+        &diff_env,
+    );
 
     assert_eq!(
         output.code, 1,
@@ -2478,19 +2477,22 @@ fn audit_demotion_skipped_diff_source_prints_explain_line() {
         output.stdout
     );
 
-    let json_run = run_fallow_raw(&[
-        "audit",
-        "--root",
-        dir.to_str().unwrap(),
-        "--base",
-        "HEAD",
-        "--gate",
-        "new-only",
-        "--no-cache",
-        "--format",
-        "json",
-        "--quiet",
-    ]);
+    let json_run = run_fallow_raw_with_env(
+        &[
+            "audit",
+            "--root",
+            dir.to_str().unwrap(),
+            "--base",
+            "HEAD",
+            "--gate",
+            "new-only",
+            "--no-cache",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        &diff_env,
+    );
     assert_eq!(json_run.code, 1);
     let json = parse_json(&json_run);
     assert_eq!(json["attribution"]["duplication_demoted"], 0);

--- a/crates/core/src/analyze/members/mod.rs
+++ b/crates/core/src/analyze/members/mod.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::discover::FileId;
 use crate::extract::{MemberInfo, MemberKind, ModuleInfo};
-use crate::graph::ModuleGraph;
+use crate::graph::{AmbiguityParticipants, ModuleGraph};
 use crate::resolve::ResolvedModule;
 use crate::results::UnusedMember;
 use crate::suppress::{IssueKind, SuppressionContext};
@@ -787,6 +787,7 @@ pub(super) struct UnusedMemberScanInput<'a> {
 }
 
 struct PreparedMemberScan<'a> {
+    ambiguity: AmbiguityParticipants,
     heritage_context: MemberHeritageContext<'a>,
     accessed_members: FxHashMap<ExportKey, FxHashSet<String>>,
     self_accessed_members: FxHashMap<FileId, FxHashSet<String>>,
@@ -879,11 +880,11 @@ impl MemberReportContext<'_, '_> {
         store_only_scan: bool,
         buckets: &mut MemberScanBuckets,
     ) {
-        if self.export_member_scan_skipped(module, export, store_only_scan) {
+        let export_name = export.name.to_string();
+        if self.export_member_scan_skipped(module, export, &export_name, store_only_scan) {
             return;
         }
 
-        let export_name = export.name.to_string();
         let export_key = ExportKey::new(module.file_id, export_name.clone());
         if self
             .prepared
@@ -911,8 +912,16 @@ impl MemberReportContext<'_, '_> {
         &self,
         module: &crate::graph::ModuleNode,
         export: &crate::graph::ExportSymbol,
+        export_name: &str,
         store_only_scan: bool,
     ) -> bool {
+        if self.prepared.ambiguity.contains_declaration(
+            module.file_id,
+            export_name,
+            export.is_type_only,
+        ) {
+            return true;
+        }
         if should_skip_export_member_scan(self.input.graph, module, export) {
             return true;
         }
@@ -1054,6 +1063,7 @@ fn prepare_member_scan(input: UnusedMemberScanInput<'_>) -> PreparedMemberScan<'
         build_ol_interaction_subclass_keys(input.resolved_modules, &parent_to_children);
 
     PreparedMemberScan {
+        ambiguity: input.graph.ambiguity_participants(),
         heritage_context,
         accessed_members,
         self_accessed_members,

--- a/crates/core/src/analyze/members/tests.rs
+++ b/crates/core/src/analyze/members/tests.rs
@@ -2893,9 +2893,9 @@ fn same_named_exports_do_not_share_member_usage() {
 }
 
 #[test]
-fn ambiguous_star_re_exports_have_no_unique_member_origin() {
+fn ambiguous_star_re_exports_suppress_only_participating_member_exports() {
     let mut graph = build_graph(&[
-        ("/src/barrel.ts", false),
+        ("/src/barrel.ts", true),
         ("/src/left.ts", false),
         ("/src/right.ts", false),
     ]);
@@ -2905,17 +2905,24 @@ fn ambiguous_star_re_exports_have_no_unique_member_origin() {
         &[make_export_with_members(
             "Widget",
             vec![make_member("left", MemberKind::ClassMethod)],
-            None,
+            Some(0),
         )],
     );
     set_exports(
         &mut graph,
         2,
-        &[make_export_with_members(
-            "Widget",
-            vec![make_member("right", MemberKind::ClassMethod)],
-            None,
-        )],
+        &[
+            make_export_with_members(
+                "Widget",
+                vec![make_member("right", MemberKind::ClassMethod)],
+                Some(0),
+            ),
+            make_export_with_members(
+                "Other",
+                vec![make_member("unused", MemberKind::ClassMethod)],
+                Some(0),
+            ),
+        ],
     );
     graph.set_re_exports(
         0,
@@ -2938,6 +2945,29 @@ fn ambiguous_star_re_exports_have_no_unique_member_origin() {
     );
 
     assert!(walk_re_export_origins(&graph, FileId(0), "Widget").is_empty());
+
+    let (_, class_members) = find_unused_members(
+        &graph,
+        &graph.resolved_modules,
+        &[],
+        &SuppressionContext::empty(),
+        &FxHashMap::default(),
+        &[],
+        &[],
+    );
+
+    assert!(
+        class_members
+            .iter()
+            .all(|member| member.parent_name != "Widget"),
+        "members behind the colliding export must abstain: {class_members:?}"
+    );
+    assert!(
+        class_members
+            .iter()
+            .any(|member| member.parent_name == "Other" && member.member_name == "unused"),
+        "an unrelated export in a contributor file must still report: {class_members:?}"
+    );
 }
 
 #[test]

--- a/crates/core/src/analyze/unprovided_inject.rs
+++ b/crates/core/src/analyze/unprovided_inject.rs
@@ -22,24 +22,22 @@
 //!   loop/parameter local), the whole project abstains, because a surviving
 //!   inject finding could be falsely flagged. Mirrors the Pinia spread-return
 //!   whole-object abstain.
+//! - **Star-collision abstain**: a key supplied by ambiguous `export *` sources
+//!   is unknown rather than unprovided, whether the provide or inject reaches it
+//!   through the broken barrel.
 //!
 //! The provided set is built LIBERALLY (the composable `provide(KEY, _)` plus
 //! app-level `*.provide(KEY, _)`): over-crediting a provided key can only
 //! suppress a finding, never create one. The inject side emits conservatively.
 //!
-//! One direction can still create a finding: a key name supplied by two
-//! different `export *` sources of a barrel exports nothing (ECMA-262
-//! ResolveExport), so `resolve_key` cannot walk it to its defining site. A
-//! provide and an inject that reach such a key by different paths (one through
-//! the barrel, one through the origin module) then no longer share an identity,
-//! and the inject is reported as unprovided even though a provide exists.
-
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::extract::{DiFramework, DiRole, ExportName, ModuleInfo};
 
 use crate::discover::FileId;
-use crate::graph::ModuleGraph;
+use crate::graph::{
+    AmbiguityParticipants, EffectiveExportResolution, ExportNamespace, ModuleGraph,
+};
 use crate::resolve::ResolvedModule;
 use crate::results::UnprovidedInject;
 use crate::suppress::{IssueKind, SuppressionContext};
@@ -95,6 +93,7 @@ pub fn find_unprovided_injects(input: UnprovidedInjectInput<'_>) -> Vec<Unprovid
     let provided = build_provided_key_set(input, &modules_by_id);
     let public_export_origins =
         public_export_origin_keys(input.graph, input.public_api_entry_points);
+    let ambiguity = input.graph.ambiguity_participants();
 
     let scan = InjectScanContext {
         input,
@@ -102,6 +101,7 @@ pub fn find_unprovided_injects(input: UnprovidedInjectInput<'_>) -> Vec<Unprovid
         path_by_id: &path_by_id,
         provided: &provided,
         public_export_origins: &public_export_origins,
+        ambiguity: &ambiguity,
     };
     collect_unprovided_inject_findings(&scan)
 }
@@ -170,6 +170,7 @@ struct InjectScanContext<'a> {
     path_by_id: &'a FxHashMap<FileId, &'a std::path::Path>,
     provided: &'a FxHashSet<ExportKey>,
     public_export_origins: &'a FxHashSet<ExportKey>,
+    ambiguity: &'a AmbiguityParticipants,
 }
 
 /// Pass 2: emit a finding for each inject site whose key is provided nowhere.
@@ -244,6 +245,12 @@ fn inject_site_has_unprovided_key(
     if canonical.is_empty() {
         return false;
     }
+    if canonical
+        .iter()
+        .any(|key| key_is_ambiguity_affected(scan, key))
+    {
+        return false;
+    }
     // Angular InjectionToken FP gate: only a USER `InjectionToken` is in scope. A
     // class / framework token (`inject(MyService)`) is FP-prone via
     // `providedIn: 'root'` and third-party `provideX()`, so abstain unless at
@@ -269,6 +276,17 @@ fn inject_site_has_unprovided_key(
     }
 
     true
+}
+
+fn key_is_ambiguity_affected(scan: &InjectScanContext<'_>, key: &ExportKey) -> bool {
+    scan.ambiguity
+        .contains_in_namespace(key.file_id, &key.export_name, ExportNamespace::Value)
+        || matches!(
+            scan.input
+                .graph
+                .resolve_export(key.file_id, &key.export_name, ExportNamespace::Value,),
+            EffectiveExportResolution::Ambiguous
+        )
 }
 
 fn inject_site_suppressed(scan: &InjectScanContext<'_>, file_id: FileId, line: u32) -> bool {

--- a/crates/core/src/analyze/unrendered_component.rs
+++ b/crates/core/src/analyze/unrendered_component.rs
@@ -32,16 +32,9 @@
 //!   framework, not flagged.
 //! - **Public-API abstain**: a component re-exported from a non-private package
 //!   entry point is rendered by a downstream consumer, not flagged.
-//!
-//! The remaining way this detector can flag a rendered component is
-//! UNDER-crediting on an ambiguous name. When two different `export *` sources
-//! of a barrel supply the same name, that name exports nothing (ECMA-262
-//! ResolveExport) and `resolve_export` answers `Ambiguous`; the crediting walks
-//! abstain there, so a component reached only through the colliding name is
-//! credited by nobody and stays eligible. The finding then names the component
-//! while the fault is in the barrel. The unused-export surface suppresses its
-//! own findings for names lost to such a collision; this detector does not, so
-//! the carve-out is real until the barrel collision is resolved.
+//! - **Star-collision abstain**: when an ambiguous `export *` name loses the
+//!   component's render credit, the component is unknown rather than unrendered.
+//!   The barrel is faulty, so this detector does not blame the source file.
 
 use std::path::Path;
 
@@ -54,7 +47,8 @@ use fallow_types::extract::{
 
 use crate::discover::FileId;
 use crate::graph::{
-    EffectiveExportBinding, EffectiveExportResolution, ExportNamespace, ModuleGraph, ModuleNode,
+    AmbiguityParticipants, EffectiveExportBinding, EffectiveExportResolution, ExportNamespace,
+    ModuleGraph, ModuleNode,
 };
 use crate::resolve::{ResolvedImport, ResolvedModule};
 use crate::results::UnrenderedComponent;
@@ -141,6 +135,7 @@ pub fn find_unrendered_components(
 
     let used = build_rendered_sfc_used_set(graph, resolved_modules, &modules_by_id);
     let reexported = build_barrel_reexported_sfcs(graph);
+    let ambiguity = graph.ambiguity_participants();
     // Public-API abstain set: every SFC binding effectively exposed by a
     // non-private package entry point. The graph owns shadowing, ambiguity,
     // namespace, and multi-hop resolution; this analysis only classifies the
@@ -150,6 +145,7 @@ pub fn find_unrendered_components(
     // Pass 3: emit.
     let scan = SfcScanContext {
         graph,
+        ambiguity: &ambiguity,
         used: &used,
         reexported: &reexported,
         public_api: &public_api,
@@ -217,6 +213,7 @@ fn build_barrel_reexported_sfcs(graph: &ModuleGraph) -> FxHashMap<FileId, FileId
 /// Shared read-only state threaded through the SFC emit (Pass 3) scan.
 struct SfcScanContext<'a> {
     graph: &'a ModuleGraph,
+    ambiguity: &'a AmbiguityParticipants,
     used: &'a FxHashSet<FileId>,
     reexported: &'a FxHashMap<FileId, FileId>,
     public_api: &'a FxHashSet<FileId>,
@@ -240,6 +237,12 @@ fn evaluate_unrendered_sfc(
     }
     // Not kept alive by a barrel: `unused-file` / `unused-import` owns it.
     let &barrel_id = scan.reexported.get(&module.file_id)?;
+    if scan
+        .ambiguity
+        .contains_in_namespace(module.file_id, "default", ExportNamespace::Value)
+    {
+        return None;
+    }
     if scan.public_api.contains(&module.file_id)
         || scan.public_api_entry_points.contains(&module.file_id)
     {

--- a/crates/core/tests/integration_test/unprovided_injects.rs
+++ b/crates/core/tests/integration_test/unprovided_injects.rs
@@ -44,10 +44,16 @@ fn flags_dead_vue_inject_and_credits_matched_pairs() {
         names.contains(&"THEME_KEY"),
         "THEME_KEY should be flagged: {found:?}"
     );
-    // SHARED_KEY (direct provide), GLOBAL_KEY (app.provide), and BARREL_KEY
-    // (provider imports it directly, consumer through a barrel) are all
-    // provided somewhere and must NOT be flagged.
-    for credited in ["SHARED_KEY", "GLOBAL_KEY", "BARREL_KEY"] {
+    // The ordinary direct, app-level, and barrel-asymmetric pairs are credited.
+    // The two star-collision keys exercise both asymmetric directions: direct
+    // provide with barrel inject, and barrel provide with direct inject.
+    for credited in [
+        "SHARED_KEY",
+        "GLOBAL_KEY",
+        "BARREL_KEY",
+        "DIRECT_PROVIDE_KEY",
+        "DIRECT_INJECT_KEY",
+    ] {
         assert!(
             !names.contains(&credited),
             "{credited} is provided and must be credited, not flagged: {found:?}"

--- a/crates/core/tests/integration_test/unrendered_components_namespace.rs
+++ b/crates/core/tests/integration_test/unrendered_components_namespace.rs
@@ -61,8 +61,8 @@ fn credits_components_rendered_through_namespace_reexport() {
         "the shadowed star binding must not be credited: {flagged:?}"
     );
     assert!(
-        flagged.contains(&"Left") && flagged.contains(&"Right"),
-        "an ambiguous star binding must not credit either component: {flagged:?}"
+        !flagged.contains(&"Left") && !flagged.contains(&"Right"),
+        "a component behind an ambiguous star binding must abstain: {flagged:?}"
     );
     assert!(
         flagged.contains(&"TypeOnly"),

--- a/crates/graph/src/graph/ambiguity.rs
+++ b/crates/graph/src/graph/ambiguity.rs
@@ -12,7 +12,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::discover::FileId;
 
-use super::{EffectiveExportResolution, ExportNamespace, ModuleGraph};
+use super::{EffectiveExportBinding, EffectiveExportResolution, ExportNamespace, ModuleGraph};
 
 /// One `export *` collision on a barrel module.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +32,8 @@ pub struct AmbiguousStarExport {
 /// A participant is neither used nor provably dead: the barrel that would carry
 /// its credit exports nothing under that name. Detectors abstain from reporting
 /// participants rather than attributing a barrel mistake to the source files.
+/// Names identify the canonical defining declaration, so a re-export alias such
+/// as `default as Widget` records `default` on the component file.
 #[derive(Debug, Default)]
 pub struct AmbiguityParticipants {
     names_by_file: FxHashMap<(FileId, ExportNamespace), FxHashSet<Box<str>>>,
@@ -40,7 +42,13 @@ pub struct AmbiguityParticipants {
 impl AmbiguityParticipants {
     /// Whether this declaration lost its credit to a star-export collision in
     /// one specific namespace.
-    fn contains(&self, file_id: FileId, name: &str, namespace: ExportNamespace) -> bool {
+    #[must_use]
+    pub fn contains_in_namespace(
+        &self,
+        file_id: FileId,
+        name: &str,
+        namespace: ExportNamespace,
+    ) -> bool {
         self.names_by_file
             .get(&(file_id, namespace))
             .is_some_and(|names| names.contains(name))
@@ -55,8 +63,8 @@ impl AmbiguityParticipants {
     /// has lost its credit just as thoroughly as a value-space participant.
     #[must_use]
     pub fn contains_declaration(&self, file_id: FileId, name: &str, is_type_only: bool) -> bool {
-        self.contains(file_id, name, ExportNamespace::Type)
-            || (!is_type_only && self.contains(file_id, name, ExportNamespace::Value))
+        self.contains_in_namespace(file_id, name, ExportNamespace::Type)
+            || (!is_type_only && self.contains_in_namespace(file_id, name, ExportNamespace::Value))
     }
 }
 
@@ -82,14 +90,34 @@ impl ModuleGraph {
     /// Declarations that lost export credit to a collision anywhere in the project.
     #[must_use]
     pub fn ambiguity_participants(&self) -> AmbiguityParticipants {
+        if !self.has_star_re_exports() {
+            return AmbiguityParticipants::default();
+        }
+
         let mut participants = AmbiguityParticipants::default();
-        for collision in self.ambiguous_star_exports() {
-            for contributor in collision.contributors {
+        for (barrel, name, namespace) in self.effective_exports.ambiguous_names() {
+            for binding in self.star_contributor_bindings(barrel, name, namespace) {
+                let declaration = self
+                    .export_binding_origin(binding)
+                    .map(|origin| {
+                        (
+                            origin.file_id(),
+                            Box::<str>::from(origin.export().name.to_string()),
+                        )
+                    })
+                    .or_else(|| {
+                        binding
+                            .is_implicit_default()
+                            .then(|| (binding.origin_file(), Box::<str>::from("default")))
+                    });
+                let Some((file_id, declaration_name)) = declaration else {
+                    continue;
+                };
                 participants
                     .names_by_file
-                    .entry((contributor, collision.namespace))
+                    .entry((file_id, namespace))
                     .or_default()
-                    .insert(collision.name.clone());
+                    .insert(declaration_name);
             }
         }
         participants
@@ -138,10 +166,27 @@ impl ModuleGraph {
         name: &str,
         namespace: ExportNamespace,
     ) -> Box<[FileId]> {
+        let mut contributors: Vec<FileId> = self
+            .star_contributor_bindings(barrel, name, namespace)
+            .into_iter()
+            .map(|binding| binding.origin_file())
+            .collect();
+        contributors.sort_unstable_by_key(|file_id| file_id.0);
+        contributors.dedup();
+        contributors.into_boxed_slice()
+    }
+
+    /// Canonical bindings supplied by the star sources for one ambiguous name.
+    fn star_contributor_bindings(
+        &self,
+        barrel: FileId,
+        name: &str,
+        namespace: ExportNamespace,
+    ) -> FxHashSet<EffectiveExportBinding> {
         if name == "default" {
-            return Box::default();
+            return FxHashSet::default();
         }
-        let mut contributors: Vec<FileId> = Vec::new();
+        let mut contributors: FxHashSet<EffectiveExportBinding> = FxHashSet::default();
         let mut visited: FxHashSet<FileId> = FxHashSet::from_iter([barrel]);
         let mut pending = vec![barrel];
         while let Some(current) = pending.pop() {
@@ -158,16 +203,14 @@ impl ModuleGraph {
                 }
                 match self.resolve_export(source, name, namespace) {
                     EffectiveExportResolution::Unique(binding) => {
-                        contributors.push(binding.origin_file());
+                        contributors.insert(binding);
                     }
                     EffectiveExportResolution::Ambiguous => pending.push(source),
                     EffectiveExportResolution::Missing => {}
                 }
             }
         }
-        contributors.sort_unstable_by_key(|file_id| file_id.0);
-        contributors.dedup();
-        contributors.into_boxed_slice()
+        contributors
     }
 }
 
@@ -206,6 +249,20 @@ mod tests {
         }
     }
 
+    fn default_export() -> ExportInfo {
+        ExportInfo {
+            name: ExportName::Default,
+            local_name: Some("Component".to_string()),
+            is_type_only: false,
+            visibility: VisibilityTag::None,
+            expected_unused_reason: None,
+            span: oxc_span::Span::default(),
+            members: vec![],
+            is_side_effect_used: false,
+            super_class: None,
+        }
+    }
+
     fn star_re_export(target: u32) -> ResolvedReExport {
         ResolvedReExport {
             info: ReExportInfo {
@@ -225,6 +282,21 @@ mod tests {
         let mut re_export = star_re_export(target);
         re_export.info.is_type_only = true;
         re_export
+    }
+
+    fn named_re_export(target: u32, imported_name: &str, exported_name: &str) -> ResolvedReExport {
+        ResolvedReExport {
+            info: ReExportInfo {
+                source: format!("./module-{target}"),
+                imported_name: imported_name.to_string(),
+                exported_name: exported_name.to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::default(),
+                statement_span: oxc_span::Span::default(),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::InternalModule(FileId(target)),
+        }
     }
 
     /// Barrel 0 `export type *`s 1 and 2, which both export `class Foo`.
@@ -344,6 +416,60 @@ mod tests {
         assert!(!participants.contains_declaration(FileId(1), "Bar", false));
     }
 
+    #[test]
+    fn aliased_default_origins_are_participants_under_their_declaration_name() {
+        let files: Vec<_> = (0..5)
+            .map(|index| DiscoveredFile {
+                id: FileId(index),
+                path: PathBuf::from(format!("/project/module-{index}.ts")),
+                size_bytes: 10,
+            })
+            .collect();
+        let modules = vec![
+            ResolvedModule {
+                file_id: FileId(0),
+                path: files[0].path.clone(),
+                re_exports: vec![star_re_export(1), star_re_export(2)],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(1),
+                path: files[1].path.clone(),
+                re_exports: vec![named_re_export(3, "default", "Widget")],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(2),
+                path: files[2].path.clone(),
+                re_exports: vec![named_re_export(4, "default", "Widget")],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(3),
+                path: files[3].path.clone(),
+                exports: vec![default_export()].into(),
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(4),
+                path: files[4].path.clone(),
+                exports: vec![default_export()].into(),
+                ..Default::default()
+            },
+        ];
+        let graph = ModuleGraph::build(&modules, &[], &files);
+
+        let participants = graph.ambiguity_participants();
+
+        assert!(participants.contains_declaration(FileId(3), "default", false));
+        assert!(participants.contains_declaration(FileId(4), "default", false));
+        assert!(!participants.contains_declaration(FileId(1), "Widget", false));
+        assert_eq!(
+            graph.ambiguous_star_exports()[0].contributors.as_ref(),
+            &[FileId(3), FileId(4)]
+        );
+    }
+
     /// A value star collision on a barrel that also takes part in the
     /// type-fallback lane, because a type-only re-export reads the barrel.
     ///
@@ -408,10 +534,10 @@ mod tests {
     fn participants_cover_only_the_colliding_name() {
         let participants = colliding_star_graph(false).ambiguity_participants();
 
-        assert!(participants.contains(FileId(1), "foo", ExportNamespace::Value));
-        assert!(participants.contains(FileId(2), "foo", ExportNamespace::Value));
-        assert!(!participants.contains(FileId(2), "bar", ExportNamespace::Value));
-        assert!(!participants.contains(FileId(1), "foo", ExportNamespace::Type));
+        assert!(participants.contains_in_namespace(FileId(1), "foo", ExportNamespace::Value));
+        assert!(participants.contains_in_namespace(FileId(2), "foo", ExportNamespace::Value));
+        assert!(!participants.contains_in_namespace(FileId(2), "bar", ExportNamespace::Value));
+        assert!(!participants.contains_in_namespace(FileId(1), "foo", ExportNamespace::Type));
     }
 
     #[test]

--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -47,11 +47,13 @@ pnpm --dir editors/vscode install
 ```
 
 `scripts/assert-local-resolution.mjs` enforces the invariant for the
-entrypoints that load third-party modules. It runs before the JavaScript lint
-and format scripts, and before contract generation reaches the extension
-codegen. When it fires it names the foreign path it resolved and the install
-command that fixes it. Entrypoints that import only `node:` builtins cannot
-escape and need no guard. The type-aware sidecar keeps its own preflight in
+entrypoints that load third-party modules. The JavaScript lint, format, and
+commitlint commands run it in their main script bodies, so npm's
+`--ignore-scripts` option cannot skip the guard. Contract generation runs its
+extension dependency preflight before any Cargo schema generation. When the
+guard fires it names the foreign path it resolved and the install command that
+fixes it. Entrypoints that import only `node:` builtins cannot escape and need
+no guard. The type-aware sidecar keeps its own preflight in
 `tools/type-aware-sidecar/src/backend-preflight.mjs` because it also checks the
 backend version.
 
@@ -86,6 +88,8 @@ Focused integration checks:
 - `npm run check:agent-adapters` for skill or adapter changes.
 - `python3 scripts/check_telemetry_doc_sync.py` when telemetry agent-source
   guidance or a public companion contract changes.
+- `node scripts/check-audit-schema-doc-sync.mjs` when audit or dead-code JSON
+  envelope versions or the public audit example change.
 
 ## Rust conventions
 

--- a/docs/reference/cli-internals.md
+++ b/docs/reference/cli-internals.md
@@ -57,16 +57,16 @@ an exit code.
   LSP, VS Code, GitHub Action, and GitLab consumers together.
 - New-only duplication demotion (issues #2164, #2220): under `--gate new-only`
   an introduced clone group none of whose instances overlap an added line is
-  demoted to inherited. On the CLI path the opt-in shared diff index
-  (`--diff-file`, `--diff-stdin`, or `$FALLOW_DIFF_FILE`) takes precedence
-  over the merge-base worktree diff for that decision
-  (`crates/cli/src/audit.rs`, `demote_preexisting_dupe_introductions`); the
-  programmatic runtime path (`crates/api/src/runtime/audit.rs`) uses only the
-  merge-base worktree diff. A supplied diff derived from a narrower base than
-  the merge base (for example a last-commit-only diff on a multi-commit
-  branch) can therefore over-demote: duplication the branch genuinely wrote
-  earlier shows no added lines in that diff and passes the gate. Demoted
-  groups stay counted as inherited and additionally surface via
+  demoted to inherited. Without an opt-in shared diff, the CLI uses the
+  merge-base worktree diff for that decision (`crates/cli/src/audit.rs`,
+  `demote_preexisting_dupe_introductions`); the programmatic runtime path
+  (`crates/api/src/runtime/audit.rs`) also uses its merge-base worktree diff.
+  When an opt-in shared diff (`--diff-file`, `--diff-stdin`, or
+  `$FALLOW_DIFF_FILE`) is active, it has already filtered the head duplication
+  report with the same added-line overlap predicate. Every retained clone group
+  therefore vetoes demotion, so a shared diff can prevent a demotion but cannot
+  produce a rendered shared-source demotion note. Demoted groups stay counted
+  as inherited and additionally surface via
   `attribution.duplication_demoted` and a per-group `demotion_reason` field;
   human output names the deciding diff source in the demotion note.
 
@@ -86,11 +86,12 @@ garbage-collects. Two subcommands with distinct semantics:
   failures. Machine consumers gate on the envelope's `complete` field.
   Defaults to the current directory as root. A pre-#1815 registration at the
   current cache path is only deregistered and stays warm on disk: it reports
-  as kept with reason `legacy-deregistered`, counts in the envelope's
-  additive `deregistered` field and the matching human summary line, and
-  never adds its size to `reclaimed_bytes`. Released SHA-keyed registrations
-  are genuinely removed (reason `legacy-registered`) and stay counted as
-  reclaimed.
+  as kept with reason `legacy-deregistered`. The envelope's `deregistered`
+  field is an informational subset of `kept`, not a fifth member of the
+  `removed + kept + skipped + failed == found` partition. It also appears in
+  the matching human summary line and never adds its size to
+  `reclaimed_bytes`. Released SHA-keyed registrations are genuinely removed
+  (reason `legacy-registered`) and stay counted as reclaimed.
 
 Shared invariants (`crates/cli/src/base_worktree.rs`):
 

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -68,14 +68,14 @@ error by suppressing a downstream detector.
   diagnostics, and review comments depend on stable keys.
 - A name supplied by two different `export *` sources is not exported by the
   barrel at all (ECMA-262 ResolveExport returns `ambiguous`). The contributing
-  declarations are therefore unknown rather than dead, so the unused-export and
-  unused-type surfaces abstain from reporting them instead of attributing the
-  barrel mistake to the source files. `export type *` collides the same way: it
-  drops the value namespace, so two value declarations behind it collide in type
-  space alone and abstention applies there too. Other cleanup detectors, notably
-  unrendered components, do not yet carry the same abstention.
-  `ModuleGraph::ambiguous_star_exports` exposes the collision and its
-  contributors for reporting surfaces.
+  declarations are therefore unknown rather than dead. Unused exports, member
+  findings, unrendered components, and unprovided injects abstain instead of
+  attributing the barrel mistake to a source file. `export type *` collides the
+  same way: it drops the value namespace, so two value declarations behind it
+  collide in type space alone and type-space abstention applies there too.
+  `ModuleGraph::ambiguous_star_exports` exposes collisions for reporting, while
+  `ModuleGraph::ambiguity_participants` identifies their canonical declarations
+  for detector gates.
 - Styling and CSS-in-JS extraction must preserve source line mapping.
 - Duplication token or normalization changes require the duplication cache
   version to move with the changed semantics.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "commitlint": "commitlint",
+    "commitlint": "node scripts/assert-local-resolution.mjs @commitlint/cli && commitlint",
     "verify": "node scripts/verify-repo.mjs --fast",
     "verify:fast": "node scripts/verify-repo.mjs --fast",
     "verify:full": "node scripts/verify-repo.mjs --full",
@@ -23,12 +23,9 @@
     "test:type-aware-corpus": "node --test scripts/type-aware-corpus.test.mjs",
     "smoke:styling-corpus": "node scripts/styling-corpus-smoke.mjs",
     "smoke:styling-prs": "node scripts/styling-pr-smoke.mjs",
-    "prelint:js": "node scripts/assert-local-resolution.mjs oxlint",
-    "lint:js": "oxlint --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs",
-    "prefmt:js": "node scripts/assert-local-resolution.mjs oxfmt",
-    "fmt:js": "oxfmt --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs",
-    "prefmt:js:check": "node scripts/assert-local-resolution.mjs oxfmt",
-    "fmt:js:check": "oxfmt --check --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs"
+    "lint:js": "node scripts/assert-local-resolution.mjs oxlint && oxlint --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs",
+    "fmt:js": "node scripts/assert-local-resolution.mjs oxfmt && oxfmt --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs",
+    "fmt:js:check": "node scripts/assert-local-resolution.mjs oxfmt && oxfmt --check --disable-nested-config npm benchmarks crates/napi .github/scripts editors/vscode/src viz-frontend/src scripts tools/type-aware-sidecar commitlint.config.mjs"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/scripts/assert-local-resolution.test.mjs
+++ b/scripts/assert-local-resolution.test.mjs
@@ -1,12 +1,23 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { assertLocalResolution, resolveDependencyDirectory } from "./assert-local-resolution.mjs";
 
 const DEPENDENCY = "fixture-dependency";
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const installPackage = (root, manifest = {}) => {
   const directory = join(root, "node_modules", DEPENDENCY);
@@ -28,6 +39,38 @@ const nestedCheckout = () => {
   const checkout = join(outer, ".git-worktrees", "nested");
   mkdirSync(join(checkout, "scripts"), { recursive: true });
   return { outer, checkout, entrypoint: join(checkout, "scripts", "entrypoint.mjs") };
+};
+
+const installFakeOxlint = (root) => {
+  const packageDirectory = join(root, "node_modules", "oxlint");
+  const binDirectory = join(root, "node_modules", ".bin");
+  mkdirSync(packageDirectory, { recursive: true });
+  mkdirSync(binDirectory, { recursive: true });
+  writeFileSync(
+    join(packageDirectory, "package.json"),
+    `${JSON.stringify({ name: "oxlint", version: "0.0.0" })}\n`,
+  );
+  if (process.platform === "win32") {
+    writeFileSync(join(binDirectory, "oxlint.cmd"), "@exit /b 0\r\n");
+  } else {
+    const binary = join(binDirectory, "oxlint");
+    writeFileSync(binary, "#!/bin/sh\nexit 0\n");
+    chmodSync(binary, 0o755);
+  }
+};
+
+const runNpmIgnoringScripts = (cwd) => {
+  if (process.platform === "win32") {
+    return spawnSync(
+      process.env.ComSpec ?? "cmd.exe",
+      ["/d", "/s", "/c", "npm run --ignore-scripts lint:js"],
+      { cwd, encoding: "utf8" },
+    );
+  }
+  return spawnSync("npm", ["run", "--ignore-scripts", "lint:js"], {
+    cwd,
+    encoding: "utf8",
+  });
 };
 
 test("resolution escaping the checkout names the foreign path and the install command", () => {
@@ -110,4 +153,35 @@ test("a dependency missing everywhere reports the install command", () => {
 test("the repository pins resolve inside this checkout", () => {
   assert.doesNotThrow(() => assertLocalResolution({ dependency: "oxlint" }));
   assert.doesNotThrow(() => assertLocalResolution({ dependency: "oxfmt" }));
+  assert.doesNotThrow(() => assertLocalResolution({ dependency: "@commitlint/cli" }));
+});
+
+test("ignore-scripts cannot bypass the lint script guard", () => {
+  const { outer, checkout } = nestedCheckout();
+  const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+  installFakeOxlint(outer);
+  writeFileSync(
+    join(checkout, "package.json"),
+    `${JSON.stringify({
+      private: true,
+      type: "module",
+      scripts: { "lint:js": packageJson.scripts["lint:js"] },
+    })}\n`,
+  );
+  copyFileSync(
+    join(REPO_ROOT, "scripts", "assert-local-resolution.mjs"),
+    join(checkout, "scripts", "assert-local-resolution.mjs"),
+  );
+  copyFileSync(
+    join(REPO_ROOT, "scripts", "cli-main.mjs"),
+    join(checkout, "scripts", "cli-main.mjs"),
+  );
+
+  try {
+    const result = runNpmIgnoringScripts(checkout);
+    assert.notEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(`${result.stdout}\n${result.stderr}`, /outside this checkout/u);
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
 });

--- a/scripts/check-audit-schema-doc-sync.mjs
+++ b/scripts/check-audit-schema-doc-sync.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const AUDIT_SOURCE_PATH = "crates/output/src/root_envelopes.rs";
+const CHECK_SOURCE_PATH = "crates/output/src/check.rs";
+const AUDIT_DOC_PATH = "cli/audit.mdx";
+
+export const parseRustSchemaVersion = (source, constantName) => {
+  const pattern = new RegExp(`^pub const ${constantName}: u32 = ([0-9]+);$`, "gmu");
+  const matches = [...source.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one public u32 constant named ${constantName}`);
+  }
+
+  const version = Number.parseInt(matches[0][1], 10);
+  if (!Number.isSafeInteger(version)) {
+    throw new Error(`${constantName} is not a safe integer`);
+  }
+  return version;
+};
+
+export const expectedAuditSchemaVersions = ({ auditSource, checkSource }) => ({
+  audit: parseRustSchemaVersion(auditSource, "AUDIT_SCHEMA_VERSION"),
+  deadCode: parseRustSchemaVersion(checkSource, "CHECK_SCHEMA_VERSION"),
+});
+
+const auditJsonExample = (document) => {
+  const pattern = /```json title="\$ fallow audit --format json"\r?\n([\s\S]*?)\r?\n```/gu;
+  const matches = [...document.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error("expected exactly one titled audit JSON example");
+  }
+  return matches[0][1].replaceAll("\r\n", "\n");
+};
+
+const schemaVersionLines = (example) =>
+  [...example.matchAll(/^(\s*)"schema_version":\s*([0-9]+),?$/gmu)].map((match) => ({
+    indentation: match[1].length,
+    value: Number.parseInt(match[2], 10),
+  }));
+
+const directDeadCodeSchemaVersion = (example) => {
+  const lines = example.split(/\r?\n/u);
+  const start = lines.findIndex((line) => line === '  "dead_code": {');
+  if (start === -1) {
+    throw new Error("audit JSON example is missing the dead_code object");
+  }
+
+  const endOffset = lines.slice(start + 1).findIndex((line) => /^  \},?$/u.test(line));
+  if (endOffset === -1) {
+    throw new Error("audit JSON example has an unterminated dead_code object");
+  }
+
+  const body = lines.slice(start + 1, start + 1 + endOffset);
+  const versions = body
+    .map((line) => line.match(/^    "schema_version":\s*([0-9]+),?$/u))
+    .filter(Boolean);
+  if (versions.length !== 1) {
+    throw new Error("dead_code must contain exactly one direct schema_version field");
+  }
+  return Number.parseInt(versions[0][1], 10);
+};
+
+export const checkAuditSchemaDoc = ({ document, expected }) => {
+  const example = auditJsonExample(document);
+  const occurrences = schemaVersionLines(example);
+  if (occurrences.length !== 2) {
+    throw new Error("audit JSON example must contain exactly two contextual schema versions");
+  }
+
+  const rootVersions = occurrences.filter(({ indentation }) => indentation === 2);
+  if (rootVersions.length !== 1) {
+    throw new Error("audit JSON example must contain exactly one root schema_version field");
+  }
+
+  const actualAudit = rootVersions[0].value;
+  const actualDeadCode = directDeadCodeSchemaVersion(example);
+  const drift = [];
+  if (actualAudit !== expected.audit) {
+    drift.push(`audit root is ${actualAudit}, expected ${expected.audit}`);
+  }
+  if (actualDeadCode !== expected.deadCode) {
+    drift.push(`dead_code is ${actualDeadCode}, expected ${expected.deadCode}`);
+  }
+  if (drift.length > 0) {
+    throw new Error(drift.join("; "));
+  }
+
+  return { audit: actualAudit, deadCode: actualDeadCode };
+};
+
+export const runAuditSchemaDocCheck = ({
+  repoRoot = REPO_ROOT,
+  docsDir = process.env.FALLOW_DOCS_DIR ?? resolve(REPO_ROOT, "../fallow-docs"),
+} = {}) => {
+  let expected;
+  try {
+    expected = expectedAuditSchemaVersions({
+      auditSource: readFileSync(resolve(repoRoot, AUDIT_SOURCE_PATH), "utf8"),
+      checkSource: readFileSync(resolve(repoRoot, CHECK_SOURCE_PATH), "utf8"),
+    });
+  } catch (error) {
+    return {
+      status: 2,
+      message: `error: could not read canonical schema versions: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const docPath = resolve(docsDir, AUDIT_DOC_PATH);
+  if (!existsSync(docPath)) {
+    return { status: 1, message: `DRIFT: expected companion doc not found: ${docPath}` };
+  }
+
+  try {
+    const actual = checkAuditSchemaDoc({
+      document: readFileSync(docPath, "utf8"),
+      expected,
+    });
+    return {
+      status: 0,
+      message: `audit schema docs match source contracts: audit=${actual.audit}, dead_code=${actual.deadCode}`,
+    };
+  } catch (error) {
+    return {
+      status: 1,
+      message: `DRIFT: ${AUDIT_DOC_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+};
+
+const main = () => {
+  const result = runAuditSchemaDocCheck();
+  const output = result.status === 0 ? console.log : console.error;
+  output(result.message);
+  process.exitCode = result.status;
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-audit-schema-doc-sync.test.mjs
+++ b/scripts/check-audit-schema-doc-sync.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  checkAuditSchemaDoc,
+  expectedAuditSchemaVersions,
+  parseRustSchemaVersion,
+  runAuditSchemaDocCheck,
+} from "./check-audit-schema-doc-sync.mjs";
+
+const auditDocument = ({ audit = 10, deadCode = 9, extra = "" } = {}) => `
+## JSON output
+
+\`\`\`json title="$ fallow audit --format json"
+{
+  "schema_version": ${audit},
+  "version": "3.16.0",
+  "command": "audit",
+  "dead_code": {
+    "schema_version": ${deadCode},
+    "total_issues": 2
+  }${extra}
+}
+\`\`\`
+
+\`\`\`json title="$ fallow audit-cache prune --format json"
+{
+  "schema_version": 1,
+  "command": "audit-cache prune"
+}
+\`\`\`
+`;
+
+test("schema constants come directly from their Rust declarations", () => {
+  assert.equal(
+    parseRustSchemaVersion("pub const AUDIT_SCHEMA_VERSION: u32 = 10;\n", "AUDIT_SCHEMA_VERSION"),
+    10,
+  );
+  assert.throws(
+    () => parseRustSchemaVersion("const AUDIT_SCHEMA_VERSION: u32 = 10;\n", "AUDIT_SCHEMA_VERSION"),
+    /exactly one public u32 constant/u,
+  );
+  assert.throws(
+    () =>
+      parseRustSchemaVersion(
+        "pub const AUDIT_SCHEMA_VERSION: u32 = 10;\npub const AUDIT_SCHEMA_VERSION: u32 = 11;\n",
+        "AUDIT_SCHEMA_VERSION",
+      ),
+    /exactly one public u32 constant/u,
+  );
+
+  assert.deepEqual(
+    expectedAuditSchemaVersions({
+      auditSource: "pub const AUDIT_SCHEMA_VERSION: u32 = 10;\n",
+      checkSource: "pub const CHECK_SCHEMA_VERSION: u32 = 9;\n",
+    }),
+    { audit: 10, deadCode: 9 },
+  );
+});
+
+test("audit documentation checks the root and nested dead-code contracts only", () => {
+  for (const document of [auditDocument(), auditDocument().replaceAll("\n", "\r\n")]) {
+    assert.deepEqual(
+      checkAuditSchemaDoc({
+        document,
+        expected: { audit: 10, deadCode: 9 },
+      }),
+      { audit: 10, deadCode: 9 },
+    );
+  }
+});
+
+test("audit documentation reports each contextual schema drift", () => {
+  assert.throws(
+    () =>
+      checkAuditSchemaDoc({
+        document: auditDocument({ audit: 3 }),
+        expected: { audit: 10, deadCode: 9 },
+      }),
+    /audit root is 3, expected 10/u,
+  );
+  assert.throws(
+    () =>
+      checkAuditSchemaDoc({
+        document: auditDocument({ deadCode: 3 }),
+        expected: { audit: 10, deadCode: 9 },
+      }),
+    /dead_code is 3, expected 9/u,
+  );
+});
+
+test("audit documentation fails closed on missing or extra schema contexts", () => {
+  assert.throws(
+    () =>
+      checkAuditSchemaDoc({
+        document: auditDocument().replace('    "schema_version": 9,\n', ""),
+        expected: { audit: 10, deadCode: 9 },
+      }),
+    /exactly two contextual schema versions/u,
+  );
+  assert.throws(
+    () =>
+      checkAuditSchemaDoc({
+        document: auditDocument({ extra: ',\n  "schema_version": 10' }),
+        expected: { audit: 10, deadCode: 9 },
+      }),
+    /exactly two contextual schema versions/u,
+  );
+});
+
+test("audit documentation parity fails closed when the companion is absent", () => {
+  const root = mkdtempSync(join(tmpdir(), "fallow-audit-schema-parity-"));
+  const result = runAuditSchemaDocCheck({ docsDir: join(root, "missing-docs") });
+
+  assert.equal(result.status, 1);
+  assert.match(result.message, /expected companion doc not found/u);
+});
+
+test("audit documentation parity fails closed when canonical sources are absent", () => {
+  const root = mkdtempSync(join(tmpdir(), "fallow-audit-schema-source-"));
+  const result = runAuditSchemaDocCheck({ repoRoot: join(root, "missing-source") });
+
+  assert.equal(result.status, 2);
+  assert.match(result.message, /could not read canonical schema versions/u);
+});

--- a/scripts/generate-all.mjs
+++ b/scripts/generate-all.mjs
@@ -114,11 +114,6 @@ const generateSchemaFiles = (stagingRoot) => {
 };
 
 const generateExtensionContracts = (stagingRoot) => {
-  assertLocalResolution({
-    dependency: "json-schema-to-typescript",
-    resolveFrom: join(REPO_ROOT, EXTENSION_CODEGEN_PATH),
-    installCommand: "pnpm --dir editors/vscode install",
-  });
   run("node", [EXTENSION_CODEGEN_PATH], {
     env: {
       FALLOW_CODEGEN_CAPABILITY_SCHEMA: join(stagingRoot, CAPABILITY_SCHEMA_PATH),
@@ -267,6 +262,12 @@ export const main = (argv = process.argv.slice(2)) => {
     console.log("Usage: node scripts/generate-all.mjs [--check]");
     return 0;
   }
+
+  assertLocalResolution({
+    dependency: "json-schema-to-typescript",
+    resolveFrom: join(REPO_ROOT, EXTENSION_CODEGEN_PATH),
+    installCommand: "pnpm --dir editors/vscode install",
+  });
 
   const { driftedPaths } = runGenerationTransaction({
     check,

--- a/scripts/generate-all.test.mjs
+++ b/scripts/generate-all.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const installForeignCodegenDependency = (root) => {
+  const directory = join(root, "node_modules", "json-schema-to-typescript");
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, "package.json"),
+    `${JSON.stringify({ name: "json-schema-to-typescript", version: "0.0.0" })}\n`,
+  );
+};
+
+const installCargoMarker = (root, marker) => {
+  const directory = join(root, "fake-bin");
+  mkdirSync(directory, { recursive: true });
+  if (process.platform === "win32") {
+    writeFileSync(join(directory, "cargo.cmd"), `@echo called>"${marker}"\r\n@exit /b 97\r\n`);
+  } else {
+    const binary = join(directory, "cargo");
+    writeFileSync(binary, `#!/bin/sh\nprintf called > "${marker}"\nexit 97\n`);
+    chmodSync(binary, 0o755);
+  }
+  return directory;
+};
+
+test("generation validates local codegen resolution before Cargo", () => {
+  const outer = mkdtempSync(join(tmpdir(), "fallow-generate-preflight-"));
+  const checkout = join(outer, ".git-worktrees", "nested");
+  const marker = join(outer, "cargo-called");
+  mkdirSync(checkout, { recursive: true });
+  cpSync(join(REPO_ROOT, "scripts"), join(checkout, "scripts"), { recursive: true });
+  writeFileSync(
+    join(checkout, "package.json"),
+    `${JSON.stringify({ private: true, type: "module" })}\n`,
+  );
+  installForeignCodegenDependency(outer);
+  const fakeBin = installCargoMarker(outer, marker);
+  const env = { ...process.env, PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}` };
+
+  try {
+    const help = spawnSync(process.execPath, ["scripts/generate-all.mjs", "--help"], {
+      cwd: checkout,
+      encoding: "utf8",
+      env,
+    });
+    assert.equal(help.status, 0, `${help.stdout}\n${help.stderr}`);
+
+    const generated = spawnSync(process.execPath, ["scripts/generate-all.mjs", "--check"], {
+      cwd: checkout,
+      encoding: "utf8",
+      env,
+    });
+    assert.equal(generated.status, 1, `${generated.stdout}\n${generated.stderr}`);
+    assert.match(`${generated.stdout}\n${generated.stderr}`, /outside this checkout/u);
+    assert.equal(existsSync(marker), false, "Cargo must not run before the codegen preflight");
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/scripts/test-command-policy.test.mjs
+++ b/scripts/test-command-policy.test.mjs
@@ -34,9 +34,25 @@ const commandScopes = (command) =>
     .slice(1)
     .filter((token) => !token.startsWith("-"));
 
+const guardedToolCommand = (script, dependency, executable) => {
+  const segments = script.split("&&").map((segment) => segment.trim());
+  assert.deepEqual(
+    segments.slice(0, 1),
+    [`node scripts/assert-local-resolution.mjs ${dependency}`],
+    `${executable} must assert local resolution in its main script body`,
+  );
+  assert.equal(segments.length, 2, `${executable} must have one guarded tool command`);
+  assert.match(segments[1], new RegExp(`^${executable}(?:\\s|$)`, "u"));
+  return segments[1];
+};
+
 const assertPreCommitCoversJavaScriptScopes = (hook, packageJson) => {
-  const lintScopes = commandScopes(packageJson.scripts["lint:js"]);
-  const formatScopes = commandScopes(packageJson.scripts["fmt:js:check"]);
+  const lintScopes = commandScopes(
+    guardedToolCommand(packageJson.scripts["lint:js"], "oxlint", "oxlint"),
+  );
+  const formatScopes = commandScopes(
+    guardedToolCommand(packageJson.scripts["fmt:js:check"], "oxfmt", "oxfmt"),
+  );
   assert.deepEqual(lintScopes, formatScopes, "root JavaScript lint and format scopes must agree");
 
   const pathExpression = hook.match(/grep -E '(\^\([^']+\))'/u)?.[1];
@@ -162,6 +178,17 @@ test("pre-commit JavaScript gate covers the root lint and format scopes", () => 
     () => assertPreCommitCoversJavaScriptScopes(hook.replace("|scripts/|", "|"), packageJson),
     /missing scripts/u,
   );
+});
+
+test("root tool scripts do not rely on skippable npm lifecycle guards", () => {
+  const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+  guardedToolCommand(packageJson.scripts.commitlint, "@commitlint/cli", "commitlint");
+  guardedToolCommand(packageJson.scripts["lint:js"], "oxlint", "oxlint");
+  guardedToolCommand(packageJson.scripts["fmt:js"], "oxfmt", "oxfmt");
+  guardedToolCommand(packageJson.scripts["fmt:js:check"], "oxfmt", "oxfmt");
+  assert.equal(packageJson.scripts["prelint:js"], undefined);
+  assert.equal(packageJson.scripts["prefmt:js"], undefined);
+  assert.equal(packageJson.scripts["prefmt:js:check"], undefined);
 });
 
 test("normal test guidance never executes benchmark targets", () => {

--- a/tests/fixtures/unprovided-inject-vue/src/collisionKeys/index.ts
+++ b/tests/fixtures/unprovided-inject-vue/src/collisionKeys/index.ts
@@ -1,0 +1,2 @@
+export * from './left'
+export * from './right'

--- a/tests/fixtures/unprovided-inject-vue/src/collisionKeys/left.ts
+++ b/tests/fixtures/unprovided-inject-vue/src/collisionKeys/left.ts
@@ -1,0 +1,2 @@
+export const DIRECT_PROVIDE_KEY = Symbol('left-direct-provide')
+export const DIRECT_INJECT_KEY = Symbol('left-direct-inject')

--- a/tests/fixtures/unprovided-inject-vue/src/collisionKeys/right.ts
+++ b/tests/fixtures/unprovided-inject-vue/src/collisionKeys/right.ts
@@ -1,0 +1,2 @@
+export const DIRECT_PROVIDE_KEY = Symbol('right-direct-provide')
+export const DIRECT_INJECT_KEY = Symbol('right-direct-inject')

--- a/tests/fixtures/unprovided-inject-vue/src/consumer.ts
+++ b/tests/fixtures/unprovided-inject-vue/src/consumer.ts
@@ -1,9 +1,13 @@
 import { inject } from 'vue'
 import { SHARED_KEY, THEME_KEY } from './keys'
 import { BARREL_KEY } from './barrelKeys'
+import { DIRECT_PROVIDE_KEY } from './collisionKeys'
+import { DIRECT_INJECT_KEY } from './collisionKeys/left'
 export function setup() {
   const a = inject(SHARED_KEY)
   const b = inject(THEME_KEY)
   const c = inject(BARREL_KEY)
-  return { a, b, c }
+  const d = inject(DIRECT_PROVIDE_KEY)
+  const e = inject(DIRECT_INJECT_KEY)
+  return { a, b, c, d, e }
 }

--- a/tests/fixtures/unprovided-inject-vue/src/provider.ts
+++ b/tests/fixtures/unprovided-inject-vue/src/provider.ts
@@ -1,7 +1,11 @@
 import { provide } from 'vue'
 import { SHARED_KEY } from './keys'
 import { BARREL_KEY } from './barrelKeys/def'
+import { DIRECT_INJECT_KEY } from './collisionKeys'
+import { DIRECT_PROVIDE_KEY } from './collisionKeys/left'
 export function setup() {
   provide(SHARED_KEY, 1)
   provide(BARREL_KEY, 2)
+  provide(DIRECT_PROVIDE_KEY, 3)
+  provide(DIRECT_INJECT_KEY, 4)
 }


### PR DESCRIPTION
Closes #2274
Closes #2276
Closes #2277

Suppresses detector findings whose credit was lost to ambiguous star exports, makes local tool resolution guards survive `npm --ignore-scripts`, closes the audit demotion and prune follow-ups, and adds a fail-closed companion-doc schema parity gate.

The public audit examples were corrected first in fallow-rs/docs#18.

## Verification

- Focused graph, detector, CLI, and Node regressions pass
- The minimal fixtures reproduce the false findings on `origin/main` and clear only the ambiguity-attributable findings on this branch
- Pinned public-project conformance smoke passes
- Full repository verification passes, including workspace tests, benchmarks, rustdoc, NAPI build, and NAPI tests
- Independent Rust, tooling, audit, and documentation reviews approve the final diff