### PR TITLE
fix(core): resolve bun.lock in unused dependency override analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transitive dependency in a bun repo was reported as unused even though the
   target resolved in `bun.lock`. These are commonly CVE-fix pins, so acting on
   the finding would have been a security downgrade. `bun.lock` (a JSONC file)
-  is now parsed into the resolved-package set. When the only lockfile is bun's
-  legacy binary `bun.lockb`, resolution ground truth is unreadable and the
-  check emits nothing instead of degrading to declaration-only analysis. The
-  transitive hint also now names the package manager whose lockfile is present
-  (`bun install --frozen-lockfile` / `npm ci`) instead of always citing pnpm.
+  is now parsed into the resolved-package set, and `npm-shrinkwrap.json` is
+  read alongside `package-lock.json` so shrinkwrap repos get the same
+  transitive crediting. When the only lockfile is bun's legacy binary
+  `bun.lockb`, resolution ground truth is unreadable and the check emits
+  nothing instead of degrading to declaration-only analysis; a stale
+  `bun.lockb` next to a parseable pnpm or npm lockfile does not disable the
+  check. The transitive hint now follows the root `package.json`
+  `packageManager` field first and the lockfiles present as fallback
+  (`bun install --frozen-lockfile` / `npm ci`), yarn repos are told that
+  `overrides` is inert and `resolutions` is the yarn mechanism, and the
+  finding's suggested actions no longer hardcode pnpm file names or commands.
   (Closes [#2341](https://github.com/fallow-rs/fallow/issues/2341).)
 
 ## [3.17.0] - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   jobs, while a credential-free gate downloads and validates the exact
   universal and platform-specific payloads from both registries.
 
+### Fixed
+
+- **`unused_dependency_overrides` no longer flags transitive-only overrides in
+  bun repositories.** bun declares overrides through the same top-level
+  `overrides` key as npm, but override resolution only consulted
+  `pnpm-lock.yaml` and `package-lock.json`, so every override targeting a
+  transitive dependency in a bun repo was reported as unused even though the
+  target resolved in `bun.lock`. These are commonly CVE-fix pins, so acting on
+  the finding would have been a security downgrade. `bun.lock` (a JSONC file)
+  is now parsed into the resolved-package set. When the only lockfile is bun's
+  legacy binary `bun.lockb`, resolution ground truth is unreadable and the
+  check emits nothing instead of degrading to declaration-only analysis. The
+  transitive hint also now names the package manager whose lockfile is present
+  (`bun install --frozen-lockfile` / `npm ci`) instead of always citing pnpm.
+  (Closes [#2341](https://github.com/fallow-rs/fallow/issues/2341).)
+
 ## [3.17.0] - 2026-08-16
 
 ### Added

--- a/crates/cli/tests/snapshots/snapshot_tests__json_mixed_severity.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_mixed_severity.snap
@@ -585,8 +585,8 @@ expression: redact_version(&json_str)
         {
           "type": "remove-dependency-override",
           "auto_fixable": false,
-          "description": "Remove the override entry from pnpm-workspace.yaml or pnpm.overrides",
-          "note": "Conservative static check; verify against `pnpm install --frozen-lockfile` before removing in case the override targets a transitive dependency (CVE-fix pattern)"
+          "description": "Remove the override entry from its declaration source (pnpm-workspace.yaml overrides, pnpm.overrides, or the package.json overrides object)",
+          "note": "Conservative static check; verify against a frozen-lockfile install (`pnpm install --frozen-lockfile`, `npm ci`, or `bun install --frozen-lockfile`) before removing in case the override targets a transitive dependency (CVE-fix pattern)"
         },
         {
           "type": "add-to-config",

--- a/crates/cli/tests/snapshots/snapshot_tests__json_output.snap
+++ b/crates/cli/tests/snapshots/snapshot_tests__json_output.snap
@@ -585,8 +585,8 @@ expression: "json_str.replace(&format!(\"\\\"version\\\": \\\"{}\\\"\", env!(\"C
         {
           "type": "remove-dependency-override",
           "auto_fixable": false,
-          "description": "Remove the override entry from pnpm-workspace.yaml or pnpm.overrides",
-          "note": "Conservative static check; verify against `pnpm install --frozen-lockfile` before removing in case the override targets a transitive dependency (CVE-fix pattern)"
+          "description": "Remove the override entry from its declaration source (pnpm-workspace.yaml overrides, pnpm.overrides, or the package.json overrides object)",
+          "note": "Conservative static check; verify against a frozen-lockfile install (`pnpm install --frozen-lockfile`, `npm ci`, or `bun install --frozen-lockfile`) before removing in case the override targets a transitive dependency (CVE-fix pattern)"
         },
         {
           "type": "add-to-config",

--- a/crates/core/src/analyze/unused_overrides.rs
+++ b/crates/core/src/analyze/unused_overrides.rs
@@ -18,13 +18,13 @@
 //!
 //! 1. **`unused-dependency-overrides`**: an override whose target package is
 //!    absent from both workspace `package.json` dep sections and the
-//!    lockfile (`pnpm-lock.yaml`, `package-lock.json`, or `bun.lock`).
-//!    Overrides targeting resolved transitive packages are treated as used
-//!    because CVE-fix pins often exist only in the lockfile. When the only
-//!    lockfile is bun's legacy binary `bun.lockb`, resolution ground truth is
-//!    unreadable, so no unused-override findings are emitted at all rather
-//!    than degrading to declaration-only analysis that would flag every
-//!    transitive-only pin.
+//!    lockfile (`pnpm-lock.yaml`, `package-lock.json`, `npm-shrinkwrap.json`,
+//!    or `bun.lock`). Overrides targeting resolved transitive packages are
+//!    treated as used because CVE-fix pins often exist only in the lockfile.
+//!    When the only lockfile is bun's legacy binary `bun.lockb`, resolution
+//!    ground truth is unreadable, so no unused-override findings are emitted
+//!    at all rather than degrading to declaration-only analysis that would
+//!    flag every transitive-only pin.
 //!
 //! 2. **`misconfigured-dependency-overrides`**: an override whose key cannot
 //!    be parsed or whose value is empty. `pnpm install` refuses to honor
@@ -56,8 +56,10 @@ use rustc_hash::FxHashSet;
 const PNPM_WORKSPACE_FILE: &str = "pnpm-workspace.yaml";
 const PNPM_LOCK_FILE: &str = "pnpm-lock.yaml";
 const NPM_LOCK_FILE: &str = "package-lock.json";
+const NPM_SHRINKWRAP_FILE: &str = "npm-shrinkwrap.json";
 const BUN_LOCK_FILE: &str = "bun.lock";
 const BUN_LOCKB_FILE: &str = "bun.lockb";
+const YARN_LOCK_FILE: &str = "yarn.lock";
 const NODE_MODULES_SEGMENT: &str = "node_modules/";
 const ROOT_PACKAGE_JSON: &str = "package.json";
 const SOURCE_LABEL_YAML: &str = "pnpm-workspace.yaml";
@@ -68,6 +70,8 @@ const HINT_MAY_BE_TRANSITIVE_BUN: &str =
     "may target a transitive dependency; bun install --frozen-lockfile is the ground truth";
 const HINT_MAY_BE_TRANSITIVE_NPM: &str =
     "may target a transitive dependency; npm ci is the ground truth";
+const HINT_OVERRIDES_IGNORED_BY_YARN: &str =
+    "yarn does not apply `overrides`; declare the pin under `resolutions` instead";
 const LOCKFILE_DEPENDENCY_SECTIONS: &[&str] = &[
     "dependencies",
     "optionalDependencies",
@@ -93,16 +97,18 @@ pub struct PnpmOverrideState {
     /// `package.json` (root + members).
     declared_packages: FxHashSet<String>,
     /// Every package name found in `pnpm-lock.yaml` package/snapshot keys,
-    /// `package-lock.json` package paths, `bun.lock` package specifiers, or
-    /// dependency sections of any of those lockfiles. Includes transitive
-    /// dependencies resolved by the package manager.
+    /// `package-lock.json` / `npm-shrinkwrap.json` package paths, `bun.lock`
+    /// package specifiers, or dependency sections of any of those lockfiles.
+    /// Includes transitive dependencies resolved by the package manager.
     lockfile_packages: FxHashSet<String>,
-    /// True when the only resolution source is bun's binary `bun.lockb`
-    /// (no parseable text lockfile). Unused-override analysis is skipped in
-    /// that case because transitive resolution cannot be established.
+    /// True when the only resolution source is bun's binary `bun.lockb`,
+    /// with no parseable text lockfile alongside it. Unused-override analysis
+    /// is skipped in that case because transitive resolution cannot be
+    /// established.
     lockfile_resolution_unavailable: bool,
     /// Package-manager-appropriate hint attached to every unused-override
-    /// finding, chosen from the lockfiles present at the root.
+    /// finding, chosen from the root `package.json` `packageManager` field
+    /// first and the lockfiles present at the root as fallback.
     transitive_hint: &'static str,
 }
 
@@ -148,7 +154,7 @@ pub fn gather_pnpm_override_state(
     }
 
     let declared_packages = collect_declared_packages(config, workspaces);
-    let lockfile_resolution = collect_lockfile_packages(config);
+    let lockfile_resolution = collect_lockfile_packages(config, root_pkg_source.as_deref());
 
     Some(PnpmOverrideState {
         workspace_yaml_data,
@@ -207,14 +213,18 @@ struct LockfileResolution {
     transitive_hint: &'static str,
 }
 
-/// Parse `pnpm-lock.yaml`, `package-lock.json`, and `bun.lock` and collect
-/// package names from resolved package keys plus dependency maps. Malformed or
-/// missing lockfiles degrade to an empty set, preserving the package.json-only
-/// fallback for projects without a lockfile. The one exception is bun's binary
-/// `bun.lockb` without a parseable text `bun.lock`: resolution exists but is
-/// unreadable, so `resolution_unavailable` is set and callers skip the unused
-/// analysis instead of flagging every transitive-only override.
-fn collect_lockfile_packages(config: &ResolvedConfig) -> LockfileResolution {
+/// Parse `pnpm-lock.yaml`, `package-lock.json` / `npm-shrinkwrap.json`, and
+/// `bun.lock` and collect package names from resolved package keys plus
+/// dependency maps. Malformed or missing lockfiles degrade to an empty set,
+/// preserving the package.json-only fallback for projects without a lockfile.
+/// The one exception is bun's binary `bun.lockb` without any parseable text
+/// lockfile alongside it: resolution exists but is unreadable, so
+/// `resolution_unavailable` is set and callers skip the unused analysis
+/// instead of flagging every transitive-only override.
+fn collect_lockfile_packages(
+    config: &ResolvedConfig,
+    root_pkg_source: Option<&str>,
+) -> LockfileResolution {
     let mut packages = FxHashSet::default();
 
     let mut has_pnpm_lock = false;
@@ -222,10 +232,15 @@ fn collect_lockfile_packages(config: &ResolvedConfig) -> LockfileResolution {
         has_pnpm_lock = true;
         packages.extend(collect_pnpm_lock_packages(&raw_source));
     }
+    // npm renames package-lock.json to npm-shrinkwrap.json for publishable
+    // packages; the format is identical and a shrinkwrap repo usually carries
+    // no package-lock.json at all.
     let mut has_npm_lock = false;
-    if let Ok(raw_source) = std::fs::read_to_string(config.root.join(NPM_LOCK_FILE)) {
-        has_npm_lock = true;
-        packages.extend(collect_npm_lock_packages(&raw_source));
+    for npm_lock_file in [NPM_LOCK_FILE, NPM_SHRINKWRAP_FILE] {
+        if let Ok(raw_source) = std::fs::read_to_string(config.root.join(npm_lock_file)) {
+            has_npm_lock = true;
+            packages.extend(collect_npm_lock_packages(&raw_source));
+        }
     }
 
     let mut has_bun_lock = false;
@@ -238,21 +253,56 @@ fn collect_lockfile_packages(config: &ResolvedConfig) -> LockfileResolution {
         }
     }
     let has_bun_lockb = config.root.join(BUN_LOCKB_FILE).exists();
+    let has_yarn_lock = config.root.join(YARN_LOCK_FILE).exists();
 
-    let transitive_hint = if has_pnpm_lock {
-        HINT_MAY_BE_TRANSITIVE_PNPM
-    } else if has_bun_lock || has_bun_lockb {
-        HINT_MAY_BE_TRANSITIVE_BUN
-    } else if has_npm_lock {
-        HINT_MAY_BE_TRANSITIVE_NPM
-    } else {
-        HINT_MAY_BE_TRANSITIVE_PNPM
+    let transitive_hint = match declared_package_manager(root_pkg_source) {
+        Some(DeclaredPackageManager::Bun) => HINT_MAY_BE_TRANSITIVE_BUN,
+        Some(DeclaredPackageManager::Npm) => HINT_MAY_BE_TRANSITIVE_NPM,
+        Some(DeclaredPackageManager::Yarn) => HINT_OVERRIDES_IGNORED_BY_YARN,
+        None if has_pnpm_lock => HINT_MAY_BE_TRANSITIVE_PNPM,
+        None if has_bun_lock || has_bun_lockb => HINT_MAY_BE_TRANSITIVE_BUN,
+        None if has_npm_lock => HINT_MAY_BE_TRANSITIVE_NPM,
+        None if has_yarn_lock => HINT_OVERRIDES_IGNORED_BY_YARN,
+        Some(DeclaredPackageManager::Pnpm) | None => HINT_MAY_BE_TRANSITIVE_PNPM,
     };
 
     LockfileResolution {
         packages,
-        resolution_unavailable: has_bun_lockb && !bun_lock_parsed,
+        // A parseable pnpm or npm lockfile is complete resolution ground
+        // truth on its own; a stale leftover bun.lockb must not silently
+        // disable the analysis when one is present.
+        resolution_unavailable: has_bun_lockb
+            && !bun_lock_parsed
+            && !has_pnpm_lock
+            && !has_npm_lock,
         transitive_hint,
+    }
+}
+
+/// Package managers the corepack `packageManager` field can name.
+#[derive(Clone, Copy)]
+enum DeclaredPackageManager {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+}
+
+/// Read the corepack `packageManager` field (`"bun@1.3.2"` names bun) from
+/// the root `package.json` source. Mirrors the packageManager-first probes in
+/// the CLI package-manager detectors so the transitive hint cannot name a
+/// package manager the repository does not use, for example a bun repo whose
+/// lockfile is not committed yet.
+fn declared_package_manager(root_pkg_source: Option<&str>) -> Option<DeclaredPackageManager> {
+    let value: serde_json::Value = serde_json::from_str(root_pkg_source?).ok()?;
+    let field = value.get("packageManager")?.as_str()?;
+    let name = field.split('@').next().unwrap_or(field);
+    match name {
+        "npm" => Some(DeclaredPackageManager::Npm),
+        "pnpm" => Some(DeclaredPackageManager::Pnpm),
+        "yarn" => Some(DeclaredPackageManager::Yarn),
+        "bun" => Some(DeclaredPackageManager::Bun),
+        _ => None,
     }
 }
 
@@ -263,6 +313,12 @@ fn collect_lockfile_packages(config: &ResolvedConfig) -> LockfileResolution {
 /// sections under `workspaces` and inside package metadata are covered by the
 /// shared dependency-map walk. Returns `None` when the file does not parse,
 /// so callers can distinguish "no resolution data" from an empty project.
+///
+/// Known limitation: the dependency-map walk also credits `peerDependencies`
+/// entries that bun lists under `optionalPeers` without installing them,
+/// matching package-lock.json behavior. The collected set means "resolvable",
+/// not "actually installed", so an override targeting such a peer is
+/// conservatively treated as used (a false negative, never removal advice).
 fn collect_bun_lock_packages(source: &str) -> Option<FxHashSet<String>> {
     let Ok(value) = fallow_config::jsonc::parse_to_value::<serde_json::Value>(source) else {
         return None;

--- a/crates/core/src/analyze/unused_overrides.rs
+++ b/crates/core/src/analyze/unused_overrides.rs
@@ -10,16 +10,21 @@
 //! npm supports the same mechanism through a top-level `overrides` object in
 //! the root `package.json`, with nesting instead of `parent>child` keys. The
 //! npm parser flattens nested objects into the shared entry shape, so all
-//! three sources run through one analysis path. yarn `resolutions` and bun
-//! overrides are out of scope.
+//! three sources run through one analysis path. bun declares overrides through
+//! the same top-level `overrides` key, so bun repos are analyzed via the npm
+//! parser and resolved against `bun.lock`. yarn `resolutions` is out of scope.
 //!
 //! Two findings are emitted:
 //!
 //! 1. **`unused-dependency-overrides`**: an override whose target package is
 //!    absent from both workspace `package.json` dep sections and the
-//!    lockfile (`pnpm-lock.yaml` or `package-lock.json`). Overrides targeting
-//!    resolved transitive packages are treated as used because CVE-fix pins
-//!    often exist only in the lockfile.
+//!    lockfile (`pnpm-lock.yaml`, `package-lock.json`, or `bun.lock`).
+//!    Overrides targeting resolved transitive packages are treated as used
+//!    because CVE-fix pins often exist only in the lockfile. When the only
+//!    lockfile is bun's legacy binary `bun.lockb`, resolution ground truth is
+//!    unreadable, so no unused-override findings are emitted at all rather
+//!    than degrading to declaration-only analysis that would flag every
+//!    transitive-only pin.
 //!
 //! 2. **`misconfigured-dependency-overrides`**: an override whose key cannot
 //!    be parsed or whose value is empty. `pnpm install` refuses to honor
@@ -51,12 +56,18 @@ use rustc_hash::FxHashSet;
 const PNPM_WORKSPACE_FILE: &str = "pnpm-workspace.yaml";
 const PNPM_LOCK_FILE: &str = "pnpm-lock.yaml";
 const NPM_LOCK_FILE: &str = "package-lock.json";
+const BUN_LOCK_FILE: &str = "bun.lock";
+const BUN_LOCKB_FILE: &str = "bun.lockb";
 const NODE_MODULES_SEGMENT: &str = "node_modules/";
 const ROOT_PACKAGE_JSON: &str = "package.json";
 const SOURCE_LABEL_YAML: &str = "pnpm-workspace.yaml";
 const SOURCE_LABEL_JSON: &str = "package.json";
-const HINT_MAY_BE_TRANSITIVE: &str =
+const HINT_MAY_BE_TRANSITIVE_PNPM: &str =
     "may target a transitive dependency; pnpm install --frozen-lockfile is the ground truth";
+const HINT_MAY_BE_TRANSITIVE_BUN: &str =
+    "may target a transitive dependency; bun install --frozen-lockfile is the ground truth";
+const HINT_MAY_BE_TRANSITIVE_NPM: &str =
+    "may target a transitive dependency; npm ci is the ground truth";
 const LOCKFILE_DEPENDENCY_SECTIONS: &[&str] = &[
     "dependencies",
     "optionalDependencies",
@@ -82,10 +93,17 @@ pub struct PnpmOverrideState {
     /// `package.json` (root + members).
     declared_packages: FxHashSet<String>,
     /// Every package name found in `pnpm-lock.yaml` package/snapshot keys,
-    /// `package-lock.json` package paths, or dependency sections of either
-    /// lockfile. Includes transitive dependencies resolved by the package
-    /// manager.
+    /// `package-lock.json` package paths, `bun.lock` package specifiers, or
+    /// dependency sections of any of those lockfiles. Includes transitive
+    /// dependencies resolved by the package manager.
     lockfile_packages: FxHashSet<String>,
+    /// True when the only resolution source is bun's binary `bun.lockb`
+    /// (no parseable text lockfile). Unused-override analysis is skipped in
+    /// that case because transitive resolution cannot be established.
+    lockfile_resolution_unavailable: bool,
+    /// Package-manager-appropriate hint attached to every unused-override
+    /// finding, chosen from the lockfiles present at the root.
+    transitive_hint: &'static str,
 }
 
 /// Read both override sources and walk workspace `package.json` files to build
@@ -130,14 +148,16 @@ pub fn gather_pnpm_override_state(
     }
 
     let declared_packages = collect_declared_packages(config, workspaces);
-    let lockfile_packages = collect_lockfile_packages(config);
+    let lockfile_resolution = collect_lockfile_packages(config);
 
     Some(PnpmOverrideState {
         workspace_yaml_data,
         package_json_data,
         npm_package_json_data,
         declared_packages,
-        lockfile_packages,
+        lockfile_packages: lockfile_resolution.packages,
+        lockfile_resolution_unavailable: lockfile_resolution.resolution_unavailable,
+        transitive_hint: lockfile_resolution.transitive_hint,
     })
 }
 
@@ -179,21 +199,98 @@ fn collect_declared_packages(
     set
 }
 
-/// Parse `pnpm-lock.yaml` and `package-lock.json` and collect package names
-/// from resolved package keys plus dependency maps. Malformed or missing
-/// lockfiles degrade to an empty set, preserving the package.json-only
-/// fallback for projects without a lockfile.
-fn collect_lockfile_packages(config: &ResolvedConfig) -> FxHashSet<String> {
+/// Resolved-package set gathered from every recognized lockfile at the root,
+/// plus the derived analysis knobs that depend on which lockfiles exist.
+struct LockfileResolution {
+    packages: FxHashSet<String>,
+    resolution_unavailable: bool,
+    transitive_hint: &'static str,
+}
+
+/// Parse `pnpm-lock.yaml`, `package-lock.json`, and `bun.lock` and collect
+/// package names from resolved package keys plus dependency maps. Malformed or
+/// missing lockfiles degrade to an empty set, preserving the package.json-only
+/// fallback for projects without a lockfile. The one exception is bun's binary
+/// `bun.lockb` without a parseable text `bun.lock`: resolution exists but is
+/// unreadable, so `resolution_unavailable` is set and callers skip the unused
+/// analysis instead of flagging every transitive-only override.
+fn collect_lockfile_packages(config: &ResolvedConfig) -> LockfileResolution {
     let mut packages = FxHashSet::default();
 
+    let mut has_pnpm_lock = false;
     if let Ok(raw_source) = std::fs::read_to_string(config.root.join(PNPM_LOCK_FILE)) {
+        has_pnpm_lock = true;
         packages.extend(collect_pnpm_lock_packages(&raw_source));
     }
+    let mut has_npm_lock = false;
     if let Ok(raw_source) = std::fs::read_to_string(config.root.join(NPM_LOCK_FILE)) {
+        has_npm_lock = true;
         packages.extend(collect_npm_lock_packages(&raw_source));
     }
 
-    packages
+    let mut has_bun_lock = false;
+    let mut bun_lock_parsed = false;
+    if let Ok(raw_source) = std::fs::read_to_string(config.root.join(BUN_LOCK_FILE)) {
+        has_bun_lock = true;
+        if let Some(bun_packages) = collect_bun_lock_packages(&raw_source) {
+            packages.extend(bun_packages);
+            bun_lock_parsed = true;
+        }
+    }
+    let has_bun_lockb = config.root.join(BUN_LOCKB_FILE).exists();
+
+    let transitive_hint = if has_pnpm_lock {
+        HINT_MAY_BE_TRANSITIVE_PNPM
+    } else if has_bun_lock || has_bun_lockb {
+        HINT_MAY_BE_TRANSITIVE_BUN
+    } else if has_npm_lock {
+        HINT_MAY_BE_TRANSITIVE_NPM
+    } else {
+        HINT_MAY_BE_TRANSITIVE_PNPM
+    };
+
+    LockfileResolution {
+        packages,
+        resolution_unavailable: has_bun_lockb && !bun_lock_parsed,
+        transitive_hint,
+    }
+}
+
+/// Collect package names from bun's text lockfile (`bun.lock`, bun 1.2+).
+/// The file is JSONC (bun writes trailing commas); every entry in the
+/// `packages` map is keyed by dependency-tree path and holds a tuple whose
+/// first element is the resolved `name@version` specifier. Dependency
+/// sections under `workspaces` and inside package metadata are covered by the
+/// shared dependency-map walk. Returns `None` when the file does not parse,
+/// so callers can distinguish "no resolution data" from an empty project.
+fn collect_bun_lock_packages(source: &str) -> Option<FxHashSet<String>> {
+    let Ok(value) = fallow_config::jsonc::parse_to_value::<serde_json::Value>(source) else {
+        return None;
+    };
+    // Empty/whitespace input parses as `null`; a valid bun.lock is always an
+    // object, so anything else counts as unparseable.
+    if !value.is_object() {
+        return None;
+    }
+
+    let mut packages = FxHashSet::default();
+    if let Some(mapping) = value.get("packages").and_then(serde_json::Value::as_object) {
+        for entry in mapping.values() {
+            let Some(specifier) = entry
+                .as_array()
+                .and_then(|tuple| tuple.first())
+                .and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            if let Some(package_name) = package_name_from_lock_key(specifier) {
+                packages.insert(package_name);
+            }
+        }
+    }
+
+    collect_json_dependency_map_names(&value, &mut packages);
+    Some(packages)
 }
 
 /// Collect package names from `package-lock.json`. Lockfile v2/v3 keys the
@@ -324,7 +421,7 @@ fn package_name_from_lock_key(raw_key: &str) -> Option<String> {
 
 /// Emit one `UnusedDependencyOverride` for every parseable override whose
 /// target package (and parent, when present) is not declared in any workspace
-/// `package.json` or resolved in `pnpm-lock.yaml`.
+/// `package.json` or resolved in any recognized lockfile.
 #[must_use]
 #[deprecated(
     since = "2.76.0",
@@ -334,6 +431,10 @@ pub fn find_unused_dependency_overrides(
     state: &PnpmOverrideState,
     config: &ResolvedConfig,
 ) -> Vec<UnusedDependencyOverride> {
+    if state.lockfile_resolution_unavailable {
+        return Vec::new();
+    }
+
     let mut findings = Vec::new();
     let yaml_path = config.root.join(PNPM_WORKSPACE_FILE);
     let json_path = config.root.join(ROOT_PACKAGE_JSON);
@@ -343,6 +444,7 @@ pub fn find_unused_dependency_overrides(
         source_path: &yaml_path,
         declared: &state.declared_packages,
         resolved: &state.lockfile_packages,
+        hint: state.transitive_hint,
         ignore_rules: &config.compiled_ignore_dependency_overrides,
         findings: &mut findings,
     });
@@ -352,6 +454,7 @@ pub fn find_unused_dependency_overrides(
         source_path: &json_path,
         declared: &state.declared_packages,
         resolved: &state.lockfile_packages,
+        hint: state.transitive_hint,
         ignore_rules: &config.compiled_ignore_dependency_overrides,
         findings: &mut findings,
     });
@@ -361,6 +464,7 @@ pub fn find_unused_dependency_overrides(
         source_path: &json_path,
         declared: &state.declared_packages,
         resolved: &state.lockfile_packages,
+        hint: state.transitive_hint,
         ignore_rules: &config.compiled_ignore_dependency_overrides,
         findings: &mut findings,
     });
@@ -373,6 +477,7 @@ struct UnusedOverrideSourceInput<'a> {
     source_path: &'a std::path::Path,
     declared: &'a FxHashSet<String>,
     resolved: &'a FxHashSet<String>,
+    hint: &'static str,
     ignore_rules: &'a [CompiledIgnoreDependencyOverrideRule],
     findings: &'a mut Vec<UnusedDependencyOverride>,
 }
@@ -417,7 +522,7 @@ fn collect_unused_from_source(input: &mut UnusedOverrideSourceInput<'_>) {
             continue;
         }
 
-        let hint = Some(HINT_MAY_BE_TRANSITIVE.to_string());
+        let hint = Some(input.hint.to_string());
 
         input.findings.push(UnusedDependencyOverride {
             raw_key: entry.raw_key.clone(),
@@ -654,5 +759,85 @@ mod tests {
     #[test]
     fn collect_lock_packages_empty_yields_empty() {
         assert!(collect_pnpm_lock_packages("").is_empty());
+    }
+
+    // Trimmed from a real `bun install` (bun 1.3.x) run; keeps bun's trailing
+    // commas so the JSONC dialect is exercised.
+    const BUN_LOCK_REAL_SHAPE: &str = r#"{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bun-repro",
+      "devDependencies": {
+        "happy-dom": "^20.10.6",
+      },
+    },
+  },
+  "overrides": {
+    "ws": "^8.21.0",
+  },
+  "packages": {
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2"],
+    "happy-dom": ["happy-dom@20.11.6", "", { "dependencies": { "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-Hl"],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt"],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-20"],
+  }
+}
+"#;
+
+    #[test]
+    fn collect_bun_lock_packages_real_shape() {
+        let packages = collect_bun_lock_packages(BUN_LOCK_REAL_SHAPE).expect("bun.lock parses");
+        for name in [
+            "happy-dom",
+            "ws",
+            "@types/whatwg-mimetype",
+            "whatwg-mimetype",
+        ] {
+            assert!(packages.contains(name), "missing {name}: {packages:?}");
+        }
+        assert!(
+            !packages.contains("bun-repro"),
+            "workspace name is not a resolved package"
+        );
+    }
+
+    #[test]
+    fn collect_bun_lock_packages_override_keys_are_not_credited_as_resolved() {
+        // bun mirrors the `overrides` map into bun.lock; only the resolved
+        // package graph may credit a target, otherwise every override would
+        // trivially count as used.
+        let source = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "name": "x" } },
+  "overrides": { "left-pad": "^1.3.0" },
+  "packages": {}
+}"#;
+        let packages = collect_bun_lock_packages(source).expect("parses");
+        assert!(!packages.contains("left-pad"), "got {packages:?}");
+    }
+
+    #[test]
+    fn collect_bun_lock_packages_nested_tree_path_uses_specifier_name() {
+        // Conflicting versions are keyed by tree path ("parent/child"); the
+        // resolved name comes from the tuple's first element.
+        let source = r#"{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "name": "x", "dependencies": { "parent-pkg": "^1.0.0" } } },
+  "packages": {
+    "parent-pkg": ["parent-pkg@1.0.0", "", { "dependencies": { "shared-dep": "^1.0.0" } }, "sha512-a"],
+    "parent-pkg/shared-dep": ["shared-dep@1.2.3", "", {}, "sha512-b"],
+  }
+}"#;
+        let packages = collect_bun_lock_packages(source).expect("parses");
+        assert!(packages.contains("shared-dep"), "got {packages:?}");
+        assert!(packages.contains("parent-pkg"), "got {packages:?}");
+    }
+
+    #[test]
+    fn collect_bun_lock_packages_malformed_returns_none() {
+        assert!(collect_bun_lock_packages("not json {{{").is_none());
+        assert!(collect_bun_lock_packages("").is_none());
     }
 }

--- a/crates/core/tests/integration_test/issue_336_unused_overrides.rs
+++ b/crates/core/tests/integration_test/issue_336_unused_overrides.rs
@@ -156,6 +156,143 @@ snapshots:
     );
 }
 
+// Trimmed from a real `bun install` run (bun 1.3.x); keeps bun's trailing
+// commas so the JSONC dialect is exercised end to end. `ws` is a transitive
+// dependency of `happy-dom`, declared in no dependency section.
+const BUN_LOCK_TRANSITIVE_WS: &str = r#"{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "issue-2341-bun-overrides",
+      "devDependencies": {
+        "happy-dom": "^20.10.6",
+      },
+    },
+  },
+  "overrides": {
+    "ws": "^8.21.0",
+  },
+  "packages": {
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2"],
+    "happy-dom": ["happy-dom@20.11.6", "", { "dependencies": { "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-Hl"],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt"],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-20"],
+  }
+}
+"#;
+
+fn write_bun_repro_package_json(root: &std::path::Path, overrides: &str) {
+    fs::write(
+        root.join("package.json"),
+        format!(
+            r#"{{
+  "name": "issue-2341-bun-overrides",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "bun@1.3.2",
+  "devDependencies": {{ "happy-dom": "^20.10.6" }},
+  "overrides": {overrides}
+}}"#
+        ),
+    )
+    .expect("write root package.json");
+}
+
+/// Issue #2341 repro: bun declares overrides through the npm-style top-level
+/// `overrides` key, and transitive resolution lives in `bun.lock`. The
+/// override target must be credited from the bun lockfile instead of being
+/// flagged as unused.
+#[test]
+fn transitive_only_targets_in_bun_lockfile_are_used() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_bun_repro_package_json(root, r#"{ "ws": "^8.21.0" }"#);
+    fs::write(root.join("bun.lock"), BUN_LOCK_TRANSITIVE_WS).expect("write bun.lock");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.unused_dependency_overrides.is_empty(),
+        "ws resolves in bun.lock as a transitive dependency of happy-dom; flagged: {:?}",
+        results.unused_dependency_overrides
+    );
+}
+
+#[test]
+fn unresolved_override_in_bun_repo_is_flagged_with_bun_hint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_bun_repro_package_json(root, r#"{ "left-pad": "^1.3.0" }"#);
+    fs::write(root.join("bun.lock"), BUN_LOCK_TRANSITIVE_WS).expect("write bun.lock");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let flagged: Vec<&str> = results
+        .unused_dependency_overrides
+        .iter()
+        .map(|f| f.entry.target_package.as_str())
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["left-pad"],
+        "left-pad appears in no dep section and not in bun.lock"
+    );
+    let hint = results.unused_dependency_overrides[0]
+        .entry
+        .hint
+        .as_deref()
+        .expect("unused override carries a hint");
+    assert!(
+        hint.contains("bun install"),
+        "hint should name bun, not pnpm, in a bun repo; got {hint:?}"
+    );
+}
+
+/// bun's legacy binary lockfile cannot be parsed, so resolution ground truth
+/// is unavailable; the analysis must stay silent instead of flagging every
+/// transitive-only override.
+#[test]
+fn bun_lockb_without_text_lockfile_suppresses_unused_overrides() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_bun_repro_package_json(root, r#"{ "ws": "^8.21.0" }"#);
+    fs::write(root.join("bun.lockb"), b"\x00binary lockfile\x01\x02").expect("write bun.lockb");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.unused_dependency_overrides.is_empty(),
+        "bun.lockb is unreadable; unused-override analysis must be skipped; flagged: {:?}",
+        results.unused_dependency_overrides
+    );
+}
+
+/// Misconfigured-override detection is static and does not depend on lockfile
+/// resolution, so it keeps reporting even when only `bun.lockb` exists.
+#[test]
+fn bun_lockb_does_not_suppress_misconfigured_overrides() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_bun_repro_package_json(root, r#"{ "ws": "" }"#);
+    fs::write(root.join("bun.lockb"), b"\x00binary lockfile\x01\x02").expect("write bun.lockb");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let any_empty_value = results.misconfigured_dependency_overrides.iter().any(|f| {
+        f.entry.raw_key == "ws" && f.entry.reason == DependencyOverrideMisconfigReason::EmptyValue
+    });
+    assert!(
+        any_empty_value,
+        "empty-value override must stay reported with bun.lockb present; got {:?}",
+        results.misconfigured_dependency_overrides
+    );
+}
+
 #[test]
 fn detects_misconfigured_overrides() {
     let root = fixture_path("issue-336-unused-overrides");

--- a/crates/core/tests/integration_test/issue_336_unused_overrides.rs
+++ b/crates/core/tests/integration_test/issue_336_unused_overrides.rs
@@ -271,6 +271,266 @@ fn bun_lockb_without_text_lockfile_suppresses_unused_overrides() {
     );
 }
 
