### PR TITLE
ci(benchmarks): add config walltime workload

### DIFF
--- a/.github/workflows/bench-rust-walltime.yml
+++ b/.github/workflows/bench-rust-walltime.yml
@@ -15,6 +15,7 @@ on:
           - analysis
           - programmatic-stable
           - component-engine
+          - component-config
           - component-output
           - dupes-detect
           - representative-sources
@@ -66,6 +67,10 @@ jobs:
             component-engine)
               echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
               echo "bench=component_engine" >> "$GITHUB_OUTPUT"
+              ;;
+            component-config)
+              echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"
+              echo "bench=component_config" >> "$GITHUB_OUTPUT"
               ;;
             component-output)
               echo "package=fallow-benchmarks" >> "$GITHUB_OUTPUT"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -14,9 +14,9 @@ persistent-session reuse as distinct benchmarks.
 Rust walltime retain gates run through the separate, manual
 `.github/workflows/bench-rust-walltime.yml` workflow. Its fixed suite choices
 cover core analysis, stable programmatic sessions, duplicate detection, focused
-source extraction, and engine and output components without accepting arbitrary
-commands. Keeping it manual avoids adding release-LTO builds to every pull
-request while preserving comparable Linux base/head evidence on CodSpeed's
+source extraction, and config, engine, and output components without accepting
+arbitrary commands. Keeping it manual avoids adding release-LTO builds to every
+pull request while preserving comparable Linux base/head evidence on CodSpeed's
 dedicated macro runners:
 
 ```bash

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -331,6 +331,8 @@ test("Rust walltime benchmarks use CodSpeed macro runners", () => {
   );
   assert.match(job, /tool: cargo-codspeed@4\.7\.0/);
   assert.match(job, /case "\$WALLTIME_WORKLOAD" in/);
+  assert.match(workflow, /- component-config/);
+  assert.match(job, /component-config\)[\s\S]*bench=component_config/);
   assert.match(workflow, /- component-output/);
   assert.match(job, /component-output\)[\s\S]*bench=component_output/);
   assert.match(workflow, /- dupes-detect/);


### PR DESCRIPTION
Adds component-config to the fixed Rust WallTime workload allowlist so config performance changes can use the same exact-base retain gate as the existing Rust suites.

The workflow still maps a closed choice to constant package and benchmark names. Permissions, pinned actions, manual dispatch, and command quoting are unchanged.

Validated with workflow policy tests, actionlint, zizmor, the component_config CodSpeed benchmark compile, and repository verification.