### PR TITLE
perf(engine): coalesce duplicate line ranges

### DIFF
--- a/crates/engine/src/duplication_detector/detect/statistics.rs
+++ b/crates/engine/src/duplication_detector/detect/statistics.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use crate::duplicates::types::{CloneGroup, DuplicationStats};
 
@@ -13,18 +13,16 @@ pub(super) fn compute_stats(
     total_lines: usize,
     total_tokens: usize,
 ) -> DuplicationStats {
-    let mut files_with_clones: FxHashSet<&Path> = FxHashSet::default();
-    let mut file_dup_lines: FxHashMap<&Path, FxHashSet<usize>> = FxHashMap::default();
+    let mut file_dup_ranges: FxHashMap<&Path, Vec<(usize, usize)>> = FxHashMap::default();
     let mut duplicated_tokens = 0usize;
     let mut clone_instances = 0usize;
 
     for group in clone_groups {
         for instance in &group.instances {
-            files_with_clones.insert(&instance.file);
             clone_instances += 1;
-            let lines = file_dup_lines.entry(&instance.file).or_default();
-            for line in instance.start_line..=instance.end_line {
-                lines.insert(line);
+            let ranges = file_dup_ranges.entry(&instance.file).or_default();
+            if instance.start_line <= instance.end_line {
+                ranges.push((instance.start_line, instance.end_line));
             }
         }
         if group.instances.len() > 1 {
@@ -32,7 +30,10 @@ pub(super) fn compute_stats(
         }
     }
 
-    let dup_line_count: usize = file_dup_lines.values().map(FxHashSet::len).sum();
+    let dup_line_count = file_dup_ranges
+        .values_mut()
+        .map(|ranges| count_covered_lines(ranges))
+        .sum();
     let duplication_percentage = if total_lines > 0 {
         (dup_line_count as f64 / total_lines as f64) * 100.0
     } else {
@@ -43,7 +44,7 @@ pub(super) fn compute_stats(
 
     DuplicationStats {
         total_files,
-        files_with_clones: files_with_clones.len(),
+        files_with_clones: file_dup_ranges.len(),
         total_lines,
         duplicated_lines: dup_line_count,
         total_tokens,
@@ -55,4 +56,24 @@ pub(super) fn compute_stats(
         clone_groups_ignored: 0,
         near_candidates_skipped: 0,
     }
+}
+
+fn count_covered_lines(ranges: &mut [(usize, usize)]) -> usize {
+    ranges.sort_unstable();
+    let Some(&(mut current_start, mut current_end)) = ranges.first() else {
+        return 0;
+    };
+
+    let mut covered = 0usize;
+    for &(start, end) in &ranges[1..] {
+        if start <= current_end.saturating_add(1) {
+            current_end = current_end.max(end);
+            continue;
+        }
+
+        covered += current_end - current_start + 1;
+        (current_start, current_end) = (start, end);
+    }
+
+    covered + current_end - current_start + 1
 }

--- a/crates/engine/src/duplication_detector/detect/tests.rs
+++ b/crates/engine/src/duplication_detector/detect/tests.rs
@@ -1146,6 +1146,45 @@ fn stats_multiple_groups_same_file() {
 }
 
 #[test]
+fn stats_coalesces_nested_adjacent_and_disjoint_ranges_per_file() {
+    use crate::duplicates::types::{CloneGroup, CloneInstance};
+
+    let instance = |file: &str, start_line, end_line| CloneInstance {
+        file: PathBuf::from(file),
+        start_line,
+        end_line,
+        start_col: 0,
+        end_col: 0,
+        fragment: String::new(),
+    };
+    let groups = vec![
+        CloneGroup {
+            instances: vec![
+                instance("a.ts", 10, 20),
+                instance("a.ts", 12, 15),
+                instance("a.ts", 21, 25),
+                instance("a.ts", 40, 42),
+            ],
+            token_count: 10,
+            line_count: 11,
+            similarity: None,
+        },
+        CloneGroup {
+            instances: vec![instance("b.ts", 5, 5), instance("b.ts", 9, 8)],
+            token_count: 5,
+            line_count: 1,
+            similarity: None,
+        },
+    ];
+
+    let stats = statistics::compute_stats(&groups, 2, 100, 100);
+
+    assert_eq!(stats.files_with_clones, 2);
+    assert_eq!(stats.clone_instances, 6);
+    assert_eq!(stats.duplicated_lines, 20);
+}
+
+#[test]
 fn stats_single_instance_no_duplicated_tokens() {
     use crate::duplicates::types::{CloneGroup, CloneInstance};
 
@@ -1391,8 +1430,42 @@ fn detector_groups_sorted_by_token_count_desc() {
 mod proptests {
     use super::*;
     use proptest::prelude::*;
+    use rustc_hash::FxHashSet;
 
     proptest! {
+        #[test]
+        fn stats_line_union_matches_set_reference(
+            ranges in prop::collection::vec((0usize..200, 0usize..50), 0..100)
+        ) {
+            use crate::duplicates::types::{CloneGroup, CloneInstance};
+
+            let instances = ranges
+                .iter()
+                .map(|&(start, len)| CloneInstance {
+                    file: PathBuf::from("a.ts"),
+                    start_line: start,
+                    end_line: start + len,
+                    start_col: 0,
+                    end_col: 0,
+                    fragment: String::new(),
+                })
+                .collect::<Vec<_>>();
+            let expected = ranges
+                .iter()
+                .flat_map(|&(start, len)| start..=start + len)
+                .collect::<FxHashSet<_>>()
+                .len();
+            let groups = vec![CloneGroup {
+                instances,
+                token_count: 1,
+                line_count: 1,
+                similarity: None,
+            }];
+
+            let stats = statistics::compute_stats(&groups, 1, 300, 300);
+            prop_assert_eq!(stats.duplicated_lines, expected);
+        }
+
         /// Suffix array is always a permutation of 0..n.
         #[test]
         fn suffix_array_is_permutation(values in prop::collection::vec(-100i64..100i64, 1..100)) {


### PR DESCRIPTION
## Summary

- Count duplicated lines by sorting and coalescing inclusive ranges per file instead of inserting every covered line into hash sets.
- Preserve first-order statistics, file counting, overlapping and adjacent range behavior, and invalid reversed-range behavior.
- Add deterministic edge-case coverage plus a property comparison against the previous set-based reference.

## Performance

Exact official WallTime on base `aba36fe9` versus head `8e857a689`:

- `dupe_detect_80x20x80_interval_pressure`: 36.1 ms to 30.9 ms, +16.88%.
- Full `dupes-detect` comparison: five improvements, five unchanged, no regressions.
- CodSpeed runs: base `6a82fc46deb38ae8dc2976e4`, head `6a82ffaadeb38ae8dc29773a`.

Simulation corroborates lower modeled CPU time, but crossed CPU models and is supporting evidence only.

## Validation

- Focused statistics tests and property parity pass.
- Full `fallow-engine` tests pass.
- Strict workspace Clippy, formatting, diff checks, typo checks, and benchmark compilation pass.
- Exact base/head RHC duplication JSON is byte-identical after normalizing only elapsed time and telemetry run ID.