+/// A stale leftover `bun.lockb` next to a parseable pnpm lockfile (bun repo
+/// migrated to pnpm, or a one-off `bun install` in a pnpm repo) must not
+/// disable the analysis: pnpm-lock.yaml is complete resolution ground truth.
+#[test]
+fn bun_lockb_alongside_pnpm_lockfile_keeps_analysis_running() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "issue-2341-bun-lockb-leftover",
+  "private": true,
+  "version": "0.0.0",
+  "devDependencies": { "happy-dom": "^20.10.6" },
+  "overrides": { "ws": "^8.21.0", "left-pad": "^1.3.0" }
+}"#,
+    )
+    .expect("write root package.json");
+    fs::write(
+        root.join("pnpm-lock.yaml"),
+        r"lockfileVersion: '9.0'
+
+packages:
+  happy-dom@20.11.6:
+    resolution: {integrity: sha512-Hl}
+  ws@8.21.3:
+    resolution: {integrity: sha512-20}
+
+snapshots:
+  happy-dom@20.11.6:
+    dependencies:
+      ws: 8.21.3
+  ws@8.21.3: {}
+",
+    )
+    .expect("write pnpm lockfile");
+    fs::write(root.join("bun.lockb"), b"\x00binary lockfile\x01\x02").expect("write bun.lockb");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let flagged: Vec<&str> = results
+        .unused_dependency_overrides
+        .iter()
+        .map(|f| f.entry.target_package.as_str())
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["left-pad"],
+        "pnpm-lock.yaml resolves ws; the stale bun.lockb must not suppress the whole check"
+    );
+}
+
+/// npm renames `package-lock.json` to `npm-shrinkwrap.json` for publishable
+/// packages; the format is identical, so shrinkwrap repos must get the same
+/// transitive-resolution crediting instead of declaration-only degradation.
+#[test]
+fn transitive_only_targets_in_npm_shrinkwrap_are_used() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "shrinkwrap-overrides",
+  "private": true,
+  "version": "0.0.0",
+  "overrides": { "postcss": ">=8.5.10", "left-pad": "^1.3.0" }
+}"#,
+    )
+    .expect("write root package.json");
+    fs::write(
+        root.join("npm-shrinkwrap.json"),
+        r#"{
+  "name": "shrinkwrap-overrides",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "name": "shrinkwrap-overrides", "version": "0.0.0" },
+    "node_modules/postcss": { "version": "8.5.10" }
+  }
+}"#,
+    )
+    .expect("write npm shrinkwrap");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let flagged: Vec<&str> = results
+        .unused_dependency_overrides
+        .iter()
+        .map(|f| f.entry.target_package.as_str())
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["left-pad"],
+        "postcss resolves in npm-shrinkwrap.json; only left-pad is unused"
+    );
+    let hint = results.unused_dependency_overrides[0]
+        .entry
+        .hint
+        .as_deref()
+        .expect("unused override carries a hint");
+    assert!(
+        hint.contains("npm ci"),
+        "hint should name npm in a shrinkwrap repo; got {hint:?}"
+    );
+}
+
+/// A malformed text `bun.lock` deliberately degrades to declaration-only
+/// analysis (matching the pnpm/npm malformed-lockfile philosophy), so the
+/// transitive-only override is flagged again, with the bun-flavored hint.
+#[test]
+fn malformed_bun_lock_degrades_to_declaration_only_with_bun_hint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_bun_repro_package_json(root, r#"{ "ws": "^8.21.0" }"#);
+    fs::write(root.join("bun.lock"), "not json {{{").expect("write bun.lock");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let flagged: Vec<&str> = results
+        .unused_dependency_overrides
+        .iter()
+        .map(|f| f.entry.target_package.as_str())
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["ws"],
+        "a malformed bun.lock degrades to declaration-only analysis"
+    );
+    let hint = results.unused_dependency_overrides[0]
+        .entry
+        .hint
+        .as_deref()
+        .expect("unused override carries a hint");
+    assert!(
+        hint.contains("bun install"),
+        "hint should name bun for a bun.lock repo; got {hint:?}"
+    );
+}
+
+/// The `packageManager` field alone (lockfile not committed yet) must pick
+/// the bun hint instead of falling back to the pnpm wording from the issue's
+/// closing paragraph.
+#[test]
+fn package_manager_field_selects_bun_hint_without_lockfile() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_bun_repro_package_json(root, r#"{ "left-pad": "^1.3.0" }"#);
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let hint = results
+        .unused_dependency_overrides
+        .first()
+        .and_then(|f| f.entry.hint.as_deref())
+        .expect("declaration-only fallback still flags left-pad with a hint");
+    assert!(
+        hint.contains("bun install"),
+        "packageManager: bun must select the bun hint even without a lockfile; got {hint:?}"
+    );
+}
+
+/// yarn (classic and berry) resolves version pins through `resolutions` and
+/// never applies the npm `overrides` object, so a yarn repo gets a hint that
+/// explains the entry is inert instead of citing a pnpm command.
+#[test]
+fn yarn_repo_gets_resolutions_hint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "yarn-overrides",
+  "private": true,
+  "version": "0.0.0",
+  "overrides": { "ws": "^8.21.0" }
+}"#,
+    )
+    .expect("write root package.json");
+    fs::write(root.join("yarn.lock"), "# yarn lockfile v1\n").expect("write yarn.lock");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let hint = results
+        .unused_dependency_overrides
+        .first()
+        .and_then(|f| f.entry.hint.as_deref())
+        .expect("inert overrides entry in a yarn repo is flagged with a hint");
+    assert!(
+        hint.contains("resolutions"),
+        "yarn repos should be pointed at `resolutions`; got {hint:?}"
+    );
+}
+
+/// bun workspace shape: the override target resolves only through a workspace
+/// member's dependency, keyed in the shared top-level `packages` map.
+#[test]
+fn bun_workspace_member_transitive_targets_are_used() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "bun-workspace-root",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "bun@1.3.2",
+  "workspaces": ["packages/*"],
+  "overrides": { "ws": "^8.21.0" }
+}"#,
+    )
+    .expect("write root package.json");
+    fs::create_dir_all(root.join("packages/app")).expect("member dir");
+    fs::write(
+        root.join("packages/app/package.json"),
+        r#"{ "name": "@repro/app", "version": "0.0.0", "devDependencies": { "happy-dom": "^20.10.6" } }"#,
+    )
+    .expect("write member package.json");
+    fs::write(
+        root.join("bun.lock"),
+        r#"{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bun-workspace-root",
+    },
+    "packages/app": {
+      "name": "@repro/app",
+      "devDependencies": {
+        "happy-dom": "^20.10.6",
+      },
+    },
+  },
+  "overrides": {
+    "ws": "^8.21.0",
+  },
+  "packages": {
+    "@repro/app": ["@repro/app@workspace:packages/app"],
+    "happy-dom": ["happy-dom@20.11.6", "", { "dependencies": { "ws": "^8.21.0" } }, "sha512-Hl"],
+    "ws": ["ws@8.21.3", "", {}, "sha512-20"],
+  }
+}
+"#,
+    )
+    .expect("write bun.lock");
+
+    let config = config_for_fixture(root.to_path_buf(), vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert!(
+        results.unused_dependency_overrides.is_empty(),
+        "ws resolves in bun.lock via the workspace member's dependency; flagged: {:?}",
+        results.unused_dependency_overrides
+    );
+}
+
 /// Misconfigured-override detection is static and does not depend on lockfile
 /// resolution, so it keeps reporting even when only `bun.lockb` exists.
 #[test]

