### PR TITLE
perf(benchmarks): track runtime coverage analysis

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.mjs
+++ b/.github/scripts/generate-benchmark-matrix.mjs
@@ -33,6 +33,10 @@ export const FAST_BENCHMARKS = [
     paths: [
       "crates/api/",
       "crates/benchmarks/benches/programmatic_stable.rs",
+      "crates/cli/src/coverage/analyze.rs",
+      "crates/cli/src/coverage/mod.rs",
+      "crates/cli/src/health/coverage.rs",
+      "crates/cli/src/health/mod.rs",
       "crates/cli/src/init.rs",
       "crates/cli/src/json_style.rs",
       "crates/cli/src/lib.rs",

--- a/.github/scripts/generate-benchmark-matrix.test.mjs
+++ b/.github/scripts/generate-benchmark-matrix.test.mjs
@@ -63,6 +63,17 @@ test("recommend production changes select the stable programmatic shard", () => 
   }
 });
 
+test("local runtime coverage analysis changes select the stable programmatic shard", () => {
+  for (const file of [
+    "crates/cli/src/coverage/analyze.rs",
+    "crates/cli/src/coverage/mod.rs",
+    "crates/cli/src/health/coverage.rs",
+    "crates/cli/src/health/mod.rs",
+  ]) {
+    assert.deepEqual(names(selectFastTargets([file])), ["programmatic_stable"]);
+  }
+});
+
 test("unrelated files select no benchmark shards", () => {
   assert.deepEqual(names(selectFastTargets(["README.md"])), []);
 });

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -20,7 +20,8 @@ use fallow_api::{
 };
 use fallow_cli::{
     benchmark_dead_code_json, benchmark_fix_dry_run, benchmark_list_json, benchmark_recommend_json,
-    benchmark_rule_pack_test_json, benchmark_security_json, benchmark_viz_html,
+    benchmark_rule_pack_test_json, benchmark_runtime_coverage_analyze_json,
+    benchmark_security_json, benchmark_viz_html,
 };
 use fallow_engine::{module_graph::impact_closure_for_changed_paths, session::AnalysisSession};
 use fallow_extract::{
@@ -45,6 +46,9 @@ const RECOMMEND_FRAMEWORK_COUNT: usize = 5;
 const RECOMMEND_WORKSPACE_COUNT: usize = 64;
 const RULE_PACK_FILE_COUNT: usize = 64;
 const RULE_PACK_FINDINGS_PER_FILE: usize = 4;
+const RUNTIME_COVERAGE_FILE_COUNT: usize = 128;
+const RUNTIME_COVERAGE_FINDING_COUNT: usize = RUNTIME_COVERAGE_FILE_COUNT;
+const RUNTIME_COVERAGE_HOT_PATH_COUNT: usize = RUNTIME_COVERAGE_FILE_COUNT / 2;
 const SECURITY_FILE_COUNT: usize = 128;
 const VIZ_MODULE_COUNT: usize = 64;
 
@@ -62,6 +66,13 @@ struct ExtractCacheInput {
 struct EditorSessionInput {
     _temp_dir: TempDir,
     session: EditorAnalysisSession,
+}
+
+struct RuntimeCoverageInput {
+    _temp_dir: TempDir,
+    root: PathBuf,
+    coverage_path: PathBuf,
+    response_bytes: Vec<u8>,
 }
 
 fn write_file(root: &Path, path: &str, source: impl AsRef<str>) {
@@ -679,6 +690,148 @@ fn create_recommend_project() -> CommandInput {
     }
 }
 
+fn create_runtime_coverage_project() -> RuntimeCoverageInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+    write_file(
+        &root,
+        "package.json",
+        r#"{"name":"bench-runtime-coverage","private":true,"type":"module","main":"src/index.ts"}"#,
+    );
+    let coverage_path = write_runtime_coverage_sources(&root);
+
+    RuntimeCoverageInput {
+        _temp_dir: temp_dir,
+        root,
+        coverage_path,
+        response_bytes: runtime_coverage_response_bytes(),
+    }
+}
+
+fn write_runtime_coverage_sources(root: &Path) -> PathBuf {
+    let mut index_source = String::new();
+    let mut scripts = Vec::with_capacity(RUNTIME_COVERAGE_FILE_COUNT);
+    for index in 0..RUNTIME_COVERAGE_FILE_COUNT {
+        writeln!(
+            &mut index_source,
+            "import {{ live_{index} }} from \"./module{index:03}\";"
+        )
+        .unwrap();
+        let source = format!(
+            "export function live_{index}(value: number): number {{ return value + {index}; }}\n\
+             export function cold_{index}(value: number): number {{ return value - {index}; }}\n"
+        );
+        let relative = format!("src/module{index:03}.ts");
+        write_file(root, &relative, &source);
+        scripts.push(serde_json::json!({
+            "scriptId": index.to_string(),
+            "url": format!("file://{}", root.join(&relative).to_string_lossy()),
+            "functions": [{
+                "functionName": format!("live_{index}"),
+                "ranges": [{
+                    "startOffset": 0,
+                    "endOffset": source.encode_utf16().count(),
+                    "count": index + 1
+                }],
+                "isBlockCoverage": false
+            }]
+        }));
+    }
+    index_source.push_str("\nexport const values = [\n");
+    for index in 0..RUNTIME_COVERAGE_FILE_COUNT {
+        writeln!(&mut index_source, "  live_{index}({index}),").unwrap();
+    }
+    index_source.push_str("];\n");
+    write_file(root, "src/index.ts", index_source);
+
+    let coverage_path = root.join("coverage-final-v8.json");
+    fs::write(
+        &coverage_path,
+        serde_json::to_vec(&serde_json::json!({"result": scripts})).unwrap(),
+    )
+    .unwrap();
+    coverage_path
+}
+
+fn runtime_coverage_response_bytes() -> Vec<u8> {
+    let findings = (0..RUNTIME_COVERAGE_FINDING_COUNT)
+        .rev()
+        .map(|index| {
+            let verdict = match index % 4 {
+                0 => "safe_to_delete",
+                1 => "review_required",
+                2 => "coverage_unavailable",
+                _ => "low_traffic",
+            };
+            serde_json::json!({
+                "id": format!("fallow:prod:{index:016x}"),
+                "file": format!("src/module{index:03}.ts"),
+                "function": format!("cold_{index}"),
+                "line": 2,
+                "verdict": verdict,
+                "invocations": if index % 4 == 2 { None } else { Some(index as u64) },
+                "confidence": if index % 2 == 0 { "high" } else { "medium" },
+                "evidence": {
+                    "static_status": if index % 4 == 0 { "unused" } else { "used" },
+                    "test_coverage": "not_covered",
+                    "v8_tracking": if index % 4 == 2 { "untracked" } else { "tracked" },
+                    "untracked_reason": if index % 4 == 2 { Some("lazy_parsed") } else { None },
+                    "observation_days": 14,
+                    "deployments_observed": 4
+                },
+                "actions": [{
+                    "kind": "review",
+                    "description": "Review runtime evidence before changing this function.",
+                    "auto_fixable": false
+                }]
+            })
+        })
+        .collect::<Vec<_>>();
+    let hot_paths = (0..RUNTIME_COVERAGE_HOT_PATH_COUNT)
+        .rev()
+        .map(|index| {
+            serde_json::json!({
+                "id": format!("fallow:hot:{index:016x}"),
+                "file": format!("src/module{index:03}.ts"),
+                "function": format!("live_{index}"),
+                "line": 1,
+                "end_line": 1,
+                "invocations": 10_000 + index,
+                "percentile": 100 - (index % 50),
+                "identity": null
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_vec(&serde_json::json!({
+        "protocol_version": "0.8.0",
+        "verdict": "cold-code-detected",
+        "summary": {
+            "functions_tracked": RUNTIME_COVERAGE_FILE_COUNT * 2,
+            "functions_hit": RUNTIME_COVERAGE_FILE_COUNT,
+            "functions_unhit": RUNTIME_COVERAGE_FILE_COUNT,
+            "functions_untracked": 0,
+            "coverage_percent": 50.0,
+            "trace_count": 1_000_000,
+            "period_days": 14,
+            "deployments_seen": 4,
+            "capture_quality": {
+                "window_seconds": 1_209_600,
+                "instances_observed": 4,
+                "lazy_parse_warning": false,
+                "untracked_ratio_percent": 0.0
+            }
+        },
+        "findings": findings,
+        "hot_paths": hot_paths,
+        "blast_radius": [],
+        "importance": [],
+        "watermark": null,
+        "errors": [],
+        "warnings": []
+    }))
+    .unwrap()
+}
+
 fn create_list_inventory_project() -> CommandInput {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
@@ -1072,6 +1225,50 @@ fn stable_recommend_workspace_json(c: &mut Criterion) {
     });
 }
 
+fn stable_coverage_analyze_local_runtime_json(c: &mut Criterion) {
+    let input = create_runtime_coverage_project();
+
+    let result = benchmark_runtime_coverage_analyze_json(
+        &input.root,
+        &input.coverage_path,
+        &input.response_bytes,
+        BENCH_THREADS,
+    );
+    assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+    assert_eq!(result.1, RUNTIME_COVERAGE_FINDING_COUNT);
+    assert_eq!(result.2, RUNTIME_COVERAGE_HOT_PATH_COUNT);
+    assert!(
+        result.3 > 50_000,
+        "request must include the broad static inventory"
+    );
+    let output: serde_json::Value = serde_json::from_str(&result.4).unwrap();
+    assert_eq!(
+        output["runtime_coverage"]["findings"][0]["path"],
+        "src/module000.ts"
+    );
+    assert_eq!(
+        output["runtime_coverage"]["hot_paths"][0]["path"],
+        "src/module063.ts"
+    );
+
+    c.bench_function("stable_coverage_analyze_local_runtime_json", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_runtime_coverage_analyze_json(
+                &input.root,
+                &input.coverage_path,
+                &input.response_bytes,
+                BENCH_THREADS,
+            );
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, RUNTIME_COVERAGE_FINDING_COUNT);
+            assert_eq!(result.2, RUNTIME_COVERAGE_HOT_PATH_COUNT);
+            assert!(result.3 > 50_000);
+            assert!(!result.4.is_empty());
+            result
+        });
+    });
+}
+
 fn stable_list_workspace_inventory_json(c: &mut Criterion) {
     let input = create_list_inventory_project();
 
@@ -1133,6 +1330,7 @@ criterion_group!(
     stable_security_many_framework_sinks_json,
     stable_rule_pack_policy_analysis_json,
     stable_recommend_workspace_json,
+    stable_coverage_analyze_local_runtime_json,
     stable_list_workspace_inventory_json,
     stable_viz_project_html
 );

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -149,6 +149,61 @@ fn run_local(path: &Path, args: &AnalyzeArgs, ctx: &RunContext<'_>) -> ExitCode 
     print_runtime_report(&report, ctx, result.elapsed, args)
 }
 
+pub fn benchmark_local_json(
+    root: &Path,
+    runtime_coverage_path: &Path,
+    response_bytes: &[u8],
+    threads: usize,
+) -> Result<(usize, usize, usize, String), ExitCode> {
+    let args = AnalyzeArgs {
+        runtime_coverage: Some(runtime_coverage_path.to_path_buf()),
+        min_invocations_hot: 100,
+        ..AnalyzeArgs::default()
+    };
+    let config_path = None;
+    let ctx = RunContext {
+        root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        quiet: true,
+        no_cache: true,
+        threads,
+        explain: false,
+        allow_remote_extends: false,
+    };
+    let runtime_coverage = fallow_engine::health::RuntimeCoverageOptions {
+        path: runtime_coverage_path.to_path_buf(),
+        min_invocations_hot: args.min_invocations_hot,
+        min_observation_volume: args.min_observation_volume,
+        low_traffic_threshold: args.low_traffic_threshold,
+        license_jwt: String::new(),
+        watermark: None,
+    };
+    let options = local_health_options(&args, &ctx, runtime_coverage);
+    let request_len = std::cell::Cell::new(0);
+    let result = crate::health::benchmark_execute_health_with_response(
+        &options,
+        response_bytes,
+        &request_len,
+    )?;
+    let report = result
+        .report
+        .runtime_coverage
+        .ok_or_else(|| ExitCode::from(2))?;
+    let output =
+        runtime_json_output(&report, result.elapsed, false).map_err(|_| ExitCode::from(2))?;
+    let rendered = crate::json_style::JsonStyle::Compact
+        .serialize(&output)
+        .map_err(|_| ExitCode::from(2))?;
+    Ok((
+        report.findings.len(),
+        report.hot_paths.len(),
+        request_len.get(),
+        rendered,
+    ))
+}
+
 /// Build the `HealthOptions` for a local `coverage analyze` run: complexity,
 /// hotspot, and gating features are off so the run focuses on the supplied
 /// runtime-coverage artifact.
@@ -1258,19 +1313,7 @@ fn print_runtime_json(
     explain: bool,
     json_style: crate::json_style::JsonStyle,
 ) -> ExitCode {
-    debug_assert_eq!(
-        RUNTIME_COVERAGE_SCHEMA_VERSION, "1",
-        "the schema-version enum has one variant serialized as \"1\"; bump CoverageAnalyzeSchemaVersion if the constant moves"
-    );
-
-    let envelope =
-        fallow_output::build_coverage_analyze_output(report, elapsed, env!("CARGO_PKG_VERSION"));
-    let output = match fallow_output::serialize_coverage_analyze_json_output(
-        envelope,
-        crate::output_runtime::current_root_envelope_mode(),
-        explain.then(crate::explain::coverage_analyze_meta),
-        crate::output_runtime::telemetry_analysis_run_id().as_deref(),
-    ) {
+    let output = match runtime_json_output(report, elapsed, explain) {
         Ok(value) => value,
         Err(err) => {
             eprintln!("Error: failed to serialize runtime coverage report: {err}");
@@ -1278,6 +1321,26 @@ fn print_runtime_json(
         }
     };
     crate::report::emit_report_json(&output, "runtime coverage JSON", json_style)
+}
+
+fn runtime_json_output(
+    report: &RuntimeCoverageReport,
+    elapsed: std::time::Duration,
+    explain: bool,
+) -> Result<serde_json::Value, serde_json::Error> {
+    debug_assert_eq!(
+        RUNTIME_COVERAGE_SCHEMA_VERSION, "1",
+        "the schema-version enum has one variant serialized as \"1\"; bump CoverageAnalyzeSchemaVersion if the constant moves"
+    );
+
+    let envelope =
+        fallow_output::build_coverage_analyze_output(report, elapsed, env!("CARGO_PKG_VERSION"));
+    fallow_output::serialize_coverage_analyze_json_output(
+        envelope,
+        crate::output_runtime::current_root_envelope_mode(),
+        explain.then(crate::explain::coverage_analyze_meta),
+        crate::output_runtime::telemetry_analysis_run_id().as_deref(),
+    )
 }
 
 const HUMAN_DEFAULT_DISPLAY_LIMIT: usize = 10;

--- a/crates/cli/src/coverage/mod.rs
+++ b/crates/cli/src/coverage/mod.rs
@@ -30,6 +30,7 @@ use crate::health::coverage as runtime_coverage;
 use crate::license;
 
 pub use analyze::AnalyzeArgs;
+pub use analyze::benchmark_local_json;
 pub use upload_inventory::UploadInventoryArgs;
 pub use upload_source_maps::UploadSourceMapsArgs;
 pub use upload_static_findings::UploadStaticFindingsArgs;

--- a/crates/cli/src/health/coverage.rs
+++ b/crates/cli/src/health/coverage.rs
@@ -271,6 +271,16 @@ pub(super) fn analyze(
 ) -> Result<RuntimeCoverageReport, u8> {
     let sidecar = discover_sidecar(Some(input.root))
         .map_err(|message| emit_printed(&message, 4, input.output))?;
+    analyze_with_transport(options, input, |request, quiet, output| {
+        run_sidecar(&sidecar, request, quiet, output)
+    })
+}
+
+pub(super) fn analyze_with_transport(
+    options: &RuntimeCoverageOptions,
+    input: &RuntimeCoverageAnalysisInput<'_>,
+    transport: impl FnOnce(&Request, bool, OutputFormat) -> Result<Response, u8>,
+) -> Result<RuntimeCoverageReport, u8> {
     let prepared_sources = prepare_coverage_sources(&options.path)
         .map_err(|message| emit_printed(&message, 5, input.output))?;
     let static_signals =
@@ -278,7 +288,7 @@ pub(super) fn analyze(
             .map_err(|message| emit_printed(&message, 2, input.output))?;
     let (request, locations) =
         build_request(options, input, &static_signals, prepared_sources.sources);
-    let response = run_sidecar(&sidecar, &request, input.quiet, input.output)?;
+    let response = transport(&request, input.quiet, input.output)?;
     // Resolve the verdict thresholds with the SAME defaults the sidecar applies
     // when they are unset, so the discriminator block (#321) reports the values
     // that actually produced the verdicts.
@@ -1747,7 +1757,11 @@ fn run_sidecar(
 
     check_sidecar_exit_status(&output_data, output)?;
 
-    let response: Response = serde_json::from_slice(&output_data.stdout).map_err(|err| {
+    decode_sidecar_response(&output_data.stdout, output)
+}
+
+fn decode_sidecar_response(bytes: &[u8], output: OutputFormat) -> Result<Response, u8> {
+    let response: Response = serde_json::from_slice(bytes).map_err(|err| {
         emit_printed(
             &format!("failed to parse sidecar response: {err}"),
             4,
@@ -1758,6 +1772,18 @@ fn run_sidecar(
     check_response_protocol(&response, output)?;
 
     Ok(response)
+}
+
+pub fn in_process_response_transport(
+    request: &Request,
+    response_bytes: &[u8],
+    output: OutputFormat,
+) -> Result<(Response, usize), u8> {
+    let mut request_bytes = Vec::new();
+    write_sidecar_request(&mut request_bytes, request, output)?;
+    let request_len = request_bytes.len();
+    std::hint::black_box(request_bytes);
+    decode_sidecar_response(response_bytes, output).map(|response| (response, request_len))
 }
 
 /// Serialize and flush the protocol request onto the sidecar's stdin.

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -268,6 +268,18 @@ pub fn execute_health_with_config(
     config: fallow_config::ResolvedConfig,
     config_ms: f64,
 ) -> Result<HealthResult, ExitCode> {
+    let seams = health_seams();
+    let result = execute_health_with_config_and_seams(opts, config, config_ms, &seams)?;
+    record_health_telemetry(&result.report, result.coverage_gaps_has_findings);
+    Ok(result)
+}
+
+fn execute_health_with_config_and_seams(
+    opts: &HealthOptions<'_>,
+    config: fallow_config::ResolvedConfig,
+    config_ms: f64,
+    seams: &HealthSeams<'_>,
+) -> Result<HealthResult, ExitCode> {
     let t = Instant::now();
     let session = fallow_engine::session::AnalysisSession::from_resolved_config(config)
         .map_err(|e| emit_error(&format!("analysis failed: {e}"), 2, opts.output))?;
@@ -287,8 +299,7 @@ pub fn execute_health_with_config(
     let parse_cpu_ms = parts.parse_cpu_ms;
 
     let scope_inputs = build_health_scope_inputs(opts, &config)?;
-    let seams = health_seams();
-    let result = execute_health_inner(
+    execute_health_inner(
         opts,
         HealthPipelineInputs {
             config,
@@ -307,11 +318,48 @@ pub fn execute_health_with_config(
             workspace_diagnostics,
         },
         scope_inputs,
-        &seams,
+        seams,
     )
-    .map_err(|e| health_err_to_exit(e, opts.output))?;
-    record_health_telemetry(&result.report, result.coverage_gaps_has_findings);
-    Ok(result)
+    .map_err(|e| health_err_to_exit(e, opts.output))
+}
+
+pub fn benchmark_execute_health_with_response(
+    opts: &HealthOptions<'_>,
+    response_bytes: &[u8],
+    request_len: &std::cell::Cell<usize>,
+) -> Result<HealthResult, ExitCode> {
+    let analyzer = |options: &fallow_engine::health::RuntimeCoverageOptions,
+                    input: RuntimeCoverageSeamInput<'_>| {
+        coverage::analyze_with_transport(
+            options,
+            &coverage::RuntimeCoverageAnalysisInput {
+                root: input.root,
+                modules: input.modules,
+                analysis_output: input.analysis_output,
+                istanbul_coverage: input.istanbul_coverage,
+                file_paths: input.file_paths,
+                ignore_set: input.ignore_set,
+                changed_files: input.changed_files,
+                ws_roots: input.ws_roots,
+                top: input.top,
+                codeowners_path: input.codeowners_path,
+                quiet: input.quiet,
+                output: input.output,
+            },
+            |request, _quiet, output| {
+                let (response, len) =
+                    coverage::in_process_response_transport(request, response_bytes, output)?;
+                request_len.set(len);
+                Ok(response)
+            },
+        )
+    };
+    let seams = HealthSeams {
+        runtime_coverage_analyzer: &analyzer,
+        note_graph_structure: &|_module_count, _edge_count| {},
+    };
+    let (config, config_ms) = load_health_config(opts)?;
+    execute_health_with_config_and_seams(opts, config, config_ms, &seams)
 }
 
 pub fn run_health(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3015,6 +3015,27 @@ pub fn benchmark_recommend_json(root: &Path) -> (ExitCode, usize, usize, bool, u
     }
 }
 
+/// Benchmark hook for local runtime coverage analysis and compact JSON
+/// rendering with an in-process sidecar response. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_runtime_coverage_analyze_json(
+    root: &Path,
+    runtime_coverage_path: &Path,
+    response_bytes: &[u8],
+    threads: usize,
+) -> (ExitCode, usize, usize, usize, String) {
+    match coverage::benchmark_local_json(root, runtime_coverage_path, response_bytes, threads) {
+        Ok((finding_count, hot_path_count, request_bytes, rendered)) => (
+            ExitCode::SUCCESS,
+            finding_count,
+            hot_path_count,
+            request_bytes,
+            rendered,
+        ),
+        Err(code) => (code, 0, 0, 0, String::new()),
+    }
+}
+
 /// Status bars refresh frequently, so their local read path bypasses telemetry,
 /// update checks, notices, and every other command epilogue.
 fn is_impact_statusline(cli: &Cli) -> bool {

--- a/crates/cli/tests/runtime_coverage_tests.rs
+++ b/crates/cli/tests/runtime_coverage_tests.rs
@@ -122,6 +122,21 @@ mod gated {
             ]
         }
 
+        fn coverage_analyze_args(&self) -> Vec<String> {
+            let fixture = fixture_path("coverage-gaps");
+            vec![
+                "coverage".to_owned(),
+                "analyze".to_owned(),
+                "--root".to_owned(),
+                fixture.to_string_lossy().into_owned(),
+                "--runtime-coverage".to_owned(),
+                self.coverage_file.to_string_lossy().into_owned(),
+                "--format".to_owned(),
+                "json".to_owned(),
+                "--quiet".to_owned(),
+            ]
+        }
+
         fn multi_capture_dir(&self) -> PathBuf {
             let dir = self.tmp.path().join("multi-capture");
             fs::create_dir_all(&dir).expect("create multi-capture dir");
@@ -255,6 +270,82 @@ mod gated {
             json.pointer("/runtime_coverage/schema_version"),
             Some(&serde_json::Value::String("1".to_owned())),
             "runtime_coverage schema_version must be stable for agent consumers"
+        );
+    }
+
+    #[test]
+    fn coverage_analyze_benchmark_transport_matches_signed_stub_output() {
+        let harness = Harness::new();
+        let root = fixture_path("coverage-gaps");
+        let response = serde_json::to_vec(&serde_json::json!({
+            "protocol_version": fallow_cov_protocol::PROTOCOL_VERSION,
+            "verdict": "clean",
+            "summary": {
+                "functions_tracked": 0,
+                "functions_hit": 0,
+                "functions_unhit": 0,
+                "functions_untracked": 0,
+                "coverage_percent": 0.0,
+                "trace_count": 0,
+                "period_days": 0,
+                "deployments_seen": 0,
+                "capture_quality": null
+            },
+            "findings": [],
+            "hot_paths": [],
+            "blast_radius": [],
+            "importance": [],
+            "watermark": null,
+            "errors": [],
+            "warnings": []
+        }))
+        .expect("serialize clean sidecar response");
+
+        let benchmark = fallow_cli::benchmark_runtime_coverage_analyze_json(
+            &root,
+            &harness.coverage_file,
+            &response,
+            1,
+        );
+        assert_eq!(benchmark.0, std::process::ExitCode::SUCCESS);
+        assert!(benchmark.3 > 0, "request JSON must be measured");
+        let benchmark_json: serde_json::Value =
+            serde_json::from_str(&benchmark.4).expect("benchmark JSON should parse");
+
+        let mut mismatched_response: serde_json::Value =
+            serde_json::from_slice(&response).expect("clean response should parse");
+        mismatched_response["protocol_version"] = serde_json::json!("99.0.0");
+        let mismatch = fallow_cli::benchmark_runtime_coverage_analyze_json(
+            &root,
+            &harness.coverage_file,
+            &serde_json::to_vec(&mismatched_response).expect("serialize mismatch response"),
+            1,
+        );
+        assert_eq!(
+            mismatch.0,
+            std::process::ExitCode::from(4),
+            "in-process response must pass through the production protocol gate"
+        );
+
+        let mut cmd = harness.fallow();
+        cmd.env("FALLOW_LICENSE", sign::mint_runtime_coverage_jwt());
+        cmd.env("FALLOW_STUB_MODE", "enforce-license-gate");
+        for arg in harness.coverage_analyze_args() {
+            cmd.arg(arg);
+        }
+        let (stdout, stderr, code) = run_with(cmd);
+        assert_eq!(code, 0, "signed stub coverage analyze failed: {stderr}");
+        assert!(
+            !stdout.trim_end().contains('\n'),
+            "compact JSON should stay on one line"
+        );
+        let signed_json: serde_json::Value =
+            serde_json::from_str(&stdout).expect("signed stub JSON should parse");
+
+        assert_eq!(
+            benchmark_json.get("runtime_coverage"),
+            signed_json.get("runtime_coverage"),
+            "in-process benchmark transport must preserve signed sidecar semantics"
         );
     }
 


### PR DESCRIPTION
## Summary

- add a stable CodSpeed benchmark for local `fallow coverage analyze --runtime-coverage`
- measure project discovery, parsing, static signals, request JSON, response decode, conversion, sorting, and compact JSON rendering without sidecar process startup
- keep production sidecar discovery, signature verification, streaming transport, and error order unchanged
- route runtime coverage CLI changes to the stable programmatic benchmark shard

## Verification

- signed stub request and output parity, including protocol mismatch rejection
- full CLI and benchmark correctness suites
- strict CLI and benchmark clippy
- benchmark harness and changed-file matrix checks
- formatting, JS lint, JS formatting, typos, hidden Unicode, and comment quality
- local release smoke: `8.3680 ms to 8.4786 ms`
- CodSpeed Simulation run `6a85fe06f7262214428143a7`: new identity measured at `76.9 ms`
- CodSpeed comparison against exact base run `6a85f265f726221442814277`: existing benchmarks unchanged, no regressions
- flamegraph confirms the intended production route through config loading, project parsing, V8 coverage preparation, static request construction, request serialization, shared response decoding, conversion and sorting, and compact JSON rendering