### PR TITLE
fix(extract): record JSX namespace member tags as member accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JSX member-expression tags (`<SC.Wrapper />`) now credit the referenced
+  export** (Closes
+  [#2348](https://github.com/fallow-rs/fallow/issues/2348)). The syntactic
+  scan only recorded plain-expression member accesses, so a namespace import
+  rendered exclusively through JSX kept its exports reported as unused, and in
+  entry-point files every sibling export of the namespace target was falsely
+  flagged. Behavior change: namespace imports in non-entry consumers now
+  narrow to the members actually used instead of marking every export used, so
+  genuinely unused siblings surface for the first time. Both the extraction
+  and graph cache versions were bumped; the first run after upgrading performs
+  one cold re-analysis.
+
 - **Declarations inside `declare module '...'` augmentation and ambient-module
   bodies are no longer reported as unused exports of the containing file**
   (Closes [#2349](https://github.com/fallow-rs/fallow/issues/2349)). An

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -249,6 +249,8 @@ mod issue_2006_cli_flag_value_dependency;
 mod issue_2213_jest_mock_phantom_package;
 #[path = "integration_test/issue_2225_root_manual_mocks.rs"]
 mod issue_2225_root_manual_mocks;
+#[path = "integration_test/issue_2348_jsx_namespace_member.rs"]
+mod issue_2348_jsx_namespace_member;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_2348_jsx_namespace_member.rs
+++ b/crates/core/tests/integration_test/issue_2348_jsx_namespace_member.rs
@@ -1,0 +1,27 @@
+use crate::common::{create_config, fixture_path};
+
+/// Issue #2348: rendering `<SC.UsedStyle />` through a direct namespace import
+/// (`import * as SC from './style'`) must credit the `UsedStyle` export in the
+/// syntactic scan, while a genuinely-unused export from the same module keeps
+/// reporting.
+#[test]
+fn jsx_namespace_member_render_credits_export() {
+    let root = fixture_path("issue-2348-jsx-namespace-member");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_export_names: Vec<&str> = results
+        .unused_exports
+        .iter()
+        .map(|e| e.export.export_name.as_str())
+        .collect();
+
+    assert!(
+        !unused_export_names.contains(&"UsedStyle"),
+        "a namespace export rendered as <SC.UsedStyle /> must be credited: {unused_export_names:?}"
+    );
+    assert!(
+        unused_export_names.contains(&"ActuallyUnusedStyle"),
+        "a genuinely-unused export on the same module must still report: {unused_export_names:?}"
+    );
+}

--- a/crates/core/tests/integration_test/issue_2348_jsx_namespace_member.rs
+++ b/crates/core/tests/integration_test/issue_2348_jsx_namespace_member.rs
@@ -4,6 +4,15 @@ use crate::common::{create_config, fixture_path};
 /// (`import * as SC from './style'`) must credit the `UsedStyle` export in the
 /// syntactic scan, while a genuinely-unused export from the same module keeps
 /// reporting.
+///
+/// The fixture pins three consumer shapes:
+/// - the entry point itself renders `<SC.UsedStyle />` (the reported repro,
+///   previously the `is_entry_with_no_access` false positive),
+/// - a non-entry component renders `<S.Wrapper />` (previously conservatively
+///   credited every export via mark-all; now narrows, so `UnusedSibling`
+///   starts reporting, a deliberate semantics widening),
+/// - a non-entry component renders `<UI.Button />` through a barrel that only
+///   star-re-exports it, exercising the synthetic star re-export path.
 #[test]
 fn jsx_namespace_member_render_credits_export() {
     let root = fixture_path("issue-2348-jsx-namespace-member");
@@ -23,5 +32,21 @@ fn jsx_namespace_member_render_credits_export() {
     assert!(
         unused_export_names.contains(&"ActuallyUnusedStyle"),
         "a genuinely-unused export on the same module must still report: {unused_export_names:?}"
+    );
+    assert!(
+        !unused_export_names.contains(&"Wrapper"),
+        "a namespace export rendered as <S.Wrapper /> from a non-entry consumer must be credited: {unused_export_names:?}"
+    );
+    assert!(
+        unused_export_names.contains(&"UnusedSibling"),
+        "a non-entry JSX consumer must narrow instead of conservatively crediting every export: {unused_export_names:?}"
+    );
+    assert!(
+        !unused_export_names.contains(&"Button"),
+        "a namespace member rendered through a star-re-exporting barrel must be credited: {unused_export_names:?}"
+    );
+    assert!(
+        unused_export_names.contains(&"UnusedButtonSibling"),
+        "a genuinely-unused export behind the barrel must still report: {unused_export_names:?}"
     );
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -934,7 +934,12 @@ use crate::MemberKind;
 /// its own `<snippet:NAME>` complexity unit and rebases the body's nesting to
 /// zero, changing the serialized `module.complexity` for snippet-using files.
 /// Warm 270 caches would keep the folded single-unit shape.
-pub(super) const CACHE_VERSION: u32 = 271;
+///
+/// Bumped to 272 for issue #2348: JSX member-expression tags
+/// (`<SC.UsedStyle />`) now record member accesses like their plain-expression
+/// spelling. Warm 271 caches lack those accesses, so namespace-imported exports
+/// rendered only through JSX would stay reported as unused.
+pub(super) const CACHE_VERSION: u32 = 272;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/member_access.rs
+++ b/crates/extract/src/tests/js_ts/member_access.rs
@@ -1,6 +1,6 @@
 use fallow_types::extract::ImportedName;
 
-use crate::tests::parse_ts as parse_source;
+use crate::tests::{parse_ts as parse_source, parse_tsx};
 
 #[test]
 fn detects_object_values_whole_use() {
@@ -124,6 +124,72 @@ fn namespace_destructuring_from_require() {
     assert!(
         has_y,
         "Should capture destructured 'y' from require namespace"
+    );
+}
+
+/// Regression test for issue #2348: rendering `<SC.UsedStyle />` through a
+/// namespace import must record the same member access as `SC.UsedStyle`
+/// in plain expression position.
+#[test]
+fn jsx_namespace_member_tag_generates_member_access() {
+    let info = parse_tsx(
+        "import * as SC from './style';\nexport const RenderedStyle = () => <SC.UsedStyle />;",
+    );
+    assert_eq!(info.imports.len(), 1);
+    assert_eq!(info.imports[0].imported_name, ImportedName::Namespace);
+    let has_access = info
+        .member_accesses
+        .iter()
+        .any(|a| a.object == "SC" && a.member == "UsedStyle");
+    assert!(
+        has_access,
+        "<SC.UsedStyle /> should record SC.UsedStyle as a member access; got {:?}",
+        info.member_accesses
+    );
+}
+
+/// Issue #2348: a nested member tag `<A.B.C />` mirrors the plain-expression
+/// walk of `A.B.C`, recording both the innermost `A.B` access (namespace
+/// crediting) and the full-path `A.B.C` access.
+#[test]
+fn jsx_nested_namespace_member_tag_generates_member_accesses() {
+    let info = parse_tsx("import * as A from './widgets';\nexport const R = () => <A.B.C />;");
+    let has_inner = info
+        .member_accesses
+        .iter()
+        .any(|a| a.object == "A" && a.member == "B");
+    let has_outer = info
+        .member_accesses
+        .iter()
+        .any(|a| a.object == "A.B" && a.member == "C");
+    assert!(
+        has_inner,
+        "<A.B.C /> should record A.B for namespace crediting; got {:?}",
+        info.member_accesses
+    );
+    assert!(
+        has_outer,
+        "<A.B.C /> should record the full A.B.C path; got {:?}",
+        info.member_accesses
+    );
+}
+
+/// Issue #2348: the closing tag of a non-self-closing member-expression
+/// element must not double-record the access.
+#[test]
+fn jsx_namespace_member_tag_records_single_access_for_paired_tags() {
+    let info = parse_tsx(
+        "import * as SC from './style';\nexport const R = () => <SC.Layout>text</SC.Layout>;",
+    );
+    let count = info
+        .member_accesses
+        .iter()
+        .filter(|a| a.object == "SC" && a.member == "Layout")
+        .count();
+    assert_eq!(
+        count, 1,
+        "paired tags should record exactly one SC.Layout access; got {:?}",
+        info.member_accesses
     );
 }
 

--- a/crates/extract/src/tests/js_ts/member_access.rs
+++ b/crates/extract/src/tests/js_ts/member_access.rs
@@ -174,6 +174,50 @@ fn jsx_nested_namespace_member_tag_generates_member_accesses() {
     );
 }
 
+/// Issue #2348: a `this` receiver in JSX tag position (`<this.Foo />`) records
+/// the same `this.Foo` access as the plain-expression spelling, and the
+/// internal `this@<id>` class-scope qualifier (issue #1821) never leaks into
+/// the emitted spellings.
+#[test]
+fn jsx_this_member_tag_generates_member_access() {
+    let info = parse_tsx(
+        "class Panel {\n  Foo = () => null;\n  render() {\n    return <this.Foo />;\n  }\n}\nexport const panel = new Panel();",
+    );
+    let has_access = info
+        .member_accesses
+        .iter()
+        .any(|a| a.object == "this" && a.member == "Foo");
+    assert!(
+        has_access,
+        "<this.Foo /> should record this.Foo as a member access; got {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses.iter().all(|a| !a.object.contains('@')),
+        "no emitted spelling may keep the internal this@<id> qualifier; got {:?}",
+        info.member_accesses
+    );
+}
+
+/// Issue #2348: a class-instance receiver in JSX tag position (`<w.Card />`)
+/// records the same member access as the plain-expression spelling, feeding
+/// the bound-member resolution that credits local class members.
+#[test]
+fn jsx_class_instance_member_tag_generates_member_access() {
+    let info = parse_tsx(
+        "class Widgets {\n  Card = () => null;\n}\nconst w = new Widgets();\nexport const R = () => <w.Card />;",
+    );
+    let has_access = info
+        .member_accesses
+        .iter()
+        .any(|a| a.object == "w" && a.member == "Card");
+    assert!(
+        has_access,
+        "<w.Card /> should record w.Card as a member access; got {:?}",
+        info.member_accesses
+    );
+}
+
 /// Issue #2348: the closing tag of a non-self-closing member-expression
 /// element must not double-record the access.
 #[test]

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -4,8 +4,8 @@ mod react;
 mod visit_impl;
 
 use oxc_ast::ast::{
-    Argument, BindingPattern, CallExpression, Expression, ImportExpression, ObjectPattern,
-    ObjectProperty, ObjectPropertyKind, Statement,
+    Argument, BindingPattern, CallExpression, Expression, ImportExpression, JSXMemberExpression,
+    JSXMemberExpressionObject, ObjectPattern, ObjectProperty, ObjectPropertyKind, Statement,
 };
 use oxc_span::Span;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1035,6 +1035,30 @@ impl ModuleInfoExtractor {
                 class.clone(),
                 member.to_string(),
             ));
+        }
+    }
+
+    /// Record member accesses for a JSX member-expression tag (`<SC.UsedStyle />`,
+    /// `<A.B.C />`), mirroring the plain-expression walk of `A.B.C`: one access
+    /// per nesting level (`{A.B, C}` and `{A, B}`), so namespace-import
+    /// narrowing sees the same stream either way (issue #2348). `this` receivers
+    /// get the same class-scope qualifier as `visit_static_member_expression`.
+    pub(crate) fn record_jsx_member_tag_accesses(&mut self, member: &JSXMemberExpression<'_>) {
+        let mut current = member;
+        loop {
+            if let Some(object_name) = jsx_member_object_name(&current.object) {
+                let object = self.qualify_this_scope(&object_name);
+                self.record_walk_order_member_access(&object, current.property.name.as_str());
+                self.member_accesses.push(MemberAccess {
+                    object,
+                    member: current.property.name.to_string(),
+                });
+            }
+            match &current.object {
+                JSXMemberExpressionObject::MemberExpression(inner) => current = inner,
+                JSXMemberExpressionObject::IdentifierReference(_)
+                | JSXMemberExpressionObject::ThisExpression(_) => break,
+            }
         }
     }
 
@@ -2900,6 +2924,21 @@ fn strip_this_scope_qualifier(spelling: &mut String) {
         *spelling = rebuilt;
     } else {
         *spelling = "this".to_string();
+    }
+}
+
+/// Flatten a JSX member-expression object to its dotted receiver spelling
+/// (`SC`, `A.B`, `this.helpers`), the JSX counterpart of
+/// `static_member_object_name`.
+fn jsx_member_object_name(object: &JSXMemberExpressionObject<'_>) -> Option<String> {
+    match object {
+        JSXMemberExpressionObject::IdentifierReference(ident) => Some(ident.name.to_string()),
+        JSXMemberExpressionObject::ThisExpression(_) => Some("this".to_string()),
+        JSXMemberExpressionObject::MemberExpression(inner) => Some(format!(
+            "{}.{}",
+            jsx_member_object_name(&inner.object)?,
+            inner.property.name
+        )),
     }
 }
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -3162,6 +3162,13 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         // non-JSX files (perf gate). The walk continues into children so nested
         // renders and host-element nesting depth are still visited.
         self.react_record_jsx_element(element);
+        // A member-expression tag (`<SC.UsedStyle />`) is the JSX spelling of
+        // `SC.UsedStyle`, so it must feed the same member-access stream that
+        // namespace-import narrowing consumes (issue #2348). Opening element
+        // only, so a paired closing tag does not double-record.
+        if let JSXElementName::MemberExpression(member) = &element.opening_element.name {
+            self.record_jsx_member_tag_accesses(member);
+        }
         walk::walk_jsx_element(self, element);
     }
 }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -112,7 +112,13 @@ pub use store::GraphCacheStore;
 /// type query reads the value lane where that lane is absent. A warm 33 payload
 /// is still read correctly, but a 33 reader would take an absent fallback lane
 /// for an absent type meaning and report consumed exports as unused.
