### PR TITLE
ci(benchmarks): extend simulation timeout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -88,7 +88,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -207,6 +207,15 @@ test("binary-size workflow isolates incompatible release builds", () => {
   }
 });
 
+test("CodSpeed simulation jobs allow release LTO plus the tracked suites", () => {
+  const workflow = readWorkflow(".github/workflows/bench.yml");
+  const fastJob = indentedBlock(workflow, "benchmark", 2);
+  const fullJob = indentedBlock(workflow, "benchmark-full", 2);
+
+  assert.match(fastJob, /timeout-minutes: 45/);
+  assert.match(fullJob, /timeout-minutes: 45/);
+});
+
 test("regular CI keeps affected checks on Ubuntu", () => {
   const workflow = readWorkflow(".github/workflows/ci.yml");
   const npmPackage = JSON.parse(readFileSync("npm/fallow/package.json", "utf8"));


### PR DESCRIPTION
## Summary

- raise the fast CodSpeed Simulation job timeout from 30 to 45 minutes
- align its budget with the existing full Simulation jobs
- pin both timeout contracts in the workflow policy suite

The stable programmatic shard now finishes its release-LTO build but reaches the former job limit during benchmark execution. This change keeps the complete stable suite tracked without changing commands, permissions, runners, or benchmark selection.

## Validation

- workflow policy tests pass
- benchmark harness passes
- actionlint passes
- zizmor reports no findings
- diff check passes