--- a/crates/types/src/output_dead_code.rs
+++ b/crates/types/src/output_dead_code.rs
@@ -2515,10 +2515,10 @@ impl UnusedDependencyOverrideFinding {
         actions.push(IssueAction::Fix(FixAction {
             kind: FixActionType::RemoveDependencyOverride,
             auto_fixable: false,
-            description: "Remove the override entry from pnpm-workspace.yaml or pnpm.overrides"
+            description: "Remove the override entry from its declaration source (pnpm-workspace.yaml overrides, pnpm.overrides, or the package.json overrides object)"
                 .to_string(),
             note: Some(
-                "Conservative static check; verify against `pnpm install --frozen-lockfile` before removing in case the override targets a transitive dependency (CVE-fix pattern)"
+                "Conservative static check; verify against a frozen-lockfile install (`pnpm install --frozen-lockfile`, `npm ci`, or `bun install --frozen-lockfile`) before removing in case the override targets a transitive dependency (CVE-fix pattern)"
                     .to_string(),
             ),
             available_in_catalogs: None,

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -371,12 +371,12 @@ pub struct AnalysisResults {
     /// Entries in pnpm-workspace.yaml's overrides: section, package.json's
     /// pnpm.overrides block, or package.json's top-level npm overrides object,
     /// whose target package is not declared by any workspace package and is
-    /// not present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default
-    /// severity is warn because projects without a readable lockfile fall back
-    /// to manifest-only checks; the hint field flags those conservative cases.
-    /// When the only lockfile is bun's binary bun.lockb, resolution cannot be
-    /// read and the check emits nothing. Wrapped in
-    /// [`UnusedDependencyOverrideFinding`].
+    /// not present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,
+    /// or bun.lock. Default severity is warn because projects without a
+    /// readable lockfile fall back to manifest-only checks; the hint field
+    /// flags those conservative cases. When the only lockfile is bun's binary
+    /// bun.lockb, resolution cannot be read and the check emits nothing.
+    /// Wrapped in [`UnusedDependencyOverrideFinding`].
     #[serde(default)]
     pub unused_dependency_overrides: Vec<UnusedDependencyOverrideFinding>,
     /// pnpm.overrides or npm overrides entries whose key or value does not

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -371,10 +371,12 @@ pub struct AnalysisResults {
     /// Entries in pnpm-workspace.yaml's overrides: section, package.json's
     /// pnpm.overrides block, or package.json's top-level npm overrides object,
     /// whose target package is not declared by any workspace package and is
-    /// not present in pnpm-lock.yaml or package-lock.json. Default severity
-    /// is warn because projects without a readable lockfile fall back to
-    /// manifest-only checks; the hint field flags those conservative cases.
-    /// Wrapped in [`UnusedDependencyOverrideFinding`].
+    /// not present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default
+    /// severity is warn because projects without a readable lockfile fall back
+    /// to manifest-only checks; the hint field flags those conservative cases.
+    /// When the only lockfile is bun's binary bun.lockb, resolution cannot be
+    /// read and the check emits nothing. Wrapped in
+    /// [`UnusedDependencyOverrideFinding`].
     #[serde(default)]
     pub unused_dependency_overrides: Vec<UnusedDependencyOverrideFinding>,
     /// pnpm.overrides or npm overrides entries whose key or value does not

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -697,7 +697,7 @@
           "items": {
             "$ref": "#/definitions/UnusedDependencyOverrideFinding"
           },
-          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml or package-lock.json. Default severity\nis warn because projects without a readable lockfile fall back to\nmanifest-only checks; the hint field flags those conservative cases.\nWrapped in [`UnusedDependencyOverrideFinding`]."
+          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default\nseverity is warn because projects without a readable lockfile fall back\nto manifest-only checks; the hint field flags those conservative cases.\nWhen the only lockfile is bun's binary bun.lockb, resolution cannot be\nread and the check emits nothing. Wrapped in\n[`UnusedDependencyOverrideFinding`]."
         },
         "misconfigured_dependency_overrides": {
           "type": "array",
@@ -1187,7 +1187,7 @@
           "items": {
             "$ref": "#/definitions/UnusedDependencyOverrideFinding"
           },
-          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml or package-lock.json. Default severity\nis warn because projects without a readable lockfile fall back to\nmanifest-only checks; the hint field flags those conservative cases.\nWrapped in [`UnusedDependencyOverrideFinding`]."
+          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default\nseverity is warn because projects without a readable lockfile fall back\nto manifest-only checks; the hint field flags those conservative cases.\nWhen the only lockfile is bun's binary bun.lockb, resolution cannot be\nread and the check emits nothing. Wrapped in\n[`UnusedDependencyOverrideFinding`]."
         },
         "misconfigured_dependency_overrides": {
           "type": "array",
@@ -6406,7 +6406,7 @@
           "items": {
             "$ref": "#/definitions/UnusedDependencyOverrideFinding"
           },
-          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml or package-lock.json. Default severity\nis warn because projects without a readable lockfile fall back to\nmanifest-only checks; the hint field flags those conservative cases.\nWrapped in [`UnusedDependencyOverrideFinding`]."
+          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default\nseverity is warn because projects without a readable lockfile fall back\nto manifest-only checks; the hint field flags those conservative cases.\nWhen the only lockfile is bun's binary bun.lockb, resolution cannot be\nread and the check emits nothing. Wrapped in\n[`UnusedDependencyOverrideFinding`]."
         },
         "misconfigured_dependency_overrides": {
           "type": "array",

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -697,7 +697,7 @@
           "items": {
             "$ref": "#/definitions/UnusedDependencyOverrideFinding"
           },
-          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default\nseverity is warn because projects without a readable lockfile fall back\nto manifest-only checks; the hint field flags those conservative cases.\nWhen the only lockfile is bun's binary bun.lockb, resolution cannot be\nread and the check emits nothing. Wrapped in\n[`UnusedDependencyOverrideFinding`]."
+          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,\nor bun.lock. Default severity is warn because projects without a\nreadable lockfile fall back to manifest-only checks; the hint field\nflags those conservative cases. When the only lockfile is bun's binary\nbun.lockb, resolution cannot be read and the check emits nothing.\nWrapped in [`UnusedDependencyOverrideFinding`]."
         },
         "misconfigured_dependency_overrides": {
           "type": "array",
@@ -1187,7 +1187,7 @@
           "items": {
             "$ref": "#/definitions/UnusedDependencyOverrideFinding"
           },
-          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default\nseverity is warn because projects without a readable lockfile fall back\nto manifest-only checks; the hint field flags those conservative cases.\nWhen the only lockfile is bun's binary bun.lockb, resolution cannot be\nread and the check emits nothing. Wrapped in\n[`UnusedDependencyOverrideFinding`]."
+          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,\nor bun.lock. Default severity is warn because projects without a\nreadable lockfile fall back to manifest-only checks; the hint field\nflags those conservative cases. When the only lockfile is bun's binary\nbun.lockb, resolution cannot be read and the check emits nothing.\nWrapped in [`UnusedDependencyOverrideFinding`]."
         },
         "misconfigured_dependency_overrides": {
           "type": "array",
@@ -6406,7 +6406,7 @@
           "items": {
             "$ref": "#/definitions/UnusedDependencyOverrideFinding"
           },
-          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, or bun.lock. Default\nseverity is warn because projects without a readable lockfile fall back\nto manifest-only checks; the hint field flags those conservative cases.\nWhen the only lockfile is bun's binary bun.lockb, resolution cannot be\nread and the check emits nothing. Wrapped in\n[`UnusedDependencyOverrideFinding`]."
+          "description": "Entries in pnpm-workspace.yaml's overrides: section, package.json's\npnpm.overrides block, or package.json's top-level npm overrides object,\nwhose target package is not declared by any workspace package and is\nnot present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,\nor bun.lock. Default severity is warn because projects without a\nreadable lockfile fall back to manifest-only checks; the hint field\nflags those conservative cases. When the only lockfile is bun's binary\nbun.lockb, resolution cannot be read and the check emits nothing.\nWrapped in [`UnusedDependencyOverrideFinding`]."
         },
         "misconfigured_dependency_overrides": {
           "type": "array",


### PR DESCRIPTION
## What was broken

In bun repositories, every `overrides` entry targeting a transitive-only dependency was reported under `unused_dependency_overrides`, even though the target resolves in `bun.lock`. The flagged set equaled `overrides - (dependencies + devDependencies)` exactly. These entries are commonly CVE-fix pins, so acting on the finding would be a security downgrade. The finding hint also cited `pnpm install --frozen-lockfile` in repos that have no pnpm.

## Root cause

bun declares overrides through the same top-level `overrides` key as npm, so the npm override parser (added in v3.11.0) picks them up. But `collect_lockfile_packages` in `crates/core/src/analyze/unused_overrides.rs` only read `pnpm-lock.yaml` and `package-lock.json`. With no recognized lockfile, the resolved-package set degraded to empty and the analysis fell back to declarations only, flagging every transitive-only override. bun overrides were out of scope for lockfile resolution but in scope for reporting.

## The fix

- Parse `bun.lock` (a JSONC file, bun writes trailing commas) through the shared `fallow_config::jsonc` helper. Each `packages`-map entry is credited from its resolved `name@version` specifier (first tuple element, which also handles nested `parent/child` tree-path keys and scoped names), and the existing recursive dependency-map walk covers the `workspaces` section and package metadata. The lockfile's mirrored top-level `overrides` map is deliberately not credited, so genuinely unused overrides stay reported.
- When the only lockfile is bun's legacy binary `bun.lockb` (no parseable text lockfile), resolution ground truth is unreadable, so unused-override analysis emits nothing instead of degrading to declaration-only false positives. Misconfigured-override detection is static and keeps reporting.
- The transitive hint now names the package manager whose lockfile is present: pnpm text for `pnpm-lock.yaml`, `bun install --frozen-lockfile` for bun lockfiles, `npm ci` for `package-lock.json` only, and the previous pnpm text as the no-lockfile fallback.
- Updated the `unused_dependency_overrides` rustdoc in `fallow-types` and regenerated `docs/output-schema.json` via `fallow-schema-emit` (description text only, no shape change).

## How it was tested

- Minimal failing repro first: `transitive_only_targets_in_bun_lockfile_are_used` reproduces the issue's exact scenario (happy-dom devDependency, `ws` override, real bun-generated `bun.lock`) and failed on unpatched main with the reported finding and pnpm hint; green after the fix.
- Regression coverage: genuinely unused override in a bun repo still flagged (with bun hint), `bun.lockb`-only suppression, misconfigured overrides unaffected by `bun.lockb`, plus unit tests for the `bun.lock` parser (real trimmed lockfile with trailing commas, nested tree-path keys, overrides-map non-crediting, malformed and empty input).
- Real-world validation: ran the built CLI on a project generated with real `bun install` (transitive `ws` no longer flagged, bogus override still flagged with bun hint) and on a production bun workspace's real 392KB `bun.lock` (945 resolved packages) mirrored with a scoped transitive-only override added: the transitive target was credited, only the bogus control override was flagged. A full `fallow check` on an unmodified real bun repo completes cleanly with zero override findings.
- Gates: `cargo fmt --all`, `cargo clippy --workspace --all-targets` clean, full `fallow-core` and `fallow-types` suites green, schema drift tests (`fallow-schema-emit`) and `schema_conformance` green, `cargo doc -p fallow-core` clean.

Fixes #2341