-pub const GRAPH_CACHE_VERSION: u32 = 34;
+///
+/// Bumped to 35 for issue #2348: JSX member-expression tags (`<SC.UsedStyle />`)
+/// now record member accesses, and namespace narrowing bakes the credited
+/// references into the persisted graph. Warm 34 caches carry the old empty
+/// accessed-members verdict, so exports rendered only through JSX would stay
+/// reported as unused on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 35;
 
 /// Cached form of a resolved target.
 ///

--- a/tests/fixtures/issue-2348-jsx-namespace-member/package.json
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue-2348-jsx-namespace-member-fixture",
+  "main": "src/component.tsx"
+}

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/barrel-consumer.tsx
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/barrel-consumer.tsx
@@ -1,0 +1,3 @@
+import * as UI from './ui';
+
+export const BarrelButton = () => <UI.Button />;

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/card-style.ts
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/card-style.ts
@@ -1,0 +1,3 @@
+export const Wrapper = () => null;
+
+export const UnusedSibling = () => null;

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/card.tsx
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/card.tsx
@@ -1,0 +1,3 @@
+import * as S from './card-style';
+
+export const RenderedCard = () => <S.Wrapper />;

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/component.tsx
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/component.tsx
@@ -1,0 +1,3 @@
+import * as SC from './style';
+
+export const RenderedStyle = () => <SC.UsedStyle />;

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/component.tsx
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/component.tsx
@@ -1,3 +1,11 @@
 import * as SC from './style';
