### PR TITLE
feat(vscode): publish platform-specific extension packages

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -122,14 +122,20 @@ description: Prepare and publish a Fallow release with version, changelog, gener
     The workflow deliberately has no tag trigger and never creates a tag or
     GitHub Release. It validates and builds the release, stores the complete
     flattened GitHub asset bundle as the `release-assets` Actions artifact, and
-    publishes registries while the tag remains absent.
+    publishes registries while the tag remains absent. The VS Code release is
+    published by separate Marketplace and Open VSX jobs. A credential-free
+    public verifier checks every exact target before the final release gate.
 11. Monitor the specific workflow run through `status=completed` and
     `conclusion=success`; a successful watch command alone is not sufficient
-    evidence. Require the `Release ready for signed tag` job to pass, then
-    verify every registry and marketplace publication is live.
+    evidence. Require the `Publish VS Code Marketplace targets`, `Publish Open
+    VSX targets`, `Verify public VS Code registry targets`, and `Release ready
+    for signed tag` jobs to pass. The public verifier requires the exact
+    universal plus six platform tuples and normalized payloads from both
+    registries, without accepting a universal fallback.
     Download the `release-assets` artifact from that exact run and confirm it
-    is non-empty. Only then create and push the signed tag and create the
-    immutable GitHub Release:
+    is non-empty. Confirm it contains the seven target VSIX files,
+    `inventory.json`, and `SHA256SUMS`. Only then create and push the signed tag
+    and create the immutable GitHub Release:
 
     ```bash
     ASSET_DIR="$(mktemp -d)"
@@ -137,6 +143,9 @@ description: Prepare and publish a Fallow release with version, changelog, gener
       --name release-assets \
       --dir "$ASSET_DIR"
     test -n "$(find "$ASSET_DIR" -maxdepth 1 -type f -print -quit)"
+    test "$(find "$ASSET_DIR" -maxdepth 1 -name 'fallow-vscode-*.vsix' -type f | wc -l | tr -d ' ')" -eq 7
+    test -f "$ASSET_DIR/inventory.json"
+    test -f "$ASSET_DIR/SHA256SUMS"
 
     if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
       echo "release tag appeared before publication completed: ${TAG}" >&2

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -123,14 +123,20 @@ description: Prepare and publish a Fallow release with version, changelog, gener
     The workflow deliberately has no tag trigger and never creates a tag or
     GitHub Release. It validates and builds the release, stores the complete
     flattened GitHub asset bundle as the `release-assets` Actions artifact, and
-    publishes registries while the tag remains absent.
+    publishes registries while the tag remains absent. The VS Code release is
+    published by separate Marketplace and Open VSX jobs. A credential-free
+    public verifier checks every exact target before the final release gate.
 11. Monitor the specific workflow run through `status=completed` and
     `conclusion=success`; a successful watch command alone is not sufficient
-    evidence. Require the `Release ready for signed tag` job to pass, then
-    verify every registry and marketplace publication is live.
+    evidence. Require the `Publish VS Code Marketplace targets`, `Publish Open
+    VSX targets`, `Verify public VS Code registry targets`, and `Release ready
+    for signed tag` jobs to pass. The public verifier requires the exact
+    universal plus six platform tuples and normalized payloads from both
+    registries, without accepting a universal fallback.
     Download the `release-assets` artifact from that exact run and confirm it
-    is non-empty. Only then create and push the signed tag and create the
-    immutable GitHub Release:
+    is non-empty. Confirm it contains the seven target VSIX files,
+    `inventory.json`, and `SHA256SUMS`. Only then create and push the signed tag
+    and create the immutable GitHub Release:
 
     ```bash
     ASSET_DIR="$(mktemp -d)"
@@ -138,6 +144,9 @@ description: Prepare and publish a Fallow release with version, changelog, gener
       --name release-assets \
       --dir "$ASSET_DIR"
     test -n "$(find "$ASSET_DIR" -maxdepth 1 -type f -print -quit)"
+    test "$(find "$ASSET_DIR" -maxdepth 1 -name 'fallow-vscode-*.vsix' -type f | wc -l | tr -d ' ')" -eq 7
+    test -f "$ASSET_DIR/inventory.json"
+    test -f "$ASSET_DIR/SHA256SUMS"
 
     if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
       echo "release tag appeared before publication completed: ${TAG}" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/release-validation.yml'
             zed:
               - 'editors/zed/**'
             npm:
@@ -807,22 +809,136 @@ jobs:
           FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow-multicall
         run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
       - run: cd editors/vscode && pnpm test:unit
-      - name: Package and verify the production VSIX shape
-        run: |
-          pnpm --dir editors/vscode package
-          vsix="$(find editors/vscode -maxdepth 1 -name '*.vsix' -print -quit)"
-          test -n "$vsix"
-          vsix="$(realpath "$vsix")"
-          archive="$RUNNER_TEMP/fallow-vsix.zip"
-          destination="$RUNNER_TEMP/fallow-vsix-ubuntu"
-          cp "$vsix" "$archive"
-          unzip -q "$archive" -d "$destination"
-          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix"
-          echo "FALLOW_EXTENSION_PATH=$destination/extension" >> "$GITHUB_ENV"
-      - name: Run extracted production VSIX host smoke
+
+  vscode-package-targets:
+    name: Package VS Code target artifacts
+    needs: changes
+    if: needs.changes.outputs.vscode == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 11.10.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - name: Install VS Code dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Test target VSIX packaging contracts
+        run: pnpm --dir editors/vscode test:packaging
+      - name: Package target VSIX artifacts
+        run: pnpm --dir editors/vscode package:variants -- --output-dir "$RUNNER_TEMP/fallow-vscode-targets"
+      - name: Upload target VSIX artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: fallow-vscode-targets
+          path: ${{ runner.temp }}/fallow-vscode-targets
+
+  vscode-target-host:
+    name: VS Code target host (${{ matrix.target }})
+    needs: [changes, vscode-package-targets]
+    if: needs.changes.outputs.vscode == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            cli: target/debug/fallow
+            lsp: target/debug/fallow-lsp
+          - os: windows-latest
+            target: win32-x64
+            cli: target/debug/fallow.exe
+            lsp: target/debug/fallow-lsp.exe
+          - os: macos-15-intel
+            target: darwin-x64
+            cli: target/debug/fallow
+            lsp: target/debug/fallow-lsp
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: vscode-target-${{ matrix.target }}
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 11.10.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - name: Cache VS Code test download
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ runner.temp }}/fallow-vscode-test-cache
+          key: vscode-target-${{ matrix.target }}-vscode-1.96.0
+      - name: Install VS Code dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build current CLI and LSP binaries
+        run: cargo build -p fallow-cli --bin fallow -p fallow-lsp --bin fallow-lsp
+      - name: Download Ubuntu-built target VSIX artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fallow-vscode-targets
+          path: ${{ runner.temp }}/fallow-vscode-targets
+      - name: Extract and verify the exact target VSIX on Unix
+        if: runner.os != 'Windows'
+        shell: bash
         env:
-          FALLOW_BIN: ${{ github.workspace }}/target/debug/fallow-multicall
+          FALLOW_VSIX_TARGET: ${{ matrix.target }}
+        run: |
+          version="$(node -p "require('./editors/vscode/package.json').version")"
+          vsix="$RUNNER_TEMP/fallow-vscode-targets/fallow-vscode-$version-$FALLOW_VSIX_TARGET.vsix"
+          test -f "$vsix"
+          destination="$RUNNER_TEMP/fallow-vscode-$FALLOW_VSIX_TARGET"
+          unzip -q "$vsix" -d "$destination"
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix" --target "$FALLOW_VSIX_TARGET"
+          echo "FALLOW_EXTENSION_PATH=$(realpath "$destination/extension")" >> "$GITHUB_ENV"
+      - name: Extract and verify the exact target VSIX on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          FALLOW_VSIX_TARGET: ${{ matrix.target }}
+        run: |
+          $version = (Get-Content editors/vscode/package.json | ConvertFrom-Json).version
+          $vsix = Join-Path $env:RUNNER_TEMP "fallow-vscode-targets/fallow-vscode-$version-$env:FALLOW_VSIX_TARGET.vsix"
+          if (-not (Test-Path -PathType Leaf $vsix)) { throw "Expected target VSIX was not downloaded: $vsix" }
+          $archive = Join-Path $env:RUNNER_TEMP "fallow-vscode-$env:FALLOW_VSIX_TARGET.zip"
+          $destination = Join-Path $env:RUNNER_TEMP "fallow-vscode-$env:FALLOW_VSIX_TARGET"
+          Copy-Item $vsix $archive
+          Expand-Archive -Path $archive -DestinationPath $destination
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" $vsix --target $env:FALLOW_VSIX_TARGET
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $extensionPath = (Resolve-Path "$destination/extension").Path
+          "FALLOW_EXTENSION_PATH=$extensionPath" >> $env:GITHUB_ENV
+      - name: Run exact target VSIX host smoke on Linux
+        if: runner.os == 'Linux'
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/${{ matrix.cli }}
+          FALLOW_LSP_BIN: ${{ github.workspace }}/${{ matrix.lsp }}
+          FALLOW_VSCODE_TEST_CACHE_PATH: ${{ runner.temp }}/fallow-vscode-test-cache
         run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
+      - name: Run exact target VSIX host smoke
+        if: runner.os != 'Linux'
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/${{ matrix.cli }}
+          FALLOW_LSP_BIN: ${{ github.workspace }}/${{ matrix.lsp }}
+          FALLOW_VSCODE_TEST_CACHE_PATH: ${{ runner.temp }}/fallow-vscode-test-cache
+        run: pnpm --dir editors/vscode run test:integration:real
 
   zed:
     name: Zed Extension
@@ -1036,7 +1152,7 @@ jobs:
   ci-ok:
     name: CI
     if: always()
-    needs: [check, windows-rust, windows-type-aware, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, zed, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor, viz-frontend]
+    needs: [check, windows-rust, windows-type-aware, doc, typos, js-lint, npm-package, action-current, fallow-self-analyze, vscode, vscode-package-targets, vscode-target-host, zed, test-gitlab-ci, audit, deny, shear, zizmor, msrv, miri, skills-vendor, viz-frontend]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
         run: cargo clippy -p fallow-cli -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings
 
   windows-type-aware:
-    name: Windows type-aware package and VS Code host
+    name: Windows type-aware npm and transport
     needs: changes
     if: needs.changes.outputs.windows-type-aware == 'true'
     runs-on: windows-latest
@@ -398,46 +398,21 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           cache-key: pr-windows-type-aware
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: 11.10.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
-          cache: pnpm
-          cache-dependency-path: editors/vscode/pnpm-lock.yaml
       - name: Test Windows npm launcher
         run: npm --prefix npm/fallow test
       - name: Test Windows child-process wiring
         run: node --test tools/type-aware-sidecar/test/windows-child-process.test.mjs
       - name: Test Rust type-aware transport
         run: cargo test -p fallow-api type_aware::transport
-      - name: Install VS Code dependencies
-        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
-      - name: Build current CLI and LSP binaries
-        run: cargo build -p fallow-cli --bin fallow -p fallow-lsp --bin fallow-lsp
+      - name: Build current CLI binary
+        run: cargo build -p fallow-cli --bin fallow
       - name: Run installed npm candidate against pinned Preact
         env:
           FALLOW_CANDIDATE_BIN: ${{ github.workspace }}\target\debug\fallow.exe
         run: node scripts/type-aware-windows-candidate-smoke.mjs
