### PR TITLE
fix: start type-aware reliably on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,7 +431,7 @@ jobs:
           $destination = Join-Path $env:RUNNER_TEMP "fallow-vsix"
           Copy-Item $vsix.FullName $archive
           Expand-Archive -Path $archive -DestinationPath $destination
-          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination\extension" $vsix.FullName
+          pnpm --dir editors/vscode verify:vsix "$destination\extension" $vsix.FullName
           "FALLOW_EXTENSION_PATH=$destination\extension" >> $env:GITHUB_ENV
       - name: Run isolated VSIX type-aware host smoke
         env:
@@ -814,11 +814,12 @@ jobs:
           pnpm --dir editors/vscode package
           vsix="$(find editors/vscode -maxdepth 1 -name '*.vsix' -print -quit)"
           test -n "$vsix"
+          vsix="$(realpath "$vsix")"
           archive="$RUNNER_TEMP/fallow-vsix.zip"
           destination="$RUNNER_TEMP/fallow-vsix-ubuntu"
           cp "$vsix" "$archive"
           unzip -q "$archive" -d "$destination"
-          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination/extension" "$vsix"
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix"
           echo "FALLOW_EXTENSION_PATH=$destination/extension" >> "$GITHUB_ENV"
       - name: Run extracted production VSIX host smoke
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       windows-rust: ${{ steps.filter.outputs.windows-rust }}
+      windows-type-aware: ${{ steps.filter.outputs.windows-type-aware }}
       vscode: ${{ steps.filter.outputs.vscode }}
       zed: ${{ steps.filter.outputs.zed }}
       npm: ${{ steps.filter.outputs.npm }}
@@ -121,6 +122,27 @@ jobs:
               - 'Cargo.lock'
               - '.clippy.toml'
               - 'rust-toolchain.toml'
+            windows-type-aware:
+              - 'npm/fallow/scripts/run-binary.js'
+              - 'npm/fallow/scripts/run-binary.test.js'
+              - 'npm/fallow/package.json'
+              - 'npm/fallow/bin/**'
+              - 'tools/type-aware-sidecar/**'
+              - 'editors/vscode/package.json'
+              - 'editors/vscode/pnpm-lock.yaml'
+              - 'editors/vscode/pnpm-workspace.yaml'
+              - 'editors/vscode/.vscodeignore'
+              - 'editors/vscode/scripts/package-type-aware.mjs'
+              - 'editors/vscode/scripts/verify-packaged-type-aware.mjs'
+              - 'editors/vscode/src/typeAwareCompanion.ts'
+              - 'editors/vscode/test/integration/fixtures/real-workspace/**'
+              - 'editors/vscode/test/integration/real/**'
+              - 'crates/api/src/type_aware/transport/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-validation.yml'
+              - 'scripts/repository-policy.test.mjs'
+              - 'scripts/type-aware-windows-candidate-smoke.mjs'
+              - 'scripts/workflow-policy.test.mjs'
             vscode:
               - 'editors/vscode/**'
               - 'crates/**'
@@ -359,6 +381,65 @@ jobs:
         run: cargo test -p fallow-cli windows_job_object_terminates_descendants_without_taskkill_lookup
       - name: Clippy platform-specific paths
         run: cargo clippy -p fallow-cli -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings
+
+  windows-type-aware:
+    name: Windows type-aware package and VS Code host
+    needs: changes
+    if: needs.changes.outputs.windows-type-aware == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: pr-windows-type-aware
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 11.10.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - name: Test Windows npm and child-process wiring
+        run: >
+          node --test
+          npm/fallow/scripts/run-binary.test.js
+          tools/type-aware-sidecar/test/windows-child-process.test.mjs
+      - name: Test Rust type-aware transport
+        run: cargo test -p fallow-api type_aware::transport
+      - name: Install VS Code dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build current CLI and LSP binaries
+        run: cargo build -p fallow-cli --bin fallow -p fallow-lsp --bin fallow-lsp
+      - name: Run installed npm candidate against pinned Preact
+        env:
+          FALLOW_CANDIDATE_BIN: ${{ github.workspace }}\target\debug\fallow.exe
+        run: node scripts/type-aware-windows-candidate-smoke.mjs
+      - name: Package universal VSIX
+        run: cd editors/vscode && pnpm package
+      - name: Extract VSIX outside the repository
+        shell: pwsh
+        run: |
+          $vsix = Get-ChildItem editors/vscode/*.vsix | Select-Object -First 1
+          if (-not $vsix) { throw "VSIX package was not created" }
+          $archive = Join-Path $env:RUNNER_TEMP "fallow-vsix.zip"
+          $destination = Join-Path $env:RUNNER_TEMP "fallow-vsix"
+          Copy-Item $vsix.FullName $archive
+          Expand-Archive -Path $archive -DestinationPath $destination
+          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination\extension" $vsix.FullName
+          "FALLOW_EXTENSION_PATH=$destination\extension" >> $env:GITHUB_ENV
+      - name: Run isolated VSIX type-aware host smoke
+        env:
+          FALLOW_BIN: ${{ github.workspace }}\target\debug\fallow.exe
+          FALLOW_LSP_BIN: ${{ github.workspace }}\target\debug\fallow-lsp.exe
+        run: pnpm --dir editors/vscode run test:integration:real
+      - name: Check for uncommitted changes
+        run: git diff --exit-code
 
   skills-vendor:
     name: Public skills contract
@@ -693,7 +774,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.vscode == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -728,7 +809,21 @@ jobs:
           FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow-multicall
         run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
       - run: cd editors/vscode && pnpm test:unit
-      - run: cd editors/vscode && pnpm package
+      - name: Package and verify the production VSIX shape
+        run: |
+          pnpm --dir editors/vscode package
+          vsix="$(find editors/vscode -maxdepth 1 -name '*.vsix' -print -quit)"
+          test -n "$vsix"
+          archive="$RUNNER_TEMP/fallow-vsix.zip"
+          destination="$RUNNER_TEMP/fallow-vsix-ubuntu"
+          cp "$vsix" "$archive"
+          unzip -q "$archive" -d "$destination"
+          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination/extension" "$vsix"
+          echo "FALLOW_EXTENSION_PATH=$destination/extension" >> "$GITHUB_ENV"
+      - name: Run extracted production VSIX host smoke
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow-multicall
+        run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
 
   zed:
     name: Zed Extension
@@ -942,7 +1037,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, windows-rust, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, zed, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor, viz-frontend]
+    needs: [check, windows-rust, windows-type-aware, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, zed, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor, viz-frontend]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Install type-aware sidecar dependencies
         run: npm ci --prefix tools/type-aware-sidecar --no-audit --no-fund --ignore-scripts
 
+      - name: Test Windows npm and child-process wiring
+        run: >
+          node --test
+          npm/fallow/scripts/run-binary.test.js
+          tools/type-aware-sidecar/test/windows-child-process.test.mjs
+
       - name: Run workspace tests
         run: cargo test --workspace --lib --bins --tests --examples
 
@@ -61,6 +67,35 @@ jobs:
 
       - name: Install contract bundle dependencies
         run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build current CLI and LSP binaries
+        run: cargo build -p fallow-cli --bin fallow -p fallow-lsp --bin fallow-lsp
+
+      - name: Run installed npm candidate against pinned Preact
+        env:
+          FALLOW_CANDIDATE_BIN: ${{ github.workspace }}\target\debug\fallow.exe
+        run: node scripts/type-aware-windows-candidate-smoke.mjs
+
+      - name: Package universal VSIX
+        run: cd editors/vscode && pnpm package
+
+      - name: Extract VSIX outside the repository
+        shell: pwsh
+        run: |
+          $vsix = Get-ChildItem editors/vscode/*.vsix | Select-Object -First 1
+          if (-not $vsix) { throw "VSIX package was not created" }
+          $archive = Join-Path $env:RUNNER_TEMP "fallow-vsix.zip"
+          $destination = Join-Path $env:RUNNER_TEMP "fallow-vsix"
+          Copy-Item $vsix.FullName $archive
+          Expand-Archive -Path $archive -DestinationPath $destination
+          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination\extension" $vsix.FullName
+          "FALLOW_EXTENSION_PATH=$destination\extension" >> $env:GITHUB_ENV
+
+      - name: Run isolated VSIX type-aware host smoke
+        env:
+          FALLOW_BIN: ${{ github.workspace }}\target\debug\fallow.exe
+          FALLOW_LSP_BIN: ${{ github.workspace }}\target\debug\fallow-lsp.exe
+        run: pnpm --dir editors/vscode run test:integration:real
 
       - name: Run staged subgenerator integration tests
         run: node --test scripts/subgenerator-staging.test.mjs

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -88,7 +88,7 @@ jobs:
           $destination = Join-Path $env:RUNNER_TEMP "fallow-vsix"
           Copy-Item $vsix.FullName $archive
           Expand-Archive -Path $archive -DestinationPath $destination
-          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination\extension" $vsix.FullName
+          pnpm --dir editors/vscode verify:vsix "$destination\extension" $vsix.FullName
           "FALLOW_EXTENSION_PATH=$destination\extension" >> $env:GITHUB_ENV
 
       - name: Run isolated VSIX type-aware host smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1130,11 +1130,12 @@ jobs:
         run: |
           vsix="$(find editors/vscode -maxdepth 1 -name '*.vsix' -print -quit)"
           test -n "$vsix"
+          vsix="$(realpath "$vsix")"
           archive="$RUNNER_TEMP/fallow-vsix.zip"
           destination="$RUNNER_TEMP/fallow-vsix-release"
           cp "$vsix" "$archive"
           unzip -q "$archive" -d "$destination"
-          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination/extension" "$vsix"
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix"
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1126,6 +1126,16 @@ jobs:
           pnpm build
           pnpm package
 
+      - name: Verify packaged type-aware payload
+        run: |
+          vsix="$(find editors/vscode -maxdepth 1 -name '*.vsix' -print -quit)"
+          test -n "$vsix"
+          archive="$RUNNER_TEMP/fallow-vsix.zip"
+          destination="$RUNNER_TEMP/fallow-vsix-release"
+          cp "$vsix" "$archive"
+          unzip -q "$archive" -d "$destination"
+          node editors/vscode/scripts/verify-packaged-type-aware.mjs "$destination/extension" "$vsix"
+
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The bundled GitHub Action and GitLab CI helpers now analyze once and render
   comment/review surfaces from the saved JSON artifact.
 
+### Fixed
+
+- **Type-aware analysis now starts reliably from npm and VS Code on Windows**
+  (Closes [#2284](https://github.com/fallow-rs/fallow/issues/2284)). The npm
+  launcher invokes the companion through Node instead of asking Windows to
+  execute its `.mjs` file directly. The VS Code package now includes every
+  supported TypeScript-Go backend, and Windows child processes stay hidden
+  while preserving the existing process-tree controls.
+
 ## [3.16.0] - 2026-08-13
 
 ### Fixed

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -9,6 +9,8 @@ tsconfig.test.json
 vitest.config.mts
 rolldown.config.mjs
 pnpm-lock.yaml
+pnpm-workspace.yaml
+scripts/**
 .fallowrc.json
 **/*.map
 .gitignore

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -910,8 +910,9 @@
     "test:unit": "vitest run",
     "test:integration": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/runTest.js",
     "test:integration:real": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/real/runTest.js",
-    "prepackage": "pnpm run codegen:contracts && pnpm run build && node -e \"require('node:fs').copyFileSync('../../LICENSE', './LICENSE')\"",
+    "prepackage": "pnpm run codegen:contracts && pnpm run build && node ./scripts/copy-license.mjs",
     "package": "vsce package --no-dependencies",
+    "verify:vsix": "node ./scripts/verify-packaged-type-aware.mjs",
     "publish": "vsce publish --no-dependencies",
     "publish:ovsx": "ovsx publish --no-dependencies"
   },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -910,7 +910,7 @@
     "test:unit": "vitest run",
     "test:integration": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/runTest.js",
     "test:integration:real": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/real/runTest.js",
-    "prepackage": "pnpm run codegen:contracts && pnpm run build && cp ../../LICENSE ./LICENSE",
+    "prepackage": "pnpm run codegen:contracts && pnpm run build && node -e \"require('node:fs').copyFileSync('../../LICENSE', './LICENSE')\"",
     "package": "vsce package --no-dependencies",
     "publish": "vsce publish --no-dependencies",
     "publish:ovsx": "ovsx publish --no-dependencies"

--- a/editors/vscode/pnpm-workspace.yaml
+++ b/editors/vscode/pnpm-workspace.yaml
@@ -6,3 +6,12 @@ minimumReleaseAgeExclude:
 
 overrides:
   "brace-expansion@5": 5.0.9
+
+supportedArchitectures:
+  os:
+    - darwin
+    - linux
+    - win32
+  cpu:
+    - arm64
+    - x64

--- a/editors/vscode/scripts/copy-license.mjs
+++ b/editors/vscode/scripts/copy-license.mjs
@@ -1,0 +1,3 @@
+import { copyFileSync } from "node:fs";
+
+copyFileSync(new URL("../../../LICENSE", import.meta.url), new URL("../LICENSE", import.meta.url));

