### PR TITLE
perf(benchmarks): track circular dependency command

### DIFF
--- a/crates/benchmarks/benches/programmatic_commands.rs
+++ b/crates/benchmarks/benches/programmatic_commands.rs
@@ -17,8 +17,7 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use fallow_api::{
     AnalysisOptions, AuditOptions, CombinedOptions, ComplexityOptions, DeadCodeOptions,
     DuplicationMode, DuplicationOptions, EditorAnalysisSession, EngineHealthRunner, run_audit,
-    run_circular_dependencies, run_combined, run_dead_code, run_duplication,
-    run_health_with_runner,
+    run_combined, run_dead_code, run_duplication, run_health_with_runner,
 };
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
@@ -563,56 +562,6 @@ export const middleware = (request: Request): Response => {
   const tenant = request.headers.get("x-tenant") ?? "default";
   return Response.json({ tenant });
 };
-"#,
-    );
-
-    CommandInput {
-        _temp_dir: temp_dir,
-        root,
-    }
-}
-
-fn create_circular_project() -> CommandInput {
-    let temp_dir = TempDir::new().unwrap();
-    let root = temp_dir.path().to_path_buf();
-
-    write_file(
-        &root,
-        "package.json",
-        package_json("bench-circulars", &[], ""),
-    );
-    for domain in ["orders", "billing", "users"] {
-        for i in 0..10 {
-            let next = (i + 1) % 10;
-            write_file(
-                &root,
-                &format!("src/domains/{domain}/node{i}.ts"),
-                format!(
-                    r#"
-import {{ value{next} }} from "./node{next}";
-
-export const value{i} = value{next} + {i};
-"#
-                ),
-            );
-        }
-        write_file(
-            &root,
-            &format!("src/domains/{domain}/index.ts"),
-            r#"
-export { value0 } from "./node0";
-"#,
-        );
-    }
-    write_file(
-        &root,
-        "src/index.ts",
-        r#"
-import { value0 as orderValue } from "./domains/orders";
-import { value0 as billingValue } from "./domains/billing";
-import { value0 as userValue } from "./domains/users";
-
-console.log(orderValue, billingValue, userValue);
 "#,
     );
 
@@ -1250,22 +1199,6 @@ fn duplication_next_route_callbacks_repeated_auth(c: &mut Criterion) {
     );
 }
 
-fn circular_dependencies_domain_graph_cycles(c: &mut Criterion) {
-    c.bench_function("circular_dependencies_domain_graph_cycles", |bencher| {
-        bencher.iter_batched_ref(
-            create_circular_project,
-            |input| {
-                let options = DeadCodeOptions {
-                    analysis: analysis_options(&input.root, true),
-                    ..DeadCodeOptions::default()
-                };
-                run_circular_dependencies(&options)
-            },
-            BatchSize::LargeInput,
-        );
-    });
-}
-
 fn health_complex_service_scoring(c: &mut Criterion) {
     c.bench_function("health_complex_service_scoring", |bencher| {
         bencher.iter_batched_ref(
@@ -1339,7 +1272,6 @@ criterion_group!(
     combined_workspace_programmatic_session_reuse,
     editor_workspace_repeated_session_analysis,
     duplication_next_route_callbacks_repeated_auth,
-    circular_dependencies_domain_graph_cycles,
     health_complex_service_scoring,
     health_complex_service_warm_complexity_hit,
     health_css_tailwind_design_system

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -14,8 +14,9 @@ use std::path::{Path, PathBuf};
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use fallow_api::{
-    AnalysisOptions, CombinedOptions, ComplexityOptions, DuplicationMode, DuplicationOptions,
-    EditorAnalysisSession, EngineHealthRunner, run_combined, run_health_with_runner,
+    AnalysisOptions, CombinedOptions, ComplexityOptions, DeadCodeOptions, DuplicationMode,
+    DuplicationOptions, EditorAnalysisSession, EngineHealthRunner, run_circular_dependencies,
+    run_combined, run_health_with_runner,
 };
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
@@ -278,6 +279,62 @@ console.log(scoreOrder({ status: "open", amount: 10, flags: ["flag1"] }));
     }
 }
 
+fn create_circular_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-circulars",
+  "private": true,
+  "type": "module",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "5.8.0"
+  }
+}"#,
+    );
+    for domain in ["orders", "billing", "users"] {
+        for index in 0..10 {
+            let next = (index + 1) % 10;
+            write_file(
+                &root,
+                &format!("src/domains/{domain}/node{index}.ts"),
+                format!(
+                    r#"
+import {{ value{next} }} from "./node{next}";
+
+export const value{index} = value{next} + {index};
+"#
+                ),
+            );
+        }
+        write_file(
+            &root,
+            &format!("src/domains/{domain}/index.ts"),
+            r#"export { value0 } from "./node0";"#,
+        );
+    }
+    write_file(
+        &root,
+        "src/index.ts",
+        r#"
+import { value0 as orderValue } from "./domains/orders";
+import { value0 as billingValue } from "./domains/billing";
+import { value0 as userValue } from "./domains/users";
+
+console.log(orderValue, billingValue, userValue);
+"#,
+    );
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_warm_complexity_health_project() -> CommandInput {
     let input = create_health_project();
     let options = ComplexityOptions {
@@ -401,11 +458,31 @@ fn stable_health_complex_service_warm_complexity_hit(c: &mut Criterion) {
     );
 }
 
+fn stable_circular_dependencies_domain_cycles(c: &mut Criterion) {
+    c.bench_function("stable_circular_dependencies_domain_cycles", |bencher| {
+        bencher.iter_batched_ref(
+            create_circular_project,
+            |input| {
+                let options = DeadCodeOptions {
+                    analysis: analysis_options(&input.root, true),
+                    ..DeadCodeOptions::default()
+                };
+                let output = run_circular_dependencies(&options)
+                    .expect("circular-dependency benchmark succeeds");
+                assert!(!output.circular_dependencies().is_empty());
+                output
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
 criterion_group!(
     benches,
     stable_combined_workspace_programmatic_session_reuse,
     stable_editor_workspace_repeated_session_analysis,
     stable_extract_workspace_monorepo_warm_hash_hit,
-    stable_health_complex_service_warm_complexity_hit
+    stable_health_complex_service_warm_complexity_hit,
+    stable_circular_dependencies_domain_cycles
 );
 criterion_main!(benches);

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -67,6 +67,8 @@ Full main/manual shards:
 
 `programmatic_commands` still exists for local walltime investigation, but it
 contains git/audit scenarios and must not run in the fast CodSpeed matrix.
+Deterministic command paths, including circular-dependency analysis, belong in
+`programmatic_stable` so CodSpeed tracks them continuously.
 `large_analysis` likewise remains available as a local-only high-cost analysis
 suite; its archived identities no longer run in CodSpeed CI.
 


### PR DESCRIPTION
Moves the deterministic circular-dependency command workload from the local-only `programmatic_commands` suite into the tracked `programmatic_stable` CodSpeed shard.

This keeps git/audit I/O out of fast CI while adding continuous regression coverage for circular graph analysis.

Validation:
- benchmark matrix and harness checks pass
- both programmatic benchmark targets compile
- the new stable benchmark completes successfully
- strict Clippy and fast repository verification pass