-      - name: Package universal VSIX
-        run: cd editors/vscode && pnpm package
-      - name: Extract VSIX outside the repository
-        shell: pwsh
-        run: |
-          $vsix = Get-ChildItem editors/vscode/*.vsix | Select-Object -First 1
-          if (-not $vsix) { throw "VSIX package was not created" }
-          $archive = Join-Path $env:RUNNER_TEMP "fallow-vsix.zip"
-          $destination = Join-Path $env:RUNNER_TEMP "fallow-vsix"
-          Copy-Item $vsix.FullName $archive
-          Expand-Archive -Path $archive -DestinationPath $destination
-          pnpm --dir editors/vscode verify:vsix "$destination\extension" $vsix.FullName
-          "FALLOW_EXTENSION_PATH=$destination\extension" >> $env:GITHUB_ENV
-      - name: Run isolated VSIX type-aware host smoke
-        env:
-          FALLOW_BIN: ${{ github.workspace }}\target\debug\fallow.exe
-          FALLOW_LSP_BIN: ${{ github.workspace }}\target\debug\fallow-lsp.exe
-        run: pnpm --dir editors/vscode run test:integration:real
       - name: Check for uncommitted changes
         run: git diff --exit-code
 

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -75,27 +75,6 @@ jobs:
           FALLOW_CANDIDATE_BIN: ${{ github.workspace }}\target\debug\fallow.exe
         run: node scripts/type-aware-windows-candidate-smoke.mjs
 
-      - name: Package universal VSIX
-        run: cd editors/vscode && pnpm package
-
-      - name: Extract VSIX outside the repository
-        shell: pwsh
-        run: |
-          $vsix = Get-ChildItem editors/vscode/*.vsix | Select-Object -First 1
-          if (-not $vsix) { throw "VSIX package was not created" }
-          $archive = Join-Path $env:RUNNER_TEMP "fallow-vsix.zip"
-          $destination = Join-Path $env:RUNNER_TEMP "fallow-vsix"
-          Copy-Item $vsix.FullName $archive
-          Expand-Archive -Path $archive -DestinationPath $destination
-          pnpm --dir editors/vscode verify:vsix "$destination\extension" $vsix.FullName
-          "FALLOW_EXTENSION_PATH=$destination\extension" >> $env:GITHUB_ENV
-
-      - name: Run isolated VSIX type-aware host smoke
-        env:
-          FALLOW_BIN: ${{ github.workspace }}\target\debug\fallow.exe
-          FALLOW_LSP_BIN: ${{ github.workspace }}\target\debug\fallow-lsp.exe
-        run: pnpm --dir editors/vscode run test:integration:real
-
       - name: Run staged subgenerator integration tests
         run: node --test scripts/subgenerator-staging.test.mjs
 
@@ -141,6 +120,133 @@ jobs:
 
       - name: Check for uncommitted changes
         run: git diff --exit-code
+
+  vscode-package-targets:
+    name: Package VS Code target artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.33.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - name: Install VS Code dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Test target VSIX packaging contracts
+        run: pnpm --dir editors/vscode test:packaging
+      - name: Package target VSIX artifacts
+        run: pnpm --dir editors/vscode package:variants -- --output-dir "$RUNNER_TEMP/fallow-vscode-targets"
+      - name: Upload target VSIX artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: validation-vscode-targets
+          path: ${{ runner.temp }}/fallow-vscode-targets
+
+  vscode-target-host:
+    name: VS Code target host (${{ matrix.target }})
+    needs: vscode-package-targets
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            cli: target/debug/fallow
+            lsp: target/debug/fallow-lsp
+          - os: windows-latest
+            target: win32-x64
+            cli: target/debug/fallow.exe
+            lsp: target/debug/fallow-lsp.exe
+          - os: macos-15-intel
+            target: darwin-x64
+            cli: target/debug/fallow
+            lsp: target/debug/fallow-lsp
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: release-vscode-target-${{ matrix.target }}
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.33.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+      - name: Cache VS Code test download
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ runner.temp }}/fallow-vscode-test-cache
+          key: release-vscode-target-${{ matrix.target }}-vscode-1.96.0
+      - name: Install VS Code dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build current CLI and LSP binaries
+        run: cargo build -p fallow-cli --bin fallow -p fallow-lsp --bin fallow-lsp
+      - name: Download Ubuntu-built target VSIX artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: validation-vscode-targets
+          path: ${{ runner.temp }}/fallow-vscode-targets
+      - name: Extract and verify the exact target VSIX on Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          FALLOW_VSIX_TARGET: ${{ matrix.target }}
+        run: |
+          version="$(node -p "require('./editors/vscode/package.json').version")"
+          vsix="$RUNNER_TEMP/fallow-vscode-targets/fallow-vscode-$version-$FALLOW_VSIX_TARGET.vsix"
+          test -f "$vsix"
+          destination="$RUNNER_TEMP/fallow-vscode-$FALLOW_VSIX_TARGET"
+          unzip -q "$vsix" -d "$destination"
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix" --target "$FALLOW_VSIX_TARGET"
+          echo "FALLOW_EXTENSION_PATH=$(realpath "$destination/extension")" >> "$GITHUB_ENV"
+      - name: Extract and verify the exact target VSIX on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          FALLOW_VSIX_TARGET: ${{ matrix.target }}
+        run: |
+          $version = (Get-Content editors/vscode/package.json | ConvertFrom-Json).version
+          $vsix = Join-Path $env:RUNNER_TEMP "fallow-vscode-targets/fallow-vscode-$version-$env:FALLOW_VSIX_TARGET.vsix"
+          if (-not (Test-Path -PathType Leaf $vsix)) { throw "Expected target VSIX was not downloaded: $vsix" }
+          $archive = Join-Path $env:RUNNER_TEMP "fallow-vscode-$env:FALLOW_VSIX_TARGET.zip"
+          $destination = Join-Path $env:RUNNER_TEMP "fallow-vscode-$env:FALLOW_VSIX_TARGET"
+          Copy-Item $vsix $archive
+          Expand-Archive -Path $archive -DestinationPath $destination
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" $vsix --target $env:FALLOW_VSIX_TARGET
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $extensionPath = (Resolve-Path "$destination/extension").Path
+          "FALLOW_EXTENSION_PATH=$extensionPath" >> $env:GITHUB_ENV
+      - name: Run exact target VSIX host smoke on Linux
+        if: runner.os == 'Linux'
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/${{ matrix.cli }}
+          FALLOW_LSP_BIN: ${{ github.workspace }}/${{ matrix.lsp }}
+          FALLOW_VSCODE_TEST_CACHE_PATH: ${{ runner.temp }}/fallow-vscode-test-cache
+        run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
+      - name: Run exact target VSIX host smoke
+        if: runner.os != 'Linux'
+        env:
+          FALLOW_BIN: ${{ github.workspace }}/${{ matrix.cli }}
+          FALLOW_LSP_BIN: ${{ github.workspace }}/${{ matrix.lsp }}
+          FALLOW_VSCODE_TEST_CACHE_PATH: ${{ runner.temp }}/fallow-vscode-test-cache
+        run: pnpm --dir editors/vscode run test:integration:real
 
   zed-verify:
     name: Zed verification (${{ matrix.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -565,7 +565,7 @@ jobs:
 
   release-assets:
     name: Stage GitHub Release assets
-    needs: release-verified
+    needs: [release-verified, vscode-prep, vscode-host-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -656,7 +656,7 @@ jobs:
   # bundle validates config/plugin/rule-pack schemas, output schema, npm
   # capability metadata, issue registry export, TS output contracts, NAPI types,
   # and agent docs.
-  # Failure here blocks `npm-publish` AND `vscode-publish`. Refs #416.
+  # Failure here blocks `npm-publish` and both VSIX publisher jobs. Refs #416.
   #
   # Prep-tier job: `contents: read` only, no publish tokens, so running
   # `pnpm install` here matches the release-workflow security boundary
@@ -1076,13 +1076,11 @@ jobs:
             exit 1
           fi
 
-  # Build the .vsix in a job with no marketplace tokens. The matching
-  # vscode-publish job below downloads the .vsix as an artifact and runs
-  # only `vsce publish --packagePath` / `ovsx publish <file>` so VSCE_PAT
-  # and OVSX_PAT are never co-resident with `pnpm install` / extension
-  # build steps that execute dependency code.
+  # Build all marketplace variants in a job with no marketplace tokens.
+  # Publisher jobs below receive only this closed artifact set. They never
+  # check out or build repository code while a registry token is present.
   vscode-prep:
-    name: Build VS Code .vsix
+    name: Build VS Code target VSIX files
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1120,90 +1118,340 @@ jobs:
       - name: Copy LICENSE into extension directory
         run: cp LICENSE editors/vscode/LICENSE
 
-      - name: Build and package extension
+      - name: Build and verify target packages
         run: |
-          cd editors/vscode
-          pnpm build
-          pnpm package
+          pnpm --dir editors/vscode package:variants -- \
+            --output-dir "$RUNNER_TEMP/fallow-vscode-targets"
 
-      - name: Verify packaged type-aware payload
+      - name: Require the closed target artifact set
+        shell: bash
         run: |
-          vsix="$(find editors/vscode -maxdepth 1 -name '*.vsix' -print -quit)"
-          test -n "$vsix"
-          vsix="$(realpath "$vsix")"
-          archive="$RUNNER_TEMP/fallow-vsix.zip"
-          destination="$RUNNER_TEMP/fallow-vsix-release"
-          cp "$vsix" "$archive"
-          unzip -q "$archive" -d "$destination"
-          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix"
+          set -euo pipefail
+          root="$RUNNER_TEMP/fallow-vscode-targets"
+          version="${RELEASE_TAG#v}"
+          targets=(
+            universal
+            darwin-arm64
+            darwin-x64
+            linux-arm64
+            linux-x64
+            win32-arm64
+            win32-x64
+          )
+          expected_files=(inventory.json SHA256SUMS)
+          for target in "${targets[@]}"; do
+            expected_files+=("fallow-vscode-${version}-${target}.vsix")
+          done
 
-      - name: Upload VSIX artifact
+          mapfile -t actual_files < <(find "$root" -maxdepth 1 -type f -printf '%f\n' | sort)
+          mapfile -t expected_sorted < <(printf '%s\n' "${expected_files[@]}" | sort)
+          if ! diff -u \
+            <(printf '%s\n' "${expected_sorted[@]}") \
+            <(printf '%s\n' "${actual_files[@]}"); then
+            echo "::error::VSIX target artifact contains missing or unexpected files"
+            exit 1
+          fi
+          jq -e \
+            --arg version "$version" \
+            --argjson targets '[["universal",null],["darwin-arm64","darwin-arm64"],["darwin-x64","darwin-x64"],["linux-arm64","linux-arm64"],["linux-x64","linux-x64"],["win32-arm64","win32-arm64"],["win32-x64","win32-x64"]]' \
+            '.schemaVersion == 1 and .extensionVersion == $version and ([.entries[] | [.target, .targetPlatform]] == $targets)' \
+            "$root/inventory.json"
+
+      - name: Upload VSIX target artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: fallow-vscode
-          path: editors/vscode/*.vsix
+          name: fallow-vscode-targets
+          path: ${{ runner.temp }}/fallow-vscode-targets/
+          if-no-files-found: error
+          retention-days: 7
+          include-hidden-files: false
 
-  vscode-publish:
-    name: Publish VS Code Extension
-    needs: [vscode-prep, release-assets]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+  # Exercise the exact staged release packages with the matching release
+  # binaries before any registry token or GitHub release asset staging runs.
+  vscode-host-smoke:
+    name: VS Code release target host (${{ matrix.target }})
+    needs: vscode-prep
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            npm_dir: linux-x64-gnu
+            cli: fallow-linux-x64-gnu
+            lsp: fallow-lsp-linux-x64-gnu
+          - os: windows-latest
+            target: win32-x64
+            npm_dir: win32-x64-msvc
+            cli: fallow-win32-x64-msvc.exe
+            lsp: fallow-lsp-win32-x64-msvc.exe
+          - os: macos-15-intel
+            target: darwin-x64
+            npm_dir: darwin-x64
+            cli: fallow-darwin-x64
+            lsp: fallow-lsp-darwin-x64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: editors/vscode/pnpm-lock.yaml
+
+      - name: Cache VS Code test download
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ runner.temp }}/fallow-vscode-test-cache
+          key: release-vscode-host-${{ matrix.target }}-vscode-1.96.0
+
+      - name: Install VS Code dependencies
+        run: cd editors/vscode && pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Download exact prepared VSIX targets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fallow-vscode-targets
+          path: ${{ runner.temp }}/fallow-vscode-targets
+
+      - name: Download matching release CLI
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fallow-cli-${{ matrix.npm_dir }}
+          path: ${{ runner.temp }}/fallow-host-bin
+
+      - name: Download matching release LSP
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fallow-lsp-${{ matrix.npm_dir }}
+          path: ${{ runner.temp }}/fallow-host-bin
+
+      - name: Prepare exact release binaries on Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          CLI_NAME: ${{ matrix.cli }}
+          LSP_NAME: ${{ matrix.lsp }}
+        run: |
+          set -euo pipefail
+          cli="$RUNNER_TEMP/fallow-host-bin/$CLI_NAME"
+          lsp="$RUNNER_TEMP/fallow-host-bin/$LSP_NAME"
+          test -f "$cli"
+          test -f "$lsp"
+          chmod +x "$cli" "$lsp"
+          echo "FALLOW_BIN=$(realpath "$cli")" >> "$GITHUB_ENV"
+          echo "FALLOW_LSP_BIN=$(realpath "$lsp")" >> "$GITHUB_ENV"
+
+      - name: Prepare exact release binaries on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          CLI_NAME: ${{ matrix.cli }}
+          LSP_NAME: ${{ matrix.lsp }}
+        run: |
+          $cli = (Resolve-Path (Join-Path $env:RUNNER_TEMP "fallow-host-bin/$env:CLI_NAME")).Path
+          $lsp = (Resolve-Path (Join-Path $env:RUNNER_TEMP "fallow-host-bin/$env:LSP_NAME")).Path
+          "FALLOW_BIN=$cli" >> $env:GITHUB_ENV
+          "FALLOW_LSP_BIN=$lsp" >> $env:GITHUB_ENV
+
+      - name: Extract and verify the exact release VSIX on Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          FALLOW_VSIX_TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          vsix="$RUNNER_TEMP/fallow-vscode-targets/fallow-vscode-$version-$FALLOW_VSIX_TARGET.vsix"
+          test -f "$vsix"
+          destination="$RUNNER_TEMP/fallow-vscode-$FALLOW_VSIX_TARGET"
+          unzip -q "$vsix" -d "$destination"
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" "$vsix" \
+            --target "$FALLOW_VSIX_TARGET" --version "$version"
+          echo "FALLOW_EXTENSION_PATH=$(realpath "$destination/extension")" >> "$GITHUB_ENV"
+
+      - name: Extract and verify the exact release VSIX on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          FALLOW_VSIX_TARGET: ${{ matrix.target }}
+        run: |
+          $version = $env:RELEASE_TAG.Substring(1)
+          $vsix = Join-Path $env:RUNNER_TEMP "fallow-vscode-targets/fallow-vscode-$version-$env:FALLOW_VSIX_TARGET.vsix"
+          if (-not (Test-Path -PathType Leaf $vsix)) { throw "Expected target VSIX was not downloaded: $vsix" }
+          $archive = Join-Path $env:RUNNER_TEMP "fallow-vscode-$env:FALLOW_VSIX_TARGET.zip"
+          $destination = Join-Path $env:RUNNER_TEMP "fallow-vscode-$env:FALLOW_VSIX_TARGET"
+          Copy-Item $vsix $archive
+          Expand-Archive -Path $archive -DestinationPath $destination
+          pnpm --dir editors/vscode verify:vsix "$destination/extension" $vsix --target $env:FALLOW_VSIX_TARGET --version $version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $extensionPath = (Resolve-Path "$destination/extension").Path
+          "FALLOW_EXTENSION_PATH=$extensionPath" >> $env:GITHUB_ENV
+
+      - name: Run exact release target VSIX host smoke on Linux
+        if: runner.os == 'Linux'
+        env:
+          FALLOW_VSCODE_TEST_CACHE_PATH: ${{ runner.temp }}/fallow-vscode-test-cache
+        run: xvfb-run -a pnpm --dir editors/vscode run test:integration:real
+
+      - name: Run exact release target VSIX host smoke
+        if: runner.os != 'Linux'
+        env:
+          FALLOW_VSCODE_TEST_CACHE_PATH: ${{ runner.temp }}/fallow-vscode-test-cache
+        run: pnpm --dir editors/vscode run test:integration:real
+
+  vscode-publish-marketplace:
+    name: Publish VS Code Marketplace targets
+    needs: [vscode-prep, vscode-host-smoke, release-assets]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: '22'
 
-      - name: Download VSIX
+      - name: Download closed VSIX target artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: fallow-vscode
-          path: vsix
+          name: fallow-vscode-targets
+          path: vscode-targets
 
-      - name: Locate VSIX
-        id: vsix
-        run: |
-          file_count=$(find vsix -maxdepth 1 -name '*.vsix' -type f | wc -l | tr -d ' ')
-          if [ "$file_count" -ne 1 ]; then
-            echo "::error::Expected exactly one .vsix file in artifact, found $file_count"
-            find vsix -maxdepth 1 -name '*.vsix' -type f | sort
-            exit 1
-          fi
-          file=$(find vsix -maxdepth 1 -name '*.vsix' -type f | sort | head -n1)
-          echo "path=$file" >> "$GITHUB_OUTPUT"
+      - name: Install VS Code Marketplace publisher
+        run: npm install -g --ignore-scripts @vscode/vsce@3.9.2
 
-      # Install the publisher CLIs with --ignore-scripts so any compromised
-      # install/postinstall script of @vscode/vsce or ovsx (or a transitive
-      # dependency) cannot execute with VSCE_PAT / OVSX_PAT in the
-      # environment. Versions are pinned to match the editor's pnpm-lock.
-      - name: Install publisher CLIs
-        run: npm install -g --ignore-scripts @vscode/vsce@3.9.1 ovsx@0.10.11
-
-      - name: Publish to VS Code Marketplace
-        # continue-on-error so a transient failure here does not skip Open VSX
-        # publish below. On a `gh run rerun --failed`, vsce will exit non-zero
-        # with version-exists, but the next step still runs.
-        continue-on-error: true
+      - name: Publish every target to VS Code Marketplace
+        shell: bash
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          VSIX_PATH: ${{ steps.vsix.outputs.path }}
-        run: vsce publish --packagePath "$VSIX_PATH" --no-dependencies
+        run: |
+          set -u
+          version="${RELEASE_TAG#v}"
+          targets=(universal darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64)
+          mapfile -t files < <(jq -er '.entries[].file' vscode-targets/inventory.json)
+          if [ "${#files[@]}" -ne "${#targets[@]}" ]; then
+            echo "::error::Inventory does not contain the exact target count"
+            exit 1
+          fi
+          for index in "${!targets[@]}"; do
+            expected="fallow-vscode-${version}-${targets[$index]}.vsix"
+            if [ "${files[$index]}" != "$expected" ]; then
+              echo "::error::Unexpected inventory filename: ${files[$index]}"
+              exit 1
+            fi
+          done
+          failed=0
+          for file in "${files[@]}"; do
+            if [ ! -f "vscode-targets/$file" ]; then
+              echo "::error::Missing inventory file: $file"
+              failed=1
+              continue
+            fi
+            if ! vsce publish \
+              --packagePath "vscode-targets/$file" \
+              --no-dependencies \
+              --skip-duplicate; then
+              echo "::error::VS Code Marketplace publication failed for $file"
+              failed=1
+            fi
+          done
+          exit "$failed"
 
-      - name: Publish to Open VSX (Cursor, VSCodium)
-        # continue-on-error so a transient 502 from openvsx.org does not block
-        # an isolated re-run from succeeding. Without this, `gh run rerun
-        # --failed` re-runs the entire job, vsce publish then fails with
-        # version-exists, and Open VSX never gets retried.
-        continue-on-error: true
+  vscode-publish-open-vsx:
+    name: Publish Open VSX targets
+    needs: [vscode-prep, vscode-host-smoke, release-assets]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
+    steps:
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+
+      - name: Download closed VSIX target artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fallow-vscode-targets
+          path: vscode-targets
+
+      - name: Install Open VSX publisher
+        run: npm install -g --ignore-scripts ovsx@1.1.0
+
+      - name: Publish every target to Open VSX
+        shell: bash
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
-          VSIX_PATH: ${{ steps.vsix.outputs.path }}
-        run: ovsx publish "$VSIX_PATH" --no-dependencies
+        run: |
+          set -u
+          version="${RELEASE_TAG#v}"
+          targets=(universal darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64)
+          mapfile -t files < <(jq -er '.entries[].file' vscode-targets/inventory.json)
+          if [ "${#files[@]}" -ne "${#targets[@]}" ]; then
+            echo "::error::Inventory does not contain the exact target count"
+            exit 1
+          fi
+          for index in "${!targets[@]}"; do
+            expected="fallow-vscode-${version}-${targets[$index]}.vsix"
+            if [ "${files[$index]}" != "$expected" ]; then
+              echo "::error::Unexpected inventory filename: ${files[$index]}"
+              exit 1
+            fi
+          done
+          failed=0
+          for file in "${files[@]}"; do
+            if [ ! -f "vscode-targets/$file" ]; then
+              echo "::error::Missing inventory file: $file"
+              failed=1
+              continue
+            fi
+            if ! ovsx publish \
+              "vscode-targets/$file" \
+              --no-dependencies \
+              --skip-duplicate; then
+              echo "::error::Open VSX publication failed for $file"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+  vscode-public-verify:
+    name: Verify public VS Code registry targets
+    needs: [vscode-prep, vscode-publish-marketplace, vscode-publish-open-vsx]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+
+      - name: Download closed VSIX target artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: fallow-vscode-targets
+          path: vscode-targets
+
+      - name: Verify exact public registry payloads
+        run: node scripts/vscode-public-verify.mjs --artifact-dir vscode-targets
 
   release-ready:
     name: Release ready for signed tag
-    needs: [publish-crates, npm-publish, vscode-publish, release-assets]
+    needs: [publish-crates, npm-publish, vscode-public-verify, release-assets]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The VS Code extension now publishes platform-specific packages for macOS,
+  Linux, and Windows.** Each targeted VSIX carries only its matching semantic
+  backend, reducing normal extension downloads by roughly 82 to 84 percent.
+  The existing universal package remains available as a compatibility fallback.
+
+### Changed
+
+- **Extension publication now verifies every public target before a release can
+  complete.** Visual Studio Marketplace and Open VSX use isolated publisher
+  jobs, while a credential-free gate downloads and validates the exact
+  universal and platform-specific payloads from both registries.
+
 ## [3.17.0] - 2026-08-16
 
 ### Added

--- a/docs/development/release-security.md
+++ b/docs/development/release-security.md
@@ -13,13 +13,16 @@ creates, moves, or publishes Git tags or GitHub Releases.
 | `build` | Build and sign release artifacts | Artifact signing only |
 | `validate` | Reusable release validation | Read only |
 | `release-verified` | Join build and validation | None |
-| `release-assets` | Flatten and store the complete GitHub asset bundle as a run artifact | Read only |
+| `release-assets` | Flatten and store the complete GitHub asset bundle, including all VSIX targets | Read only |
 | `release-ready` | Join publication jobs and prove the tag is still absent | Read only |
 | `publish-crates` | Publish prevalidated crates in dependency order | crates.io OIDC |
 | `npm-prep` | Install, assemble, and pack npm artifacts | Read only |
 | `npm-publish` | Publish downloaded tarballs | npm publication |
-| `vscode-prep` | Install, build, and package the extension | Read only |
-| `vscode-publish` | Publish the downloaded VSIX | Marketplace tokens |
+| `vscode-prep` | Build seven VSIX targets plus their inventory and checksums | Read only |
+| `vscode-host-smoke` | Run the exact prepared x64 target VSIX on Linux, Windows, and macOS with matching release binaries | Read only |
+| `vscode-publish-marketplace` | Publish the closed VSIX set to Visual Studio Marketplace | VSCE token only |
+| `vscode-publish-open-vsx` | Publish the closed VSIX set to Open VSX | OVSX token only |
+| `vscode-public-verify` | Verify exact public target payloads from both registries | Read only |
 
 Preparation jobs may execute dependency code because they have no publication
 credentials. Publication jobs must remain small. They must not install
@@ -30,10 +33,27 @@ globally with `--ignore-scripts`.
 ## Invariants
 
 - Keep every checkout at `persist-credentials: false`.
-- Keep repository dependency installation out of `npm-publish`,
-  `vscode-publish`, and `publish-crates`.
+- Keep repository dependency installation out of `npm-publish`, both VSIX
+  publisher jobs, and `publish-crates`.
 - Keep `--ignore-scripts` on every privileged `npm publish`.
 - Keep global publication tools pinned to reviewed versions.
+- Keep the VSIX artifact closed to the seven universal and platform-specific
+  packages, `inventory.json`, and `SHA256SUMS`. The inventory is universal
+  first and publication follows that order.
+- Make `vscode-host-smoke` download the exact `vscode-prep` artifact and the
+  matching release CLI and LSP artifacts. It must verify and load the exact
+  extracted `linux-x64`, `win32-x64`, and `darwin-x64` extension paths, preserve
+  archive executable modes on Unix, and never rebuild those release binaries.
+  Both VSIX publishers and `release-assets` must wait for this matrix.
+- Give each VSIX publisher only its matching token and pinned CLI. It must not
+  check out repository code or build packages. Publish every inventory entry
+  with `--skip-duplicate`, attempt the remaining entries after an unexpected
+  failure, and fail the job after the loop.
+- Gate `release-ready` directly on `vscode-public-verify`. The verifier has no
+  registry credentials. It waits for the exact version and target tuples with
+  bounded retries, downloads each exact registry asset, and compares its
+  normalized extension payload with the prepared inventory. Universal fallback
+  never satisfies a platform target.
 - Keep `cargo publish --no-verify` in the credential-bearing job. Compilation
   and validation happen before credentials are present.
 - Keep the publishable crate list in dependency order and aligned with the

--- a/docs/reference/vscode-internals.md
+++ b/docs/reference/vscode-internals.md
@@ -38,6 +38,13 @@ Do not duplicate the full setting list in durable prose.
   synchronized with Rust sources.
 - Multi-root workspace selection remains explicit and paths stay scoped to the
   selected project.
+- The extension runs as a workspace extension. Local and remote extension hosts
+  therefore select binaries and platform-specific VSIX payloads for the machine
+  that owns the workspace, not the VS Code UI machine.
+- `editors/vscode/scripts/vsix-targets.mjs` is the closed source of truth for
+  VSIX targets and their TypeScript backend packages. Target packages contain
+  one matching backend; the untargeted universal fallback contains all
+  supported backends.
 - `dist/` is generated for packaging and remains untracked.
 
 ## Verification
@@ -46,7 +53,11 @@ Do not duplicate the full setting list in durable prose.
 pnpm --dir editors/vscode run lint
 pnpm --dir editors/vscode run check:contracts
 pnpm --dir editors/vscode run build
+pnpm --dir editors/vscode run test:packaging
 ```
 
 Run focused editor tests for command, configuration, download, or diagnostic
-changes.
+changes. Release packaging uses `package:variants` to build the universal
+fallback and every platform target from one build into an explicit output
+directory. Verify extracted artifacts with `verify:vsix` and the matching
+`--target` value.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -57,6 +57,9 @@
     "workspaceContains:**/package.json"
   ],
   "main": "./dist/extension.js",
