### PR TITLE
fix(audit): score the base attribution pass with the supplied Istanbul coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   jobs, while a credential-free gate downloads and validates the exact
   universal and platform-specific payloads from both registries.
 
+### Fixed
+
+- **`fallow audit` now scores the base attribution pass with the same Istanbul
+  coverage map as the head pass.** The base worktree pass previously matched no
+  coverage entry (the map records head-checkout paths), silently fell back to
+  the reachability estimate, and flipped unchanged high-CRAP functions to
+  `introduced` (#2347). The rebase applies to `--coverage`, `FALLOW_COVERAGE`,
+  and auto-detected `coverage/coverage-final.json` maps; base functions shifted
+  by unrelated edits still match their coverage entry when the function name is
+  unambiguous in its file. Attribution can shift after upgrading: both sides
+  now score from the head-generated map, so complexity findings in files the
+  map reports as untested attribute as inherited once the base function also
+  exceeded the threshold, and coverage regressions surface through
+  `rules.coverage-gaps` and health trends rather than `introduced` complexity
+  findings.
+
 ## [3.17.0] - 2026-08-16
 
 ### Added

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -781,6 +781,11 @@ pub struct ComplexityOptions {
     pub coverage: Option<PathBuf>,
     /// Absolute path prefix the coverage report recorded its files under.
     pub coverage_root: Option<PathBuf>,
+    /// The coverage map was recorded against a different checkout of this
+    /// project, so function line numbers may have drifted arbitrarily.
+    /// Set internally by the audit base-worktree pass; leave `false` for
+    /// same-checkout coverage.
+    pub coverage_relocated: bool,
 }
 
 /// Health threshold overrides accepted by the programmatic API.
@@ -801,6 +806,9 @@ pub struct ComplexityCoverageInputs<'a> {
     pub coverage: Option<&'a Path>,
     /// Absolute path prefix the coverage report recorded its files under.
     pub coverage_root: Option<&'a Path>,
+    /// The coverage map was recorded against a different checkout of this
+    /// project; tolerate arbitrary line drift for unambiguous name matches.
+    pub coverage_relocated: bool,
 }
 
 /// Input for deriving effective health sections from API-owned flags.
@@ -1037,6 +1045,7 @@ pub fn derive_complexity_run_options(options: &ComplexityOptions) -> ComplexityR
         coverage_inputs: ComplexityCoverageInputs {
             coverage: options.coverage.as_deref(),
             coverage_root: options.coverage_root.as_deref(),
+            coverage_relocated: options.coverage_relocated,
         },
     }
 }
@@ -1123,6 +1132,7 @@ const fn coverage_inputs_to_engine(
     fallow_engine::health::HealthCoverageInputs {
         coverage: coverage_inputs.coverage,
         coverage_root: coverage_inputs.coverage_root,
+        coverage_relocated: coverage_inputs.coverage_relocated,
     }
 }
 

