### PR TITLE
perf(benchmarks): cover derived security outputs

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.mjs
+++ b/.github/scripts/generate-benchmark-matrix.mjs
@@ -54,6 +54,7 @@ export const FAST_BENCHMARKS = [
       "crates/cli/src/list.rs",
       "crates/cli/src/onboarding.rs",
       "crates/cli/src/output_runtime.rs",
+      "crates/cli/src/security.rs",
       "crates/cli/src/watch.rs",
       "crates/config/",
       "crates/core/",

--- a/.github/scripts/generate-benchmark-matrix.test.mjs
+++ b/.github/scripts/generate-benchmark-matrix.test.mjs
@@ -71,6 +71,7 @@ test("stable CLI production changes select the stable programmatic shard", () =>
     "crates/cli/src/list.rs",
     "crates/cli/src/onboarding.rs",
     "crates/cli/src/output_runtime.rs",
+    "crates/cli/src/security.rs",
     "crates/cli/src/watch.rs",
   ]) {
     assert.deepEqual(names(selectFastTargets([file])), ["programmatic_stable"]);

--- a/crates/benchmarks/benches/programmatic_stable.rs
+++ b/crates/benchmarks/benches/programmatic_stable.rs
@@ -20,14 +20,15 @@ use fallow_api::{
     run_circular_dependencies, run_combined, run_feature_flags, run_health_with_runner,
 };
 use fallow_cli::{
-    AuditReviewBenchmarkCorpus, InspectBenchmarkCorpus, WatchFilterBenchmarkGlobalGitignore,
-    benchmark_audit_review_brief_many_changed_files_json, benchmark_dead_code_json,
-    benchmark_fix_dry_run, benchmark_inspect_file_evidence_bundle_json,
+    AuditReviewBenchmarkCorpus, InspectBenchmarkCorpus, SecurityBlindSpotsBenchmarkResult,
+    WatchFilterBenchmarkGlobalGitignore, benchmark_audit_review_brief_many_changed_files_json,
+    benchmark_dead_code_json, benchmark_fix_dry_run, benchmark_inspect_file_evidence_bundle_json,
     benchmark_list_boundaries_json, benchmark_list_json, benchmark_recommend_json,
     benchmark_rule_pack_test_json, benchmark_runtime_coverage_analyze_json,
-    benchmark_security_json, benchmark_viz_html, benchmark_watch_filter_initialization,
+    benchmark_security_blind_spots_json, benchmark_security_json,
+    benchmark_security_survivors_json, benchmark_viz_html, benchmark_watch_filter_initialization,
     create_audit_review_benchmark_corpus, create_inspect_benchmark_corpus,
-    create_watch_filter_benchmark_global_gitignore,
+    create_security_survivors_benchmark_corpus, create_watch_filter_benchmark_global_gitignore,
 };
 use fallow_config::{FallowConfig, OutputFormat};
 use fallow_engine::{
@@ -40,7 +41,11 @@ use fallow_extract::{
     cache::{CacheStore, module_to_cached},
     parse_all_files, parse_single_file,
 };
-use fallow_types::discover::{DiscoveredFile, FileId};
+use fallow_types::{
+    discover::{DiscoveredFile, FileId},
+    extract::{SkippedSecurityCalleeExpressionKind, SkippedSecurityCalleeReason},
+    results::SecurityUnresolvedCalleeDiagnostic,
+};
 use tempfile::TempDir;
 
 const BENCH_THREADS: usize = 4;
@@ -71,6 +76,13 @@ const RUNTIME_COVERAGE_FILE_COUNT: usize = 128;
 const RUNTIME_COVERAGE_FINDING_COUNT: usize = RUNTIME_COVERAGE_FILE_COUNT;
 const RUNTIME_COVERAGE_HOT_PATH_COUNT: usize = RUNTIME_COVERAGE_FILE_COUNT / 2;
 const SECURITY_FILE_COUNT: usize = 128;
+const SECURITY_SURVIVOR_COUNT: usize = 86;
+const SECURITY_DISMISSED_COUNT: usize = 85;
+const SECURITY_NEEDS_HUMAN_REVIEW_COUNT: usize = 85;
+const SECURITY_UNRESOLVED_CALLEE_COUNT: usize = 4_096;
+const SECURITY_UNRESOLVED_CALLEE_FILE_COUNT: usize = 512;
+const SECURITY_UNRESOLVED_CALLEE_GROUP_COUNT: usize = 10;
+const SECURITY_UNRESOLVED_CALLEE_SAMPLE_COUNT: usize = 25;
 const TRACE_CLONE_FILE_COUNT: usize = 64;
 const TRACE_GRAPH_IMPORTER_COUNT: usize = 128;
 const VIZ_MODULE_COUNT: usize = 64;
@@ -815,6 +827,33 @@ app.post("/run/{index}", (req) => {{
         _temp_dir: temp_dir,
         root,
     }
+}
+
+fn create_security_unresolved_callee_corpus(
+    root: &Path,
+) -> Vec<SecurityUnresolvedCalleeDiagnostic> {
+    (0..SECURITY_UNRESOLVED_CALLEE_COUNT)
+        .rev()
+        .map(|index| SecurityUnresolvedCalleeDiagnostic {
+            path: root.join(format!(
+                "src/routes/route{:03}.ts",
+                index % SECURITY_UNRESOLVED_CALLEE_FILE_COUNT
+            )),
+            line: u32::try_from(index % 400 + 1).unwrap(),
+            col: u32::try_from(index % 12).unwrap(),
+            reason: match index % 3 {
+                0 => SkippedSecurityCalleeReason::ComputedMember,
+                1 => SkippedSecurityCalleeReason::DynamicDispatch,
+                _ => SkippedSecurityCalleeReason::UnsupportedAssignmentObject,
+            },
+            expression_kind: match index % 4 {
+                0 => SkippedSecurityCalleeExpressionKind::StaticMemberExpression,
+                1 => SkippedSecurityCalleeExpressionKind::ComputedMemberExpression,
+                2 => SkippedSecurityCalleeExpressionKind::Identifier,
+                _ => SkippedSecurityCalleeExpressionKind::Other,
+            },
+        })
+        .collect()
 }
 
 fn create_rule_pack_project() -> CommandInput {
@@ -1590,6 +1629,139 @@ fn stable_security_many_framework_sinks_json(c: &mut Criterion) {
     });
 }
 
+fn stable_security_survivors_verdict_join_json(c: &mut Criterion) {
+    let input = create_security_project();
+    let corpus = create_security_survivors_benchmark_corpus(&input.root, BENCH_THREADS)
+        .expect("security survivors benchmark corpus");
+    let result = benchmark_security_survivors_json(&corpus);
+    assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+    assert_eq!(result.1, SECURITY_SURVIVOR_COUNT);
+    assert_eq!(result.2, SECURITY_DISMISSED_COUNT);
+    assert_eq!(result.3, SECURITY_NEEDS_HUMAN_REVIEW_COUNT);
+    assert_eq!(result.4, 0);
+    assert!(result.5 > 0);
+
+    c.bench_function("stable_security_survivors_verdict_join_json", |bencher| {
+        bencher.iter(|| {
+            let result = benchmark_security_survivors_json(&corpus);
+            assert_eq!(result.0, std::process::ExitCode::SUCCESS);
+            assert_eq!(result.1, SECURITY_SURVIVOR_COUNT);
+            assert_eq!(result.2, SECURITY_DISMISSED_COUNT);
+            assert_eq!(result.3, SECURITY_NEEDS_HUMAN_REVIEW_COUNT);
+            assert_eq!(result.4, 0);
+            assert!(result.5 > 0);
+            result
+        });
+    });
+}
+
+fn assert_security_blind_spots_benchmark_result(result: &SecurityBlindSpotsBenchmarkResult) {
+    let expected_groups = [
+        (
+            SkippedSecurityCalleeReason::ComputedMember,
+            SkippedSecurityCalleeExpressionKind::ComputedMemberExpression,
+            3,
+            "src/routes/route001.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::ComputedMember,
+            SkippedSecurityCalleeExpressionKind::StaticMemberExpression,
+            3,
+            "src/routes/route000.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::DynamicDispatch,
+            SkippedSecurityCalleeExpressionKind::ComputedMemberExpression,
+            3,
+            "src/routes/route001.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::DynamicDispatch,
+            SkippedSecurityCalleeExpressionKind::Identifier,
+            3,
+            "src/routes/route002.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::UnsupportedAssignmentObject,
+            SkippedSecurityCalleeExpressionKind::Identifier,
+            3,
+            "src/routes/route002.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::UnsupportedAssignmentObject,
+            SkippedSecurityCalleeExpressionKind::StaticMemberExpression,
+            3,
+            "src/routes/route000.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::ComputedMember,
+            SkippedSecurityCalleeExpressionKind::Identifier,
+            2,
+            "src/routes/route002.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::DynamicDispatch,
+            SkippedSecurityCalleeExpressionKind::StaticMemberExpression,
+            2,
+            "src/routes/route000.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::UnsupportedAssignmentObject,
+            SkippedSecurityCalleeExpressionKind::ComputedMemberExpression,
+            2,
+            "src/routes/route001.ts",
+        ),
+        (
+            SkippedSecurityCalleeReason::ComputedMember,
+            SkippedSecurityCalleeExpressionKind::Other,
+            1,
+            "src/routes/route003.ts",
+        ),
+    ];
+
+    assert_eq!(
+        result.output.summary.unresolved_callee_sites,
+        SECURITY_UNRESOLVED_CALLEE_COUNT
+    );
+    assert_eq!(
+        result.output.summary.sampled_callee_sites,
+        SECURITY_UNRESOLVED_CALLEE_SAMPLE_COUNT
+    );
+    assert_eq!(
+        result.output.groups.len(),
+        SECURITY_UNRESOLVED_CALLEE_GROUP_COUNT
+    );
+    for (group, (reason, expression_kind, sampled_count, path)) in
+        result.output.groups.iter().zip(expected_groups)
+    {
+        assert_eq!(group.reason, reason);
+        assert_eq!(group.expression_kind, expression_kind);
+        assert_eq!(group.sampled_count, sampled_count);
+        assert_eq!(group.files.len(), 1);
+        assert_eq!(group.files[0].path, path);
+        assert_eq!(group.files[0].sampled_count, sampled_count);
+    }
+    assert!(result.rendered_bytes > 0);
+}
+
+fn stable_security_blind_spots_unresolved_callees_json(c: &mut Criterion) {
+    let input = create_security_project();
+    let diagnostics = create_security_unresolved_callee_corpus(&input.root);
+    let result = benchmark_security_blind_spots_json(&input.root, &diagnostics);
+    assert_security_blind_spots_benchmark_result(&result);
+
+    c.bench_function(
+        "stable_security_blind_spots_unresolved_callees_json",
+        |bencher| {
+            bencher.iter(|| {
+                let result = benchmark_security_blind_spots_json(&input.root, &diagnostics);
+                assert_security_blind_spots_benchmark_result(&result);
+                result
+            });
+        },
+    );
+}
+
 fn stable_rule_pack_policy_analysis_json(c: &mut Criterion) {
     let input = create_rule_pack_project();
     let expected_findings = RULE_PACK_FILE_COUNT * RULE_PACK_FINDINGS_PER_FILE;
@@ -1881,6 +2053,8 @@ criterion_group!(
     stable_inspect_file_evidence_bundle_json,
     stable_dead_code_many_exports_json,
     stable_security_many_framework_sinks_json,
+    stable_security_survivors_verdict_join_json,
+    stable_security_blind_spots_unresolved_callees_json,
     stable_rule_pack_policy_analysis_json,
     stable_recommend_workspace_json,
     stable_coverage_analyze_local_runtime_json,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3022,6 +3022,48 @@ pub fn benchmark_security_json(root: &Path, threads: usize) -> (ExitCode, usize,
     }
 }
 
+#[doc(hidden)]
+pub use security::{SecurityBlindSpotsBenchmarkResult, SecuritySurvivorsBenchmarkCorpus};
+
+/// Build the explicit candidate and verifier inputs outside the timed
+/// survivors benchmark. This is not a supported API.
+#[doc(hidden)]
+pub fn create_security_survivors_benchmark_corpus(
+    root: &Path,
+    threads: usize,
+) -> Result<SecuritySurvivorsBenchmarkCorpus, ExitCode> {
+    security::create_security_survivors_benchmark_corpus(root, threads)
+}
+
+/// Benchmark the production survivors loaders, candidate/verdict join, and
+/// compact JSON serializer. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_security_survivors_json(
+    corpus: &SecuritySurvivorsBenchmarkCorpus,
+) -> (ExitCode, usize, usize, usize, usize, usize) {
+    match security::benchmark_security_survivors_json(corpus) {
+        Ok((survivors, dismissed, needs_human_review, unverdicted, rendered_bytes)) => (
+            ExitCode::SUCCESS,
+            survivors,
+            dismissed,
+            needs_human_review,
+            unverdicted,
+            rendered_bytes,
+        ),
+        Err(_) => (ExitCode::from(2), 0, 0, 0, 0, 0),
+    }
+}
+
+/// Benchmark unresolved-callee normalization, blind-spot grouping, and compact
+/// JSON serialization without project I/O. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_security_blind_spots_json(
+    root: &Path,
+    diagnostics: &[fallow_types::results::SecurityUnresolvedCalleeDiagnostic],
+) -> SecurityBlindSpotsBenchmarkResult {
+    security::benchmark_security_blind_spots_json(root, diagnostics)
+}
+
 /// Benchmark hook for the production list inventory and JSON rendering
 /// pipeline. This is not a supported API.
 #[doc(hidden)]

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -267,6 +267,178 @@ pub fn benchmark_security_json(root: &Path, threads: usize) -> Result<(usize, us
     Ok((finding_count, rendered.len()))
 }
 
+/// Self-contained candidate and verdict files for the survivors benchmark.
+/// This is not a supported API.
+#[doc(hidden)]
+pub struct SecuritySurvivorsBenchmarkCorpus {
+    _temp_dir: tempfile::TempDir,
+    candidates: PathBuf,
+    verdicts: PathBuf,
+}
+
+/// Build the security candidates and explicit verifier inputs outside the
+/// timed survivors benchmark. This is not a supported API.
+#[doc(hidden)]
+pub fn create_security_survivors_benchmark_corpus(
+    root: &Path,
+    threads: usize,
+) -> Result<SecuritySurvivorsBenchmarkCorpus, ExitCode> {
+    let config_path = None;
+    let files: &[PathBuf] = &[];
+    let opts = SecurityOptions {
+        root,
+        config_path: &config_path,
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        no_cache: true,
+        threads,
+        quiet: true,
+        allow_remote_extends: false,
+        fail_on_issues: false,
+        sarif_file: None,
+        summary: false,
+        changed_since: None,
+        use_shared_diff_index: true,
+        workspace: None,
+        changed_workspaces: None,
+        file: files,
+        surface: false,
+        gate: None,
+        runtime_coverage: None,
+        min_invocations_hot: crate::DEFAULT_MIN_INVOCATIONS_HOT,
+        explain: false,
+    };
+    let (output, _) = build_security_command_output(&opts, Instant::now())?;
+    write_security_survivors_benchmark_corpus(&output)
+        .map_err(|message| emit_error(&message, 2, OutputFormat::Json))
+}
+
+fn write_security_survivors_benchmark_corpus(
+    output: &SecurityOutput,
+) -> Result<SecuritySurvivorsBenchmarkCorpus, String> {
+    let temp_dir = tempfile::tempdir()
+        .map_err(|err| format!("Failed to create survivors benchmark corpus: {err}"))?;
+    let candidates = temp_dir.path().join("candidates.json");
+    let verdicts = temp_dir.path().join("verdicts.json");
+    let candidate_json = render_json_with_style(output, crate::json_style::JsonStyle::Compact);
+    std::fs::write(&candidates, candidate_json)
+        .map_err(|err| format!("Failed to write survivors benchmark candidates: {err}"))?;
+
+    let verdicts_json: Vec<_> = output
+        .security_findings
+        .iter()
+        .enumerate()
+        .map(|(index, finding)| SecurityVerifierVerdict {
+            schema_version: "fallow-security-verdict/v1".to_owned(),
+            finding_id: finding.finding_id.clone(),
+            verdict: match index % 3 {
+                0 => SecurityVerifierVerdictStatus::Survivor,
+                1 => SecurityVerifierVerdictStatus::Dismissed,
+                _ => SecurityVerifierVerdictStatus::NeedsHumanReview,
+            },
+            reason: Some(format!("benchmark-verdict-{index}")),
+            rationale: Some("stable benchmark verifier rationale".to_owned()),
+            confidence: Some("high".to_owned()),
+            impact: Some("benchmark impact".to_owned()),
+            fix_direction: Some("benchmark fix direction".to_owned()),
+        })
+        .collect();
+    let verdicts_json = serde_json::to_vec(&serde_json::json!({
+        "schema_version": "fallow-security-verdicts/v1",
+        "verdicts": verdicts_json,
+    }))
+    .map_err(|err| format!("Failed to serialize survivors benchmark verdicts: {err}"))?;
+    std::fs::write(&verdicts, verdicts_json)
+        .map_err(|err| format!("Failed to write survivors benchmark verdicts: {err}"))?;
+
+    Ok(SecuritySurvivorsBenchmarkCorpus {
+        _temp_dir: temp_dir,
+        candidates,
+        verdicts,
+    })
+}
+
+/// Benchmark the production candidate/verdict loaders, join, and compact JSON
+/// serializer against a self-contained corpus. This is not a supported API.
+#[doc(hidden)]
+pub fn benchmark_security_survivors_json(
+    corpus: &SecuritySurvivorsBenchmarkCorpus,
+) -> Result<(usize, usize, usize, usize, usize), String> {
+    let opts = SecuritySurvivorsOptions {
+        output: OutputFormat::Json,
+        json_style: crate::json_style::JsonStyle::Compact,
+        candidates: &corpus.candidates,
+        verdicts: &corpus.verdicts,
+        require_verdict_for_each_candidate: true,
+    };
+    let output = build_survivors_output(&opts, Instant::now())?;
+    let rendered = render_survivors_output(opts.output, opts.json_style, &output);
+    Ok((
+        output.summary.survivors,
+        output.summary.dismissed,
+        output.summary.needs_human_review,
+        output.summary.unverdicted,
+        rendered.len(),
+    ))
+}
+
+/// Production blind-spots output retained for benchmark contract assertions.
+/// This is not a supported API.
+#[doc(hidden)]
+pub struct SecurityBlindSpotsBenchmarkResult {
+    /// Derived production output before compact serialization.
+    pub output: SecurityBlindSpotsOutput,
+    /// Compact serialized output size.
+    pub rendered_bytes: usize,
+}
+
+/// Benchmark unresolved-callee normalization, blind-spot grouping, and compact
+/// JSON serialization without reading the project root. This is not a
+/// supported API.
+#[doc(hidden)]
+pub fn benchmark_security_blind_spots_json(
+    root: &Path,
+    diagnostics: &[SecurityUnresolvedCalleeDiagnostic],
+) -> SecurityBlindSpotsBenchmarkResult {
+    let normalized = unresolved_callee_diagnostics(diagnostics, root);
+    let output = SecurityOutput {
+        schema_version: SecuritySchemaVersion::V8,
+        version: ToolVersion(env!("CARGO_PKG_VERSION").to_owned()),
+        elapsed_ms: ElapsedMs(0),
+        config: SecurityOutputConfig {
+            rules: SecurityOutputRulesConfig {
+                security_client_server_leak: SecurityRuleSeverityConfig {
+                    configured: Severity::Off,
+                    effective: Severity::Warn,
+                },
+                security_sink: SecurityRuleSeverityConfig {
+                    configured: Severity::Off,
+                    effective: Severity::Warn,
+                },
+            },
+            categories_include: None,
+            categories_exclude: None,
+        },
+        meta: None,
+        gate: None,
+        security_findings: Vec::new(),
+        attack_surface: None,
+        unresolved_edge_files: 0,
+        unresolved_callee_sites: diagnostics.len(),
+        unresolved_callee_diagnostics: normalized,
+    };
+    let output = build_blind_spots_output(&output);
+    let rendered = render_blind_spots_output(
+        OutputFormat::Json,
+        crate::json_style::JsonStyle::Compact,
+        &output,
+    );
+    SecurityBlindSpotsBenchmarkResult {
+        output,
+        rendered_bytes: rendered.len(),
+    }
+}
+
 fn build_security_command_output(
     opts: &SecurityOptions<'_>,
     started: Instant,
@@ -3132,6 +3304,64 @@ mod tests {
             categories_include: None,
             categories_exclude: None,
         }
+    }
+
+    #[test]
+    fn survivors_benchmark_uses_only_its_explicit_corpus_files() {
+        let root = Path::new("/removed/security-benchmark-project");
+        let findings = ["sec-a", "sec-b", "sec-c"]
+            .into_iter()
+            .map(|finding_id| {
+                let mut finding = sample_finding(root);
+                finding.finding_id = finding_id.to_owned();
+                finding
+            })
+            .collect();
+        let corpus = write_security_survivors_benchmark_corpus(&output_with(findings, 0))
+            .expect("self-contained survivors corpus");
+
+        let result = benchmark_security_survivors_json(&corpus)
+            .expect("benchmark should only read the explicit corpus files");
+        assert_eq!(result.0, 1);
+        assert_eq!(result.1, 1);
+        assert_eq!(result.2, 1);
+        assert_eq!(result.3, 0);
+        assert!(result.4 > 0);
+    }
+
+    #[test]
+    fn blind_spots_benchmark_normalizes_without_project_io() {
+        let root = Path::new("/removed/security-benchmark-project");
+        let diagnostics: Vec<_> = (0..64)
+            .rev()
+            .map(|index| SecurityUnresolvedCalleeDiagnostic {
+                path: root.join(format!("src/module{}.ts", index % 8)),
+                line: index + 1,
+                col: index % 4,
+                reason: if index % 2 == 0 {
+                    fallow_types::extract::SkippedSecurityCalleeReason::ComputedMember
+                } else {
+                    fallow_types::extract::SkippedSecurityCalleeReason::DynamicDispatch
+                },
+                expression_kind: if index % 2 == 0 {
+                    fallow_types::extract::SkippedSecurityCalleeExpressionKind::ComputedMemberExpression
+                } else {
+                    fallow_types::extract::SkippedSecurityCalleeExpressionKind::Other
+                },
+            })
+            .collect();
+
+        let result = benchmark_security_blind_spots_json(root, &diagnostics);
+        assert_eq!(
+            result.output.summary.unresolved_callee_sites,
+            diagnostics.len()
+        );
+        assert_eq!(
+            result.output.summary.sampled_callee_sites,
+            UNRESOLVED_CALLEE_SAMPLE_LIMIT
+        );
+        assert_eq!(result.output.groups.len(), 2);
+        assert!(result.rendered_bytes > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add stable CodSpeed coverage for the security survivors candidate/verdict join and compact JSON output
- add stable CodSpeed coverage for unresolved-callee normalization, blind-spot grouping, and compact JSON output
- keep project setup outside the timed paths and route security production changes to the stable programmatic shard

## CodSpeed

- final Simulation run: `6a8700c3309e9b1d47143e63`
- `stable_security_survivors_verdict_join_json`: 99.9148 ms
- `stable_security_blind_spots_unresolved_callees_json`: 19.9182 ms
- comparison against post-trace main `6a86fe1321d1410ed75f04ac`: 2 new, 80 unchanged, no regressions
- some unrelated controls were skipped because their base and head samples used different runner hardware
- survivors flamegraph covers explicit candidate/verdict loading, validation, join, and compact JSON serialization
- blind-spots flamegraph covers unresolved-callee normalization, stable sorting, file/reason aggregation, grouping, and compact JSON serialization

## Validation

- security behavior and no-project-I/O tests pass
- benchmark compile and local release smoke pass
- Rust clippy passes with warnings denied
- benchmark matrix, workflow policy, and harness checks pass
- independent review approved the original change and the post-trace rebase
