### PR TITLE
perf(benchmarks): track rule-pack policy analysis

### DIFF
--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -19,7 +19,8 @@ use fallow_api::{
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
 use fallow_cli::{
-    benchmark_fix_dry_run, benchmark_list_json, benchmark_security_json, benchmark_viz_html,
+    benchmark_fix_dry_run, benchmark_list_json, benchmark_rule_pack_test_json,
+    benchmark_security_json, benchmark_viz_html,
 };
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
@@ -35,6 +36,8 @@ const LIST_WORKSPACE_COUNT: usize = 8;
 // Each workspace index is reported once as a default index and once from its
 // package metadata, preserving both production entry-point sources.
 const LIST_ENTRY_POINT_COUNT: usize = LIST_WORKSPACE_COUNT * 2;
+const RULE_PACK_FILE_COUNT: usize = 64;
+const RULE_PACK_FINDINGS_PER_FILE: usize = 4;
 const SECURITY_FILE_COUNT: usize = 128;
 const VIZ_MODULE_COUNT: usize = 64;
 
@@ -489,6 +492,80 @@ app.post("/run/{index}", (req) => {{
     }
 }
 
+fn create_rule_pack_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-rule-pack-test",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": { "moment": "2.30.1" }
+}"#,
+    );
+    write_file(
+        &root,
+        ".fallowrc.json",
+        r#"{
+  "rules": { "policy-violation": "warn" },
+  "rulePacks": ["rule-packs/benchmark.jsonc"]
+}"#,
+    );
+    write_file(
+        &root,
+        "rule-packs/benchmark.jsonc",
+        r#"{
+  "version": 1,
+  "name": "benchmark-policy",
+  "rules": [
+    { "id": "no-console", "kind": "banned-call", "callees": ["console.log"] },
+    { "id": "no-moment", "kind": "banned-import", "specifiers": ["moment"] },
+    { "id": "no-network", "kind": "banned-effect", "effects": ["network"] },
+    { "id": "no-legacy-api", "kind": "banned-export", "exports": ["legacyApi"] }
+  ]
+}"#,
+    );
+
+    let mut index_source = String::new();
+    for index in 0..RULE_PACK_FILE_COUNT {
+        writeln!(
+            &mut index_source,
+            "import {{ run as run{index} }} from \"./features/feature{index}\";"
+        )
+        .unwrap();
+        write_file(
+            &root,
+            &format!("src/features/feature{index}.ts"),
+            format!(
+                r#"
+import moment from "moment";
+
+export const legacyApi = moment;
+export function run(): Promise<Response> {{
+  console.log("feature-{index}");
+  return fetch("/api/feature-{index}");
+}}
+"#
+            ),
+        );
+    }
+    index_source.push_str("\nvoid Promise.all([\n");
+    for index in 0..RULE_PACK_FILE_COUNT {
+        writeln!(&mut index_source, "  run{index}(),").unwrap();
+    }
+    index_source.push_str("]);\n");
+    write_file(&root, "src/index.ts", index_source);
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_list_inventory_project() -> CommandInput {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
@@ -789,6 +866,28 @@ fn stable_security_many_framework_sinks_json(c: &mut Criterion) {
     });
 }
 