+import { RenderedCard } from './card';
+import { BarrelButton } from './barrel-consumer';
 
-export const RenderedStyle = () => <SC.UsedStyle />;
+export const RenderedStyle = () => (
+  <div>
+    <SC.UsedStyle />
+    <RenderedCard />
+    <BarrelButton />
+  </div>
+);

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/style.ts
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/style.ts
@@ -1,0 +1,3 @@
+export const UsedStyle = () => null;
+
+export const ActuallyUnusedStyle = () => null;

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/ui/button.ts
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/ui/button.ts
@@ -1,0 +1,3 @@
+export const Button = () => null;
+
+export const UnusedButtonSibling = () => null;

--- a/tests/fixtures/issue-2348-jsx-namespace-member/src/ui/index.ts
+++ b/tests/fixtures/issue-2348-jsx-namespace-member/src/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './button';


### PR DESCRIPTION
## What was broken

The syntactic dead-code scan reported an exported JSX component as unused when it was rendered through a direct namespace import, such as `<SC.UsedStyle />` after `import * as SC from './style'`. Plain property access (`SC.UsedStyle`) through the same namespace was recognized; the gap was specific to JSX member-expression tags. The type-aware companion already credited the use, so syntactic and type-aware results disagreed.

## Root cause

Extraction records `MemberAccess { object, member }` entries in `visit_static_member_expression`, but a JSX member-expression tag (`JSXElementName::MemberExpression`) is a separate AST node that no visitor arm recorded. `narrow_namespace_references` in the graph then saw an entry-point consumer with zero accessed members for the namespace binding and marked nothing used, so every export of the imported module stayed unreferenced.

