### PR TITLE
chore(benchmarks): remove stale CodSpeed coverage

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -134,10 +134,6 @@ jobs:
             cache_key: full-scaling-analysis
             package: fallow-core
             bench: scaling_analysis
-          - label: large analysis
-            cache_key: full-large-analysis
-            package: fallow-core
-            bench: large_analysis
           - label: engine dupes pipeline
             cache_key: full-engine-dupes-pipeline
             package: fallow-engine

--- a/crates/engine/benches/dupes_pipeline.rs
+++ b/crates/engine/benches/dupes_pipeline.rs
@@ -158,16 +158,6 @@ fn create_dupes_input(name: &str, file_count: usize) -> DupesInput {
 fn bench_dupes_pipeline(c: &mut Criterion) {
     let mut group = c.benchmark_group("dupes_pipeline");
 
-    group.bench_function("scaling_dupes_full_pipeline_1000_files", |bencher| {
-        bencher.iter_batched_ref(
-            || create_dupes_input("1000", 1000),
-            |input| {
-                fallow_engine::duplicates::find_duplicates(&input.root, &input.files, &input.config)
-            },
-            BatchSize::LargeInput,
-        );
-    });
-
     group.bench_function("dupes_full_pipeline_1000_files", |bencher| {
         bencher.iter_batched_ref(
             || create_dupes_input("1000", 1000),

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -62,12 +62,13 @@ Fast PR shards:
 Full main/manual shards:
 
 - `fallow-core/scaling_analysis`: larger synthetic scaling probes.
-- `fallow-core/large_analysis`: broad high-cost analysis probes.
+- `fallow-engine/dupes_pipeline`: full duplicate-detection pipelines at large
+  project sizes.
 
 `programmatic_commands` still exists for local walltime investigation, but it
 contains git/audit scenarios and must not run in the fast CodSpeed matrix.
-`dupes_pipeline` in `crates/engine/benches/` is likewise a local-only bench
-outside the fast CodSpeed matrix.
+`large_analysis` likewise remains available as a local-only high-cost analysis
+suite; its archived identities no longer run in CodSpeed CI.
 
 ## Adding Benchmarks
 

--- a/scripts/check-benchmark-harness.py
+++ b/scripts/check-benchmark-harness.py
@@ -33,10 +33,12 @@ TYPE_AWARE_BENCH = REPO_ROOT / "tools" / "type-aware-sidecar" / "bench" / "sessi
 TYPE_AWARE_MANIFEST = REPO_ROOT / "tools" / "type-aware-sidecar" / "package.json"
 MAX_BENCHES_PER_SHARD = 1_000
 NOISY_FAST_TARGETS = {
-    ("fallow-benchmarks", "programmatic_commands"),
     ("fallow-core", "scaling_analysis"),
-    ("fallow-core", "large_analysis"),
     ("fallow-engine", "dupes_pipeline"),
+}
+LOCAL_ONLY_TARGETS = {
+    ("fallow-benchmarks", "programmatic_commands"),
+    ("fallow-core", "large_analysis"),
 }
 REQUIRED_FAST_TARGETS = {
     ("fallow-core", "analysis"),
@@ -50,7 +52,7 @@ REQUIRED_FAST_TARGETS = {
 }
 REQUIRED_FULL_TARGETS = {
     ("fallow-core", "scaling_analysis"),
-    ("fallow-core", "large_analysis"),
+    ("fallow-engine", "dupes_pipeline"),
 }
 
 
@@ -276,6 +278,9 @@ def validate_targets(targets: list[BenchTarget]) -> list[str]:
 
         if target.job == FAST_JOB and key in NOISY_FAST_TARGETS:
             errors.append(f"noisy target {target.package}/{target.bench} cannot run in fast PR job")
+
+        if key in LOCAL_ONLY_TARGETS:
+            errors.append(f"local-only target {target.package}/{target.bench} cannot run in CodSpeed CI")
 
         if target.bench == "programmatic_stable":
             unstable = [name for name in names if not name.startswith("stable_")]


### PR DESCRIPTION
Removes the duplicate `scaling_dupes_full_pipeline_1000_files` identity and stops uploading the fully archived `large_analysis` suite to CodSpeed.

The local `large_analysis`, `programmatic_commands`, and allocation benchmarks remain available. The harness now prevents local-only suites from being added back to CodSpeed CI and requires the retained duplicate-pipeline shard.

Verification:
- benchmark matrix and harness checks pass
- workflow security checks pass
- workspace bench compilation and strict Clippy pass
- repository fast verification passes