### PR TITLE
perf(benchmarks): track dead-code JSON pipeline

### DIFF
--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -19,8 +19,8 @@ use fallow_api::{
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
 use fallow_cli::{
-    benchmark_fix_dry_run, benchmark_list_json, benchmark_rule_pack_test_json,
-    benchmark_security_json, benchmark_viz_html,
+    benchmark_dead_code_json, benchmark_fix_dry_run, benchmark_list_json,
+    benchmark_rule_pack_test_json, benchmark_security_json, benchmark_viz_html,
 };
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
@@ -30,6 +30,7 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
+const DEAD_CODE_FINDING_COUNT: usize = FIX_FILE_COUNT;
 const FIX_FILE_COUNT: usize = 128;
 const LIST_FILE_COUNT: usize = 128;
 const LIST_WORKSPACE_COUNT: usize = 8;
@@ -844,6 +845,26 @@ fn stable_fix_dry_run_many_exports(c: &mut Criterion) {
     );
 }
 
+fn stable_dead_code_many_exports_json(c: &mut Criterion) {
+    let input = create_fix_project();
+
+    let (status, issue_count, rendered_bytes) =
+        benchmark_dead_code_json(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(issue_count, DEAD_CODE_FINDING_COUNT);
+    assert!(rendered_bytes > 0);
+
+    c.bench_function("stable_dead_code_many_exports_json", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_dead_code_json(&input.root, BENCH_THREADS);
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, DEAD_CODE_FINDING_COUNT);
+            assert!(result.2 > 0);
+            result
+        });
+    });
+}
+
 fn stable_security_many_framework_sinks_json(c: &mut Criterion) {
     let input = create_security_project();
     let expected_findings = SECURITY_FILE_COUNT * 2;
@@ -944,6 +965,7 @@ criterion_group!(
     stable_circular_dependencies_domain_cycles,
     stable_feature_flags_workspace_analysis,
     stable_fix_dry_run_many_exports,
+    stable_dead_code_many_exports_json,
     stable_security_many_framework_sinks_json,
     stable_rule_pack_policy_analysis_json,
     stable_list_workspace_inventory_json,

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -1106,6 +1106,80 @@ pub fn execute_check(opts: &CheckOptions<'_>) -> Result<CheckResult, ExitCode> {
     }))
 }
 
+pub fn benchmark_dead_code_json(
+    root: &std::path::Path,
+    threads: usize,
+) -> Result<(usize, usize), ExitCode> {
+    let config_path = None;
+    let filters = IssueFilters::default();
+    let trace_opts = TraceOptions {
+        trace_export: None,
+        trace_file: None,
+        trace_dependency: None,
+        impact_closure: None,
+        symbol_impact: None,
+        performance: false,
+    };
+    let result = execute_check(&CheckOptions {
+        root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        no_cache: true,
+        threads,
+        quiet: true,
+        allow_remote_extends: false,
+        fail_on_issues: false,
+        filters: &filters,
+        changed_since: None,
+        diff_index: None,
+        use_shared_diff_index: true,
+        baseline: None,
+        save_baseline: None,
+        sarif_file: None,
+        production: false,
+        production_override: Some(false),
+        workspace: None,
+        changed_workspaces: None,
+        group_by: None,
+        include_dupes: false,
+        type_aware: None,
+        type_aware_config_override: None,
+        type_aware_projects: &[],
+        type_aware_require: None,
+        trace_opts: &trace_opts,
+        explain: false,
+        top: None,
+        file: &[],
+        include_entry_exports: false,
+        summary: false,
+        regression_opts: RegressionOpts {
+            fail_on_regression: false,
+            tolerance: crate::regression::Tolerance::Absolute(0),
+            regression_baseline_file: None,
+            save_target: crate::regression::SaveRegressionTarget::None,
+            scoped: false,
+            quiet: true,
+            output: OutputFormat::Json,
+        },
+        retain_modules_for_health: false,
+        defer_performance: false,
+        analysis_snapshot: fallow_config::AnalysisSnapshot::Current,
+    })?;
+    let rendered = report::render_check_json(&report::CheckJsonRenderInput {
+        results: &result.results,
+        root: &result.config.root,
+        elapsed: result.elapsed,
+        type_aware: result.type_aware_meta.as_ref(),
+        regression: result.regression.as_ref(),
+        baseline_matched: result.baseline_matched,
+        config_fixable: result.config_fixable,
+        json_style: crate::json_style::JsonStyle::Compact,
+    })
+    .map_err(|_| ExitCode::from(2))?;
+    Ok((result.results.total_issues(), rendered.len()))
+}
+
 fn validate_effective_type_aware_output(
     output: fallow_config::OutputFormat,
     enabled: bool,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2941,6 +2941,16 @@ pub fn benchmark_fix_dry_run(root: &Path, threads: usize) -> (ExitCode, usize) {
     })
 }
 
+/// Benchmark hook for the production dead-code analysis and compact JSON
+/// rendering pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_dead_code_json(root: &Path, threads: usize) -> (ExitCode, usize, usize) {
+    match check::benchmark_dead_code_json(root, threads) {
+        Ok((issue_count, rendered_bytes)) => (ExitCode::SUCCESS, issue_count, rendered_bytes),
+        Err(code) => (code, 0, 0),
+    }
+}
+
 /// Benchmark hook for the production security analysis and JSON rendering
 /// pipeline. This is not a supported API.
 #[doc(hidden)]