--- a/crates/api/src/runtime/audit.rs
+++ b/crates/api/src/runtime/audit.rs
@@ -248,6 +248,7 @@ struct AuditSubanalysisOptions {
 fn audit_subanalysis_options(
     options: &AuditOptions,
     analysis: &AnalysisOptions,
+    coverage_relocated: bool,
 ) -> AuditSubanalysisOptions {
     AuditSubanalysisOptions {
         dead_code: DeadCodeOptions {
@@ -268,6 +269,7 @@ fn audit_subanalysis_options(
             css_deep: options.css.unwrap_or(true) && options.css_deep.unwrap_or(true),
             coverage: options.coverage.clone(),
             coverage_root: options.coverage_root.clone(),
+            coverage_relocated,
             ..ComplexityOptions::default()
         },
     }
@@ -277,9 +279,16 @@ fn run_audit_subanalyses(
     options: &AuditOptions,
     analysis: &AnalysisOptions,
     changed_files: Option<&FxHashSet<PathBuf>>,
+    coverage_relocated: bool,
 ) -> ProgrammaticResult<AuditSubanalyses> {
     let resolved = resolve_programmatic_analysis_context_deferred_workspace(analysis)?;
-    run_audit_subanalyses_with_context(options, analysis, &resolved, changed_files)
+    run_audit_subanalyses_in_context(
+        options,
+        analysis,
+        &resolved,
+        changed_files,
+        coverage_relocated,
+    )
 }
 
 fn run_audit_subanalyses_with_context(
@@ -288,7 +297,17 @@ fn run_audit_subanalyses_with_context(
     resolved: &ProgrammaticAnalysisContext,
     changed_files: Option<&FxHashSet<PathBuf>>,
 ) -> ProgrammaticResult<AuditSubanalyses> {
-    let subanalysis_options = audit_subanalysis_options(options, analysis);
+    run_audit_subanalyses_in_context(options, analysis, resolved, changed_files, false)
+}
+
+fn run_audit_subanalyses_in_context(
+    options: &AuditOptions,
+    analysis: &AnalysisOptions,
+    resolved: &ProgrammaticAnalysisContext,
+    changed_files: Option<&FxHashSet<PathBuf>>,
+    coverage_relocated: bool,
+) -> ProgrammaticResult<AuditSubanalyses> {
+    let subanalysis_options = audit_subanalysis_options(options, analysis, coverage_relocated);
     let production_modes = resolve_effective_production_modes(
         resolved,
         options.production_dead_code,
@@ -795,8 +814,36 @@ fn compute_base_snapshot(
         explain: false,
         ..options.analysis.clone()
     };
-    let base = run_audit_subanalyses(options, &base_analysis, None)?;
+    let base_options = base_snapshot_options(options, &current_root);
+    let base = run_audit_subanalyses(&base_options, &base_analysis, None, true)?;
     Ok(snapshot_from_analyses(&base))
+}
+
+/// Audit options for the base-worktree pass, with Istanbul coverage inputs
+/// remapped onto that worktree.
+///
+/// The coverage file lives in (and its recorded paths point at) the HEAD
+/// checkout, while the base pass analyzes a temporary worktree. The coverage
+/// path is resolved against the HEAD root so the base pass reads the same
+/// file, and when no explicit `coverage_root` exists the HEAD root becomes
+/// the strip prefix so every entry rebases onto the base worktree; otherwise
+/// base CRAP silently degrades to the reachability estimate and unchanged
+/// functions flip to `introduced` (#2347). An explicit `coverage_root` is
+/// forwarded unchanged: the base pass rebases it onto its own root.
+fn base_snapshot_options(options: &AuditOptions, current_root: &Path) -> AuditOptions {
+    let Some(coverage) = options.coverage.as_deref() else {
+        return options.clone();
+    };
+    let mut base_options = options.clone();
+    base_options.coverage = Some(fallow_engine::health::scoring::resolve_relative_to_root(
+        coverage,
+        Some(current_root),
+    ));
+    if base_options.coverage_root.is_none() {
+        base_options.coverage_root =
+            Some(dunce::canonicalize(current_root).unwrap_or_else(|_| current_root.to_path_buf()));
+    }
+    base_options
 }
 
 fn analysis_root_from_options(options: &AuditOptions) -> ProgrammaticResult<PathBuf> {
@@ -1072,6 +1119,102 @@ mod tests {
                 .iter()
                 .any(|finding| finding["line"] == 3 && finding["introduced"] == true)
         );
+    }
+
+    /// #2347: a pre-existing high-CRAP function must stay `introduced: false`
+    /// when Istanbul coverage is supplied and an unrelated edit touches its
+    /// file. The base snapshot analyzes a temporary worktree, so the coverage
+    /// entries (recorded against the HEAD checkout) must be rebased onto that
+    /// worktree; otherwise the base side falls back to the reachability
+    /// estimate, scores below threshold, and the unchanged finding flips the
+    /// new-only gate.
+    #[test]
+    fn run_audit_coverage_keeps_unchanged_function_inherited() {
+        let project = tempfile::tempdir().expect("project");
+        let root = project.path();
+        std::fs::create_dir_all(root.join("src")).expect("create src");
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"name":"audit-api-coverage","type":"module","main":"src/index.ts","devDependencies":{"vitest":"^3.0.0"}}"#,
+        )
+        .expect("write package");
+        std::fs::write(root.join("src/index.ts"), "console.log('entry');\n").expect("write entry");
+        std::fs::write(
+            root.join("src/branchy.ts"),
+            "export function branchy(n: number): number {\n\
+             \x20 if (n < 0) return -1;\n\
+             \x20 if (n === 0) return 0;\n\
+             \x20 if (n < 10) return 1;\n\
+             \x20 if (n < 100) return 2;\n\
+             \x20 if (n < 1000) return 3;\n\
+             \x20 if (n < 10000) return 4;\n\
+             \x20 return 5;\n\
+             }\n",
+        )
+        .expect("write branchy");
+        std::fs::write(
+            root.join("src/branchy.test.ts"),
+            "import { branchy } from './branchy';\nbranchy(1);\n",
+        )
+        .expect("write test reference");
+        git(root, &["init"]);
+        git(root, &["add", "."]);
+        git(
+            root,
+            &[
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+        let mut source = std::fs::read_to_string(root.join("src/branchy.ts")).expect("branchy");
+        source.push_str("branchy(-1);\n");
+        std::fs::write(root.join("src/branchy.ts"), source).expect("append unrelated statement");
+
+        std::fs::create_dir_all(root.join("artifacts")).expect("create artifacts");
+        let recorded = root.join("src/branchy.ts");
+        let recorded = recorded.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            root.join("artifacts/coverage-final.json"),
+            format!(
+                r#"{{"{recorded}":{{"path":"{recorded}","statementMap":{{}},"fnMap":{{"0":{{"name":"branchy","line":1,"decl":{{"start":{{"line":1,"column":16}},"end":{{"line":1,"column":23}}}},"loc":{{"start":{{"line":1,"column":44}},"end":{{"line":9,"column":1}}}}}}}},"branchMap":{{}},"s":{{}},"f":{{"0":0}},"b":{{}}}}}}"#
+            ),
+        )
+        .expect("write coverage");
+
+        let output = run_audit(&AuditOptions {
+            analysis: AnalysisOptions {
+                root: Some(root.to_path_buf()),
+                no_cache: true,
+                ..AnalysisOptions::default()
+            },
+            base: Some("HEAD".to_string()),
+            gate: AuditGate::NewOnly,
+            max_crap: Some(10.0),
+            coverage: Some(root.join("artifacts/coverage-final.json")),
+            ..AuditOptions::default()
+        })
+        .expect("audit output");
+
+        assert_eq!(output.attribution.complexity_introduced, 0);
+        assert_eq!(output.attribution.complexity_inherited, 1);
+        assert_eq!(output.verdict, AuditVerdict::Pass);
+        let json = crate::serialize_audit_programmatic_json(output).expect("audit json");
+        let findings = json["complexity"]["findings"]
+            .as_array()
+            .expect("complexity findings");
+        let branchy = findings
+            .iter()
+            .find(|finding| finding["name"] == "branchy")
+            .expect("branchy reported above the CRAP threshold with 0% measured coverage");
+        assert_eq!(branchy["introduced"], false);
+        assert_eq!(branchy["coverage_source"], "istanbul");
     }
 
     #[test]

--- a/crates/api/src/runtime/audit.rs
+++ b/crates/api/src/runtime/audit.rs
@@ -824,24 +824,37 @@ fn compute_base_snapshot(
 ///
 /// The coverage file lives in (and its recorded paths point at) the HEAD
 /// checkout, while the base pass analyzes a temporary worktree. The coverage
-/// path is resolved against the HEAD root so the base pass reads the same
-/// file, and when no explicit `coverage_root` exists the HEAD root becomes
-/// the strip prefix so every entry rebases onto the base worktree; otherwise
-/// base CRAP silently degrades to the reachability estimate and unchanged
-/// functions flip to `introduced` (#2347). An explicit `coverage_root` is
-/// forwarded unchanged: the base pass rebases it onto its own root.
+/// path is resolved against the canonical HEAD root so the base pass reads
+/// the same file, and when no explicit `coverage_root` exists that root
+/// becomes the strip prefix so every entry rebases onto the base worktree;
+/// otherwise base CRAP silently degrades to the reachability estimate and
+/// unchanged functions flip to `introduced` (#2347). Without explicit
+/// coverage, the head pass auto-detects `coverage/coverage-final.json`
+/// against the HEAD root, which the base worktree never materializes; the
+/// same auto-detection runs here so both passes score from the same map. An
+/// explicit `coverage_root` is forwarded unchanged: the base pass rebases it
+/// onto its own root. The canonical root serves both the path resolution and
+/// the default prefix, so a relative `analysis.root` cannot make the two
+/// mechanisms disagree.
 fn base_snapshot_options(options: &AuditOptions, current_root: &Path) -> AuditOptions {
-    let Some(coverage) = options.coverage.as_deref() else {
+    let canonical_root =
+        dunce::canonicalize(current_root).unwrap_or_else(|_| current_root.to_path_buf());
+    let coverage = options.coverage.as_deref().map_or_else(
+        || fallow_engine::health::scoring::auto_detect_coverage(&canonical_root),
+        |coverage| {
+            Some(fallow_engine::health::scoring::resolve_relative_to_root(
+                coverage,
+                Some(&canonical_root),
+            ))
+        },
+    );
+    let Some(coverage) = coverage else {
         return options.clone();
     };
     let mut base_options = options.clone();
-    base_options.coverage = Some(fallow_engine::health::scoring::resolve_relative_to_root(
-        coverage,
-        Some(current_root),
-    ));
+    base_options.coverage = Some(coverage);
     if base_options.coverage_root.is_none() {
-        base_options.coverage_root =
-            Some(dunce::canonicalize(current_root).unwrap_or_else(|_| current_root.to_path_buf()));
+        base_options.coverage_root = Some(canonical_root);
     }
     base_options
 }

--- a/crates/benchmarks/benches/component_engine.rs
+++ b/crates/benchmarks/benches/component_engine.rs
@@ -793,6 +793,7 @@ fn warm_istanbul_crap_options(fixture: &IstanbulCrapFixture) -> HealthExecutionO
         coverage_inputs: HealthCoverageInputs {
             coverage: Some(&fixture.coverage_path),
             coverage_root: None,
+            coverage_relocated: false,
         },
         ..warm_health_options(&fixture.fixture)
     }

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -320,8 +320,14 @@ fn compute_base_snapshot(
         .config_path
         .clone()
         .or_else(|| fallow_config::FallowConfig::find_config_path(opts.root));
-    let base_opts =
-        build_base_audit_options(opts, &base_root, &current_config_path, &base_cache_dir);
+    let base_coverage_root = base_worktree_coverage_root(opts);
+    let base_opts = build_base_audit_options(
+        opts,
+        &base_root,
+        &current_config_path,
+        &base_cache_dir,
+        base_coverage_root.as_deref(),
+    );
 
     let base_changed_files = remap_focus_files(base_focus_files, opts.root, &base_root);
     let check_production = opts.production_dead_code.unwrap_or(opts.production);
@@ -361,7 +367,7 @@ fn compute_base_snapshot(
     } else {
         None
     };
-    let health = run_audit_health(&base_opts, None, shared_parse)?;
+    let health = run_audit_health(&base_opts, None, shared_parse, true)?;
     if let Some(ref mut check) = check {
         check.shared_parse = None;
     }
@@ -499,6 +505,28 @@ fn public_api_keys_from_check(check: Option<&CheckResult>, root: &Path) -> FxHas
     review_deltas::public_export_keys_for(graph, &check.config, &check.workspaces, root)
 }
 
+/// Coverage-root for the base-worktree analysis pass.
+///
+/// The Istanbul map records HEAD-checkout file paths, while the base pass
+/// analyzes a temporary worktree; without a rebase no coverage entry ever
+/// matches a base file and base CRAP silently degrades to the reachability
+/// estimate, splitting base/head attribution for unchanged functions (#2347).
+/// When `--coverage` is set without `--coverage-root`, the HEAD project root
+/// becomes the strip prefix so `load_istanbul_coverage` remaps every entry
+/// onto the base worktree (the base pass's project root). An explicit
+/// `--coverage-root` is forwarded unchanged, with or without `--coverage`
+/// (auto-detect also consumes it): the base pass already rebases it onto its
+/// own root.
+fn base_worktree_coverage_root(opts: &AuditOptions<'_>) -> Option<PathBuf> {
+    match (opts.coverage, opts.coverage_root) {
+        (_, Some(root)) => Some(root.to_path_buf()),
+        (Some(_), None) => {
+            Some(dunce::canonicalize(opts.root).unwrap_or_else(|_| opts.root.to_path_buf()))
+        }
+        (None, None) => None,
+    }
+}
+
 /// Build the `AuditOptions` for the isolated base-worktree analysis pass.
 #[expect(
     clippy::ref_option,
@@ -509,6 +537,7 @@ fn build_base_audit_options<'a>(
     base_root: &'a Path,
     current_config_path: &'a Option<PathBuf>,
     base_cache_dir: &'a Path,
+    base_coverage_root: Option<&'a Path>,
 ) -> AuditOptions<'a> {
     AuditOptions {
         root: base_root,
@@ -537,7 +566,7 @@ fn build_base_audit_options<'a>(
         health_baseline_mode: fallow_engine::baseline::HealthBaselineMode::default(),
         max_crap: opts.max_crap,
         coverage: opts.coverage,
-        coverage_root: opts.coverage_root,
+        coverage_root: base_coverage_root,
         gate: AuditGate::All,
         include_entry_exports: opts.include_entry_exports,
         // Base styling keys keep opt-in `rules.css-* = error` gated on
@@ -1126,7 +1155,7 @@ fn run_audit_head_analyses(
     } else {
         None
     };
-    let health = run_audit_health(opts, changed_since, shared_parse)?;
+    let health = run_audit_health(opts, changed_since, shared_parse, false)?;
     Ok(HeadAnalyses {
         check,
         dupes,
@@ -2780,10 +2809,14 @@ fn build_audit_dupes_options<'a>(
 }
 
 /// Run complexity analysis for the audit pipeline (findings only, no scores/hotspots/targets).
+///
+/// `coverage_relocated` marks the base-worktree pass, whose Istanbul map was
+/// recorded against the HEAD checkout; see `base_worktree_coverage_root`.
 fn run_audit_health<'a>(
     opts: &'a AuditOptions<'a>,
     changed_since: Option<&'a str>,
     shared_parse: Option<fallow_engine::health::HealthSharedParseData>,
+    coverage_relocated: bool,
 ) -> Result<Option<HealthResult>, ExitCode> {
     let runtime_coverage = match opts.runtime_coverage {
         Some(path) => Some(crate::health::coverage::prepare_options(
@@ -2796,7 +2829,8 @@ fn run_audit_health<'a>(
         None => None,
     };
 
-    let health_opts = build_audit_health_options(opts, changed_since, runtime_coverage);
+    let health_opts =
+        build_audit_health_options(opts, changed_since, runtime_coverage, coverage_relocated);
     let health_run = if let Some(shared) = shared_parse {
         crate::health::execute_health_with_shared_parse(&health_opts, shared)
     } else {
@@ -2814,6 +2848,7 @@ fn build_audit_health_options<'a>(
     opts: &'a AuditOptions<'a>,
     changed_since: Option<&'a str>,
     runtime_coverage: Option<fallow_engine::health::RuntimeCoverageOptions>,
+    coverage_relocated: bool,
 ) -> HealthOptions<'a> {
     HealthOptions {
         root: opts.root,
@@ -2870,6 +2905,7 @@ fn build_audit_health_options<'a>(
         coverage_inputs: fallow_engine::health::HealthCoverageInputs {
             coverage: opts.coverage,
             coverage_root: opts.coverage_root,
+            coverage_relocated,
         },
         performance: opts.performance,
         runtime_coverage,

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -320,13 +320,13 @@ fn compute_base_snapshot(
         .config_path
         .clone()
         .or_else(|| fallow_config::FallowConfig::find_config_path(opts.root));
-    let base_coverage_root = base_worktree_coverage_root(opts);
+    let base_coverage = base_worktree_coverage_inputs(opts);
     let base_opts = build_base_audit_options(
         opts,
         &base_root,
         &current_config_path,
         &base_cache_dir,
-        base_coverage_root.as_deref(),
+        &base_coverage,
     );
 
     let base_changed_files = remap_focus_files(base_focus_files, opts.root, &base_root);
@@ -505,25 +505,41 @@ fn public_api_keys_from_check(check: Option<&CheckResult>, root: &Path) -> FxHas
     review_deltas::public_export_keys_for(graph, &check.config, &check.workspaces, root)
 }
 
-/// Coverage-root for the base-worktree analysis pass.
+/// Istanbul coverage inputs for the base-worktree analysis pass.
+struct BaseCoverageInputs {
+    coverage: Option<PathBuf>,
+    coverage_root: Option<PathBuf>,
+}
+
+/// Coverage inputs for the base-worktree analysis pass.
 ///
 /// The Istanbul map records HEAD-checkout file paths, while the base pass
 /// analyzes a temporary worktree; without a rebase no coverage entry ever
 /// matches a base file and base CRAP silently degrades to the reachability
 /// estimate, splitting base/head attribution for unchanged functions (#2347).
-/// When `--coverage` is set without `--coverage-root`, the HEAD project root
-/// becomes the strip prefix so `load_istanbul_coverage` remaps every entry
-/// onto the base worktree (the base pass's project root). An explicit
-/// `--coverage-root` is forwarded unchanged, with or without `--coverage`
-/// (auto-detect also consumes it): the base pass already rebases it onto its
-/// own root.
-fn base_worktree_coverage_root(opts: &AuditOptions<'_>) -> Option<PathBuf> {
-    match (opts.coverage, opts.coverage_root) {
+/// Without `--coverage`, the head pass auto-detects
+/// `coverage/coverage-final.json` against the head root, which the base
+/// worktree never materializes; the same auto-detection runs here against the
+/// head root so both passes score from the same map. When no
+/// `--coverage-root` was given, the HEAD project root becomes the strip
+/// prefix so `load_istanbul_coverage` remaps every entry onto the base
+/// worktree (the base pass's project root). An explicit `--coverage-root` is
+/// forwarded unchanged: the base pass already rebases it onto its own root.
+fn base_worktree_coverage_inputs(opts: &AuditOptions<'_>) -> BaseCoverageInputs {
+    let coverage = opts
+        .coverage
+        .map(Path::to_path_buf)
+        .or_else(|| fallow_engine::health::scoring::auto_detect_coverage(opts.root));
+    let coverage_root = match (&coverage, opts.coverage_root) {
         (_, Some(root)) => Some(root.to_path_buf()),
         (Some(_), None) => {
             Some(dunce::canonicalize(opts.root).unwrap_or_else(|_| opts.root.to_path_buf()))
         }
         (None, None) => None,
+    };
+    BaseCoverageInputs {
+        coverage,
+        coverage_root,
     }
 }
 
@@ -537,7 +553,7 @@ fn build_base_audit_options<'a>(
     base_root: &'a Path,
     current_config_path: &'a Option<PathBuf>,
     base_cache_dir: &'a Path,
-    base_coverage_root: Option<&'a Path>,
+    base_coverage: &'a BaseCoverageInputs,
 ) -> AuditOptions<'a> {
     AuditOptions {
         root: base_root,
@@ -565,8 +581,8 @@ fn build_base_audit_options<'a>(
         dupes_baseline: None,
         health_baseline_mode: fallow_engine::baseline::HealthBaselineMode::default(),
         max_crap: opts.max_crap,
-        coverage: opts.coverage,
-        coverage_root: base_coverage_root,
+        coverage: base_coverage.coverage.as_deref(),
+        coverage_root: base_coverage.coverage_root.as_deref(),
         gate: AuditGate::All,
         include_entry_exports: opts.include_entry_exports,
         // Base styling keys keep opt-in `rules.css-* = error` gated on

--- a/crates/cli/src/audit_cache.rs
+++ b/crates/cli/src/audit_cache.rs
@@ -13,7 +13,10 @@ use super::{AuditKeySnapshot, AuditOptions};
 use crate::base_worktree::{git_rev_parse, git_toplevel};
 use crate::error::emit_error;
 
-pub(super) const AUDIT_BASE_SNAPSHOT_CACHE_VERSION: u8 = 6;
+/// Version 7: the base pass rebases Istanbul coverage paths onto the base
+/// worktree (#2347), so snapshots computed by the coverage-blind base pass
+/// must not be reused.
+pub(super) const AUDIT_BASE_SNAPSHOT_CACHE_VERSION: u8 = 7;
 const MAX_AUDIT_BASE_SNAPSHOT_CACHE_SIZE: usize = 16 * 1024 * 1024;
 
 pub(super) struct AuditBaseSnapshotCacheKey {

--- a/crates/cli/src/audit_cache.rs
+++ b/crates/cli/src/audit_cache.rs
@@ -279,9 +279,13 @@ pub(super) fn audit_base_snapshot_cache_key(
         return Ok(None);
     };
     let config_file = config_file_fingerprint(opts)?;
+    // Auto-detected coverage feeds the base pass too (#2347), so its content
+    // must invalidate cached base snapshots exactly like explicit `--coverage`.
     let coverage_file = opts
         .coverage
-        .map(|p| coverage_file_fingerprint(p, opts.root));
+        .map(Path::to_path_buf)
+        .or_else(|| fallow_engine::health::scoring::auto_detect_coverage(opts.root))
+        .map(|p| coverage_file_fingerprint(&p, opts.root));
     let materialized_context =
         fallow_engine::repo_refs::audit_materialized_context_fingerprint(opts.root);
     let bytes = AuditCacheKeyBuilder::new(

--- a/crates/cli/src/audit_cache.rs
+++ b/crates/cli/src/audit_cache.rs
@@ -129,11 +129,38 @@ pub(super) fn audit_base_snapshot_cache_file(
 
 pub(super) fn ensure_audit_base_snapshot_cache_dir(dir: &Path) -> Result<(), std::io::Error> {
     std::fs::create_dir_all(dir)?;
+    sweep_stale_snapshot_cache_versions(dir);
     let gitignore = dir.join(".gitignore");
     if std::fs::read_to_string(&gitignore).ok().as_deref() != Some("*\n") {
         std::fs::write(gitignore, "*\n")?;
     }
     Ok(())
+}
+
+/// Best-effort removal of lower-versioned `audit-base-v*` sibling directories.
+/// A cache version bump would otherwise strand every previous payload
+/// permanently: the age-based sweep governed by `audit.cacheMaxAgeDays`
+/// targets the reusable worktrees, not stale snapshot cache versions.
+fn sweep_stale_snapshot_cache_versions(current_dir: &Path) {
+    let Some(parent) = current_dir.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(version) = name
+            .to_str()
+            .and_then(|n| n.strip_prefix("audit-base-v"))
+            .and_then(|v| v.parse::<u8>().ok())
+        else {
+            continue;
+        };
+        if version < AUDIT_BASE_SNAPSHOT_CACHE_VERSION {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 pub(super) fn load_cached_base_snapshot(

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -2635,6 +2635,40 @@ fn audit_base_snapshot_cache_dir_writes_gitignore() {
 }
 
 #[test]
+fn audit_base_snapshot_cache_dir_sweeps_lower_versions() {
+    let tmp = tempfile::TempDir::new().expect("temp dir should be created");
+    let cache_root = tmp.path().join(".custom-fallow-cache");
+    let cache_parent = cache_root.join("cache");
+    let stale = cache_parent.join(format!(
+        "audit-base-v{}",
+        AUDIT_BASE_SNAPSHOT_CACHE_VERSION - 1
+    ));
+    fs::create_dir_all(&stale).expect("stale dir should be created");
+    fs::write(stale.join("deadbeef.bin"), b"stale").expect("stale payload should write");
+    let newer = cache_parent.join(format!(
+        "audit-base-v{}",
+        AUDIT_BASE_SNAPSHOT_CACHE_VERSION + 1
+    ));
+    fs::create_dir_all(&newer).expect("newer dir should be created");
+    let unrelated = cache_parent.join("resolve");
+    fs::create_dir_all(&unrelated).expect("unrelated dir should be created");
+
+    let cache_dir = audit_base_snapshot_cache_dir(&cache_root);
+    ensure_audit_base_snapshot_cache_dir(&cache_dir).expect("cache dir should be created");
+
+    assert!(
+        !stale.exists(),
+        "lower-versioned snapshot cache directories should be swept"
+    );
+    assert!(
+        newer.exists(),
+        "an older binary must not delete a newer version's cache"
+    );
+    assert!(unrelated.exists(), "unrelated cache dirs must be untouched");
+    assert!(cache_dir.exists());
+}
+
+#[test]
 fn audit_base_snapshot_cache_roundtrips_from_disk() {
     let tmp = tempfile::TempDir::new().expect("temp dir should be created");
     let config_path = None;

--- a/crates/cli/src/combined/mod.rs
+++ b/crates/cli/src/combined/mod.rs
@@ -573,6 +573,7 @@ fn build_health_opts<'a>(opts: &'a CombinedOptions<'a>) -> HealthOptions<'a> {
         coverage_inputs: fallow_engine::health::HealthCoverageInputs {
             coverage: opts.coverage,
             coverage_root: opts.coverage_root,
+            coverage_relocated: false,
         },
         performance: opts.performance,
         runtime_coverage: None,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5789,6 +5789,7 @@ fn health_coverage_inputs(
     fallow_engine::health::HealthCoverageInputs {
         coverage: coverage_inputs.coverage.as_deref(),
         coverage_root: coverage_inputs.coverage_root.as_deref(),
+        coverage_relocated: false,
     }
 }
 

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -3323,6 +3323,177 @@ fn audit_coverage_relative_path_resolves_against_root_through_base_snapshot() {
     assert_eq!(json["verdict"].as_str(), Some("pass"));
 }
 
+/// Write an Istanbul map recording `branchy` (declared at 1-based `line` in
+/// `coverage_source_path`) as never executed (fn hit count 0, no statements),
+/// i.e. measured 0% coverage.
+fn write_uncovered_branchy_coverage(
+    coverage_path: &std::path::Path,
+    coverage_source_path: &str,
+    line: u32,
+) {
+    fs::create_dir_all(coverage_path.parent().unwrap()).unwrap();
+    let mut coverage = serde_json::Map::new();
+    coverage.insert(
+        coverage_source_path.to_string(),
+        serde_json::json!({
+            "path": coverage_source_path,
+            "statementMap": {},
+            "fnMap": {
+                "0": {
+                    "name": "branchy",
+                    "line": line,
+                    "decl": {
+                        "start": { "line": line, "column": 16 },
+                        "end": { "line": line, "column": 23 }
+                    },
+                    "loc": {
+                        "start": { "line": line, "column": 44 },
+                        "end": { "line": line + 8, "column": 1 }
+                    }
+                }
+            },
+            "branchMap": {},
+            "s": {},
+            "f": { "0": 0 },
+            "b": {}
+        }),
+    );
+    fs::write(coverage_path, serde_json::to_string(&coverage).unwrap()).unwrap();
+}
+
+/// The uncovered high-CRAP `branchy` function plus an external test reference,
+/// committed as the audit base state. Returns the path to `src/branchy.ts`.
+/// The vitest devDependency makes `src/branchy.test.ts` a test entry; without
+/// a test-runner plugin the graph estimate is 0% on both sides and the
+/// base/head divergence guarded by the #2347 tests never occurs.
+fn commit_branchy_with_test_reference(dir: &std::path::Path) -> std::path::PathBuf {
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name": "audit-test", "main": "src/index.ts", "devDependencies": {"vitest": "^3.0.0"}}"#,
+    )
+    .unwrap();
+    let branchy_path = dir.join("src/branchy.ts");
+    fs::write(
+        &branchy_path,
+        "export function branchy(n: number): number {\n\
+         \x20 if (n < 0) return -1;\n\
+         \x20 if (n === 0) return 0;\n\
+         \x20 if (n < 10) return 1;\n\
+         \x20 if (n < 100) return 2;\n\
+         \x20 if (n < 1000) return 3;\n\
+         \x20 if (n < 10000) return 4;\n\
+         \x20 return 5;\n\
+         }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/branchy.test.ts"),
+        "import { branchy } from './branchy';\nbranchy(1);\n",
+    )
+    .unwrap();
+    commit_all(dir, "add branchy with an external test reference");
+    branchy_path
+}
+
+/// Run `fallow audit --base HEAD~1 --max-crap 10` on `root`, optionally with
+/// `--coverage <path>`.
+fn run_branchy_audit(
+    root: &std::path::Path,
+    coverage_path: Option<&std::path::Path>,
+) -> common::CommandOutput {
+    let mut args = vec![
+        "audit",
+        "--root",
+        root.to_str().unwrap(),
+        "--base",
+        "HEAD~1",
+        "--max-crap",
+        "10",
+    ];
+    if let Some(coverage_path) = coverage_path {
+        args.push("--coverage");
+        args.push(coverage_path.to_str().unwrap());
+    }
+    args.extend(["--format", "json", "--quiet"]);
+    run_fallow_raw(&args)
+}
+
+/// Assert the audit passed with the `branchy` CRAP finding scored from
+/// Istanbul data and attributed `introduced: false`.
+fn assert_branchy_inherited(output: &common::CommandOutput) {
+    let json = parse_json(output);
+    let findings = json["complexity"]["findings"]
+        .as_array()
+        .expect("audit JSON should include complexity findings");
+    let branchy = findings
+        .iter()
+        .find(|f| f["name"].as_str() == Some("branchy"))
+        .expect("branchy should be reported above the CRAP threshold with 0% measured coverage");
+    assert_eq!(
+        branchy["introduced"].as_bool(),
+        Some(false),
+        "branchy is byte-identical on both sides; the base snapshot must score it with the same Istanbul data as HEAD. stderr: {}",
+        output.stderr
+    );
+    assert_eq!(
+        output.code, 0,
+        "gate new-only must not fail on the inherited finding. stderr: {}",
+        output.stderr
+    );
+}
+
+/// #2347: a pre-existing high-CRAP function must stay `introduced: false` when
+/// `--coverage` is supplied and an unrelated edit touches its file. The base
+/// snapshot runs in a temporary worktree, so the Istanbul paths (which point
+/// at the HEAD checkout) must be rebased onto that worktree; otherwise the
+/// base side falls back to the reachability estimate, scores below threshold,
+/// and the unchanged head finding fails `--gate new-only`.
+#[test]
+fn audit_coverage_keeps_unchanged_function_inherited_through_base_snapshot() {
+    let dir = create_audit_fixture("coverage-base-attribution");
+    let branchy_path = commit_branchy_with_test_reference(dir.path());
+
+    let mut source = fs::read_to_string(&branchy_path).unwrap();
+    source.push_str("branchy(-1);\n");
+    fs::write(&branchy_path, source).unwrap();
+    commit_all(dir.path(), "append an unrelated statement below branchy");
+
+    let without_coverage = run_branchy_audit(dir.path(), None);
+    assert_eq!(
+        without_coverage.code, 0,
+        "the graph estimate must score branchy below the CRAP threshold, or this test no longer exercises the base/head divergence. stderr: {}",
+        without_coverage.stderr
+    );
+
+    let coverage_path = dir.path().join("artifacts/coverage-final.json");
+    write_uncovered_branchy_coverage(&coverage_path, &branchy_path.to_string_lossy(), 1);
+
+    let with_coverage = run_branchy_audit(dir.path(), Some(&coverage_path));
+    assert_branchy_inherited(&with_coverage);
+}
+
+/// #2347, line-shift variant: the unrelated edit prepends lines ABOVE the
+/// function, so the base worktree sees it far from where the HEAD-generated
+/// Istanbul map recorded it. The base pass must still match the function
+/// (relocated coverage tolerates line drift for unambiguous names) instead of
+/// degrading to the reachability estimate and flipping it to introduced.
+#[test]
+fn audit_coverage_keeps_line_shifted_function_inherited_through_base_snapshot() {
+    let dir = create_audit_fixture("coverage-base-line-shift");
+    let branchy_path = commit_branchy_with_test_reference(dir.path());
+
+    let source = fs::read_to_string(&branchy_path).unwrap();
+    let padding = "// padding\n".repeat(19);
+    fs::write(&branchy_path, format!("{padding}{source}")).unwrap();
+    commit_all(dir.path(), "prepend unrelated lines above branchy");
+
+    let coverage_path = dir.path().join("artifacts/coverage-final.json");
+    write_uncovered_branchy_coverage(&coverage_path, &branchy_path.to_string_lossy(), 20);
+
+    let with_coverage = run_branchy_audit(dir.path(), Some(&coverage_path));
+    assert_branchy_inherited(&with_coverage);
+}
+
 #[test]
 fn audit_coverage_env_fallback_feeds_crap_scoring() {
     let dir = create_audit_fixture("coverage-env");

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -3323,42 +3323,61 @@ fn audit_coverage_relative_path_resolves_against_root_through_base_snapshot() {
     assert_eq!(json["verdict"].as_str(), Some("pass"));
 }
 
-/// Write an Istanbul map recording `branchy` (declared at 1-based `line` in
-/// `coverage_source_path`) as never executed (fn hit count 0, no statements),
-/// i.e. measured 0% coverage.
-fn write_uncovered_branchy_coverage(
+/// Write an Istanbul map recording each `(name, line)` function (declared at
+/// its 1-based `line` in `coverage_source_path`) with the given fn hit count
+/// and no statements: `hits == 0` means measured 0% coverage, anything higher
+/// means 100%.
+fn write_fns_coverage(
     coverage_path: &std::path::Path,
     coverage_source_path: &str,
-    line: u32,
+    fns: &[(&str, u32)],
+    hits: u64,
 ) {
     fs::create_dir_all(coverage_path.parent().unwrap()).unwrap();
+    let mut fn_map = serde_json::Map::new();
+    let mut fn_hits = serde_json::Map::new();
+    for (index, (name, line)) in fns.iter().enumerate() {
+        fn_map.insert(
+            index.to_string(),
+            serde_json::json!({
+                "name": name,
+                "line": line,
+                "decl": {
+                    "start": { "line": line, "column": 16 },
+                    "end": { "line": line, "column": 23 }
+                },
+                "loc": {
+                    "start": { "line": line, "column": 44 },
+                    "end": { "line": line + 8, "column": 1 }
+                }
+            }),
+        );
+        fn_hits.insert(index.to_string(), serde_json::json!(hits));
+    }
     let mut coverage = serde_json::Map::new();
     coverage.insert(
         coverage_source_path.to_string(),
         serde_json::json!({
             "path": coverage_source_path,
             "statementMap": {},
-            "fnMap": {
-                "0": {
-                    "name": "branchy",
-                    "line": line,
-                    "decl": {
-                        "start": { "line": line, "column": 16 },
-                        "end": { "line": line, "column": 23 }
-                    },
-                    "loc": {
-                        "start": { "line": line, "column": 44 },
-                        "end": { "line": line + 8, "column": 1 }
-                    }
-                }
-            },
+            "fnMap": fn_map,
             "branchMap": {},
             "s": {},
-            "f": { "0": 0 },
+            "f": fn_hits,
             "b": {}
         }),
     );
     fs::write(coverage_path, serde_json::to_string(&coverage).unwrap()).unwrap();
+}
+
+/// Write an Istanbul map recording `branchy` (declared at 1-based `line` in
+/// `coverage_source_path`) as never executed, i.e. measured 0% coverage.
+fn write_uncovered_branchy_coverage(
+    coverage_path: &std::path::Path,
+    coverage_source_path: &str,
+    line: u32,
+) {
+    write_fns_coverage(coverage_path, coverage_source_path, &[("branchy", line)], 0);
 }
 
 /// The uncovered high-CRAP `branchy` function plus an external test reference,
@@ -3418,6 +3437,33 @@ fn run_branchy_audit(
     run_fallow_raw(&args)
 }
 
+/// Assert an estimate-only run passes with `branchy` scored below the CRAP
+/// threshold. The coverage variants rely on the estimate and the Istanbul map
+/// disagreeing; if fixture drift stopped `branchy.test.ts` from being a test
+/// entry, the estimate would hit 0% on both sides, the finding would be
+/// inherited either way, and the coverage assertions would pass without
+/// exercising the base/head divergence.
+fn assert_branchy_below_threshold(output: &common::CommandOutput) {
+    assert_eq!(
+        output.code, 0,
+        "the estimate-only control run must pass. stderr: {}",
+        output.stderr
+    );
+    let json = parse_json(output);
+    let has_branchy = json["complexity"]["findings"]
+        .as_array()
+        .is_some_and(|findings| {
+            findings
+                .iter()
+                .any(|f| f["name"].as_str() == Some("branchy"))
+        });
+    assert!(
+        !has_branchy,
+        "the graph estimate must score branchy below the CRAP threshold, or this test no longer exercises the base/head divergence. stdout: {}",
+        output.stdout
+    );
+}
+
 /// Assert the audit passed with the `branchy` CRAP finding scored from
 /// Istanbul data and attributed `introduced: false`.
 fn assert_branchy_inherited(output: &common::CommandOutput) {
@@ -3458,12 +3504,7 @@ fn audit_coverage_keeps_unchanged_function_inherited_through_base_snapshot() {
     fs::write(&branchy_path, source).unwrap();
     commit_all(dir.path(), "append an unrelated statement below branchy");
 
-    let without_coverage = run_branchy_audit(dir.path(), None);
-    assert_eq!(
-        without_coverage.code, 0,
-        "the graph estimate must score branchy below the CRAP threshold, or this test no longer exercises the base/head divergence. stderr: {}",
-        without_coverage.stderr
-    );
+    assert_branchy_below_threshold(&run_branchy_audit(dir.path(), None));
 
     let coverage_path = dir.path().join("artifacts/coverage-final.json");
     write_uncovered_branchy_coverage(&coverage_path, &branchy_path.to_string_lossy(), 1);
@@ -3487,11 +3528,121 @@ fn audit_coverage_keeps_line_shifted_function_inherited_through_base_snapshot() 
     fs::write(&branchy_path, format!("{padding}{source}")).unwrap();
     commit_all(dir.path(), "prepend unrelated lines above branchy");
 
+    assert_branchy_below_threshold(&run_branchy_audit(dir.path(), None));
+
     let coverage_path = dir.path().join("artifacts/coverage-final.json");
     write_uncovered_branchy_coverage(&coverage_path, &branchy_path.to_string_lossy(), 20);
 
     let with_coverage = run_branchy_audit(dir.path(), Some(&coverage_path));
     assert_branchy_inherited(&with_coverage);
+}
+
+/// Failure direction for #2347: rebasing the Istanbul map onto the base
+/// worktree must not disable the gate. A genuinely new high-CRAP function in
+/// the same 0%-covered file stays `introduced: true` with exit 1, while the
+/// pre-existing one stays inherited, both scored from Istanbul data.
+#[test]
+fn audit_coverage_still_gates_new_high_crap_function() {
+    let dir = create_audit_fixture("coverage-gate-new-fn");
+    let branchy_path = commit_branchy_with_test_reference(dir.path());
+
+    let mut source = fs::read_to_string(&branchy_path).unwrap();
+    source.push_str(
+        "export function freshlyBranchy(n: number): number {\n\
+         \x20 if (n < 0) return -1;\n\
+         \x20 if (n === 0) return 0;\n\
+         \x20 if (n < 10) return 1;\n\
+         \x20 if (n < 100) return 2;\n\
+         \x20 if (n < 1000) return 3;\n\
+         \x20 if (n < 10000) return 4;\n\
+         \x20 return 5;\n\
+         }\n",
+    );
+    fs::write(&branchy_path, source).unwrap();
+    fs::write(
+        dir.path().join("src/branchy.test.ts"),
+        "import { branchy, freshlyBranchy } from './branchy';\nbranchy(1);\nfreshlyBranchy(1);\n",
+    )
+    .unwrap();
+    commit_all(dir.path(), "add a new high-complexity function");
+
+    let coverage_path = dir.path().join("artifacts/coverage-final.json");
+    write_fns_coverage(
+        &coverage_path,
+        &branchy_path.to_string_lossy(),
+        &[("branchy", 1), ("freshlyBranchy", 10)],
+        0,
+    );
+
+    let output = run_branchy_audit(dir.path(), Some(&coverage_path));
+    assert_eq!(
+        output.code, 1,
+        "new high-CRAP debt must still fail gate new-only when coverage is supplied. stderr: {}",
+        output.stderr
+    );
+    let json = parse_json(&output);
+    let findings = json["complexity"]["findings"]
+        .as_array()
+        .expect("audit JSON should include complexity findings");
+    let fresh = findings
+        .iter()
+        .find(|f| f["name"].as_str() == Some("freshlyBranchy"))
+        .expect("the new function should be reported above the CRAP threshold");
+    assert_eq!(fresh["introduced"].as_bool(), Some(true));
+    assert_eq!(fresh["coverage_source"].as_str(), Some("istanbul"));
+    let branchy = findings
+        .iter()
+        .find(|f| f["name"].as_str() == Some("branchy"))
+        .expect("the pre-existing function should still be reported");
+    assert_eq!(branchy["introduced"].as_bool(), Some(false));
+    assert!(
+        json["attribution"]["complexity_introduced"]
+            .as_u64()
+            .is_some_and(|count| count >= 1),
+        "attribution should count the new function as introduced: {}",
+        json["attribution"]
+    );
+}
+
+/// #2347 for the zero-flag flow (`vitest --coverage && fallow audit`): the
+/// head pass auto-detects `coverage/coverage-final.json`, and the base pass
+/// must consume the same map instead of auto-detecting against the base
+/// worktree (which never materializes coverage output). The first run also
+/// caches a base snapshot without any coverage, so the second run pins that
+/// auto-detected coverage participates in the base-snapshot cache key.
+#[test]
+fn audit_auto_detected_coverage_keeps_unchanged_function_inherited() {
+    let dir = create_audit_fixture("coverage-auto-detect-base");
+    let branchy_path = commit_branchy_with_test_reference(dir.path());
+
+    let mut source = fs::read_to_string(&branchy_path).unwrap();
+    source.push_str("branchy(-1);\n");
+    fs::write(&branchy_path, source).unwrap();
+    commit_all(dir.path(), "append an unrelated statement below branchy");
+
+    assert_branchy_below_threshold(&run_branchy_audit(dir.path(), None));
+
+    let coverage_path = dir.path().join("coverage/coverage-final.json");
+    write_fns_coverage(
+        &coverage_path,
+        &branchy_path.to_string_lossy(),
+        &[("branchy", 1)],
+        1,
+    );
+    let covered = run_branchy_audit(dir.path(), None);
+    assert_eq!(
+        covered.code, 0,
+        "a fully covered map scores branchy below the CRAP threshold on both sides. stderr: {}",
+        covered.stderr
+    );
+
+    // Rewriting the map in place (a vitest re-run after a test was removed)
+    // must invalidate the cached base snapshot: the auto-detected file's
+    // content participates in the base-snapshot cache key exactly like an
+    // explicit `--coverage` file.
+    write_uncovered_branchy_coverage(&coverage_path, &branchy_path.to_string_lossy(), 1);
+    let auto_detected = run_branchy_audit(dir.path(), None);
+    assert_branchy_inherited(&auto_detected);
 }
 
 #[test]

--- a/crates/engine/src/health/coverage_settings.rs
+++ b/crates/engine/src/health/coverage_settings.rs
@@ -42,6 +42,7 @@ fn load_health_coverage(
             coverage_path,
             opts.coverage_inputs.coverage_root,
             Some(&config.root),
+            opts.coverage_inputs.coverage_relocated,
         )
         .map(Some)
         .map_err(|e| HealthError::message(format!("coverage: {e}"), 2));
@@ -60,6 +61,7 @@ fn load_health_coverage(
         &auto_path,
         opts.coverage_inputs.coverage_root,
         Some(&config.root),
+        opts.coverage_inputs.coverage_relocated,
     )
     .ok())
 }

--- a/crates/engine/src/health/coverage_settings.rs
+++ b/crates/engine/src/health/coverage_settings.rs
@@ -38,14 +38,21 @@ fn load_health_coverage(
     config: &ResolvedConfig,
 ) -> Result<Option<scoring::IstanbulCoverage>, HealthError> {
     if let Some(coverage_path) = opts.coverage_inputs.coverage {
-        return scoring::load_istanbul_coverage(
+        return match scoring::load_istanbul_coverage(
             coverage_path,
             opts.coverage_inputs.coverage_root,
             Some(&config.root),
             opts.coverage_inputs.coverage_relocated,
-        )
-        .map(Some)
-        .map_err(|e| HealthError::message(format!("coverage: {e}"), 2));
+        ) {
+            Ok(coverage) => Ok(Some(coverage)),
+            // The relocated (audit base-worktree) pass may have been handed a
+            // file the head pass only auto-detected and loads leniently below;
+            // failing hard here would turn lenient auto-detection into an
+            // audit error. Explicit user coverage still fails loudly: the
+            // head pass loads the same file strictly.
+            Err(_) if opts.coverage_inputs.coverage_relocated => Ok(None),
+            Err(e) => Err(HealthError::message(format!("coverage: {e}"), 2)),
+        };
     }
 
     let Some(auto_path) = scoring::auto_detect_coverage(&config.root) else {

--- a/crates/engine/src/health/mod.rs
+++ b/crates/engine/src/health/mod.rs
@@ -275,6 +275,12 @@ pub struct HealthCoverageInputs<'a> {
     /// Absolute coverage-path prefix to strip before rebasing files onto the
     /// project root.
     pub coverage_root: Option<&'a Path>,
+    /// The coverage map was recorded against a different checkout of this
+    /// project (the audit base-worktree pass), so function line numbers may
+    /// have drifted arbitrarily. Enables the distance-free unambiguous-name
+    /// match in the Istanbul lookup; keep `false` for same-checkout coverage,
+    /// where the bounded fuzz protects against stale data (#2347).
+    pub coverage_relocated: bool,
 }
 
 /// Validate that a coverage-data root is absolute under Unix or Windows path

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -979,13 +979,14 @@ fn resolve_crap_coverage<'a>(
     }
 }
 
-/// Load Istanbul coverage data from a `coverage-final.json` file or directory.
-///
 /// Auto-detect a `coverage-final.json` file in common locations relative to the project root.
 ///
 /// Checks (in order): `coverage/coverage-final.json`, `.nyc_output/coverage-final.json`.
 /// Returns the first path found, or `None` if no coverage file exists.
-pub(super) fn auto_detect_coverage(root: &std::path::Path) -> Option<std::path::PathBuf> {
+/// The audit base-worktree pass uses the same detection against the head
+/// project root, so auto-detected coverage scores both attribution sides
+/// (#2347).
+pub fn auto_detect_coverage(root: &std::path::Path) -> Option<std::path::PathBuf> {
     let candidates = [
         root.join("coverage/coverage-final.json"),
         root.join(".nyc_output/coverage-final.json"),

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -829,6 +829,10 @@ pub struct IstanbulFileCoverage {
     /// `decl.start`, so multiline TypeScript signatures still match the
     /// function start that fallow extracts.
     functions: rustc_hash::FxHashMap<(String, u32, u32), f64>,
+    /// The coverage map was recorded against a different checkout of the
+    /// project, so line numbers may have drifted beyond the bounded fuzz.
+    /// Enables the distance-free unambiguous-name fallback in [`Self::lookup`].
+    relocated: bool,
 }
 
 impl IstanbulFileCoverage {
@@ -848,6 +852,15 @@ impl IstanbulFileCoverage {
     /// Istanbul records the function as anonymous. `load_istanbul_coverage`
     /// indexes declaration aliases so standard Istanbul producers still
     /// participate in this fallback. See issues #155, #166, #181, and #370.
+    ///
+    /// When the map is `relocated` (recorded against a different checkout of
+    /// the project, as in the audit base-worktree pass), a distance-free
+    /// name match runs between steps 2 and 3: if every entry named `name`
+    /// carries the same coverage value, that value is returned regardless of
+    /// line drift. Unrelated edits can shift a function arbitrarily far
+    /// between the two checkouts, and when all same-named candidates agree
+    /// the choice among them cannot matter (#2347). Same-checkout lookups
+    /// keep the bounded fuzz, which protects against stale coverage data.
     pub fn lookup(&self, name: &str, line: u32, col: u32) -> Option<f64> {
         if let Some(&pct) = self.functions.get(&(name.to_string(), line, col)) {
             return Some(pct);
@@ -858,6 +871,11 @@ impl IstanbulFileCoverage {
             .filter(|((n, l, _), _)| n == name && l.abs_diff(line) <= 2)
             .min_by_key(|((_, l, c), _)| (l.abs_diff(line), c.abs_diff(col)))
             .map(|(_, &pct)| pct)
+        {
+            return Some(pct);
+        }
+        if self.relocated
+            && let Some(pct) = self.unambiguous_named_pct(name)
         {
             return Some(pct);
         }
@@ -893,6 +911,27 @@ impl IstanbulFileCoverage {
             }
         }
         if tied { None } else { nearest_pct }
+    }
+
+    /// The single coverage value shared by every entry named `name`, or
+    /// `None` when the name is absent or its entries disagree. Bit-exact
+    /// comparison: agreeing entries are either the primary/declaration alias
+    /// pair of one function (inserted with the identical value) or distinct
+    /// functions whose value coincides, in which case the choice among them
+    /// cannot change the result.
+    fn unambiguous_named_pct(&self, name: &str) -> Option<f64> {
+        let mut found: Option<f64> = None;
+        for ((n, _, _), &pct) in &self.functions {
+            if n != name {
+                continue;
+            }
+            match found {
+                None => found = Some(pct),
+                Some(prev) if prev.to_bits() == pct.to_bits() => {}
+                Some(_) => return None,
+            }
+        }
+        found
     }
 }
 
@@ -983,10 +1022,14 @@ pub fn resolve_relative_to_root(
 /// `path` itself is resolved against `project_root` when relative, so callers
 /// can pass `--coverage coverage/foo.json` from a parent directory and have it
 /// land under the `--root` they configured.
+///
+/// `relocated` marks a map recorded against a different checkout of the
+/// project; see [`IstanbulFileCoverage::lookup`].
 pub(super) fn load_istanbul_coverage(
     path: &std::path::Path,
     coverage_root: Option<&std::path::Path>,
     project_root: Option<&std::path::Path>,
+    relocated: bool,
 ) -> Result<IstanbulCoverage, String> {
     super::validate_coverage_root_absolute(coverage_root)?;
     let resolved = resolve_relative_to_root(path, project_root);
@@ -1019,10 +1062,7 @@ pub(super) fn load_istanbul_coverage(
     for file_cov in raw.values() {
         let raw_path = std::path::PathBuf::from(&file_cov.path);
         let file_path = if let (Some(cov_root), Some(proj_root)) = (coverage_root, project_root) {
-            raw_path
-                .strip_prefix(cov_root)
-                .map(|rel| proj_root.join(rel))
-                .unwrap_or(raw_path)
+            rebase_coverage_path(raw_path, cov_root, proj_root)
         } else {
             raw_path
         };
@@ -1034,10 +1074,39 @@ pub(super) fn load_istanbul_coverage(
             insert_istanbul_function_coverage(&mut functions, fn_entry, coverage_pct);
         }
 
-        files.insert(canonical, IstanbulFileCoverage { functions });
+        files.insert(
+            canonical,
+            IstanbulFileCoverage {
+                functions,
+                relocated,
+            },
+        );
     }
 
     Ok(IstanbulCoverage { files })
+}
+
+/// Rebase one Istanbul file path from `coverage_root` onto `project_root`.
+///
+/// When the recorded path does not start with `coverage_root` verbatim, retry
+/// with its canonicalized form: coverage generated inside a symlinked
+/// directory (macOS `/var` vs `/private/var`) records the symlinked spelling
+/// while the rebase prefix is typically canonical. Paths under neither
+/// spelling are kept as-is, matching the previous behavior.
+fn rebase_coverage_path(
+    raw_path: std::path::PathBuf,
+    coverage_root: &std::path::Path,
+    project_root: &std::path::Path,
+) -> std::path::PathBuf {
+    if let Ok(rel) = raw_path.strip_prefix(coverage_root) {
+        return project_root.join(rel);
+    }
+    if let Ok(canonical) = dunce::canonicalize(&raw_path)
+        && let Ok(rel) = canonical.strip_prefix(coverage_root)
+    {
+        return project_root.join(rel);
+    }
+    raw_path
 }
 
 fn insert_istanbul_function_coverage(
@@ -4246,7 +4315,10 @@ mod tests {
         let funcs = vec![make_fn_complexity(10)];
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("test_fn".to_string(), 1, 0), 41.56);
-        let file_cov = IstanbulFileCoverage { functions };
+        let file_cov = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
 
         let result = istanbul_crap_default(&funcs, Some(&file_cov), false);
         assert!((result.per_function[0].crap - 30.0).abs() < f64::EPSILON);
@@ -4519,7 +4591,10 @@ mod tests {
         let funcs = vec![make_fn_complexity(10)];
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("test_fn".to_string(), 1, 0), 80.0);
-        let file_cov = IstanbulFileCoverage { functions };
+        let file_cov = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         let result = istanbul_crap_default(&funcs, Some(&file_cov), false);
         assert!((result.max_crap - 10.8).abs() < 0.1);
         assert_eq!(result.signals.above, 0);
@@ -4530,6 +4605,7 @@ mod tests {
         let funcs = vec![make_fn_complexity(6)];
         let file_cov = IstanbulFileCoverage {
             functions: rustc_hash::FxHashMap::default(),
+            relocated: false,
         };
         let result = istanbul_crap_default(&funcs, Some(&file_cov), false);
         assert!((result.max_crap - 42.0).abs() < f64::EPSILON);
@@ -4549,7 +4625,10 @@ mod tests {
         let funcs = vec![make_fn_complexity(5)];
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("test_fn".to_string(), 1, 0), 0.0);
-        let file_cov = IstanbulFileCoverage { functions };
+        let file_cov = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         let result = istanbul_crap_default(&funcs, Some(&file_cov), false);
         assert!((result.max_crap - 30.0).abs() < f64::EPSILON);
         assert_eq!(result.signals.above, 1);
@@ -4787,6 +4866,7 @@ mod tests {
             std::path::Path::new("coverage/coverage-final.json"),
             None,
             Some(temp.path()),
+            false,
         )
         .expect("relative path must resolve against project_root");
         assert!(
@@ -4837,7 +4917,7 @@ mod tests {
             }),
         );
 
-        let coverage = load_istanbul_coverage(&coverage_path, None, None).unwrap();
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
@@ -4875,7 +4955,7 @@ mod tests {
             }),
         );
 
-        let coverage = load_istanbul_coverage(&coverage_path, None, None).unwrap();
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
@@ -4917,7 +4997,7 @@ mod tests {
             }),
         );
 
-        let coverage = load_istanbul_coverage(&coverage_path, None, None).unwrap();
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
@@ -4928,7 +5008,10 @@ mod tests {
     fn istanbul_lookup_exact_match() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("handleClick".to_string(), 10, 0), 85.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!((fc.lookup("handleClick", 10, 0).unwrap() - 85.0).abs() < f64::EPSILON);
     }
 
@@ -4936,7 +5019,10 @@ mod tests {
     fn istanbul_lookup_fuzzy_match_within_offset() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("handleClick".to_string(), 10, 0), 72.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!((fc.lookup("handleClick", 11, 0).unwrap() - 72.0).abs() < f64::EPSILON);
         assert!((fc.lookup("handleClick", 12, 0).unwrap() - 72.0).abs() < f64::EPSILON);
     }
@@ -4945,15 +5031,68 @@ mod tests {
     fn istanbul_lookup_fuzzy_match_outside_offset() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("handleClick".to_string(), 10, 0), 72.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!(fc.lookup("handleClick", 13, 0).is_none());
+    }
+
+    #[test]
+    fn istanbul_lookup_relocated_matches_unique_name_at_any_distance() {
+        let mut functions = rustc_hash::FxHashMap::default();
+        functions.insert(("handleClick".to_string(), 29, 0), 72.0);
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: true,
+        };
+        assert!((fc.lookup("handleClick", 10, 0).unwrap() - 72.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn istanbul_lookup_relocated_accepts_declaration_alias_pair() {
+        let mut functions = rustc_hash::FxHashMap::default();
+        functions.insert(("handleClick".to_string(), 29, 16), 72.0);
+        functions.insert(("handleClick".to_string(), 29, 0), 72.0);
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: true,
+        };
+        assert!((fc.lookup("handleClick", 10, 0).unwrap() - 72.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn istanbul_lookup_relocated_bails_on_disagreeing_same_name_entries() {
+        let mut functions = rustc_hash::FxHashMap::default();
+        functions.insert(("render".to_string(), 29, 0), 72.0);
+        functions.insert(("render".to_string(), 80, 0), 10.0);
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: true,
+        };
+        assert!(fc.lookup("render", 10, 0).is_none());
+    }
+
+    #[test]
+    fn istanbul_lookup_relocated_prefers_bounded_fuzzy_match() {
+        let mut functions = rustc_hash::FxHashMap::default();
+        functions.insert(("render".to_string(), 11, 0), 72.0);
+        functions.insert(("render".to_string(), 80, 0), 10.0);
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: true,
+        };
+        assert!((fc.lookup("render", 10, 0).unwrap() - 72.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn istanbul_lookup_name_mismatch() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("handleClick".to_string(), 10, 0), 85.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!(fc.lookup("handleSubmit", 10, 0).is_none());
     }
 
@@ -4961,6 +5100,7 @@ mod tests {
     fn istanbul_lookup_empty() {
         let fc = IstanbulFileCoverage {
             functions: rustc_hash::FxHashMap::default(),
+            relocated: false,
         };
         assert!(fc.lookup("anything", 1, 0).is_none());
     }
@@ -4970,7 +5110,10 @@ mod tests {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("render".to_string(), 8, 0), 60.0);
         functions.insert(("render".to_string(), 12, 0), 90.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         let result = fc.lookup("render", 10, 0);
         assert!(result.is_some());
         let pct = result.unwrap();
@@ -4981,7 +5124,10 @@ mod tests {
     fn istanbul_lookup_anonymous_fallback_single_candidate() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("(anonymous_0)".to_string(), 28, 0), 75.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!((fc.lookup("myHandler", 28, 0).unwrap() - 75.0).abs() < f64::EPSILON);
         assert!((fc.lookup("myHandler", 30, 0).unwrap() - 75.0).abs() < f64::EPSILON);
     }
@@ -4990,7 +5136,10 @@ mod tests {
     fn istanbul_lookup_anonymous_fallback_rejects_nearby_far_column() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("(anonymous_0)".to_string(), 4, 28), 75.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
 
         assert!(fc.lookup("declaredHelper", 3, 0).is_none());
     }
@@ -5000,7 +5149,10 @@ mod tests {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("(anonymous_0)".to_string(), 28, 0), 75.0);
         functions.insert(("(anonymous_1)".to_string(), 29, 0), 50.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!((fc.lookup("myHandler", 28, 0).unwrap() - 75.0).abs() < f64::EPSILON);
     }
 
@@ -5009,7 +5161,10 @@ mod tests {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("(anonymous_0)".to_string(), 1, 23), 90.0); // outer
         functions.insert(("(anonymous_1)".to_string(), 1, 43), 10.0); // inner
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!((fc.lookup("<arrow>", 1, 43).unwrap() - 10.0).abs() < f64::EPSILON);
         assert!((fc.lookup("<arrow>", 1, 23).unwrap() - 90.0).abs() < f64::EPSILON);
     }
@@ -5019,7 +5174,10 @@ mod tests {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("(anonymous_0)".to_string(), 27, 0), 75.0);
         functions.insert(("(anonymous_1)".to_string(), 29, 0), 50.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!(fc.lookup("myHandler", 28, 0).is_none());
     }
 
@@ -5027,7 +5185,10 @@ mod tests {
     fn istanbul_lookup_anonymous_fallback_outside_offset() {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("(anonymous_0)".to_string(), 28, 0), 75.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!(fc.lookup("myHandler", 31, 0).is_none());
     }
 
@@ -5036,7 +5197,10 @@ mod tests {
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("handleClick".to_string(), 10, 0), 90.0);
         functions.insert(("(anonymous_7)".to_string(), 11, 0), 10.0);
-        let fc = IstanbulFileCoverage { functions };
+        let fc = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         assert!((fc.lookup("handleClick", 10, 0).unwrap() - 90.0).abs() < f64::EPSILON);
     }
 
@@ -5075,7 +5239,10 @@ mod tests {
         }];
         let mut functions = rustc_hash::FxHashMap::default();
         functions.insert(("test_fn".to_string(), 1, 0), 80.0);
-        let file_cov = IstanbulFileCoverage { functions };
+        let file_cov = IstanbulFileCoverage {
+            functions,
+            relocated: false,
+        };
         let result = istanbul_crap_default(&funcs, Some(&file_cov), true);
         assert_eq!(result.matched, 1);
         assert_eq!(result.total, 2);

--- a/crates/mcp/src/tools/health.rs
+++ b/crates/mcp/src/tools/health.rs
@@ -368,6 +368,7 @@ fn health_options_from_params(params: &HealthParams) -> Result<ComplexityOptions
         min_commits: params.min_commits,
         coverage: non_empty_path(params.coverage.as_deref()),
         coverage_root: non_empty_path(params.coverage_root.as_deref()),
+        coverage_relocated: false,
     })
 }
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -494,6 +494,7 @@ impl TryFrom<ComplexityOptions> for api::ComplexityOptions {
             min_commits: value.min_commits,
             coverage: value.coverage.map(std::path::PathBuf::from),
             coverage_root: value.coverage_root.map(std::path::PathBuf::from),
+            coverage_relocated: false,
         })
     }
 }

--- a/docs/reference/cli-internals.md
+++ b/docs/reference/cli-internals.md
@@ -43,6 +43,19 @@ an exit code.
 - Resolve user-provided file inputs against the user's project root before an
   audit switches to a base worktree. Prefix values such as `--coverage-root`
   remain absolute prefixes and must not be reinterpreted as input files.
+- Audit base coverage attribution (#2347): the base-worktree pass scores from
+  the same head-generated Istanbul map as the head pass, for explicit and
+  auto-detected coverage alike. When no `--coverage-root` was given, the
+  canonical head project root becomes the strip prefix so every recorded path
+  rebases onto the base worktree; an explicit prefix is forwarded unchanged.
+  Relocated base lookups (`coverage_relocated`) tolerate unbounded line drift
+  only when every same-named entry in the file agrees on one value.
+  Consequences: complexity growth in files the map reports as untested
+  attributes as inherited once the base function also exceeds the threshold,
+  and test deletions cannot surface as `introduced` complexity findings (the
+  base is scored with the post-deletion map); coverage regressions belong to
+  `rules.coverage-gaps` and health trends. The auto-detected map's content
+  participates in the base-snapshot cache key exactly like `--coverage`.
 - Audit worktree cleanup must be scoped to Fallow-owned paths and registrations.
   Never prune unrelated user worktrees.
 - JSON mode emits structured errors on stdout and keeps progress off stdout.


### PR DESCRIPTION
## What was broken

`fallow audit --gate new-only --coverage <istanbul>` reported pre-existing, byte-identical high-CRAP functions as `introduced: true` whenever any other part of their file changed, failing PR gates for code the PR never touched. Reproduced both with no line shift (a statement appended below the function) and with a pure line shift (lines prepended above it).

## Root cause

The base-snapshot pass already forwarded `--coverage`, but it analyzes the base ref in a temporary worktree while the Istanbul map records HEAD-checkout file paths. `IstanbulCoverage` is keyed by canonical path, so no entry ever matched a base-worktree file. Base CRAP then silently fell back to the reachability estimate (`crap = cc` for test-reachable files) while HEAD scored real measured coverage (`cc^2 + cc` at 0%). For a function whose only tests live outside the coverage file (the reporter's testing-trophy setup), the base side scored below the threshold, produced no finding, and the unchanged HEAD finding lost its pairing.

The line-shift variant had a second layer: even with the paths rebased, the Istanbul function lookup tolerates only two lines of drift, so a function pushed down by an addition above it still missed on the base side.

## The fix

- `compute_base_snapshot` (CLI) and the programmatic audit runtime now default the base pass's coverage root to the canonicalized HEAD project root when no `--coverage-root` was given, so `load_istanbul_coverage` rebases every entry onto the base worktree. An explicit `--coverage-root` is forwarded unchanged; the base pass already rebases it onto its own root. The rebase retries the prefix strip with the canonicalized recorded path so symlinked directory spellings (macOS `/var` vs `/private/var`) still match.
- Coverage loaded for a relocated checkout (only the audit base pass sets this) tolerates arbitrary line drift when every same-named entry in a file carries the same coverage value; if candidates agree, the choice among them cannot change the result. Same-checkout lookups keep the bounded two-line fuzz, which protects against stale coverage data, and the existing outside-offset contract is unchanged.
- `AUDIT_BASE_SNAPSHOT_CACHE_VERSION` is bumped so snapshots computed by the coverage-blind base pass are not reused.
- The programmatic runtime also resolves a relative coverage path against the HEAD root before the base pass, which previously would have looked inside the base worktree.

The issue's alternative (b), identity-based pairing, would not have helped: the base finding was absent entirely (scored below threshold), not present under a mismatched key. Scoring both sides from the same data fixes the divergence at its source.

## How it was tested

- New CLI integration tests covering both reported variants: unchanged function with an unrelated appended statement, and the same function pushed down 19 lines by prepended lines. Both assert exit 0 and `introduced: false` on the finding, and both fail against the pre-fix code (verified by reverting each mechanism separately).
- New programmatic-API regression test mirroring the no-shift variant through `run_audit`, also verified to fail pre-fix.
- New engine unit tests for the relocated lookup semantics: unique-name match at distance, declaration-alias pairs, bail on disagreeing same-name entries, bounded fuzz still preferred.
- Manual end-to-end repro in a scratch project confirmed the exact reported behavior before the fix (verdict fail, `introduced: true`) and the corrected attribution after (verdict pass, `complexity_inherited`).
- Real-project validation: `fallow audit --coverage` against a production Next.js repo with a real `coverage-final.json` (subdirectory root inside the git toplevel), with and without coverage; attribution is identical and sane, no crashes, and the repository is left clean.
- Gates: `cargo fmt --all`, `cargo clippy --workspace --all-targets` clean, `cargo doc` clean for touched crates, full test suites green for engine, api, cli (audit, health, baseline, combined and runtime coverage), mcp, and napi.

No public contract, JSON schema, or generated surface changed: the new `coverage_relocated` field is internal (set only by the audit base pass), and the napi and MCP parameter surfaces are untouched.

Fixes #2347
