### PR TITLE
perf(benchmarks): track Viz HTML generation

### DIFF
--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -18,7 +18,9 @@ use fallow_api::{
     DuplicationOptions, EditorAnalysisSession, EngineHealthRunner, FeatureFlagsOptions,
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
-use fallow_cli::{benchmark_fix_dry_run, benchmark_list_json, benchmark_security_json};
+use fallow_cli::{
+    benchmark_fix_dry_run, benchmark_list_json, benchmark_security_json, benchmark_viz_html,
+};
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
     parse_all_files, parse_single_file,
@@ -34,6 +36,7 @@ const LIST_WORKSPACE_COUNT: usize = 8;
 // package metadata, preserving both production entry-point sources.
 const LIST_ENTRY_POINT_COUNT: usize = LIST_WORKSPACE_COUNT * 2;
 const SECURITY_FILE_COUNT: usize = 128;
+const VIZ_MODULE_COUNT: usize = 64;
 
 struct CommandInput {
     _temp_dir: TempDir,
@@ -535,6 +538,47 @@ fn create_list_inventory_project() -> CommandInput {
     }
 }
 
+fn create_viz_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-viz-html",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts"
+}"#,
+    );
+
+    let mut index_source = String::new();
+    for index in 0..VIZ_MODULE_COUNT {
+        writeln!(
+            index_source,
+            "import {{ value{index} }} from './features/feature{index}.js';"
+        )
+        .unwrap();
+        write_file(
+            &root,
+            &format!("src/features/feature{index}.ts"),
+            format!("export const value{index} = {{ id: {index}, label: 'feature-{index}' }};\n"),
+        );
+    }
+    index_source.push_str("\nexport const features = [\n");
+    for index in 0..VIZ_MODULE_COUNT {
+        writeln!(index_source, "  value{index},").unwrap();
+    }
+    index_source.push_str("];\n");
+    write_file(&root, "src/index.ts", index_source);
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_warm_complexity_health_project() -> CommandInput {
     let input = create_health_project();
     let options = ComplexityOptions {
@@ -769,6 +813,29 @@ fn stable_list_workspace_inventory_json(c: &mut Criterion) {
     });
 }
 
+fn stable_viz_project_html(c: &mut Criterion) {
+    let input = create_viz_project();
+    let expected_files = VIZ_MODULE_COUNT + 1;
+
+    let (status, file_count, edge_count, rendered_bytes) =
+        benchmark_viz_html(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(file_count, expected_files);
+    assert_eq!(edge_count, VIZ_MODULE_COUNT);
+    assert!(rendered_bytes > 0);
+
+    c.bench_function("stable_viz_project_html", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_viz_html(&input.root, BENCH_THREADS);
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, expected_files);
+            assert_eq!(result.2, VIZ_MODULE_COUNT);
+            assert!(result.3 > 0);
+            result
+        });
+    });
+}
+
 criterion_group!(
     benches,
     stable_combined_workspace_programmatic_session_reuse,
@@ -779,6 +846,7 @@ criterion_group!(
     stable_feature_flags_workspace_analysis,
     stable_fix_dry_run_many_exports,
     stable_security_many_framework_sinks_json,
-    stable_list_workspace_inventory_json
+    stable_list_workspace_inventory_json,
+    stable_viz_project_html
 );
 criterion_main!(benches);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2967,6 +2967,18 @@ pub fn benchmark_list_json(root: &Path, threads: usize) -> (ExitCode, usize, usi
     }
 }
 
