### PR TITLE
perf(benchmarks): track list inventory

### DIFF
--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -18,7 +18,7 @@ use fallow_api::{
     DuplicationOptions, EditorAnalysisSession, EngineHealthRunner, FeatureFlagsOptions,
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
-use fallow_cli::{benchmark_fix_dry_run, benchmark_security_json};
+use fallow_cli::{benchmark_fix_dry_run, benchmark_list_json, benchmark_security_json};
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
     parse_all_files, parse_single_file,
@@ -28,6 +28,11 @@ use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
 const FIX_FILE_COUNT: usize = 128;
+const LIST_FILE_COUNT: usize = 128;
+const LIST_WORKSPACE_COUNT: usize = 8;
+// Each workspace index is reported once as a default index and once from its
+// package metadata, preserving both production entry-point sources.
+const LIST_ENTRY_POINT_COUNT: usize = LIST_WORKSPACE_COUNT * 2;
 const SECURITY_FILE_COUNT: usize = 128;
 
 struct CommandInput {
@@ -481,6 +486,55 @@ app.post("/run/{index}", (req) => {{
     }
 }
 
+fn create_list_inventory_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-list-inventory",
+  "private": true,
+  "type": "module",
+  "workspaces": ["packages/*"]
+}"#,
+    );
+
+    let files_per_workspace = LIST_FILE_COUNT / LIST_WORKSPACE_COUNT;
+    for workspace in 0..LIST_WORKSPACE_COUNT {
+        write_file(
+            &root,
+            &format!("packages/pkg{workspace}/package.json"),
+            format!(
+                r#"{{
+  "name": "@bench/pkg{workspace}",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts"
+}}"#
+            ),
+        );
+        for file in 0..files_per_workspace {
+            let name = if file == 0 {
+                "index.ts".to_string()
+            } else {
+                format!("module{file}.ts")
+            };
+            write_file(
+                &root,
+                &format!("packages/pkg{workspace}/src/{name}"),
+                format!("export const value{workspace}_{file} = {file};\n"),
+            );
+        }
+    }
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_warm_complexity_health_project() -> CommandInput {
     let input = create_health_project();
     let options = ComplexityOptions {
@@ -691,6 +745,30 @@ fn stable_security_many_framework_sinks_json(c: &mut Criterion) {
     });
 }
 
+fn stable_list_workspace_inventory_json(c: &mut Criterion) {
+    let input = create_list_inventory_project();
+
+    let (status, file_count, entry_point_count, workspace_count, rendered_bytes) =
+        benchmark_list_json(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(file_count, LIST_FILE_COUNT);
+    assert_eq!(entry_point_count, LIST_ENTRY_POINT_COUNT);
+    assert_eq!(workspace_count, LIST_WORKSPACE_COUNT);
+    assert!(rendered_bytes > 0);
+
+    c.bench_function("stable_list_workspace_inventory_json", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_list_json(&input.root, BENCH_THREADS);
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, LIST_FILE_COUNT);
+            assert_eq!(result.2, LIST_ENTRY_POINT_COUNT);
+            assert_eq!(result.3, LIST_WORKSPACE_COUNT);
+            assert!(result.4 > 0);
+            result
+        });
+    });
+}
+
 criterion_group!(
     benches,
     stable_combined_workspace_programmatic_session_reuse,
@@ -700,6 +778,7 @@ criterion_group!(
     stable_circular_dependencies_domain_cycles,
     stable_feature_flags_workspace_analysis,
     stable_fix_dry_run_many_exports,
-    stable_security_many_framework_sinks_json
+    stable_security_many_framework_sinks_json,
+    stable_list_workspace_inventory_json
 );
 criterion_main!(benches);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2951,6 +2951,22 @@ pub fn benchmark_security_json(root: &Path, threads: usize) -> (ExitCode, usize,
     }
 }
 
+/// Benchmark hook for the production list inventory and JSON rendering
+/// pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_list_json(root: &Path, threads: usize) -> (ExitCode, usize, usize, usize, usize) {
+    match list::benchmark_list_json(root, threads) {
+        Ok((file_count, entry_point_count, workspace_count, rendered_bytes)) => (
+            ExitCode::SUCCESS,
+            file_count,
+            entry_point_count,
+            workspace_count,
+            rendered_bytes,
+        ),
+        Err(code) => (code, 0, 0, 0, 0),
+    }
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {

--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -81,6 +81,72 @@ pub fn run_list(opts: &ListOptions<'_>) -> ExitCode {
     }
 }
 
