### PR TITLE
perf(benchmarks): cover recommend workspace JSON

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.mjs
+++ b/.github/scripts/generate-benchmark-matrix.mjs
@@ -33,6 +33,10 @@ export const FAST_BENCHMARKS = [
     paths: [
       "crates/api/",
       "crates/benchmarks/benches/programmatic_stable.rs",
+      "crates/cli/src/init.rs",
+      "crates/cli/src/json_style.rs",
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/onboarding.rs",
       "crates/config/",
       "crates/core/",
       "crates/engine/",

--- a/.github/scripts/generate-benchmark-matrix.test.mjs
+++ b/.github/scripts/generate-benchmark-matrix.test.mjs
@@ -52,6 +52,17 @@ test("component bench file changes select the matching shard", () => {
   ]);
 });
 
+test("recommend production changes select the stable programmatic shard", () => {
+  for (const file of [
+    "crates/cli/src/init.rs",
+    "crates/cli/src/json_style.rs",
+    "crates/cli/src/lib.rs",
+    "crates/cli/src/onboarding.rs",
+  ]) {
+    assert.deepEqual(names(selectFastTargets([file])), ["programmatic_stable"]);
+  }
+});
+
 test("unrelated files select no benchmark shards", () => {
   assert.deepEqual(names(selectFastTargets(["README.md"])), []);
 });

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -19,7 +19,7 @@ use fallow_api::{
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
 use fallow_cli::{
-    benchmark_dead_code_json, benchmark_fix_dry_run, benchmark_list_json,
+    benchmark_dead_code_json, benchmark_fix_dry_run, benchmark_list_json, benchmark_recommend_json,
     benchmark_rule_pack_test_json, benchmark_security_json, benchmark_viz_html,
 };
 use fallow_engine::{module_graph::impact_closure_for_changed_paths, session::AnalysisSession};
@@ -40,6 +40,9 @@ const LIST_WORKSPACE_COUNT: usize = 8;
 // Each workspace index is reported once as a default index and once from its
 // package metadata, preserving both production entry-point sources.
 const LIST_ENTRY_POINT_COUNT: usize = LIST_WORKSPACE_COUNT * 2;
+const RECOMMEND_DECISION_COUNT: usize = 13;
+const RECOMMEND_FRAMEWORK_COUNT: usize = 5;
+const RECOMMEND_WORKSPACE_COUNT: usize = 64;
 const RULE_PACK_FILE_COUNT: usize = 64;
 const RULE_PACK_FINDINGS_PER_FILE: usize = 4;
 const SECURITY_FILE_COUNT: usize = 128;
@@ -629,6 +632,53 @@ export function run(): Promise<Response> {{
     }
 }
 
+fn create_recommend_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-recommend-workspace",
+  "private": true,
+  "packageManager": "pnpm@10.0.0",
+  "workspaces": ["packages/*"]
+}"#,
+    );
+    write_file(
+        &root,
+        "pnpm-workspace.yaml",
+        "packages:\n  - \"packages/*\"\n",
+    );
+    write_file(&root, "tsconfig.json", "{}\n");
+    write_file(&root, ".storybook/main.ts", "export default {};\n");
+
+    let frameworks = ["next", "react", "vue", "svelte", "@angular/core"];
+    let test_frameworks = ["vitest", "jest", "@playwright/test"];
+    for index in 0..RECOMMEND_WORKSPACE_COUNT {
+        let framework = frameworks[index % frameworks.len()];
+        let test_framework = test_frameworks[index % test_frameworks.len()];
+        write_file(
+            &root,
+            &format!("packages/package{index}/package.json"),
+            format!(
+                r#"{{
+  "name": "@bench/package{index}",
+  "private": true,
+  "dependencies": {{ "{framework}": "1.0.0" }},
+  "devDependencies": {{ "{test_framework}": "1.0.0" }}
+}}"#,
+            ),
+        );
+    }
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_list_inventory_project() -> CommandInput {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
@@ -999,6 +1049,29 @@ fn stable_rule_pack_policy_analysis_json(c: &mut Criterion) {
     });
 }
 