--- a/editors/vscode/scripts/package-type-aware.mjs
+++ b/editors/vscode/scripts/package-type-aware.mjs
@@ -1,4 +1,12 @@
-import { chmodSync, cpSync, mkdirSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,14 +14,75 @@ const extensionRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = join(extensionRoot, "..", "..");
 const sourceRoot = join(repoRoot, "tools", "type-aware-sidecar");
 const destination = join(extensionRoot, "dist", "type-aware");
+const protocol = JSON.parse(
+  readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
+);
+const backendVersion = protocol.backend.version;
+const platformPackages = [
+  { name: "@typescript/typescript-darwin-arm64", os: "darwin", cpu: "arm64", bin: "tsc" },
+  { name: "@typescript/typescript-darwin-x64", os: "darwin", cpu: "x64", bin: "tsc" },
+  { name: "@typescript/typescript-linux-arm64", os: "linux", cpu: "arm64", bin: "tsc" },
+  { name: "@typescript/typescript-linux-x64", os: "linux", cpu: "x64", bin: "tsc" },
+  {
+    name: "@typescript/typescript-win32-arm64",
+    os: "win32",
+    cpu: "arm64",
+    bin: "tsc.exe",
+  },
+  {
+    name: "@typescript/typescript-win32-x64",
+    os: "win32",
+    cpu: "x64",
+    bin: "tsc.exe",
+  },
+];
+
+const readPackage = (directory) =>
+  JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
+
+const copyPlatformPackage = ({ name, os, cpu, bin }) => {
+  const source = join(typescriptNodeModules, ...name.split("/"));
+  const manifest = readPackage(source);
+  if (
+    manifest.name !== name ||
+    manifest.version !== backendVersion ||
+    !manifest.os?.includes(os) ||
+    !manifest.cpu?.includes(cpu)
+  ) {
+    throw new Error(`invalid bundled TypeScript backend metadata for ${name}`);
+  }
+  const executable = join(source, "lib", bin);
+  const mode = statSync(executable).mode;
+  if (process.platform !== "win32" && os !== "win32" && (mode & 0o111) === 0) {
+    throw new Error(`bundled TypeScript backend is not executable: ${name}`);
+  }
+  cpSync(source, join(destination, "node_modules", ...name.split("/")), {
+    dereference: true,
+    recursive: true,
+  });
+};
 
 rmSync(destination, { recursive: true, force: true });
 mkdirSync(join(destination, "node_modules"), { recursive: true });
 cpSync(join(sourceRoot, "fallow-type-aware.mjs"), join(destination, "fallow-type-aware.mjs"));
 cpSync(join(sourceRoot, "src"), join(destination, "src"), { recursive: true });
 cpSync(join(sourceRoot, "package.json"), join(destination, "package.json"));
-cpSync(join(extensionRoot, "node_modules", "typescript"), join(destination, "node_modules", "typescript"), {
+const typescriptSource = join(extensionRoot, "node_modules", "typescript");
+const typescriptNodeModules = dirname(realpathSync(typescriptSource));
+const typescriptManifest = readPackage(typescriptSource);
+if (typescriptManifest.version !== backendVersion) {
+  throw new Error(`expected TypeScript ${backendVersion}, found ${typescriptManifest.version}`);
+}
+for (const { name } of platformPackages) {
+  if (typescriptManifest.optionalDependencies?.[name] !== backendVersion) {
+    throw new Error(`TypeScript does not pin ${name} to ${backendVersion}`);
+  }
+}
+cpSync(typescriptSource, join(destination, "node_modules", "typescript"), {
   dereference: true,
   recursive: true,
 });
+for (const platformPackage of platformPackages) {
+  copyPlatformPackage(platformPackage);
+}
 chmodSync(join(destination, "fallow-type-aware.mjs"), 0o755);

--- a/editors/vscode/scripts/verify-packaged-type-aware.mjs
+++ b/editors/vscode/scripts/verify-packaged-type-aware.mjs
@@ -1,0 +1,56 @@
+import { accessSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_VSIX_BYTES = 70 * 1024 * 1024;
+const extensionRoot = resolve(process.argv[2] ?? "");
+const vsixPath = process.argv[3] ? resolve(process.argv[3]) : undefined;
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const protocol = JSON.parse(
+  readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
+);
+const platformPackages = [
+  { name: "typescript-darwin-arm64", os: "darwin", cpu: "arm64", bin: "tsc" },
+  { name: "typescript-darwin-x64", os: "darwin", cpu: "x64", bin: "tsc" },
+  { name: "typescript-linux-arm64", os: "linux", cpu: "arm64", bin: "tsc" },
+  { name: "typescript-linux-x64", os: "linux", cpu: "x64", bin: "tsc" },
+  { name: "typescript-win32-arm64", os: "win32", cpu: "arm64", bin: "tsc.exe" },
+  { name: "typescript-win32-x64", os: "win32", cpu: "x64", bin: "tsc.exe" },
+];
+
+if (!process.argv[2]) {
+  throw new Error("usage: verify-packaged-type-aware.mjs <extension-root> [vsix-path]");
+}
+
+const packageRoot = join(extensionRoot, "dist", "type-aware", "node_modules", "@typescript");
+const actualPackages = readdirSync(packageRoot).sort();
+const expectedPackages = platformPackages.map(({ name }) => name).sort();
+if (JSON.stringify(actualPackages) !== JSON.stringify(expectedPackages)) {
+  throw new Error(`unexpected packaged TypeScript backends: ${actualPackages.join(", ")}`);
+}
+
+for (const { name, os, cpu, bin } of platformPackages) {
+  const directory = join(packageRoot, name);
+  const manifest = JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
+  if (
+    manifest.name !== `@typescript/${name}` ||
+    manifest.version !== protocol.backend.version ||
+    !manifest.os?.includes(os) ||
+    !manifest.cpu?.includes(cpu)
+  ) {
+    throw new Error(`invalid packaged TypeScript backend metadata for ${name}`);
+  }
+  const executable = join(directory, "lib", bin);
+  accessSync(executable);
+  if (process.platform !== "win32" && os !== "win32" && (statSync(executable).mode & 0o111) === 0) {
+    throw new Error(`packaged TypeScript backend is not executable: ${name}`);
+  }
+}
+
+accessSync(join(extensionRoot, "dist", "type-aware", "fallow-type-aware.mjs"));
+accessSync(join(extensionRoot, "dist", "type-aware", "src", "windows-child-process.mjs"));
+if (vsixPath && statSync(vsixPath).size > MAX_VSIX_BYTES) {
+  throw new Error(`VSIX exceeds ${MAX_VSIX_BYTES} bytes: ${vsixPath}`);
+}
+
+process.stdout.write("Packaged type-aware VSIX payload is complete.\n");

--- a/editors/vscode/test/integration/fixtures/real-workspace/src/index.ts
+++ b/editors/vscode/test/integration/fixtures/real-workspace/src/index.ts
@@ -1,1 +1,3 @@
-export const fixtureEntry = "entry";
+import { used } from "./used.js";
+
+export const fixtureEntry = used;

--- a/editors/vscode/test/integration/fixtures/real-workspace/src/used.ts
+++ b/editors/vscode/test/integration/fixtures/real-workspace/src/used.ts
@@ -1,0 +1,2 @@
+export const used = "entry";
+export const unused = "candidate";

--- a/editors/vscode/test/integration/fixtures/real-workspace/tsconfig.json
+++ b/editors/vscode/test/integration/fixtures/real-workspace/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/editors/vscode/test/integration/real/runTest.ts
+++ b/editors/vscode/test/integration/real/runTest.ts
@@ -3,20 +3,32 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { runTests } from "@vscode/test-electron";
 
-const extensionDevelopmentPath = path.resolve(__dirname, "../../../..");
+const repositoryExtensionPath = path.resolve(__dirname, "../../../..");
+const extensionDevelopmentPath = process.env["FALLOW_EXTENSION_PATH"]
+  ? path.resolve(process.env["FALLOW_EXTENSION_PATH"])
+  : repositoryExtensionPath;
 const extensionTestsPath = path.resolve(__dirname, "suite/index.js");
 const vscodeTestCachePath = path.join(os.tmpdir(), "fallow-vscode-test-cache");
 const fixtureWorkspacePath = path.resolve(
-  extensionDevelopmentPath,
+  repositoryExtensionPath,
   "test/integration/fixtures/real-workspace",
 );
 
 const requiredCurrentBinary = (): string => {
   const configured = process.env["FALLOW_BIN"];
   if (!configured) {
-    throw new Error(
-      "FALLOW_BIN is required for the real VS Code CLI/LSP contract smoke",
-    );
+    throw new Error("FALLOW_BIN is required for the real VS Code CLI/LSP contract smoke");
+  }
+
+  const binary = path.resolve(configured);
+  fs.accessSync(binary, fs.constants.X_OK);
+  return binary;
+};
+
+const requiredWindowsLspBinary = (): string => {
+  const configured = process.env["FALLOW_LSP_BIN"];
+  if (!configured) {
+    throw new Error("FALLOW_LSP_BIN is required for the real VS Code Windows contract smoke");
   }
 
   const binary = path.resolve(configured);
@@ -35,20 +47,28 @@ const createWorkspace = (binary: string): string => {
   );
   const vscodeDir = path.join(workspaceDir, ".vscode");
   const binDir = path.join(workspaceDir, "bin");
-  const cliPath = path.join(binDir, "fallow");
-  const lspPath = path.join(binDir, "fallow-lsp");
+  const executableSuffix = process.platform === "win32" ? ".exe" : "";
+  const cliPath = path.join(binDir, `fallow${executableSuffix}`);
+  const lspPath = path.join(binDir, `fallow-lsp${executableSuffix}`);
 
   fs.cpSync(fixtureWorkspacePath, workspaceDir, { recursive: true });
   fs.mkdirSync(vscodeDir, { recursive: true });
   fs.mkdirSync(binDir, { recursive: true });
-  fs.symlinkSync(binary, cliPath);
-  writeExecutable(lspPath, '#!/bin/sh\nexec "$FALLOW_BIN" lsp-server\n');
+  if (process.platform === "win32") {
+    fs.copyFileSync(binary, cliPath);
+    fs.copyFileSync(requiredWindowsLspBinary(), lspPath);
+  } else {
+    fs.symlinkSync(binary, cliPath);
+    writeExecutable(lspPath, '#!/bin/sh\nexec "$FALLOW_BIN" lsp-server\n');
+  }
   fs.writeFileSync(
     path.join(vscodeDir, "settings.json"),
     `${JSON.stringify(
       {
         "fallow.autoDownload": false,
         "fallow.lspPath": lspPath,
+        "fallow.typeAware.enabled": true,
+        "fallow.typeAware.require": "complete",
       },
       null,
       2,

--- a/editors/vscode/test/integration/real/suite/extension.test.ts
+++ b/editors/vscode/test/integration/real/suite/extension.test.ts
@@ -41,9 +41,7 @@ const testContext = (): vscode.ExtensionContext =>
     workspaceState: inMemoryMemento(),
   }) as vscode.ExtensionContext;
 
-const fallowDiagnostics = async (
-  uri: vscode.Uri,
-): Promise<readonly vscode.Diagnostic[]> => {
+const fallowDiagnostics = async (uri: vscode.Uri): Promise<readonly vscode.Diagnostic[]> => {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     const diagnostics = vscode.languages
@@ -58,7 +56,7 @@ const fallowDiagnostics = async (
 };
 
 describe("Fallow VS Code real-process contracts", () => {
-  it("parses the current CLI envelope and receives current LSP diagnostics", async () => {
+  it("parses the current CLI envelope with complete type-aware evidence", async () => {
     const extension = vscode.extensions.getExtension("fallow-rs.fallow-vscode");
     assert.ok(extension, "extension should be discoverable");
     const api = (await extension.activate()) as ExtensionApi;
@@ -76,7 +74,10 @@ describe("Fallow VS Code real-process contracts", () => {
     assert.ok(unusedExport, "current CLI should report the fixture's unused export");
     assert.equal(unusedExport.semantic?.status, "complete");
     assert.equal(unusedExport.semantic?.decision, "confirmed-no-static-references");
+  });
 
+  const lspTest = process.platform === "win32" ? it.skip : it;
+  lspTest("receives current LSP diagnostics", async () => {
     const orphanUri = vscode.Uri.joinPath(workspaceFolder().uri, "src", "orphan.ts");
     const document = await vscode.workspace.openTextDocument(orphanUri);
     await vscode.window.showTextDocument(document);

--- a/editors/vscode/test/integration/real/suite/extension.test.ts
+++ b/editors/vscode/test/integration/real/suite/extension.test.ts
@@ -70,6 +70,12 @@ describe("Fallow VS Code real-process contracts", () => {
       result.check.unused_files.some((finding) => finding.path === "src/orphan.ts"),
       "current CLI should report the real fixture's unused file",
     );
+    const unusedExport = result.check.unused_exports.find(
+      (finding) => finding.path === "src/used.ts" && finding.export_name === "unused",
+    );
+    assert.ok(unusedExport, "current CLI should report the fixture's unused export");
+    assert.equal(unusedExport.semantic?.status, "complete");
+    assert.equal(unusedExport.semantic?.decision, "confirmed-no-static-references");
 
     const orphanUri = vscode.Uri.joinPath(workspaceFolder().uri, "src", "orphan.ts");
     const document = await vscode.workspace.openTextDocument(orphanUri);

--- a/npm/fallow/scripts/run-binary.js
+++ b/npm/fallow/scripts/run-binary.js
@@ -145,18 +145,38 @@ function resolveTypeAwareCompanion(
   }
 }
 
-function childEnvironment(resolvedVersion, resolveCompanion = resolveTypeAwareCompanion) {
+function typeAwareCommand(
+  companion,
+  { platform = process.platform, execPath = process.execPath } = {},
+) {
+  return platform === "win32"
+    ? { binary: execPath, script: companion }
+    : { binary: companion, script: undefined };
+}
+
+function childEnvironment(
+  resolvedVersion,
+  resolveCompanion = resolveTypeAwareCompanion,
+  commandOptions,
+) {
   if (process.env.FALLOW_TYPE_AWARE_BIN) return process.env;
   const companion = resolveCompanion(resolvedVersion);
-  return companion === undefined
-    ? process.env
-    : {
-        ...process.env,
-        FALLOW_TYPE_AWARE_BIN: companion,
-        // Marks the wiring as launcher-provided node_modules resolution so
-        // `type-aware status` does not report it as a user-set override.
-        FALLOW_TYPE_AWARE_BIN_SOURCE: "npm-wrapper",
-      };
+  if (companion === undefined) return process.env;
+
+  const command = typeAwareCommand(companion, commandOptions);
+  const environment = {
+    ...process.env,
+    FALLOW_TYPE_AWARE_BIN: command.binary,
+    // Marks the wiring as launcher-provided node_modules resolution so
+    // `type-aware status` does not report it as a user-set override.
+    FALLOW_TYPE_AWARE_BIN_SOURCE: "npm-wrapper",
+  };
+  if (command.script) {
+    environment.FALLOW_TYPE_AWARE_SCRIPT = command.script;
+  } else {
+    delete environment.FALLOW_TYPE_AWARE_SCRIPT;
+  }
+  return environment;
 }
 
 // Swallow EPIPE on stdout. When fallow's output is piped into a reader that

--- a/npm/fallow/scripts/run-binary.test.js
+++ b/npm/fallow/scripts/run-binary.test.js
@@ -162,15 +162,31 @@ test("resolveTypeAwareCompanion accepts only an exact matching package", (t) => 
 test("childEnvironment marks launcher-wired companions as npm-wrapper", (t) => {
   const { childEnvironment } = require(RUN_BINARY);
   const previousBin = process.env.FALLOW_TYPE_AWARE_BIN;
+  const previousScript = process.env.FALLOW_TYPE_AWARE_SCRIPT;
   delete process.env.FALLOW_TYPE_AWARE_BIN;
+  delete process.env.FALLOW_TYPE_AWARE_SCRIPT;
   t.after(() => {
     if (previousBin === undefined) delete process.env.FALLOW_TYPE_AWARE_BIN;
     else process.env.FALLOW_TYPE_AWARE_BIN = previousBin;
+    if (previousScript === undefined) delete process.env.FALLOW_TYPE_AWARE_SCRIPT;
+    else process.env.FALLOW_TYPE_AWARE_SCRIPT = previousScript;
   });
 
-  const env = childEnvironment("3.8.0", () => "/tmp/fallow-type-aware.mjs");
+  const env = childEnvironment("3.8.0", () => "/tmp/fallow-type-aware.mjs", {
+    platform: "linux",
+    execPath: "/usr/bin/node",
+  });
   assert.equal(env.FALLOW_TYPE_AWARE_BIN, "/tmp/fallow-type-aware.mjs");
+  assert.equal(env.FALLOW_TYPE_AWARE_SCRIPT, undefined);
   assert.equal(env.FALLOW_TYPE_AWARE_BIN_SOURCE, "npm-wrapper");
+
+  const windowsEnv = childEnvironment("3.8.0", () => "C:\\pkg\\fallow-type-aware.mjs", {
+    platform: "win32",
+    execPath: "C:\\Program Files\\nodejs\\node.exe",
+  });
+  assert.equal(windowsEnv.FALLOW_TYPE_AWARE_BIN, "C:\\Program Files\\nodejs\\node.exe");
+  assert.equal(windowsEnv.FALLOW_TYPE_AWARE_SCRIPT, "C:\\pkg\\fallow-type-aware.mjs");
+  assert.equal(windowsEnv.FALLOW_TYPE_AWARE_BIN_SOURCE, "npm-wrapper");
 
   // No resolvable companion: the environment passes through untouched.
   const untouched = childEnvironment("3.8.0", () => undefined);
@@ -181,14 +197,19 @@ test("childEnvironment marks launcher-wired companions as npm-wrapper", (t) => {
 test("childEnvironment leaves a user-set override unmarked", (t) => {
   const { childEnvironment } = require(RUN_BINARY);
   const previousBin = process.env.FALLOW_TYPE_AWARE_BIN;
+  const previousScript = process.env.FALLOW_TYPE_AWARE_SCRIPT;
   process.env.FALLOW_TYPE_AWARE_BIN = "/opt/custom-sidecar";
+  process.env.FALLOW_TYPE_AWARE_SCRIPT = "/opt/custom-sidecar.mjs";
   t.after(() => {
     if (previousBin === undefined) delete process.env.FALLOW_TYPE_AWARE_BIN;
     else process.env.FALLOW_TYPE_AWARE_BIN = previousBin;
+    if (previousScript === undefined) delete process.env.FALLOW_TYPE_AWARE_SCRIPT;
+    else process.env.FALLOW_TYPE_AWARE_SCRIPT = previousScript;
   });
 
   const env = childEnvironment("3.8.0", () => "/tmp/fallow-type-aware.mjs");
   assert.equal(env, process.env);
+  assert.equal(env.FALLOW_TYPE_AWARE_SCRIPT, "/opt/custom-sidecar.mjs");
   assert.equal(env.FALLOW_TYPE_AWARE_BIN_SOURCE, undefined);
 });
 

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -147,6 +147,20 @@ test("type-aware manifest keeps every runtime and package surface in parity", ()
   const sidecarLock = readJson("tools/type-aware-sidecar/package-lock.json");
   const generated = readFileSync("tools/type-aware-sidecar/src/generated-protocol.mjs", "utf8");
   const vscodePackager = readFileSync("editors/vscode/scripts/package-type-aware.mjs", "utf8");
+  const vscodePackageVerifier = readFileSync(
+    "editors/vscode/scripts/verify-packaged-type-aware.mjs",
+    "utf8",
+  );
+  const vscodeWorkspace = readFileSync("editors/vscode/pnpm-workspace.yaml", "utf8");
+  const vscodePackage = readJson("editors/vscode/package.json");
+  const bundledBackends = [
+    "@typescript/typescript-darwin-arm64",
+    "@typescript/typescript-darwin-x64",
+    "@typescript/typescript-linux-arm64",
+    "@typescript/typescript-linux-x64",
+    "@typescript/typescript-win32-arm64",
+    "@typescript/typescript-win32-x64",
+  ];
 
   assert.equal(manifest.schema_version, 1);
   assert.equal(manifest.wire_protocol_version, 7);
@@ -167,6 +181,7 @@ test("type-aware manifest keeps every runtime and package surface in parity", ()
   assert.equal(sidecarLock.version, workspaceVersion);
   assert.equal(sidecarLock.packages[""].version, workspaceVersion);
   assert.equal(sidecarPackage.dependencies.typescript, manifest.backend.version);
+  assert.equal(vscodePackage.devDependencies.typescript, manifest.backend.version);
   assert.equal(sidecarLock.packages[""].dependencies.typescript, manifest.backend.version);
   assert.equal(sidecarLock.packages["node_modules/typescript"].version, manifest.backend.version);
   assert.deepEqual(sidecarPackage.bin, {
@@ -177,6 +192,16 @@ test("type-aware manifest keeps every runtime and package surface in parity", ()
   assert.ok(sidecarPackage.files.includes("src"));
   assert.match(generated, /Generated from crates\/api\/type-aware-protocol\.json/u);
   assert.match(vscodePackager, /cpSync\(join\(sourceRoot, "src"\)/u);
+  for (const packageName of bundledBackends) {
+    assert.match(vscodePackager, new RegExp(packageName.replace("/", "\\/"), "u"));
+    assert.match(vscodePackageVerifier, new RegExp(packageName.replace("@typescript/", ""), "u"));
+  }
+  assert.match(vscodePackager, /tsc(?:\\\\\.exe)?/u);
+  assert.match(vscodePackageVerifier, /MAX_VSIX_BYTES/u);
+  assert.match(vscodeWorkspace, /supportedArchitectures:/u);
+  assert.match(vscodeWorkspace, /- win32/u);
+  assert.match(vscodeWorkspace, /- darwin/u);
+  assert.match(vscodeWorkspace, /- linux/u);
 });
 
 test("type-aware public surfaces expose only the stable protocol", () => {

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -182,6 +182,8 @@ test("type-aware manifest keeps every runtime and package surface in parity", ()
   assert.equal(sidecarLock.packages[""].version, workspaceVersion);
   assert.equal(sidecarPackage.dependencies.typescript, manifest.backend.version);
   assert.equal(vscodePackage.devDependencies.typescript, manifest.backend.version);
+  assert.match(vscodePackage.scripts.prepackage, /scripts\/copy-license\.mjs/u);
+  assert.match(vscodePackage.scripts["verify:vsix"], /verify-packaged-type-aware\.mjs/u);
   assert.equal(sidecarLock.packages[""].dependencies.typescript, manifest.backend.version);
   assert.equal(sidecarLock.packages["node_modules/typescript"].version, manifest.backend.version);
   assert.deepEqual(sidecarPackage.bin, {

--- a/scripts/type-aware-windows-candidate-smoke.mjs
+++ b/scripts/type-aware-windows-candidate-smoke.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { accessSync, copyFileSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const PREACT_COMMIT = "055cc5b8c62326fbb0fcaccb9816504e82f121b8";
+const COMMAND_TIMEOUT_MS = 180_000;
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const candidateBinary = process.env.FALLOW_CANDIDATE_BIN;
+const npmCli = join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+const backendVersion = JSON.parse(
+  readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
+).backend.version;
+
+if (process.platform !== "win32") throw new Error("Windows candidate smoke requires win32");
+if (!candidateBinary) throw new Error("FALLOW_CANDIDATE_BIN is required");
+accessSync(npmCli);
+
+const run = (command, args, options = {}) => {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: COMMAND_TIMEOUT_MS,
+    ...options,
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(" ")} failed\n${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+  );
+  return result.stdout;
+};
+
+const runNpm = (args, options = {}) => run(process.execPath, [npmCli, ...args], options);
+
+const temporaryRoot = realpathSync(mkdtempSync(join(tmpdir(), "fallow-windows-candidate-")));
+try {
+  const wrapperPack = JSON.parse(
+    runNpm([
+      "pack",
+      join(repoRoot, "npm", "fallow"),
+      "--pack-destination",
+      temporaryRoot,
+      "--json",
+    ]),
+  )[0].filename;
+  const sidecarPack = JSON.parse(
+    runNpm([
+      "pack",
+      join(repoRoot, "tools", "type-aware-sidecar"),
+      "--pack-destination",
+      temporaryRoot,
+      "--json",
+    ]),
+  )[0].filename;
+  runNpm([
+    "install",
+    "--prefix",
+    temporaryRoot,
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    join(temporaryRoot, wrapperPack),
+    join(temporaryRoot, sidecarPack),
+  ]);
+
+  const installedFallow = join(temporaryRoot, "node_modules", "fallow");
+  const require = createRequire(import.meta.url);
+  const { getPlatformPackage } = require(join(installedFallow, "scripts", "platform-package.js"));
+  const platformPackage = getPlatformPackage(process.platform, process.arch);
+  assert.ok(platformPackage);
+  const platformManifest = require.resolve(`${platformPackage}/package.json`, {
+    paths: [installedFallow],
+  });
+  const installedBinary = join(dirname(platformManifest), "fallow.exe");
+  copyFileSync(resolve(candidateBinary), installedBinary);
+  const wrapper = join(installedFallow, "bin", "fallow");
+  const environment = { ...process.env, FALLOW_SKIP_BINARY_VERIFY: "1" };
+  const status = JSON.parse(
+    run(process.execPath, [wrapper, "type-aware", "status", "--format", "json", "--quiet"], {
+      env: environment,
+    }),
+  );
+  assert.equal(status.available, true);
+  assert.equal(status.discovery_source, "npm-wrapper");
+  assert.equal(status.backend_version, backendVersion);
+
+  const preactRoot = join(temporaryRoot, "preact");
+  run("git", [
+    "clone",
+    "--depth",
+    "1",
+    "--branch",
+    "10.25.4",
+    "https://github.com/preactjs/preact.git",
+    preactRoot,
+  ]);
+  assert.equal(run("git", ["-C", preactRoot, "rev-parse", "HEAD"]).trim(), PREACT_COMMIT);
+
+  const result = JSON.parse(
+    run(
+      process.execPath,
+      [
+        wrapper,
+        "dead-code",
+        "--root",
+        preactRoot,
+        "--unused-exports",
+        "--unused-types",
+        "--type-aware",
+        "--format",
+        "json",
+        "--quiet",
+      ],
+      { env: environment },
+    ),
+  );
+  const metadata = result._meta?.type_aware ?? result._meta?.check?.type_aware;
+  assert.equal(metadata?.executed, true);
+  assert.equal(metadata?.backend_version, backendVersion);
+  assert.ok(metadata.candidate_count > 0);
+  assert.ok(metadata.projects.length > 0);
+  process.stdout.write("Windows npm candidate completed the pinned Preact semantic smoke.\n");
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/type-aware-windows-candidate-smoke.mjs
+++ b/scripts/type-aware-windows-candidate-smoke.mjs
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 
 const PREACT_COMMIT = "055cc5b8c62326fbb0fcaccb9816504e82f121b8";
 const COMMAND_TIMEOUT_MS = 180_000;
+const SUCCESS_OR_FINDINGS_EXIT_CODES = [0, 1];
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const candidateBinary = process.env.FALLOW_CANDIDATE_BIN;
 const npmCli = join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
@@ -19,7 +20,7 @@ if (process.platform !== "win32") throw new Error("Windows candidate smoke requi
 if (!candidateBinary) throw new Error("FALLOW_CANDIDATE_BIN is required");
 accessSync(npmCli);
 
-const run = (command, args, options = {}) => {
+const run = (command, args, { acceptedExitCodes = [0], ...options } = {}) => {
   const result = spawnSync(command, args, {
     cwd: repoRoot,
     encoding: "utf8",
@@ -27,9 +28,8 @@ const run = (command, args, options = {}) => {
     timeout: COMMAND_TIMEOUT_MS,
     ...options,
   });
-  assert.equal(
-    result.status,
-    0,
+  assert.ok(
+    acceptedExitCodes.includes(result.status),
     `${command} ${args.join(" ")} failed\n${result.stdout ?? ""}\n${result.stderr ?? ""}`,
   );
   return result.stdout;
@@ -116,7 +116,7 @@ try {
         "json",
         "--quiet",
       ],
-      { env: environment },
+      { acceptedExitCodes: SUCCESS_OR_FINDINGS_EXIT_CODES, env: environment },
     ),
   );
   const metadata = result._meta?.type_aware ?? result._meta?.check?.type_aware;

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -273,10 +273,10 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.match(windowsTypeAwareJob, /cargo test -p fallow-api type_aware::transport/);
   assert.match(windowsTypeAwareJob, /type-aware-windows-candidate-smoke\.mjs/);
   assert.match(windowsTypeAwareJob, /FALLOW_LSP_BIN:/);
-  assert.match(windowsTypeAwareJob, /verify-packaged-type-aware\.mjs/);
+  assert.match(windowsTypeAwareJob, /verify:vsix/);
   assert.match(windowsTypeAwareJob, /pnpm package/);
   assert.match(windowsTypeAwareJob, /test:integration:real/);
-  assert.match(vscodeJob, /verify-packaged-type-aware\.mjs/);
+  assert.match(vscodeJob, /verify:vsix/);
   assert.match(vscodeJob, /FALLOW_EXTENSION_PATH=/);
   assert.match(vscodeJob, /name: Run extracted production VSIX host smoke/);
   assert.match(zedJob, /runs-on: ubuntu-latest/);
@@ -353,7 +353,7 @@ test("release runs Windows correctness and lifecycle verification without creden
   assert.match(job, /cargo fmt --all -- --check/);
   assert.match(job, /npm run publish:prepare/);
   assert.match(job, /cd crates\/napi && npm test/);
-  assert.match(job, /verify-packaged-type-aware\.mjs/);
+  assert.match(job, /verify:vsix/);
   assert.match(job, /FALLOW_LSP_BIN:/);
   assert.match(job, /type-aware-windows-candidate-smoke\.mjs/);
   assert.match(job, /FALLOW_CANDIDATE_BIN:/);
@@ -421,7 +421,7 @@ test("release publication waits for the aggregate verification gate", () => {
   assert.match(releaseAssets, /needs: release-verified/);
   assert.match(releaseAssets, /permissions:\n\s+contents: read/);
   assert.match(npmPublish, /needs: \[npm-prep, release-assets\]/);
-  assert.match(vscodePrep, /verify-packaged-type-aware\.mjs/);
+  assert.match(vscodePrep, /verify:vsix/);
   assert.match(vscodePublish, /needs: \[vscode-prep, release-assets\]/);
   assert.match(
     releaseReady,

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -210,13 +210,18 @@ test("binary-size workflow isolates incompatible release builds", () => {
 test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const windowsRustPaths = listedPaths(indentedBlock(workflow, "windows-rust", 12));
+  const windowsTypeAwarePaths = listedPaths(indentedBlock(workflow, "windows-type-aware", 12));
   const checkJob = indentedBlock(workflow, "check", 2);
   const windowsRustJob = indentedBlock(workflow, "windows-rust", 2);
+  const windowsTypeAwareJob = indentedBlock(workflow, "windows-type-aware", 2);
+  const vscodeJob = indentedBlock(workflow, "vscode", 2);
   const zedJob = indentedBlock(workflow, "zed", 2);
   const aggregateJob = indentedBlock(workflow, "ci-ok", 2);
-  const workflowWithoutWindowsRust = workflow.replace(windowsRustJob, "");
+  const workflowWithoutWindowsJobs = workflow
+    .replace(windowsRustJob, "")
+    .replace(windowsTypeAwareJob, "");
 
-  assert.doesNotMatch(workflowWithoutWindowsRust, /windows-latest|windows-11-arm|macos-latest/);
+  assert.doesNotMatch(workflowWithoutWindowsJobs, /windows-latest|windows-11-arm|macos-latest/);
   assert.match(checkJob, /runs-on: ubuntu-latest/);
   assert.match(checkJob, /timeout-minutes: 20/);
   assert.doesNotMatch(checkJob, /matrix\.|windows-latest|macos-latest/);
@@ -252,6 +257,28 @@ test("regular CI keeps affected checks on Ubuntu", () => {
     windowsRustJob,
     /^[ \t]+run: cargo clippy -p fallow-cli -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings$/m,
   );
+  assert.match(windowsTypeAwareJob, /needs: changes/);
+  assert.match(windowsTypeAwareJob, /if: needs\.changes\.outputs\.windows-type-aware == 'true'/);
+  assert.match(windowsTypeAwareJob, /runs-on: windows-latest/);
+  assert.ok(windowsTypeAwarePaths.includes("npm/fallow/scripts/run-binary.js"));
+  assert.ok(windowsTypeAwarePaths.includes("npm/fallow/package.json"));
+  assert.ok(windowsTypeAwarePaths.includes("npm/fallow/bin/**"));
+  assert.ok(windowsTypeAwarePaths.includes("tools/type-aware-sidecar/**"));
+  assert.ok(windowsTypeAwarePaths.includes("editors/vscode/scripts/package-type-aware.mjs"));
+  assert.ok(
+    windowsTypeAwarePaths.includes("editors/vscode/scripts/verify-packaged-type-aware.mjs"),
+  );
+  assert.ok(windowsTypeAwarePaths.includes("crates/api/src/type_aware/transport/**"));
+  assert.match(windowsTypeAwareJob, /npm\/fallow\/scripts\/run-binary\.test\.js/);
+  assert.match(windowsTypeAwareJob, /cargo test -p fallow-api type_aware::transport/);
+  assert.match(windowsTypeAwareJob, /type-aware-windows-candidate-smoke\.mjs/);
+  assert.match(windowsTypeAwareJob, /FALLOW_LSP_BIN:/);
+  assert.match(windowsTypeAwareJob, /verify-packaged-type-aware\.mjs/);
+  assert.match(windowsTypeAwareJob, /pnpm package/);
+  assert.match(windowsTypeAwareJob, /test:integration:real/);
+  assert.match(vscodeJob, /verify-packaged-type-aware\.mjs/);
+  assert.match(vscodeJob, /FALLOW_EXTENSION_PATH=/);
+  assert.match(vscodeJob, /name: Run extracted production VSIX host smoke/);
   assert.match(zedJob, /runs-on: ubuntu-latest/);
   assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);
   assert.throws(() => indentedBlock(workflow, "windows-arm64", 2), /missing windows-arm64 block/);
@@ -260,6 +287,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
     /missing windows-audit-smoke block/,
   );
   assert.match(aggregateJob, /windows-rust/);
+  assert.match(aggregateJob, /windows-type-aware/);
   assert.match(aggregateJob, /needs: \[[^\n]*\bzed\b[^\n]*\]/);
   assert.doesNotMatch(aggregateJob, /windows-audit-smoke|windows-arm64/);
 });
@@ -325,6 +353,10 @@ test("release runs Windows correctness and lifecycle verification without creden
   assert.match(job, /cargo fmt --all -- --check/);
   assert.match(job, /npm run publish:prepare/);
   assert.match(job, /cd crates\/napi && npm test/);
+  assert.match(job, /verify-packaged-type-aware\.mjs/);
+  assert.match(job, /FALLOW_LSP_BIN:/);
+  assert.match(job, /type-aware-windows-candidate-smoke\.mjs/);
+  assert.match(job, /FALLOW_CANDIDATE_BIN:/);
   assert.match(job, /audit_orphan_sweep_removes_dead_pid_worktree/);
   assert.match(job, /run_fallow_timeout_terminates_and_reaps_windows_job_tree/);
 });
@@ -373,6 +405,7 @@ test("release publication waits for the aggregate verification gate", () => {
   const releaseAssets = indentedBlock(workflow, "release-assets", 2);
   const releaseReady = indentedBlock(workflow, "release-ready", 2);
   const npmPublish = indentedBlock(workflow, "npm-publish", 2);
+  const vscodePrep = indentedBlock(workflow, "vscode-prep", 2);
   const vscodePublish = indentedBlock(workflow, "vscode-publish", 2);
 
   assert.match(context, /permissions:\n\s+contents: read/);
@@ -388,6 +421,7 @@ test("release publication waits for the aggregate verification gate", () => {
   assert.match(releaseAssets, /needs: release-verified/);
   assert.match(releaseAssets, /permissions:\n\s+contents: read/);
   assert.match(npmPublish, /needs: \[npm-prep, release-assets\]/);
+  assert.match(vscodePrep, /verify-packaged-type-aware\.mjs/);
   assert.match(vscodePublish, /needs: \[vscode-prep, release-assets\]/);
   assert.match(
     releaseReady,

--- a/tools/type-aware-sidecar/fallow-type-aware.mjs
+++ b/tools/type-aware-sidecar/fallow-type-aware.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
-import { assertTypescriptBackendResolvable } from "./src/backend-preflight.mjs";
+import { installWindowsChildProcessPolicy } from "./src/windows-child-process.mjs";
+
+installWindowsChildProcessPolicy();
 
 try {
+  const { assertTypescriptBackendResolvable } = await import("./src/backend-preflight.mjs");
   assertTypescriptBackendResolvable();
   const { run } = await import("./src/cli.mjs");
   await run({ input: process.stdin, output: process.stdout, args: process.argv.slice(2) });

--- a/tools/type-aware-sidecar/src/windows-child-process.mjs
+++ b/tools/type-aware-sidecar/src/windows-child-process.mjs
@@ -1,0 +1,25 @@
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+
+const INSTALL_MARKER = Symbol.for("fallow.type-aware.windows-child-process-policy");
+
+const hiddenOptions = (options) => ({ ...options, windowsHide: true });
+
+/** Keep TypeScript-Go child processes hidden when the sidecar runs on Windows. */
+export const installWindowsChildProcessPolicy = ({
+  childProcess: processApi = childProcess,
+  platform = process.platform,
+  syncBuiltinESMExports: syncExports = syncBuiltinESMExports,
+} = {}) => {
+  if (platform !== "win32" || processApi[INSTALL_MARKER] === true) return;
+
+  const originalSpawn = processApi.spawn;
+  processApi.spawn = function spawnHidden(command, args, options) {
+    if (Array.isArray(args)) {
+      return originalSpawn.call(this, command, args, hiddenOptions(options));
+    }
+    return originalSpawn.call(this, command, hiddenOptions(args));
+  };
+  Object.defineProperty(processApi, INSTALL_MARKER, { value: true });
+  syncExports();
+};

--- a/tools/type-aware-sidecar/test/windows-child-process.test.mjs
+++ b/tools/type-aware-sidecar/test/windows-child-process.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import { installWindowsChildProcessPolicy } from "../src/windows-child-process.mjs";
+
+const fakeChildProcess = () => {
+  const calls = [];
+  return {
+    calls,
+    spawn(...args) {
+      calls.push(args);
+      return { pid: 42 };
+    },
+  };
+};
+
+test("Windows child process policy hides both spawn overloads", () => {
+  const childProcess = fakeChildProcess();
+  let syncCount = 0;
+  installWindowsChildProcessPolicy({
+    childProcess,
+    platform: "win32",
+    syncBuiltinESMExports: () => {
+      syncCount += 1;
+    },
+  });
+
+  const argsOptions = {
+    cwd: "C:\\project",
+    detached: false,
+    env: { FALLOW_TEST: "1" },
+    stdio: ["ignore", "pipe", "inherit"],
+    windowsHide: false,
+  };
+  childProcess.spawn("tsc.exe", ["--api"], argsOptions);
+  assert.deepEqual(childProcess.calls[0], [
+    "tsc.exe",
+    ["--api"],
+    { ...argsOptions, windowsHide: true },
+  ]);
+  assert.equal(argsOptions.windowsHide, false);
+
+  const optionsOnly = { cwd: "C:\\project", shell: false };
+  childProcess.spawn("tsc.exe", optionsOnly);
+  assert.deepEqual(childProcess.calls[1], ["tsc.exe", { ...optionsOnly, windowsHide: true }]);
+  assert.equal(syncCount, 1);
+});
+
+test("Windows child process policy is idempotent", () => {
+  const childProcess = fakeChildProcess();
+  let syncCount = 0;
+  const options = {
+    childProcess,
+    platform: "win32",
+    syncBuiltinESMExports: () => {
+      syncCount += 1;
+    },
+  };
+  installWindowsChildProcessPolicy(options);
+  const wrapped = childProcess.spawn;
+  installWindowsChildProcessPolicy(options);
+
+  assert.equal(childProcess.spawn, wrapped);
+  assert.equal(syncCount, 1);
+});
+
+test("child process policy leaves non-Windows spawn unchanged", () => {
+  const childProcess = fakeChildProcess();
+  const original = childProcess.spawn;
+  let synced = false;
+  installWindowsChildProcessPolicy({
+    childProcess,
+    platform: "linux",
+    syncBuiltinESMExports: () => {
+      synced = true;
+    },
+  });
+
+  assert.equal(childProcess.spawn, original);
+  assert.equal(synced, false);
+});
+
+test("Windows child process policy updates the real ESM spawn binding", () => {
+  const policyUrl = new URL("../src/windows-child-process.mjs", import.meta.url).href;
+  const script = `
+    import assert from "node:assert/strict";
+    import childProcess, { spawn } from "node:child_process";
+    import { installWindowsChildProcessPolicy } from ${JSON.stringify(policyUrl)};
+    let call;
+    childProcess.spawn = (...args) => { call = args; return { pid: 42 }; };
+    installWindowsChildProcessPolicy({ platform: "win32" });
+    spawn("tsc.exe", { cwd: "C:\\\\project", windowsHide: false });
+    assert.deepEqual(call, ["tsc.exe", { cwd: "C:\\\\project", windowsHide: true }]);
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+});


### PR DESCRIPTION
Fixes the Windows startup and packaging failures reported in #2284.

Thank you @VariableVince for the detailed npm and VS Code observations.

Fixes #2284.