### PR TITLE
perf(benchmarks): track fix dry runs

### DIFF
--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -18,6 +18,7 @@ use fallow_api::{
     DuplicationOptions, EditorAnalysisSession, EngineHealthRunner, FeatureFlagsOptions,
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
+use fallow_cli::benchmark_fix_dry_run;
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
     parse_all_files, parse_single_file,
@@ -26,6 +27,7 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
+const FIX_FILE_COUNT: usize = 128;
 
 struct CommandInput {
     _temp_dir: TempDir,
@@ -396,6 +398,48 @@ export const unusedFallback{index} = (): boolean => false;
     }
 }
 
+fn create_fix_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-fix-preview",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts"
+}"#,
+    );
+
+    let mut index_source = String::new();
+    for index in 0..FIX_FILE_COUNT {
+        writeln!(
+            &mut index_source,
+            "import {{ used{index} }} from \"./features/feature{index}\";"
+        )
+        .unwrap();
+        writeln!(&mut index_source, "console.log(used{index});").unwrap();
+        write_file(
+            &root,
+            &format!("src/features/feature{index}.ts"),
+            format!(
+                r"
+export const used{index} = {index};
+export const unused{index} = {index} * 2;
+"
+            ),
+        );
+    }
+    write_file(&root, "src/index.ts", index_source);
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_warm_complexity_health_project() -> CommandInput {
     let input = create_health_project();
     let options = ComplexityOptions {
@@ -556,6 +600,34 @@ fn stable_feature_flags_workspace_analysis(c: &mut Criterion) {
     });
 }
 
+fn stable_fix_dry_run_many_exports(c: &mut Criterion) {
+    let input = create_fix_project();
+    let representative_path = input.root.join("src/features/feature0.ts");
+    let original_source = fs::read_to_string(&representative_path).unwrap();
+
+    let (status, fix_count) = benchmark_fix_dry_run(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(fix_count, FIX_FILE_COUNT);
+    assert_eq!(
+        fs::read_to_string(&representative_path).unwrap(),
+        original_source
+    );
+
+    c.bench_function("stable_fix_dry_run_many_exports", |bencher| {
+        bencher.iter(|| {
+            let (status, fix_count) = benchmark_fix_dry_run(&input.root, BENCH_THREADS);
+            assert_eq!(status, std::process::ExitCode::SUCCESS);
+            assert_eq!(fix_count, FIX_FILE_COUNT);
+            (status, fix_count)
+        });
+    });
+
+    assert_eq!(
+        fs::read_to_string(representative_path).unwrap(),
+        original_source
+    );
+}
+
 criterion_group!(
     benches,
     stable_combined_workspace_programmatic_session_reuse,
@@ -563,6 +635,7 @@ criterion_group!(
     stable_extract_workspace_monorepo_warm_hash_hit,
     stable_health_complex_service_warm_complexity_hit,
     stable_circular_dependencies_domain_cycles,
-    stable_feature_flags_workspace_analysis
+    stable_feature_flags_workspace_analysis,
+    stable_fix_dry_run_many_exports
 );
 criterion_main!(benches);

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -84,6 +84,7 @@ pub struct FixOptions<'a> {
     pub no_cache: bool,
     pub threads: usize,
     pub quiet: bool,
+    pub emit_output: bool,
     pub allow_remote_extends: bool,
     pub dry_run: bool,
     pub yes: bool,
@@ -99,6 +100,16 @@ pub struct FixOptions<'a> {
 }
 
 pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
+    run_fix_with_count(opts).0
+}
+
+pub fn run_fix_with_count(opts: &FixOptions<'_>) -> (ExitCode, usize) {
+    let mut fix_count = 0;
+    let exit_code = run_fix_impl(opts, &mut fix_count);
+    (exit_code, fix_count)
+}
+
+fn run_fix_impl(opts: &FixOptions<'_>, fix_count: &mut usize) -> ExitCode {
     if !opts.dry_run && !opts.yes && !std::io::stdin().is_terminal() {
         let msg = "fix command requires --yes (or --force) in non-interactive environments. \
                    Use --dry-run to preview changes first, then pass --yes to confirm.";
@@ -137,7 +148,11 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
     };
 
     if results.total_issues() == 0 {
-        return emit_empty_fix_output(opts);
+        return if opts.emit_output {
+            emit_empty_fix_output(opts)
+        } else {
+            ExitCode::SUCCESS
+        };
     }
 
     let mut fixes: Vec<serde_json::Value> = Vec::new();
@@ -161,7 +176,9 @@ pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
         fixes: &mut fixes,
     });
 
