### PR TITLE
chore(ci): bump dorny/paths-filter to v4.0.3 and Swatinem/rust-cache pin

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -43,6 +43,6 @@ runs:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 
-    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+    - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       with:
         key: ${{ inputs.cache-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       viz: ${{ steps.filter.outputs.viz }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |
@@ -1071,7 +1071,7 @@ jobs:
           rustup toolchain install "$MIRI_TOOLCHAIN" --component miri
           cargo +"$MIRI_TOOLCHAIN" miri setup
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
           key: miri
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Detect coverage-affecting changes
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: coverage_filter
         with:
           filters: |

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           toolchain: nightly-2026-07-20
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
           workspaces: fuzz -> target
           key: fuzz-smoke-nightly-2026-07-20-cargo-fuzz-0.13.2

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -664,7 +664,7 @@ test("coverage path filter contains the complete CI Rust contract", () => {
   const ciChangesJob = indentedBlock(ciWorkflow, "changes", 2);
   const ciRustPaths = listedPaths(indentedBlock(ciChangesJob, "rust", 12));
 
-  assert.match(coverageJob, /dorny\/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706/);
+  assert.match(coverageJob, /dorny\/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d/);
   for (const path of ciRustPaths) {
     assert.ok(coveragePaths.includes(path), `coverage filter is missing CI Rust path ${path}`);
   }


### PR DESCRIPTION
Supersedes #2294 and #2295 with the companion edits Dependabot cannot make itself:

- dorny/paths-filter 4.0.2 -> 4.0.3 in ci.yml and coverage.yml, plus the pinned SHA assertion in scripts/workflow-policy.test.mjs (the reason #2294 went red).
- Swatinem/rust-cache pin refresh in ci.yml, fuzz-smoke.yml, and .github/actions/setup-rust/action.yml; Dependabot missed the composite action, and its SHA-to-SHA commit header is 127 chars so #2295 can never pass commitlint.

Local gate: node --test scripts/*.test.mjs green.