## The fix

Earliest incorrect layer is extraction. `visit_jsx_element` now records member accesses for member-expression element names, mirroring the plain-expression walk: one access per nesting level (`<A.B.C />` records `{A.B, C}` and `{A, B}`), the same `this`-receiver scope qualification, and walk-order class crediting. Only the opening element is processed, so paired tags record a single access.

## Behavior change: non-entry consumers narrow instead of mark-all

When the JSX consumer is not an entry point, its previously-empty accessed-members routed namespace narrowing to the conservative mark-all branch, crediting every export of the imported module. With JSX member-tag accesses recorded, those consumers now narrow to the rendered members only, so genuinely-unused siblings start reporting. `import * as S from './styles'` plus `<S.Wrapper />` no longer shields an unused `UnusedSibling` export. This is intended (parity with the plain `S.Wrapper` spelling and with type-aware results), but it is a finding-count increase on upgrade for namespace-import codebases, and it lands in regression baselines and `--max-issues` gates. The release notes must state this widening explicitly.

## Cache invalidation

Both cache layers are bumped:

- extract `CACHE_VERSION` 271 -> 272, so warm extraction caches re-extract the new member accesses;
- `GRAPH_CACHE_VERSION` 34 -> 35, because unused-export verdicts are read off the persisted graph and namespace narrowing bakes credited references into it at graph build. Without the graph bump, a warm `.fallow` written by a previous release replays the false positive verbatim (graph cache hit skips the narrow phase entirely).

