### PR TITLE
perf(benchmarks): track security analysis

### DIFF
--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -18,7 +18,7 @@ use fallow_api::{
     DuplicationOptions, EditorAnalysisSession, EngineHealthRunner, FeatureFlagsOptions,
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
-use fallow_cli::benchmark_fix_dry_run;
+use fallow_cli::{benchmark_fix_dry_run, benchmark_security_json};
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
     parse_all_files, parse_single_file,
@@ -28,6 +28,7 @@ use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
 const FIX_FILE_COUNT: usize = 128;
+const SECURITY_FILE_COUNT: usize = 128;
 
 struct CommandInput {
     _temp_dir: TempDir,
@@ -440,6 +441,46 @@ export const unused{index} = {index} * 2;
     }
 }
 
+fn create_security_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-security-framework-sinks",
+  "private": true,
+  "type": "module",
+  "dependencies": { "express": "5.1.0" }
+}"#,
+    );
+
+    for index in 0..SECURITY_FILE_COUNT {
+        write_file(
+            &root,
+            &format!("src/routes/route{index}.ts"),
+            format!(
+                r#"
+declare const app: {{
+  post(path: string, handler: (req: unknown) => void): void;
+}};
+
+app.post("/run/{index}", (req) => {{
+  eval(req);
+  eval(req.body);
+}});
+"#
+            ),
+        );
+    }
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_warm_complexity_health_project() -> CommandInput {
     let input = create_health_project();
     let options = ComplexityOptions {
@@ -628,6 +669,28 @@ fn stable_fix_dry_run_many_exports(c: &mut Criterion) {
     );
 }
 
+fn stable_security_many_framework_sinks_json(c: &mut Criterion) {
+    let input = create_security_project();
+    let expected_findings = SECURITY_FILE_COUNT * 2;
+
+    let (status, finding_count, rendered_bytes) =
+        benchmark_security_json(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(finding_count, expected_findings);
+    assert!(rendered_bytes > 0);
+
+    c.bench_function("stable_security_many_framework_sinks_json", |bencher| {
+        bencher.iter(|| {
+            let (status, finding_count, rendered_bytes) =
+                benchmark_security_json(&input.root, BENCH_THREADS);
+            assert_eq!(status, std::process::ExitCode::SUCCESS);
+            assert_eq!(finding_count, expected_findings);
+            assert!(rendered_bytes > 0);
+            (status, finding_count, rendered_bytes)
+        });
+    });
+}
+
 criterion_group!(
     benches,
     stable_combined_workspace_programmatic_session_reuse,
@@ -636,6 +699,7 @@ criterion_group!(
     stable_health_complex_service_warm_complexity_hit,
     stable_circular_dependencies_domain_cycles,
     stable_feature_flags_workspace_analysis,
-    stable_fix_dry_run_many_exports
+    stable_fix_dry_run_many_exports,
+    stable_security_many_framework_sinks_json
 );
 criterion_main!(benches);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2941,6 +2941,16 @@ pub fn benchmark_fix_dry_run(root: &Path, threads: usize) -> (ExitCode, usize) {
     })
 }
 
+/// Benchmark hook for the production security analysis and JSON rendering
+/// pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_security_json(root: &Path, threads: usize) -> (ExitCode, usize, usize) {
+    match security::benchmark_security_json(root, threads) {
+        Ok((finding_count, rendered_bytes)) => (ExitCode::SUCCESS, finding_count, rendered_bytes),
+        Err(code) => (code, 0, 0),
+    }
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -232,6 +232,41 @@ pub fn run(opts: &SecurityOptions<'_>) -> ExitCode {
     security_exit_code(opts, &output, effective_severities)
 }
 
+/// Benchmark hook for the production security analysis and JSON rendering
+/// pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_security_json(root: &Path, threads: usize) -> Result<(usize, usize), ExitCode> {
+    let config_path = None;
+    let files: &[PathBuf] = &[];
+    let opts = SecurityOptions {
+        root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        no_cache: true,
+        threads,
+        quiet: true,
+        allow_remote_extends: false,
+        fail_on_issues: false,
+        sarif_file: None,
+        summary: false,
+        changed_since: None,
+        use_shared_diff_index: true,
+        workspace: None,
+        changed_workspaces: None,
+        file: files,
+        surface: false,
+        gate: None,
+        runtime_coverage: None,
+        min_invocations_hot: crate::DEFAULT_MIN_INVOCATIONS_HOT,
+        explain: false,
+    };
+    let (output, _) = build_security_command_output(&opts, Instant::now())?;
+    let finding_count = output.security_findings.len();
+    let rendered = render_security_output(&opts, &output);
+    Ok((finding_count, rendered.len()))
+}
+
 fn build_security_command_output(
     opts: &SecurityOptions<'_>,
     started: Instant,

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -47,7 +47,8 @@ Fast PR shards:
 - `fallow-engine/dupes_detect`: duplicate-detection engine paths (triggered by
   `crates/engine/`, `crates/extract/`, and `crates/types/` changes).
 - `fallow-benchmarks/programmatic_stable`: deterministic programmatic API,
-  session reuse, warm parse-cache, health-cache, and fix dry-run planning paths.
+  session reuse, warm parse-cache, health-cache, fix dry-run planning, and
+  opt-in security candidate analysis paths.
 - `fallow-benchmarks/representative_sources`: focused source-shape extraction
   probes.
 - `fallow-benchmarks/component_config`: config loading, resolution, workspace


### PR DESCRIPTION
## Summary

- add a stable benchmark for opt-in security candidate analysis and JSON rendering
- exercise Express route sources with deterministic tainted-sink findings
- assert the exact finding count on every measured iteration
- document security analysis in the stable programmatic shard

## Verification

- benchmark harness and benchmark matrix policy
- focused and complete CLI suites
- strict CLI and benchmark Clippy
- `npm run verify:fast`
- local Criterion workload, approximately 12.5 ms
- exact base/head RHC security JSON parity with no worktree mutation
- CodSpeed run `6a8523fe6c0d28d888db101d`: 108.1 ms Simulation
- flamegraph confirms production candidate analysis, dead-code pipeline, JSON output assembly, and rendering paths