+fn stable_rule_pack_policy_analysis_json(c: &mut Criterion) {
+    let input = create_rule_pack_project();
+    let expected_findings = RULE_PACK_FILE_COUNT * RULE_PACK_FINDINGS_PER_FILE;
+
+    let (status, finding_count, rendered_bytes) =
+        benchmark_rule_pack_test_json(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(finding_count, expected_findings);
+    assert!(rendered_bytes > 0);
+
+    c.bench_function("stable_rule_pack_policy_analysis_json", |bencher| {
+        bencher.iter(|| {
+            let (status, finding_count, rendered_bytes) =
+                benchmark_rule_pack_test_json(&input.root, BENCH_THREADS);
+            assert_eq!(status, std::process::ExitCode::SUCCESS);
+            assert_eq!(finding_count, expected_findings);
+            assert!(rendered_bytes > 0);
+            (status, finding_count, rendered_bytes)
+        });
+    });
+}
+
 fn stable_list_workspace_inventory_json(c: &mut Criterion) {
     let input = create_list_inventory_project();
 
@@ -846,6 +945,7 @@ criterion_group!(
     stable_feature_flags_workspace_analysis,
     stable_fix_dry_run_many_exports,
     stable_security_many_framework_sinks_json,
+    stable_rule_pack_policy_analysis_json,
     stable_list_workspace_inventory_json,
     stable_viz_project_html
 );

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2979,6 +2979,16 @@ pub fn benchmark_viz_html(root: &Path, threads: usize) -> (ExitCode, usize, usiz
     }
 }
 
+/// Benchmark hook for the production rule-pack analysis and JSON rendering
+/// pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_rule_pack_test_json(root: &Path, threads: usize) -> (ExitCode, usize, usize) {
+    match rule_pack::benchmark_rule_pack_test_json(root, threads) {
+        Ok((finding_count, rendered_bytes)) => (ExitCode::SUCCESS, finding_count, rendered_bytes),
+        Err(code) => (code, 0, 0),
+    }
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {

--- a/crates/cli/src/rule_pack/mod.rs
+++ b/crates/cli/src/rule_pack/mod.rs
@@ -10,6 +10,8 @@ mod list;
 mod templates;
 mod test;
 
+pub use test::benchmark_rule_pack_test_json;
+
 #[allow(
     dead_code,
     reason = "the command family is wired before every subcommand consumes all context fields"

--- a/crates/cli/src/rule_pack/test.rs
+++ b/crates/cli/src/rule_pack/test.rs
@@ -13,23 +13,15 @@ pub fn run(args: &TestArgs, ctx: &RulePackContext<'_>) -> ExitCode {
         Err(code) => return code,
     };
 
-    let forced_severity = if config.rules.policy_violation == Severity::Off {
-        config.rules.policy_violation = Severity::Warn;
+    let forced_severity = enable_policy_violations(&mut config);
+    if forced_severity {
         eprintln!("note: rules.policy-violation is off; forcing warn for this test run");
-        true
-    } else {
-        false
-    };
+    }
 
-    let analysis =
-        match fallow_engine::session::AnalysisSession::from_resolved_config(config.clone())
-            .and_then(|session| session.analyze_dead_code())
-        {
-            Ok(analysis) => analysis,
-            Err(error) => return crate::error::emit_error(error.message(), 2, ctx.output),
-        };
-    let findings = analysis.results.policy_violations;
-    let summaries = build_rule_summaries(&config, &findings);
+    let (summaries, findings) = match analyze_rule_pack(&config, ctx.output) {
+        Ok(result) => result,
+        Err(code) => return code,
+    };
 
     if matches!(ctx.output, OutputFormat::Json) {
         return emit_json(
@@ -42,6 +34,26 @@ pub fn run(args: &TestArgs, ctx: &RulePackContext<'_>) -> ExitCode {
     }
 
     emit_human(&summaries, &findings, ctx.root, forced_severity)
+}
+
+fn enable_policy_violations(config: &mut ResolvedConfig) -> bool {
+    if config.rules.policy_violation != Severity::Off {
+        return false;
+    }
+    config.rules.policy_violation = Severity::Warn;
+    true
+}
+
+fn analyze_rule_pack(
+    config: &ResolvedConfig,
+    output: OutputFormat,
+) -> Result<(Vec<RuleSummary>, Vec<PolicyViolationFinding>), ExitCode> {
+    let analysis = fallow_engine::session::AnalysisSession::from_resolved_config(config.clone())
+        .and_then(|session| session.analyze_dead_code())
+        .map_err(|error| crate::error::emit_error(error.message(), 2, output))?;
+    let findings = analysis.results.policy_violations;
+    let summaries = build_rule_summaries(config, &findings);
+    Ok((summaries, findings))
 }
 
 fn load_test_config(
@@ -133,24 +145,64 @@ fn emit_json(
     json_style: crate::json_style::JsonStyle,
 ) -> ExitCode {
     super::emit_json(
-        &json!({
-            "kind": "rule-pack-test",
-            "packs": config.rule_packs.iter().map(|pack| pack.name.as_str()).collect::<Vec<_>>(),
-            "forced_severity": forced_severity,
-            "rules": summaries.iter().map(|summary| {
-                json!({
-                    "pack": summary.pack,
-                    "rule_id": summary.rule_id,
-                    "kind": summary.kind,
-                    "severity": summary.severity.to_string(),
-                    "findings": summary.findings,
-                })
-            }).collect::<Vec<_>>(),
-            "findings": findings,
-        }),
+        &build_json_output(config, forced_severity, summaries, findings),
         "rule-pack-test",
         json_style,
     )
+}
+
+fn build_json_output(
+    config: &ResolvedConfig,
+    forced_severity: bool,
+    summaries: &[RuleSummary],
+    findings: &[PolicyViolationFinding],
+) -> serde_json::Value {
+    json!({
+        "kind": "rule-pack-test",
+        "packs": config.rule_packs.iter().map(|pack| pack.name.as_str()).collect::<Vec<_>>(),
+        "forced_severity": forced_severity,
+        "rules": summaries.iter().map(|summary| {
+            json!({
+                "pack": summary.pack,
+                "rule_id": summary.rule_id,
+                "kind": summary.kind,
+                "severity": summary.severity.to_string(),
+                "findings": summary.findings,
+            })
+        }).collect::<Vec<_>>(),
+        "findings": findings,
+    })
+}
+
+/// Benchmark hook for the production rule-pack analysis and JSON rendering
+/// pipeline. This is not a supported API.
+pub fn benchmark_rule_pack_test_json(
+    root: &std::path::Path,
+    threads: usize,
+) -> Result<(usize, usize), ExitCode> {
+    let config_path = None;
+    let ctx = RulePackContext {
+        root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        quiet: true,
+        no_cache: true,
+        threads: Some(threads),
+        allow_remote_extends: false,
+    };
+    let mut config = load_test_config(&TestArgs { pack: None }, &ctx)?;
+    let forced_severity = enable_policy_violations(&mut config);
+    let (summaries, findings) = analyze_rule_pack(&config, ctx.output)?;
+    let output = build_json_output(&config, forced_severity, &summaries, &findings);
+    let rendered = ctx.json_style.serialize(&output).map_err(|error| {
+        crate::error::emit_error(
+            &format!("failed to serialize rule-pack-test output: {error}"),
+            2,
+            ctx.output,
+        )
+    })?;
+    Ok((findings.len(), rendered.len()))
 }
 
 fn emit_human(

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -48,8 +48,8 @@ Fast PR shards:
   `crates/engine/`, `crates/extract/`, and `crates/types/` changes).
 - `fallow-benchmarks/programmatic_stable`: deterministic programmatic API,
   session reuse, warm parse-cache, health-cache, fix dry-run planning, and
-  opt-in security candidate analysis, list inventory rendering, and Viz HTML
-  payload paths.
+  opt-in security and rule-pack policy analysis, list inventory rendering, and
+  Viz HTML payload paths.
 - `fallow-benchmarks/representative_sources`: focused source-shape extraction
   probes.
 - `fallow-benchmarks/component_config`: config loading, resolution, workspace


### PR DESCRIPTION
## Summary

- add a stable CodSpeed identity for the production `rule-pack test` analysis and compact JSON path
- reuse the command's config, severity, analysis, summary, and rendering builders in the benchmark hook
- exercise banned calls, imports, effects, and exports across a deterministic project fixture

Fixture creation stays outside timing, and the benchmark asserts the complete finding shape before and during measurement.

## CodSpeed

- PR run `6a856e257915fb99a0ac464e` registers `stable_rule_pack_policy_analysis_json` at 61.4 ms Simulation
- the callgraph roots in `benchmark_rule_pack_test_json` and includes production config loading, parsing, policy analysis, summary construction, and compact JSON rendering
- `run_policy_detector` accounts for 17.5 ms and policy callee matching for 14.7 ms, confirming that the intended Rule-pack workload is measured

## Validation

- focused Rule-pack CLI tests pass
- strict CLI and benchmark Clippy passes
- benchmark harness and matrix pass
- local release Criterion passes
- generated contracts and repository fast verification pass
- formatting and diff checks pass
