### PR TITLE
test(npm): run the launcher verify tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,12 @@ jobs:
             windows-type-aware:
               - 'npm/fallow/scripts/run-binary.js'
               - 'npm/fallow/scripts/run-binary.test.js'
+              - 'npm/fallow/scripts/verify-binary.js'
+              - 'npm/fallow/scripts/verify-binary.test.js'
+              - 'npm/fallow/scripts/sentinel-path.js'
+              - 'npm/fallow/scripts/sentinel-path.test.js'
+              - 'npm/fallow/scripts/platform-package.js'
+              - 'npm/fallow/scripts/platform-package.test.js'
               - 'npm/fallow/package.json'
               - 'npm/fallow/bin/**'
               - 'tools/type-aware-sidecar/**'
@@ -409,6 +415,9 @@ jobs:
         run: >
           node --test
           npm/fallow/scripts/run-binary.test.js
+          npm/fallow/scripts/verify-binary.test.js
+          npm/fallow/scripts/sentinel-path.test.js
+          npm/fallow/scripts/platform-package.test.js
           tools/type-aware-sidecar/test/windows-child-process.test.mjs
       - name: Test Rust type-aware transport
         run: cargo test -p fallow-api type_aware::transport

--- a/npm/fallow/scripts/sentinel-path.test.js
+++ b/npm/fallow/scripts/sentinel-path.test.js
@@ -220,12 +220,19 @@ test("resolveSentinelPath honors injected isWritable + ensureDir for full test i
 test("resolveSentinelPath skips cache-dir-env when ensureDir fails for it", () => {
   // FALLOW_VERIFY_CACHE_DIR points at a non-creatable path, XDG points at a
   // creatable one. Confirm the resolver moves past the env override.
+  //
+  // A directory nested under a regular FILE is the portable way to make mkdir
+  // fail: `/dev/null/inside/a/file` only refuses on POSIX, and on Windows the
+  // recursive mkdir succeeds against the current drive, which both defeats the
+  // assertion and creates C:\dev outside any temp directory.
   const homeDir = mkTmp();
+  const blocker = path.join(homeDir, "not-a-directory");
+  fs.writeFileSync(blocker, "");
   try {
     const result = resolveSentinelPath({
       platformPkgDir: undefined,
       packageName: "@fallow-cli/darwin-arm64",
-      env: { FALLOW_VERIFY_CACHE_DIR: "/dev/null/inside/a/file" },
+      env: { FALLOW_VERIFY_CACHE_DIR: path.join(blocker, "inside", "a", "file") },
       homedir: homeDir,
       platform: "darwin",
     });

--- a/npm/fallow/scripts/verify-binary.test.js
+++ b/npm/fallow/scripts/verify-binary.test.js
@@ -239,10 +239,20 @@ test("verifyBinaryAt uses the embedded production public key", () => {
   }
 });
 
+// Mirror binaryTargetsForPlatform: the suffix comes from the platformId under
+// test, never from the live process.platform. A `dirOverride` run without an
+// explicit platformId is labelled "test-platform" by
+// resolvePlatformPackageForVerify, so the binary it looks for is plain `fallow`
+// on every host -- a fixture keyed off process.platform writes `fallow.exe` on a
+// Windows host and the verify then finds nothing.
+function extForPlatformId(platformId) {
+  return typeof platformId === "string" && platformId.startsWith("win32") ? ".exe" : "";
+}
+
 function makePlatformDir(privateKey, options) {
   const opts = options || {};
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fallow-vbtest-"));
-  const ext = process.platform === "win32" ? ".exe" : "";
+  const ext = extForPlatformId(opts.platformId);
   for (const base of ["fallow"]) {
     const binaryPath = path.join(dir, `${base}${ext}`);
     const content = Buffer.from(`mock ${base} contents`);
@@ -326,6 +336,42 @@ test("verifyInstalled with dirOverride returns ok when every binary verifies", a
   });
   assert.equal(result.ok, true);
   assert.equal(result.package, "<override>");
+});
+
+// binaryTargetsForPlatform reads windows-ness off the platformId so a Windows
+// verify can be synthesized anywhere. Nothing exercised that, which left the
+// `.exe` target unverified on Linux CI and unverified on Windows too.
+test("verifyInstalled verifies the .exe target for a win32 platformId on any host", async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const platformId = "win32-x64-msvc";
+  const dir = makePlatformDir(privateKey, { platformId });
+  t.after(() => cleanup(dir));
+  assert.ok(fs.existsSync(path.join(dir, "fallow.exe")), "fixture must write the .exe target");
+
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    platformId,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: makeDigestProvider(dir),
+  });
+  assert.equal(result.ok, true);
+});
+
+test("verifyInstalled reports the .exe name when a win32 signature is absent", async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const platformId = "win32-arm64-msvc";
+  const dir = makePlatformDir(privateKey, { platformId, skipSigFor: "fallow" });
+  t.after(() => cleanup(dir));
+
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    platformId,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: makeDigestProvider(dir),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "sig-missing");
+  assert.match(result.message, /fallow\.exe/);
 });
 
 test("verifyInstalled resolves a global npm install from the fallow package directory", async (t) => {
@@ -460,8 +506,8 @@ test("verifyInstalled honors FALLOW_SKIP_BINARY_VERIFY", async (t) => {
   assert.equal(result.skipped, true);
 });
 
-function computeDigestsForDir(dir) {
-  const ext = process.platform === "win32" ? ".exe" : "";
+function computeDigestsForDir(dir, platformId) {
+  const ext = extForPlatformId(platformId);
   const out = {};
   for (const base of ["fallow"]) {
     const fileName = `${base}${ext}`;
@@ -581,7 +627,7 @@ test("verifyInstalled returns digest-mismatch when the embedded digest disagrees
   const { privateKey, rawPub } = makeKeypair();
   const dir = makePlatformDir(privateKey);
   t.after(() => cleanup(dir));
-  const ext = process.platform === "win32" ? ".exe" : "";
+  const ext = extForPlatformId();
   writeManifest(dir, {
     name: "@fallow-cli/x",
     version: "1.0.0",


### PR DESCRIPTION
`npm/fallow/scripts/verify-binary.test.js` fails **18 of 44** on a Windows host and `sentinel-path.test.js` **1 of 15**, while both pass on Linux. Neither runs in CI on any platform — the Windows npm step covers `run-binary.test.js` and the child-process policy only — so the launcher's signature and digest verification has no Windows coverage, on a package that ships `win32-x64-msvc` and `win32-arm64-msvc`.

Both are fixture bugs. The launcher itself is correct, which is why this is test-side only.

| file | Linux before | Windows before | after (both) |
|---|---|---|---|
| `verify-binary.test.js` | 44 / 0 | 26 / **18** | 46 / 0 |
| `sentinel-path.test.js` | 15 / 0 | 14 / **1** | 15 / 0 |
| `run-binary.test.js` | 10 / 0 | 8 / 0 | unchanged |
| `platform-package.test.js` | 4 / 0 | 4 / 0 | unchanged |

## 1. The fixtures took `.exe` from the host, not from the platformId

`binaryTargetsForPlatform` deliberately reads windows-ness off the platformId:

```js
// Derive the `.exe` suffix from the platformId, not from the live
// process.platform. […] tests can synthesize a Windows verify without
// running on Windows.
```

and `resolvePlatformPackageForVerify` labels a `dirOverride` run `"test-platform"` when the test names no platformId. So for every override-based test the binary under verification is plain `fallow`, on every host. The fixtures did the opposite of what that comment asks:

```js
const ext = process.platform === "win32" ? ".exe" : "";
```

On Linux both sides yield `""` and the tests pass. On Windows the fixture writes `fallow.exe` and `verifyInstalled` looks for `fallow` — 18 failures, all of them `verifyInstalled` / `verifyInstalledSync` reduced to `false !== true`.

Three sites fed override runs (`makePlatformDir`, `computeDigestsForDir`, and one inline `fallowDigests` key) and now go through one helper that mirrors the production rule. The fourth stays on `process.platform` on purpose: it stages a global npm install and resolves the *real* platform package, so there windows-ness genuinely is the host's — and that test already passed on Windows.

### The win32 branch was never exercised

Keeping the derivation off `process.platform` exists so a Windows verify can be synthesized anywhere, but no test did, so the `.exe` target was unverified on Linux CI and unverified on Windows too. Two tests now cover it — `.exe` accepted, and the `.exe` name surfaced in the `sig-missing` message:

```js
const dir = makePlatformDir(privateKey, { platformId: "win32-x64-msvc" });
const result = await verifyInstalled({ dirOverride: dir, platformId: "win32-x64-msvc", … });
```

Negative control: reverting `binaryTargetsForPlatform`'s suffix to a constant `""` fails both of them (and one pre-existing test), so they are load-bearing rather than decorative.

## 2. `sentinel-path`'s uncreatable directory was POSIX-only

The cascade test pointed `FALLOW_VERIFY_CACHE_DIR` at `/dev/null/inside/a/file` to make `ensureDirExists` fail so the resolver falls through to `home-cache`. Only POSIX refuses that. On Windows the recursive `mkdir` resolves it against the current drive and **succeeds**, so the resolver correctly stopped at `cache-dir-env` — the assertion was reading a real difference in the fixture, not a bug in the resolver:

```
+ actual - expected
+ 'cache-dir-env'
- 'home-cache'
```

Two consequences, one of them worse than the failure: the run left a real `C:\dev\null\inside\a\file` tree behind, outside any temp directory, so the suite wrote into the developer's filesystem root. It now nests the path under a regular file inside the test's own temp dir, which `mkdir` refuses on both platforms.

## 3. Wiring

`verify-binary.test.js`, `sentinel-path.test.js` and `platform-package.test.js` join the existing **Test Windows npm and child-process wiring** step, and the `windows-type-aware` path filter learns the six files behind them so the job triggers when they change.

## Left out on purpose

`lazy-verify.test.js` fails 12 on Windows and **2 on Linux** (`ensureVerified honors FALLOW_VERIFY_CACHE_DIR when platform pkg dir is non-writable`, `ensureVerified rejects a sentinel written for a different install dir`). Its fixture has the same `process.platform` ext helper, but `lazy-verify.js` derives the suffix from its `platform` input — which `baseInput` sets to `process.platform` — so the two agree and the cause is something else. I did not diagnose it, so I have not wired that file into CI or guessed at a fix; flagging it rather than shipping it. Happy to take it separately.

## Verification

`node --test` on each file, both platforms — Windows `node v24.18.0` (`x86_64-pc-windows-msvc`), Linux `node v18.19.1`:

```
=== WINDOWS ===                        === LINUX ===
run-binary.test.js       pass 8        run-binary.test.js       pass 10
verify-binary.test.js    pass 46       verify-binary.test.js    pass 46
sentinel-path.test.js    pass 15       sentinel-path.test.js    pass 15
platform-package.test.js pass 4        platform-package.test.js pass 4
```

(`run-binary` skips two `fallow-lsp` / `fallow-mcp` cases on Windows, which is pre-existing.)

Also run: `scripts/workflow-policy.test.mjs` 22/0 and `scripts/repository-policy.test.mjs` 13/0 — the two suites that assert CI structure, since this touches `ci.yml`. `oxfmt --check` and `oxlint` clean on the changed files at the pinned versions (0.63.0 / 1.78.0).

No production file changes; the launcher's behaviour is identical.