### PR TITLE
test(npm): run all launcher verification tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,7 @@ jobs:
               - '.clippy.toml'
               - 'rust-toolchain.toml'
             windows-type-aware:
-              - 'npm/fallow/scripts/run-binary.js'
-              - 'npm/fallow/scripts/run-binary.test.js'
-              - 'npm/fallow/scripts/verify-binary.js'
-              - 'npm/fallow/scripts/verify-binary.test.js'
-              - 'npm/fallow/scripts/sentinel-path.js'
-              - 'npm/fallow/scripts/sentinel-path.test.js'
-              - 'npm/fallow/scripts/platform-package.js'
-              - 'npm/fallow/scripts/platform-package.test.js'
+              - 'npm/fallow/scripts/**'
               - 'npm/fallow/package.json'
               - 'npm/fallow/bin/**'
               - 'tools/type-aware-sidecar/**'
@@ -411,14 +404,10 @@ jobs:
           node-version: '22'
           cache: pnpm
           cache-dependency-path: editors/vscode/pnpm-lock.yaml
-      - name: Test Windows npm and child-process wiring
-        run: >
-          node --test
-          npm/fallow/scripts/run-binary.test.js
-          npm/fallow/scripts/verify-binary.test.js
-          npm/fallow/scripts/sentinel-path.test.js
-          npm/fallow/scripts/platform-package.test.js
-          tools/type-aware-sidecar/test/windows-child-process.test.mjs
+      - name: Test Windows npm launcher
+        run: npm --prefix npm/fallow test
+      - name: Test Windows child-process wiring
+        run: node --test tools/type-aware-sidecar/test/windows-child-process.test.mjs
       - name: Test Rust type-aware transport
         run: cargo test -p fallow-api type_aware::transport
       - name: Install VS Code dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,12 @@ jobs:
             windows-type-aware:
               - 'npm/fallow/scripts/run-binary.js'
               - 'npm/fallow/scripts/run-binary.test.js'
+              - 'npm/fallow/scripts/verify-binary.js'
+              - 'npm/fallow/scripts/verify-binary.test.js'
+              - 'npm/fallow/scripts/sentinel-path.js'
+              - 'npm/fallow/scripts/sentinel-path.test.js'
+              - 'npm/fallow/scripts/platform-package.js'
+              - 'npm/fallow/scripts/platform-package.test.js'
               - 'npm/fallow/package.json'
               - 'npm/fallow/bin/**'
               - 'tools/type-aware-sidecar/**'
@@ -409,6 +415,9 @@ jobs:
         run: >
           node --test
           npm/fallow/scripts/run-binary.test.js
+          npm/fallow/scripts/verify-binary.test.js
+          npm/fallow/scripts/sentinel-path.test.js
+          npm/fallow/scripts/platform-package.test.js
           tools/type-aware-sidecar/test/windows-child-process.test.mjs
       - name: Test Rust type-aware transport
         run: cargo test -p fallow-api type_aware::transport

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -50,11 +50,10 @@ jobs:
       - name: Install type-aware sidecar dependencies
         run: npm ci --prefix tools/type-aware-sidecar --no-audit --no-fund --ignore-scripts
 
-      - name: Test Windows npm and child-process wiring
-        run: >
-          node --test
-          npm/fallow/scripts/run-binary.test.js
-          tools/type-aware-sidecar/test/windows-child-process.test.mjs
+      - name: Test Windows npm launcher
+        run: npm --prefix npm/fallow test
+      - name: Test Windows child-process wiring
+        run: node --test tools/type-aware-sidecar/test/windows-child-process.test.mjs
 
       - name: Run workspace tests
         run: cargo test --workspace --lib --bins --tests --examples

--- a/npm/fallow/scripts/lazy-verify.js
+++ b/npm/fallow/scripts/lazy-verify.js
@@ -235,6 +235,9 @@ function isSkipRequested(env) {
 //                    production install path always has fallowDigests)
 //   env            - process.env (defaults to process.env)
 //   platform       - process.platform (defaults to process.platform)
+//   homedir        - os.homedir() override (tests only)
+//   isWritable     - sentinel directory probe override (tests only)
+//   ensureDir      - sentinel directory creation override (tests only)
 //   logger         - function (line: string) -> void (defaults to stderr)
 //
 // Returns one of:
@@ -250,6 +253,16 @@ function buildVerifyOptions(input, manifest) {
   };
   if (typeof input.verifyFn === "function") opts.verifyFn = input.verifyFn;
   if (typeof input.digestProvider === "function") opts.digestProvider = input.digestProvider;
+  return opts;
+}
+
+function buildSentinelOptions(input, platformPkgDir, packageName, env, platform) {
+  const opts = { platformPkgDir, packageName, env, platform };
+  for (const key of ["homedir", "isWritable", "ensureDir"]) {
+    if (Object.prototype.hasOwnProperty.call(input, key)) {
+      opts[key] = input[key];
+    }
+  }
   return opts;
 }
 
