### PR TITLE
perf(benchmarks): cover list boundaries

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.mjs
+++ b/.github/scripts/generate-benchmark-matrix.mjs
@@ -41,6 +41,7 @@ export const FAST_BENCHMARKS = [
       "crates/cli/src/inspect.rs",
       "crates/cli/src/json_style.rs",
       "crates/cli/src/lib.rs",
+      "crates/cli/src/list.rs",
       "crates/cli/src/onboarding.rs",
       "crates/config/",
       "crates/core/",

--- a/.github/scripts/generate-benchmark-matrix.test.mjs
+++ b/.github/scripts/generate-benchmark-matrix.test.mjs
@@ -58,6 +58,7 @@ test("stable CLI production changes select the stable programmatic shard", () =>
     "crates/cli/src/inspect.rs",
     "crates/cli/src/json_style.rs",
     "crates/cli/src/lib.rs",
+    "crates/cli/src/list.rs",
     "crates/cli/src/onboarding.rs",
   ]) {
     assert.deepEqual(names(selectFastTargets([file])), ["programmatic_stable"]);

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -20,9 +20,10 @@ use fallow_api::{
 };
 use fallow_cli::{
     InspectBenchmarkCorpus, benchmark_dead_code_json, benchmark_fix_dry_run,
-    benchmark_inspect_file_evidence_bundle_json, benchmark_list_json, benchmark_recommend_json,
-    benchmark_rule_pack_test_json, benchmark_runtime_coverage_analyze_json,
-    benchmark_security_json, benchmark_viz_html, create_inspect_benchmark_corpus,
+    benchmark_inspect_file_evidence_bundle_json, benchmark_list_boundaries_json,
+    benchmark_list_json, benchmark_recommend_json, benchmark_rule_pack_test_json,
+    benchmark_runtime_coverage_analyze_json, benchmark_security_json, benchmark_viz_html,
+    create_inspect_benchmark_corpus,
 };
 use fallow_engine::{module_graph::impact_closure_for_changed_paths, session::AnalysisSession};
 use fallow_extract::{
@@ -38,6 +39,9 @@ const FIX_FILE_COUNT: usize = 128;
 const IMPACT_LAYER_COUNT: usize = 32;
 const IMPACT_LAYER_WIDTH: usize = 16;
 const INSPECT_CHILD_CALL_COUNT: usize = 6;
+const LIST_BOUNDARY_FILES_PER_ZONE: usize = 16;
+const LIST_BOUNDARY_ZONE_COUNT: usize = 32;
+const LIST_BOUNDARY_FILE_COUNT: usize = LIST_BOUNDARY_FILES_PER_ZONE * LIST_BOUNDARY_ZONE_COUNT;
 const LIST_FILE_COUNT: usize = 128;
 const LIST_WORKSPACE_COUNT: usize = 8;
 // Each workspace index is reported once as a default index and once from its
@@ -910,6 +914,64 @@ fn create_list_inventory_project() -> CommandInput {
     }
 }
 
+fn create_list_boundaries_project() -> CommandInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{
+  "name": "bench-list-boundaries",
+  "private": true,
+  "type": "module"
+}"#,
+    );
+
+    let zones = (0..LIST_BOUNDARY_ZONE_COUNT)
+        .map(|zone| {
+            serde_json::json!({
+                "name": format!("zone-{zone:02}"),
+                "patterns": [format!("src/zone-{zone:02}/*.ts")],
+            })
+        })
+        .collect::<Vec<_>>();
+    let rules = (0..LIST_BOUNDARY_ZONE_COUNT)
+        .map(|zone| {
+            serde_json::json!({
+                "from": format!("zone-{zone:02}"),
+                "allow": [format!("zone-{:02}", (zone + 1) % LIST_BOUNDARY_ZONE_COUNT)],
+            })
+        })
+        .collect::<Vec<_>>();
+    write_file(
+        &root,
+        ".fallowrc.json",
+        serde_json::to_string(&serde_json::json!({
+            "boundaries": {
+                "zones": zones,
+                "rules": rules,
+            }
+        }))
+        .unwrap(),
+    );
+
+    for zone in 0..LIST_BOUNDARY_ZONE_COUNT {
+        for file in 0..LIST_BOUNDARY_FILES_PER_ZONE {
+            write_file(
+                &root,
+                &format!("src/zone-{zone:02}/module-{file:02}.ts"),
+                format!("export const value_{zone:02}_{file:02} = {file};\n"),
+            );
+        }
+    }
+
+    CommandInput {
+        _temp_dir: temp_dir,
+        root,
+    }
+}
+
 fn create_viz_project() -> CommandInput {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
@@ -1346,6 +1408,30 @@ fn stable_list_workspace_inventory_json(c: &mut Criterion) {
     });
 }
 