+/// Benchmark hook for the production list inventory and JSON rendering
+/// pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_list_json(
+    root: &std::path::Path,
+    threads: usize,
+) -> Result<(usize, usize, usize, usize), ExitCode> {
+    let config_path = None;
+    let opts = ListOptions {
+        root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        threads,
+        no_cache: true,
+        entry_points: false,
+        files: false,
+        plugins: false,
+        boundaries: false,
+        workspaces: false,
+        production: false,
+        allow_remote_extends: false,
+    };
+    let config = load_config(
+        root,
+        &config_path,
+        LoadConfigArgs {
+            output: opts.output,
+            no_cache: opts.no_cache,
+            threads: opts.threads,
+            production: opts.production,
+            quiet: true,
+            allow_remote_extends: opts.allow_remote_extends,
+        },
+    )?;
+    let data = collect_list_data(&opts, &config)?;
+    let file_count = data.discovered.as_deref().map_or(0, <[_]>::len);
+    let entry_point_count = data.entry_points.as_deref().map_or(0, <[_]>::len);
+    let workspace_count = data
+        .workspace_data
+        .as_ref()
+        .map_or(0, |data| data.workspaces.len());
+    let rendered = render_list_json(&ListJsonInput {
+        opts: &opts,
+        show_all: data.show_all,
+        plugin_result: data.plugin_result.as_ref(),
+        discovered: data.discovered.as_deref(),
+        entry_points: data.entry_points.as_deref(),
+        boundary_data: data.boundary_data.as_ref(),
+        workspace_data: data.workspace_data.as_ref(),
+    })
+    .map_err(|err| {
+        crate::error::emit_error(
+            &format!("failed to serialize list output: {err}"),
+            2,
+            OutputFormat::Json,
+        )
+    })?;
+    Ok((
+        file_count,
+        entry_point_count,
+        workspace_count,
+        rendered.len(),
+    ))
+}
+
 /// Collect plugins, files, entry points, boundary, and workspace data for a
 /// `fallow list` run, honoring which listing modes are active.
 fn collect_list_data(
@@ -289,6 +355,19 @@ struct ListJsonInput<'a> {
 }
 
 fn print_list_json(input: &ListJsonInput<'_>) -> ExitCode {
+    match render_list_json(input) {
+        Ok(json) => {
+            println!("{json}");
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("Error: failed to serialize list output: {err}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn render_list_json(input: &ListJsonInput<'_>) -> Result<String, String> {
     let has_boundaries = input.boundary_data.is_some();
     let workspace_only = input.opts.workspaces
         && !input.opts.plugins
@@ -303,28 +382,18 @@ fn print_list_json(input: &ListJsonInput<'_>) -> ExitCode {
         ListJsonEnvelope::Plain
     };
 
-    let output = match fallow_api::serialize_list_json_output(
+    let output = fallow_api::serialize_list_json_output(
         build_list_json_output_input(input),
         crate::output_runtime::current_root_envelope_mode(),
         envelope,
-    ) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("Error: failed to serialize list output: {err}");
-            return ExitCode::from(2);
-        }
-    };
+    )
+    .map_err(|err| err.to_string())?;
 
-    match input.opts.json_style.serialize(&output) {
-        Ok(json) => {
-            println!("{json}");
-            ExitCode::SUCCESS
-        }
-        Err(e) => {
-            eprintln!("Error: failed to serialize list output: {e}");
-            ExitCode::from(2)
-        }
-    }
+    input
+        .opts
+        .json_style
+        .serialize(&output)
+        .map_err(|err| err.to_string())
 }
 
 /// Assemble the typed JSON body for a `fallow list` run, one section per

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -48,7 +48,7 @@ Fast PR shards:
   `crates/engine/`, `crates/extract/`, and `crates/types/` changes).
 - `fallow-benchmarks/programmatic_stable`: deterministic programmatic API,
   session reuse, warm parse-cache, health-cache, fix dry-run planning, and
-  opt-in security candidate analysis paths.
+  opt-in security candidate analysis, plus list inventory rendering paths.
 - `fallow-benchmarks/representative_sources`: focused source-shape extraction
   probes.
 - `fallow-benchmarks/component_config`: config loading, resolution, workspace


### PR DESCRIPTION
## Summary

- add a stable benchmark for complete list inventory and compact JSON rendering
- exercise source discovery, plugin detection, entry points, and workspaces in one deterministic fixture
- reuse the production list collection and serialization path without terminal I/O
- document list coverage in the stable programmatic shard

## Verification

- benchmark harness and benchmark matrix policy
- focused and complete CLI suites
- strict CLI and benchmark Clippy
- `npm run verify:fast`
- local Criterion workload, approximately 11.5 ms
- exact base/head RHC list JSON parity
- CodSpeed run `6a8529516c0d28d888db105d`: 19 ms Simulation
- flamegraph confirms production config, discovery, plugin, inventory, and JSON rendering paths