+  "extensionKind": [
+    "workspace"
+  ],
   "contributes": {
     "jsonValidation": [
       {
@@ -908,10 +911,12 @@
     "lint": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "pnpm run test:unit && pnpm run test:integration",
     "test:unit": "vitest run",
+    "test:packaging": "node --test ./scripts/*.test.mjs",
     "test:integration": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/runTest.js",
     "test:integration:real": "pnpm run build && tsc -p tsconfig.test.json && node ./.test-dist/test/integration/real/runTest.js",
     "prepackage": "pnpm run codegen:contracts && pnpm run build && node ./scripts/copy-license.mjs",
     "package": "vsce package --no-dependencies",
+    "package:variants": "pnpm run build && node ./scripts/copy-license.mjs && node ./scripts/package-vsix-variants.mjs",
     "verify:vsix": "node ./scripts/verify-packaged-type-aware.mjs",
     "publish": "vsce publish --no-dependencies",
     "publish:ovsx": "ovsx publish --no-dependencies"
@@ -931,6 +936,7 @@
     "rolldown": "1.2.2",
     "ovsx": "1.1.0",
     "typescript": "7.0.2",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yauzl": "3.3.2"
   }
 }

--- a/editors/vscode/pnpm-lock.yaml
+++ b/editors/vscode/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@26.1.2)(vite@8.0.8(@types/node@26.1.2))
+      yauzl:
+        specifier: 3.3.2
+        version: 3.3.2
 
 packages:
 

--- a/editors/vscode/scripts/package-type-aware.mjs
+++ b/editors/vscode/scripts/package-type-aware.mjs
@@ -7,82 +7,94 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const extensionRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const repoRoot = join(extensionRoot, "..", "..");
-const sourceRoot = join(repoRoot, "tools", "type-aware-sidecar");
-const destination = join(extensionRoot, "dist", "type-aware");
-const protocol = JSON.parse(
-  readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
-);
-const backendVersion = protocol.backend.version;
-const platformPackages = [
-  { name: "@typescript/typescript-darwin-arm64", os: "darwin", cpu: "arm64", bin: "tsc" },
-  { name: "@typescript/typescript-darwin-x64", os: "darwin", cpu: "x64", bin: "tsc" },
-  { name: "@typescript/typescript-linux-arm64", os: "linux", cpu: "arm64", bin: "tsc" },
-  { name: "@typescript/typescript-linux-x64", os: "linux", cpu: "x64", bin: "tsc" },
-  {
-    name: "@typescript/typescript-win32-arm64",
-    os: "win32",
-    cpu: "arm64",
-    bin: "tsc.exe",
-  },
-  {
-    name: "@typescript/typescript-win32-x64",
-    os: "win32",
-    cpu: "x64",
-    bin: "tsc.exe",
-  },
-];
+import { getVsixVariant, TYPE_AWARE_BACKENDS, UNIVERSAL_VSIX_TARGET } from "./vsix-targets.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultExtensionRoot = join(dirname(scriptPath), "..");
+const defaultRepoRoot = join(defaultExtensionRoot, "..", "..");
 
 const readPackage = (directory) =>
   JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
 
