### PR TITLE
perf(engine): preallocate health candidate paths

### DIFF
--- a/crates/engine/src/health/filters.rs
+++ b/crates/engine/src/health/filters.rs
@@ -90,13 +90,17 @@ pub(super) fn collect_candidate_paths(
     ws_roots: Option<&[PathBuf]>,
     ignore_set: &globset::GlobSet,
 ) -> FxHashSet<PathBuf> {
-    files
-        .iter()
-        .filter(|file| {
-            path_in_health_scope(&file.path, config, changed_files, ws_roots, ignore_set)
-        })
-        .map(|file| file.path.clone())
-        .collect()
+    let capacity = changed_files.map_or(files.len(), |changed| files.len().min(changed.len()));
+    let mut candidates = FxHashSet::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher);
+    candidates.extend(
+        files
+            .iter()
+            .filter(|file| {
+                path_in_health_scope(&file.path, config, changed_files, ws_roots, ignore_set)
+            })
+            .map(|file| file.path.clone()),
+    );
+    candidates
 }
 
 pub(super) fn filter_files_to_paths(


### PR DESCRIPTION
Preallocates the health candidate-path set from the exact available upper bound while preserving every scope filter.

Performance on exact matching-runner WallTime:
- `component_engine_warm_session_health`: 1.479122 ms to 1.396810 ms, 5.6% faster
- all other measured component-engine identities unchanged

Simulation also improves the target from 2.082 ms to 1.958 ms and removes the measured hash-table growth cost.

Validated with full repository verification, focused and full engine tests, strict workspace Clippy, benchmark compilation, and byte-identical normalized RHC health JSON.