### PR TITLE
fix(extract): stop reporting module augmentation interfaces as unused types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   jobs, while a credential-free gate downloads and validates the exact
   universal and platform-specific payloads from both registries.
 
+### Fixed
+
+- **Declarations inside `declare module '...'` augmentation and ambient-module
+  bodies are no longer reported as unused exports of the containing file**
+  (Closes [#2349](https://github.com/fallow-rs/fallow/issues/2349)). An
+  `export interface` inside a module augmentation describes the augmented
+  module, so following the previous remove-export advice broke type checking.
+  Named re-exports inside ambient bodies still credit their target symbols and
+  keep the source file reachable. The extraction cache version was bumped, so
+  the first run after upgrading performs one cold re-extract (relevant to CI
+  cache sizing). Existing `fallow-ignore` suppressions placed above
+  augmentation-scoped declarations as a workaround now surface as
+  stale-suppression findings (warn by default) and can be removed.
+
 ## [3.17.0] - 2026-08-16
 
 ### Added

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -75,6 +75,8 @@ mod html_entry;
 mod issue_1032_tsconfig_sibling_src_paths;
 #[path = "integration_test/issue_1304_effect_schema_same_name.rs"]
 mod issue_1304_effect_schema_same_name;
+#[path = "integration_test/issue_2349_module_augmentation.rs"]
+mod issue_2349_module_augmentation;
 #[path = "integration_test/issue_546_storybook_runtime_resources.rs"]
 mod issue_546_storybook_runtime_resources;
 #[path = "integration_test/issue_914_pnpm_bare_binary.rs"]

--- a/crates/core/tests/integration_test/issue_2349_module_augmentation.rs
+++ b/crates/core/tests/integration_test/issue_2349_module_augmentation.rs
@@ -1,0 +1,38 @@
+//! Issue #2349: an interface declared inside a `declare module './library'`
+//! augmentation block augments the named module. It is not an export of the
+//! declaring file and must not surface as `unused-type`, while genuinely
+//! unused exports outside the augmentation body in the same file must keep
+//! reporting.
+
+use super::common::{create_config, fixture_path};
+
+#[test]
+fn module_augmentation_interface_is_not_reported_unused() {
+    let root = fixture_path("issue-2349-module-augmentation");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_type_names: Vec<&str> = results
+        .unused_types
+        .iter()
+        .map(|t| t.export.export_name.as_str())
+        .collect();
+    let unused_export_names: Vec<&str> = results
+        .unused_exports
+        .iter()
+        .map(|e| e.export.export_name.as_str())
+        .collect();
+
+    assert!(
+        !unused_type_names.contains(&"Theme") && !unused_export_names.contains(&"Theme"),
+        "the augmentation-scoped `Theme` interface must not be reported as an \
+         unused export of theme-augmentation.ts; \
+         types: {unused_type_names:?}, exports: {unused_export_names:?}"
+    );
+    assert!(
+        unused_type_names.contains(&"UnusedLocalAlias")
+            || unused_export_names.contains(&"UnusedLocalAlias"),
+        "a genuinely unused export outside the `declare module` body must keep \
+         reporting; types: {unused_type_names:?}, exports: {unused_export_names:?}"
+    );
+}

--- a/crates/core/tests/integration_test/issue_2349_module_augmentation.rs
+++ b/crates/core/tests/integration_test/issue_2349_module_augmentation.rs
@@ -35,4 +35,23 @@ fn module_augmentation_interface_is_not_reported_unused() {
         "a genuinely unused export outside the `declare module` body must keep \
          reporting; types: {unused_type_names:?}, exports: {unused_export_names:?}"
     );
+
+    // ambient.d.ts re-exports `helper` from ./impl inside a
+    // `declare module 'untyped-pkg'` body. Deleting `helper` would break tsc,
+    // so the re-export must both keep impl.ts reachable and keep `helper`
+    // credited as used.
+    assert!(
+        !unused_export_names.contains(&"helper") && !unused_type_names.contains(&"helper"),
+        "`helper` is re-exported from an ambient module body and must keep its \
+         export credit; types: {unused_type_names:?}, exports: {unused_export_names:?}"
+    );
+    let unused_files: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.file.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    assert!(
+        !unused_files.iter().any(|p| p.ends_with("impl.ts")),
+        "impl.ts is reachable via the ambient-module re-export: {unused_files:?}"
+    );
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -934,7 +934,12 @@ use crate::MemberKind;
 /// its own `<snippet:NAME>` complexity unit and rebases the body's nesting to
 /// zero, changing the serialized `module.complexity` for snippet-using files.
 /// Warm 270 caches would keep the folded single-unit shape.
-pub(super) const CACHE_VERSION: u32 = 271;
+///
+/// Bumped to 272 for issue #2349: exports declared inside
+/// `declare module '<specifier>'` augmentation and ambient-module bodies are no
+/// longer recorded as file-level exports. Warm 271 caches would keep replaying
+/// augmentation-scoped declarations as unused exported types.
+pub(super) const CACHE_VERSION: u32 = 272;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -397,6 +397,12 @@ pub(crate) struct ModuleInfoExtractor {
     native_html_element_alias_candidates: FxHashSet<String>,
     structural_class_call_candidates: Vec<StructuralClassCallCandidate>,
     namespace_depth: u32,
+    /// Depth of `declare module '<specifier>' { ... }` ambient-module and
+    /// module-augmentation bodies currently being walked. Inner `export`
+    /// statements describe the named module, not the containing file, so
+    /// file-level export recording is suppressed while non-zero (issue #2349).
+    /// Transient visitor state; never persisted.
+    ambient_module_depth: u32,
     pending_namespace_members: Vec<MemberInfo>,
     class_heritage: Vec<ClassHeritageInfo>,
     /// `(token_export_name, interface_name)` for `new InjectionToken<I>(...)`

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -5197,7 +5197,7 @@ fn ambient_module_declaration_exports_are_not_file_exports() {
 fn ambient_module_named_re_export_keeps_reference_without_file_export() {
     let info = parse(
         "declare module 'pkg' {\n\
-           export { helper } from './impl';\n\
+           export { helper, other as renamed } from './impl';\n\
          }\n\
          export {};\n",
     );
@@ -5207,11 +5207,48 @@ fn ambient_module_named_re_export_keeps_reference_without_file_export() {
         info.exports,
         info.re_exports
     );
+    // One Named type-space import per specifier: the target file stays
+    // reachable and each re-exported symbol keeps its export credit.
+    let entries: Vec<_> = info
+        .imports
+        .iter()
+        .filter(|i| i.source == "./impl")
+        .collect();
+    assert_eq!(
+        entries.len(),
+        2,
+        "expected one import per re-export specifier: {:?}",
+        info.imports
+    );
+    for entry in &entries {
+        assert!(entry.is_type_only);
+    }
+    assert!(
+        matches!(&entries[0].imported_name, ImportedName::Named(n) if n == "helper"),
+        "first specifier must credit `helper`: {:?}",
+        entries[0].imported_name
+    );
+    assert!(
+        matches!(&entries[1].imported_name, ImportedName::Named(n) if n == "other"),
+        "aliased specifier must credit the source-side name `other`: {:?}",
+        entries[1].imported_name
+    );
+}
+
+#[test]
+fn ambient_module_bare_re_export_keeps_side_effect_reference() {
+    let info = parse(
+        "declare module 'pkg' {\n\
+           export {} from './impl';\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(info.exports.is_empty() && info.re_exports.is_empty());
     let entry = info
         .imports
         .iter()
         .find(|i| i.source == "./impl")
-        .expect("re-export source inside an ambient module must stay referenced");
+        .expect("bare re-export source inside an ambient module must stay referenced");
     assert!(entry.is_type_only);
     assert!(matches!(entry.imported_name, ImportedName::SideEffect));
 }

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -5154,6 +5154,69 @@ fn export_declare_namespace() {
 }
 
 #[test]
+fn module_augmentation_interface_is_not_a_file_export() {
+    // Issue #2349: `export interface Theme` inside `declare module './library'`
+    // augments `./library`; it is not an export of the containing file and must
+    // not surface as an unused exported type.
+    let info = parse(
+        "type AppTheme = { brand: string };\n\
+         declare module './library' {\n\
+           export interface Theme extends AppTheme {}\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        !info
+            .exports
+            .iter()
+            .any(|e| matches!(&e.name, ExportName::Named(n) if n == "Theme")),
+        "augmentation-scoped interface must not be recorded as a file export: {:?}",
+        info.exports
+    );
+}
+
+#[test]
+fn ambient_module_declaration_exports_are_not_file_exports() {
+    // Same rule for package ambient declarations: `declare module 'pkg'` bodies
+    // describe `pkg`, not the declaring file.
+    let info = parse(
+        "declare module 'some-pkg' {\n\
+           export function helper(): void;\n\
+           export interface Options { flag: boolean }\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "ambient module member exports must not be recorded as file exports: {:?}",
+        info.exports
+    );
+}
+
+#[test]
+fn ambient_module_named_re_export_keeps_reference_without_file_export() {
+    let info = parse(
+        "declare module 'pkg' {\n\
+           export { helper } from './impl';\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty() && info.re_exports.is_empty(),
+        "ambient-module re-exports must not surface on the file: exports {:?}, re_exports {:?}",
+        info.exports,
+        info.re_exports
+    );
+    let entry = info
+        .imports
+        .iter()
+        .find(|i| i.source == "./impl")
+        .expect("re-export source inside an ambient module must stay referenced");
+    assert!(entry.is_type_only);
+    assert!(matches!(entry.imported_name, ImportedName::SideEffect));
+}
+
+#[test]
 fn re_export_named() {
     let info = parse("export { foo } from './bar';");
     assert_eq!(info.re_exports.len(), 1);

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2433,19 +2433,36 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         // named module; they are not exports of the containing file, so they
         // must not feed unused-export/unused-type findings (issue #2349). The
         // body is still walked so `typeof import()` references and type usage
-        // keep extracting (#396/#397). A named re-export's source still counts
-        // as a type-space reference so the target file stays reachable.
+        // keep extracting (#396/#397). A named re-export becomes one type-space
+        // import per specifier (mirroring `visit_ts_import_type`) so the target
+        // file stays reachable AND each re-exported symbol keeps its export
+        // credit; a bare `export {} from '...'` falls back to a side-effect
+        // reference for reachability alone.
         if self.ambient_module_depth > 0 {
             if let Some(source) = &decl.source {
-                self.imports.push(ImportInfo {
-                    source: source.value.to_string(),
-                    imported_name: ImportedName::SideEffect,
-                    local_name: String::new(),
-                    is_type_only: true,
-                    from_style: false,
-                    span: decl.span,
-                    source_span: source.span,
-                });
+                if decl.specifiers.is_empty() {
+                    self.imports.push(ImportInfo {
+                        source: source.value.to_string(),
+                        imported_name: ImportedName::SideEffect,
+                        local_name: String::new(),
+                        is_type_only: true,
+                        from_style: false,
+                        span: decl.span,
+                        source_span: source.span,
+                    });
+                } else {
+                    for spec in &decl.specifiers {
+                        self.imports.push(ImportInfo {
+                            source: source.value.to_string(),
+                            imported_name: ImportedName::Named(spec.local.name().to_string()),
+                            local_name: String::new(),
+                            is_type_only: true,
+                            from_style: false,
+                            span: spec.span,
+                            source_span: source.span,
+                        });
+                    }
+                }
             }
             walk::walk_export_named_declaration(self, decl);
             return;

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2429,6 +2429,28 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             return;
         }
 
+        // Exports inside `declare module '<specifier>' { ... }` augment the
+        // named module; they are not exports of the containing file, so they
+        // must not feed unused-export/unused-type findings (issue #2349). The
+        // body is still walked so `typeof import()` references and type usage
+        // keep extracting (#396/#397). A named re-export's source still counts
+        // as a type-space reference so the target file stays reachable.
+        if self.ambient_module_depth > 0 {
+            if let Some(source) = &decl.source {
+                self.imports.push(ImportInfo {
+                    source: source.value.to_string(),
+                    imported_name: ImportedName::SideEffect,
+                    local_name: String::new(),
+                    is_type_only: true,
+                    from_style: false,
+                    span: decl.span,
+                    source_span: source.span,
+                });
+            }
+            walk::walk_export_named_declaration(self, decl);
+            return;
+        }
+
         let is_type_only = decl.export_kind.is_type();
 
         if let Some(source) = &decl.source {
@@ -2451,6 +2473,14 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
+        // See the ambient-module guard in `visit_export_named_declaration`:
+        // a default export declared inside `declare module '<specifier>'`
+        // belongs to the named module, not the containing file (issue #2349).
+        if self.ambient_module_depth > 0 {
+            walk::walk_export_default_declaration(self, decl);
+            return;
+        }
+
         let (members, super_class, implemented_interfaces, instance_bindings) =
             if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &decl.declaration {
                 let is_angular = has_angular_class_decorator(class);
@@ -2520,6 +2550,23 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         });
 
         walk::walk_export_default_declaration(self, decl);
+    }
+
+    fn visit_ts_module_declaration(&mut self, decl: &TSModuleDeclaration<'a>) {
+        // A string-literal module name (`declare module './library'`,
+        // `declare module 'pkg'`) marks a module augmentation or ambient
+        // module declaration. Track the depth so export visitors skip
+        // file-level recording inside the body (issue #2349). Identifier-named
+        // declarations (`namespace Foo`, `declare global`) keep existing
+        // behavior.
+        let is_ambient_specifier = matches!(&decl.id, TSModuleDeclarationName::StringLiteral(_));
+        if is_ambient_specifier {
+            self.ambient_module_depth += 1;
+        }
+        walk::walk_ts_module_declaration(self, decl);
+        if is_ambient_specifier {
+            self.ambient_module_depth -= 1;
+        }
     }
 
     fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -37,6 +37,12 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   cached fact or its meaning changes. Do not document the current numeric value
   as a durable contract.
 - Keep cache serialization deterministic and backwards failure safe.
+- A string-literal-named `TSModuleDeclaration` body (module augmentation or
+  ambient module declaration) contributes no file-level export surface. Its
+  body is still walked for `typeof import()` and type-space references, and a
+  named re-export inside it becomes one type-space import per specifier so the
+  target keeps its export credit. Identifier-named namespaces and
+  `declare global` keep their existing behavior.
 
 ## Verification
 

--- a/tests/fixtures/issue-2349-module-augmentation/package.json
+++ b/tests/fixtures/issue-2349-module-augmentation/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-2349-module-augmentation",
+  "type": "module",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/tests/fixtures/issue-2349-module-augmentation/src/ambient.d.ts
+++ b/tests/fixtures/issue-2349-module-augmentation/src/ambient.d.ts
@@ -1,0 +1,3 @@
+declare module 'untyped-pkg' {
+  export { helper } from './impl';
+}

--- a/tests/fixtures/issue-2349-module-augmentation/src/impl.ts
+++ b/tests/fixtures/issue-2349-module-augmentation/src/impl.ts
@@ -1,0 +1,1 @@
+export const helper = (): number => 1;

--- a/tests/fixtures/issue-2349-module-augmentation/src/index.ts
+++ b/tests/fixtures/issue-2349-module-augmentation/src/index.ts
@@ -1,0 +1,4 @@
+import './theme-augmentation';
+import type { Theme } from './library';
+
+export const readBrand = (theme: Theme) => theme.brand;

--- a/tests/fixtures/issue-2349-module-augmentation/src/library.ts
+++ b/tests/fixtures/issue-2349-module-augmentation/src/library.ts
@@ -1,0 +1,1 @@
+export interface Theme {}

--- a/tests/fixtures/issue-2349-module-augmentation/src/theme-augmentation.ts
+++ b/tests/fixtures/issue-2349-module-augmentation/src/theme-augmentation.ts
@@ -1,0 +1,11 @@
+type AppTheme = {
+  brand: string;
+};
+
+declare module './library' {
+  export interface Theme extends AppTheme {}
+}
+
+export type UnusedLocalAlias = string;
+
+export {};


### PR DESCRIPTION
## What was broken

`fallow dead-code --unused-exports --unused-types` reported an interface declared inside a valid TypeScript module augmentation (`declare module './library' { export interface Theme extends AppTheme {} }`) as an `unused-type` on the augmenting file. Removing it would break the augmented library contract. The type-aware companion retained the finding as `confirmed-no-static-references` because the candidate should never have existed.

## Root cause

The extraction visitor has no handler for string-named `TSModuleDeclaration` bodies, so the default walk carried inner `export` statements into the ordinary export-recording path. An `export interface` inside `declare module './x'` (or `declare module 'pkg'`) was recorded as a file-level export of the augmenting file, and since nothing imports that name from that file, unused-exports flagged it.

## The fix

- The visitor now tracks an ambient-module depth for string-named `declare module` bodies (identifier-named `namespace Foo` and `declare global` keep existing behavior).
- While inside such a body, named and default exports are not recorded as file-level exports. The body is still walked, so `typeof import()` references (#396/#397) and type usage keep extracting.
- A named re-export source inside an ambient body (`export { a } from './impl'`) still records a type-space reference so the target file stays reachable, without surfacing a file-level export.
- Extraction `CACHE_VERSION` bumped: warm caches would otherwise replay the stale export surface.

## How it was tested

- Extraction unit tests: the issue repro (augmentation interface), a package ambient declaration (`declare module 'pkg'` with function/interface exports), and the ambient named re-export reference case. All fail before the fix.
- New integration fixture `tests/fixtures/issue-2349-module-augmentation` mirroring the issue repro end to end: the augmented `Theme` is no longer reported, while a genuinely unused export outside the `declare module` body in the same file keeps reporting. Red before the fix, green after.
- CLI run on the fixture with the issue's exact command reports only the genuine unused export; cold and warm cache runs agree.
- Real-project smokes: a pnpm monorepo with wildcard asset ambient modules (`declare module '*.png'` with default exports) and a styled-components design system with a `DefaultTheme` augmentation both show a byte-identical finding set before vs after the fix (no collateral changes).
- Full `fallow-extract`, `fallow-core`, `fallow-graph`, and `fallow-engine` suites green; `cargo fmt`, workspace clippy (all targets), and `cargo doc -p fallow-extract` clean.

The `--type-aware` half of the report needs no sidecar change: the candidate is no longer produced, so the companion never sees it.

Fixes #2349
