### PR TITLE
fix(extract): record Astro and MDX member-expression tags as member accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the extraction and graph cache versions were bumped, so the first run after
   upgrading performs one cold re-analysis.
 
+- **Member-expression component tags in Astro markup and MDX bodies
+  (`<SC.Card />`) now credit the referenced export** (Closes
+  [#2355](https://github.com/fallow-rs/fallow/issues/2355)). The Astro
+  template scan credited only the tag root, and the MDX extractor read only
+  `import` / `export` lines, so a namespace import rendered exclusively through
+  a dotted tag in `.astro` or `.mdx` markup kept its exports reported as
+  unused, and in entry-point pages every sibling export of the namespace
+  target was falsely flagged. Astro now records dotted tags from the markup
+  and runs every `{ ... }` expression region the parser accepts through the
+  same member-recording visitor `.tsx` uses (`icon={SC.Moon}`,
+  `{SC.helper()}`, `Object.keys(SC)`); MDX records dotted tags and dotted
+  chains from prose lines. Narrowing then applies under one structural
+  guarantee for Astro and MDX consumers: a namespace import (or a CSS module
+  default import, the other binding whose exports the graph narrows by member
+  access) narrows to the recorded members only when every mention of the
+  binding in the whole file was structurally understood: in Astro markup a
+  component tag root or a parsed `{ ... }` expression region, in MDX a prose
+  line outside code, and in the Astro frontmatter or on an MDX `import` /
+  `export` line a static dotted access the visitor recorded or a JSX tag root.
+  Every other mention records a whole-object use that keeps every export
+  credited, for entry-point pages as well: a `define:vars` or `set:html`
+  directive on a `<style>` / `<script>` tag, an HTML comment, text content, an
+  attribute string, an expression the parser rejects, an MDX fenced code block
+  or inline code span, a template literal the MDX line scanner cannot tell
+  apart from a code span, and a script-side alias, cast, call argument,
+  `Object.assign`, array or object literal element, or JSX attribute value
+  (`const N = NS`, `pick(NS)`, `export const all = NS`,
+  `<Callout all={NS} />`). Behavior change: a namespace import in a non-entry
+  Astro or MDX consumer whose every mention is a dotted tag, a parsed
+  expression, or a recorded dotted script access now narrows to the members
+  actually accessed instead of marking every export used, so genuinely unused
+  siblings surface for the first time; every other shape keeps the previous
+  mark-all crediting, which can hide an unused sibling but never reports a
+  used one. Astro expression accesses also reach the consumers that already
+  read frontmatter accesses (CSS module default-import narrowing, enum and
+  class member crediting), matching what `.tsx` records; the markup guard
+  covers those bindings too, so an enum or class mentioned in an HTML comment,
+  text content, or an attribute string of an Astro or MDX template credits
+  every member. MDX prose records dotted chains only for import locals of the
+  file, so a documentation sentence naming `process.env.API_KEY` never makes
+  the MDX module a secret source for `fallow security`. Both the extraction
+  and graph cache versions were bumped; the first run after upgrading performs
+  one cold re-analysis.
+
 - **JSX member-expression tags (`<SC.Wrapper />`) now credit the referenced
   export** (Closes
   [#2348](https://github.com/fallow-rs/fallow/issues/2348)). The syntactic

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -257,6 +257,8 @@ mod issue_2213_jest_mock_phantom_package;
 mod issue_2225_root_manual_mocks;
 #[path = "integration_test/issue_2348_jsx_namespace_member.rs"]
 mod issue_2348_jsx_namespace_member;
+#[path = "integration_test/issue_2355_astro_mdx_member_tags.rs"]
+mod issue_2355_astro_mdx_member_tags;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_2355_astro_mdx_member_tags.rs
+++ b/crates/core/tests/integration_test/issue_2355_astro_mdx_member_tags.rs
@@ -1,0 +1,248 @@
+use fallow_config::Severity;
+
+use crate::common::{create_config, create_config_with_rules, fixture_path};
+
+/// Run the issue #2355 fixture (Astro plugin enabled so `src/pages/**` is an
+/// entry surface) and return every reported unused export as a
+/// `(file name, export name)` pair. File names are unique across the fixture,
+/// so no path separators take part in the comparison.
+fn reported_unused_exports() -> Vec<(String, String)> {
+    let root = fixture_path("issue-2355-astro-mdx-member-tags");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            let file = e
+                .export
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+            (file, e.export.export_name.clone())
+        })
+        .collect()
+}
+
+fn is_reported(reported: &[(String, String)], file: &str, name: &str) -> bool {
+    reported
+        .iter()
+        .any(|(reported_file, reported_name)| reported_file == file && reported_name == name)
+}
+
+/// Issue #2355: a namespace import rendered only through a member-expression
+/// tag in Astro markup (`<SC.UsedStyle />`) or an MDX body (`<MD.UsedBlock />`)
+/// must credit the referenced export, while genuinely unused siblings keep
+/// reporting, matching the `.tsx` semantics from #2348.
+///
+/// Precision retained (every mention of the binding is a dotted tag or a
+/// parsed expression, so the binding narrows and its unused sibling reports):
+/// - entry `index.astro` (`SC`), non-entry `Card.astro` (`S`),
+/// - entry `guide.mdx` (`MD`), non-entry `notes.mdx` (`Doc`),
+/// - non-entry `Mixed.astro` / `mixed.mdx` mixing a dotted tag with an
+///   attribute expression, a call, or a multi-line block (`Moon` credited,
+///   the sibling reports), while a namespace passed whole (`all={NS}`) keeps
+///   every export credited.
+#[test]
+fn astro_and_mdx_member_tags_credit_namespace_exports() {
+    let reported = reported_unused_exports();
+
+    for (file, name) in [
+        ("style.ts", "ActuallyUnusedStyle"),
+        ("card-style.ts", "UnusedSibling"),
+        ("md-style.ts", "UnusedMdBlock"),
+        ("doc-style.ts", "UnusedDocSibling"),
+        ("attr-icons.ts", "AttrUnused"),
+        ("call-icons.ts", "CallUnused"),
+        ("md-attr-icons.ts", "MdAttrUnused"),
+        ("md-call-icons.ts", "MdCallUnused"),
+        ("md-multi-icons.ts", "MdMultiUnused"),
+    ] {
+        assert!(
+            is_reported(&reported, file, name),
+            "{file}:{name}: a binding used only through dotted tags and parsed expressions must narrow so its unused sibling reports: {reported:?}"
+        );
+    }
+
+    for (file, name) in [
+        ("style.ts", "UsedStyle"),
+        ("style.ts", "Layout"),
+        ("card-style.ts", "Wrapper"),
+        ("md-style.ts", "UsedBlock"),
+        ("doc-style.ts", "Note"),
+        ("attr-icons.ts", "Star"),
+        ("attr-icons.ts", "Moon"),
+        ("call-icons.ts", "Star"),
+        ("call-icons.ts", "Moon"),
+        ("md-attr-icons.ts", "Star"),
+        ("md-attr-icons.ts", "Moon"),
+        ("md-call-icons.ts", "Star"),
+        ("md-call-icons.ts", "Moon"),
+        ("md-multi-icons.ts", "Star"),
+        ("md-multi-icons.ts", "Moon"),
+        ("whole-icons.ts", "WholeShielded"),
+        ("md-whole-icons.ts", "MdWholeShielded"),
+    ] {
+        assert!(
+            !is_reported(&reported, file, name),
+            "{file}:{name}: a member used through a dotted tag, a parsed expression, or a whole-object pass must stay credited: {reported:?}"
+        );
+    }
+}
+
+/// Issue #2355 completeness guard: a mention of an import binding that the
+/// template passes could not classify keeps the binding on the mark-all path,
+/// so no used member is ever reported, for an entry page and a non-entry
+/// consumer of each kind:
+/// - Astro (`shapes.astro` in pages, `Shapes.astro` in components):
+///   `<style define:vars={{ accent: NS.accent }}>`, `<script define:vars={{
+///   moon: NS.Moon }}>`, `<script is:inline set:html={NS.code}>`, `<script
+///   define:vars={{ NS }}>`, and a CSS module class read through
+///   `define:vars`,
+/// - MDX (`shapes.mdx` in pages and docs): a template literal attribute
+///   `title={`Moon: ${NS.Moon}`}`, a whole pass inside a literal
+///   `{`${JSON.stringify(NS)}`}`, a CSS module class read through
+///   `className={`${styles.spare} x`}`, a fenced code block mentioning
+///   `<NS.Foo />`, and an inline code span mentioning `<NS.CodeOnly />`.
+#[test]
+fn astro_and_mdx_unexplained_mentions_keep_mark_all() {
+    let reported = reported_unused_exports();
+
+    for prefix in ["ea", "na"] {
+        for (file, name) in [
+            ("style-vars.ts", "Star"),
+            ("style-vars.ts", "accent"),
+            ("script-vars.ts", "Star"),
+            ("script-vars.ts", "Moon"),
+            ("set-html.ts", "Star"),
+            ("set-html.ts", "code"),
+            ("whole-vars.ts", "Star"),
+            ("whole-vars.ts", "Moon"),
+            ("whole-vars.ts", "Extra"),
+            ("card.module.css", "root"),
+            ("card.module.css", "accent"),
+        ] {
+            let file = format!("{prefix}-{file}");
+            assert!(
+                !is_reported(&reported, &file, name),
+                "{file}:{name}: a mention on a masked <style> / <script> opening tag must keep the binding on mark-all: {reported:?}"
+            );
+        }
+    }
+
+    for prefix in ["em", "nm"] {
+        for (file, name) in [
+            ("literal.ts", "Star"),
+            ("literal.ts", "Moon"),
+            ("literal-whole.ts", "Star"),
+            ("literal-whole.ts", "Moon"),
+            ("literal-whole.ts", "Extra"),
+            ("doc.module.css", "root"),
+            ("doc.module.css", "spare"),
+            ("fenced.ts", "Star"),
+            ("fenced.ts", "Foo"),
+            ("inline.ts", "Star"),
+            ("inline.ts", "CodeOnly"),
+        ] {
+            let file = format!("{prefix}-{file}");
+            assert!(
+                !is_reported(&reported, &file, name),
+                "{file}:{name}: a mention inside a template literal, fenced code, or inline code must keep the binding on mark-all: {reported:?}"
+            );
+        }
+    }
+}
+
+/// Issue #2355 script-side guard: a bare mention of a namespace in the Astro
+/// frontmatter or on an MDX statement line that the visitor does not record
+/// as a whole-object use keeps the binding on the mark-all path, so the
+/// members reached through the copy (and every sibling) stay credited, for an
+/// entry page and a non-entry consumer of each kind:
+/// - Astro (`script-shapes.astro` in pages, `ScriptShapes.astro` in
+///   components): an alias (`const N = NS`), a cast (`NS as Record<...>`), a
+///   call argument (`pick(NS)`), `Object.assign({}, NS)`, an array literal
+///   (`[NS]`), and a props object (`{ all: NS }` spread into a component),
+/// - MDX (`script-shapes.mdx` in pages and docs): `export const all = NS`, a
+///   JSX attribute on an exported component (`<Callout all={NS} />`), and a
+///   default-export layout passing the namespace whole.
+///
+/// Precision retained: a namespace used in the frontmatter or on a statement
+/// line only through a dotted access (`const moon = NS.Moon`) still narrows,
+/// so its unused sibling reports.
+#[test]
+fn astro_and_mdx_script_mentions_keep_mark_all() {
+    let reported = reported_unused_exports();
+
+    for (prefixes, shapes, dotted) in [
+        (
+            ["ea", "na"],
+            &[
+                "fm-alias",
+                "fm-as-cast",
+                "fm-call-arg",
+                "fm-object-assign",
+                "fm-array-literal",
+                "fm-props-pass",
+            ][..],
+            "fm-dotted",
+        ),
+        (
+            ["em", "nm"],
+            &["stmt-whole", "stmt-attr", "stmt-default"][..],
+            "stmt-dotted",
+        ),
+    ] {
+        for prefix in prefixes {
+            for shape in shapes {
+                let file = format!("{prefix}-{shape}.ts");
+                for name in ["Star", "Moon", "Shielded"] {
+                    assert!(
+                        !is_reported(&reported, &file, name),
+                        "{file}:{name}: a bare script mention must keep the binding on mark-all: {reported:?}"
+                    );
+                }
+            }
+            let file = format!("{prefix}-{dotted}.ts");
+            for name in ["Star", "Moon"] {
+                assert!(
+                    !is_reported(&reported, &file, name),
+                    "{file}:{name}: a dotted script access must stay credited: {reported:?}"
+                );
+            }
+            assert!(
+                is_reported(&reported, &file, "DottedUnused"),
+                "{file}:DottedUnused: a binding used only through dotted accesses must still narrow: {reported:?}"
+            );
+        }
+    }
+}
+
+/// Issue #2355: a documentation sentence in MDX prose naming
+/// `process.env.API_KEY` is not an environment read. The prose scan records
+/// dotted chains only for import-local roots, so the MDX module never becomes
+/// a secret source and a `"use client"` page importing it reports no
+/// `client-server-leak`, while a sibling client importing a module that really
+/// reads the variable still does.
+#[test]
+fn mdx_prose_env_mention_is_not_a_secret_source() {
+    let root = fixture_path("issue-2355-mdx-prose-env-mention");
+    let config = create_config_with_rules(root, |rules| {
+        rules.security_client_server_leak = Severity::Warn;
+    });
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let anchors: Vec<String> = results
+        .security_findings
+        .iter()
+        .map(|finding| finding.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    assert!(
+        anchors.iter().any(|path| path.ends_with("app/control.tsx")),
+        "the client importing a real process.env read must report: {anchors:?}"
+    );
+    assert!(
+        !anchors.iter().any(|path| path.ends_with("app/page.tsx")),
+        "an unfenced env mention in MDX prose must not make the module a secret source: {anchors:?}"
+    );
+}

--- a/crates/extract/src/astro.rs
+++ b/crates/extract/src/astro.rs
@@ -19,8 +19,15 @@ use crate::asset_url::normalize_asset_url;
 use crate::html::is_remote_url;
 use crate::sfc::{SfcScript, SourceRegion};
 use crate::source_map::ExtractionResult;
-use crate::visitor::ModuleInfoExtractor;
-use crate::{ImportInfo, ImportedName, ModuleInfo};
+use crate::template_expression_scan::{
+    TemplateScanMode, guarded_import_locals, import_declaration_ranges, merge_ranges,
+    narrowable_import_locals, pos_in_ranges, record_unexplained_mentions,
+    record_unexplained_script_mentions, recorded_member_pairs, scan_template_usage,
+};
+use crate::visitor::{
+    ModuleInfoExtractor, extend_member_accesses, extend_whole_object_uses, push_member_tag_accesses,
+};
+use crate::{ImportInfo, ImportedName, MemberAccess, ModuleInfo};
 use fallow_types::discover::FileId;
 
 /// Regex to extract Astro frontmatter (content between `---` delimiters at file start).
@@ -66,6 +73,15 @@ static TEMPLATE_IDENT_RE: LazyLock<regex::Regex> =
 static TEMPLATE_TAG_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| crate::static_regex(r"</?\s*([A-Za-z_$][A-Za-z0-9_$]*)"));
 
+/// Regex matching an opening member-expression component tag (`<SC.Card`,
+/// `<A.B.C`) and capturing its full dotted name. Opening tags only, so a paired
+/// closing tag does not double-record. The whitespace allowance after `<`
+/// mirrors `TEMPLATE_TAG_RE`, so every dotted tag whose root the used-name scan
+/// credits also feeds the member-access stream (issue #2355).
+static TEMPLATE_MEMBER_TAG_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    crate::static_regex(r"<\s*([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+)")
+});
+
 /// Regex matching the `define:vars=` directive prefix. The expression object
 /// that follows (`define:vars={{ a, b: c }}`) passes frontmatter values into a
 /// scoped `<style>` / `<script>` / element, so the identifiers it references are
@@ -74,11 +90,11 @@ static DEFINE_VARS_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| crate::static_regex(r"define:vars\s*="));
 
 /// Build the disjoint, ascending list of byte ranges to mask when scanning the
-/// Astro template: `<script>` / `<style>` block bodies and HTML comments. The
-/// three `find_iter` passes are concatenated (not globally sorted, and their
-/// ranges overlap when e.g. an HTML comment wraps a `<script>`), then sorted by
-/// start and merged into a non-overlapping ascending list so membership can be
-/// tested by binary search (`pos_in_masked_ranges`) instead of a linear scan
+/// Astro template: whole `<script>` / `<style>` blocks (opening tag included)
+/// and HTML comments. The three `find_iter` passes are concatenated (not
+/// globally sorted, and their ranges overlap when e.g. an HTML comment wraps a
+/// `<script>`), then merged into a non-overlapping ascending list so membership
+/// can be tested by binary search (`pos_in_ranges`) instead of a linear scan
 /// over every range per position. The merged union covers exactly the same byte
 /// positions as the raw ranges, so masking decisions are byte-identical.
 fn build_masked_ranges(template: &str) -> Vec<(usize, usize)> {
@@ -98,31 +114,7 @@ fn build_masked_ranges(template: &str) -> Vec<(usize, usize)> {
             .find_iter(template)
             .map(|m| (m.start(), m.end())),
     );
-    masked.sort_unstable_by_key(|&(start, _)| start);
-    // Merge overlapping / touching ranges so the result is disjoint and ascending,
-    // the invariant `pos_in_masked_ranges`'s binary search relies on.
-    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(masked.len());
-    for (start, end) in masked {
-        if let Some(last) = merged.last_mut()
-            && start <= last.1
-        {
-            last.1 = last.1.max(end);
-        } else {
-            merged.push((start, end));
-        }
-    }
-    merged
-}
-
-/// Test whether `pos` falls inside any masked range. `ranges` must be the disjoint
-/// ascending list produced by `build_masked_ranges`; membership is a binary search
-/// (`partition_point`) rather than a linear `.any()` scan, keeping the per-position
-/// cost logarithmic when a template carries many masked regions. Because the list
-/// is disjoint and ascending, only the last range with `start <= pos` can contain
-/// it, so a single bounds check on that candidate decides membership.
-fn pos_in_masked_ranges(ranges: &[(usize, usize)], pos: usize) -> bool {
-    let idx = ranges.partition_point(|&(start, _)| start <= pos);
-    idx > 0 && pos < ranges[idx - 1].1
+    merge_ranges(masked)
 }
 
 /// Collect the set of identifier names that appear USED in the Astro template