+fn stable_recommend_workspace_json(c: &mut Criterion) {
+    let input = create_recommend_project();
+
+    let result = benchmark_recommend_json(&input.root);
+    assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+    assert_eq!(result.1, RECOMMEND_DECISION_COUNT);
+    assert_eq!(result.2, RECOMMEND_FRAMEWORK_COUNT);
+    assert!(result.3);
+    assert!(result.4 > 0);
+
+    c.bench_function("stable_recommend_workspace_json", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_recommend_json(&input.root);
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, RECOMMEND_DECISION_COUNT);
+            assert_eq!(result.2, RECOMMEND_FRAMEWORK_COUNT);
+            assert!(result.3);
+            assert!(result.4 > 0);
+            result
+        });
+    });
+}
+
 fn stable_list_workspace_inventory_json(c: &mut Criterion) {
     let input = create_list_inventory_project();
 
@@ -1059,6 +1132,7 @@ criterion_group!(
     stable_dead_code_many_exports_json,
     stable_security_many_framework_sinks_json,
     stable_rule_pack_policy_analysis_json,
+    stable_recommend_workspace_json,
     stable_list_workspace_inventory_json,
     stable_viz_project_html
 );

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2999,6 +2999,22 @@ pub fn benchmark_rule_pack_test_json(root: &Path, threads: usize) -> (ExitCode, 
     }
 }
 
+/// Benchmark hook for the production recommendation discovery and compact JSON
+/// rendering pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_recommend_json(root: &Path) -> (ExitCode, usize, usize, bool, usize) {
+    match onboarding::benchmark_recommend_json(root) {
+        Ok((decision_count, framework_count, heterogeneous, rendered_bytes)) => (
+            ExitCode::SUCCESS,
+            decision_count,
+            framework_count,
+            heterogeneous,
+            rendered_bytes,
+        ),
+        Err(_) => (ExitCode::from(2), 0, 0, false, 0),
+    }
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {

--- a/crates/cli/src/onboarding.rs
+++ b/crates/cli/src/onboarding.rs
@@ -648,6 +648,29 @@ pub fn run_recommend(
     }
 }
 
+/// Benchmark hook for the production recommendation discovery and compact JSON
+/// rendering path. This is not a supported API.
+pub fn benchmark_recommend_json(
+    root: &Path,
+) -> Result<(usize, usize, bool, usize), serde_json::Error> {
+    let recommendation = build_recommendation(root);
+    let decision_count = recommendation.decisions.len();
+    let framework_count = recommendation.detected["frameworks_present"]
+        .as_array()
+        .map_or(0, Vec::len);
+    let heterogeneous = recommendation.detected["heterogeneous_frameworks"]
+        .as_bool()
+        .unwrap_or(false);
+    let rendered =
+        render_recommendation_json(&recommendation, crate::json_style::JsonStyle::Compact)?;
+    Ok((
+        decision_count,
+        framework_count,
+        heterogeneous,
+        rendered.len(),
+    ))
+}
+
 fn render_recommendation_json(
     recommendation: &Recommendation,
     json_style: crate::json_style::JsonStyle,


### PR DESCRIPTION
## Summary

- add a stable CodSpeed identity for `fallow recommend --format json`
- exercise a deterministic heterogeneous pnpm monorepo fixture
- assert recommendation decisions, detected frameworks, heterogeneity, and rendered output
- route future recommendation production changes to the stable programmatic benchmark shard

## Validation

- benchmark identity executes successfully
- benchmark harness and matrix checks pass
- strict Clippy, Rust and JavaScript formatting, and diff checks pass
- independent Rust and benchmark-routing reviews approved

## CodSpeed

- exact-head Simulation run `6a85a83c6d68b1789c870554` registers `stable_recommend_workspace_json` at 9.5 ms
- comparison against exact base `6a859aeb707a2c5bf84a028c` reports the new identity, all existing comparable benchmarks unchanged, and no regressions
- the flamegraph roots in the production recommendation hook and includes project detection, workspace discovery, package loading, recommendation assembly, and compact JSON rendering