-const copyPlatformPackage = ({ name, os, cpu, bin }) => {
-  const source = join(typescriptNodeModules, ...name.split("/"));
-  const manifest = readPackage(source);
-  if (
-    manifest.name !== name ||
-    manifest.version !== backendVersion ||
-    !manifest.os?.includes(os) ||
-    !manifest.cpu?.includes(cpu)
-  ) {
-    throw new Error(`invalid bundled TypeScript backend metadata for ${name}`);
+export const packageTypeAware = ({
+  target = UNIVERSAL_VSIX_TARGET,
+  extensionRoot = defaultExtensionRoot,
+  repoRoot = defaultRepoRoot,
+  destination = join(extensionRoot, "dist", "type-aware"),
+} = {}) => {
+  const variant = getVsixVariant(target);
+  const sourceRoot = join(repoRoot, "tools", "type-aware-sidecar");
+  const protocol = JSON.parse(
+    readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
+  );
+  const backendVersion = protocol.backend.version;
+  const typescriptSource = join(extensionRoot, "node_modules", "typescript");
+  const typescriptNodeModules = dirname(realpathSync(typescriptSource));
+  const typescriptManifest = readPackage(typescriptSource);
+
+  if (typescriptManifest.version !== backendVersion) {
+    throw new Error(`expected TypeScript ${backendVersion}, found ${typescriptManifest.version}`);
   }
-  const executable = join(source, "lib", bin);
-  const mode = statSync(executable).mode;
-  if (process.platform !== "win32" && os !== "win32" && (mode & 0o111) === 0) {
-    throw new Error(`bundled TypeScript backend is not executable: ${name}`);
+  for (const { packageName } of TYPE_AWARE_BACKENDS) {
+    if (typescriptManifest.optionalDependencies?.[packageName] !== backendVersion) {
+      throw new Error(`TypeScript does not pin ${packageName} to ${backendVersion}`);
+    }
   }
-  cpSync(source, join(destination, "node_modules", ...name.split("/")), {
+
+  rmSync(destination, { recursive: true, force: true });
+  mkdirSync(join(destination, "node_modules"), { recursive: true });
+  cpSync(join(sourceRoot, "fallow-type-aware.mjs"), join(destination, "fallow-type-aware.mjs"));
+  cpSync(join(sourceRoot, "src"), join(destination, "src"), {
     dereference: true,
     recursive: true,
   });
+  cpSync(join(sourceRoot, "package.json"), join(destination, "package.json"));
+  cpSync(typescriptSource, join(destination, "node_modules", "typescript"), {
+    dereference: true,
+    recursive: true,
+  });
+
+  for (const { packageName, os, cpu, executable } of variant.backends) {
+    const source = join(typescriptNodeModules, ...packageName.split("/"));
+    const manifest = readPackage(source);
+    if (
+      manifest.name !== packageName ||
+      manifest.version !== backendVersion ||
+      !manifest.os?.includes(os) ||
+      !manifest.cpu?.includes(cpu)
+    ) {
+      throw new Error(`invalid bundled TypeScript backend metadata for ${packageName}`);
+    }
+    const sourceExecutable = join(source, "lib", executable);
+    if (
+      process.platform !== "win32" &&
+      os !== "win32" &&
+      (statSync(sourceExecutable).mode & 0o111) === 0
+    ) {
+      throw new Error(`bundled TypeScript backend is not executable: ${packageName}`);
+    }
+    const targetDirectory = join(destination, "node_modules", ...packageName.split("/"));
+    cpSync(source, targetDirectory, { dereference: true, recursive: true });
+    const targetExecutable = join(targetDirectory, "lib", executable);
+    if (
+      process.platform !== "win32" &&
+      os !== "win32" &&
+      (statSync(targetExecutable).mode & 0o111) === 0
+    ) {
+      throw new Error(`copied TypeScript backend is not executable: ${packageName}`);
+    }
+  }
+
+  chmodSync(join(destination, "fallow-type-aware.mjs"), 0o755);
+  return { backendVersion, destination, variant };
 };
 
-rmSync(destination, { recursive: true, force: true });
-mkdirSync(join(destination, "node_modules"), { recursive: true });
-cpSync(join(sourceRoot, "fallow-type-aware.mjs"), join(destination, "fallow-type-aware.mjs"));
-cpSync(join(sourceRoot, "src"), join(destination, "src"), { recursive: true });
-cpSync(join(sourceRoot, "package.json"), join(destination, "package.json"));
-const typescriptSource = join(extensionRoot, "node_modules", "typescript");
-const typescriptNodeModules = dirname(realpathSync(typescriptSource));
-const typescriptManifest = readPackage(typescriptSource);
-if (typescriptManifest.version !== backendVersion) {
-  throw new Error(`expected TypeScript ${backendVersion}, found ${typescriptManifest.version}`);
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(scriptPath);
+if (isMain) {
+  const target = process.argv[2] ?? UNIVERSAL_VSIX_TARGET;
+  const destination = process.argv[3] ? resolve(process.argv[3]) : undefined;
+  packageTypeAware({ target, ...(destination ? { destination } : {}) });
 }
-for (const { name } of platformPackages) {
-  if (typescriptManifest.optionalDependencies?.[name] !== backendVersion) {
-    throw new Error(`TypeScript does not pin ${name} to ${backendVersion}`);
-  }
-}
-cpSync(typescriptSource, join(destination, "node_modules", "typescript"), {
-  dereference: true,
-  recursive: true,
-});
-for (const platformPackage of platformPackages) {
-  copyPlatformPackage(platformPackage);
-}
-chmodSync(join(destination, "fallow-type-aware.mjs"), 0o755);

--- a/editors/vscode/scripts/package-vsix-variants.mjs
+++ b/editors/vscode/scripts/package-vsix-variants.mjs
@@ -1,0 +1,153 @@
+import {
+  accessSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createVSIX, listFiles, PackageManager } from "@vscode/vsce";
+
+import { packageTypeAware } from "./package-type-aware.mjs";
+import { verifyPackagedTypeAware } from "./verify-packaged-type-aware.mjs";
+import { createInventory, writeInventory } from "./vsix-inventory.mjs";
+import { VSIX_VARIANTS, vsixFilename } from "./vsix-targets.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultExtensionRoot = join(dirname(scriptPath), "..");
+const defaultRepoRoot = join(defaultExtensionRoot, "..", "..");
+const DEFAULT_SOURCE_DATE_EPOCH = "315532800";
+
+const prepareOutputDirectory = (outputDirectory) => {
+  mkdirSync(outputDirectory, { recursive: true });
+  const existing = readdirSync(outputDirectory);
+  if (existing.length > 0) {
+    throw new Error(`VSIX output directory must be empty: ${outputDirectory}`);
+  }
+};
+
+const copyPackageFiles = (extensionRoot, stageRoot, packageFiles) => {
+  for (const relativePath of packageFiles) {
+    const normalizedPath = relativePath.replaceAll("\\", "/");
+    if (
+      normalizedPath.startsWith("dist/type-aware/") ||
+      normalizedPath.endsWith("/.metadata_never_index")
+    ) {
+      continue;
+    }
+    const source = join(extensionRoot, relativePath);
+    const destination = join(stageRoot, relativePath);
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(source, destination, { dereference: true, recursive: true });
+  }
+  const ignoreSource = join(extensionRoot, ".vscodeignore");
+  accessSync(ignoreSource);
+  cpSync(ignoreSource, join(stageRoot, ".vscodeignore"));
+};
+
+export const packageVsixVariants = async ({
+  outputDirectory,
+  extensionRoot = defaultExtensionRoot,
+  repoRoot = defaultRepoRoot,
+  createVsix = createVSIX,
+  createStagingRoot = () => mkdtempSync(join(tmpdir(), "fallow-vsix-variants-")),
+  listPackageFiles = listFiles,
+  packagePayload = packageTypeAware,
+  removeStagingRoot = (path) => rmSync(path, { recursive: true, force: true }),
+  verifyPackage = verifyPackagedTypeAware,
+  writeOutputInventory = writeInventory,
+} = {}) => {
+  if (!outputDirectory) {
+    throw new Error("packageVsixVariants requires outputDirectory");
+  }
+  const outputRoot = resolve(outputDirectory);
+  const sourceRoot = resolve(extensionRoot);
+  const repositoryRoot = resolve(repoRoot);
+  accessSync(join(sourceRoot, "dist", "extension.js"));
+  accessSync(join(sourceRoot, "dist", "type-aware", "fallow-type-aware.mjs"));
+  prepareOutputDirectory(outputRoot);
+
+  const manifest = JSON.parse(readFileSync(join(sourceRoot, "package.json"), "utf8"));
+  const packageFiles = await listPackageFiles({
+    cwd: sourceRoot,
+    packageManager: PackageManager.None,
+    packagedDependencies: [],
+  });
+  const stagingRoot = createStagingRoot();
+  const previousEpoch = process.env.SOURCE_DATE_EPOCH;
+  process.env.SOURCE_DATE_EPOCH = previousEpoch || DEFAULT_SOURCE_DATE_EPOCH;
+
+  try {
+    const entries = [];
+    for (const variant of VSIX_VARIANTS) {
+      const stageRoot = join(stagingRoot, variant.target);
+      mkdirSync(stageRoot, { recursive: true });
+      copyPackageFiles(sourceRoot, stageRoot, packageFiles);
+      packagePayload({
+        target: variant.target,
+        extensionRoot: sourceRoot,
+        repoRoot: repositoryRoot,
+        destination: join(stageRoot, "dist", "type-aware"),
+      });
+      const file = vsixFilename(manifest.version, variant.target);
+      const vsixPath = join(outputRoot, file);
+      await createVsix({
+        cwd: stageRoot,
+        packagePath: vsixPath,
+        target: variant.targetPlatform ?? undefined,
+        dependencies: false,
+      });
+      const verified = await verifyPackage({
+        extensionRoot: stageRoot,
+        vsixPath,
+        target: variant.target,
+        expectedVersion: manifest.version,
+        repoRoot: repositoryRoot,
+      });
+      entries.push({ file, ...verified });
+    }
+    const inventory = createInventory(manifest.version, entries);
+    writeOutputInventory(outputRoot, inventory);
+    return inventory;
+  } finally {
+    if (previousEpoch === undefined) {
+      delete process.env.SOURCE_DATE_EPOCH;
+    } else {
+      process.env.SOURCE_DATE_EPOCH = previousEpoch;
+    }
+    removeStagingRoot(stagingRoot);
+  }
+};
+
+const parseArguments = (args) => {
+  let outputDirectory;
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--") {
+      continue;
+    }
+    if (args[index] === "--output-dir") {
+      outputDirectory = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`unknown package variants argument ${args[index]}`);
+    }
+  }
+  if (!outputDirectory) {
+    throw new Error("usage: package-vsix-variants.mjs --output-dir <directory>");
+  }
+  return { outputDirectory };
+};
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(scriptPath);
+if (isMain) {
+  const options = parseArguments(process.argv.slice(2));
+  const inventory = await packageVsixVariants(options);
+  process.stdout.write(
+    `Packaged ${inventory.entries.length} VSIX variants in ${resolve(options.outputDirectory)}.\n`,
+  );
+}

--- a/editors/vscode/scripts/verify-packaged-type-aware.mjs
+++ b/editors/vscode/scripts/verify-packaged-type-aware.mjs
@@ -1,56 +1,239 @@
-import { accessSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { lstatSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const MAX_VSIX_BYTES = 70 * 1024 * 1024;
-const extensionRoot = resolve(process.argv[2] ?? "");
-const vsixPath = process.argv[3] ? resolve(process.argv[3]) : undefined;
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
-const protocol = JSON.parse(
-  readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
-);
-const platformPackages = [
-  { name: "typescript-darwin-arm64", os: "darwin", cpu: "arm64", bin: "tsc" },
-  { name: "typescript-darwin-x64", os: "darwin", cpu: "x64", bin: "tsc" },
-  { name: "typescript-linux-arm64", os: "linux", cpu: "arm64", bin: "tsc" },
-  { name: "typescript-linux-x64", os: "linux", cpu: "x64", bin: "tsc" },
-  { name: "typescript-win32-arm64", os: "win32", cpu: "arm64", bin: "tsc.exe" },
-  { name: "typescript-win32-x64", os: "win32", cpu: "x64", bin: "tsc.exe" },
-];
+import { archiveFileRecord, inspectVsixArchive } from "./vsix-archive.mjs";
+import {
+  backendExecutableMode,
+  getVsixVariant,
+  TYPE_AWARE_BACKENDS,
+  TYPE_AWARE_SIDECAR_FILES,
+  UNIVERSAL_VSIX_TARGET,
+} from "./vsix-targets.mjs";
 
-if (!process.argv[2]) {
-  throw new Error("usage: verify-packaged-type-aware.mjs <extension-root> [vsix-path]");
-}
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultRepoRoot = join(dirname(scriptPath), "..", "..", "..");
 
-const packageRoot = join(extensionRoot, "dist", "type-aware", "node_modules", "@typescript");
-const actualPackages = readdirSync(packageRoot).sort();
-const expectedPackages = platformPackages.map(({ name }) => name).sort();
-if (JSON.stringify(actualPackages) !== JSON.stringify(expectedPackages)) {
-  throw new Error(`unexpected packaged TypeScript backends: ${actualPackages.join(", ")}`);
-}
+const readPackage = (directory) =>
+  JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
 
-for (const { name, os, cpu, bin } of platformPackages) {
-  const directory = join(packageRoot, name);
-  const manifest = JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
-  if (
-    manifest.name !== `@typescript/${name}` ||
-    manifest.version !== protocol.backend.version ||
-    !manifest.os?.includes(os) ||
-    !manifest.cpu?.includes(cpu)
-  ) {
-    throw new Error(`invalid packaged TypeScript backend metadata for ${name}`);
+const assertNoSymlinks = (root) => {
+  const visit = (path) => {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`packaged type-aware payload contains a symlink: ${relative(root, path)}`);
+    }
+    if (!stat.isDirectory()) {
+      return;
+    }
+    for (const entry of readdirSync(path)) {
+      visit(join(path, entry));
+    }
+  };
+  visit(root);
+};
+
+const fileMode = (path) => statSync(path).mode & 0o777;
+
+const assertExecutable = (path, label) => {
+  if (process.platform !== "win32" && (fileMode(path) & 0o111) === 0) {
+    throw new Error(`packaged ${label} is not executable`);
   }
-  const executable = join(directory, "lib", bin);
-  accessSync(executable);
-  if (process.platform !== "win32" && os !== "win32" && (statSync(executable).mode & 0o111) === 0) {
-    throw new Error(`packaged TypeScript backend is not executable: ${name}`);
+};
+
+export const assertVsixTargetPlatform = (actualTargetPlatform, target) => {
+  const variant = getVsixVariant(target);
+  if (actualTargetPlatform !== variant.targetPlatform) {
+    throw new Error(
+      `unexpected TargetPlatform for ${target}: expected ${variant.targetPlatform ?? "absent"}, found ${actualTargetPlatform ?? "absent"}`,
+    );
   }
-}
+};
 
-accessSync(join(extensionRoot, "dist", "type-aware", "fallow-type-aware.mjs"));
-accessSync(join(extensionRoot, "dist", "type-aware", "src", "windows-child-process.mjs"));
-if (vsixPath && statSync(vsixPath).size > MAX_VSIX_BYTES) {
-  throw new Error(`VSIX exceeds ${MAX_VSIX_BYTES} bytes: ${vsixPath}`);
-}
+const requireArchiveMode = (record, expectedMode, label) => {
+  if (record.mode !== expectedMode) {
+    throw new Error(
+      `unexpected archived mode for ${label}: expected ${expectedMode.toString(8)}, found ${record.mode === null ? "absent" : record.mode.toString(8)}`,
+    );
+  }
+};
 
-process.stdout.write("Packaged type-aware VSIX payload is complete.\n");
+const sidecarRecords = (archive) =>
+  TYPE_AWARE_SIDECAR_FILES.map(({ path, mode }) => {
+    const record = archiveFileRecord(archive, `extension/${path}`);
+    requireArchiveMode(record, mode, path);
+    return record;
+  });
+
+export const verifyPackagedTypeAware = async ({
+  extensionRoot,
+  vsixPath,
+  target = UNIVERSAL_VSIX_TARGET,
+  expectedVersion,
+  repoRoot = defaultRepoRoot,
+}) => {
+  const root = resolve(extensionRoot);
+  const variant = getVsixVariant(target);
+  const protocol = JSON.parse(
+    readFileSync(join(repoRoot, "crates", "api", "type-aware-protocol.json"), "utf8"),
+  );
+  const typeAwareRoot = join(root, "dist", "type-aware");
+  const packageRoot = join(typeAwareRoot, "node_modules", "@typescript");
+  const actualPackages = readdirSync(packageRoot).toSorted();
+  const expectedPackages = variant.backends
+    .map(({ packageName }) => packageName.slice("@typescript/".length))
+    .toSorted();
+  if (JSON.stringify(actualPackages) !== JSON.stringify(expectedPackages)) {
+    throw new Error(
+      `unexpected packaged TypeScript backends for ${target}: ${actualPackages.join(", ")}`,
+    );
+  }
+
+  assertNoSymlinks(typeAwareRoot);
+  const typescriptManifest = readPackage(join(typeAwareRoot, "node_modules", "typescript"));
+  if (typescriptManifest.version !== protocol.backend.version) {
+    throw new Error(
+      `invalid packaged TypeScript version: expected ${protocol.backend.version}, found ${typescriptManifest.version}`,
+    );
+  }
+  for (const { packageName } of TYPE_AWARE_BACKENDS) {
+    if (typescriptManifest.optionalDependencies?.[packageName] !== protocol.backend.version) {
+      throw new Error(
+        `packaged TypeScript does not pin ${packageName} to ${protocol.backend.version}`,
+      );
+    }
+  }
+
+  const sidecarEntrypoint = join(typeAwareRoot, "fallow-type-aware.mjs");
+  statSync(sidecarEntrypoint);
+  statSync(join(typeAwareRoot, "src", "windows-child-process.mjs"));
+  assertExecutable(sidecarEntrypoint, "type-aware sidecar entrypoint");
+
+  const extensionManifest = readPackage(root);
+  if (expectedVersion && extensionManifest.version !== expectedVersion) {
+    throw new Error(
+      `unexpected extension version: expected ${expectedVersion}, found ${extensionManifest.version}`,
+    );
+  }
+
+  const backendPayloads = variant.backends.map(({ packageName, os, cpu, executable }) => {
+    const packageDirectory = join(packageRoot, packageName.slice("@typescript/".length));
+    const manifest = readPackage(packageDirectory);
+    if (
+      manifest.name !== packageName ||
+      manifest.version !== protocol.backend.version ||
+      !manifest.os?.includes(os) ||
+      !manifest.cpu?.includes(cpu)
+    ) {
+      throw new Error(`invalid packaged TypeScript backend metadata for ${packageName}`);
+    }
+    const executablePath = join(packageDirectory, "lib", executable);
+    statSync(executablePath);
+    if (os !== "win32") {
+      assertExecutable(executablePath, `TypeScript backend ${packageName}`);
+    }
+    return { packageName, os, cpu, executable, executablePath };
+  });
+
+  if (!vsixPath) {
+    return {
+      target,
+      targetPlatform: variant.targetPlatform,
+      version: extensionManifest.version,
+      typescriptVersion: typescriptManifest.version,
+    };
+  }
+
+  const archive = await inspectVsixArchive(resolve(vsixPath));
+  assertVsixTargetPlatform(archive.targetPlatform, target);
+  if (archive.version !== extensionManifest.version) {
+    throw new Error(
+      `VSIX version ${archive.version} does not match extracted extension ${extensionManifest.version}`,
+    );
+  }
+  if (archive.bytes > variant.maxBytes) {
+    throw new Error(`VSIX exceeds ${variant.maxBytes} bytes for ${target}: ${vsixPath}`);
+  }
+
+  const backends = backendPayloads.map(({ packageName, os, cpu, executable }) => {
+    const archivePath = [
+      "extension",
+      "dist",
+      "type-aware",
+      "node_modules",
+      ...packageName.split("/"),
+      "lib",
+      executable,
+    ].join("/");
+    const record = archiveFileRecord(archive, archivePath);
+    requireArchiveMode(record, backendExecutableMode({ os }), packageName);
+    return {
+      package: packageName,
+      os,
+      cpu,
+      executable: record.path,
+      bytes: record.bytes,
+      sha256: record.sha256,
+      mode: record.mode,
+    };
+  });
+
+  return {
+    target,
+    targetPlatform: archive.targetPlatform,
+    version: archive.version,
+    bytes: archive.bytes,
+    sha256: archive.sha256,
+    payload: {
+      fileCount: archive.payload.fileCount,
+      sha256: archive.payload.sha256,
+    },
+    typescriptVersion: typescriptManifest.version,
+    backends,
+    sidecar: sidecarRecords(archive),
+  };
+};
+
+const parseArguments = (args) => {
+  const [extensionRoot, vsixPath, ...options] = args;
+  if (!extensionRoot) {
+    throw new Error(
+      "usage: verify-packaged-type-aware.mjs <extension-root> [vsix-path] [--target <target>] [--version <version>] [--json]",
+    );
+  }
+  let target = UNIVERSAL_VSIX_TARGET;
+  let expectedVersion;
+  let json = false;
+  for (let index = 0; index < options.length; index += 1) {
+    const option = options[index];
+    if (option === "--target") {
+      target = options[index + 1];
+      index += 1;
+    } else if (option === "--version") {
+      expectedVersion = options[index + 1];
+      index += 1;
+    } else if (option === "--json") {
+      json = true;
+    } else {
+      throw new Error(`unknown verifier argument ${option}`);
+    }
+  }
+  if (!target) {
+    throw new Error("--target requires a value");
+  }
+  if (options.includes("--version") && !expectedVersion) {
+    throw new Error("--version requires a value");
+  }
+  return { extensionRoot, vsixPath, target, expectedVersion, json };
+};
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(scriptPath);
+if (isMain) {
+  const { json, ...options } = parseArguments(process.argv.slice(2));
+  const result = await verifyPackagedTypeAware(options);
+  process.stdout.write(
+    json
+      ? `${JSON.stringify(result, null, 2)}\n`
+      : `Packaged type-aware VSIX payload is complete for ${result.target}.\n`,
+  );
+}

--- a/editors/vscode/scripts/vsix-archive.mjs
+++ b/editors/vscode/scripts/vsix-archive.mjs
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { open } = require("yauzl");
+
+const ZIP_HOST_UNIX = 3;
+
+const unixMode = (entry) =>
+  entry.versionMadeBy >>> 8 === ZIP_HOST_UNIX
+    ? (entry.externalFileAttributes >>> 16) & 0o777
+    : null;
+
+const readArchiveEntries = (vsixPath) =>
+  new Promise((resolve, reject) => {
+    open(
+      vsixPath,
+      { lazyEntries: true, strictFileNames: true, validateEntrySizes: true },
+      (openError, zipFile) => {
+        if (openError) {
+          reject(openError);
+          return;
+        }
+
+        const entries = new Map();
+        const modes = new Map();
+        let settled = false;
+        const fail = (error) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          zipFile.close();
+          reject(error);
+        };
+
+        zipFile.on("error", fail);
+        zipFile.on("end", () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          resolve({ entries, modes });
+        });
+        zipFile.on("entry", (entry) => {
+          const path = entry.fileName.replaceAll("\\", "/").toLowerCase();
+          if (entries.has(path) || modes.has(path)) {
+            fail(new Error(`VSIX archive contains duplicate entry ${path}`));
+            return;
+          }
+          if (path.endsWith("/")) {
+            zipFile.readEntry();
+            return;
+          }
+          zipFile.openReadStream(entry, (streamError, stream) => {
+            if (streamError) {
+              fail(streamError);
+              return;
+            }
+            const chunks = [];
+            stream.on("error", fail);
+            stream.on("data", (chunk) => chunks.push(chunk));
+            stream.on("end", () => {
+              if (settled) {
+                return;
+              }
+              entries.set(path, Buffer.concat(chunks));
+              modes.set(path, unixMode(entry));
+              zipFile.readEntry();
+            });
+          });
+        });
+        zipFile.readEntry();
+      },
+    );
+  });
+
+export const sha256Buffer = (contents) => createHash("sha256").update(contents).digest("hex");
+
+export const sha256File = (path) => sha256Buffer(readFileSync(path));
+
+export const parseVsixTargetPlatform = (xml) => {
+  const identity = xml.match(/<Identity\b[^>]*>/iu)?.[0];
+  if (!identity) {
+    throw new Error("VSIX manifest does not contain an Identity element");
+  }
+  const target = identity.match(/\bTargetPlatform\s*=\s*(["'])([^"']+)\1/iu)?.[2];
+  return target ?? null;
+};
+
+export const normalizedPayload = (entries) => {
+  const files = [...entries.entries()]
+    .filter(([path]) => path.startsWith("extension/") && !path.endsWith("/"))
+    .map(([path, contents]) => ({
+      path: path.replaceAll("\\", "/").toLowerCase(),
+      bytes: contents.byteLength,
+      sha256: sha256Buffer(contents),
+    }))
+    .toSorted((left, right) => left.path.localeCompare(right.path));
+  const canonical = files
+    .map(({ path, bytes, sha256 }) => `${JSON.stringify([path, bytes, sha256])}\n`)
+    .join("");
+  return {
+    fileCount: files.length,
+    sha256: sha256Buffer(Buffer.from(canonical, "utf8")),
+    files,
+  };
+};
+
+export const inspectVsixArchive = async (vsixPath) => {
+  const { entries, modes } = await readArchiveEntries(vsixPath);
+  const rawPackage = entries.get("extension/package.json");
+  if (!rawPackage) {
+    throw new Error("VSIX archive is missing extension/package.json");
+  }
+  const rawManifest = entries.get("extension.vsixmanifest");
+  if (!rawManifest) {
+    throw new Error("VSIX archive is missing extension.vsixmanifest");
+  }
+  const manifest = JSON.parse(rawPackage.toString("utf8"));
+  return {
+    bytes: statSync(vsixPath).size,
+    entries,
+    modes,
+    payload: normalizedPayload(entries),
+    sha256: sha256File(vsixPath),
+    targetPlatform: parseVsixTargetPlatform(rawManifest.toString("utf8")),
+    version: manifest.version,
+  };
+};
+
+export const archiveFileRecord = (archive, path) => {
+  const normalizedPath = path.replaceAll("\\", "/").toLowerCase();
+  const contents = archive.entries.get(normalizedPath);
+  if (!contents) {
+    throw new Error(`VSIX archive is missing ${path}`);
+  }
+  return {
+    path: normalizedPath.replace(/^extension\//u, ""),
+    bytes: contents.byteLength,
+    sha256: sha256Buffer(contents),
+    mode: archive.modes.get(normalizedPath) ?? null,
+  };
+};

--- a/editors/vscode/scripts/vsix-inventory.mjs
+++ b/editors/vscode/scripts/vsix-inventory.mjs
@@ -10,8 +10,8 @@ import {
 } from "./vsix-targets.mjs";
 
 export const INVENTORY_FILENAME = "inventory.json";
-export const CHECKSUMS_FILENAME = "SHA256SUMS";
-export const INVENTORY_SCHEMA_VERSION = 1;
+const CHECKSUMS_FILENAME = "SHA256SUMS";
+const INVENTORY_SCHEMA_VERSION = 1;
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
 
@@ -114,7 +114,7 @@ export const createInventory = (extensionVersion, entries) =>
     entries: entries.map(({ file, ...entry }) => ({ file, ...entry })),
   });
 
-export const serializeInventory = (inventory) =>
+const serializeInventory = (inventory) =>
   `${JSON.stringify(validateInventory(inventory), null, 2)}\n`;
 
 export const writeInventory = (outputDirectory, inventory) => {

--- a/editors/vscode/scripts/vsix-inventory.mjs
+++ b/editors/vscode/scripts/vsix-inventory.mjs
@@ -1,0 +1,133 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { sha256Buffer, sha256File } from "./vsix-archive.mjs";
+import {
+  backendExecutableMode,
+  TYPE_AWARE_SIDECAR_FILES,
+  VSIX_VARIANTS,
+  vsixFilename,
+} from "./vsix-targets.mjs";
+
+export const INVENTORY_FILENAME = "inventory.json";
+export const CHECKSUMS_FILENAME = "SHA256SUMS";
+export const INVENTORY_SCHEMA_VERSION = 1;
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+
+const requireSha256 = (value, label) => {
+  if (!SHA256_PATTERN.test(value)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest`);
+  }
+};
+
+const validateEntry = (entry, variant, extensionVersion) => {
+  const expectedFile = vsixFilename(extensionVersion, variant.target);
+  if (entry.file !== expectedFile) {
+    throw new Error(`unexpected inventory filename for ${variant.target}: ${entry.file}`);
+  }
+  if (entry.target !== variant.target || entry.targetPlatform !== variant.targetPlatform) {
+    throw new Error(`inventory target metadata does not match ${variant.target}`);
+  }
+  if (entry.version !== extensionVersion) {
+    throw new Error(`inventory version does not match ${extensionVersion} for ${variant.target}`);
+  }
+  if (!Number.isSafeInteger(entry.bytes) || entry.bytes <= 0 || entry.bytes > variant.maxBytes) {
+    throw new Error(`invalid inventory size for ${variant.target}: ${entry.bytes}`);
+  }
+  requireSha256(entry.sha256, `${variant.target} archive`);
+  if (!Number.isSafeInteger(entry.payload?.fileCount) || entry.payload.fileCount <= 0) {
+    throw new Error(`invalid payload file count for ${variant.target}`);
+  }
+  requireSha256(entry.payload.sha256, `${variant.target} payload`);
+  if (typeof entry.typescriptVersion !== "string" || entry.typescriptVersion.length === 0) {
+    throw new Error(`missing TypeScript version for ${variant.target}`);
+  }
+  const expectedBackends = variant.backends.map(({ packageName }) => packageName);
+  const actualBackends = entry.backends?.map(({ package: packageName }) => packageName);
+  if (JSON.stringify(actualBackends) !== JSON.stringify(expectedBackends)) {
+    throw new Error(`inventory backend closure does not match ${variant.target}`);
+  }
+  for (const backend of entry.backends) {
+    const descriptor = variant.backends.find(({ packageName }) => packageName === backend.package);
+    const expectedExecutable = descriptor
+      ? `dist/type-aware/node_modules/${descriptor.packageName}/lib/${descriptor.executable}`
+      : null;
+    if (
+      !descriptor ||
+      backend.os !== descriptor.os ||
+      backend.cpu !== descriptor.cpu ||
+      backend.executable !== expectedExecutable ||
+      !Number.isSafeInteger(backend.bytes) ||
+      backend.bytes <= 0 ||
+      backend.mode !== backendExecutableMode(descriptor)
+    ) {
+      throw new Error(`invalid backend inventory for ${backend.package}`);
+    }
+    requireSha256(backend.sha256, `${backend.package} executable`);
+  }
+  if (!Array.isArray(entry.sidecar) || entry.sidecar.length !== TYPE_AWARE_SIDECAR_FILES.length) {
+    throw new Error(`invalid sidecar inventory for ${variant.target}`);
+  }
+  for (let index = 0; index < TYPE_AWARE_SIDECAR_FILES.length; index += 1) {
+    const sidecar = entry.sidecar[index];
+    const expected = TYPE_AWARE_SIDECAR_FILES[index];
+    if (
+      sidecar.path !== expected.path ||
+      !Number.isSafeInteger(sidecar.bytes) ||
+      sidecar.bytes <= 0 ||
+      sidecar.mode !== expected.mode
+    ) {
+      throw new Error(`invalid sidecar inventory for ${variant.target}`);
+    }
+    requireSha256(sidecar.sha256, `${sidecar.path} sidecar`);
+  }
+};
+
+export const validateInventory = (inventory) => {
+  if (inventory.schemaVersion !== INVENTORY_SCHEMA_VERSION) {
+    throw new Error(`unsupported VSIX inventory schema ${inventory.schemaVersion}`);
+  }
+  if (typeof inventory.extensionVersion !== "string") {
+    throw new Error("VSIX inventory is missing extensionVersion");
+  }
+  if (!Array.isArray(inventory.entries) || inventory.entries.length !== VSIX_VARIANTS.length) {
+    throw new Error(`VSIX inventory must contain exactly ${VSIX_VARIANTS.length} entries`);
+  }
+  const seenTargets = new Set();
+  for (let index = 0; index < VSIX_VARIANTS.length; index += 1) {
+    const variant = VSIX_VARIANTS[index];
+    const entry = inventory.entries[index];
+    if (seenTargets.has(entry.target)) {
+      throw new Error(`duplicate VSIX inventory target ${entry.target}`);
+    }
+    seenTargets.add(entry.target);
+    validateEntry(entry, variant, inventory.extensionVersion);
+  }
+  return inventory;
+};
+
+export const createInventory = (extensionVersion, entries) =>
+  validateInventory({
+    schemaVersion: INVENTORY_SCHEMA_VERSION,
+    extensionVersion,
+    entries: entries.map(({ file, ...entry }) => ({ file, ...entry })),
+  });
+
+export const serializeInventory = (inventory) =>
+  `${JSON.stringify(validateInventory(inventory), null, 2)}\n`;
+
+export const writeInventory = (outputDirectory, inventory) => {
+  const inventoryPath = join(outputDirectory, INVENTORY_FILENAME);
+  writeFileSync(inventoryPath, serializeInventory(inventory));
+  const checksumEntries = [
+    ...inventory.entries.map(({ file, sha256 }) => ({ file, sha256 })),
+    { file: INVENTORY_FILENAME, sha256: sha256File(inventoryPath) },
+  ];
+  const checksums = `${checksumEntries.map(({ file, sha256 }) => `${sha256}  ${file}`).join("\n")}\n`;
+  writeFileSync(join(outputDirectory, CHECKSUMS_FILENAME), checksums);
+  return {
+    inventoryPath,
+    inventorySha256: sha256Buffer(Buffer.from(readFileSync(inventoryPath))),
+  };
+};

--- a/editors/vscode/scripts/vsix-packaging.test.mjs
+++ b/editors/vscode/scripts/vsix-packaging.test.mjs
@@ -1,0 +1,663 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { packageTypeAware } from "./package-type-aware.mjs";
+import { packageVsixVariants } from "./package-vsix-variants.mjs";
+import { normalizedPayload, parseVsixTargetPlatform, sha256File } from "./vsix-archive.mjs";
+import {
+  createInventory,
+  INVENTORY_FILENAME,
+  validateInventory,
+  writeInventory,
+} from "./vsix-inventory.mjs";
+import {
+  getVsixVariant,
+  TYPE_AWARE_BACKENDS,
+  TYPE_AWARE_SIDECAR_FILES,
+  VSIX_VARIANTS,
+  vsixFilename,
+} from "./vsix-targets.mjs";
+import {
+  assertVsixTargetPlatform,
+  verifyPackagedTypeAware,
+} from "./verify-packaged-type-aware.mjs";
+
+const VERSION = "1.2.3";
+const BACKEND_VERSION = "7.0.2";
+
+const write = (path, contents = "fixture\n") => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+};
+
+const writeJson = (path, value) => write(path, `${JSON.stringify(value, null, 2)}\n`);
+
+const crc32 = (contents) => {
+  let crc = 0xffffffff;
+  for (const byte of contents) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const writeStoredZip = (path, files) => {
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+  for (const file of files) {
+    const name = Buffer.from(file.path, "utf8");
+    const contents = Buffer.isBuffer(file.contents)
+      ? file.contents
+      : Buffer.from(file.contents, "utf8");
+    const checksum = crc32(contents);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0x800, 6);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(0, 10);
+    local.writeUInt16LE(0x21, 12);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(contents.length, 18);
+    local.writeUInt32LE(contents.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(0, 28);
+    localParts.push(local, name, contents);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(0x0314, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0x800, 8);
+    central.writeUInt16LE(0, 10);
+    central.writeUInt16LE(0, 12);
+    central.writeUInt16LE(0x21, 14);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(contents.length, 20);
+    central.writeUInt32LE(contents.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt16LE(0, 34);
+    central.writeUInt16LE(0, 36);
+    central.writeUInt32LE(((0o100000 | file.mode) << 16) >>> 0, 38);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+    offset += local.length + name.length + contents.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(files.length, 8);
+  end.writeUInt16LE(files.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+  writeFileSync(path, Buffer.concat([...localParts, centralDirectory, end]));
+};
+
+const fixture = (context) => {
+  const root = mkdtempSync(join(tmpdir(), "fallow-vsix-test-"));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  const repoRoot = join(root, "repo");
+  const extensionRoot = join(repoRoot, "editors", "vscode");
+  const storeNodeModules = join(root, "store", "node_modules");
+  const optionalDependencies = Object.fromEntries(
+    TYPE_AWARE_BACKENDS.map(({ packageName }) => [packageName, BACKEND_VERSION]),
+  );
+
+  writeJson(join(repoRoot, "crates", "api", "type-aware-protocol.json"), {
+    backend: { version: BACKEND_VERSION },
+  });
+  write(join(repoRoot, "tools", "type-aware-sidecar", "fallow-type-aware.mjs"));
+  write(join(repoRoot, "tools", "type-aware-sidecar", "src", "windows-child-process.mjs"));
+  writeJson(join(repoRoot, "tools", "type-aware-sidecar", "package.json"), {
+    name: "fallow-type-aware",
+    version: VERSION,
+  });
+  writeJson(join(storeNodeModules, "typescript", "package.json"), {
+    name: "typescript",
+    version: BACKEND_VERSION,
+    optionalDependencies,
+  });
+  write(join(storeNodeModules, "typescript", "lib", "typescript.js"));
+  for (const { packageName, os, cpu, executable } of TYPE_AWARE_BACKENDS) {
+    const directory = join(storeNodeModules, ...packageName.split("/"));
+    writeJson(join(directory, "package.json"), {
+      name: packageName,
+      version: BACKEND_VERSION,
+      os: [os],
+      cpu: [cpu],
+    });
+    const executablePath = join(directory, "lib", executable);
+    write(executablePath, `${packageName}\n`);
+    if (os !== "win32") {
+      chmodSync(executablePath, 0o755);
+    }
+  }
+  mkdirSync(join(extensionRoot, "node_modules"), { recursive: true });
+  symlinkSync(
+    join(storeNodeModules, "typescript"),
+    join(extensionRoot, "node_modules", "typescript"),
+  );
+  writeJson(join(extensionRoot, "package.json"), { name: "fallow-vscode", version: VERSION });
+  write(join(extensionRoot, ".vscodeignore"), "src/**\n");
+  write(join(extensionRoot, "dist", "extension.js"));
+  return { extensionRoot, repoRoot };
+};
+
+const packagedNames = (destination) =>
+  readdirSync(join(destination, "node_modules", "@typescript")).sort();
+
+const inventoryEntry = (variant) => ({
+  file: vsixFilename(VERSION, variant.target),
+  target: variant.target,
+  targetPlatform: variant.targetPlatform,
+  version: VERSION,
+  bytes: 1024,
+  sha256: "a".repeat(64),
+  payload: { fileCount: 3, sha256: "b".repeat(64) },
+  typescriptVersion: BACKEND_VERSION,
+  backends: variant.backends.map(({ packageName, os, cpu, executable }) => ({
+    package: packageName,
+    os,
+    cpu,
+    executable: `dist/type-aware/node_modules/${packageName}/lib/${executable}`,
+    bytes: 8,
+    sha256: "c".repeat(64),
+    mode: os === "win32" ? 0o644 : 0o755,
+  })),
+  sidecar: TYPE_AWARE_SIDECAR_FILES.map(({ path, mode }) => ({
+    path,
+    bytes: 8,
+    sha256: "d".repeat(64),
+    mode,
+  })),
+});
+
+const archiveFiles = (extensionRoot, target, modeOverrides = {}) => {
+  const typeAwareRoot = join(extensionRoot, "dist", "type-aware");
+  const variant = getVsixVariant(target);
+  const files = [
+    {
+      path: "extension/package.json",
+      contents: readFileSync(join(extensionRoot, "package.json")),
+      mode: 0o644,
+    },
+    {
+      path: "extension.vsixmanifest",
+      contents: `<PackageManifest><Metadata><Identity Id="fallow-vscode" Version="${VERSION}" TargetPlatform="${target}" /></Metadata></PackageManifest>`,
+      mode: 0o644,
+    },
+    ...TYPE_AWARE_SIDECAR_FILES.map(({ path, mode }) => ({
+      path: `extension/${path}`,
+      contents: readFileSync(join(extensionRoot, ...path.split("/"))),
+      mode: modeOverrides[path] ?? mode,
+    })),
+    ...variant.backends.map(({ packageName, os, executable }) => {
+      const path = `dist/type-aware/node_modules/${packageName}/lib/${executable}`;
+      return {
+        path: `extension/${path}`,
+        contents: readFileSync(
+          join(typeAwareRoot, "node_modules", ...packageName.split("/"), "lib", executable),
+        ),
+        mode: modeOverrides[path] ?? (os === "win32" ? 0o644 : 0o755),
+      };
+    }),
+  ];
+  return files;
+};
+
+test("target catalog is closed and deterministic", () => {
+  assert.deepEqual(
+    VSIX_VARIANTS.map(({ target }) => target),
+    [
+      "universal",
+      "darwin-arm64",
+      "darwin-x64",
+      "linux-arm64",
+      "linux-x64",
+      "win32-arm64",
+      "win32-x64",
+    ],
+  );
+  assert.equal(vsixFilename(VERSION, "linux-x64"), "fallow-vscode-1.2.3-linux-x64.vsix");
+  assert.throws(() => getVsixVariant("linux-armhf"), /unsupported VSIX target/u);
+  assert.throws(() => vsixFilename("latest", "linux-x64"), /invalid VSIX version/u);
+});
+
+test("target and universal payloads are isolated and dereferenced", (context) => {
+  const { extensionRoot, repoRoot } = fixture(context);
+  const targetDestination = join(extensionRoot, "target-payload");
+  const universalDestination = join(extensionRoot, "universal-payload");
+  packageTypeAware({
+    target: "linux-x64",
+    extensionRoot,
+    repoRoot,
+    destination: targetDestination,
+  });
+  packageTypeAware({
+    extensionRoot,
+    repoRoot,
+    destination: universalDestination,
+  });
+  assert.deepEqual(packagedNames(targetDestination), ["typescript-linux-x64"]);
+  assert.equal(packagedNames(universalDestination).length, TYPE_AWARE_BACKENDS.length);
+  assert.equal(
+    lstatSync(join(targetDestination, "node_modules", "typescript")).isSymbolicLink(),
+    false,
+  );
+});
+
+test("verifier rejects closure, metadata, mode, and symlink defects", async (context) => {
+  const { extensionRoot, repoRoot } = fixture(context);
+  const destination = join(extensionRoot, "dist", "type-aware");
+  packageTypeAware({ target: "linux-x64", extensionRoot, repoRoot, destination });
+  await verifyPackagedTypeAware({ extensionRoot, target: "linux-x64", repoRoot });
+
+  mkdirSync(join(destination, "node_modules", "@typescript", "typescript-extra"));
+  await assert.rejects(
+    verifyPackagedTypeAware({ extensionRoot, target: "linux-x64", repoRoot }),
+    /unexpected packaged TypeScript backends/u,
+  );
+  rmSync(join(destination, "node_modules", "@typescript", "typescript-extra"), {
+    recursive: true,
+  });
+
+  const manifestPath = join(
+    destination,
+    "node_modules",
+    "@typescript",
+    "typescript-linux-x64",
+    "package.json",
+  );
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  writeJson(manifestPath, { ...manifest, cpu: ["arm64"] });
+  await assert.rejects(
+    verifyPackagedTypeAware({ extensionRoot, target: "linux-x64", repoRoot }),
+    /invalid packaged TypeScript backend metadata/u,
+  );
+  writeJson(manifestPath, manifest);
+
+  if (process.platform !== "win32") {
+    const executable = join(dirname(manifestPath), "lib", "tsc");
+    chmodSync(executable, 0o644);
+    await assert.rejects(
+      verifyPackagedTypeAware({ extensionRoot, target: "linux-x64", repoRoot }),
+      /not executable/u,
+    );
+    chmodSync(executable, 0o755);
+
+    const source = join(destination, "src", "windows-child-process.mjs");
+    const link = join(destination, "src", "linked.mjs");
+    symlinkSync(source, link);
+    await assert.rejects(
+      verifyPackagedTypeAware({ extensionRoot, target: "linux-x64", repoRoot }),
+      /contains a symlink/u,
+    );
+  }
+});
+
+test("verifier reads required executable modes from VSIX central-directory metadata", async (context) => {
+  const { extensionRoot, repoRoot } = fixture(context);
+  const target = "linux-x64";
+  packageTypeAware({
+    target,
+    extensionRoot,
+    repoRoot,
+    destination: join(extensionRoot, "dist", "type-aware"),
+  });
+
+  const goodVsix = join(dirname(extensionRoot), "good.vsix");
+  writeStoredZip(goodVsix, archiveFiles(extensionRoot, target));
+  const verified = await verifyPackagedTypeAware({
+    extensionRoot,
+    vsixPath: goodVsix,
+    target,
+    repoRoot,
+  });
+  assert.equal(verified.backends[0].mode, 0o755);
+  assert.deepEqual(
+    verified.sidecar.map(({ path, mode }) => ({ path, mode })),
+    TYPE_AWARE_SIDECAR_FILES,
+  );
+
+  const entrypoint = TYPE_AWARE_SIDECAR_FILES[0].path;
+  const badSidecarVsix = join(dirname(extensionRoot), "bad-sidecar-mode.vsix");
+  writeStoredZip(badSidecarVsix, archiveFiles(extensionRoot, target, { [entrypoint]: 0o644 }));
+  await assert.rejects(
+    verifyPackagedTypeAware({ extensionRoot, vsixPath: badSidecarVsix, target, repoRoot }),
+    /unexpected archived mode for dist\/type-aware\/fallow-type-aware\.mjs/u,
+  );
+
+  const backend = getVsixVariant(target).backends[0];
+  const backendPath = `dist/type-aware/node_modules/${backend.packageName}/lib/${backend.executable}`;
+  const badBackendVsix = join(dirname(extensionRoot), "bad-backend-mode.vsix");
+  writeStoredZip(badBackendVsix, archiveFiles(extensionRoot, target, { [backendPath]: 0o644 }));
+  await assert.rejects(
+    verifyPackagedTypeAware({ extensionRoot, vsixPath: badBackendVsix, target, repoRoot }),
+    /unexpected archived mode for @typescript\/typescript-linux-x64/u,
+  );
+
+  const sourcePath = `extension/${TYPE_AWARE_SIDECAR_FILES[1].path}`;
+  const missingSourceVsix = join(dirname(extensionRoot), "missing-source.vsix");
+  writeStoredZip(
+    missingSourceVsix,
+    archiveFiles(extensionRoot, target).filter(({ path }) => path !== sourcePath),
+  );
+  await assert.rejects(
+    verifyPackagedTypeAware({ extensionRoot, vsixPath: missingSourceVsix, target, repoRoot }),
+    /VSIX archive is missing extension\/dist\/type-aware\/src\/windows-child-process\.mjs/u,
+  );
+
+  const duplicateSourceVsix = join(dirname(extensionRoot), "duplicate-source.vsix");
+  const files = archiveFiles(extensionRoot, target);
+  writeStoredZip(duplicateSourceVsix, [...files, files.find(({ path }) => path === sourcePath)]);
+  await assert.rejects(
+    verifyPackagedTypeAware({ extensionRoot, vsixPath: duplicateSourceVsix, target, repoRoot }),
+    /duplicate entry extension\/dist\/type-aware\/src\/windows-child-process\.mjs/u,
+  );
+});
+
+test("TargetPlatform parsing distinguishes universal and targeted VSIX manifests", () => {
+  assert.equal(
+    parseVsixTargetPlatform(
+      '<PackageManifest><Metadata><Identity Id="x" /></Metadata></PackageManifest>',
+    ),
+    null,
+  );
+  assert.equal(
+    parseVsixTargetPlatform(
+      '<PackageManifest><Metadata><Identity TargetPlatform="win32-x64" Id="x" /></Metadata></PackageManifest>',
+    ),
+    "win32-x64",
+  );
+  assert.throws(() => parseVsixTargetPlatform("<PackageManifest />"), /Identity element/u);
+  assert.doesNotThrow(() => assertVsixTargetPlatform("linux-x64", "linux-x64"));
+  assert.doesNotThrow(() => assertVsixTargetPlatform(null, "universal"));
+  assert.throws(
+    () => assertVsixTargetPlatform(null, "linux-x64"),
+    /expected linux-x64, found absent/u,
+  );
+  assert.throws(
+    () => assertVsixTargetPlatform("win32-x64", "linux-x64"),
+    /expected linux-x64, found win32-x64/u,
+  );
+});
+
+test("normalized payload hashes ignore entry order but detect content changes", () => {
+  const first = normalizedPayload(
+    new Map([
+      ["extension/b.txt", Buffer.from("b")],
+      ["extension/a.txt", Buffer.from("a")],
+      ["extension.vsixmanifest", Buffer.from("ignored")],
+    ]),
+  );
+  const reordered = normalizedPayload(
+    new Map([
+      ["extension/a.txt", Buffer.from("a")],
+      ["extension/b.txt", Buffer.from("b")],
+    ]),
+  );
+  const changed = normalizedPayload(
+    new Map([
+      ["extension/a.txt", Buffer.from("changed")],
+      ["extension/b.txt", Buffer.from("b")],
+    ]),
+  );
+  assert.equal(first.sha256, reordered.sha256);
+  assert.notEqual(first.sha256, changed.sha256);
+});
+
+test("inventory rejects missing, duplicate, reordered, and malformed variants", (context) => {
+  const entries = VSIX_VARIANTS.map(inventoryEntry);
+  const inventory = createInventory(VERSION, entries);
+  assert.equal(validateInventory(inventory), inventory);
+  assert.throws(
+    () => validateInventory({ ...inventory, entries: entries.slice(0, -1) }),
+    /exactly 7 entries/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({ ...inventory, entries: [entries[0], entries[0], ...entries.slice(2)] }),
+    /duplicate VSIX inventory target/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({ ...inventory, entries: [entries[1], entries[0], ...entries.slice(2)] }),
+    /unexpected inventory filename for universal/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [{ ...entries[0], file: "wrong.vsix" }, ...entries.slice(1)],
+      }),
+    /unexpected inventory filename/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [
+          entries[0],
+          { ...entries[1], bytes: getVsixVariant(entries[1].target).maxBytes + 1 },
+          ...entries.slice(2),
+        ],
+      }),
+    /invalid inventory size/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [{ ...entries[0], sha256: "invalid" }, ...entries.slice(1)],
+      }),
+    /lowercase SHA-256 digest/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [
+          {
+            ...entries[0],
+            backends: [
+              { ...entries[0].backends[0], executable: "dist/type-aware/wrong" },
+              ...entries[0].backends.slice(1),
+            ],
+          },
+          ...entries.slice(1),
+        ],
+      }),
+    /invalid backend inventory/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [
+          {
+            ...entries[0],
+            backends: [{ ...entries[0].backends[0], mode: 0o644 }, ...entries[0].backends.slice(1)],
+          },
+          ...entries.slice(1),
+        ],
+      }),
+    /invalid backend inventory/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [{ ...entries[0], sidecar: entries[0].sidecar.slice(0, 1) }, ...entries.slice(1)],
+      }),
+    /invalid sidecar inventory/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [
+          { ...entries[0], sidecar: [entries[0].sidecar[0], entries[0].sidecar[0]] },
+          ...entries.slice(1),
+        ],
+      }),
+    /invalid sidecar inventory/u,
+  );
+  assert.throws(
+    () =>
+      validateInventory({
+        ...inventory,
+        entries: [
+          {
+            ...entries[0],
+            sidecar: [{ ...entries[0].sidecar[0], mode: 0o644 }, entries[0].sidecar[1]],
+          },
+          ...entries.slice(1),
+        ],
+      }),
+    /invalid sidecar inventory/u,
+  );
+
+  const output = mkdtempSync(join(tmpdir(), "fallow-vsix-inventory-"));
+  context.after(() => rmSync(output, { recursive: true, force: true }));
+  for (const entry of entries) {
+    write(join(output, entry.file), entry.target);
+    entry.sha256 = sha256File(join(output, entry.file));
+  }
+  const written = createInventory(VERSION, entries);
+  writeInventory(output, written);
+  const checksums = readFileSync(join(output, "SHA256SUMS"), "utf8");
+  assert.match(
+    checksums,
+    new RegExp(`${sha256File(join(output, INVENTORY_FILENAME))}  inventory\\.json`, "u"),
+  );
+});
+
+test("variant orchestration is ordered, isolated, cleaned, and deterministic", async (context) => {
+  const { extensionRoot, repoRoot } = fixture(context);
+  packageTypeAware({
+    extensionRoot,
+    repoRoot,
+    destination: join(extensionRoot, "dist", "type-aware"),
+  });
+  const scratchRoot = dirname(repoRoot);
+
+  const run = async (label) => {
+    const outputDirectory = join(scratchRoot, `output-${label}`);
+    const stagingRoot = join(scratchRoot, `staging-${label}`);
+    const events = [];
+    const createVsixCalls = [];
+    const inventory = await packageVsixVariants({
+      outputDirectory,
+      extensionRoot,
+      repoRoot,
+      createStagingRoot: () => {
+        mkdirSync(stagingRoot);
+        return stagingRoot;
+      },
+      listPackageFiles: async () => ["package.json", "dist/extension.js"],
+      packagePayload: ({ target, destination }) => {
+        events.push(`payload:${target}`);
+        write(join(destination, "variant.txt"), target);
+      },
+      createVsix: async (options) => {
+        const target = options.target ?? "universal";
+        events.push(`vsix:${target}`);
+        createVsixCalls.push(options);
+        assert.equal(
+          readFileSync(join(options.cwd, "dist", "type-aware", "variant.txt"), "utf8"),
+          target,
+        );
+        write(options.packagePath, target);
+      },
+      verifyPackage: async ({ extensionRoot: stageRoot, vsixPath, target }) => {
+        events.push(`verify:${target}`);
+        assert.equal(stageRoot, join(stagingRoot, target));
+        const verified = inventoryEntry(getVsixVariant(target));
+        delete verified.file;
+        verified.bytes = readFileSync(vsixPath).byteLength;
+        verified.sha256 = sha256File(vsixPath);
+        return verified;
+      },
+      removeStagingRoot: (path) => {
+        events.push("cleanup");
+        rmSync(path, { recursive: true, force: true });
+      },
+    });
+    assert.equal(existsSync(stagingRoot), false);
+    assert.deepEqual(
+      createVsixCalls.map(({ target }) => target),
+      VSIX_VARIANTS.map(({ targetPlatform }) => targetPlatform ?? undefined),
+    );
+    assert.deepEqual(events, [
+      ...VSIX_VARIANTS.flatMap(({ target }) => [
+        `payload:${target}`,
+        `vsix:${target}`,
+        `verify:${target}`,
+      ]),
+      "cleanup",
+    ]);
+    return { inventory, outputDirectory };
+  };
+
+  const first = await run("first");
+  const second = await run("second");
+  assert.deepEqual(first.inventory, second.inventory);
+  assert.deepEqual(readdirSync(first.outputDirectory), readdirSync(second.outputDirectory));
+  for (const file of readdirSync(first.outputDirectory)) {
+    assert.deepEqual(
+      readFileSync(join(first.outputDirectory, file)),
+      readFileSync(join(second.outputDirectory, file)),
+    );
+  }
+});
+
+test("variant orchestration removes isolated staging after a packaging failure", async (context) => {
+  const { extensionRoot, repoRoot } = fixture(context);
+  packageTypeAware({
+    extensionRoot,
+    repoRoot,
+    destination: join(extensionRoot, "dist", "type-aware"),
+  });
+  const stagingRoot = join(dirname(repoRoot), "failed-staging");
+  await assert.rejects(
+    packageVsixVariants({
+      outputDirectory: join(dirname(repoRoot), "failed-output"),
+      extensionRoot,
+      repoRoot,
+      createStagingRoot: () => {
+        mkdirSync(stagingRoot);
+        return stagingRoot;
+      },
+      listPackageFiles: async () => ["package.json", "dist/extension.js"],
+      packagePayload: ({ destination }) => write(join(destination, "variant.txt")),
+      createVsix: async () => {
+        throw new Error("fixture packaging failure");
+      },
+    }),
+    /fixture packaging failure/u,
+  );
+  assert.equal(existsSync(stagingRoot), false);
+});

--- a/editors/vscode/scripts/vsix-targets.mjs
+++ b/editors/vscode/scripts/vsix-targets.mjs
@@ -1,7 +1,7 @@
 const MEBIBYTE = 1024 * 1024;
 
-export const VSIX_EXECUTABLE_MODE = 0o755;
-export const VSIX_REGULAR_FILE_MODE = 0o644;
+const VSIX_EXECUTABLE_MODE = 0o755;
+const VSIX_REGULAR_FILE_MODE = 0o644;
 
 export const TYPE_AWARE_SIDECAR_FILES = Object.freeze([
   Object.freeze({
@@ -67,14 +67,14 @@ const defineVariant = ({ target, targetPlatform, maxBytes, backends }) =>
 
 export const UNIVERSAL_VSIX_TARGET = "universal";
 
-export const UNIVERSAL_VSIX_VARIANT = defineVariant({
+const UNIVERSAL_VSIX_VARIANT = defineVariant({
   target: UNIVERSAL_VSIX_TARGET,
   targetPlatform: null,
   maxBytes: 70 * MEBIBYTE,
   backends: TYPE_AWARE_BACKENDS,
 });
 
-export const TARGETED_VSIX_VARIANTS = Object.freeze(
+const TARGETED_VSIX_VARIANTS = Object.freeze(
   TYPE_AWARE_BACKENDS.map((backend) =>
     defineVariant({
       target: backend.target,

--- a/editors/vscode/scripts/vsix-targets.mjs
+++ b/editors/vscode/scripts/vsix-targets.mjs
@@ -1,0 +1,115 @@
+const MEBIBYTE = 1024 * 1024;
+
+export const VSIX_EXECUTABLE_MODE = 0o755;
+export const VSIX_REGULAR_FILE_MODE = 0o644;
+
+export const TYPE_AWARE_SIDECAR_FILES = Object.freeze([
+  Object.freeze({
+    path: "dist/type-aware/fallow-type-aware.mjs",
+    mode: VSIX_EXECUTABLE_MODE,
+  }),
+  Object.freeze({
+    path: "dist/type-aware/src/windows-child-process.mjs",
+    mode: VSIX_REGULAR_FILE_MODE,
+  }),
+]);
+
+const defineBackend = ({ target, packageName, os, cpu, executable }) =>
+  Object.freeze({ target, packageName, os, cpu, executable });
+
+export const TYPE_AWARE_BACKENDS = Object.freeze([
+  defineBackend({
+    target: "darwin-arm64",
+    packageName: "@typescript/typescript-darwin-arm64",
+    os: "darwin",
+    cpu: "arm64",
+    executable: "tsc",
+  }),
+  defineBackend({
+    target: "darwin-x64",
+    packageName: "@typescript/typescript-darwin-x64",
+    os: "darwin",
+    cpu: "x64",
+    executable: "tsc",
+  }),
+  defineBackend({
+    target: "linux-arm64",
+    packageName: "@typescript/typescript-linux-arm64",
+    os: "linux",
+    cpu: "arm64",
+    executable: "tsc",
+  }),
+  defineBackend({
+    target: "linux-x64",
+    packageName: "@typescript/typescript-linux-x64",
+    os: "linux",
+    cpu: "x64",
+    executable: "tsc",
+  }),
+  defineBackend({
+    target: "win32-arm64",
+    packageName: "@typescript/typescript-win32-arm64",
+    os: "win32",
+    cpu: "arm64",
+    executable: "tsc.exe",
+  }),
+  defineBackend({
+    target: "win32-x64",
+    packageName: "@typescript/typescript-win32-x64",
+    os: "win32",
+    cpu: "x64",
+    executable: "tsc.exe",
+  }),
+]);
+
+const defineVariant = ({ target, targetPlatform, maxBytes, backends }) =>
+  Object.freeze({ target, targetPlatform, maxBytes, backends: Object.freeze([...backends]) });
+
+export const UNIVERSAL_VSIX_TARGET = "universal";
+
+export const UNIVERSAL_VSIX_VARIANT = defineVariant({
+  target: UNIVERSAL_VSIX_TARGET,
+  targetPlatform: null,
+  maxBytes: 70 * MEBIBYTE,
+  backends: TYPE_AWARE_BACKENDS,
+});
+
+export const TARGETED_VSIX_VARIANTS = Object.freeze(
+  TYPE_AWARE_BACKENDS.map((backend) =>
+    defineVariant({
+      target: backend.target,
+      targetPlatform: backend.target,
+      maxBytes: 15 * MEBIBYTE,
+      backends: [backend],
+    }),
+  ),
+);
+
+export const VSIX_VARIANTS = Object.freeze([UNIVERSAL_VSIX_VARIANT, ...TARGETED_VSIX_VARIANTS]);
+
+const variantsByTarget = new Map(VSIX_VARIANTS.map((variant) => [variant.target, variant]));
+
+if (variantsByTarget.size !== VSIX_VARIANTS.length) {
+  throw new Error("VSIX target catalog contains duplicate targets");
+}
+
+export const getVsixVariant = (target = UNIVERSAL_VSIX_TARGET) => {
+  const variant = variantsByTarget.get(target);
+  if (!variant) {
+    throw new Error(
+      `unsupported VSIX target ${target}; expected one of ${VSIX_VARIANTS.map(({ target: value }) => value).join(", ")}`,
+    );
+  }
+  return variant;
+};
+
+export const backendExecutableMode = ({ os }) =>
+  os === "win32" ? VSIX_REGULAR_FILE_MODE : VSIX_EXECUTABLE_MODE;
+
+export const vsixFilename = (version, target) => {
+  getVsixVariant(target);
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u.test(version)) {
+    throw new Error(`invalid VSIX version ${version}`);
+  }
+  return `fallow-vscode-${version}-${target}.vsix`;
+};

--- a/editors/vscode/test/integration/real/extensionPath.ts
+++ b/editors/vscode/test/integration/real/extensionPath.ts
@@ -1,0 +1,8 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** Resolve the exact extension root that the real-host smoke must load. */
+export const resolveExtensionDevelopmentPath = (
+  repositoryPath: string,
+  configuredPath: string | undefined,
+): string => realpathSync(resolve(configuredPath ?? repositoryPath));

--- a/editors/vscode/test/integration/real/runTest.ts
+++ b/editors/vscode/test/integration/real/runTest.ts
@@ -2,13 +2,19 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { runTests } from "@vscode/test-electron";
+import { resolveExtensionDevelopmentPath } from "./extensionPath.js";
 
 const repositoryExtensionPath = path.resolve(__dirname, "../../../..");
-const extensionDevelopmentPath = process.env["FALLOW_EXTENSION_PATH"]
-  ? path.resolve(process.env["FALLOW_EXTENSION_PATH"])
-  : repositoryExtensionPath;
+const configuredExtensionPath = process.env["FALLOW_EXTENSION_PATH"];
+const extensionDevelopmentPath = resolveExtensionDevelopmentPath(
+  repositoryExtensionPath,
+  configuredExtensionPath,
+);
 const extensionTestsPath = path.resolve(__dirname, "suite/index.js");
-const vscodeTestCachePath = path.join(os.tmpdir(), "fallow-vscode-test-cache");
+const vscodeTestCachePath = path.resolve(
+  process.env["FALLOW_VSCODE_TEST_CACHE_PATH"] ??
+    path.join(os.tmpdir(), "fallow-vscode-test-cache"),
+);
 const fixtureWorkspacePath = path.resolve(
   repositoryExtensionPath,
   "test/integration/fixtures/real-workspace",
@@ -25,11 +31,9 @@ const requiredCurrentBinary = (): string => {
   return binary;
 };
 
-const requiredWindowsLspBinary = (): string => {
+const configuredLspBinary = (): string | undefined => {
   const configured = process.env["FALLOW_LSP_BIN"];
-  if (!configured) {
-    throw new Error("FALLOW_LSP_BIN is required for the real VS Code Windows contract smoke");
-  }
+  if (!configured) return undefined;
 
   const binary = path.resolve(configured);
   fs.accessSync(binary, fs.constants.X_OK);
@@ -54,12 +58,20 @@ const createWorkspace = (binary: string): string => {
   fs.cpSync(fixtureWorkspacePath, workspaceDir, { recursive: true });
   fs.mkdirSync(vscodeDir, { recursive: true });
   fs.mkdirSync(binDir, { recursive: true });
+  const lspBinary = configuredLspBinary();
   if (process.platform === "win32") {
+    if (!lspBinary) {
+      throw new Error("FALLOW_LSP_BIN is required for the real VS Code Windows contract smoke");
+    }
     fs.copyFileSync(binary, cliPath);
-    fs.copyFileSync(requiredWindowsLspBinary(), lspPath);
+    fs.copyFileSync(lspBinary, lspPath);
   } else {
     fs.symlinkSync(binary, cliPath);
-    writeExecutable(lspPath, '#!/bin/sh\nexec "$FALLOW_BIN" lsp-server\n');
+    if (lspBinary) {
+      fs.symlinkSync(lspBinary, lspPath);
+    } else {
+      writeExecutable(lspPath, '#!/bin/sh\nexec "$FALLOW_BIN" lsp-server\n');
+    }
   }
   fs.writeFileSync(
     path.join(vscodeDir, "settings.json"),
@@ -89,7 +101,10 @@ const main = async (): Promise<void> => {
     await runTests({
       cachePath: vscodeTestCachePath,
       extensionDevelopmentPath,
-      extensionTestsEnv: { FALLOW_BIN: binary },
+      extensionTestsEnv: {
+        FALLOW_BIN: binary,
+        ...(configuredExtensionPath ? { FALLOW_EXTENSION_PATH: extensionDevelopmentPath } : {}),
+      },
       extensionTestsPath,
       launchArgs: [
         workspaceDir,

--- a/editors/vscode/test/integration/real/suite/extension.test.ts
+++ b/editors/vscode/test/integration/real/suite/extension.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
 import * as path from "node:path";
 // VS Code injects this module into the extension host at runtime.
 // fallow-ignore-next-line unlisted-dependency
@@ -56,6 +57,15 @@ const fallowDiagnostics = async (uri: vscode.Uri): Promise<readonly vscode.Diagn
 };
 
 describe("Fallow VS Code real-process contracts", () => {
+  it("runs the exact packaged extension requested by the host smoke", () => {
+    const expectedPath = process.env["FALLOW_EXTENSION_PATH"];
+    if (!expectedPath) return;
+
+    const extension = vscode.extensions.getExtension("fallow-rs.fallow-vscode");
+    assert.ok(extension, "extension should be discoverable");
+    assert.equal(fs.realpathSync(extension.extensionPath), fs.realpathSync(expectedPath));
+  });
+
   it("parses the current CLI envelope with complete type-aware evidence", async () => {
     const extension = vscode.extensions.getExtension("fallow-rs.fallow-vscode");
     assert.ok(extension, "extension should be discoverable");

--- a/editors/vscode/test/package-manifest.test.ts
+++ b/editors/vscode/test/package-manifest.test.ts
@@ -35,6 +35,7 @@ interface ConfigProperty {
 }
 
 interface ExtensionPackage {
+  readonly extensionKind: readonly string[];
   readonly contributes: {
     readonly commands: readonly CommandContribution[];
     readonly configuration: {
@@ -69,6 +70,12 @@ const viewTitleCommand = (id: string): MenuContribution | undefined =>
 
 const commandPaletteEntry = (id: string): MenuContribution | undefined =>
   pkg.contributes.menus.commandPalette.find((entry) => entry.command === id);
+
+describe("package.json extension host", () => {
+  it("runs beside the workspace so platform backends match local and remote hosts", () => {
+    expect(pkg.extensionKind).toEqual(["workspace"]);
+  });
+});
 
 describe("package.json command contributions", () => {
   it("uses search only for the initial analysis action", () => {

--- a/editors/vscode/test/real-extension-path.test.ts
+++ b/editors/vscode/test/real-extension-path.test.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveExtensionDevelopmentPath } from "./integration/real/extensionPath.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "fallow-extension-path-"));
+  temporaryRoots.push(root);
+  return root;
+};
+
+describe("real extension host path", () => {
+  it("canonicalizes the configured packaged extension path", () => {
+    const root = temporaryRoot();
+    const extensionPath = join(root, "extension");
+    mkdirSync(extensionPath);
+
+    expect(
+      resolveExtensionDevelopmentPath(
+        join(root, "repository"),
+        join(root, "nested", "..", "extension"),
+      ),
+    ).toBe(realpathSync(extensionPath));
+  });
+
+  it("fails instead of falling back when the configured path is missing", () => {
+    const root = temporaryRoot();
+    const repositoryPath = join(root, "repository");
+    mkdirSync(repositoryPath);
+
+    expect(() =>
+      resolveExtensionDevelopmentPath(repositoryPath, join(root, "missing-extension")),
+    ).toThrow();
+  });
+});

--- a/scripts/fixtures/vscode-public-verify/marketplace.json
+++ b/scripts/fixtures/vscode-public-verify/marketplace.json
@@ -1,0 +1,86 @@
+{
+  "results": [
+    {
+      "extensions": [
+        {
+          "publisher": {
+          "publisherName": "Fallow-rs"
+          },
+          "extensionName": "fallow-vscode",
+          "versions": [
+            {
+              "version": "3.17.0",
+              "targetPlatform": null,
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/universal.vsix"
+                }
+              ]
+            },
+            {
+              "version": "3.17.0",
+              "targetPlatform": "darwin-arm64",
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/darwin-arm64.vsix"
+                }
+              ]
+            },
+            {
+              "version": "3.17.0",
+              "targetPlatform": "darwin-x64",
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/darwin-x64.vsix"
+                }
+              ]
+            },
+            {
+              "version": "3.17.0",
+              "targetPlatform": "linux-arm64",
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/linux-arm64.vsix"
+                }
+              ]
+            },
+            {
+              "version": "3.17.0",
+              "targetPlatform": "linux-x64",
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/linux-x64.vsix"
+                }
+              ]
+            },
+            {
+              "version": "3.17.0",
+              "targetPlatform": "win32-arm64",
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/win32-arm64.vsix"
+                }
+              ]
+            },
+            {
+              "version": "3.17.0",
+              "targetPlatform": "win32-x64",
+              "files": [
+                {
+                  "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                  "source": "https://example.invalid/win32-x64.vsix"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/repository-policy.test.mjs
+++ b/scripts/repository-policy.test.mjs
@@ -151,6 +151,7 @@ test("type-aware manifest keeps every runtime and package surface in parity", ()
     "editors/vscode/scripts/verify-packaged-type-aware.mjs",
     "utf8",
   );
+  const vscodeTargets = readFileSync("editors/vscode/scripts/vsix-targets.mjs", "utf8");
   const vscodeWorkspace = readFileSync("editors/vscode/pnpm-workspace.yaml", "utf8");
   const vscodePackage = readJson("editors/vscode/package.json");
   const windowsCandidateSmoke = readFileSync(
@@ -199,17 +200,40 @@ test("type-aware manifest keeps every runtime and package surface in parity", ()
   assert.match(generated, /Generated from crates\/api\/type-aware-protocol\.json/u);
   assert.match(vscodePackager, /cpSync\(join\(sourceRoot, "src"\)/u);
   for (const packageName of bundledBackends) {
-    assert.match(vscodePackager, new RegExp(packageName.replace("/", "\\/"), "u"));
-    assert.match(vscodePackageVerifier, new RegExp(packageName.replace("@typescript/", ""), "u"));
+    assert.match(vscodeTargets, new RegExp(packageName.replace("/", "\\/"), "u"));
   }
-  assert.match(vscodePackager, /tsc(?:\\\\\.exe)?/u);
-  assert.match(vscodePackageVerifier, /MAX_VSIX_BYTES/u);
+  assert.match(vscodePackageVerifier, /getVsixVariant/u);
+  assert.match(vscodeTargets, /tsc(?:\\\\\.exe)?/u);
+  assert.match(vscodeTargets, /maxBytes/u);
   assert.match(vscodeWorkspace, /supportedArchitectures:/u);
   assert.match(vscodeWorkspace, /- win32/u);
   assert.match(vscodeWorkspace, /- darwin/u);
   assert.match(vscodeWorkspace, /- linux/u);
   assert.match(windowsCandidateSmoke, /platformPackage\.replace\("@fallow-cli\/", ""\)/u);
   assert.match(windowsCandidateSmoke, /join\(temporaryRoot, platformPack\)/u);
+});
+
+test("VS Code public release verification stays exact and credential-free", () => {
+  const vscodePackage = readJson("editors/vscode/package.json");
+  const verifier = readFileSync("scripts/vscode-public-verify.mjs", "utf8");
+  const verifierTests = readFileSync("scripts/vscode-public-verify.test.mjs", "utf8");
+  const releaseSecurity = readFileSync("docs/development/release-security.md", "utf8");
+  const releaseSkill = readFileSync(".agents/skills/release/SKILL.md", "utf8");
+  assert.equal(vscodePackage.devDependencies["@vscode/vsce"], "3.9.2");
+  assert.equal(vscodePackage.devDependencies.ovsx, "1.1.0");
+  assert.match(verifier, /from "\.\.\/editors\/vscode\/scripts\/vsix-targets\.mjs"/u);
+  assert.match(verifier, /VSIX_VARIANTS\.map\(\(\{ target \}\) => target\)/u);
+  assert.match(verifier, /marketplace\.visualstudio\.com\/.*extensionquery/u);
+  assert.match(verifier, /open-vsx\.org\/api/u);
+  assert.match(verifier, /target === "universal" \? version/u);
+  assert.match(verifier, /payload.*fileCount.*sha256/su);
+  assert.match(verifier, /DEFAULT_ATTEMPTS = 24/u);
+  assert.doesNotMatch(verifier, /VSCE_PAT|OVSX_PAT|secrets\./u);
+  assert.match(verifierTests, /missing[\s\S]*duplicate[\s\S]*stale/u);
+  assert.match(verifierTests, /universal fallback/u);
+  assert.match(verifierTests, /changed content/u);
+  assert.match(releaseSecurity, /vscode-public-verify/u);
+  assert.match(releaseSkill, /Verify public VS Code registry targets/u);
 });
 
 test("type-aware public surfaces expose only the stable protocol", () => {

--- a/scripts/vscode-public-verify.mjs
+++ b/scripts/vscode-public-verify.mjs
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  createWriteStream,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, relative, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import {
+  backendExecutableMode,
+  getVsixVariant,
+  TYPE_AWARE_SIDECAR_FILES,
+  VSIX_VARIANTS,
+  vsixFilename,
+} from "../editors/vscode/scripts/vsix-targets.mjs";
+
+export const EXPECTED_TARGETS = VSIX_VARIANTS.map(({ target }) => target);
+
+const PUBLISHER = "fallow-rs";
+const EXTENSION_NAME = "fallow-vscode";
+const EXTENSION_ID = `${PUBLISHER}.${EXTENSION_NAME}`;
+const MARKETPLACE_QUERY_URL =
+  "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=7.2-preview.1";
+const OPEN_VSX_API_ROOT = "https://open-vsx.org/api";
+const MARKETPLACE_PACKAGE_ASSET = "Microsoft.VisualStudio.Services.VSIXPackage";
+const DEFAULT_ATTEMPTS = 24;
+const DEFAULT_RETRY_MS = 15_000;
+const REQUEST_TIMEOUT_MS = 120_000;
+
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+const hashFile = (path) => sha256(readFileSync(path));
+
+const normalizeTarget = (targetPlatform) => targetPlatform || "universal";
+
+const sleep = (durationMs) => new Promise((accept) => setTimeout(accept, durationMs));
+
+const assertHttpsUrl = (value, label) => {
+  const url = new URL(value);
+  assert.equal(url.protocol, "https:", `${label} must use HTTPS`);
+  return url.href;
+};
+
+const assertExactTargets = (targets, label) => {
+  assert.deepEqual(targets, EXPECTED_TARGETS, `${label} must contain the exact target set`);
+};
+
+/** Validate the immutable package inventory produced by the release packaging job. */
+export const validateInventory = (inventory) => {
+  assert.equal(inventory?.schemaVersion, 1, "inventory schemaVersion must be 1");
+  assert.match(
+    inventory?.extensionVersion ?? "",
+    /^\d+\.\d+\.\d+$/u,
+    "inventory extensionVersion must be semantic",
+  );
+  assert.ok(Array.isArray(inventory.entries), "inventory entries must be an array");
+  assertExactTargets(
+    inventory.entries.map((entry) => entry.target),
+    "inventory",
+  );
+
+  for (const [index, entry] of inventory.entries.entries()) {
+    const target = EXPECTED_TARGETS[index];
+    const targetPlatform = target === "universal" ? null : target;
+    assert.equal(entry.targetPlatform, targetPlatform, `${target} targetPlatform mismatch`);
+    assert.equal(entry.version, inventory.extensionVersion, `${target} version mismatch`);
+    assert.equal(
+      entry.file,
+      vsixFilename(inventory.extensionVersion, target),
+      `${target} filename mismatch`,
+    );
+    assert.ok(Number.isSafeInteger(entry.bytes) && entry.bytes > 0, `${target} bytes are invalid`);
+    assert.match(entry.sha256 ?? "", /^[a-f0-9]{64}$/u, `${target} sha256 is invalid`);
+    assert.ok(
+      Number.isSafeInteger(entry.payload?.fileCount) && entry.payload.fileCount > 0,
+      `${target} payload fileCount is invalid`,
+    );
+    assert.match(
+      entry.payload?.sha256 ?? "",
+      /^[a-f0-9]{64}$/u,
+      `${target} payload sha256 is invalid`,
+    );
+    assert.equal(
+      entry.typescriptVersion?.length > 0,
+      true,
+      `${target} TypeScript version is invalid`,
+    );
+    const variant = getVsixVariant(target);
+    assert.equal(
+      entry.backends?.length,
+      variant.backends.length,
+      `${target} backend count mismatch`,
+    );
+    for (let backendIndex = 0; backendIndex < variant.backends.length; backendIndex += 1) {
+      const backend = entry.backends[backendIndex];
+      const descriptor = variant.backends[backendIndex];
+      assert.equal(backend.package, descriptor.packageName, `${target} backend package mismatch`);
+      assert.equal(backend.os, descriptor.os, `${target} backend OS mismatch`);
+      assert.equal(backend.cpu, descriptor.cpu, `${target} backend CPU mismatch`);
+      assert.equal(
+        backend.executable,
+        `dist/type-aware/node_modules/${descriptor.packageName}/lib/${descriptor.executable}`,
+        `${target} backend path mismatch`,
+      );
+      assert.equal(
+        backend.mode,
+        backendExecutableMode(descriptor),
+        `${target} backend mode mismatch`,
+      );
+      assert.match(backend.sha256 ?? "", /^[a-f0-9]{64}$/u, `${target} backend hash is invalid`);
+    }
+    assert.deepEqual(
+      entry.sidecar?.map(({ path, mode }) => ({ path, mode })),
+      TYPE_AWARE_SIDECAR_FILES,
+      `${target} sidecar contract mismatch`,
+    );
+    for (const sidecar of entry.sidecar) {
+      assert.match(sidecar.sha256 ?? "", /^[a-f0-9]{64}$/u, `${target} sidecar hash is invalid`);
+    }
+  }
+
+  return inventory;
+};
+
+/** Parse the packaging checksum file and reject duplicate or malformed records. */
+export const parseChecksums = (source) => {
+  const checksums = new Map();
+  for (const line of source.trim().split(/\r?\n/u)) {
+    const match = line.match(/^([a-f0-9]{64})  ([^/\\]+)$/u);
+    assert.ok(match, `invalid SHA256SUMS record: ${line}`);
+    assert.ok(!checksums.has(match[2]), `duplicate SHA256SUMS record: ${match[2]}`);
+    checksums.set(match[2], match[1]);
+  }
+  return checksums;
+};
+
+/** Check every local artifact before using its inventory as the public reference. */
+export const validateArtifactDirectory = (artifactDir) => {
+  const inventoryPath = join(artifactDir, "inventory.json");
+  const checksumsPath = join(artifactDir, "SHA256SUMS");
+  const inventory = validateInventory(JSON.parse(readFileSync(inventoryPath, "utf8")));
+  const checksums = parseChecksums(readFileSync(checksumsPath, "utf8"));
+  const expectedChecksumFiles = [...inventory.entries.map((entry) => entry.file), "inventory.json"];
+  assert.deepEqual(
+    [...checksums.keys()].toSorted(),
+    expectedChecksumFiles.toSorted(),
+    "SHA256SUMS must cover only the VSIX files and inventory",
+  );
+
+  for (const entry of inventory.entries) {
+    const path = join(artifactDir, entry.file);
+    assert.ok(existsSync(path), `missing packaged VSIX: ${entry.file}`);
+    assert.equal(statSync(path).size, entry.bytes, `${entry.file} byte size mismatch`);
+    assert.equal(hashFile(path), entry.sha256, `${entry.file} sha256 mismatch`);
+    assert.equal(checksums.get(entry.file), entry.sha256, `${entry.file} checksum mismatch`);
+  }
+  assert.equal(
+    checksums.get("inventory.json"),
+    hashFile(inventoryPath),
+    "inventory checksum mismatch",
+  );
+  return inventory;
+};
+
+/** Resolve exact version and target downloads from a Marketplace gallery response. */
+export const marketplaceDownloads = (response, version) => {
+  const extensions = (response?.results ?? []).flatMap((result) => result.extensions ?? []);
+  const matches = extensions.filter(
+    (extension) =>
+      extension.publisher?.publisherName?.toLowerCase() === PUBLISHER &&
+      extension.extensionName === EXTENSION_NAME,
+  );
+  assert.equal(matches.length, 1, `Marketplace metadata must contain exactly one ${EXTENSION_ID}`);
+
+  const versions = (matches[0].versions ?? []).filter((candidate) => candidate.version === version);
+  const downloads = new Map();
+  for (const candidate of versions) {
+    const target = normalizeTarget(candidate.targetPlatform);
+    assert.ok(
+      EXPECTED_TARGETS.includes(target),
+      `Marketplace returned unexpected target ${target}`,
+    );
+    assert.ok(!downloads.has(target), `Marketplace returned duplicate target ${target}`);
+    const packageFile = (candidate.files ?? []).find(
+      (file) => file.assetType === MARKETPLACE_PACKAGE_ASSET,
+    );
+    assert.ok(packageFile?.source, `Marketplace ${target} is missing its VSIX package`);
+    downloads.set(target, assertHttpsUrl(packageFile.source, `Marketplace ${target} download`));
+  }
+  assertExactTargets(
+    EXPECTED_TARGETS.filter((target) => downloads.has(target)),
+    "Marketplace metadata",
+  );
+  return new Map(EXPECTED_TARGETS.map((target) => [target, downloads.get(target)]));
+};
+
+/** Validate one exact Open VSX target endpoint without accepting universal fallback. */
+export const openVsxDownload = (metadata, version, target) => {
+  assert.equal(metadata?.namespace, PUBLISHER, `Open VSX ${target} namespace mismatch`);
+  assert.equal(metadata?.name, EXTENSION_NAME, `Open VSX ${target} extension mismatch`);
+  assert.equal(metadata?.version, version, `Open VSX ${target} version mismatch`);
+  assert.equal(
+    normalizeTarget(metadata?.targetPlatform),
+    target,
+    `Open VSX ${target} returned a different target`,
+  );
+  assert.ok(metadata?.files?.download, `Open VSX ${target} is missing its VSIX download`);
+  return assertHttpsUrl(metadata.files.download, `Open VSX ${target} download`);
+};
+
+/** Retry registry propagation checks with a fixed upper bound. */
+export const retry = async (label, operation, options = {}) => {
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const retryMs = options.retryMs ?? DEFAULT_RETRY_MS;
+  assert.ok(Number.isSafeInteger(attempts) && attempts > 0, "attempts must be positive");
+  assert.ok(Number.isSafeInteger(retryMs) && retryMs >= 0, "retryMs must be non-negative");
+
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation(attempt);
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+      console.log(`${label} is not ready (attempt ${attempt}/${attempts}): ${error.message}`);
+      await sleep(retryMs);
+    }
+  }
+  throw new Error(`${label} did not become ready after ${attempts} attempts`, { cause: lastError });
+};
+
+export const fetchJson = async (url, options = {}) => {
+  const response = await fetch(url, {
+    ...options,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  return response.json();
+};
+
+const queryMarketplace = async (version) => {
+  const response = await fetchJson(MARKETPLACE_QUERY_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json;api-version=7.2-preview.1",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      filters: [
+        {
+          criteria: [{ filterType: 7, value: EXTENSION_ID }],
+          pageNumber: 1,
+          pageSize: 1,
+          sortBy: 0,
+          sortOrder: 0,
+        },
+      ],
+      assetTypes: [MARKETPLACE_PACKAGE_ASSET],
+      flags: 3,
+    }),
+  });
+  return marketplaceDownloads(response, version);
+};
+
+const queryOpenVsx = async (version) => {
+  const downloads = new Map();
+  for (const target of EXPECTED_TARGETS) {
+    const suffix = target === "universal" ? version : `${target}/${version}`;
+    const url = `${OPEN_VSX_API_ROOT}/${PUBLISHER}/${EXTENSION_NAME}/${suffix}`;
+    const metadata = await fetchJson(url);
+    downloads.set(target, openVsxDownload(metadata, version, target));
+  }
+  return downloads;
+};
+
+const downloadToFile = async (url, destination) => {
+  const response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+  if (!response.ok || !response.body) {
+    await response.body?.cancel();
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+};
+
+const walkFiles = (root) => {
+  const files = [];
+  const visit = (directory) => {
+    for (const name of readdirSync(directory).toSorted()) {
+      const path = join(directory, name);
+      const stat = lstatSync(path);
+      if (stat.isDirectory()) {
+        visit(path);
+      } else {
+        assert.ok(stat.isFile(), `payload contains unsupported entry ${path}`);
+        files.push(path);
+      }
+    }
+  };
+  visit(root);
+  return files;
+};
+
+/** Compute the signature-independent extension payload digest used by packaging. */
+export const computePayload = (extractedRoot) => {
+  const extensionRoot = join(extractedRoot, "extension");
+  assert.ok(existsSync(extensionRoot), "VSIX is missing its extension payload");
+  const records = walkFiles(extensionRoot)
+    .map((path) => {
+      const content = readFileSync(path);
+      const archivePath =
+        `extension/${relative(extensionRoot, path).split(sep).join("/")}`.toLowerCase();
+      return [archivePath, content.byteLength, sha256(content)];
+    })
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  const digest = createHash("sha256");
+  for (const record of records) digest.update(`${JSON.stringify(record)}\n`, "utf8");
+  return { fileCount: records.length, sha256: digest.digest("hex") };
+};
+
+const manifestAttributes = (manifest) => {
+  const identity = manifest.match(/<Identity\s+([^>]+)\/>/u)?.[1];
+  assert.ok(identity, "VSIX manifest is missing Identity");
+  return new Map(
+    [...identity.matchAll(/([A-Za-z]+)="([^"]*)"/gu)].map((match) => [match[1], match[2]]),
+  );
+};
+
+/** Compare one extracted registry download with the prepared semantic payload. */
+export const verifyExtractedPayload = (extractedRoot, entry) => {
+  const manifest = readFileSync(join(extractedRoot, "extension.vsixmanifest"), "utf8");
+  const identity = manifestAttributes(manifest);
+  assert.equal(identity.get("Publisher"), PUBLISHER, `${entry.target} publisher mismatch`);
+  assert.equal(identity.get("Id"), EXTENSION_NAME, `${entry.target} extension name mismatch`);
+  assert.equal(identity.get("Version"), entry.version, `${entry.target} manifest version mismatch`);
+  assert.equal(
+    normalizeTarget(identity.get("TargetPlatform")),
+    entry.target,
+    `${entry.target} manifest target mismatch`,
+  );
+
+  const packageJson = JSON.parse(
+    readFileSync(join(extractedRoot, "extension", "package.json"), "utf8"),
+  );
+  assert.equal(packageJson.publisher, PUBLISHER, `${entry.target} package publisher mismatch`);
+  assert.equal(packageJson.name, EXTENSION_NAME, `${entry.target} package name mismatch`);
+  assert.equal(packageJson.version, entry.version, `${entry.target} package version mismatch`);
+  const extensionRoot = resolve(extractedRoot, "extension");
+  for (const record of [
+    ...entry.backends.map(({ executable, mode }) => ({ path: executable, mode })),
+    ...entry.sidecar,
+  ]) {
+    const filePath = resolve(extensionRoot, record.path);
+    assert.ok(
+      filePath.startsWith(`${extensionRoot}${sep}`),
+      `${record.path} escapes the extension`,
+    );
+    assert.equal(
+      statSync(filePath).mode & 0o777,
+      record.mode,
+      `${entry.target} archived mode mismatch for ${record.path}`,
+    );
+  }
+  assert.deepEqual(
+    computePayload(extractedRoot),
+    entry.payload,
+    `${entry.target} payload mismatch`,
+  );
+};
+
+const extractVsix = (archive, destination) => {
+  const result = spawnSync("unzip", ["-q", archive, "-d", destination], { encoding: "utf8" });
+  assert.equal(result.status, 0, `could not extract ${basename(archive)}: ${result.stderr}`);
+};
+
+const verifyDownload = async (registry, url, entry, temporaryRoot, retryOptions) =>
+  retry(
+    `${registry} ${entry.target} payload`,
+    async (attempt) => {
+      const archive = join(temporaryRoot, `${registry}-${entry.target}-${attempt}.vsix`);
+      const extractedRoot = join(temporaryRoot, `${registry}-${entry.target}-${attempt}`);
+      try {
+        await downloadToFile(url, archive);
+        assert.ok(
+          statSync(archive).size <= getVsixVariant(entry.target).maxBytes,
+          `${registry} ${entry.target} exceeds its VSIX size limit`,
+        );
+        extractVsix(archive, extractedRoot);
+        verifyExtractedPayload(extractedRoot, entry);
+      } finally {
+        rmSync(archive, { force: true });
+        rmSync(extractedRoot, { force: true, recursive: true });
+      }
+    },
+    retryOptions,
+  );
+
+const parseArguments = (arguments_) => {
+  const options = {
+    artifactDir: null,
+    attempts: DEFAULT_ATTEMPTS,
+    retryMs: DEFAULT_RETRY_MS,
+  };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const value = arguments_[index + 1];
+    if (arguments_[index] === "--artifact-dir" && value) {
+      options.artifactDir = resolve(value);
+      index += 1;
+    } else if (arguments_[index] === "--attempts" && value) {
+      options.attempts = Number(value);
+      index += 1;
+    } else if (arguments_[index] === "--retry-ms" && value) {
+      options.retryMs = Number(value);
+      index += 1;
+    } else {
+      throw new Error(`unknown or incomplete argument: ${arguments_[index]}`);
+    }
+  }
+  assert.ok(options.artifactDir, "--artifact-dir is required");
+  return options;
+};
+
+const main = async () => {
+  const options = parseArguments(process.argv.slice(2));
+  const inventory = validateArtifactDirectory(options.artifactDir);
+  const retryOptions = { attempts: options.attempts, retryMs: options.retryMs };
+  const version = inventory.extensionVersion;
+
+  const [marketplace, openVsx] = await Promise.all([
+    retry("VS Code Marketplace metadata", () => queryMarketplace(version), retryOptions),
+    retry("Open VSX metadata", () => queryOpenVsx(version), retryOptions),
+  ]);
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), "fallow-vscode-public-"));
+  try {
+    await Promise.all(
+      inventory.entries.flatMap((entry) => [
+        verifyDownload(
+          "marketplace",
+          marketplace.get(entry.target),
+          entry,
+          temporaryRoot,
+          retryOptions,
+        ),
+        verifyDownload("open-vsx", openVsx.get(entry.target), entry, temporaryRoot, retryOptions),
+      ]),
+    );
+  } finally {
+    rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+  console.log(`Verified ${EXTENSION_ID} ${version} for every public registry target`);
+};
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/vscode-public-verify.test.mjs
+++ b/scripts/vscode-public-verify.test.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import {
+  backendExecutableMode,
+  getVsixVariant,
+  TYPE_AWARE_SIDECAR_FILES,
+} from "../editors/vscode/scripts/vsix-targets.mjs";
+import {
+  EXPECTED_TARGETS,
+  computePayload,
+  fetchJson,
+  marketplaceDownloads,
+  openVsxDownload,
+  parseChecksums,
+  retry,
+  validateInventory,
+  verifyExtractedPayload,
+} from "./vscode-public-verify.mjs";
+
+const VERSION = "3.17.0";
+const FIXTURE_ROOT = "scripts/fixtures/vscode-public-verify";
+
+const loadMarketplace = () =>
+  JSON.parse(readFileSync(join(FIXTURE_ROOT, "marketplace.json"), "utf8"));
+
+const entryFor = (target) => {
+  const variant = getVsixVariant(target);
+  return {
+    file: `fallow-vscode-${VERSION}-${target}.vsix`,
+    target,
+    targetPlatform: target === "universal" ? null : target,
+    version: VERSION,
+    bytes: 100,
+    sha256: "1".repeat(64),
+    payload: { fileCount: 2, sha256: "2".repeat(64) },
+    typescriptVersion: "7.0.0-dev.20260815.1",
+    backends: variant.backends.map((backend) => ({
+      package: backend.packageName,
+      os: backend.os,
+      cpu: backend.cpu,
+      executable: `dist/type-aware/node_modules/${backend.packageName}/lib/${backend.executable}`,
+      bytes: 10,
+      sha256: "3".repeat(64),
+      mode: backendExecutableMode(backend),
+    })),
+    sidecar: TYPE_AWARE_SIDECAR_FILES.map(({ path, mode }) => ({
+      path,
+      bytes: 10,
+      sha256: "4".repeat(64),
+      mode,
+    })),
+  };
+};
+
+const writeModeRecords = (extension, entry) => {
+  for (const record of [
+    ...entry.backends.map(({ executable, mode }) => ({ path: executable, mode })),
+    ...entry.sidecar,
+  ]) {
+    const path = join(extension, record.path);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, record.path);
+    chmodSync(path, record.mode);
+  }
+};
+
+const validInventory = () => ({
+  schemaVersion: 1,
+  extensionVersion: VERSION,
+  entries: EXPECTED_TARGETS.map(entryFor),
+});
+
+const withTemporaryDirectory = (operation) => {
+  const root = mkdtempSync(join(tmpdir(), "fallow-public-verify-test-"));
+  try {
+    return operation(root);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+};
+
+test("inventory requires the universal-first closed target catalog", () => {
+  assert.equal(validateInventory(validInventory()).entries[0].target, "universal");
+
+  const missing = validInventory();
+  missing.entries.pop();
+  assert.throws(() => validateInventory(missing), /exact target set/u);
+
+  const reordered = validInventory();
+  [reordered.entries[0], reordered.entries[1]] = [reordered.entries[1], reordered.entries[0]];
+  assert.throws(() => validateInventory(reordered), /exact target set/u);
+
+  const unexpected = validInventory();
+  unexpected.entries[6] = { ...unexpected.entries[6], target: "freebsd-x64" };
+  assert.throws(() => validateInventory(unexpected), /exact target set/u);
+});
+
+test("checksum records reject path traversal and duplicates", () => {
+  const hash = "a".repeat(64);
+  assert.deepEqual([...parseChecksums(`${hash}  archive.vsix\n`).keys()], ["archive.vsix"]);
+  assert.throws(() => parseChecksums(`${hash}  ../archive.vsix\n`), /invalid/u);
+  assert.throws(
+    () => parseChecksums(`${hash}  archive.vsix\n${hash}  archive.vsix\n`),
+    /duplicate/u,
+  );
+});
+
+test("Marketplace metadata requires every exact version and target tuple", () => {
+  const downloads = marketplaceDownloads(loadMarketplace(), VERSION);
+  assert.deepEqual([...downloads.keys()], EXPECTED_TARGETS);
+
+  const missing = loadMarketplace();
+  missing.results[0].extensions[0].versions.pop();
+  assert.throws(() => marketplaceDownloads(missing, VERSION), /exact target set/u);
+
+  const duplicate = loadMarketplace();
+  duplicate.results[0].extensions[0].versions.push(
+    structuredClone(duplicate.results[0].extensions[0].versions[0]),
+  );
+  assert.throws(() => marketplaceDownloads(duplicate, VERSION), /duplicate target universal/u);
+
+  const stale = loadMarketplace();
+  stale.results[0].extensions[0].versions[0].version = "3.16.0";
+  assert.throws(() => marketplaceDownloads(stale, VERSION), /exact target set/u);
+});
+
+test("Open VSX exact endpoint metadata rejects universal fallback", () => {
+  const metadata = {
+    namespace: "fallow-rs",
+    name: "fallow-vscode",
+    version: VERSION,
+    targetPlatform: "linux-x64",
+    files: { download: "https://example.invalid/linux-x64.vsix" },
+  };
+  assert.equal(
+    openVsxDownload(metadata, VERSION, "linux-x64"),
+    "https://example.invalid/linux-x64.vsix",
+  );
+  assert.throws(
+    () => openVsxDownload({ ...metadata, targetPlatform: "universal" }, VERSION, "linux-x64"),
+    /different target/u,
+  );
+  assert.throws(
+    () => openVsxDownload({ ...metadata, version: "3.16.0" }, VERSION, "linux-x64"),
+    /version mismatch/u,
+  );
+});
+
+test("registry metadata rejects rate limits and non-JSON responses", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => new Response("rate limited", { status: 429 });
+    await assert.rejects(fetchJson("https://example.invalid/metadata"), /HTTP 429/u);
+
+    globalThis.fetch = async () =>
+      new Response("<html>not registry metadata</html>", {
+        headers: { "content-type": "text/html" },
+        status: 200,
+      });
+    await assert.rejects(fetchJson("https://example.invalid/metadata"), /JSON/u);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("normalized payload verification ignores filesystem metadata but not content", () =>
+  withTemporaryDirectory((root) => {
+    const extension = join(root, "extension");
+    mkdirSync(join(extension, "dist"), { recursive: true });
+    writeFileSync(join(extension, "package.json"), '{"name":"fallow-vscode"}\n');
+    writeFileSync(join(extension, "dist", "extension.js"), "export {};\n");
+    const before = computePayload(root);
+    assert.equal(before.fileCount, 2);
+
+    writeFileSync(join(extension, "dist", "extension.js"), "export const changed = true;\n");
+    assert.notEqual(computePayload(root).sha256, before.sha256);
+  }));
+
+test("semantic payload verification rejects a registry package with changed content", () =>
+  withTemporaryDirectory((root) => {
+    const extension = join(root, "extension");
+    mkdirSync(extension, { recursive: true });
+    writeFileSync(
+      join(root, "extension.vsixmanifest"),
+      `<Identity Id="fallow-vscode" Version="${VERSION}" Publisher="fallow-rs" TargetPlatform="linux-x64" />`,
+    );
+    writeFileSync(
+      join(extension, "package.json"),
+      JSON.stringify({ name: "fallow-vscode", publisher: "fallow-rs", version: VERSION }),
+    );
+    const entry = entryFor("linux-x64");
+    writeModeRecords(extension, entry);
+    entry.payload = computePayload(root);
+    verifyExtractedPayload(root, entry);
+
+    chmodSync(join(extension, entry.sidecar[0].path), 0o644);
+    assert.throws(() => verifyExtractedPayload(root, entry), /archived mode mismatch/u);
+    chmodSync(join(extension, entry.sidecar[0].path), entry.sidecar[0].mode);
+    writeFileSync(join(extension, "package.json"), "{}\n");
+    assert.throws(() => verifyExtractedPayload(root, entry), /package publisher mismatch/u);
+  }));
+
+test("registry propagation retry succeeds within its bound and rejects exhaustion", async () => {
+  let attempts = 0;
+  const result = await retry(
+    "fixture registry",
+    async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error("not propagated");
+      return "ready";
+    },
+    { attempts: 3, retryMs: 0 },
+  );
+  assert.equal(result, "ready");
+  assert.equal(attempts, 3);
+
+  await assert.rejects(
+    retry("fixture registry", async () => Promise.reject(new Error("still missing")), {
+      attempts: 2,
+      retryMs: 0,
+    }),
+    /did not become ready after 2 attempts/u,
+  );
+});

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -212,20 +212,26 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   const npmPackage = JSON.parse(readFileSync("npm/fallow/package.json", "utf8"));
   const windowsRustPaths = listedPaths(indentedBlock(workflow, "windows-rust", 12));
   const windowsTypeAwarePaths = listedPaths(indentedBlock(workflow, "windows-type-aware", 12));
+  const vscodePaths = listedPaths(indentedBlock(workflow, "vscode", 12));
   const checkJob = indentedBlock(workflow, "check", 2);
   const windowsRustJob = indentedBlock(workflow, "windows-rust", 2);
   const windowsTypeAwareJob = indentedBlock(workflow, "windows-type-aware", 2);
-  const vscodeJob = indentedBlock(workflow, "vscode", 2);
+  const vscodePackageTargetsJob = indentedBlock(workflow, "vscode-package-targets", 2);
+  const vscodeTargetHostJob = indentedBlock(workflow, "vscode-target-host", 2);
   const zedJob = indentedBlock(workflow, "zed", 2);
   const aggregateJob = indentedBlock(workflow, "ci-ok", 2);
   const workflowWithoutWindowsJobs = workflow
     .replace(windowsRustJob, "")
-    .replace(windowsTypeAwareJob, "");
+    .replace(windowsTypeAwareJob, "")
+    .replace(vscodePackageTargetsJob, "")
+    .replace(vscodeTargetHostJob, "");
 
   assert.doesNotMatch(workflowWithoutWindowsJobs, /windows-latest|windows-11-arm|macos-latest/);
   assert.match(checkJob, /runs-on: ubuntu-latest/);
   assert.match(checkJob, /timeout-minutes: 20/);
   assert.doesNotMatch(checkJob, /matrix\.|windows-latest|macos-latest/);
+  assert.match(vscodePackageTargetsJob, /runs-on: ubuntu-latest/);
+  assert.match(vscodeTargetHostJob, /linux-x64[\s\S]*win32-x64[\s\S]*darwin-x64/u);
   assert.match(windowsRustJob, /needs: changes/);
   assert.match(windowsRustJob, /if: needs\.changes\.outputs\.windows-rust == 'true'/);
   assert.match(windowsRustJob, /runs-on: windows-latest/);
@@ -274,13 +280,15 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.ok(windowsTypeAwarePaths.includes("crates/api/src/type_aware/transport/**"));
   assert.match(windowsTypeAwareJob, /cargo test -p fallow-api type_aware::transport/);
   assert.match(windowsTypeAwareJob, /type-aware-windows-candidate-smoke\.mjs/);
-  assert.match(windowsTypeAwareJob, /FALLOW_LSP_BIN:/);
-  assert.match(windowsTypeAwareJob, /verify:vsix/);
-  assert.match(windowsTypeAwareJob, /pnpm package/);
-  assert.match(windowsTypeAwareJob, /test:integration:real/);
-  assert.match(vscodeJob, /verify:vsix/);
-  assert.match(vscodeJob, /FALLOW_EXTENSION_PATH=/);
-  assert.match(vscodeJob, /name: Run extracted production VSIX host smoke/);
+  assert.match(vscodePackageTargetsJob, /package:variants/);
+  assert.match(vscodePackageTargetsJob, /test:packaging/);
+  assert.ok(vscodePaths.includes(".github/workflows/release.yml"));
+  assert.ok(vscodePaths.includes(".github/workflows/release-validation.yml"));
+  assert.match(vscodeTargetHostJob, /verify:vsix/);
+  assert.match(vscodeTargetHostJob, /FALLOW_EXTENSION_PATH=/);
+  assert.match(vscodeTargetHostJob, /FALLOW_BIN:/);
+  assert.match(vscodeTargetHostJob, /FALLOW_LSP_BIN:/);
+  assert.match(vscodeTargetHostJob, /name: Run exact target VSIX host smoke/);
   assert.match(zedJob, /runs-on: ubuntu-latest/);
   assert.doesNotMatch(zedJob, /matrix\.|windows-latest|macos-latest/);
   assert.throws(() => indentedBlock(workflow, "windows-arm64", 2), /missing windows-arm64 block/);
@@ -338,6 +346,8 @@ test("release runs Windows correctness and lifecycle verification without creden
   const releaseWorkflow = readWorkflow(".github/workflows/release.yml");
   const validationWorkflow = readWorkflow(".github/workflows/release-validation.yml");
   const job = indentedBlock(validationWorkflow, "windows-verify", 2);
+  const vscodePackageJob = indentedBlock(validationWorkflow, "vscode-package-targets", 2);
+  const vscodeTargetJob = indentedBlock(validationWorkflow, "vscode-target-host", 2);
   const buildJob = indentedBlock(releaseWorkflow, "build", 2);
 
   assert.match(buildJob, /target: x86_64-pc-windows-msvc/);
@@ -356,8 +366,11 @@ test("release runs Windows correctness and lifecycle verification without creden
   assert.match(job, /cargo fmt --all -- --check/);
   assert.match(job, /npm run publish:prepare/);
   assert.match(job, /cd crates\/napi && npm test/);
-  assert.match(job, /verify:vsix/);
-  assert.match(job, /FALLOW_LSP_BIN:/);
+  assert.match(vscodeTargetJob, /verify:vsix/);
+  assert.match(vscodeTargetJob, /FALLOW_LSP_BIN:/);
+  assert.match(vscodePackageJob, /name: validation-vscode-targets/);
+  assert.match(vscodePackageJob, /test:packaging/);
+  assert.doesNotMatch(vscodePackageJob, /name: fallow-vscode-targets/);
   assert.match(job, /type-aware-windows-candidate-smoke\.mjs/);
   assert.match(job, /FALLOW_CANDIDATE_BIN:/);
   assert.match(job, /audit_orphan_sweep_removes_dead_pid_worktree/);
@@ -409,7 +422,11 @@ test("release publication waits for the aggregate verification gate", () => {
   const releaseReady = indentedBlock(workflow, "release-ready", 2);
   const npmPublish = indentedBlock(workflow, "npm-publish", 2);
   const vscodePrep = indentedBlock(workflow, "vscode-prep", 2);
-  const vscodePublish = indentedBlock(workflow, "vscode-publish", 2);
+  const vscodeHostSmoke = indentedBlock(workflow, "vscode-host-smoke", 2);
+  const vscodeMarketplace = indentedBlock(workflow, "vscode-publish-marketplace", 2);
+  const vscodeOpenVsx = indentedBlock(workflow, "vscode-publish-open-vsx", 2);
+  const vscodePublicVerify = indentedBlock(workflow, "vscode-public-verify", 2);
+  const vscodePackage = JSON.parse(readFileSync("editors/vscode/package.json", "utf8"));
 
   assert.match(context, /permissions:\n\s+contents: read/);
   assert.doesNotMatch(context, /^\s+\w+: write$/mu);
@@ -421,14 +438,75 @@ test("release publication waits for the aggregate verification gate", () => {
   assert.match(gate, /needs: \[build, validate\]/);
   assert.match(gate, /permissions: \{\}/);
   assert.match(publishCrates, /needs: \[release-verified, release-assets\]/);
-  assert.match(releaseAssets, /needs: release-verified/);
+  assert.match(releaseAssets, /needs: \[release-verified, vscode-prep, vscode-host-smoke\]/);
   assert.match(releaseAssets, /permissions:\n\s+contents: read/);
+  assert.match(releaseAssets, /pattern: fallow-\*/);
   assert.match(npmPublish, /needs: \[npm-prep, release-assets\]/);
-  assert.match(vscodePrep, /verify:vsix/);
-  assert.match(vscodePublish, /needs: \[vscode-prep, release-assets\]/);
+  assert.match(vscodePrep, /package:variants --/);
+  assert.match(vscodePrep, /fallow-vscode-targets/);
+  assert.match(vscodePrep, /targets=\(\s+universal/su);
+  assert.match(vscodePrep, /inventory\.json SHA256SUMS/);
+  assert.match(vscodePrep, /\.entries\[\].*\.targetPlatform/su);
+  assert.match(vscodeHostSmoke, /needs: vscode-prep/);
+  assert.match(vscodeHostSmoke, /linux-x64[\s\S]*win32-x64[\s\S]*darwin-x64/u);
+  assert.match(vscodeHostSmoke, /name: fallow-vscode-targets/);
+  assert.match(vscodeHostSmoke, /name: fallow-cli-\$\{\{ matrix\.npm_dir \}\}/);
+  assert.match(vscodeHostSmoke, /name: fallow-lsp-\$\{\{ matrix\.npm_dir \}\}/);
+  assert.match(vscodeHostSmoke, /fallow-vscode-\$version-\$FALLOW_VSIX_TARGET\.vsix/);
+  assert.match(vscodeHostSmoke, /verify:vsix[\s\S]*--target[\s\S]*--version/u);
+  assert.match(vscodeHostSmoke, /FALLOW_EXTENSION_PATH=/);
+  assert.match(vscodeHostSmoke, /FALLOW_BIN=/);
+  assert.match(vscodeHostSmoke, /FALLOW_LSP_BIN=/);
+  assert.match(vscodeHostSmoke, /chmod \+x/);
+  assert.match(vscodeHostSmoke, /unzip -q/);
+  assert.match(vscodeHostSmoke, /test:integration:real/);
+  assert.match(vscodeHostSmoke, /persist-credentials: false/);
+  assert.doesNotMatch(vscodeHostSmoke, /secrets\.|cargo (?:build|install)/u);
+
+  for (const [job, registry, cli, pin, secret, otherSecret] of [
+    [
+      vscodeMarketplace,
+      "VS Code Marketplace",
+      "@vscode/vsce",
+      vscodePackage.devDependencies["@vscode/vsce"],
+      "VSCE_PAT",
+      "OVSX_PAT",
+    ],
+    [vscodeOpenVsx, "Open VSX", "ovsx", vscodePackage.devDependencies.ovsx, "OVSX_PAT", "VSCE_PAT"],
+  ]) {
+    assert.match(job, /needs: \[vscode-prep, vscode-host-smoke, release-assets\]/, registry);
+    assert.match(job, /permissions: \{\}/, registry);
+    assert.match(
+      job,
+      new RegExp(
+        `npm install -g --ignore-scripts ${cli.replace("/", "\\/")}@${pin.replaceAll(".", "\\.")}`,
+        "u",
+      ),
+      registry,
+    );
+    assert.match(job, new RegExp(`secrets\\.${secret}`, "u"), registry);
+    assert.doesNotMatch(job, new RegExp(`secrets\\.${otherSecret}`, "u"), registry);
+    assert.doesNotMatch(
+      job,
+      /actions\/checkout|pnpm|npm (?:ci|install)(?! -g)|\bbuild\b/u,
+      registry,
+    );
+    assert.doesNotMatch(job, /continue-on-error/u, registry);
+    assert.match(job, /\.entries\[\]\.file/u, registry);
+    assert.match(job, /--skip-duplicate/u, registry);
+    assert.match(job, /failed=1[\s\S]*exit "\$failed"/u, registry);
+  }
+
+  assert.match(
+    vscodePublicVerify,
+    /needs: \[vscode-prep, vscode-publish-marketplace, vscode-publish-open-vsx\]/,
+  );
+  assert.match(vscodePublicVerify, /persist-credentials: false/);
+  assert.match(vscodePublicVerify, /node scripts\/vscode-public-verify\.mjs --artifact-dir/);
+  assert.doesNotMatch(vscodePublicVerify, /secrets\.|_PAT|npm install|pnpm install/u);
   assert.match(
     releaseReady,
-    /needs: \[publish-crates, npm-publish, vscode-publish, release-assets\]/,
+    /needs: \[publish-crates, npm-publish, vscode-public-verify, release-assets\]/,
   );
   assert.match(releaseReady, /permissions:\n\s+contents: read/);
   assert.match(releaseReady, /Release tag .* appeared before the release workflow completed/u);

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -280,6 +280,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.ok(windowsTypeAwarePaths.includes("crates/api/src/type_aware/transport/**"));
   assert.match(windowsTypeAwareJob, /cargo test -p fallow-api type_aware::transport/);
   assert.match(windowsTypeAwareJob, /type-aware-windows-candidate-smoke\.mjs/);
+  assert.doesNotMatch(windowsTypeAwareJob, /pnpm package|verify:vsix|FALLOW_EXTENSION_PATH/);
   assert.match(vscodePackageTargetsJob, /package:variants/);
   assert.match(vscodePackageTargetsJob, /test:packaging/);
   assert.ok(vscodePaths.includes(".github/workflows/release.yml"));


### PR DESCRIPTION
Publishes smaller platform-specific VSIX packages for macOS, Linux, and Windows while retaining the universal extension as a compatibility fallback.

Target packages contain only the matching semantic backend. Release publication now uses isolated registry credentials and verifies the exact public target set before the release-ready gate.

Validation:
- focused packaging and negative archive tests
- exact seven-variant package build with inventory and checksum verification
- editor lint and unit tests
- workflow policy, actionlint, and security checks
- full repository verification