@@ -137,16 +129,18 @@ fn pos_in_masked_ranges(ranges: &[(usize, usize)], pos: usize) -> bool {
 /// credit a frontmatter import. The complement (a frontmatter import referenced
 /// in NEITHER the frontmatter script NOR a tag/expression position) is the
 /// genuinely-dead case the `unused-import` / `unrendered-component` arms surface.
-fn collect_astro_template_used_names(template: &str) -> FxHashSet<String> {
+/// `masked` is the template's `build_masked_ranges` result: positions inside it
+/// are skipped rather than mutating the source (mutation would corrupt
+/// multibyte UTF-8 inside a masked range).
+fn collect_astro_template_used_names(
+    template: &str,
+    masked: &[(usize, usize)],
+) -> FxHashSet<String> {
     let mut used = FxHashSet::default();
     if template.is_empty() {
         return used;
     }
-    // Byte ranges of `<script>` / `<style>` bodies and HTML comments. Positions
-    // inside any of these are skipped rather than mutating the source (mutation
-    // would corrupt multibyte UTF-8 inside a masked range).
-    let masked = build_masked_ranges(template);
-    let is_masked = |pos: usize| pos_in_masked_ranges(&masked, pos);
+    let is_masked = |pos: usize| pos_in_ranges(masked, pos);
 
     // Component tag roots.
     for cap in TEMPLATE_TAG_RE.captures_iter(template) {
@@ -259,77 +253,215 @@ fn collect_brace_expression_idents(
     }
 }
 
-/// Collect the body text of every top-level `{ ... }` expression region in the
-/// Astro markup, skipping `<script>` / `<style>` / HTML-comment ranges. Mirrors
-/// `collect_brace_expression_idents`'s scan but returns each region body verbatim
-/// (for re-parsing) instead of tokenizing identifiers. See issue #1713.
-fn collect_template_expression_regions(template: &str) -> Vec<String> {
+/// Collect the body byte range (`{` exclusive, `}` exclusive) of every
+/// top-level `{ ... }` expression region in the Astro markup, skipping
+/// `<script>` / `<style>` / HTML-comment ranges. Mirrors
+/// `collect_brace_expression_idents`'s scan but returns each region's position
+/// (for re-parsing and for the completeness guard) instead of tokenizing
+/// identifiers. See issues #1713 and #2355.
+fn collect_template_expression_regions(
+    template: &str,
+    masked: &[(usize, usize)],
+) -> Vec<(usize, usize)> {
     let mut regions = Vec::new();
     if template.is_empty() {
         return regions;
     }
-    let masked = build_masked_ranges(template);
-    let is_masked = |pos: usize| pos_in_masked_ranges(&masked, pos);
-
     let bytes = template.as_bytes();
     let len = bytes.len();
     let mut i = 0;
     while i < len {
-        if bytes[i] != b'{' || is_masked(i) {
+        if bytes[i] != b'{' || pos_in_ranges(masked, i) {
             i += 1;
             continue;
         }
         let start = i + 1;
         let region_end = brace_body_end(bytes, i);
-        if let Some(region) = template.get(start..region_end) {
-            let trimmed = region.trim();
-            if !trimmed.is_empty() {
-                regions.push(trimmed.to_string());
-            }
+        if region_end > start {
+            regions.push((start, region_end));
         }
         i = region_end.max(start);
     }
     regions
 }
 
-/// Run the member-recording visitor over each Astro template `{ ... }` expression
-/// region so `.map()` / `.forEach()` / `for...of` iteration bindings in the
-/// template body credit the element-class members the same way the frontmatter
-/// does (issue #1713). Each region is parsed as a standalone TSX expression
-/// (Astro template expressions contain JSX), visited with a fresh extractor
-/// seeded with the frontmatter's array element-type map so
-/// `bind_iterable_callback_parameter` can resolve the receiver's element class,
-/// and the re-emitted class-qualified member accesses are appended to `info`.
+/// Collect the member accesses implied by member-expression component tags in
+/// the Astro markup (`<SC.Card />` records `SC.Card`, `<A.B.C />` one access
+/// per nesting level), skipping the same `<script>` / `<style>` / HTML-comment
+/// ranges the used-name scan masks. The root credit from
+/// `collect_astro_template_used_names` keeps the import binding alive; this
+/// adds the member-level stream the JSX visitor records for `.tsx` (issue
+/// #2348), so a namespace import rendered only through dotted tags narrows to
+/// the members actually used instead of crediting nothing (entry files) or
+/// everything (non-entry files). See issue #2355.
+fn collect_template_member_tag_accesses(
+    template: &str,
+    masked: &[(usize, usize)],
+) -> Vec<MemberAccess> {
+    let mut accesses = Vec::new();
+    if template.is_empty() {
+        return accesses;
+    }
+    for cap in TEMPLATE_MEMBER_TAG_RE.captures_iter(template) {
+        if let Some(name) = cap.get(1)
+            && !pos_in_ranges(masked, name.start())
+        {
+            push_member_tag_accesses(&mut accesses, name.as_str());
+        }
+    }
+    accesses
+}
+
+/// Run the member-recording visitor over every Astro template `{ ... }`
+/// expression region and append what it records to `info`: the member accesses
+/// (`icon={SC.Moon}`, `{SC.helper()}`) and whole-object uses (`{...SC}`,
+/// `Object.keys(SC)`) the visitor records for `.tsx`, plus the class-qualified
+/// iteration credits (`{utils.map((util) => util.getter)}` resolves to
+/// `Util.getter` through the seeded frontmatter element types, issue #1713).
+/// Each region is parsed as a standalone TSX expression (Astro template
+/// expressions contain JSX) and visited by one extractor shared across the
+/// file's regions. A bare mention of a frontmatter import binding inside a
+/// parsed region (`all={SC}`) is the one shape the visitor does not record as
+/// a whole-object use, so the text scan adds it.
 ///
-/// Over-credit only: the drained accesses are span-less name pairs (`Util.getter`)
-/// that the analyze layer resolves through the frontmatter imports; they can only
-/// suppress a false `unused-class-member`, never introduce a finding. A region
-/// that fails to parse or resolves no element type contributes nothing.
-fn extend_template_expression_member_accesses(
+/// Returns the byte ranges of the regions the parser accepted. Inside those,
+/// every mention of an import binding is either a member access the visitor
+/// recorded or a whole-object use the text scan recorded, so they count as
+/// structurally understood for the completeness guard
+/// (`extend_unexplained_template_mentions`). A region the parser rejects is
+/// left out: its mentions stay unexplained and keep their bindings on the
+/// mark-all path. See issue #2355.
+fn extend_template_expression_usage(
     info: &mut ModuleInfo,
     template: &str,
+    regions: &[(usize, usize)],
     frontmatter_array_element_types: &rustc_hash::FxHashMap<String, String>,
-) {
-    if frontmatter_array_element_types.is_empty() {
-        return;
+) -> Vec<(usize, usize)> {
+    let mut parsed_regions = Vec::with_capacity(regions.len());
+    if regions.is_empty() {
+        return parsed_regions;
     }
-    for region in collect_template_expression_regions(template) {
+    let import_locals: FxHashSet<&str> = info
+        .imports
+        .iter()
+        .map(|import| import.local_name.as_str())
+        .collect();
+    let mut accesses = Vec::new();
+    let mut whole_object_uses = Vec::new();
+    let mut extractor = ModuleInfoExtractor::new();
+    extractor.seed_array_binding_element_types(frontmatter_array_element_types);
+    for &(start, end) in regions {
+        let Some(region) = template.get(start..end) else {
+            continue;
+        };
+        let region = region.trim();
+        if region.is_empty() {
+            continue;
+        }
         // Wrap as a parenthesized expression statement so the region parses as a
-        // valid TSX program. Spans are irrelevant: only span-less member accesses
-        // are drained.
+        // valid TSX program. Spans are irrelevant: only span-less name pairs are
+        // drained.
         let wrapped = format!("({region});");
         let allocator = Allocator::default();
         let parser_return = Parser::new(&allocator, &wrapped, SourceType::tsx()).parse();
-        if parser_return.panicked {
+        if parser_return.panicked || !parser_return.errors.is_empty() {
             continue;
         }
-        let mut extractor = ModuleInfoExtractor::new();
-        extractor.seed_array_binding_element_types(frontmatter_array_element_types);
         extractor.visit_program(&parser_return.program);
-        let mut member_accesses = std::mem::take(&mut info.member_accesses).to_vec();
-        member_accesses.extend(extractor.take_resolved_iteration_member_accesses());
-        info.member_accesses = member_accesses.into();
+        scan_template_usage(
+            region,
+            &import_locals,
+            TemplateScanMode::AstroParsedRegion,
+            &mut accesses,
+            &mut whole_object_uses,
+        );
+        parsed_regions.push((start, end));
     }
+    let (visited_accesses, visited_whole_object_uses) = extractor.take_template_expression_usage();
+    accesses.extend(visited_accesses);
+    whole_object_uses.extend(visited_whole_object_uses);
+    extend_member_accesses(info, accesses);
+    extend_whole_object_uses(info, whole_object_uses);
+    parsed_regions
+}
+
+/// Completeness guard for the template-sourced access stream (issue #2355).
+///
+/// Namespace-import (and CSS-module, enum, class member) narrowing trusts the
+/// member-access stream: one recorded access from a non-entry consumer narrows
+/// the target to the accessed members, so every mention of a binding the
+/// structured passes did not see would turn a used sibling into a finding. The
+/// structured passes cover exactly two kinds of span: component tag roots
+/// outside the masked ranges (the tag scans) and `{ ... }` regions the parser
+/// accepted (the region visitor plus the bare-mention scan). Every other
+/// mention of a frontmatter import binding in the raw template text, including
+/// the masked `<script>` / `<style>` blocks and their opening-tag directives
+/// (`define:vars={{ accent: NS.accent }}`, `set:html={NS.code}`), HTML
+/// comments, attribute strings, text content, and regions the parser rejected,
+/// records a whole-object use so the graph keeps mark-all crediting for that
+/// binding. Together with `extend_unexplained_frontmatter_mentions` this
+/// covers the whole file, so narrowing applies only when every mention was
+/// structurally understood; any unmodelled shape degrades to over-credit.
+fn extend_unexplained_template_mentions(
+    info: &mut ModuleInfo,
+    template: &str,
+    masked: &[(usize, usize)],
+    parsed_regions: Vec<(usize, usize)>,
+) {
+    let guarded = guarded_import_locals(&info.imports);
+    if guarded.is_empty() || template.is_empty() {
+        return;
+    }
+    let mut explained = parsed_regions;
+    explained.extend(
+        TEMPLATE_TAG_RE
+            .captures_iter(template)
+            .filter_map(|cap| cap.get(1))
+            .filter(|root| !pos_in_ranges(masked, root.start()))
+            .map(|root| (root.start(), root.end())),
+    );
+    let explained = merge_ranges(explained);
+    let mut whole_object_uses = Vec::new();
+    record_unexplained_mentions(template, &guarded, &explained, &mut whole_object_uses);
+    extend_whole_object_uses(info, whole_object_uses);
+}
+
+/// Script-side completeness guard (issue #2355), the frontmatter half of
+/// `extend_unexplained_template_mentions`. The visitor parsed the frontmatter,
+/// but it records a bare import binding as a whole-object use only for an
+/// allow-list of positions, so an alias (`const N = NS`), a cast (`NS as T`),
+/// a call argument (`pick(NS)`), `Object.assign({}, NS)`, an array literal
+/// (`[NS]`), or a props object (`{ all: NS }`) would leave the binding free to
+/// narrow to its dotted accesses and report the members reached through the
+/// copy. Every mention of a namespace or CSS-module binding (the bindings the
+/// graph narrows exports for) in the frontmatter outside its own import
+/// declaration that is not a dotted access the visitor recorded therefore
+/// records a whole-object use; class and enum bindings keep the visitor's
+/// member crediting, since a type annotation or `new` expression names them
+/// bare in ordinary code. Runs after the template passes so the recorded pairs
+/// cover the whole file.
+fn extend_unexplained_frontmatter_mentions(info: &mut ModuleInfo, frontmatter: Option<&SfcScript>) {
+    let Some(script) = frontmatter else {
+        return;
+    };
+    let mut whole_object_uses = Vec::new();
+    {
+        let guarded = narrowable_import_locals(&info.imports);
+        if guarded.is_empty() || script.body.is_empty() {
+            return;
+        }
+        let recorded = recorded_member_pairs(&info.member_accesses, &guarded);
+        let excluded = import_declaration_ranges(&info.imports);
+        record_unexplained_script_mentions(
+            &script.body,
+            script.byte_offset,
+            &guarded,
+            &excluded,
+            &recorded,
+            &mut whole_object_uses,
+        );
+    }
+    extend_whole_object_uses(info, whole_object_uses);
 }
 
 /// Extract frontmatter from an Astro component.
@@ -469,11 +601,14 @@ pub(crate) fn parse_astro_to_module(
         .as_ref()
         .map_or(0, |script| script.byte_offset + script.body.len());
     let template = source.get(template_offset..).unwrap_or("");
+    // `<script>` / `<style>` blocks and HTML comments, shared by every template
+    // scan below.
+    let masked = build_masked_ranges(template);
 
     // Names used in the template markup (rendered components, expression
     // bindings). Passed to the frontmatter semantic pass so a template-only-used
     // import is not falsely classified as an unused binding.
-    let template_used = collect_astro_template_used_names(template);
+    let template_used = collect_astro_template_used_names(template, &masked);
 
     let frontmatter_offset = frontmatter.as_ref().map_or(0, |script| script.byte_offset);
 
@@ -499,17 +634,25 @@ pub(crate) fn parse_astro_to_module(
 
     let mut info = extractor.into_module_info(file_id, content_hash, parsed_suppressions);
 
-    // Run the member-recording visitor over the Astro template `{...}` expression
-    // regions so `.map()` / `.forEach()` / `for...of` iteration-binding member
-    // accesses in the TEMPLATE body are credited the same as the frontmatter
-    // (issue #1713). Over-credit only: it can only re-emit a class-qualified
-    // member access that later suppresses a false `unused-class-member`, never a
-    // new finding.
-    extend_template_expression_member_accesses(
+    // Member-expression component tags (`<SC.Card />`) feed the same
+    // member-access stream namespace narrowing reads for `.tsx` (issue #2355).
+    extend_member_accesses(
+        &mut info,
+        collect_template_member_tag_accesses(template, &masked),
+    );
+    // The `{ ... }` expression regions add the expression accesses (issue #2355)
+    // and carry the iteration credits of issue #1713; the pass is unconditional
+    // because narrowing on a partial stream turns used members into findings.
+    let parsed_regions = extend_template_expression_usage(
         &mut info,
         template,
+        &collect_template_expression_regions(template, &masked),
         &frontmatter_array_element_types,
     );
+    // Every mention the two passes above did not classify keeps its binding on
+    // the mark-all path (issue #2355), in the markup and in the frontmatter.
+    extend_unexplained_template_mentions(&mut info, template, &masked, parsed_regions);
+    extend_unexplained_frontmatter_mentions(&mut info, frontmatter.as_ref());
     // Astro-only: thread the frontmatter binding usage onto the module so
     // `referenced_import_bindings` (derived from `imports` minus
     // `unused_import_bindings` in `release_resolution_payload`) reflects ACTUAL
@@ -1243,7 +1386,7 @@ mod tests {
         );
         for pos in 0..template.len() {
             assert_eq!(
-                pos_in_masked_ranges(&merged, pos),
+                pos_in_ranges(&merged, pos),
                 linear(pos),
                 "masking decision differs at byte {pos}"
             );
@@ -1252,7 +1395,8 @@ mod tests {
 
     #[test]
     fn astro_template_used_names_masks_comments_credits_braces() {
-        let used = collect_astro_template_used_names(MASKED_MIX_TEMPLATE);
+        let masked = build_masked_ranges(MASKED_MIX_TEMPLATE);
+        let used = collect_astro_template_used_names(MASKED_MIX_TEMPLATE, &masked);
 
         // Credited: tag roots + brace-expression identifiers outside masked regions.
         for name in ["Header", "Footer", "fmt", "x", "items", "map", "i", "label"] {
@@ -1270,5 +1414,358 @@ mod tests {
                 "expected {name} to stay masked, got {used:?}"
             );
         }
+    }
+
+    fn template_member_accesses(source: &str) -> Vec<(String, String)> {
+        parse_astro_to_module(FileId(0), source, 0, false)
+            .member_accesses
+            .iter()
+            .map(|access| (access.object.clone(), access.member.clone()))
+            .collect()
+    }
+
+    /// Issue #2355: a member-expression component tag in the markup
+    /// (`<SC.Card />`) records the same `SC.Card` access the JSX visitor records
+    /// for `.tsx`, while the root credit that keeps `SC` a used import binding
+    /// stays in place.
+    #[test]
+    fn astro_template_member_tag_records_member_access() {
+        let source = "---\nimport * as SC from './style';\n---\n<SC.Card />\n";
+        let info = parse_astro_to_module(FileId(0), source, 0, false);
+        assert!(
+            info.member_accesses
+                .iter()
+                .any(|access| access.object == "SC" && access.member == "Card"),
+            "<SC.Card /> should record SC.Card; got {:?}",
+            info.member_accesses
+        );
+        assert!(
+            !info.unused_import_bindings.iter().any(|b| b == "SC"),
+            "the dotted tag root must still credit the SC import binding; got {:?}",
+            info.unused_import_bindings
+        );
+    }
+
+    /// Issue #2355: `<A.B.C />` records one access per nesting level, matching
+    /// the plain-expression walk of `A.B.C` (`{A, B}` and `{A.B, C}`).
+    #[test]
+    fn astro_template_nested_member_tag_records_each_level() {
+        let accesses = template_member_accesses(
+            "---\nimport * as A from './widgets';\n---\n<A.B.C label=\"x\" />\n",
+        );
+        assert!(
+            accesses.contains(&("A".to_string(), "B".to_string())),
+            "<A.B.C /> should record A.B for namespace crediting; got {accesses:?}"
+        );
+        assert!(
+            accesses.contains(&("A.B".to_string(), "C".to_string())),
+            "<A.B.C /> should record the full A.B.C path; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: only the opening tag records, so a paired
+    /// `<SC.Layout>..</SC.Layout>` yields exactly one `SC.Layout` access.
+    #[test]
+    fn astro_template_paired_member_tag_records_single_access() {
+        let accesses = template_member_accesses(
+            "---\nimport * as SC from './style';\n---\n<SC.Layout>\n  <p>text</p>\n</SC.Layout>\n",
+        );
+        let count = accesses
+            .iter()
+            .filter(|(object, member)| object == "SC" && member == "Layout")
+            .count();
+        assert_eq!(
+            count, 1,
+            "paired tags should record exactly one SC.Layout access; got {accesses:?}"
+        );
+    }
+
+    fn template_whole_object_uses(source: &str) -> Vec<String> {
+        parse_astro_to_module(FileId(0), source, 0, false)
+            .whole_object_uses
+            .to_vec()
+    }
+
+    /// Issue #2355: member tags inside masked ranges (HTML comments,
+    /// `<script>` and `<style>` bodies) never record an access, mirroring the
+    /// root-credit masking, but the mention is unexplained, so the binding
+    /// keeps its mark-all crediting instead of narrowing to the visible tag.
+    #[test]
+    fn astro_template_member_tag_in_masked_region_records_no_access_but_keeps_mark_all() {
+        let source = "---\nimport * as SC from './style';\n---\n\
+             <!-- <SC.Commented /> -->\n\
+             <script>const x = '<SC.Scripted />';</script>\n\
+             <style>/* <SC.Styled /> */</style>\n\
+             <SC.Visible />\n";
+        let accesses = template_member_accesses(source);
+        assert_eq!(
+            accesses,
+            vec![("SC".to_string(), "Visible".to_string())],
+            "only the unmasked member tag should record; got {accesses:?}"
+        );
+        assert_eq!(
+            template_whole_object_uses(source),
+            vec!["SC".to_string()],
+            "a masked mention must keep SC on the mark-all path"
+        );
+    }
+
+    /// Issue #2355: a namespace member read inside a template expression
+    /// (attribute value or text expression) records the same access a dotted
+    /// tag does, so a component mixing `<NS.Star />` with `icon={NS.Moon}` and
+    /// `{NS.Moon()}` narrows to a complete member set.
+    #[test]
+    fn astro_template_expression_member_access_records() {
+        let accesses = template_member_accesses(
+            "---\nimport * as NS from './icons';\nimport Callout from './Callout.astro';\n---\n\
+             <NS.Star />\n<Callout icon={NS.Moon} />\n<p>{NS.Sun()}</p>\n",
+        );
+        for member in ["Star", "Moon", "Sun"] {
+            assert!(
+                accesses.contains(&("NS".to_string(), member.to_string())),
+                "NS.{member} should be recorded from the markup; got {accesses:?}"
+            );
+        }
+    }
+
+    /// Issue #2355: passing the namespace object whole through an expression
+    /// (`all={NS}`) records a whole-object use so narrowing falls back to
+    /// crediting every export, while a bare identifier that is not an import
+    /// binding records nothing.
+    #[test]
+    fn astro_template_whole_namespace_pass_records_whole_object_use() {
+        let info = parse_astro_to_module(
+            FileId(0),
+            "---\nimport * as NS from './icons';\nimport Callout from './Callout.astro';\n\
+             const local = 1;\n---\n<NS.Star />\n<Callout all={NS} count={local} />\n",
+            0,
+            false,
+        );
+        assert!(
+            info.whole_object_uses.iter().any(|name| name == "NS"),
+            "all={{NS}} should record a whole-object use; got {:?}",
+            info.whole_object_uses
+        );
+        assert!(
+            !info.whole_object_uses.iter().any(|name| name == "local"),
+            "a frontmatter local is not an import binding; got {:?}",
+            info.whole_object_uses
+        );
+    }
+
+    /// Issue #2355: a member tag nested inside an expression region
+    /// (`{flag && <EX.Cond />}`) is seen by both the masking-aware tag scan and
+    /// the region visitor, and still records once.
+    #[test]
+    fn astro_template_member_tag_inside_expression_records_once() {
+        let accesses = template_member_accesses(
+            "---\nimport * as EX from './ex';\nconst flag = true;\n---\n{flag && <EX.Cond />}\n",
+        );
+        let count = accesses
+            .iter()
+            .filter(|(object, member)| object == "EX" && member == "Cond")
+            .count();
+        assert_eq!(
+            count, 1,
+            "a tag inside an expression region should record exactly once; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: a parsed expression region is read with the visitor's
+    /// expression semantics, so a dotted name inside a string literal is not an
+    /// access, while a reflective whole-object use (`Object.keys(NS)`) records
+    /// the same whole-object use it records for `.tsx`.
+    #[test]
+    fn astro_template_parsed_expression_uses_visitor_semantics() {
+        let info = parse_astro_to_module(
+            FileId(0),
+            "---\nimport * as NS from './icons';\n---\n\
+             <NS.Star />\n<p>{\"NS.Ghost\"}</p>\n<p>{Object.keys(NS).length}</p>\n",
+            0,
+            false,
+        );
+        assert!(
+            !info
+                .member_accesses
+                .iter()
+                .any(|access| access.object == "NS" && access.member == "Ghost"),
+            "a string literal is not a member access; got {:?}",
+            info.member_accesses
+        );
+        assert!(
+            info.whole_object_uses.iter().any(|name| name == "NS"),
+            "Object.keys(NS) should record a whole-object use; got {:?}",
+            info.whole_object_uses
+        );
+    }
+
+    /// Issue #2355: a region the visitor cannot parse cleanly (`{NS.Moon(}`)
+    /// is not structurally understood, so its mention keeps the binding on the
+    /// mark-all path and narrowing never runs on a partial view.
+    #[test]
+    fn astro_template_unparsed_expression_region_keeps_binding_on_mark_all() {
+        let source = "---\nimport * as NS from './icons';\n---\n<NS.Star />\n<p>{NS.Moon(}</p>\n";
+        let accesses = template_member_accesses(source);
+        assert!(
+            !accesses.contains(&("NS".to_string(), "Moon".to_string())),
+            "an unparsed region records no access; got {accesses:?}"
+        );
+        assert_eq!(
+            template_whole_object_uses(source),
+            vec!["NS".to_string()],
+            "an unparsed region must keep NS on the mark-all path"
+        );
+    }
+
+    /// Issue #2355 completeness guard: `{ ... }` expressions on the opening tag
+    /// of a masked `<style>` / `<script>` block (`define:vars`, `set:html`)
+    /// never reach the region visitor, so the binding they mention must keep
+    /// its mark-all crediting rather than narrow to the dotted tag. The same
+    /// holds for a CSS module default import read through `define:vars`.
+    #[test]
+    fn astro_template_masked_tag_directive_mention_keeps_binding_on_mark_all() {
+        let source = "---\n\
+             import * as SV from './sv';\nimport * as SD from './sd';\n\
+             import * as SH from './sh';\nimport * as SW from './sw';\n\
+             import styles from './card.module.css';\n\
+             ---\n\
+             <SV.Star /><SD.Star /><SH.Star /><SW.Star />\n\
+             <div class={styles.root}></div>\n\
+             <style define:vars={{ accent: SV.accent }}>div { color: var(--accent); }</style>\n\
+             <script define:vars={{ moon: SD.Moon }}>console.log(moon);</script>\n\
+             <script is:inline set:html={SH.code}></script>\n\
+             <script define:vars={{ SW }}>console.log(SW);</script>\n\
+             <style define:vars={{ spare: styles.spare }}></style>\n";
+        let accesses = template_member_accesses(source);
+        for root in ["SV", "SD", "SH", "SW"] {
+            assert!(
+                accesses.contains(&(root.to_string(), "Star".to_string())),
+                "{root}.Star should still record from the dotted tag; got {accesses:?}"
+            );
+        }
+        assert!(
+            accesses.contains(&("styles".to_string(), "root".to_string())),
+            "styles.root should record from the markup expression; got {accesses:?}"
+        );
+        let mut whole = template_whole_object_uses(source);
+        whole.sort();
+        assert_eq!(
+            whole,
+            vec![
+                "SD".to_string(),
+                "SH".to_string(),
+                "SV".to_string(),
+                "SW".to_string(),
+                "styles".to_string(),
+            ],
+            "every binding mentioned on a masked opening tag must keep mark-all"
+        );
+    }
+
+    /// Issue #2355 completeness guard: mentions in an HTML comment, in text
+    /// content, in an attribute string, and in a `<script>` body are outside
+    /// every structured span, so each keeps its binding on the mark-all path.
+    #[test]
+    fn astro_template_unstructured_mention_keeps_binding_on_mark_all() {
+        let source = "---\n\
+             import * as CM from './cm';\nimport * as TX from './tx';\n\
+             import * as AT from './at';\nimport * as SB from './sb';\n\
+             ---\n\
+             <CM.Star /><TX.Star /><AT.Star /><SB.Star />\n\
+             <!-- {CM.Moon} -->\n\
+             <p>see TX.Moon for details</p>\n\
+             <div data-icon=\"AT.Moon\"></div>\n\
+             <script>SB.Moon();</script>\n";
+        let mut whole = template_whole_object_uses(source);
+        whole.sort();
+        assert_eq!(
+            whole,
+            vec![
+                "AT".to_string(),
+                "CM".to_string(),
+                "SB".to_string(),
+                "TX".to_string(),
+            ],
+            "got {whole:?}"
+        );
+    }
+
+    /// Issue #2355 precision: when every mention of a binding sits in a tag
+    /// root or a parsed expression region, no whole-object use is recorded and
+    /// narrowing stays precise. Paired tags, a dotted tag nested in an
+    /// expression, attribute and text expressions, a template literal inside an
+    /// expression, and a rendered default import all count as understood.
+    #[test]
+    fn astro_template_fully_understood_mentions_record_no_whole_object_use() {
+        let source = "---\n\
+             import * as NS from './icons';\nimport Card from './Card.astro';\n\
+             import styles from './card.module.css';\nconst flag = true;\n\
+             ---\n\
+             <NS.Star />\n<NS.Moon>\n  <Card icon={NS.Sun} class={styles.root} />\n</NS.Moon>\n\
+             {flag && <NS.Cond />}\n<p>{NS.helper()}</p>\n<p class={`x ${styles.spare}`}>{`${NS.Tpl}`}</p>\n";
+        let whole = template_whole_object_uses(source);
+        assert!(
+            whole.is_empty(),
+            "fully understood mentions must not record a whole-object use; got {whole:?}"
+        );
+        let accesses = template_member_accesses(source);
+        for member in ["Star", "Moon", "Sun", "Cond", "helper", "Tpl"] {
+            assert!(
+                accesses.contains(&("NS".to_string(), member.to_string())),
+                "NS.{member} should be recorded; got {accesses:?}"
+            );
+        }
+        for class in ["root", "spare"] {
+            assert!(
+                accesses.contains(&("styles".to_string(), class.to_string())),
+                "styles.{class} should be recorded; got {accesses:?}"
+            );
+        }
+    }
+
+    /// Issue #2355 script guard: a frontmatter mention of a namespace (or a
+    /// CSS module) the visitor does not record as a whole-object use, such as
+    /// an alias, a cast, a call argument, `Object.assign`, an array literal,
+    /// or a props object, keeps the binding on the mark-all path, while a
+    /// dotted-only frontmatter use (`const moon = FD.Moon`) records no
+    /// whole-object use and stays precise. A class named in a type annotation
+    /// and a `new` expression is not guarded: its members keep the visitor's
+    /// crediting. A binding the visitor already records whole
+    /// (`Object.keys(AL)`) is recorded once, not once per guard.
+    #[test]
+    fn astro_frontmatter_bare_mention_keeps_narrowable_binding_on_mark_all() {
+        let source = "---\n\
+             import * as AL from './al';\nimport * as AC from './ac';\n\
+             import * as CA from './ca';\nimport * as OA from './oa';\n\
+             import * as AR from './ar';\nimport * as PP from './pp';\n\
+             import * as FD from './fd';\nimport styles from './card.module.css';\n\
+             import { Util } from './util';\nimport Callout from './Callout.astro';\n\
+             const N = AL;\nconst keys = Object.keys(AL);\n\
+             const rec = AC as Record<string, unknown>;\n\
+             const pick = (o: object) => o;\nconst picked = pick(CA);\n\
+             const merged = Object.assign({}, OA);\n\
+             const list = [AR];\n\
+             const props = { all: PP, classes: styles };\n\
+             const moon = FD.Moon;\n\
+             const util: Util = new Util();\nconst value = util.getter;\n\
+             ---\n\
+             <AL.Star /><AC.Star /><CA.Star /><OA.Star /><AR.Star /><PP.Star /><FD.Star />\n\
+             <p class={styles.root}>{N.Moon}{keys.length}{rec.Moon}{picked}{merged.Moon}{list.length}{moon}{value}</p>\n\
+             <Callout {...props} />\n";
+        let mut whole = template_whole_object_uses(source);
+        whole.sort();
+        assert_eq!(
+            whole,
+            vec!["AC", "AL", "AR", "CA", "OA", "PP", "styles"]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+            "every bare frontmatter mention of a narrowable binding must keep it on mark-all, once"
+        );
+        let accesses = template_member_accesses(source);
+        assert!(
+            accesses.contains(&("FD".to_string(), "Moon".to_string())),
+            "the dotted-only frontmatter access should be recorded; got {accesses:?}"
+        );
     }
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -958,7 +958,13 @@ use crate::MemberKind;
 /// type *` keeps the file-level shape. Warm 274 caches would keep replaying
 /// the star surface on the declaring file and would classify a
 /// bare-specifier ambient star re-export as runtime usage.
-pub(super) const CACHE_VERSION: u32 = 275;
+///
+/// Bumped to 276 for issue #2355 (275 was taken by issue #2357 while this
+/// change was in review): Astro markup and MDX bodies now record
+/// member accesses for member-expression component tags (`<SC.Card />`). Warm
+/// 275 caches lack those accesses, so namespace-imported exports rendered only
+/// in Astro or MDX markup would stay reported as unused.
+pub(super) const CACHE_VERSION: u32 = 276;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -41,6 +41,7 @@ pub mod suppress;
 /// Tailwind CSS arbitrary-value detection.
 pub mod tailwind;
 pub(crate) mod template_complexity;
+mod template_expression_scan;
 mod template_usage;
 /// Visitor utilities for AST extraction.
 pub mod visitor;

--- a/crates/extract/src/mdx.rs
+++ b/crates/extract/src/mdx.rs
@@ -1,7 +1,14 @@
 //! MDX import/export statement extraction.
 //!
 //! Extracts `import` and `export` lines from MDX files (Markdown with JSX),
-//! handling multi-line imports via brace depth tracking.
+//! handling multi-line imports via brace depth tracking, and scans the prose
+//! body for the member accesses (`<NS.Card />`, `{NS.helper()}`) and
+//! whole-object passes (`all={NS}`) of its import bindings so namespace-imported
+//! exports used only there are credited. Fenced code and inline code spans are
+//! documentation: they record no access, and a binding mentioned inside them
+//! keeps its mark-all crediting; a bare mention of a binding on a statement
+//! line the visitor does not record (`export const all = NS`) does the same
+//! (issue #2355).
 
 use std::path::Path;
 
@@ -10,22 +17,27 @@ use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-use crate::ModuleInfo;
-use crate::source_map::{ExtractionResult, SfcExtractor};
-use crate::visitor::ModuleInfoExtractor;
+use crate::source_map::ExtractionResult;
+use crate::template_expression_scan::{
+    TemplateScanMode, guarded_import_locals, import_declaration_ranges, narrowable_import_locals,
+    record_unexplained_mentions, record_unexplained_script_mentions, recorded_member_pairs,
+    scan_template_usage,
+};
+use crate::visitor::{ModuleInfoExtractor, extend_member_accesses, extend_whole_object_uses};
+use crate::{ImportInfo, MemberAccess, ModuleInfo};
 use fallow_types::discover::FileId;
 
-struct MdxExtractor;
-
-impl SfcExtractor for MdxExtractor {
-    fn extract(&self, source: &str) -> Vec<ExtractionResult> {
-        let extracted = extract_mdx_source(source);
-        if extracted.body.is_empty() {
-            Vec::new()
-        } else {
-            vec![extracted]
-        }
-    }
+/// Everything the MDX line scan yields: the source-mapped `import` / `export`
+/// statements the JavaScript parser consumes (and the same lines with their
+/// source offsets, for the script-side completeness guard), the prose lines
+/// whose usage is scanned once the import bindings are known, and the
+/// fenced-code lines (fence delimiters included) whose mentions only feed the
+/// completeness guard (issue #2355).
+struct MdxScan<'a> {
+    statements: ExtractionResult,
+    statement_lines: Vec<(usize, &'a str)>,
+    prose_lines: Vec<&'a str>,
+    code_lines: Vec<&'a str>,
 }
 
 /// Extract import/export statements from MDX content.
@@ -38,20 +50,22 @@ impl SfcExtractor for MdxExtractor {
 /// MDX import/export extraction only handles JS/TS `import`/`export` statements.
 #[must_use]
 pub fn extract_mdx_statements(source: &str) -> String {
-    extract_mdx_source(source).body
+    extract_mdx_source(source).statements.body
 }
 
-fn extract_mdx_source(source: &str) -> ExtractionResult {
+fn extract_mdx_source(source: &str) -> MdxScan<'_> {
     let mut scanner = MdxStatementScanner::default();
     for (line_start, line) in lines_with_offsets(source) {
         scanner.scan_line(line_start, line);
     }
-    scanner.into_extraction()
+    scanner.into_scan()
 }
 
 #[derive(Default)]
 struct MdxStatementScanner<'a> {
     statements: Vec<(usize, &'a str)>,
+    prose_lines: Vec<&'a str>,
+    code_lines: Vec<&'a str>,
     in_multiline: bool,
     brace_depth: i32,
     code_fence: Option<CodeFence>,
@@ -62,6 +76,7 @@ impl<'a> MdxStatementScanner<'a> {
         let trimmed = line.trim();
 
         if self.consume_code_fence(trimmed) {
+            self.code_lines.push(line);
             return;
         }
 
@@ -72,7 +87,16 @@ impl<'a> MdxStatementScanner<'a> {
 
         if is_statement_start(trimmed) {
             self.push_statement_start(line_start, line, trimmed);
+            return;
         }
+
+        // Prose lines are the only place the statement parser never looks, so
+        // a namespace member rendered in the body (`<NS.Card />`,
+        // `{NS.helper()}`) is credited here or not at all (issue #2355).
+        // Statement lines are excluded so a tag inside
+        // `export const X = () => <NS.Card />` records once, through the JSX
+        // visitor.
+        self.prose_lines.push(line);
     }
 
     fn consume_code_fence(&mut self, trimmed: &str) -> bool {
@@ -112,13 +136,88 @@ impl<'a> MdxStatementScanner<'a> {
         }
     }
 
-    fn into_extraction(self) -> ExtractionResult {
-        let mut result = ExtractionResult::default();
-        for (line_start, line) in self.statements {
-            result.push_mapped(line, line_start);
+    fn into_scan(self) -> MdxScan<'a> {
+        let mut statements = ExtractionResult::default();
+        for &(line_start, line) in &self.statements {
+            statements.push_mapped(line, line_start);
         }
-        result
+        MdxScan {
+            statements,
+            statement_lines: self.statements,
+            prose_lines: self.prose_lines,
+            code_lines: self.code_lines,
+        }
     }
+}
+
+/// Scan the body for the member accesses (`<NS.Card />`, `{NS.helper()}`,
+/// `icon={NS.Moon}`) and whole-object passes (`all={NS}`) of the parsed import
+/// bindings. The prose scan is line-based and brace-agnostic on purpose: a
+/// `{ ... }` expression may span lines, so a dotted chain records wherever it
+/// appears and a bare mention of an import binding (inside an expression or in
+/// prose) records a whole-object use that keeps the binding on the mark-all
+/// path.
+///
+/// Completeness guard (issue #2355): every line that is not a parsed `import`
+/// / `export` statement is either a prose line, where the scan classifies
+/// every identifier and hands the inline code spans it skips to the guard, or
+/// a fenced-code line, which records no access and goes to the guard whole. A
+/// binding mentioned in documentation code (or in a template literal the line
+/// scanner cannot tell apart from a code span) therefore keeps its mark-all
+/// crediting, so narrowing applies only when every mention of the binding was
+/// structurally understood. Statement lines are parsed by the JSX visitor and
+/// guarded separately by `collect_unexplained_statement_mentions`.
+fn collect_body_usage(
+    scan: &MdxScan<'_>,
+    imports: &[ImportInfo],
+) -> (Vec<MemberAccess>, Vec<String>) {
+    let mut accesses = Vec::new();
+    let mut whole_object_uses = Vec::new();
+    let import_locals = guarded_import_locals(imports);
+    for line in &scan.prose_lines {
+        scan_template_usage(
+            line,
+            &import_locals,
+            TemplateScanMode::MdxProse,
+            &mut accesses,
+            &mut whole_object_uses,
+        );
+    }
+    for line in &scan.code_lines {
+        record_unexplained_mentions(line, &import_locals, &[], &mut whole_object_uses);
+    }
+    (accesses, whole_object_uses)
+}
+
+/// Script-side completeness guard for the `import` / `export` statement lines
+/// (issue #2355). The JSX visitor parsed them, but it records a bare import
+/// binding as a whole-object use only for an allow-list of positions, so
+/// `export const all = NS`, `export const Demo = () => <Callout all={NS} />`,
+/// or `export default (props) => <Callout all={NS} {...props} />` would leave
+/// the binding free to narrow to its dotted tags. Every mention of a namespace
+/// or CSS-module binding (the bindings the graph narrows exports for) on a
+/// statement line outside its own import declaration that is not a dotted
+/// access the visitor recorded (or a JSX tag root) records a whole-object use.
+/// Runs after the prose scan so the recorded pairs cover the whole file.
+fn collect_unexplained_statement_mentions(scan: &MdxScan<'_>, info: &ModuleInfo) -> Vec<String> {
+    let mut whole_object_uses = Vec::new();
+    let guarded = narrowable_import_locals(&info.imports);
+    if guarded.is_empty() {
+        return whole_object_uses;
+    }
+    let recorded = recorded_member_pairs(&info.member_accesses, &guarded);
+    let excluded = import_declaration_ranges(&info.imports);
+    for &(line_start, line) in &scan.statement_lines {
+        record_unexplained_script_mentions(
+            line,
+            line_start,
+            &guarded,
+            &excluded,
+            &recorded,
+            &mut whole_object_uses,
+        );
+    }
+    whole_object_uses
 }
 
 fn is_statement_start(trimmed: &str) -> bool {
@@ -186,26 +285,29 @@ pub(crate) fn is_mdx_file(path: &Path) -> bool {
         .is_some_and(|ext| ext == "mdx")
 }
 
-/// Parse an MDX file by extracting import/export statements.
+/// Parse an MDX file by extracting import/export statements, then append the
+/// member accesses and whole-object uses scanned from the prose body.
 pub(crate) fn parse_mdx_to_module(file_id: FileId, source: &str, content_hash: u64) -> ModuleInfo {
     let parsed_suppressions = crate::suppress::parse_suppressions_from_source(source);
     let line_offsets = fallow_types::extract::compute_line_offsets(source);
-    let extraction = MdxExtractor.extract(source).into_iter().next();
+    let scan = extract_mdx_source(source);
 
-    if let Some(statements) = extraction {
+    let mut info = if scan.statements.body.is_empty() {
+        ModuleInfoExtractor::new().into_module_info(file_id, content_hash, parsed_suppressions)
+    } else {
         let source_type = SourceType::jsx();
         let allocator = Allocator::default();
-        let parser_return = Parser::new(&allocator, &statements.body, source_type).parse();
+        let parser_return = Parser::new(&allocator, &scan.statements.body, source_type).parse();
         let mut extractor = ModuleInfoExtractor::new();
         extractor.visit_program(&parser_return.program);
-        extractor.remap_spans_with(|span| statements.remap_span(span));
-        let mut info = extractor.into_module_info(file_id, content_hash, parsed_suppressions);
-        info.line_offsets = line_offsets;
-        return info;
-    }
-
-    let mut info =
-        ModuleInfoExtractor::new().into_module_info(file_id, content_hash, parsed_suppressions);
+        extractor.remap_spans_with(|span| scan.statements.remap_span(span));
+        extractor.into_module_info(file_id, content_hash, parsed_suppressions)
+    };
+    let (body_accesses, body_whole_object_uses) = collect_body_usage(&scan, &info.imports);
+    extend_member_accesses(&mut info, body_accesses);
+    extend_whole_object_uses(&mut info, body_whole_object_uses);
+    let statement_whole_object_uses = collect_unexplained_statement_mentions(&scan, &info);
+    extend_whole_object_uses(&mut info, statement_whole_object_uses);
     info.line_offsets = line_offsets;
     info
 }
@@ -535,5 +637,292 @@ import { Visible } from './Visible'
         );
         assert!(info.imports.is_empty());
         assert!(info.exports.is_empty());
+    }
+
+    fn body_member_accesses(source: &str) -> Vec<(String, String)> {
+        parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0)
+            .member_accesses
+            .iter()
+            .map(|access| (access.object.clone(), access.member.clone()))
+            .collect()
+    }
+
+    /// Issue #2355: member-expression tags in the MDX body (`<NS.Card />`,
+    /// paired `<NS.Panel>`) record the same per-tag member access the JSX
+    /// visitor records for `.tsx`, once per opening tag.
+    #[test]
+    fn mdx_body_member_tag_records_member_access() {
+        let accesses = body_member_accesses(
+            "import * as NS from './ns'\n\n# Title\n\n<NS.Card />\n\n<NS.Panel>\ntext\n</NS.Panel>\n",
+        );
+        assert_eq!(
+            accesses,
+            vec![
+                ("NS".to_string(), "Card".to_string()),
+                ("NS".to_string(), "Panel".to_string()),
+            ],
+            "body member tags should each record once; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: `<A.B.C>` records one access per nesting level, matching
+    /// the plain-expression walk of `A.B.C` (`{A.B, C}` then `{A, B}`).
+    #[test]
+    fn mdx_body_nested_member_tag_records_each_level() {
+        let accesses = body_member_accesses("import * as A from './a'\n\n<A.B.C>nested</A.B.C>\n");
+        assert_eq!(
+            accesses,
+            vec![
+                ("A.B".to_string(), "C".to_string()),
+                ("A".to_string(), "B".to_string()),
+            ],
+            "<A.B.C> should record both nesting levels; got {accesses:?}"
+        );
+    }
+
+    fn body_whole_object_uses(source: &str) -> Vec<String> {
+        parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0)
+            .whole_object_uses
+            .to_vec()
+    }
+
+    /// Issue #2355: fenced code blocks (backtick or tilde fences) are
+    /// documentation, so member tags inside them never record an access; the
+    /// mention is unexplained, so the binding keeps its mark-all crediting
+    /// instead of narrowing to the visible tag.
+    #[test]
+    fn mdx_fenced_code_member_tag_records_no_access_but_keeps_mark_all() {
+        let source = "import * as NS from './ns'\nimport * as Only from './only'\n\n```tsx\n<NS.Fenced />\n```\n\n~~~\n<NS.Tilde />\n~~~\n\n<NS.Visible />\n<Only.Visible />\n";
+        let accesses = body_member_accesses(source);
+        assert_eq!(
+            accesses,
+            vec![
+                ("NS".to_string(), "Visible".to_string()),
+                ("Only".to_string(), "Visible".to_string()),
+            ],
+            "fenced member tags must not record; got {accesses:?}"
+        );
+        assert_eq!(
+            body_whole_object_uses(source),
+            vec!["NS".to_string()],
+            "a fenced mention must keep NS on the mark-all path while Only stays precise"
+        );
+    }
+
+    /// Issue #2355: inline code spans (single or double backtick runs) are
+    /// prose, so member tags inside them never record an access, while an
+    /// unmatched backtick stays literal and does not hide the rest of the
+    /// line. The mention inside the span is unexplained and keeps the binding
+    /// on the mark-all path.
+    #[test]
+    fn mdx_inline_code_member_tag_records_no_access_but_keeps_mark_all() {
+        let source = "import * as NS from './ns'\n\nUse `<NS.Single />` or ``<NS.Double />`` but render <NS.Visible />.\n\nA stray ` backtick before <NS.Literal /> is not a span.\n";
+        let accesses = body_member_accesses(source);
+        assert_eq!(
+            accesses,
+            vec![
+                ("NS".to_string(), "Visible".to_string()),
+                ("NS".to_string(), "Literal".to_string()),
+            ],
+            "inline-code member tags must not record; got {accesses:?}"
+        );
+        assert_eq!(body_whole_object_uses(source), vec!["NS".to_string()]);
+    }
+
+    /// Issue #2355: lowercase intrinsic tags (`<div>`, `<a>`, `<br/>`) are
+    /// host elements and record nothing, while a dotted tag with a lowercase
+    /// root (`<ui.Card />`) is still a member expression in JSX and records.
+    #[test]
+    fn mdx_lowercase_intrinsic_tag_records_nothing() {
+        let source = "import * as ui from './ui'\n\n<div>\n  <a href=\"x\">link</a>\n  <br/>\n  <ui.Card />\n</div>\n";
+        let accesses = body_member_accesses(source);
+        assert_eq!(
+            accesses,
+            vec![("ui".to_string(), "Card".to_string())],
+            "only the dotted tag should record; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: an `export` line containing a member tag is parsed by the
+    /// JSX visitor, so the body scan must not record it a second time while
+    /// still recording the tags in the prose body.
+    #[test]
+    fn mdx_export_line_member_tag_is_not_double_recorded() {
+        let accesses = body_member_accesses(
+            "import * as NS from './ns'\nexport const Demo = () => <NS.Card />\n\n<NS.Body />\n",
+        );
+        assert_eq!(
+            accesses,
+            vec![
+                ("NS".to_string(), "Card".to_string()),
+                ("NS".to_string(), "Body".to_string()),
+            ],
+            "a statement-line member tag should record exactly once; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: a namespace member read inside a body expression (attribute
+    /// value, text expression, call) records the same access a dotted tag does,
+    /// so `<NS.Star />` next to `icon={NS.Moon}` narrows to a complete set.
+    #[test]
+    fn mdx_body_expression_member_access_records() {
+        let accesses = body_member_accesses(
+            "import * as NS from './ns'\n\n<NS.Star />\n\n<Callout icon={NS.Moon}>x</Callout>\n\n{NS.Sun()}\n",
+        );
+        assert_eq!(
+            accesses,
+            vec![
+                ("NS".to_string(), "Star".to_string()),
+                ("NS".to_string(), "Moon".to_string()),
+                ("NS".to_string(), "Sun".to_string()),
+            ],
+            "expression member accesses should record; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: a `{ ... }` expression that spans lines still records the
+    /// dotted access on its own line, because the scan is brace-agnostic.
+    #[test]
+    fn mdx_body_multiline_expression_records_member_access() {
+        let accesses = body_member_accesses(
+            "import * as NS from './ns'\n\n<NS.Star />\n\n{\n  NS.Moon()\n}\n",
+        );
+        assert!(
+            accesses.contains(&("NS".to_string(), "Moon".to_string())),
+            "a dotted access inside a multi-line expression should record; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: passing the namespace whole (`all={NS}`) records a
+    /// whole-object use so the graph keeps every export credited, while a
+    /// namespace used only through dotted tags records none and narrows.
+    #[test]
+    fn mdx_body_whole_namespace_pass_records_whole_object_use() {
+        let whole = body_whole_object_uses(
+            "import * as NS from './ns'\nimport * as Tags from './tags'\n\n<NS.Star />\n<Tags.Only />\n\n<Callout all={NS}>x</Callout>\n",
+        );
+        assert_eq!(
+            whole,
+            vec!["NS".to_string()],
+            "only the namespace passed whole should record a whole-object use; got {whole:?}"
+        );
+    }
+
+    /// Issue #2355: the conservative fallback. A bare mention of an import
+    /// binding anywhere in prose keeps it on the mark-all path, and so does
+    /// the same mention inside an inline code span (unexplained by the scan),
+    /// while a binding that is not mentioned records nothing.
+    #[test]
+    fn mdx_prose_mention_of_import_binding_is_whole_object_use() {
+        let whole = body_whole_object_uses(
+            "import * as NS from './ns'\nimport Layout from './Layout'\n\nNS is documented here.\n\n<NS.Star />\n",
+        );
+        assert_eq!(whole, vec!["NS".to_string()], "got {whole:?}");
+
+        let whole = body_whole_object_uses(
+            "import * as NS from './ns'\nimport Layout from './Layout'\n\nOnly `NS` in code.\n\n<NS.Star />\n",
+        );
+        assert_eq!(
+            whole,
+            vec!["NS".to_string()],
+            "a code-span mention is unexplained; got {whole:?}"
+        );
+    }
+
+    /// Issue #2355 completeness guard: a backtick inside a JSX expression is a
+    /// template literal, which the line scanner cannot tell apart from a code
+    /// span, so the mention it swallows keeps the binding on the mark-all path
+    /// (a namespace interpolated in an attribute, a namespace passed whole
+    /// inside the literal, and a CSS module class read through a literal).
+    #[test]
+    fn mdx_template_literal_inside_expression_keeps_binding_on_mark_all() {
+        let source = "import * as NS from './ns'\nimport * as Whole from './whole'\nimport styles from './doc.module.css'\n\n\
+             <NS.Star />\n<Whole.Star />\n<div className={styles.root}></div>\n\n\
+             <Callout title={`Moon: ${NS.Moon}`}>x</Callout>\n\n\
+             {`${JSON.stringify(Whole)}`}\n\n\
+             <div className={`${styles.spare} extra`}></div>\n";
+        let accesses = body_member_accesses(source);
+        assert!(
+            accesses.contains(&("NS".to_string(), "Star".to_string()))
+                && accesses.contains(&("styles".to_string(), "root".to_string())),
+            "structured accesses still record; got {accesses:?}"
+        );
+        let mut whole = body_whole_object_uses(source);
+        whole.sort();
+        assert_eq!(
+            whole,
+            vec!["NS".to_string(), "Whole".to_string(), "styles".to_string()],
+            "every binding mentioned inside a template literal must keep mark-all"
+        );
+    }
+
+    /// Issue #2355 precision: when every mention of a binding is a dotted tag
+    /// (single, paired, nested in a `<div>`), a dotted chain in an expression
+    /// (attribute, text, multi-line block), or a rendered default import, no
+    /// whole-object use is recorded and narrowing stays precise.
+    #[test]
+    fn mdx_fully_understood_body_records_no_whole_object_use() {
+        let source = "import * as NS from './ns'\nimport Layout from './Layout'\nimport styles from './doc.module.css'\n\n\
+             # Title\n\n<Layout>\n  <NS.Star />\n  <NS.Panel icon={NS.Moon} className={styles.root}>\n    {NS.helper()}\n  </NS.Panel>\n</Layout>\n\n\
+             {\n  NS.Sun()\n}\n";
+        let whole = body_whole_object_uses(source);
+        assert!(
+            whole.is_empty(),
+            "fully understood mentions must not record a whole-object use; got {whole:?}"
+        );
+        let accesses = body_member_accesses(source);
+        for member in ["Star", "Panel", "Moon", "helper", "Sun"] {
+            assert!(
+                accesses.contains(&("NS".to_string(), member.to_string())),
+                "NS.{member} should be recorded; got {accesses:?}"
+            );
+        }
+    }
+
+    /// Issue #2355 script guard: a statement-line mention of a namespace the
+    /// JSX visitor does not record as a whole-object use (`export const all =
+    /// NS`, a JSX attribute on an exported component, a default-export
+    /// layout) keeps the binding on the mark-all path, while a dotted-only
+    /// statement use (`export const moon = SP.Moon`) records no whole-object
+    /// use and stays precise.
+    #[test]
+    fn mdx_statement_line_bare_mention_keeps_binding_on_mark_all() {
+        let source = "import * as SW from './sw';\nimport * as SA from './sa';\n\
+             import * as SD from './sd';\nimport * as SP from './sp';\n\
+             import Callout from './Callout.astro';\n\n\
+             export const all = SW;\n\n\
+             export const Demo = () => <Callout all={SA} />;\n\n\
+             export default (props) => <Callout all={SD} {...props} />;\n\n\
+             export const moon = SP.Moon;\n\n\
+             <SW.Star /><SA.Star /><SD.Star /><SP.Star />\n";
+        let mut whole = body_whole_object_uses(source);
+        whole.sort();
+        assert_eq!(
+            whole,
+            vec!["SA".to_string(), "SD".to_string(), "SW".to_string()],
+            "every bare statement-line mention must keep its namespace on mark-all"
+        );
+        let accesses = body_member_accesses(source);
+        assert!(
+            accesses.contains(&("SP".to_string(), "Moon".to_string())),
+            "the dotted statement access should be recorded; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2355: a prose chain rooted outside the import locals
+    /// (`process.env.API_KEY` in a setup sentence) records no member access,
+    /// so documentation never turns the MDX module into a secret source, while
+    /// a chain rooted at an import local still records.
+    #[test]
+    fn mdx_prose_env_mention_records_no_member_access() {
+        let source = "import * as NS from './ns'\n\n# Setup\n\n\
+             Set process.env.API_KEY and import.meta.env.SECRET before running {NS.helper()}.\n";
+        let accesses = body_member_accesses(source);
+        assert_eq!(
+            accesses,
+            vec![("NS".to_string(), "helper".to_string())],
+            "only import-local roots record; got {accesses:?}"
+        );
+        assert!(body_whole_object_uses(source).is_empty());
     }
 }

--- a/crates/extract/src/source_map.rs
+++ b/crates/extract/src/source_map.rs
@@ -2,12 +2,6 @@
 
 use oxc_span::Span;
 
-/// Extractor contract for container formats that feed extracted source to Oxc.
-pub trait SfcExtractor {
-    /// Return one or more source-mapped extracted fragments from `source`.
-    fn extract(&self, source: &str) -> Vec<ExtractionResult>;
-}
-
 #[derive(Debug, Clone)]
 struct FragmentMap {
     generated_start: u32,

--- a/crates/extract/src/template_expression_scan.rs
+++ b/crates/extract/src/template_expression_scan.rs
@@ -1,0 +1,732 @@
+//! Text-side usage scan and completeness guard for markup the JSX visitor
+//! cannot fully account for: MDX prose lines (never parsed) and Astro `{ ... }`
+//! expression regions (parsed, but a bare identifier passed whole is not a
+//! whole-object use the visitor records).
+//!
+//! Namespace-import narrowing trusts the member-access stream it is given: once
+//! one access is recorded for a binding in a non-entry consumer, every sibling
+//! export missing from the stream is reported as unused. A text scanner of a
+//! template cannot promise that stream is complete shape by shape (a directive
+//! on a masked `<style>` tag, a template literal that looks like a code span),
+//! so completeness is enforced structurally instead, over the whole file:
+//! every structured template pass reports the byte spans it classified, and
+//! [`record_unexplained_mentions`] turns every mention of an import binding
+//! outside those spans into a whole-object use; the script side the visitor
+//! parsed (Astro frontmatter, MDX statement lines) goes through
+//! [`record_unexplained_script_mentions`], which explains a mention only by a
+//! static dotted access the visitor recorded or a JSX tag root, because the
+//! visitor records a bare identifier as a whole-object use for an allow-list
+//! of positions only (`const N = NS`, `pick(NS)`, `[NS]` are not on it). Both
+//! keep the graph on its mark-all path. Narrowing therefore applies only when
+//! every mention of the binding was structurally understood; for the
+//! dead-code crediting consumers (namespace, CSS module, enum, and class
+//! member crediting) an unmodelled shape degrades to over-credit.
+//!
+//! Member accesses also feed consumers that create findings from them (the
+//! security secret-source index reads `process.env.X` / `import.meta.env.X`
+//! pairs), so the MDX prose scan records a dotted chain only when its root is
+//! an import local of the file: a documentation sentence mentioning
+//! `process.env.API_KEY` is not a secret read. See issue #2355.
+
+use rustc_hash::FxHashSet;
+
+use crate::visitor::push_member_tag_accesses;
+use crate::{ImportInfo, MemberAccess};
+
+/// The import locals the completeness guards protect: every import binding
+/// with a local name (namespace, default, named, CSS module, type-only).
+/// Enum and class member crediting and CSS-module narrowing read the same
+/// whole-object uses as namespace narrowing, so the guards cover them too.
+pub fn guarded_import_locals(imports: &[ImportInfo]) -> FxHashSet<&str> {
+    imports
+        .iter()
+        .map(|import| import.local_name.as_str())
+        .filter(|local| !local.is_empty())
+        .collect()
+}
+
+/// The import locals whose exports the graph narrows by member access: a
+/// namespace import (`import * as NS`) and a default import of a CSS module
+/// (`import styles from './card.module.css'`, mirroring the graph's CSS-module
+/// path test). The script-side guard covers exactly these, so a class or enum
+/// named in a frontmatter type annotation or `new` expression keeps the
+/// visitor's own member crediting instead of falling back to every member.
+pub fn narrowable_import_locals(imports: &[ImportInfo]) -> FxHashSet<&str> {
+    imports
+        .iter()
+        .filter(|import| match import.imported_name {
+            crate::ImportedName::Namespace => true,
+            crate::ImportedName::Default => is_css_module_source(&import.source),
+            crate::ImportedName::Named(_) | crate::ImportedName::SideEffect => false,
+        })
+        .map(|import| import.local_name.as_str())
+        .filter(|local| !local.is_empty())
+        .collect()
+}
+
+fn is_css_module_source(source: &str) -> bool {
+    let file_name = source.rsplit(['/', '\\']).next().unwrap_or(source);
+    let Some((stem, extension)) = file_name.rsplit_once('.') else {
+        return false;
+    };
+    stem.ends_with(".module") && matches!(extension, "css" | "scss")
+}
+
+/// The `(object, member)` pairs recorded for the guarded bindings, which
+/// [`record_unexplained_script_mentions`] explains dotted mentions against.
+pub fn recorded_member_pairs<'a>(
+    accesses: &'a [MemberAccess],
+    guarded: &FxHashSet<&str>,
+) -> FxHashSet<(&'a str, &'a str)> {
+    accesses
+        .iter()
+        .filter(|access| guarded.contains(access.object.as_str()))
+        .map(|access| (access.object.as_str(), access.member.as_str()))
+        .collect()
+}
+
+/// The import declaration spans in file coordinates, merged for
+/// [`pos_in_ranges`]: the local name inside its own declaration is not a
+/// mention.
+pub fn import_declaration_ranges(imports: &[ImportInfo]) -> Vec<(usize, usize)> {
+    merge_ranges(
+        imports
+            .iter()
+            .map(|import| (import.span.start as usize, import.span.end as usize))
+            .collect(),
+    )
+}
+
+/// Which markup fragment [`scan_template_usage`] is reading.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TemplateScanMode {
+    /// An MDX prose line: the only tag and expression scan the body gets, so
+    /// opening dotted tags and dotted chains whose root is an import local
+    /// record member accesses (every crediting consumer is keyed by import
+    /// locals; a foreign root such as `process.env` in prose is documentation,
+    /// not a read). Inline code spans are documentation too: nothing inside
+    /// them records an access, and a binding mentioned there falls back to a
+    /// whole-object use.
+    MdxProse,
+    /// An Astro `{ ... }` region the visitor parsed cleanly: the visitor owns
+    /// the dotted chains (and the tag scan the dotted tags), so only the bare
+    /// whole-object passes (`all={NS}`) the visitor does not record are added.
+    /// Backticks are template literals, never code spans.
+    AstroParsedRegion,
+}
+
+/// Where an identifier chain sits relative to a JSX tag delimiter.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TagPosition {
+    /// Immediately after `</`: the opening tag already recorded.
+    Closing,
+    /// Immediately after `<`: a component tag name.
+    Opening,
+    /// Plain expression or prose position.
+    None,
+}
+
+/// Scan one text fragment and append what it implies for usage crediting.
+///
+/// Identifier chains (`Ident`, `Ident.Ident`, ...) are classified by the byte in
+/// front of them: after `</` nothing records; after `<` a dotted name records
+/// one access per nesting level in MDX mode while a bare name never does
+/// (rendering a component is not a whole-object pass); anywhere else a dotted
+/// chain records one access per level in MDX mode, and a bare name that is an
+/// import binding records a deduplicated whole-object use. In MDX mode a
+/// dotted chain records only when its root is an import binding, so prose
+/// never creates member accesses on foreign roots (`process.env.API_KEY`,
+/// `items.map`). Only the byte directly in front counts as a tag delimiter,
+/// so `{a < NS}` keeps `NS` a whole-object use instead of mistaking it for a
+/// tag.
+///
+/// Every identifier in the fragment is classified by one of those arms, so the
+/// whole fragment counts as structurally understood, except the inline code
+/// spans MDX mode skips: those are handed to [`record_unexplained_mentions`]
+/// so a binding mentioned inside one (a real code span, or a template literal
+/// the line scanner cannot tell apart from one) keeps its mark-all crediting.
+///
+/// The scan is byte-based, but every boundary it slices on (`<`, `/`, `.`,
+/// backtick, ASCII identifier bytes) is ASCII, so slices always land on char
+/// boundaries.
+pub fn scan_template_usage(
+    text: &str,
+    import_locals: &FxHashSet<&str>,
+    mode: TemplateScanMode,
+    accesses: &mut Vec<MemberAccess>,
+    whole_object_uses: &mut Vec<String>,
+) {
+    let record_dotted = mode == TemplateScanMode::MdxProse;
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if byte == b'`' && mode == TemplateScanMode::MdxProse {
+            let end = skip_inline_code_span(bytes, i);
+            if let Some(span) = text.get(i..end) {
+                record_unexplained_mentions(span, import_locals, &[], whole_object_uses);
+            }
+            i = end;
+            continue;
+        }
+        if !is_identifier_start(byte) {
+            i += 1;
+            continue;
+        }
+        let end = dotted_chain_end(bytes, i);
+        let Some(chain) = text.get(i..end) else {
+            return;
+        };
+        let dotted = chain.contains('.');
+        match tag_position(bytes, i) {
+            TagPosition::Opening | TagPosition::None if dotted => {
+                if record_dotted && import_locals.contains(chain_root(chain)) {
+                    push_member_tag_accesses(accesses, chain);
+                }
+            }
+            TagPosition::None => push_whole_object_use(whole_object_uses, import_locals, chain),
+            TagPosition::Closing | TagPosition::Opening => {}
+        }
+        i = end;
+    }
+}
+
+/// Record a whole-object use for every guarded binding mentioned in `text`
+/// outside `explained`, the disjoint ascending byte ranges a structured pass
+/// classified (see [`merge_ranges`]). A mention is the binding name on
+/// identifier boundaries that is not the property of a member access (so
+/// `NS.Moon` and the spread `...NS` mention `NS`, while `other.NS` and
+/// `other?.NS` do not). Whole-object uses are deduplicated.
+///
+/// This is the completeness guard of issue #2355: a binding whose every
+/// mention lies inside an explained span narrows on the accesses the
+/// structured passes recorded; one unexplained mention keeps it on the
+/// mark-all path.
+pub fn record_unexplained_mentions(
+    text: &str,
+    guarded: &FxHashSet<&str>,
+    explained: &[(usize, usize)],
+    whole_object_uses: &mut Vec<String>,
+) {
+    if guarded.is_empty() {
+        return;
+    }
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if !is_identifier_start(bytes[i]) {
+            i += 1;
+            continue;
+        }
+        let end = identifier_end(bytes, i);
+        if !is_member_property(bytes, i)
+            && !pos_in_ranges(explained, i)
+            && let Some(name) = text.get(i..end)
+        {
+            push_whole_object_use(whole_object_uses, guarded, name);
+        }
+        i = end;
+    }
+}
+
+/// Completeness guard for script text the visitor parsed: the Astro
+/// frontmatter and the MDX `import` / `export` statement lines (issue #2355).
+///
+/// The visitor records a bare identifier as a whole-object use only for an
+/// allow-list of positions (spread, `Object.keys(NS)`, `for ... in`, computed
+/// non-string access, rest destructuring), so an alias (`const N = NS`), a
+/// cast (`NS as T`), a call argument (`pick(NS)`), `Object.assign({}, NS)`,
+/// an array literal (`[NS]`), a property value (`{ all: NS }`), or a JSX
+/// attribute on a statement line (`<Callout all={NS} />`) leaves no trace and
+/// would let the binding narrow to its dotted accesses. This guard walks the
+/// raw script text starting at `text_offset` in the file and records a
+/// whole-object use for every guarded binding (see
+/// [`narrowable_import_locals`]) mentioned on identifier boundaries outside
+/// the `excluded` ranges (the import declarations, in file coordinates, merged
+/// by [`merge_ranges`]) unless the mention is structurally understood: a
+/// static dotted access `NS.member` whose `(NS, member)` pair the visitor
+/// `recorded`, or a JSX tag root (`<NS.Card`, `</Callout`). Set membership
+/// rather than a count keeps the guard independent of how many times the
+/// visitor records one access and of the deduplication applied to
+/// template-sourced accesses. Mentions the visitor does understand more
+/// precisely (`NS["Moon"]`, `NS?.Moon`) are unexplained here and keep the
+/// binding on mark-all, which only over-credits. The member property of an
+/// access (`other.NS`) is not a mention; the spread `...NS` is.
+pub fn record_unexplained_script_mentions(
+    text: &str,
+    text_offset: usize,
+    guarded: &FxHashSet<&str>,
+    excluded: &[(usize, usize)],
+    recorded: &FxHashSet<(&str, &str)>,
+    whole_object_uses: &mut Vec<String>,
+) {
+    if guarded.is_empty() {
+        return;
+    }
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if !is_identifier_start(bytes[i]) {
+            i += 1;
+            continue;
+        }
+        let end = identifier_end(bytes, i);
+        let Some(name) = text.get(i..end) else {
+            return;
+        };
+        if guarded.contains(name)
+            && !is_member_property(bytes, i)
+            && !pos_in_ranges(excluded, text_offset + i)
+            && !is_explained_script_mention(bytes, text, i, end, recorded)
+        {
+            push_whole_object_use(whole_object_uses, guarded, name);
+        }
+        i = end;
+    }
+}
+
+/// Whether the guarded identifier at `start..end` is a static dotted access the
+/// visitor `recorded` or a JSX tag root.
+fn is_explained_script_mention(
+    bytes: &[u8],
+    text: &str,
+    start: usize,
+    end: usize,
+    recorded: &FxHashSet<(&str, &str)>,
+) -> bool {
+    if tag_position(bytes, start) != TagPosition::None {
+        return true;
+    }
+    if bytes.get(end) != Some(&b'.') {
+        return false;
+    }
+    let member_end = identifier_end(bytes, end + 1);
+    if member_end == end + 1 {
+        return false;
+    }
+    match (text.get(start..end), text.get(end + 1..member_end)) {
+        (Some(object), Some(member)) => recorded.contains(&(object, member)),
+        _ => false,
+    }
+}
+
+/// The root identifier of a dotted chain (`NS` for `NS.Card.Body`).
+fn chain_root(chain: &str) -> &str {
+    chain.split('.').next().unwrap_or(chain)
+}
+
+/// Whether the identifier at `start` is the property of a member access: it is
+/// preceded by a `.` that is not the tail of a spread operator (`...`).
+fn is_member_property(bytes: &[u8], start: usize) -> bool {
+    match bytes[..start] {
+        [.., b'.', b'.', b'.'] => false,
+        [.., b'.'] => true,
+        _ => false,
+    }
+}
+
+fn push_whole_object_use(
+    whole_object_uses: &mut Vec<String>,
+    guarded: &FxHashSet<&str>,
+    name: &str,
+) {
+    if guarded.contains(name) && !whole_object_uses.iter().any(|existing| existing == name) {
+        whole_object_uses.push(name.to_string());
+    }
+}
+
+/// Sort byte ranges by start and merge overlapping or touching ones into the
+/// disjoint ascending list [`pos_in_ranges`] relies on. The union covers
+/// exactly the same byte positions as the input.
+pub fn merge_ranges(mut ranges: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    ranges.sort_unstable_by_key(|&(start, _)| start);
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        if let Some(last) = merged.last_mut()
+            && start <= last.1
+        {
+            last.1 = last.1.max(end);
+        } else {
+            merged.push((start, end));
+        }
+    }
+    merged
+}
+
+/// Test whether `pos` falls inside any range of the disjoint ascending list
+/// produced by [`merge_ranges`]. Membership is a binary search
+/// (`partition_point`): because the list is disjoint and ascending, only the
+/// last range with `start <= pos` can contain it, so a single bounds check on
+/// that candidate decides membership.
+pub fn pos_in_ranges(ranges: &[(usize, usize)], pos: usize) -> bool {
+    let idx = ranges.partition_point(|&(start, _)| start <= pos);
+    idx > 0 && pos < ranges[idx - 1].1
+}
+
+fn tag_position(bytes: &[u8], start: usize) -> TagPosition {
+    match bytes[..start] {
+        [.., b'<', b'/'] => TagPosition::Closing,
+        [.., b'<'] => TagPosition::Opening,
+        _ => TagPosition::None,
+    }
+}
+
+/// Given `open` = the index of a backtick, return the index just past the
+/// matching code-span closer: a backtick run of exactly the same length, as
+/// CommonMark defines code spans. An unmatched run is literal text, so the
+/// scan resumes right after it instead of hiding the rest of the line.
+fn skip_inline_code_span(bytes: &[u8], open: usize) -> usize {
+    let run = backtick_run_len(bytes, open);
+    let mut j = open + run;
+    while j < bytes.len() {
+        if bytes[j] != b'`' {
+            j += 1;
+            continue;
+        }
+        let closer = backtick_run_len(bytes, j);
+        if closer == run {
+            return j + closer;
+        }
+        j += closer;
+    }
+    open + run
+}
+
+fn backtick_run_len(bytes: &[u8], start: usize) -> usize {
+    bytes[start..].iter().take_while(|&&b| b == b'`').count()
+}
+
+/// Return the end index of the dotted identifier chain starting at `start`
+/// (`NS.Card` in `<NS.Card />`). A dot that is not followed by another
+/// identifier is left unconsumed.
+fn dotted_chain_end(bytes: &[u8], start: usize) -> usize {
+    let mut end = identifier_end(bytes, start);
+    while end < bytes.len() && bytes[end] == b'.' {
+        let segment_end = identifier_end(bytes, end + 1);
+        if segment_end == end + 1 {
+            break;
+        }
+        end = segment_end;
+    }
+    end
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+}
+
+fn identifier_end(bytes: &[u8], start: usize) -> usize {
+    if !bytes.get(start).is_some_and(|&b| is_identifier_start(b)) {
+        return start;
+    }
+    let mut end = start + 1;
+    while bytes
+        .get(end)
+        .is_some_and(|&b| b.is_ascii_alphanumeric() || b == b'_' || b == b'$')
+    {
+        end += 1;
+    }
+    end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MDX: TemplateScanMode = TemplateScanMode::MdxProse;
+    const ASTRO: TemplateScanMode = TemplateScanMode::AstroParsedRegion;
+
+    fn scan(text: &str, locals: &[&str], mode: TemplateScanMode) -> (Vec<String>, Vec<String>) {
+        let import_locals: FxHashSet<&str> = locals.iter().copied().collect();
+        let mut accesses = Vec::new();
+        let mut whole = Vec::new();
+        scan_template_usage(text, &import_locals, mode, &mut accesses, &mut whole);
+        let accesses = accesses
+            .into_iter()
+            .map(|access| format!("{}.{}", access.object, access.member))
+            .collect();
+        (accesses, whole)
+    }
+
+    fn unexplained(text: &str, guarded: &[&str], explained: &[(usize, usize)]) -> Vec<String> {
+        let guarded: FxHashSet<&str> = guarded.iter().copied().collect();
+        let mut whole = Vec::new();
+        record_unexplained_mentions(text, &guarded, explained, &mut whole);
+        whole
+    }
+
+    #[test]
+    fn dotted_chain_records_each_level_and_bare_import_local_records_whole_use() {
+        let (accesses, whole) = scan("icon={NS.Moon} all={NS} {A.B.C}", &["NS", "A"], MDX);
+        assert_eq!(accesses, vec!["NS.Moon", "A.B.C", "A.B"]);
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn bare_identifier_that_is_not_an_import_records_nothing() {
+        let (accesses, whole) = scan("{items.map((item) => item)}", &["NS"], MDX);
+        assert!(
+            accesses.is_empty(),
+            "a chain rooted outside the import locals is not a use; got {accesses:?}"
+        );
+        assert!(whole.is_empty());
+    }
+
+    /// Issue #2355: prose chains record only for import-local roots, so a
+    /// documentation sentence naming `process.env.API_KEY` never becomes a
+    /// secret-source member access, while `{NS.helper()}` still records.
+    #[test]
+    fn mdx_prose_dotted_chain_with_foreign_root_records_nothing() {
+        let (accesses, whole) = scan(
+            "Set process.env.API_KEY and import.meta.env.SECRET, then {NS.helper()} <NS.Card />",
+            &["NS"],
+            MDX,
+        );
+        assert_eq!(accesses, vec!["NS.helper", "NS.Card"]);
+        assert!(whole.is_empty());
+
+        let (accesses, _) = scan("Set process.env.API_KEY first", &["process"], MDX);
+        assert_eq!(
+            accesses,
+            vec!["process.env.API_KEY", "process.env"],
+            "an imported `process` binding is a real root"
+        );
+    }
+
+    fn script(
+        text: &str,
+        offset: usize,
+        guarded: &[&str],
+        excluded: &[(usize, usize)],
+        recorded: &[(&str, &str)],
+    ) -> Vec<String> {
+        let guarded: FxHashSet<&str> = guarded.iter().copied().collect();
+        let recorded: FxHashSet<(&str, &str)> = recorded.iter().copied().collect();
+        let mut whole = Vec::new();
+        record_unexplained_script_mentions(text, offset, &guarded, excluded, &recorded, &mut whole);
+        whole
+    }
+
+    /// Issue #2355 script guard: a mention is explained only by a static
+    /// dotted access the visitor recorded or a JSX tag root; an alias, a cast,
+    /// a call argument, a literal element, a property value, and a dotted
+    /// access the visitor did not record all keep the binding on mark-all.
+    #[test]
+    fn script_mentions_are_explained_only_by_recorded_dotted_access_or_tag_root() {
+        let recorded = [("NS", "Moon"), ("NS", "Star"), ("CSS", "root")];
+        for shape in [
+            "const N = NS;",
+            "const rec = NS as Record<string, unknown>;",
+            "const picked = pick(NS);",
+            "const merged = Object.assign({}, NS);",
+            "const list = [NS];",
+            "const props = { all: NS };",
+            "export const all = NS;",
+            "export const Demo = () => <Callout all={NS} />;",
+            "const sun = NS.Sun;",
+            "const moon = NS?.Moon;",
+            "const moon = NS[\"Moon\"];",
+            "const copy = { ...NS };",
+        ] {
+            assert_eq!(
+                script(shape, 0, &["NS"], &[], &recorded),
+                vec!["NS"],
+                "{shape}"
+            );
+        }
+        for shape in [
+            "const moon = NS.Moon; const star = NS.Star.Deep;",
+            "export const Demo = () => <NS.Moon><NS.Star /></NS.Moon>;",
+            "const cls = CSS.root; const other = outer.NS; const n = NSX + fooNS;",
+            "<Callout all={other} />",
+        ] {
+            assert!(
+                script(shape, 0, &["NS", "CSS"], &[], &recorded).is_empty(),
+                "{shape}"
+            );
+        }
+    }
+
+    /// Issue #2355 script guard scope: namespace imports and CSS-module
+    /// default imports are narrowable; other default, named, and side-effect
+    /// imports are not.
+    #[test]
+    fn narrowable_import_locals_cover_namespace_and_css_module_bindings() {
+        let import = |source: &str, imported_name: crate::ImportedName, local: &str| ImportInfo {
+            source: source.to_string(),
+            imported_name,
+            local_name: local.to_string(),
+            is_type_only: false,
+            from_style: false,
+            span: oxc_span::Span::default(),
+            source_span: oxc_span::Span::default(),
+        };
+        let imports = [
+            import("./ns", crate::ImportedName::Namespace, "NS"),
+            import("./card.module.css", crate::ImportedName::Default, "styles"),
+            import("../a/b.module.scss", crate::ImportedName::Default, "scss"),
+            import("./plain.css", crate::ImportedName::Default, "plain"),
+            import("./module.ts", crate::ImportedName::Default, "Layout"),
+            import("./util", crate::ImportedName::Named("Util".into()), "Util"),
+            import("./side", crate::ImportedName::SideEffect, ""),
+        ];
+        let mut locals: Vec<&str> = narrowable_import_locals(&imports).into_iter().collect();
+        locals.sort_unstable();
+        assert_eq!(locals, vec!["NS", "scss", "styles"]);
+        assert_eq!(guarded_import_locals(&imports).len(), 6);
+    }
+
+    /// Issue #2355 script guard: the import declaration's own span is not a
+    /// mention, positions are compared in file coordinates, and only guarded
+    /// bindings record.
+    #[test]
+    fn script_mentions_skip_excluded_import_spans_and_honour_offsets() {
+        let text = "import * as NS from './ns';\nconst N = NS;\n";
+        let import_span = merge_ranges(vec![(100, 127)]);
+        assert_eq!(script(text, 100, &["NS"], &import_span, &[]), vec!["NS"]);
+
+        let text = "import * as NS from './ns';\nconst moon = NS.Moon;\n";
+        assert!(script(text, 100, &["NS"], &import_span, &[("NS", "Moon")]).is_empty());
+        assert_eq!(
+            script(text, 0, &["NS"], &import_span, &[("NS", "Moon")]),
+            vec!["NS"],
+            "an offset mismatch leaves the declaration unexcluded"
+        );
+        assert!(script(text, 100, &[], &import_span, &[]).is_empty());
+    }
+
+    #[test]
+    fn opening_tag_records_member_tag_only_in_mdx_mode() {
+        let (accesses, whole) = scan("<NS.Card /> <NS.Card>x</NS.Card> <NS />", &["NS"], MDX);
+        assert_eq!(accesses, vec!["NS.Card", "NS.Card"]);
+        assert!(
+            whole.is_empty(),
+            "a rendered tag is not a whole-object pass"
+        );
+
+        let (accesses, whole) = scan("<NS.Card /> <NS.Card>x</NS.Card>", &["NS"], ASTRO);
+        assert!(
+            accesses.is_empty(),
+            "Astro leaves tags to its template scan"
+        );
+        assert!(whole.is_empty());
+    }
+
+    #[test]
+    fn parsed_astro_region_records_only_bare_whole_object_passes() {
+        let (accesses, whole) = scan("fn(NS.Moon, NS) + other.prop", &["NS", "other"], ASTRO);
+        assert!(
+            accesses.is_empty(),
+            "chains belong to the visitor; got {accesses:?}"
+        );
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn comparison_operator_is_not_a_tag_delimiter() {
+        let (accesses, whole) = scan("{a < NS} {b <NS.max}", &["NS"], MDX);
+        assert_eq!(accesses, vec!["NS.max"]);
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn whole_object_uses_are_deduplicated() {
+        let (_, whole) = scan("{NS} {NS} {fn(NS)}", &["NS"], MDX);
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn inline_code_span_records_no_access_but_keeps_mentioned_binding_on_mark_all() {
+        let (accesses, whole) = scan("Use `NS.Hidden` and `Other` but {NS.Shown}", &["NS"], MDX);
+        assert_eq!(accesses, vec!["NS.Shown"]);
+        assert_eq!(
+            whole,
+            vec!["NS"],
+            "a binding mentioned inside a code span is unexplained"
+        );
+
+        let (accesses, whole) = scan("Use `Other.Thing` but {NS.Shown}", &["NS"], MDX);
+        assert_eq!(accesses, vec!["NS.Shown"]);
+        assert!(
+            whole.is_empty(),
+            "only guarded bindings record; got {whole:?}"
+        );
+
+        let (accesses, whole) = scan("{`${NS.Tpl}`} {`${NS}`}", &["NS"], ASTRO);
+        assert!(accesses.is_empty());
+        assert_eq!(whole, vec!["NS"], "Astro backticks are template literals");
+    }
+
+    #[test]
+    fn template_literal_mistaken_for_code_span_still_keeps_binding_on_mark_all() {
+        let (accesses, whole) = scan(
+            "<NS.Star /> <Callout title={`Moon: ${NS.Moon}`}>",
+            &["NS"],
+            MDX,
+        );
+        assert_eq!(accesses, vec!["NS.Star"]);
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn multibyte_text_around_chains_does_not_panic() {
+        let (accesses, whole) = scan("Café {NS.Uni} 日本語 {NS} ✓", &["NS"], MDX);
+        assert_eq!(accesses, vec!["NS.Uni"]);
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn unexplained_mentions_honour_identifier_boundaries_and_dots() {
+        let whole = unexplained("NSX fooNS other.NS a?.NS", &["NS"], &[]);
+        assert!(whole.is_empty(), "got {whole:?}");
+
+        let whole = unexplained("x NS.Moon y", &["NS"], &[]);
+        assert_eq!(whole, vec!["NS"]);
+
+        let whole = unexplained("<Callout {...NS} />", &["NS"], &[]);
+        assert_eq!(whole, vec!["NS"], "a spread is a mention, not a property");
+
+        let whole = unexplained(
+            "(NS) {NS} <NS /> $NS _NS NS$",
+            &["NS", "$NS", "_NS", "NS$"],
+            &[],
+        );
+        assert_eq!(whole, vec!["NS", "$NS", "_NS", "NS$"]);
+    }
+
+    #[test]
+    fn unexplained_mentions_skip_explained_ranges() {
+        let text = "{NS.Moon} <NS.Star /> define:vars={{ NS }}";
+        let explained = merge_ranges(vec![(1, 8), (11, 13)]);
+        assert_eq!(unexplained(text, &["NS"], &explained), vec!["NS"]);
+
+        let explained = merge_ranges(vec![(1, 8), (11, 13), (36, 40)]);
+        assert!(unexplained(text, &["NS"], &explained).is_empty());
+    }
+
+    #[test]
+    fn unexplained_mentions_on_multibyte_text_do_not_panic() {
+        let whole = unexplained("Café NS 日本語 NS ✓ éNS", &["NS"], &[]);
+        assert_eq!(whole, vec!["NS"]);
+    }
+
+    #[test]
+    fn merge_ranges_sorts_and_merges_overlaps() {
+        assert_eq!(
+            merge_ranges(vec![(10, 20), (0, 5), (15, 25), (5, 7), (30, 31)]),
+            vec![(0, 7), (10, 25), (30, 31)]
+        );
+        let merged = merge_ranges(vec![(10, 20), (0, 5), (15, 25)]);
+        for (pos, inside) in [
+            (0, true),
+            (4, true),
+            (5, false),
+            (9, false),
+            (10, true),
+            (24, true),
+            (25, false),
+        ] {
+            assert_eq!(pos_in_ranges(&merged, pos), inside, "pos {pos}");
+        }
+    }
+}

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -898,29 +898,27 @@ impl ModuleInfoExtractor {
         }
     }
 
-    /// Run the bound-member resolution finalize and take the member accesses that
-    /// resolved onto a SEEDED element class. For the Astro template-expression
-    /// pass (issue #1713): a fresh extractor seeded with the frontmatter element
-    /// types visits the template `{...}` expression regions,
-    /// `bind_iterable_callback_parameter` types each `.map((util) => ...)` callback
-    /// param to its element class during the walk, and `resolve_bound_member_accesses`
-    /// re-emits the class-qualified access (`Util.getter`). This returns ONLY those
-    /// class-qualified accesses (object == a seeded element-class name), dropping
-    /// the raw `util.getter` / `utils.map` noise so nothing but the intended
-    /// element-class credit reaches the module. Accesses are span-less name pairs,
-    /// so no un-remapped template-region span ever leaks into the module.
-    pub(crate) fn take_resolved_iteration_member_accesses(&mut self) -> Vec<MemberAccess> {
+    /// Run the bound-member resolution finalize and take every member access and
+    /// whole-object use this extractor recorded. For the Astro template-expression
+    /// pass: a fresh extractor seeded with the frontmatter element types visits
+    /// the template `{...}` expression regions, `bind_iterable_callback_parameter`
+    /// types each `.map((util) => ...)` callback param to its element class during
+    /// the walk, and `resolve_bound_member_accesses` re-emits the class-qualified
+    /// access (`Util.getter`, issue #1713). The raw accesses (`NS.Moon`,
+    /// `utils.map`) are kept as well: namespace-import narrowing is only sound
+    /// when the stream holds every access of a binding, not just the tagged ones
+    /// (issue #2355), and they are the same pairs the visitor records for `.tsx`.
+    /// Accesses are span-less name pairs, so no un-remapped template-region span
+    /// ever leaks into the module, and `this@<id>` qualifiers are stripped exactly
+    /// as `finalize_resolution_phase` does before any spelling is emitted.
+    pub(crate) fn take_template_expression_usage(&mut self) -> (Vec<MemberAccess>, Vec<String>) {
         self.resolve_typed_destructure_bindings();
         self.resolve_bound_member_accesses();
-        let element_classes: FxHashSet<&str> = self
-            .array_binding_element_types
-            .values()
-            .map(String::as_str)
-            .collect();
-        self.member_accesses
-            .drain(..)
-            .filter(|access| element_classes.contains(access.object.as_str()))
-            .collect()
+        self.strip_this_scope_qualifiers();
+        (
+            std::mem::take(&mut self.member_accesses),
+            std::mem::take(&mut self.whole_object_uses),
+        )
     }
 
     /// Build the class-scoped `binding_target_names` key for a `this.<suffix>`
@@ -2957,6 +2955,69 @@ fn jsx_member_object_name(object: &JSXMemberExpressionObject<'_>) -> Option<Stri
             inner.property.name
         )),
     }
+}
+
+/// Record the member accesses a dotted component tag name implies, one per
+/// nesting level (`A.B.C` records `{A.B, C}` then `{A, B}`), for template
+/// pipelines that scan markup as text instead of visiting a JSX AST (Astro
+/// markup, MDX bodies; issue #2355). This is the text counterpart of
+/// `record_jsx_member_tag_accesses`, so namespace-import narrowing sees the
+/// same stream from every pipeline. A name without a dot records nothing.
+pub(crate) fn push_member_tag_accesses(accesses: &mut Vec<MemberAccess>, dotted_tag: &str) {
+    let mut end = dotted_tag.len();
+    while let Some(dot) = dotted_tag[..end].rfind('.') {
+        let object = &dotted_tag[..dot];
+        let member = &dotted_tag[dot + 1..end];
+        if object.is_empty() || member.is_empty() {
+            return;
+        }
+        accesses.push(MemberAccess {
+            object: object.to_string(),
+            member: member.to_string(),
+        });
+        end = dot;
+    }
+}
+
+/// Append template-scanned member accesses to a finished module record,
+/// skipping pairs the record already holds: a dotted tag inside an Astro
+/// expression region is seen by both the template tag scan and the region
+/// visitor, and no consumer counts repeats. The accesses live behind an
+/// `Arc<[_]>` once the extractor is consumed, so the slice is rebuilt only when
+/// there is something to add.
+pub(crate) fn extend_member_accesses(info: &mut ModuleInfo, extra: Vec<MemberAccess>) {
+    if extra.is_empty() {
+        return;
+    }
+    let mut accesses = std::mem::take(&mut info.member_accesses).to_vec();
+    let mut seen: FxHashSet<(String, String)> = accesses
+        .iter()
+        .map(|access| (access.object.clone(), access.member.clone()))
+        .collect();
+    for access in extra {
+        if seen.insert((access.object.clone(), access.member.clone())) {
+            accesses.push(access);
+        }
+    }
+    info.member_accesses = accesses.into();
+}
+
+/// Append template-scanned whole-object uses to a finished module record, the
+/// `whole_object_uses` counterpart of `extend_member_accesses`: names the
+/// record already holds are skipped, so the region pass, the template guard,
+/// and the script guard can each report the same binding without the
+/// persisted record growing duplicates.
+pub(crate) fn extend_whole_object_uses(info: &mut ModuleInfo, extra: Vec<String>) {
+    if extra.is_empty() {
+        return;
+    }
+    let mut uses = std::mem::take(&mut info.whole_object_uses).to_vec();
+    for name in extra {
+        if !uses.contains(&name) {
+            uses.push(name);
+        }
+    }
+    info.whole_object_uses = uses.into();
 }
 
 fn try_extract_require<'a, 'b>(

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -136,7 +136,15 @@ pub use store::GraphCacheStore;
 /// bare-specifier ambient star, and type-lane-only credits that leave the
 /// value half of a same-name type and value pair unreferenced, and a
 /// graph-cache hit would replay all of them.
-pub const GRAPH_CACHE_VERSION: u32 = 37;
+///
+/// Bumped to 38 for issue #2355 (37 was taken by issue #2357 while this
+/// change was in review): Astro markup and MDX bodies now record member
+/// accesses for member-expression component tags (`<SC.Card />`), and namespace
+/// narrowing bakes the credited references into the persisted graph. Warm 37
+/// caches carry the old empty accessed-members verdict for those consumers, so
+/// exports rendered only in Astro or MDX markup would stay reported as unused
+/// on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 38;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -1703,6 +1703,111 @@ mod tests {
         );
     }
 
+    /// Issue #2355: the template completeness guard records a whole-object use
+    /// for any binding mention it could not classify. On an entry-point
+    /// consumer that must still mean mark-all: the zero-access branch (an entry
+    /// file whose namespace import has no recorded access credits nothing) is
+    /// reserved for the case with no whole-object use either.
+    #[test]
+    fn attach_ref_namespace_whole_object_on_entry_point_marks_all_not_nothing() {
+        fn build(whole_object: bool) -> ModuleGraph {
+            let files = vec![
+                DiscoveredFile {
+                    id: FileId(0),
+                    path: std::path::PathBuf::from("/project/entry.ts"),
+                    size_bytes: 100,
+                },
+                DiscoveredFile {
+                    id: FileId(1),
+                    path: std::path::PathBuf::from("/project/utils.ts"),
+                    size_bytes: 50,
+                },
+            ];
+            let entry_points = vec![fallow_types::discover::EntryPoint {
+                path: std::path::PathBuf::from("/project/entry.ts"),
+                source: fallow_types::discover::EntryPointSource::PackageJsonMain,
+            }];
+            let whole_object_uses: Vec<String> = if whole_object {
+                vec!["utils".to_string()]
+            } else {
+                vec![]
+            };
+            let resolved_modules = vec![
+                ResolvedModule {
+                    file_id: FileId(0),
+                    path: std::path::PathBuf::from("/project/entry.ts"),
+                    resolved_imports: vec![ResolvedImport {
+                        info: fallow_types::extract::ImportInfo {
+                            source: "./utils".to_string(),
+                            imported_name: ImportedName::Namespace,
+                            local_name: "utils".to_string(),
+                            is_type_only: false,
+                            from_style: false,
+                            span: oxc_span::Span::new(0, 10),
+                            source_span: oxc_span::Span::default(),
+                        },
+                        target: ResolveResult::InternalModule(FileId(1)),
+                    }],
+                    whole_object_uses: whole_object_uses.into(),
+                    ..Default::default()
+                },
+                ResolvedModule {
+                    file_id: FileId(1),
+                    path: std::path::PathBuf::from("/project/utils.ts"),
+                    exports: vec![
+                        fallow_types::extract::ExportInfo {
+                            name: ExportName::Named("foo".to_string()),
+                            local_name: Some("foo".to_string()),
+                            is_type_only: false,
+                            visibility: VisibilityTag::None,
+                            expected_unused_reason: None,
+                            span: oxc_span::Span::new(0, 20),
+                            members: vec![],
+                            is_side_effect_used: false,
+                            super_class: None,
+                        },
+                        fallow_types::extract::ExportInfo {
+                            name: ExportName::Named("bar".to_string()),
+                            local_name: Some("bar".to_string()),
+                            is_type_only: false,
+                            visibility: VisibilityTag::None,
+                            expected_unused_reason: None,
+                            span: oxc_span::Span::new(25, 45),
+                            members: vec![],
+                            is_side_effect_used: false,
+                            super_class: None,
+                        },
+                    ]
+                    .into(),
+                    ..Default::default()
+                },
+            ];
+            ModuleGraph::build(&resolved_modules, &entry_points, &files)
+        }
+
+        let graph = build(true);
+        assert!(
+            graph.entry_points.contains(&FileId(0)),
+            "the consumer must be an entry point for this test to mean anything"
+        );
+        for export in &graph.modules[1].exports {
+            assert!(
+                !export.references.is_empty(),
+                "{} should be referenced when an entry-point consumer uses the namespace whole",
+                export.name
+            );
+        }
+
+        let graph = build(false);
+        for export in &graph.modules[1].exports {
+            assert!(
+                export.references.is_empty(),
+                "{} should stay unreferenced when an entry-point consumer records no access",
+                export.name
+            );
+        }
+    }
+
     #[test]
     fn attach_ref_css_module_narrows_to_member_accesses() {
         let files = vec![

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -60,6 +60,41 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   local namespace cannot merge with an exported one. The body is still walked
   so imports referenced inside it keep their credit. `export namespace Foo`
   keeps recording one export with the inner declarations as members.
+- A template pipeline that records member accesses for an import binding must
+  make narrowing safe structurally, not shape by shape. Namespace-import
+  narrowing (and CSS module, enum, and class member crediting) trusts the
+  stream: one recorded access from a non-entry consumer narrows the target to
+  the accessed members, so any mention the pipeline did not classify would
+  turn a used sibling into an `unused-export` finding. Astro and MDX apply a
+  completeness guard (`record_unexplained_mentions` in
+  `crates/extract/src/template_expression_scan.rs`): every structured pass
+  reports the byte spans it classified (Astro: component tag roots outside the
+  masked `<script>` / `<style>` / comment ranges, and `{ ... }` regions the
+  parser accepted; MDX: prose lines outside fenced code and inline code
+  spans), and every identifier-boundary mention of an import binding outside
+  those spans (a `define:vars` or `set:html` directive on a masked tag, an
+  HTML comment, an attribute string, text content, a rejected region, a code
+  sample, a template literal mistaken for a code span) records a whole-object
+  use, which keeps the graph on mark-all for entry-point and non-entry
+  consumers alike. The script side the visitor parsed (Astro frontmatter, MDX
+  `import` / `export` lines) is guarded too
+  (`record_unexplained_script_mentions`), because the visitor records a bare
+  identifier as a whole-object use only for an allow-list of positions: for
+  the bindings the graph narrows exports for (namespace imports and CSS
+  module default imports) a mention outside the import declaration is
+  explained only by a static dotted access whose `(root, member)` pair the
+  visitor recorded or by a JSX tag root, so `const N = NS`, `NS as T`,
+  `pick(NS)`, `Object.assign({}, NS)`, `[NS]`, `{ all: NS }`, and
+  `export const all = NS` record a whole-object use. Class and enum bindings
+  are not script-guarded (a type annotation or `new` expression names them
+  bare in ordinary code), so their member crediting stays at visitor parity
+  with `.tsx` on the script side while the markup guard covers them. Narrowing
+  applies only when every mention of the binding in the whole file was
+  structurally understood; otherwise every export is credited, which for the
+  dead-code crediting consumers degrades to over-credit. Member accesses also
+  feed the security secret-source index, so MDX prose records a dotted chain
+  only when its root is an import local of the file: prose never creates
+  member accesses on foreign roots such as `process.env`.
 
 ## Verification
 

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/package.json
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "issue-2355-astro-mdx-member-tags-fixture",
+  "private": true,
+  "dependencies": {
+    "astro": "^4.0.0"
+  }
+}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Callout.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Callout.astro
@@ -1,0 +1,4 @@
+---
+const { icon, all } = Astro.props;
+---
+<div>{icon}{all}<slot /></div>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Card.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Card.astro
@@ -1,0 +1,4 @@
+---
+import * as S from './card-style';
+---
+<S.Wrapper />

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Mixed.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Mixed.astro
@@ -1,0 +1,12 @@
+---
+import * as Attr from './attr-icons';
+import * as Call from './call-icons';
+import * as Whole from './whole-icons';
+import Callout from './Callout.astro';
+---
+<Attr.Star />
+<Callout icon={Attr.Moon} />
+<Call.Star />
+<p>{Call.Moon()}</p>
+<Whole.Star />
+<Callout all={Whole} />

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/ScriptShapes.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/ScriptShapes.astro
@@ -1,0 +1,32 @@
+---
+import * as Alias from '../shapes/na-fm-alias';
+import * as AsCast from '../shapes/na-fm-as-cast';
+import * as CallArg from '../shapes/na-fm-call-arg';
+import * as Assign from '../shapes/na-fm-object-assign';
+import * as ArrayLit from '../shapes/na-fm-array-literal';
+import * as PropsPass from '../shapes/na-fm-props-pass';
+import * as Dotted from '../shapes/na-fm-dotted';
+import Callout from './Callout.astro';
+const N = Alias;
+const rec = AsCast as Record<string, unknown>;
+const pick = (o: object) => o;
+const picked = pick(CallArg);
+const merged = Object.assign({}, Assign);
+const list = [ArrayLit];
+const props = { all: PropsPass };
+const moon = Dotted.Moon;
+---
+<Alias.Star />
+<p>{N.Moon}</p>
+<AsCast.Star />
+<p>{rec.Moon}</p>
+<CallArg.Star />
+<p>{picked}</p>
+<Assign.Star />
+<p>{merged.Moon}</p>
+<ArrayLit.Star />
+<p>{list.length}</p>
+<PropsPass.Star />
+<Callout {...props} />
+<Dotted.Star />
+<p>{moon}</p>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Shapes.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/Shapes.astro
@@ -1,0 +1,19 @@
+---
+import * as StyleVars from '../shapes/na-style-vars';
+import * as ScriptVars from '../shapes/na-script-vars';
+import * as SetHtml from '../shapes/na-set-html';
+import * as WholeVars from '../shapes/na-whole-vars';
+import styles from '../shapes/na-card.module.css';
+---
+<StyleVars.Star />
+<ScriptVars.Star />
+<SetHtml.Star />
+<WholeVars.Star />
+<div class={styles.root}></div>
+<style define:vars={{ accent: StyleVars.accent }}>
+  div { color: var(--accent); }
+</style>
+<style define:vars={{ accentClass: styles.accent }}></style>
+<script define:vars={{ moon: ScriptVars.Moon }}>console.log(moon);</script>
+<script is:inline set:html={SetHtml.code}></script>
+<script define:vars={{ WholeVars }}>console.log(WholeVars);</script>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/attr-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/attr-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const AttrUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/call-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/call-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const CallUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/card-style.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/card-style.ts
@@ -1,0 +1,3 @@
+export const Wrapper = () => null;
+
+export const UnusedSibling = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/doc-style.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/doc-style.ts
@@ -1,0 +1,3 @@
+export const Note = () => null;
+
+export const UnusedDocSibling = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-attr-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-attr-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const MdAttrUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-call-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-call-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const MdCallUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-multi-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-multi-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const MdMultiUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-style.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-style.ts
@@ -1,0 +1,3 @@
+export const UsedBlock = () => null;
+
+export const UnusedMdBlock = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-whole-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/md-whole-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const MdWholeShielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/style.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/style.ts
@@ -1,0 +1,5 @@
+export const UsedStyle = () => null;
+
+export const Layout = () => null;
+
+export const ActuallyUnusedStyle = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/whole-icons.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/components/whole-icons.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const WholeShielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/mixed.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/mixed.mdx
@@ -1,0 +1,23 @@
+import * as MdAttr from '../components/md-attr-icons';
+import * as MdCall from '../components/md-call-icons';
+import * as MdWhole from '../components/md-whole-icons';
+import * as MdMulti from '../components/md-multi-icons';
+import Callout from '../components/Callout.astro';
+
+<MdAttr.Star />
+
+<Callout icon={MdAttr.Moon}>attribute expression</Callout>
+
+<MdCall.Star />
+
+{MdCall.Moon()}
+
+<MdWhole.Star />
+
+<Callout all={MdWhole}>whole-object pass</Callout>
+
+<MdMulti.Star />
+
+{
+  MdMulti.Moon()
+}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/notes.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/notes.mdx
@@ -1,0 +1,3 @@
+import * as Doc from '../components/doc-style';
+
+<Doc.Note>Rendered from a non-entry MDX consumer.</Doc.Note>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/script-shapes.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/script-shapes.mdx
@@ -1,0 +1,25 @@
+import * as StmtWhole from '../shapes/nm-stmt-whole';
+import * as StmtAttr from '../shapes/nm-stmt-attr';
+import * as StmtDefault from '../shapes/nm-stmt-default';
+import * as StmtDotted from '../shapes/nm-stmt-dotted';
+import Callout from '../components/Callout.astro';
+
+export const all = StmtWhole;
+
+export const Demo = () => <Callout all={StmtAttr} />;
+
+export default (props) => <Callout all={StmtDefault} {...props} />;
+
+export const moon = StmtDotted.Moon;
+
+<StmtWhole.Star />
+
+<StmtAttr.Star />
+
+<StmtDefault.Star />
+
+<StmtDotted.Star />
+
+<Demo />
+
+{moon}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/shapes.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/docs/shapes.mdx
@@ -1,0 +1,28 @@
+import * as Literal from '../shapes/nm-literal';
+import * as LiteralWhole from '../shapes/nm-literal-whole';
+import * as Fenced from '../shapes/nm-fenced';
+import * as Inline from '../shapes/nm-inline';
+import styles from '../shapes/nm-doc.module.css';
+import Callout from '../components/Callout.astro';
+
+<Literal.Star />
+
+<Callout title={`Moon: ${Literal.Moon}`}>template literal attribute</Callout>
+
+<LiteralWhole.Star />
+
+{`${JSON.stringify(LiteralWhole)}`}
+
+<div className={styles.root}></div>
+
+<div className={`${styles.spare} extra`}></div>
+
+<Fenced.Star />
+
+```tsx
+<Fenced.Foo />
+```
+
+<Inline.Star />
+
+Inline code keeps `<Inline.CodeOnly />` as documentation.

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/guide.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/guide.mdx
@@ -1,0 +1,5 @@
+import * as MD from '../components/md-style';
+
+# Guide
+
+<MD.UsedBlock />

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/index.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/index.astro
@@ -1,0 +1,22 @@
+---
+import * as SC from '../components/style';
+import Card from '../components/Card.astro';
+import Mixed from '../components/Mixed.astro';
+import Shapes from '../components/Shapes.astro';
+import ScriptShapes from '../components/ScriptShapes.astro';
+import Notes from '../docs/notes.mdx';
+import MixedNotes from '../docs/mixed.mdx';
+import ShapeNotes from '../docs/shapes.mdx';
+import ScriptShapeNotes from '../docs/script-shapes.mdx';
+---
+<SC.UsedStyle />
+<SC.Layout>
+  <Card />
+  <Mixed />
+  <Shapes />
+  <ScriptShapes />
+  <Notes />
+  <MixedNotes />
+  <ShapeNotes />
+  <ScriptShapeNotes />
+</SC.Layout>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/script-shapes.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/script-shapes.astro
@@ -1,0 +1,32 @@
+---
+import * as Alias from '../shapes/ea-fm-alias';
+import * as AsCast from '../shapes/ea-fm-as-cast';
+import * as CallArg from '../shapes/ea-fm-call-arg';
+import * as Assign from '../shapes/ea-fm-object-assign';
+import * as ArrayLit from '../shapes/ea-fm-array-literal';
+import * as PropsPass from '../shapes/ea-fm-props-pass';
+import * as Dotted from '../shapes/ea-fm-dotted';
+import Callout from '../components/Callout.astro';
+const N = Alias;
+const rec = AsCast as Record<string, unknown>;
+const pick = (o: object) => o;
+const picked = pick(CallArg);
+const merged = Object.assign({}, Assign);
+const list = [ArrayLit];
+const props = { all: PropsPass };
+const moon = Dotted.Moon;
+---
+<Alias.Star />
+<p>{N.Moon}</p>
+<AsCast.Star />
+<p>{rec.Moon}</p>
+<CallArg.Star />
+<p>{picked}</p>
+<Assign.Star />
+<p>{merged.Moon}</p>
+<ArrayLit.Star />
+<p>{list.length}</p>
+<PropsPass.Star />
+<Callout {...props} />
+<Dotted.Star />
+<p>{moon}</p>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/script-shapes.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/script-shapes.mdx
@@ -1,0 +1,25 @@
+import * as StmtWhole from '../shapes/em-stmt-whole';
+import * as StmtAttr from '../shapes/em-stmt-attr';
+import * as StmtDefault from '../shapes/em-stmt-default';
+import * as StmtDotted from '../shapes/em-stmt-dotted';
+import Callout from '../components/Callout.astro';
+
+export const all = StmtWhole;
+
+export const Demo = () => <Callout all={StmtAttr} />;
+
+export default (props) => <Callout all={StmtDefault} {...props} />;
+
+export const moon = StmtDotted.Moon;
+
+<StmtWhole.Star />
+
+<StmtAttr.Star />
+
+<StmtDefault.Star />
+
+<StmtDotted.Star />
+
+<Demo />
+
+{moon}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/shapes.astro
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/shapes.astro
@@ -1,0 +1,19 @@
+---
+import * as StyleVars from '../shapes/ea-style-vars';
+import * as ScriptVars from '../shapes/ea-script-vars';
+import * as SetHtml from '../shapes/ea-set-html';
+import * as WholeVars from '../shapes/ea-whole-vars';
+import styles from '../shapes/ea-card.module.css';
+---
+<StyleVars.Star />
+<ScriptVars.Star />
+<SetHtml.Star />
+<WholeVars.Star />
+<div class={styles.root}></div>
+<style define:vars={{ accent: StyleVars.accent }}>
+  div { color: var(--accent); }
+</style>
+<style define:vars={{ accentClass: styles.accent }}></style>
+<script define:vars={{ moon: ScriptVars.Moon }}>console.log(moon);</script>
+<script is:inline set:html={SetHtml.code}></script>
+<script define:vars={{ WholeVars }}>console.log(WholeVars);</script>

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/shapes.mdx
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/pages/shapes.mdx
@@ -1,0 +1,28 @@
+import * as Literal from '../shapes/em-literal';
+import * as LiteralWhole from '../shapes/em-literal-whole';
+import * as Fenced from '../shapes/em-fenced';
+import * as Inline from '../shapes/em-inline';
+import styles from '../shapes/em-doc.module.css';
+import Callout from '../components/Callout.astro';
+
+<Literal.Star />
+
+<Callout title={`Moon: ${Literal.Moon}`}>template literal attribute</Callout>
+
+<LiteralWhole.Star />
+
+{`${JSON.stringify(LiteralWhole)}`}
+
+<div className={styles.root}></div>
+
+<div className={`${styles.spare} extra`}></div>
+
+<Fenced.Star />
+
+```tsx
+<Fenced.Foo />
+```
+
+<Inline.Star />
+
+Inline code keeps `<Inline.CodeOnly />` as documentation.

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-card.module.css
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-card.module.css
@@ -1,0 +1,11 @@
+.root {
+  display: block;
+}
+
+.accent {
+  display: block;
+}
+
+.spare {
+  display: block;
+}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-alias.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-alias.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-array-literal.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-array-literal.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-as-cast.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-as-cast.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-call-arg.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-call-arg.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-dotted.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-dotted.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const DottedUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-object-assign.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-object-assign.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-props-pass.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-fm-props-pass.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-script-vars.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-script-vars.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const Moon = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-set-html.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-set-html.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const code = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-style-vars.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-style-vars.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const accent = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-whole-vars.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/ea-whole-vars.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Extra = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-doc.module.css
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-doc.module.css
@@ -1,0 +1,11 @@
+.root {
+  display: block;
+}
+
+.spare {
+  display: block;
+}
+
+.extra {
+  display: block;
+}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-fenced.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-fenced.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const Foo = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-inline.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-inline.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const CodeOnly = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-literal-whole.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-literal-whole.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Extra = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-literal.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-literal.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const Moon = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-attr.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-attr.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-default.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-default.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-dotted.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-dotted.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const DottedUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-whole.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/em-stmt-whole.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-card.module.css
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-card.module.css
@@ -1,0 +1,11 @@
+.root {
+  display: block;
+}
+
+.accent {
+  display: block;
+}
+
+.spare {
+  display: block;
+}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-alias.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-alias.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-array-literal.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-array-literal.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-as-cast.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-as-cast.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-call-arg.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-call-arg.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-dotted.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-dotted.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const DottedUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-object-assign.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-object-assign.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-props-pass.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-fm-props-pass.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-script-vars.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-script-vars.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const Moon = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-set-html.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-set-html.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const code = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-style-vars.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-style-vars.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const accent = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-whole-vars.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/na-whole-vars.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Extra = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-doc.module.css
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-doc.module.css
@@ -1,0 +1,11 @@
+.root {
+  display: block;
+}
+
+.spare {
+  display: block;
+}
+
+.extra {
+  display: block;
+}

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-fenced.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-fenced.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const Foo = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-inline.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-inline.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const CodeOnly = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-literal-whole.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-literal-whole.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Extra = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-literal.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-literal.ts
@@ -1,0 +1,3 @@
+export const Star = () => null;
+
+export const Moon = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-attr.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-attr.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-default.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-default.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-dotted.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-dotted.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const DottedUnused = () => null;

--- a/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-whole.ts
+++ b/tests/fixtures/issue-2355-astro-mdx-member-tags/src/shapes/nm-stmt-whole.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Shielded = () => null;

--- a/tests/fixtures/issue-2355-mdx-prose-env-mention/app/control.tsx
+++ b/tests/fixtures/issue-2355-mdx-prose-env-mention/app/control.tsx
@@ -1,0 +1,5 @@
+"use client";
+import { apiKey } from "./server";
+export function Control() {
+  return apiKey();
+}

--- a/tests/fixtures/issue-2355-mdx-prose-env-mention/app/page.tsx
+++ b/tests/fixtures/issue-2355-mdx-prose-env-mention/app/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+import Setup from "./setup.mdx";
+export default function Page() {
+  return <Setup />;
+}

--- a/tests/fixtures/issue-2355-mdx-prose-env-mention/app/server.ts
+++ b/tests/fixtures/issue-2355-mdx-prose-env-mention/app/server.ts
@@ -1,0 +1,3 @@
+export function apiKey(): string | undefined {
+  return process.env.API_KEY;
+}

--- a/tests/fixtures/issue-2355-mdx-prose-env-mention/app/setup.mdx
+++ b/tests/fixtures/issue-2355-mdx-prose-env-mention/app/setup.mdx
@@ -1,0 +1,3 @@
+# Setup
+
+Set process.env.API_KEY and import.meta.env.SECRET before running the dev server.

--- a/tests/fixtures/issue-2355-mdx-prose-env-mention/package.json
+++ b/tests/fixtures/issue-2355-mdx-prose-env-mention/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "issue-2355-mdx-prose-env-mention-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@next/mdx": "15.0.0",
+    "next": "15.0.0",
+    "react": "19.0.0"
+  }
+}


### PR DESCRIPTION
## What was broken

#2348 taught the JSX visitor to record member-expression tags (`<SC.Wrapper />`) as member accesses, but two template pipelines never reached that visitor:

- **Astro**: the markup scan credited only the tag root, so `<SC.Card />` kept `SC` alive as an import binding while the `SC.Card` access was never recorded. An entry-point `.astro` page with a namespace import still reported every export of the namespace target as unused (the pre-#2348 false-positive shape), and a non-entry `.astro` component fell back to crediting every export.
- **MDX**: the extractor parsed only `import` / `export` lines, so JSX member tags in the prose body were invisible to usage crediting entirely.

## Root cause

`narrow_namespace_references` reads `ResolvedModule.member_accesses`, which the graph copies verbatim from `ModuleInfo.member_accesses`. Neither `parse_astro_to_module` nor `parse_mdx_to_module` ever populated it from markup, so the namespace binding arrived with an empty accessed-member list: entry consumers narrowed to nothing, non-entry consumers marked everything.

Narrowing is only sound on a complete access stream, and a text scanner of a template cannot promise completeness shape by shape. Earlier revisions recorded dotted tags alone, then added the expression regions, then a structural guard over the template; review of that revision found two remaining gaps: the guard did not cover the script side (a namespace passed bare in the Astro frontmatter or on an MDX statement line still narrowed), and MDX prose recorded dotted chains for any root, so a documentation sentence naming `process.env.API_KEY` turned the MDX module into a secret source for `fallow security`. This revision closes both.

## The fix

The guarantee, for Astro and MDX consumers: **a namespace import (or a CSS module default import, the other binding whose exports the graph narrows by member access) narrows only when every mention of the binding in the whole file was structurally understood; otherwise every export is credited.** Structurally understood means: in Astro markup a component tag root or a parsed `{ ... }` expression region; in MDX a prose line outside code; in the Astro frontmatter or on an MDX `import` / `export` line a static dotted access whose `(root, member)` pair the visitor recorded, or a JSX tag root.

- `crates/extract/src/template_expression_scan.rs`
  - `record_unexplained_mentions` (template side, unchanged): every identifier-boundary mention of an import binding outside the byte spans the structured template passes classified records a whole-object use.
  - `record_unexplained_script_mentions` (new, script side): the visitor records a bare identifier as a whole-object use only for an allow-list of positions (spread, `Object.keys(NS)`, `for ... in`, computed non-string access, rest destructuring), so an alias (`const N = NS`), a cast (`NS as T`), a call argument (`pick(NS)`), `Object.assign({}, NS)`, an array literal (`[NS]`), a props object (`{ all: NS }`), `export const all = NS`, or a JSX attribute on a statement line (`<Callout all={NS} />`) left no trace. The guard walks the raw script text, skips the import declaration spans, and explains a mention only by a recorded static dotted access or a JSX tag root; everything else records a whole-object use. Set membership against the visitor's recorded pairs (instead of a mention count) keeps it independent of how many times one access is recorded and of the deduplication applied to template accesses. `narrowable_import_locals` scopes this guard to namespace imports and CSS-module default imports, so a class or enum named in a frontmatter type annotation or `new` expression keeps the visitor's member crediting (the markup guard still covers every import binding, as before).
  - `scan_template_usage` in MDX prose mode records a dotted chain only when its root is an import local of the file. Every crediting consumer (namespace, CSS module, enum and class member) is keyed by import locals, so nothing is lost; the security secret-source index, which also reads member accesses, no longer sees `process.env.X` / `import.meta.env.X` pairs spelled in prose.
- `crates/extract/src/astro.rs`: `extend_unexplained_frontmatter_mentions` runs the script guard over the frontmatter body after the template passes.
- `crates/extract/src/mdx.rs`: the statement lines are kept with their source offsets and `collect_unexplained_statement_mentions` runs the script guard over them after the prose scan.
- `crates/extract/src/visitor/mod.rs`: `extend_whole_object_uses` skips names already present, so the region pass, the template guard, and the script guard cannot grow duplicates in the persisted record.

## Behavior change

- A namespace import in a non-entry Astro or MDX consumer whose every mention is a dotted tag, a parsed expression, or a recorded dotted script access narrows to the members actually accessed (the same widening #2348 introduced for `.tsx`), so genuinely unused siblings surface. Every other mention keeps mark-all crediting: a `define:vars` or `set:html` directive on a `<style>` / `<script>` tag, an HTML comment, text content, an attribute string, an expression the parser rejects, an MDX fenced code block or inline code span, a template literal inside an MDX expression, and a script-side alias, cast, call argument, `Object.assign`, array or object literal element, or JSX attribute value. Mark-all can hide an unused sibling; it never reports a used one.
- Entry-point pages follow the same rule: a dotted-only namespace narrows (the rendered members are credited, the rest report), and an unexplained mention credits every export.
- Astro expression accesses reach the consumers that already read frontmatter accesses (CSS module default-import narrowing, enum and class member crediting), matching `.tsx`. The markup guard covers those bindings too: an enum or class mentioned in an HTML comment, text content, or an attribute string of an Astro or MDX template credits every member (the `.tsx` visitor would not). The script guard does not cover them, so class and enum member crediting on the frontmatter and statement side stays at `.tsx` parity.
- MDX prose records dotted chains only for import locals, so `fallow security` no longer reports a `client-server-leak` for a `"use client"` file importing an MDX document whose prose mentions `process.env.API_KEY`.

## Cache invalidation

- `CACHE_VERSION` 274 -> 276 (`crates/extract/src/cache/types.rs`)
- `GRAPH_CACHE_VERSION` 36 -> 38 (`crates/graph/src/cache/mod.rs`)

Rebased onto `main` after #2356 took 274 / 36 and again after #2357 took 275 / 37, so the final values are 276 / 38. Warm-cache proof (executed at the first rebase, before the second bump) on a copy of the fixture: the `main` binary (274 / 36) ran cold and wrote `.fallow/`, the rebased binary (275 / 37) on that cache reported the fixed set, a second warm run and a fresh `--no-cache` run were identical after dropping `analysis_run_id` / `elapsed_ms`.

| run | unused exports |
|---|---|
| `main` cold and warm | every export of the entry pages' namespaces (65 findings, incl. `UsedStyle`, `Layout`, `UsedBlock`, and all `ea-*` / `em-*` shape members) |
| rebased warm 1, warm 2, cold | `ActuallyUnusedStyle, UnusedSibling, UnusedMdBlock, UnusedDocSibling, AttrUnused, CallUnused, MdAttrUnused, MdCallUnused, MdMultiUnused` plus the four `DottedUnused` precision rows and the seven exports the two `script-shapes.mdx` documents declare themselves (`all`, `Demo`, `moon`, `default`; reported by `main` too), 20 findings |

## How it was tested

- Scan unit tests (`template_expression_scan.rs`): prose chains with a foreign root (`process.env.API_KEY`, `items.map`) record nothing while import-local roots still record; the script guard explains a mention only by a recorded dotted access or a tag root (alias, cast, call argument, `Object.assign`, literal element, property value, `export const all = NS`, JSX attribute, unrecorded `NS.Sun`, `NS?.Moon`, `NS["Moon"]`, spread all keep mark-all; recorded `NS.Moon`, `NS.Star.Deep`, `<NS.Moon>`, `</NS.Moon>`, `outer.NS`, `NSX` do not); import declaration spans excluded in file coordinates; `narrowable_import_locals` covers namespace and CSS-module bindings only.
- Astro unit test: alias, cast, call argument, `Object.assign`, array literal, props object, and a CSS module passed in an object each record one whole-object use; a dotted-only frontmatter use records none; a class in a type annotation and `new` expression is not guarded; `Object.keys(AL)` next to `const N = AL` records `AL` once.
- MDX unit tests: `export const all = NS`, `<Callout all={NS} />` on an exported component, and a default-export layout each record a whole-object use while a dotted-only statement use stays precise; an unfenced prose `process.env.API_KEY` records no member access.
- Integration fixture `tests/fixtures/issue-2355-astro-mdx-member-tags`: `astro_and_mdx_script_mentions_keep_mark_all` pins the six frontmatter shapes and the three statement shapes for an entry page and a non-entry consumer of each kind (no `Star` / `Moon` / `Shielded` reported), plus a dotted-only namespace per consumer whose `DottedUnused` sibling must still report. Fixture `tests/fixtures/issue-2355-mdx-prose-env-mention`: `mdx_prose_env_mention_is_not_a_secret_source` runs `client-server-leak` on a `"use client"` page importing an MDX document with an unfenced env mention (no finding) next to a control client importing a module that really reads `process.env.API_KEY` (finding).
- Mutation evidence: six targeted neutralisations at HEAD (prose root filter off, script guard off, dotted mention always explained, import span not excluded, named imports guarded, whole-object dedup removed) each fail the tests that pin that piece; with every round-4 source hunk reverted the two new integration tests fail and the earlier ones pass.
- Reviewer fixtures from the previous round (alias, as-cast, call-arg, Object.assign, array literal, props pass, MDX statement whole / attr whole / default whole): zero unused-export findings with the fixed binary where the baseline had zero; the `.tsx` twins are unchanged (pre-existing visitor gap, tracked as a follow-up). Security probe (Next.js `"use client"` page importing an MDX with `Set process.env.API_KEY before running`): baseline 0, previous revision 1, fixed 0.
- Real-world runs, baseline vs fixed, `dead-code` and `security` with `--no-cache --format json`: Starlight `docs/` (25 `.astro`, 289 `.mdx`), `packages/starlight` (61 `.astro`, 12 `.mdx`), and the Docusaurus website (1326 `.mdx`) produce identical normalized output. None of the trees uses a namespace import or a CSS module from `.astro` / `.mdx`, and no `"use client"` module imports an MDX document there, so there is nothing for the narrowing, the guards, or the prose root filter to move.
- Gates on the rebased tree: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `cargo check --workspace --benches`, `cargo doc` with `-D warnings`, `typos`, hidden-unicode scan, comment-quality check.

## Known, deferred

- `push_member_tag_accesses` is a third text-side dotted-chain splitter next to `glimmer::emit_chain_member_accesses` and the Vue/Svelte dotted-tag path; same per-hop semantics, left for a separate consolidation.
- Pre-existing, to be filed as follow-ups: in `.ts` / `.tsx` a namespace passed whole through a JSX attribute, a plain call argument, or an assignment (`const N = NS`) is not a whole-object use in the visitor, so the namespace narrows to its dotted accesses (the Astro and MDX guards now cover those shapes on the template and script side); an MDX prose line that starts with `import ` or `export ` is classified as a statement and breaks the import parse of the file.

Fixes #2355