Warm-cache proof on the fixture, three debug binaries sharing one `.fallow` directory:

1. origin/main binary (graph v34, no fix), cold run: falsely reports `UsedStyle` (and `Button` behind a star-re-exporting barrel), writes the cache.
2. extract-bump-only binary (graph v34) on that warm cache: identical stale replay; the fix is invisible.
3. patched binary (graph v35) on the same cache: `UsedStyle` and `Button` credited; `ActuallyUnusedStyle`, `UnusedSibling`, and `UnusedButtonSibling` report. A second warm run is stable.

## How it was tested

- Extract-level repro tests: `<SC.UsedStyle />` records the member access, nested `<A.B.C />` records both levels, paired tags record exactly one access (all failed before the fix), `<this.Foo />` records the `this` receiver without leaking the internal `this@<id>` class-scope qualifier, and a local class-instance receiver (`<w.Card />`) records its access.
- Integration test on fixture `issue-2348-jsx-namespace-member` pins three consumer shapes: the entry-point repro (`UsedStyle` credited, `ActuallyUnusedStyle` reported), a non-entry consumer (rendered `Wrapper` credited, `UnusedSibling` now reported, pinning the widening above), and a barrel consumer whose rendered member only exists via `export *` (synthetic star re-export path: `Button` credited, `UnusedButtonSibling` reported).
- CLI run of the issue's exact reproduction (entry config, tsconfig with `jsx: preserve`): now reports only `ActuallyUnusedStyle`.
- Warm-cache scenario above (previous-release cache, patched binary on top).
- Real-project smokes: `dead-code` on the in-repo viz-frontend and on an external design-system monorepo with namespace TSX imports, both complete cleanly.
- Gates: cargo fmt check, clippy workspace with warnings denied, cargo doc with warnings denied, typos, and full test suites for fallow-extract, fallow-graph, fallow-core, fallow-engine, and fallow-cli all green.

Fixes #2348