+fn stable_list_boundaries_many_zones_json(c: &mut Criterion) {
+    let input = create_list_boundaries_project();
+
+    let (status, zone_count, rule_count, matched_file_count, rendered_bytes) =
+        benchmark_list_boundaries_json(&input.root, BENCH_THREADS);
+    assert_eq!(status, std::process::ExitCode::SUCCESS);
+    assert_eq!(zone_count, LIST_BOUNDARY_ZONE_COUNT);
+    assert_eq!(rule_count, LIST_BOUNDARY_ZONE_COUNT);
+    assert_eq!(matched_file_count, LIST_BOUNDARY_FILE_COUNT);
+    assert!(rendered_bytes > 0);
+
+    c.bench_function("stable_list_boundaries_many_zones_json", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_list_boundaries_json(&input.root, BENCH_THREADS);
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, LIST_BOUNDARY_ZONE_COUNT);
+            assert_eq!(result.2, LIST_BOUNDARY_ZONE_COUNT);
+            assert_eq!(result.3, LIST_BOUNDARY_FILE_COUNT);
+            assert!(result.4 > 0);
+            result
+        });
+    });
+}
+
 fn stable_viz_project_html(c: &mut Criterion) {
     let input = create_viz_project();
     let expected_files = VIZ_MODULE_COUNT + 1;
@@ -1386,6 +1472,7 @@ criterion_group!(
     stable_recommend_workspace_json,
     stable_coverage_analyze_local_runtime_json,
     stable_list_workspace_inventory_json,
+    stable_list_boundaries_many_zones_json,
     stable_viz_project_html
 );
 criterion_main!(benches);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3003,6 +3003,25 @@ pub fn benchmark_list_json(root: &Path, threads: usize) -> (ExitCode, usize, usi
     }
 }
 
+/// Benchmark hook for the production boundaries listing and compact JSON
+/// rendering pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_list_boundaries_json(
+    root: &Path,
+    threads: usize,
+) -> (ExitCode, usize, usize, usize, usize) {
+    match list::benchmark_list_boundaries_json(root, threads) {
+        Ok((zone_count, rule_count, matched_file_count, rendered_bytes)) => (
+            ExitCode::SUCCESS,
+            zone_count,
+            rule_count,
+            matched_file_count,
+            rendered_bytes,
+        ),
+        Err(code) => (code, 0, 0, 0, 0),
+    }
+}
+
 /// Benchmark hook for the production Viz analysis, payload, and HTML
 /// rendering pipeline. This is not a supported API.
 #[doc(hidden)]

--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -104,9 +104,61 @@ pub fn benchmark_list_json(
         production: false,
         allow_remote_extends: false,
     };
-    let config = load_config(
+    let (data, rendered_bytes) = benchmark_list_data_json(&opts)?;
+    let file_count = data.discovered.as_deref().map_or(0, <[_]>::len);
+    let entry_point_count = data.entry_points.as_deref().map_or(0, <[_]>::len);
+    let workspace_count = data
+        .workspace_data
+        .as_ref()
+        .map_or(0, |data| data.workspaces.len());
+    Ok((
+        file_count,
+        entry_point_count,
+        workspace_count,
+        rendered_bytes,
+    ))
+}
+
+/// Benchmark hook for the production boundaries listing and JSON rendering
+/// pipeline. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_list_boundaries_json(
+    root: &std::path::Path,
+    threads: usize,
+) -> Result<(usize, usize, usize, usize), ExitCode> {
+    let config_path = None;
+    let opts = ListOptions {
         root,
-        &config_path,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        threads,
+        no_cache: true,
+        entry_points: false,
+        files: false,
+        plugins: false,
+        boundaries: true,
+        workspaces: false,
+        production: false,
+        allow_remote_extends: false,
+    };
+    let (data, rendered_bytes) = benchmark_list_data_json(&opts)?;
+    let Some(boundary_data) = data.boundary_data else {
+        return Err(ExitCode::from(2));
+    };
+    let matched_file_count = boundary_data.zones.iter().map(|zone| zone.file_count).sum();
+    Ok((
+        boundary_data.zones.len(),
+        boundary_data.rules.len(),
+        matched_file_count,
+        rendered_bytes,
+    ))
+}
+
+fn benchmark_list_data_json(opts: &ListOptions<'_>) -> Result<(ListData, usize), ExitCode> {
+    let config = load_config(
+        opts.root,
+        opts.config_path,
         LoadConfigArgs {
             output: opts.output,
             no_cache: opts.no_cache,
@@ -116,15 +168,9 @@ pub fn benchmark_list_json(
             allow_remote_extends: opts.allow_remote_extends,
         },
     )?;
-    let data = collect_list_data(&opts, &config)?;
-    let file_count = data.discovered.as_deref().map_or(0, <[_]>::len);
-    let entry_point_count = data.entry_points.as_deref().map_or(0, <[_]>::len);
-    let workspace_count = data
-        .workspace_data
-        .as_ref()
-        .map_or(0, |data| data.workspaces.len());
+    let data = collect_list_data(opts, &config)?;
     let rendered = render_list_json(&ListJsonInput {
-        opts: &opts,
+        opts,
         show_all: data.show_all,
         plugin_result: data.plugin_result.as_ref(),
         discovered: data.discovered.as_deref(),
@@ -139,12 +185,7 @@ pub fn benchmark_list_json(
             OutputFormat::Json,
         )
     })?;
-    Ok((
-        file_count,
-        entry_point_count,
-        workspace_count,
-        rendered.len(),
-    ))
+    Ok((data, rendered.len()))
 }
 
 /// Collect plugins, files, entry points, boundary, and workspace data for a


### PR DESCRIPTION
## Summary

- add `stable_list_boundaries_many_zones_json` for the production `list --boundaries` path
- benchmark config loading, file discovery, boundary classification, and compact JSON rendering over 32 zones and 512 files
- route `crates/cli/src/list.rs` changes to the stable programmatic CodSpeed shard

## Performance evidence

- CodSpeed Simulation run `6a86b4ee2bcb212e8d600163`
- new identity measured at 319.9 ms
- flamegraph follows the production path, with boundary zone classification at 68.1% and config loading at 19.4%
- existing comparable identities are unchanged, with no regressions

## Verification

- targeted Criterion smoke
- focused list CLI tests and full workspace tests
- workspace benchmark check
- strict Clippy and Rust formatting
- benchmark harness and matrix tests
- JavaScript lint and formatting
- rustdoc with warnings denied
- independent Rust review approved with no blockers