--- a/crates/cli/src/report/json.rs
+++ b/crates/cli/src/report/json.rs
@@ -38,27 +38,28 @@ pub(super) struct PrintJsonInput<'a> {
 }
 
 pub(super) fn print_json(input: &PrintJsonInput<'_>) -> ExitCode {
-    let results = input.results;
-    let root = input.root;
-    let elapsed = input.elapsed;
-    let explain = input.explain;
-    let regression = input.regression;
-    let baseline_matched = input.baseline_matched;
-    let config_fixable = input.config_fixable;
-    match api_check_json_document_with_config_fixable_meta_and_extras(
-        results,
-        root,
-        elapsed,
-        config_fixable,
-        check_output_meta(explain, input.type_aware),
-        check_json_extras(regression, None, baseline_matched),
-    ) {
-        Ok(output) => emit_report_json(&output, "JSON", input.json_style),
+    match render_json(input) {
+        Ok(output) => {
+            outln!("{output}");
+            ExitCode::SUCCESS
+        }
         Err(e) => {
             eprintln!("Error: failed to serialize results: {e}");
             ExitCode::from(2)
         }
     }
+}
+
+pub(super) fn render_json(input: &PrintJsonInput<'_>) -> Result<String, serde_json::Error> {
+    let output = api_check_json_document_with_config_fixable_meta_and_extras(
+        input.results,
+        input.root,
+        input.elapsed,
+        input.config_fixable,
+        check_output_meta(input.explain, input.type_aware),
+        check_json_extras(input.regression, None, input.baseline_matched),
+    )?;
+    input.json_style.serialize(&output)
 }
 
 #[must_use]

--- a/crates/cli/src/report/mod.rs
+++ b/crates/cli/src/report/mod.rs
@@ -235,6 +235,33 @@ pub(crate) fn emit_report_json(
     }
 }
 
+pub(crate) struct CheckJsonRenderInput<'a> {
+    pub(crate) results: &'a AnalysisResults,
+    pub(crate) root: &'a Path,
+    pub(crate) elapsed: Duration,
+    pub(crate) type_aware: Option<&'a fallow_types::envelope::TypeAwareMeta>,
+    pub(crate) regression: Option<&'a crate::regression::RegressionOutcome>,
+    pub(crate) baseline_matched: Option<(usize, usize)>,
+    pub(crate) config_fixable: bool,
+    pub(crate) json_style: crate::json_style::JsonStyle,
+}
+
+pub(crate) fn render_check_json(
+    input: &CheckJsonRenderInput<'_>,
+) -> Result<String, serde_json::Error> {
+    json::render_json(&json::PrintJsonInput {
+        results: input.results,
+        root: input.root,
+        elapsed: input.elapsed,
+        explain: false,
+        type_aware: input.type_aware,
+        regression: input.regression,
+        baseline_matched: input.baseline_matched,
+        config_fixable: input.config_fixable,
+        json_style: input.json_style,
+    })
+}
+
 /// Elide the common directory prefix between a base path and a target path.
 /// Only strips complete directory segments (never partial filenames).
 /// Returns the remaining suffix of `target`.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -47,9 +47,9 @@ Fast PR shards:
 - `fallow-engine/dupes_detect`: duplicate-detection engine paths (triggered by
   `crates/engine/`, `crates/extract/`, and `crates/types/` changes).
 - `fallow-benchmarks/programmatic_stable`: deterministic programmatic API,
-  session reuse, warm parse-cache, health-cache, fix dry-run planning, and
-  opt-in security and rule-pack policy analysis, list inventory rendering, and
-  Viz HTML payload paths.
+  session reuse, warm parse-cache, health-cache, dead-code analysis and compact
+  JSON rendering, fix dry-run planning, opt-in security and rule-pack policy
+  analysis, list inventory rendering, and Viz HTML payload paths.
 - `fallow-benchmarks/representative_sources`: focused source-shape extraction
   probes.
 - `fallow-benchmarks/component_config`: config loading, resolution, workspace


### PR DESCRIPTION
## Summary

- add a stable CodSpeed identity for the complete `dead-code` analysis and compact JSON pipeline
- reuse the production check executor and root-envelope renderer in the benchmark hook
- exercise a deterministic many-export project with one reported issue per feature module

Fixture creation stays outside timing. The measured iteration performs production config loading, discovery, analysis, typed envelope construction, next-step assembly, and compact JSON serialization without terminal I/O.

## CodSpeed

- PR run `6a8578f081fbe1efeddb202f` registers `stable_dead_code_many_exports_json` at 45.3 ms Simulation
- the callgraph roots in `benchmark_dead_code_json` and includes the production `execute_check`, parsing, engine dead-code pipeline, typed result assembly, plugin processing, and JSON serialization
- the independently selected output component shard also passes, covering the shared renderer refactor

## Validation

- focused JSON contract and complete CLI tests pass
- strict CLI and benchmark Clippy passes
- benchmark harness, matrix, compilation, and execution pass
- generated contracts and repository fast verification pass
- exact current-base and head RHC output is byte-identical after normalizing only timing and telemetry run identity
- formatting, diff, and commit-signature checks pass
