### PR TITLE
perf(benchmarks): cover watch filter initialization

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.mjs
+++ b/.github/scripts/generate-benchmark-matrix.mjs
@@ -43,6 +43,7 @@ export const FAST_BENCHMARKS = [
       "crates/cli/src/lib.rs",
       "crates/cli/src/list.rs",
       "crates/cli/src/onboarding.rs",
+      "crates/cli/src/watch.rs",
       "crates/config/",
       "crates/core/",
       "crates/engine/",

--- a/.github/scripts/generate-benchmark-matrix.test.mjs
+++ b/.github/scripts/generate-benchmark-matrix.test.mjs
@@ -60,6 +60,7 @@ test("stable CLI production changes select the stable programmatic shard", () =>
     "crates/cli/src/lib.rs",
     "crates/cli/src/list.rs",
     "crates/cli/src/onboarding.rs",
+    "crates/cli/src/watch.rs",
   ]) {
     assert.deepEqual(names(selectFastTargets([file])), ["programmatic_stable"]);
   }

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -19,12 +19,14 @@ use fallow_api::{
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
 use fallow_cli::{
-    InspectBenchmarkCorpus, benchmark_dead_code_json, benchmark_fix_dry_run,
-    benchmark_inspect_file_evidence_bundle_json, benchmark_list_boundaries_json,
-    benchmark_list_json, benchmark_recommend_json, benchmark_rule_pack_test_json,
-    benchmark_runtime_coverage_analyze_json, benchmark_security_json, benchmark_viz_html,
-    create_inspect_benchmark_corpus,
+    InspectBenchmarkCorpus, WatchFilterBenchmarkGlobalGitignore, benchmark_dead_code_json,
+    benchmark_fix_dry_run, benchmark_inspect_file_evidence_bundle_json,
+    benchmark_list_boundaries_json, benchmark_list_json, benchmark_recommend_json,
+    benchmark_rule_pack_test_json, benchmark_runtime_coverage_analyze_json,
+    benchmark_security_json, benchmark_viz_html, benchmark_watch_filter_initialization,
+    create_inspect_benchmark_corpus, create_watch_filter_benchmark_global_gitignore,
 };
+use fallow_config::{FallowConfig, OutputFormat};
 use fallow_engine::{module_graph::impact_closure_for_changed_paths, session::AnalysisSession};
 use fallow_extract::{
     cache::{CacheStore, module_to_cached},
@@ -57,6 +59,10 @@ const RUNTIME_COVERAGE_FINDING_COUNT: usize = RUNTIME_COVERAGE_FILE_COUNT;
 const RUNTIME_COVERAGE_HOT_PATH_COUNT: usize = RUNTIME_COVERAGE_FILE_COUNT / 2;
 const SECURITY_FILE_COUNT: usize = 128;
 const VIZ_MODULE_COUNT: usize = 64;
+const WATCH_FILTER_FILES_PER_PACKAGE: usize = 16;
+const WATCH_FILTER_PACKAGE_COUNT: usize = 64;
+const WATCH_FILTER_PROJECT_MATCHER_COUNT: usize = WATCH_FILTER_PACKAGE_COUNT + 3;
+const WATCH_FILTER_PROJECT_PATTERN_COUNT: usize = WATCH_FILTER_PACKAGE_COUNT * 2 + 4;
 
 struct CommandInput {
     _temp_dir: TempDir,
@@ -85,6 +91,12 @@ struct RuntimeCoverageInput {
     root: PathBuf,
     coverage_path: PathBuf,
     response_bytes: Vec<u8>,
+}
+
+struct WatchFilterInput {
+    _temp_dir: TempDir,
+    config: fallow_config::ResolvedConfig,
+    global_gitignore: WatchFilterBenchmarkGlobalGitignore,
 }
 
 fn write_file(root: &Path, path: &str, source: impl AsRef<str>) {
@@ -972,6 +984,58 @@ fn create_list_boundaries_project() -> CommandInput {
     }
 }
 
+fn create_watch_filter_project() -> WatchFilterInput {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().to_path_buf();
+
+    write_file(
+        &root,
+        "package.json",
+        r#"{"name":"bench-watch-filter","private":true,"type":"module"}"#,
+    );
+    write_file(&root, ".git/info/exclude", "scratch/**\n");
+    write_file(&root, ".gitignore", "dist/**\n*.log\n");
+    write_file(&root, ".storybook/.gitignore", "storybook-static/**\n");
+
+    // These matchers must not be discovered: one is in a disallowed hidden
+    // directory and one is pruned by the resolved user ignore patterns.
+    write_file(&root, ".cache/.gitignore", "generated/**\n");
+    write_file(&root, "vendor/ignored/.gitignore", "generated/**\n");
+
+    for package in 0..WATCH_FILTER_PACKAGE_COUNT {
+        let package_root = format!("packages/pkg-{package:02}");
+        write_file(
+            &root,
+            &format!("{package_root}/.gitignore"),
+            "generated/**\n!generated/keep.ts\n",
+        );
+        for file in 0..WATCH_FILTER_FILES_PER_PACKAGE {
+            let directory = if file % 2 == 0 { "src" } else { "generated" };
+            write_file(
+                &root,
+                &format!("{package_root}/{directory}/module-{file:02}.ts"),
+                format!("export const value_{package:02}_{file:02} = {file};\n"),
+            );
+        }
+    }
+
+    let config = FallowConfig {
+        ignore_patterns: vec![
+            "vendor/ignored".to_string(),
+            "vendor/ignored/**".to_string(),
+        ],
+        ..FallowConfig::default()
+    }
+    .resolve(root, OutputFormat::Json, BENCH_THREADS, false, true, None);
+    let global_gitignore = create_watch_filter_benchmark_global_gitignore();
+
+    WatchFilterInput {
+        _temp_dir: temp_dir,
+        config,
+        global_gitignore,
+    }
+}
+
 fn create_viz_project() -> CommandInput {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path().to_path_buf();
@@ -1432,6 +1496,27 @@ fn stable_list_boundaries_many_zones_json(c: &mut Criterion) {
     });
 }
 
+fn stable_watch_filter_initialization_nested_gitignores(c: &mut Criterion) {
+    let input = create_watch_filter_project();
+
+    let result = benchmark_watch_filter_initialization(&input.config, &input.global_gitignore);
+    assert_eq!(result.0, WATCH_FILTER_PROJECT_MATCHER_COUNT);
+    assert_eq!(result.1, WATCH_FILTER_PROJECT_PATTERN_COUNT);
+
+    c.bench_function(
+        "stable_watch_filter_initialization_nested_gitignores",
+        |bencher| {
+            bencher.iter(|| {
+                let result =
+                    benchmark_watch_filter_initialization(&input.config, &input.global_gitignore);
+                assert_eq!(result.0, WATCH_FILTER_PROJECT_MATCHER_COUNT);
+                assert_eq!(result.1, WATCH_FILTER_PROJECT_PATTERN_COUNT);
+                result
+            });
+        },
+    );
+}
+
 fn stable_viz_project_html(c: &mut Criterion) {
     let input = create_viz_project();
     let expected_files = VIZ_MODULE_COUNT + 1;
@@ -1473,6 +1558,7 @@ criterion_group!(
     stable_coverage_analyze_local_runtime_json,
     stable_list_workspace_inventory_json,
     stable_list_boundaries_many_zones_json,
+    stable_watch_filter_initialization_nested_gitignores,
     stable_viz_project_html
 );
 criterion_main!(benches);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3022,6 +3022,28 @@ pub fn benchmark_list_boundaries_json(
     }
 }
 
+/// Opaque deterministic global matcher for the watch-filter benchmark. This is
+/// not a supported API.
+#[doc(hidden)]
+pub use watch::WatchFilterBenchmarkGlobalGitignore;
+
+/// Build a deterministic global gitignore matcher outside the timed watch
+/// benchmark. This is not a supported API.
+#[doc(hidden)]
+pub fn create_watch_filter_benchmark_global_gitignore() -> WatchFilterBenchmarkGlobalGitignore {
+    watch::create_benchmark_global_gitignore()
+}
+
+/// Benchmark hook for production watch-filter initialization and project
+/// gitignore discovery. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_watch_filter_initialization(
+    config: &fallow_config::ResolvedConfig,
+    global_gitignore: &WatchFilterBenchmarkGlobalGitignore,
+) -> (usize, usize) {
+    watch::benchmark_filter_initialization(config, global_gitignore)
+}
+
 /// Benchmark hook for the production Viz analysis, payload, and HTML
 /// rendering pipeline. This is not a supported API.
 #[doc(hidden)]

--- a/crates/cli/src/watch.rs
+++ b/crates/cli/src/watch.rs
@@ -100,8 +100,15 @@ struct WatchFilter {
 
 impl WatchFilter {
     fn new(config: &fallow_config::ResolvedConfig) -> Self {
-        let gitignores = build_project_gitignores(config);
         let (global_gitignore, _) = ignore::gitignore::Gitignore::global();
+        Self::new_with_global_gitignore(config, global_gitignore)
+    }
+
+    fn new_with_global_gitignore(
+        config: &fallow_config::ResolvedConfig,
+        global_gitignore: ignore::gitignore::Gitignore,
+    ) -> Self {
+        let gitignores = build_project_gitignores(config);
         Self {
             root: config.root.clone(),
             ignore_patterns: config.ignore_patterns.clone(),
@@ -156,6 +163,32 @@ impl WatchFilter {
         }
         ignored
     }
+}
+
+#[doc(hidden)]
+pub struct WatchFilterBenchmarkGlobalGitignore(ignore::gitignore::Gitignore);
+
+/// Build a deterministic global matcher outside the timed watch-filter
+/// benchmark. This is not a supported API.
+#[doc(hidden)]
+pub fn create_benchmark_global_gitignore() -> WatchFilterBenchmarkGlobalGitignore {
+    WatchFilterBenchmarkGlobalGitignore(ignore::gitignore::Gitignore::empty())
+}
+
+/// Benchmark hook for project gitignore discovery and watch-filter
+/// initialization. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_filter_initialization(
+    config: &fallow_config::ResolvedConfig,
+    global_gitignore: &WatchFilterBenchmarkGlobalGitignore,
+) -> (usize, usize) {
+    let filter = WatchFilter::new_with_global_gitignore(config, global_gitignore.0.clone());
+    let pattern_count = filter
+        .gitignores
+        .iter()
+        .map(|gitignore| gitignore.len())
+        .sum();
+    (filter.gitignores.len(), pattern_count)
 }
 
 fn build_project_gitignores(


### PR DESCRIPTION
## Summary

- add a stable CodSpeed identity for watch-filter initialization across a nested gitignore project
- measure production project gitignore discovery and filter construction with fixture, config, and deterministic global matcher setup outside the timed region
- route watch implementation changes to the stable programmatic benchmark shard

## Performance evidence

- CodSpeed Simulation run `6a86bf5649202529db4b7c01`
- new identity measured at 78.4 ms
- flamegraph enters the production constructor core, project gitignore walk, matcher compilation, and glob automata construction
- existing comparable identities are unchanged, with no regressions

## Validation

- targeted Criterion smoke for the new identity
- CLI library tests
- strict workspace Clippy and benchmark compilation
- benchmark matrix and harness checks
- Rust and JavaScript format/lint checks
- independent Rust review approved after removing ambient global Git configuration from the timed region