+/// Benchmark hook for the production Viz analysis, payload, and HTML
+/// rendering pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_viz_html(root: &Path, threads: usize) -> (ExitCode, usize, usize, usize) {
+    match viz::benchmark_viz_html(root, threads) {
+        Ok((file_count, edge_count, rendered_bytes)) => {
+            (ExitCode::SUCCESS, file_count, edge_count, rendered_bytes)
+        }
+        Err(code) => (code, 0, 0, 0),
+    }
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {

--- a/crates/cli/src/viz.rs
+++ b/crates/cli/src/viz.rs
@@ -59,7 +59,51 @@ pub struct VizOptions<'a> {
 pub fn run_viz(opts: &VizOptions<'_>) -> ExitCode {
     let start = Instant::now();
 
-    let config = match load_config(
+    let data = match build_viz_data_from_options(opts) {
+        Ok(data) => data,
+        Err(code) => return code,
+    };
+    let elapsed = start.elapsed();
+
+    match opts.format {
+        VizFormat::Html => write_html(opts, &data, elapsed),
+        VizFormat::Dot => write_text_format(opts, &generate_dot(&data)),
+        VizFormat::Mermaid => write_text_format(opts, &generate_mermaid(&data)),
+    }
+}
+
+/// Benchmark hook for the production Viz analysis, payload, and HTML
+/// rendering pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_viz_html(root: &Path, threads: usize) -> Result<(usize, usize, usize), ExitCode> {
+    let config_path = None;
+    let opts = VizOptions {
+        root,
+        config_path: &config_path,
+        no_cache: true,
+        threads,
+        quiet: true,
+        production: false,
+        allow_remote_extends: false,
+        output_path: None,
+        no_open: true,
+        format: VizFormat::Html,
+    };
+    let data = build_viz_data_from_options(&opts)?;
+    let file_count = data.files.len();
+    let edge_count = data.edges.len();
+    let html = render_html(&data).map_err(|message| {
+        emit_error(
+            &format!("Failed to serialize viz data: {message}"),
+            2,
+            OutputFormat::Human,
+        )
+    })?;
+    Ok((file_count, edge_count, html.len()))
+}
+
+fn build_viz_data_from_options(opts: &VizOptions<'_>) -> Result<VizData, ExitCode> {
+    let config = load_config(
         opts.root,
         opts.config_path,
         LoadConfigArgs {
@@ -70,14 +114,17 @@ pub fn run_viz(opts: &VizOptions<'_>) -> ExitCode {
             quiet: opts.quiet,
             allow_remote_extends: opts.allow_remote_extends,
         },
-    ) {
-        Ok(c) => c,
-        Err(code) => return code,
-    };
+    )?;
 
     let session = match AnalysisSession::from_resolved_config(config) {
         Ok(session) => session,
-        Err(e) => return emit_error(&format!("Analysis error: {e}"), 2, OutputFormat::Human),
+        Err(e) => {
+            return Err(emit_error(
+                &format!("Analysis error: {e}"),
+                2,
+                OutputFormat::Human,
+            ));
+        }
     };
     let duplicates_config = session.config().duplicates.clone();
     let artifacts = match session.analyze_project_with_artifacts(
@@ -90,15 +137,19 @@ pub fn run_viz(opts: &VizOptions<'_>) -> ExitCode {
     ) {
         Ok(artifacts) => artifacts,
         Err(e) => {
-            return emit_error(&format!("Analysis error: {e}"), 2, OutputFormat::Human);
+            return Err(emit_error(
+                &format!("Analysis error: {e}"),
+                2,
+                OutputFormat::Human,
+            ));
         }
     };
 
     let Some(graph) = artifacts.dead_code.graph.as_ref() else {
-        return emit_error("Graph not available", 2, OutputFormat::Human);
+        return Err(emit_error("Graph not available", 2, OutputFormat::Human));
     };
 
-    let data = build_viz_data(&VizBuildInput {
+    Ok(build_viz_data(&VizBuildInput {
         results: &artifacts.dead_code.results,
         graph,
         modules: artifacts.dead_code.modules.as_deref(),
@@ -106,14 +157,7 @@ pub fn run_viz(opts: &VizOptions<'_>) -> ExitCode {
         duplication: &artifacts.duplication,
         workspaces: session.workspaces(),
         config: session.config(),
-    });
-    let elapsed = start.elapsed();
-
-    match opts.format {
-        VizFormat::Html => write_html(opts, &data, elapsed),
-        VizFormat::Dot => write_text_format(opts, &generate_dot(&data)),
-        VizFormat::Mermaid => write_text_format(opts, &generate_mermaid(&data)),
-    }
+    }))
 }
 
 /// Emit a DOT/Mermaid document: to `--out` when given (symlink-safe,
@@ -175,8 +219,8 @@ fn write_output(path: &Path, content: &str) -> Result<(), String> {
 }
 
 fn write_html(opts: &VizOptions<'_>, data: &VizData, elapsed: std::time::Duration) -> ExitCode {
-    let json = match serde_json::to_string(data) {
-        Ok(j) => j,
+    let html = match render_html(data) {
+        Ok(html) => html,
         Err(e) => {
             return emit_error(
                 &format!("Failed to serialize viz data: {e}"),
@@ -185,28 +229,6 @@ fn write_html(opts: &VizOptions<'_>, data: &VizData, elapsed: std::time::Duratio
             );
         }
     };
-
-    let json_safe = escape_payload_json(&json);
-    let title = html_escape(&data.root);
-
-    let css = VIZ_CSS;
-    let js = VIZ_JS;
-    let html = format!(
-        r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="color-scheme" content="dark light">
-<title>fallow map: {title}</title>
-<style>{css}</style>
-</head>
-<body>
-<script>window.__FALLOW_DATA__={json_safe};</script>
-<script>{js}</script>
-</body>
-</html>"#,
-    );
 
     let output_path = opts
         .output_path
@@ -240,6 +262,32 @@ fn write_html(opts: &VizOptions<'_>, data: &VizData, elapsed: std::time::Duratio
     }
 
     ExitCode::SUCCESS
+}
+
+fn render_html(data: &VizData) -> Result<String, serde_json::Error> {
+    let json = serde_json::to_string(data)?;
+
+    let json_safe = escape_payload_json(&json);
+    let title = html_escape(&data.root);
+
+    let css = VIZ_CSS;
+    let js = VIZ_JS;
+    Ok(format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="dark light">
+<title>fallow map: {title}</title>
+<style>{css}</style>
+</head>
+<body>
+<script>window.__FALLOW_DATA__={json_safe};</script>
+<script>{js}</script>
+</body>
+</html>"#,
+    ))
 }
 
 // ── DOT generation ──────────────────────────────────────────────
@@ -434,6 +482,17 @@ mod tests {
         let value: serde_json::Value =
             serde_json::from_str(&escaped).expect("escaped payload stays valid JSON");
         assert_eq!(value["files"][0]["path"], "</script><!--<script>alert(1)");
+    }
+
+    #[test]
+    fn render_html_embeds_the_payload_and_static_assets() {
+        let html = render_html(&sample_data()).expect("render viz HTML");
+
+        assert!(html.starts_with("<!DOCTYPE html>"));
+        assert!(html.contains("<script>window.__FALLOW_DATA__={"));
+        assert!(html.contains("\"files\":[{"));
+        assert!(html.contains("<style>"));
+        assert!(html.contains("</html>"));
     }
 
     #[test]

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -48,7 +48,8 @@ Fast PR shards:
   `crates/engine/`, `crates/extract/`, and `crates/types/` changes).
 - `fallow-benchmarks/programmatic_stable`: deterministic programmatic API,
   session reuse, warm parse-cache, health-cache, fix dry-run planning, and
-  opt-in security candidate analysis, plus list inventory rendering paths.
+  opt-in security candidate analysis, list inventory rendering, and Viz HTML
+  payload paths.
 - `fallow-benchmarks/representative_sources`: focused source-shape extraction
   probes.
 - `fallow-benchmarks/component_config`: config loading, resolution, workspace


### PR DESCRIPTION
## Summary

- add a stable CodSpeed identity for the complete `fallow viz` HTML path
- reuse the production analysis, typed Viz payload, JSON, CSS, and JavaScript assembly
- keep fixture creation, file output, and browser launch outside the measured iteration

## Evidence

- `stable_viz_project_html` registers at 29.2 ms in Simulation run `6a852dd56c0d28d888db109f`
- the callgraph reaches `AnalysisSession::analyze_project_with_artifacts`, Viz data construction, and embedded HTML formatting
- exact main-based Simulation: https://github.com/fallow-rs/fallow/actions/runs/32216105901

## Validation

- focused and full CLI tests
- strict CLI and benchmark Clippy
- benchmark harness, matrix, compilation, and local Criterion run
- `verify:fast`
- byte-identical real-project Viz HTML output
