### PR TITLE
chore(contracts): regenerate output contract types for bun.lock override resolution

### DIFF
--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -2286,9 +2286,11 @@ unresolved_catalog_references?: UnresolvedCatalogReferenceFinding[]
  * Entries in pnpm-workspace.yaml's overrides: section, package.json's
  * pnpm.overrides block, or package.json's top-level npm overrides object,
  * whose target package is not declared by any workspace package and is
- * not present in pnpm-lock.yaml or package-lock.json. Default severity
- * is warn because projects without a readable lockfile fall back to
- * manifest-only checks; the hint field flags those conservative cases.
+ * not present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,
+ * or bun.lock. Default severity is warn because projects without a
+ * readable lockfile fall back to manifest-only checks; the hint field
+ * flags those conservative cases. When the only lockfile is bun's binary
+ * bun.lockb, resolution cannot be read and the check emits nothing.
  * Wrapped in [`UnusedDependencyOverrideFinding`].
  */
 unused_dependency_overrides?: UnusedDependencyOverrideFinding[]
@@ -10595,9 +10597,11 @@ unresolved_catalog_references?: UnresolvedCatalogReferenceFinding[]
  * Entries in pnpm-workspace.yaml's overrides: section, package.json's
  * pnpm.overrides block, or package.json's top-level npm overrides object,
  * whose target package is not declared by any workspace package and is
- * not present in pnpm-lock.yaml or package-lock.json. Default severity
- * is warn because projects without a readable lockfile fall back to
- * manifest-only checks; the hint field flags those conservative cases.
+ * not present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,
+ * or bun.lock. Default severity is warn because projects without a
+ * readable lockfile fall back to manifest-only checks; the hint field
+ * flags those conservative cases. When the only lockfile is bun's binary
+ * bun.lockb, resolution cannot be read and the check emits nothing.
  * Wrapped in [`UnusedDependencyOverrideFinding`].
  */
 unused_dependency_overrides?: UnusedDependencyOverrideFinding[]

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -2286,9 +2286,11 @@ unresolved_catalog_references?: UnresolvedCatalogReferenceFinding[]
  * Entries in pnpm-workspace.yaml's overrides: section, package.json's
  * pnpm.overrides block, or package.json's top-level npm overrides object,
  * whose target package is not declared by any workspace package and is
- * not present in pnpm-lock.yaml or package-lock.json. Default severity
- * is warn because projects without a readable lockfile fall back to
- * manifest-only checks; the hint field flags those conservative cases.
+ * not present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,
+ * or bun.lock. Default severity is warn because projects without a
+ * readable lockfile fall back to manifest-only checks; the hint field
+ * flags those conservative cases. When the only lockfile is bun's binary
+ * bun.lockb, resolution cannot be read and the check emits nothing.
  * Wrapped in [`UnusedDependencyOverrideFinding`].
  */
 unused_dependency_overrides?: UnusedDependencyOverrideFinding[]
@@ -10595,9 +10597,11 @@ unresolved_catalog_references?: UnresolvedCatalogReferenceFinding[]
  * Entries in pnpm-workspace.yaml's overrides: section, package.json's
  * pnpm.overrides block, or package.json's top-level npm overrides object,
  * whose target package is not declared by any workspace package and is
- * not present in pnpm-lock.yaml or package-lock.json. Default severity
- * is warn because projects without a readable lockfile fall back to
- * manifest-only checks; the hint field flags those conservative cases.
+ * not present in pnpm-lock.yaml, package-lock.json, npm-shrinkwrap.json,
+ * or bun.lock. Default severity is warn because projects without a
+ * readable lockfile fall back to manifest-only checks; the hint field
+ * flags those conservative cases. When the only lockfile is bun's binary
+ * bun.lockb, resolution cannot be read and the check emits nothing.
  * Wrapped in [`UnusedDependencyOverrideFinding`].
  */
 unused_dependency_overrides?: UnusedDependencyOverrideFinding[]


### PR DESCRIPTION
npm run generate:contracts:check flagged the two TypeScript output-contract surfaces as stale after #2350: the UnusedDependencyOverrideFinding rustdoc now mentions npm-shrinkwrap.json, bun.lock, and the bun.lockb fallback, and the generated declaration files did not carry that doc update. Regenerated via the canonical generator, no structural changes.