@@ -315,7 +328,9 @@ function ensureVerified(input) {
     };
   }
 
-  const sentinel = resolveSentinelPath({ platformPkgDir, packageName, env, platform });
+  const sentinel = resolveSentinelPath(
+    buildSentinelOptions(input || {}, platformPkgDir, packageName, env, platform),
+  );
 
   // Cache hit: sentinel exists, schema matches, mtimes match, version matches.
   if (sentinel.path && isSentinelValid(sentinel.path, platformPkgDir, manifest, platform)) {

--- a/npm/fallow/scripts/lazy-verify.test.js
+++ b/npm/fallow/scripts/lazy-verify.test.js
@@ -16,6 +16,9 @@ const { _verifyWithKey, SKIP_ENV } = require("./verify-binary");
 
 // ---- shared fixtures ------------------------------------------------------
 
+const DEFAULT_PLATFORM = "linux";
+const DEFAULT_PACKAGE_NAME = "@fallow-cli/test-platform";
+
 function makeKeypair() {
   const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
   const spki = publicKey.export({ format: "der", type: "spki" });
@@ -23,18 +26,18 @@ function makeKeypair() {
   return { privateKey, rawPub };
 }
 
-function ext() {
-  return process.platform === "win32" ? ".exe" : "";
+function packageNameForPlatform(platform) {
+  return platform === "win32" ? "@fallow-cli/win32-x64-msvc" : DEFAULT_PACKAGE_NAME;
 }
 
-function binaryNames() {
+function binaryNames(platform) {
   // Platform packages ship a single multicall `fallow` binary.
-  return [`fallow${ext()}`];
+  return [platform === "win32" ? "fallow.exe" : "fallow"];
 }
 
-function computeDigestsForDir(dir) {
+function computeDigestsForDir(dir, platform) {
   const out = {};
-  for (const base of binaryNames()) {
+  for (const base of binaryNames(platform)) {
     const full = path.join(dir, base);
     out[base] = "sha256:" + crypto.createHash("sha256").update(fs.readFileSync(full)).digest("hex");
   }
@@ -43,8 +46,9 @@ function computeDigestsForDir(dir) {
 
 function mkPlatformDir(privateKey, options) {
   const opts = options || {};
+  const platform = opts.platform || DEFAULT_PLATFORM;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fallow-lazy-test-"));
-  for (const base of binaryNames()) {
+  for (const base of binaryNames(platform)) {
     const binaryPath = path.join(dir, base);
     const content = Buffer.from(`mock ${base}`);
     fs.writeFileSync(binaryPath, content);
@@ -56,9 +60,9 @@ function mkPlatformDir(privateKey, options) {
   fs.writeFileSync(
     path.join(dir, "package.json"),
     JSON.stringify({
-      name: opts.packageName || "@fallow-cli/test-platform",
+      name: opts.packageName || packageNameForPlatform(platform),
       version: opts.version || "2.81.0",
-      fallowDigests: opts.skipDigests ? undefined : computeDigestsForDir(dir),
+      fallowDigests: opts.skipDigests ? undefined : computeDigestsForDir(dir, platform),
     }),
   );
   return dir;
@@ -88,13 +92,15 @@ function setupCacheRoot(t) {
 }
 
 function baseInput(dir, verifyFn, extras) {
+  const manifestPath = path.join(dir, "package.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   return {
     platformPkgDir: dir,
-    packageName: "@fallow-cli/test-platform",
-    manifestPath: path.join(dir, "package.json"),
+    packageName: manifest.name,
+    manifestPath,
     verifyFn,
     env: {},
-    platform: process.platform,
+    platform: DEFAULT_PLATFORM,
     ...extras,
   };
 }
@@ -118,6 +124,29 @@ test("ensureVerified verifies on cache miss and writes the sentinel", (t) => {
   assert.equal(sentinel.packageVersion, "2.81.0");
   assert.equal(sentinel.packageName, "@fallow-cli/test-platform");
   assert.equal(Object.keys(sentinel.binaries).length, 1);
+});
+
+test("ensureVerified verifies and caches a win32 executable on any host", (t) => {
+  _resetWarningState();
+  const { privateKey, rawPub } = makeKeypair();
+  const dir = mkPlatformDir(privateKey, { platform: "win32" });
+  t.after(() => cleanup(dir));
+  const input = baseInput(dir, (binaryPath) => _verifyWithKey(binaryPath, rawPub), {
+    platform: "win32",
+  });
+
+  const verified = ensureVerified(input);
+  assert.equal(verified.ok, true);
+  assert.equal(verified.cached, false);
+  const sentinel = JSON.parse(fs.readFileSync(verified.sentinelPath, "utf8"));
+  assert.deepEqual(Object.keys(sentinel.binaries), ["fallow.exe"]);
+
+  const cached = ensureVerified({
+    ...input,
+    verifyFn: () => assert.fail("signature verification must not run on a cache hit"),
+  });
+  assert.equal(cached.ok, true);
+  assert.equal(cached.cached, true);
 });
 
 test("ensureVerified returns cached:true on a valid sentinel", (t) => {
@@ -154,7 +183,7 @@ test("ensureVerified invalidates sentinel on mtime drift", (t) => {
 
   // Bump the mtime of one binary; sentinel should now be stale.
   const newTime = new Date(Date.now() + 10_000);
-  fs.utimesSync(path.join(dir, `fallow${ext()}`), newTime, newTime);
+  fs.utimesSync(path.join(dir, binaryNames(DEFAULT_PLATFORM)[0]), newTime, newTime);
 
   let verifyCallCount = 0;
   const result = ensureVerified(
@@ -215,7 +244,9 @@ test("ensureVerified invalidates sentinel on packageName drift", (t) => {
       packageVersion: "2.81.0",
       packageName: "@fallow-cli/wrong-name",
       binaries: {
-        [`fallow${ext()}`]: { mtimeMs: fs.statSync(path.join(dir, `fallow${ext()}`)).mtimeMs },
+        [binaryNames(DEFAULT_PLATFORM)[0]]: {
+          mtimeMs: fs.statSync(path.join(dir, binaryNames(DEFAULT_PLATFORM)[0])).mtimeMs,
+        },
       },
     }),
   );
@@ -261,7 +292,7 @@ test("ensureVerified invalidates sentinel on schemaVersion drift", (t) => {
 test("ensureVerified returns sig-invalid on a tampered signature", (t) => {
   _resetWarningState();
   const { privateKey, rawPub } = makeKeypair();
-  const dir = mkPlatformDir(privateKey, { corruptSigFor: `fallow${ext()}` });
+  const dir = mkPlatformDir(privateKey, { corruptSigFor: binaryNames(DEFAULT_PLATFORM)[0] });
   t.after(() => cleanup(dir));
 
   const result = ensureVerified(baseInput(dir, (p) => _verifyWithKey(p, rawPub)));
@@ -289,89 +320,43 @@ test("ensureVerified returns digest-unavailable on a pre-#597 manifest", (t) => 
 
 test("ensureVerified honors FALLOW_VERIFY_CACHE_DIR when platform pkg dir is non-writable", (t) => {
   _resetWarningState();
-  if (process.platform === "win32") {
-    t.skip("Windows ACL chmod is not portable; covered by sentinel-path tests");
-    return;
-  }
   const { privateKey, rawPub } = makeKeypair();
   const dir = mkPlatformDir(privateKey);
   const cacheRoot = setupCacheRoot(t);
+  t.after(() => cleanup(dir));
 
-  fs.chmodSync(dir, 0o555);
-  try {
-    const result = ensureVerified({
-      ...baseInput(dir, (p) => _verifyWithKey(p, rawPub)),
-      env: { FALLOW_VERIFY_CACHE_DIR: cacheRoot },
-    });
-    assert.equal(result.ok, true);
-    assert.equal(result.cached, false);
-    assert.match(result.sentinelPath, new RegExp(cacheRoot.replace(/\\/g, "\\\\")));
-  } finally {
-    fs.chmodSync(dir, 0o755);
-    cleanup(dir);
-  }
+  const result = ensureVerified({
+    ...baseInput(dir, (p) => _verifyWithKey(p, rawPub)),
+    env: { FALLOW_VERIFY_CACHE_DIR: cacheRoot },
+    isWritable: (candidate) => candidate !== dir,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.cached, false);
+  assert.match(result.sentinelPath, new RegExp(cacheRoot.replace(/\\/g, "\\\\")));
 });
 
-test("ensureVerified emits a single warning when sentinel write fails", (t) => {
+test("ensureVerified emits a single warning when no sentinel location is writable", (t) => {
   _resetWarningState();
-  if (process.platform === "win32") {
-    t.skip("Windows ACL chmod is not portable");
-    return;
-  }
   const { privateKey, rawPub } = makeKeypair();
   const dir = mkPlatformDir(privateKey);
   const stderr = captureStderr(t);
+  t.after(() => cleanup(dir));
+  const input = {
+    ...baseInput(dir, (p) => _verifyWithKey(p, rawPub)),
+    homedir: undefined,
+    isWritable: () => false,
+  };
 
-  // Make platform pkg dir non-writable AND point FALLOW_VERIFY_CACHE_DIR at
-  // a non-existent path. resolveSentinelPath will still find the XDG / home
-  // fallback, but we can simulate "every cache location read-only" by giving
-  // it a writable dir that we then chmod down right before ensureVerified
-  // runs writeSentinel. Simpler: instead of fighting the cascade in env,
-  // simulate write failure via a non-writable FALLOW_VERIFY_CACHE_DIR that
-  // PASSES isWritable() but then has its perms revoked between resolve and
-  // write. Since that race is hard to script, we test the warn-once helper
-  // via a synthetic path that fails the rename atomically: pass a sentinel-
-  // chmod-locked dir.
-  //
-  // The portable shape: chmod the platform pkg dir read-only AND pass a
-  // FALLOW_VERIFY_CACHE_DIR that is a regular file (not a dir). isWritable
-  // returns false for both, so resolveSentinelPath falls through to XDG. If
-  // the user has no HOME (synthetic env), the cascade returns null. We can
-  // achieve this only by injecting both env.HOME='' AND env.XDG_CACHE_HOME=''
-  // AND ensuring os.homedir() is not consulted; ensureVerified does not
-  // accept a homedir override, so the warn-once path is unreachable via env
-  // alone on a machine with a real HOME. Skip this test on machines with a
-  // real homedir; the warn-once helper is otherwise covered by the
-  // "no-writable-location" branch in sentinel-path tests.
-  if (os.homedir() && os.homedir().length > 0) {
-    t.skip(
-      "warn-once-on-no-writable-cache requires homedir-override knob (covered by sentinel-path unit test)",
-    );
-    cleanup(dir);
-    return;
-  }
+  const result = ensureVerified(input);
+  assert.equal(result.sentinelPath, null);
+  const warnings = stderr.lines.filter((line) => line.includes("no writable cache location"));
+  assert.equal(warnings.length, 1);
 
-  fs.chmodSync(dir, 0o555);
-  try {
-    const env = { HOME: "", XDG_CACHE_HOME: "" };
-    const result = ensureVerified({
-      ...baseInput(dir, (p) => _verifyWithKey(p, rawPub)),
-      env,
-    });
-    if (result.sentinelPath !== null) {
-      t.diagnostic(`sentinel landed at ${result.sentinelPath} despite empty HOME; skipping`);
-      return;
-    }
-    const warnings = stderr.lines.filter((l) => l.includes("no writable cache location"));
-    assert.equal(warnings.length, 1);
-    // Second call: no new warning.
-    ensureVerified({ ...baseInput(dir, (p) => _verifyWithKey(p, rawPub)), env });
-    const warnings2 = stderr.lines.filter((l) => l.includes("no writable cache location"));
-    assert.equal(warnings2.length, 1);
-  } finally {
-    fs.chmodSync(dir, 0o755);
-    cleanup(dir);
-  }
+  ensureVerified(input);
+  const repeatedWarnings = stderr.lines.filter((line) =>
+    line.includes("no writable cache location"),
+  );
+  assert.equal(repeatedWarnings.length, 1);
 });
 
 // ---- FALLOW_SKIP_BINARY_VERIFY -------------------------------------------
@@ -457,10 +442,6 @@ test("ensureVerified is idempotent under concurrent first-runs", async (t) => {
 
 test("ensureVerified rejects a sentinel written for a different install dir", (t) => {
   _resetWarningState();
-  if (process.platform === "win32") {
-    t.skip("chmod-based read-only platform pkg dir is not portable on Windows");
-    return;
-  }
   // Two installs of the same package + version. install A is clean and writes
   // a sentinel to a shared cache; install B has a tampered binary at the same
   // package name + version. B must NOT trust A's sentinel via cache hit even
@@ -471,17 +452,14 @@ test("ensureVerified rejects a sentinel written for a different install dir", (t
   // Tamper install B's fallow binary AFTER mkPlatformDir wrote a valid sig
   // for the original bytes (mkPlatformDir does not expose a corrupt-binary
   // option, so simulate the attack by overwriting bytes here).
-  fs.writeFileSync(path.join(installB, `fallow${ext()}`), Buffer.from("tampered bytes"));
+  fs.writeFileSync(
+    path.join(installB, binaryNames(DEFAULT_PLATFORM)[0]),
+    Buffer.from("tampered bytes"),
+  );
   const sharedCache = fs.mkdtempSync(path.join(os.tmpdir(), "fallow-shared-cache-"));
+  const isWritable = (candidate) => candidate !== installA && candidate !== installB;
 
-  // Force the shared-cache cascade by making both platform pkg dirs
-  // non-writable (simulates yarn PnP / Docker layered images / pnpm
-  // verify-store invariants).
-  fs.chmodSync(installA, 0o555);
-  fs.chmodSync(installB, 0o555);
   t.after(() => {
-    fs.chmodSync(installA, 0o755);
-    fs.chmodSync(installB, 0o755);
     cleanup(installA);
     cleanup(installB);
     cleanup(sharedCache);
@@ -492,6 +470,7 @@ test("ensureVerified rejects a sentinel written for a different install dir", (t
   const resultA = ensureVerified({
     ...baseInput(installA, (p) => _verifyWithKey(p, rawPub)),
     env: { FALLOW_VERIFY_CACHE_DIR: sharedCache },
+    isWritable,
   });
   assert.equal(resultA.ok, true);
   assert.match(resultA.sentinelPath, new RegExp(sharedCache.replace(/\\/g, "\\\\")));
@@ -502,7 +481,6 @@ test("ensureVerified rejects a sentinel written for a different install dir", (t
   // + SHA-256 binding must prevent that.
   for (const name of binaryNames()) {
     const aStat = fs.statSync(path.join(installA, name));
-    fs.chmodSync(path.join(installB, name), 0o644);
     fs.utimesSync(path.join(installB, name), aStat.atime, aStat.mtime);
   }
 
@@ -513,6 +491,7 @@ test("ensureVerified rejects a sentinel written for a different install dir", (t
       return _verifyWithKey(p, rawPub);
     }),
     env: { FALLOW_VERIFY_CACHE_DIR: sharedCache },
+    isWritable,
   });
   assert.equal(resultB.ok, false);
   assert.equal(resultB.code, "sig-invalid");
@@ -530,7 +509,7 @@ test("ensureVerified rejects a sentinel where bytes drift but mtime stays", (t) 
 
   // Tamper the binary in place AND restore the prior mtime, so the mtime
   // pre-filter matches but the bytes do not.
-  const binPath = path.join(dir, `fallow${ext()}`);
+  const binPath = path.join(dir, binaryNames(DEFAULT_PLATFORM)[0]);
   const before = fs.statSync(binPath);
   fs.writeFileSync(binPath, Buffer.from("tampered"));
   fs.utimesSync(binPath, before.atime, before.mtime);

--- a/npm/fallow/scripts/sentinel-path.test.js
+++ b/npm/fallow/scripts/sentinel-path.test.js
@@ -220,12 +220,19 @@ test("resolveSentinelPath honors injected isWritable + ensureDir for full test i
 test("resolveSentinelPath skips cache-dir-env when ensureDir fails for it", () => {
   // FALLOW_VERIFY_CACHE_DIR points at a non-creatable path, XDG points at a
   // creatable one. Confirm the resolver moves past the env override.
+  //
+  // A directory nested under a regular FILE is the portable way to make mkdir
+  // fail: `/dev/null/inside/a/file` only refuses on POSIX, and on Windows the
+  // recursive mkdir succeeds against the current drive, which both defeats the
+  // assertion and creates C:\dev outside any temp directory.
   const homeDir = mkTmp();
+  const blocker = path.join(homeDir, "not-a-directory");
+  fs.writeFileSync(blocker, "");
   try {
     const result = resolveSentinelPath({
       platformPkgDir: undefined,
       packageName: "@fallow-cli/darwin-arm64",
-      env: { FALLOW_VERIFY_CACHE_DIR: "/dev/null/inside/a/file" },
+      env: { FALLOW_VERIFY_CACHE_DIR: path.join(blocker, "inside", "a", "file") },
       homedir: homeDir,
       platform: "darwin",
     });

--- a/npm/fallow/scripts/sentinel-path.test.js
+++ b/npm/fallow/scripts/sentinel-path.test.js
@@ -77,7 +77,7 @@ test("resolveSentinelPath falls back to FALLOW_VERIFY_CACHE_DIR when platform pk
   const cacheDir = mkTmp();
   try {
     const result = resolveSentinelPath({
-      platformPkgDir: "/dev/null/not-a-dir",
+      platformPkgDir: path.join(cacheDir, "missing-platform-package"),
       packageName: "@fallow-cli/darwin-arm64",
       env: { FALLOW_VERIFY_CACHE_DIR: cacheDir },
     });

--- a/npm/fallow/scripts/verify-binary.test.js
+++ b/npm/fallow/scripts/verify-binary.test.js
@@ -239,10 +239,20 @@ test("verifyBinaryAt uses the embedded production public key", () => {
   }
 });
 
+// Mirror binaryTargetsForPlatform: the suffix comes from the platformId under
+// test, never from the live process.platform. A `dirOverride` run without an
+// explicit platformId is labelled "test-platform" by
+// resolvePlatformPackageForVerify, so the binary it looks for is plain `fallow`
+// on every host -- a fixture keyed off process.platform writes `fallow.exe` on a
+// Windows host and the verify then finds nothing.
+function extForPlatformId(platformId) {
+  return typeof platformId === "string" && platformId.startsWith("win32") ? ".exe" : "";
+}
+
 function makePlatformDir(privateKey, options) {
   const opts = options || {};
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fallow-vbtest-"));
-  const ext = process.platform === "win32" ? ".exe" : "";
+  const ext = extForPlatformId(opts.platformId);
   for (const base of ["fallow"]) {
     const binaryPath = path.join(dir, `${base}${ext}`);
     const content = Buffer.from(`mock ${base} contents`);
@@ -326,6 +336,42 @@ test("verifyInstalled with dirOverride returns ok when every binary verifies", a
   });
   assert.equal(result.ok, true);
   assert.equal(result.package, "<override>");
+});
+
+// binaryTargetsForPlatform reads windows-ness off the platformId so a Windows
+// verify can be synthesized anywhere. Nothing exercised that, which left the
+// `.exe` target unverified on Linux CI and unverified on Windows too.
+test("verifyInstalled verifies the .exe target for a win32 platformId on any host", async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const platformId = "win32-x64-msvc";
+  const dir = makePlatformDir(privateKey, { platformId });
+  t.after(() => cleanup(dir));
+  assert.ok(fs.existsSync(path.join(dir, "fallow.exe")), "fixture must write the .exe target");
+
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    platformId,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: makeDigestProvider(dir),
+  });
+  assert.equal(result.ok, true);
+});
+
+test("verifyInstalled reports the .exe name when a win32 signature is absent", async (t) => {
+  const { privateKey, rawPub } = makeKeypair();
+  const platformId = "win32-arm64-msvc";
+  const dir = makePlatformDir(privateKey, { platformId, skipSigFor: "fallow" });
+  t.after(() => cleanup(dir));
+
+  const result = await verifyInstalled({
+    dirOverride: dir,
+    platformId,
+    verifyFn: (p) => _verifyWithKey(p, rawPub),
+    digestProvider: makeDigestProvider(dir),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "sig-missing");
+  assert.match(result.message, /fallow\.exe/);
 });
 
 test("verifyInstalled resolves a global npm install from the fallow package directory", async (t) => {
@@ -460,8 +506,8 @@ test("verifyInstalled honors FALLOW_SKIP_BINARY_VERIFY", async (t) => {
   assert.equal(result.skipped, true);
 });
 
-function computeDigestsForDir(dir) {
-  const ext = process.platform === "win32" ? ".exe" : "";
+function computeDigestsForDir(dir, platformId) {
+  const ext = extForPlatformId(platformId);
   const out = {};
   for (const base of ["fallow"]) {
     const fileName = `${base}${ext}`;
@@ -581,7 +627,7 @@ test("verifyInstalled returns digest-mismatch when the embedded digest disagrees
   const { privateKey, rawPub } = makeKeypair();
   const dir = makePlatformDir(privateKey);
   t.after(() => cleanup(dir));
-  const ext = process.platform === "win32" ? ".exe" : "";
+  const ext = extForPlatformId();
   writeManifest(dir, {
     name: "@fallow-cli/x",
     version: "1.0.0",

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -209,6 +209,7 @@ test("binary-size workflow isolates incompatible release builds", () => {
 
 test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
+  const npmPackage = JSON.parse(readFileSync("npm/fallow/package.json", "utf8"));
   const windowsRustPaths = listedPaths(indentedBlock(workflow, "windows-rust", 12));
   const windowsTypeAwarePaths = listedPaths(indentedBlock(workflow, "windows-type-aware", 12));
   const checkJob = indentedBlock(workflow, "check", 2);
@@ -260,7 +261,9 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.match(windowsTypeAwareJob, /needs: changes/);
   assert.match(windowsTypeAwareJob, /if: needs\.changes\.outputs\.windows-type-aware == 'true'/);
   assert.match(windowsTypeAwareJob, /runs-on: windows-latest/);
-  assert.ok(windowsTypeAwarePaths.includes("npm/fallow/scripts/run-binary.js"));
+  assert.ok(windowsTypeAwarePaths.includes("npm/fallow/scripts/**"));
+  assert.equal(npmPackage.scripts.test, "node --test scripts/*.test.js");
+  assert.match(windowsTypeAwareJob, /npm --prefix npm\/fallow test/);
   assert.ok(windowsTypeAwarePaths.includes("npm/fallow/package.json"));
   assert.ok(windowsTypeAwarePaths.includes("npm/fallow/bin/**"));
   assert.ok(windowsTypeAwarePaths.includes("tools/type-aware-sidecar/**"));
@@ -269,7 +272,6 @@ test("regular CI keeps affected checks on Ubuntu", () => {
     windowsTypeAwarePaths.includes("editors/vscode/scripts/verify-packaged-type-aware.mjs"),
   );
   assert.ok(windowsTypeAwarePaths.includes("crates/api/src/type_aware/transport/**"));
-  assert.match(windowsTypeAwareJob, /npm\/fallow\/scripts\/run-binary\.test\.js/);
   assert.match(windowsTypeAwareJob, /cargo test -p fallow-api type_aware::transport/);
   assert.match(windowsTypeAwareJob, /type-aware-windows-candidate-smoke\.mjs/);
   assert.match(windowsTypeAwareJob, /FALLOW_LSP_BIN:/);
@@ -344,6 +346,7 @@ test("release runs Windows correctness and lifecycle verification without creden
   assert.match(job, /runs-on: windows-latest/);
   assert.match(job, /permissions:\n\s+contents: read/);
   assert.doesNotMatch(job, /id-token: write|contents: write|secrets\./);
+  assert.match(job, /npm --prefix npm\/fallow test/);
   assert.match(
     job,
     /name: Install type-aware sidecar dependencies[\s\S]*npm ci --prefix tools\/type-aware-sidecar --no-audit --no-fund --ignore-scripts[\s\S]*name: Run workspace tests/,


### PR DESCRIPTION
Thanks @NgoQuocViet2001 for identifying and fixing the host-dependent fixtures in #2288.

This maintainer follow-up preserves that fix and completes the Windows launcher verification coverage:

- runs the full npm launcher suite in regular Windows CI and release validation
- fixes the lazy verification fixture used by the synchronous production path
- adds a host-independent Win32 executable and sentinel cache regression test
- replaces chmod and POSIX path assumptions with injected, portable filesystem probes
- locks the workflow path filter and npm test command into workflow policy tests

Verification:

- `npm --prefix npm/fallow test`
- `node --test scripts/workflow-policy.test.mjs scripts/repository-policy.test.mjs`
- `npm run verify:fast`
- `npm run verify:full`
- `actionlint .github/workflows/ci.yml .github/workflows/release-validation.yml`
- packaged npm wrapper smoke against Vite v8.0.1
- negative control confirms the Win32 lazy verification test fails with host-derived binary naming
- Windows Node 22 launcher, child-process, Preact candidate, and VS Code host checks passed in CI
- aggregate CI passed