-    finalize_fix_run(opts, plan, &mut fixes, had_write_error, &catalog_totals)
+    let exit_code = finalize_fix_run(opts, plan, &mut fixes, had_write_error, &catalog_totals);
+    *fix_count = fixes.len();
+    exit_code
 }
 
 /// Commit the plan, emit output, and compute the exit code after every fixer ran.
@@ -192,19 +209,21 @@ fn finalize_fix_run(
         had_write_error = true;
     }
 
-    if let Err(code) = emit_fix_output(&FixOutputInput {
-        output: opts.output,
-        json_style: opts.json_style,
-        quiet: opts.quiet,
-        dry_run: opts.dry_run,
-        fixes,
-        catalog_applied: catalog_totals.applied,
-        catalog_skipped: catalog_totals.skipped,
-        catalog_comment_lines_removed: catalog_totals.comment_lines_removed,
-        content_changed_count: skip_counts.content_changed,
-        mixed_line_endings_count: skip_counts.mixed_line_endings,
-        low_confidence_count: skip_counts.low_confidence,
-    }) {
+    if opts.emit_output
+        && let Err(code) = emit_fix_output(&FixOutputInput {
+            output: opts.output,
+            json_style: opts.json_style,
+            quiet: opts.quiet,
+            dry_run: opts.dry_run,
+            fixes,
+            catalog_applied: catalog_totals.applied,
+            catalog_skipped: catalog_totals.skipped,
+            catalog_comment_lines_removed: catalog_totals.comment_lines_removed,
+            content_changed_count: skip_counts.content_changed,
+            mixed_line_endings_count: skip_counts.mixed_line_endings,
+            low_confidence_count: skip_counts.low_confidence,
+        })
+    {
         return code;
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2915,6 +2915,32 @@ pub fn run() -> ExitCode {
     record_run_epilogue(telemetry_run, exit_code, None, cli.parent_run.as_deref())
 }
 
+/// Benchmark hook for the production fix dry-run pipeline. This is not a
+/// supported API. Rendered output is disabled so the benchmark measures
+/// analysis and fix planning rather than terminal I/O.
+#[doc(hidden)]
+pub fn benchmark_fix_dry_run(root: &Path, threads: usize) -> (ExitCode, usize) {
+    let config_path = None;
+    fix::run_fix_with_count(&fix::FixOptions {
+        root,
+        config_path: &config_path,
+        output: fallow_config::OutputFormat::Json,
+        json_style: json_style::JsonStyle::Compact,
+        no_cache: true,
+        threads,
+        quiet: true,
+        emit_output: false,
+        allow_remote_extends: false,
+        dry_run: true,
+        yes: false,
+        production: false,
+        no_create_config: true,
+        type_aware: None,
+        type_aware_projects: &[],
+        type_aware_require: None,
+    })
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {
@@ -4755,6 +4781,7 @@ fn dispatch_fix(dispatch: &DispatchContext<'_>, args: FixDispatchArgs) -> ExitCo
         no_cache: cli.no_cache,
         threads: dispatch.threads,
         quiet: dispatch.quiet,
+        emit_output: true,
         allow_remote_extends: cli.allow_remote_extends,
         dry_run: args.dry_run,
         yes: args.yes,

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -47,7 +47,7 @@ Fast PR shards:
 - `fallow-engine/dupes_detect`: duplicate-detection engine paths (triggered by
   `crates/engine/`, `crates/extract/`, and `crates/types/` changes).
 - `fallow-benchmarks/programmatic_stable`: deterministic programmatic API,
-  session reuse, warm parse-cache, and health-cache paths.
+  session reuse, warm parse-cache, health-cache, and fix dry-run planning paths.
 - `fallow-benchmarks/representative_sources`: focused source-shape extraction
   probes.
 - `fallow-benchmarks/component_config`: config loading, resolution, workspace


### PR DESCRIPTION
## Summary

- add a stable benchmark for the production `fix --dry-run` analysis and planning path
- suppress terminal rendering only inside the hidden benchmark hook
- assert exactly 128 planned fixes and unchanged fixture source
- document fix planning in the stable programmatic shard

## Verification

- benchmark harness
- CLI fix integration suite and architecture boundaries
- strict CLI and benchmark Clippy
- `npm run verify:fast`
- local Criterion workload, approximately 27 ms
- exact base/head RHC fix JSON parity with no worktree mutation
- exact-head stable CodSpeed shard passed in
  https://github.com/fallow-rs/fallow/actions/runs/32207204411; unrelated engine
  shards were later cancelled by workflow concurrency
- CodSpeed run `6a8514b36c0d28d888db0f15`: 40.5 ms Simulation
- flamegraph roots the measured iteration in `benchmark_fix_dry_run`, with the
  production dead-code pipeline and `fix::apply_all_fixes` below it
