### PR TITLE
fix(extract): keep non-exported namespace members out of file-level exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consults the config keys only when a call falls back to the CLI; routing
   that route through the same precedence is tracked as a follow-up.
 
+- **Inner `export` declarations of a namespace declared without the `export`
+  keyword are no longer reported as unused exports of the containing file**
+  (Closes [#2356](https://github.com/fallow-rs/fallow/issues/2356)). A
+  top-level `namespace Foo { export const inner = 1 }` (also
+  `declare namespace`, legacy `module Foo {}`, dotted `namespace A.B.C {}`,
+  and namespaces nested inside those or inside `declare global`) is a local
+  binding, so `inner` is a member of `Foo` rather than a file export, and
+  following the previous remove-export advice broke consumers of `Foo.inner`.
+  Imports referenced inside such a body keep their credit, and exported
+  namespaces keep their existing member extraction. Both the extraction and
+  graph cache versions were bumped; the first run after upgrading performs one
+  cold re-analysis. Existing `fallow-ignore` suppressions placed above these
+  declarations as a workaround now surface as stale-suppression findings (warn
+  by default) and can be removed.
+
 - **`fallow audit` now scores the base attribution pass with the same Istanbul
   coverage map as the head pass.** The base worktree pass previously matched no
   coverage entry (the map records head-checkout paths), silently fell back to

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -77,6 +77,8 @@ mod issue_1032_tsconfig_sibling_src_paths;
 mod issue_1304_effect_schema_same_name;
 #[path = "integration_test/issue_2349_module_augmentation.rs"]
 mod issue_2349_module_augmentation;
+#[path = "integration_test/issue_2356_local_namespace.rs"]
+mod issue_2356_local_namespace;
 #[path = "integration_test/issue_546_storybook_runtime_resources.rs"]
 mod issue_546_storybook_runtime_resources;
 #[path = "integration_test/issue_914_pnpm_bare_binary.rs"]

--- a/crates/core/tests/integration_test/issue_2356_local_namespace.rs
+++ b/crates/core/tests/integration_test/issue_2356_local_namespace.rs
@@ -1,0 +1,61 @@
+//! Issue #2356: a top-level namespace declared without the `export` keyword is
+//! a local binding. Its inner `export` declarations are members of that local
+//! namespace, never exports of the containing file, so they must not surface
+//! as `unused-export` findings. Genuinely unused exports in the same file and
+//! unused exported namespaces keep reporting, and imports referenced inside a
+//! local namespace body keep their credit.
+
+use super::common::{create_config, fixture_path};
+
+#[test]
+fn local_namespace_inner_exports_are_not_reported_unused() {
+    let root = fixture_path("issue-2356-local-namespace");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_export_names: Vec<&str> = results
+        .unused_exports
+        .iter()
+        .map(|e| e.export.export_name.as_str())
+        .collect();
+    let unused_type_names: Vec<&str> = results
+        .unused_types
+        .iter()
+        .map(|t| t.export.export_name.as_str())
+        .collect();
+
+    for local_member in ["inner", "viaSpecifier", "value"] {
+        assert!(
+            !unused_export_names.contains(&local_member)
+                && !unused_type_names.contains(&local_member),
+            "`{local_member}` is a member of a local namespace and must not be reported \
+             as an unused export; exports: {unused_export_names:?}, types: {unused_type_names:?}"
+        );
+    }
+
+    assert!(
+        unused_export_names.contains(&"unusedSibling"),
+        "a genuinely unused export next to a local namespace must keep reporting: \
+         {unused_export_names:?}"
+    );
+    assert!(
+        unused_export_names.contains(&"Exported"),
+        "an unused exported namespace keeps reporting as before: {unused_export_names:?}"
+    );
+
+    // `helper` is only referenced inside the local `Wrapped` namespace body.
+    assert!(
+        !unused_export_names.contains(&"helper"),
+        "an import referenced inside a local namespace body keeps its credit: \
+         {unused_export_names:?}"
+    );
+    let unused_files: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.file.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+    assert!(
+        !unused_files.iter().any(|p| p.ends_with("helper.ts")),
+        "helper.ts is reachable through the local namespace body: {unused_files:?}"
+    );
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -944,7 +944,12 @@ use crate::MemberKind;
 /// (`<SC.UsedStyle />`) now record member accesses like their plain-expression
 /// spelling. Warm 272 caches lack those accesses, so namespace-imported exports
 /// rendered only through JSX would stay reported as unused.
-pub(super) const CACHE_VERSION: u32 = 273;
+///
+/// Bumped to 274 for issue #2356: `export` declarations inside a namespace
+/// declared without the `export` keyword (`namespace Foo { export const x }`)
+/// are no longer recorded as file-level exports. Warm 273 caches would keep
+/// replaying those local namespace members as unused exports.
+pub(super) const CACHE_VERSION: u32 = 274;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -403,6 +403,17 @@ pub(crate) struct ModuleInfoExtractor {
     /// file-level export recording is suppressed while non-zero (issue #2349).
     /// Transient visitor state; never persisted.
     ambient_module_depth: u32,
+    /// Depth of namespace bodies declared without the `export` keyword
+    /// (`namespace Foo {}`, `declare namespace Foo {}`, legacy `module Foo {}`,
+    /// dotted `namespace A.B.C {}`, and namespaces nested in those or in
+    /// `declare global`) currently being walked. The namespace is a local
+    /// binding, so its inner `export` statements are members of that binding
+    /// rather than file-level exports; export recording is suppressed while
+    /// non-zero and nothing is queued in `pending_namespace_members` because
+    /// there is no exported owner to attach to (issue #2356). Kept separate
+    /// from `namespace_depth`, which only tracks exported namespace bodies.
+    /// Transient visitor state; never persisted.
+    local_namespace_depth: u32,
     pending_namespace_members: Vec<MemberInfo>,
     class_heritage: Vec<ClassHeritageInfo>,
     /// `(token_export_name, interface_name)` for `new InjectionToken<I>(...)`

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -5253,6 +5253,210 @@ fn ambient_module_bare_re_export_keeps_side_effect_reference() {
     assert!(matches!(entry.imported_name, ImportedName::SideEffect));
 }
 
+fn export_names(info: &crate::ModuleInfo) -> Vec<String> {
+    info.exports.iter().map(|e| e.name.to_string()).collect()
+}
+
+#[test]
+fn local_namespace_inner_exports_are_not_file_exports() {
+    // Issue #2356: `Foo` is a local binding, so `inner` is a member of `Foo`
+    // and not an export of the containing file. Recording it leaked a
+    // file-level `unused-export` finding whose remove-export advice broke
+    // consumers of `Foo.inner`.
+    let info = parse(
+        "namespace Foo {\n\
+           export const inner = 1;\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "local namespace members must not be recorded as file exports: {:?}",
+        export_names(&info)
+    );
+    // The body is still walked: both the namespace and its inner declarations
+    // keep feeding the local declaration registry.
+    let locals: Vec<&str> = info
+        .local_type_declarations
+        .iter()
+        .map(|d| d.name.as_str())
+        .collect();
+    assert!(
+        locals.contains(&"Foo"),
+        "the local namespace itself must stay a local declaration: {locals:?}"
+    );
+}
+
+#[test]
+fn declare_namespace_inner_exports_are_not_file_exports() {
+    let info = parse(
+        "declare namespace Foo {\n\
+           export const inner: number;\n\
+           export interface Shape { a: number }\n\
+           export type Alias = string;\n\
+           export function helper(): void;\n\
+           export class Widget {}\n\
+           export enum Mode { A }\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "ambient local namespace members must not be recorded as file exports: {:?}",
+        export_names(&info)
+    );
+}
+
+#[test]
+fn legacy_module_keyword_namespace_inner_exports_are_not_file_exports() {
+    let info = parse(
+        "module Legacy {\n\
+           export const inner = 1;\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "legacy `module Foo {{}}` members must not be recorded as file exports: {:?}",
+        export_names(&info)
+    );
+}
+
+#[test]
+fn dotted_local_namespace_inner_exports_are_not_file_exports() {
+    let info = parse(
+        "namespace A.B.C {\n\
+           export const inner = 1;\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "dotted local namespace members must not be recorded as file exports: {:?}",
+        export_names(&info)
+    );
+}
+
+#[test]
+fn nested_exported_namespace_inside_local_namespace_stays_local() {
+    let info = parse(
+        "namespace A {\n\
+           export namespace B {\n\
+             export const c = 1;\n\
+           }\n\
+           export const d = 2;\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "a namespace exported from a local namespace is still local: {:?}",
+        export_names(&info)
+    );
+}
+
+#[test]
+fn local_namespace_body_references_keep_import_credit() {
+    let info = parse(
+        "import { helper } from './helper';\n\
+         import type { Shape } from './shape';\n\
+         namespace Foo {\n\
+           export const x = helper();\n\
+           export type Y = Shape;\n\
+         }\n\
+         export {};\n",
+    );
+    assert!(info.exports.is_empty(), "{:?}", export_names(&info));
+    assert!(
+        !info.unused_import_bindings.iter().any(|b| b == "helper"),
+        "a value import referenced inside a local namespace body must stay credited: {:?}",
+        info.unused_import_bindings
+    );
+    assert!(
+        !info.unused_import_bindings.iter().any(|b| b == "Shape"),
+        "a type import referenced inside a local namespace body must stay credited: {:?}",
+        info.unused_import_bindings
+    );
+    assert!(
+        info.value_referenced_import_bindings
+            .iter()
+            .any(|b| b == "helper"),
+        "`helper` must be value-referenced: {:?}",
+        info.value_referenced_import_bindings
+    );
+    assert!(
+        info.type_referenced_import_bindings
+            .iter()
+            .any(|b| b == "Shape"),
+        "`Shape` must be type-referenced: {:?}",
+        info.type_referenced_import_bindings
+    );
+}
+
+#[test]
+fn namespace_nested_inside_declare_global_is_local() {
+    // `declare global { namespace NodeJS { ... } }` reaches the namespace arm
+    // with no exported owner, so its inner exports follow the local rule.
+    let info = parse(
+        "export {};\n\
+         declare global {\n\
+           namespace NodeJS {\n\
+             export interface ProcessEnv { FOO: string }\n\
+           }\n\
+         }\n",
+    );
+    assert!(
+        info.exports.is_empty(),
+        "members of a namespace nested in `declare global` must not be file exports: {:?}",
+        export_names(&info)
+    );
+}
+
+#[test]
+fn exported_namespace_member_extraction_is_unchanged() {
+    // Pin: an exported namespace still records one file export carrying its
+    // inner exported declarations as members (flattened through nesting).
+    let info = parse(
+        "export namespace Foo {\n\
+           export const x = 1;\n\
+           export namespace Bar {\n\
+             export const y = 2;\n\
+           }\n\
+         }\n",
+    );
+    assert_eq!(export_names(&info), ["Foo"]);
+    let members: Vec<&str> = info.exports[0]
+        .members
+        .iter()
+        .map(|m| m.name.as_str())
+        .collect();
+    assert_eq!(members, ["x", "Bar", "y"]);
+    assert!(
+        info.exports[0]
+            .members
+            .iter()
+            .all(|m| m.kind == MemberKind::NamespaceMember)
+    );
+}
+
+#[test]
+fn declare_global_direct_body_exports_keep_file_level_recording() {
+    // Pin of today's behaviour for direct `declare global` bodies, written
+    // before the #2356 change so any drift there is visible.
+    let info = parse(
+        "export {};\n\
+         declare global {\n\
+           export const directGlobal: number;\n\
+           export interface DirectGlobalShape { a: number }\n\
+         }\n",
+    );
+    assert_eq!(
+        export_names(&info),
+        ["directGlobal", "DirectGlobalShape"],
+        "direct `declare global` body exports keep their existing recording"
+    );
+}
+
 #[test]
 fn re_export_named() {
     let info = parse("export { foo } from './bar';");

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2415,6 +2415,19 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
         let is_namespace = matches!(&decl.declaration, Some(Declaration::TSModuleDeclaration(_)));
 
+        // Exports inside a namespace declared without the `export` keyword are
+        // members of that local binding, not exports of the containing file
+        // (issue #2356). TS2395 forbids merging a local namespace with an
+        // exported declaration of the same name, so there is no exported owner
+        // to attach members to: nothing is recorded here and nothing is queued
+        // in `pending_namespace_members`. The body is still walked so imports
+        // referenced inside it keep their credit and nested namespaces reach
+        // `visit_ts_module_declaration`.
+        if self.local_namespace_depth > 0 {
+            walk::walk_export_named_declaration(self, decl);
+            return;
+        }
+
         if self.namespace_depth > 0 {
             if let Some(declaration) = &decl.declaration {
                 self.extract_namespace_members(declaration);
@@ -2573,14 +2586,28 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         // A string-literal module name (`declare module './library'`,
         // `declare module 'pkg'`) marks a module augmentation or ambient
         // module declaration. Track the depth so export visitors skip
-        // file-level recording inside the body (issue #2349). Identifier-named
-        // declarations (`namespace Foo`, `declare global`) keep existing
-        // behavior.
+        // file-level recording inside the body (issue #2349).
         let is_ambient_specifier = matches!(&decl.id, TSModuleDeclarationName::StringLiteral(_));
+        // An identifier-named namespace reached outside an exported namespace
+        // body (`export namespace Foo` raises `namespace_depth` before its
+        // declaration is walked) and outside an ambient module is a local
+        // binding: `namespace Foo {}`, `declare namespace Foo {}`, legacy
+        // `module Foo {}`, each segment of a dotted `namespace A.B.C {}`, and a
+        // namespace nested in one of those or in `declare global`. Its inner
+        // `export` statements are members of the local binding, not file
+        // exports (issue #2356).
+        let is_local_namespace =
+            !is_ambient_specifier && self.namespace_depth == 0 && self.ambient_module_depth == 0;
         if is_ambient_specifier {
             self.ambient_module_depth += 1;
         }
+        if is_local_namespace {
+            self.local_namespace_depth += 1;
+        }
         walk::walk_ts_module_declaration(self, decl);
+        if is_local_namespace {
+            self.local_namespace_depth -= 1;
+        }
         if is_ambient_specifier {
             self.ambient_module_depth -= 1;
         }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -118,7 +118,13 @@ pub use store::GraphCacheStore;
 /// references into the persisted graph. Warm 34 caches carry the old empty
 /// accessed-members verdict, so exports rendered only through JSX would stay
 /// reported as unused on upgrade.
-pub const GRAPH_CACHE_VERSION: u32 = 35;
+///
+/// Bumped to 36 for issue #2356: `export` declarations inside a namespace
+/// declared without the `export` keyword no longer contribute file-level
+/// exports, and unused-export verdicts are read off the persisted export set.
+/// Warm 35 caches still carry those local namespace members as file exports
+/// and would keep reporting them as unused on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 36;
 
 /// Cached form of a resolved target.
 ///

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -41,8 +41,16 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   ambient module declaration) contributes no file-level export surface. Its
   body is still walked for `typeof import()` and type-space references, and a
   named re-export inside it becomes one type-space import per specifier so the
-  target keeps its export credit. Identifier-named namespaces and
-  `declare global` keep their existing behavior.
+  target keeps its export credit. Exported namespaces and `declare global`
+  keep their existing behavior.
+- A namespace declared without the `export` keyword (`namespace Foo {}`,
+  `declare namespace Foo {}`, legacy `module Foo {}`, dotted
+  `namespace A.B.C {}`, and namespaces nested in those or in `declare global`)
+  is a local binding. Its inner `export` declarations are members of that
+  binding, not file-level exports, and are attached to no owner because a
+  local namespace cannot merge with an exported one. The body is still walked
+  so imports referenced inside it keep their credit. `export namespace Foo`
+  keeps recording one export with the inner declarations as members.
 
 ## Verification
 

--- a/tests/fixtures/issue-2356-local-namespace/package.json
+++ b/tests/fixtures/issue-2356-local-namespace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-2356-local-namespace",
+  "type": "module",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/tests/fixtures/issue-2356-local-namespace/src/body-reference.ts
+++ b/tests/fixtures/issue-2356-local-namespace/src/body-reference.ts
@@ -1,0 +1,7 @@
+import { helper } from './helper';
+
+namespace Wrapped {
+  export const value = helper();
+}
+
+export const unusedSibling = 1;

--- a/tests/fixtures/issue-2356-local-namespace/src/exported-namespace.ts
+++ b/tests/fixtures/issue-2356-local-namespace/src/exported-namespace.ts
@@ -1,0 +1,3 @@
+export namespace Exported {
+  export const kept = 1;
+}

--- a/tests/fixtures/issue-2356-local-namespace/src/helper.ts
+++ b/tests/fixtures/issue-2356-local-namespace/src/helper.ts
@@ -1,0 +1,1 @@
+export const helper = (): number => 1;

--- a/tests/fixtures/issue-2356-local-namespace/src/index.ts
+++ b/tests/fixtures/issue-2356-local-namespace/src/index.ts
@@ -1,0 +1,6 @@
+import './ns';
+import './body-reference';
+import './exported-namespace';
+import { Spec } from './specifier';
+
+console.log(Spec.viaSpecifier);

--- a/tests/fixtures/issue-2356-local-namespace/src/ns.ts
+++ b/tests/fixtures/issue-2356-local-namespace/src/ns.ts
@@ -1,0 +1,4 @@
+namespace Foo {
+  export const inner = 1;
+}
+export {};

--- a/tests/fixtures/issue-2356-local-namespace/src/specifier.ts
+++ b/tests/fixtures/issue-2356-local-namespace/src/specifier.ts
@@ -1,0 +1,4 @@
+namespace Spec {
+  export const viaSpecifier = 1;
+}
+export { Spec };


### PR DESCRIPTION
## What was broken

A namespace declared without the `export` keyword had its inner `export` declarations recorded as file-level exports. For the issue's snippet

```ts
// src/ns.ts
namespace Foo {
  export const inner = 1;
}
export {};
```

`fallow dead-code` reported `inner` as an unused export with an auto-fixable remove-export action. Following that advice removes `inner` from the namespace's public surface and breaks every consumer of `Foo.inner`. The same leak hit `declare namespace Foo {}`, legacy `module Foo {}`, dotted `namespace A.B.C {}`, a namespace exported from inside a local namespace, and a local namespace exported afterwards through `export { Foo }` or `export = Foo` (its members were reported unused even while a consumer used `Foo.member`).

## Root cause

`namespace_depth` is only raised inside `visit_export_named_declaration`, so a `TSModuleDeclaration` reached as a plain statement never entered namespace mode and its inner `export` statements fell through to the file-level export recorder. Re-using `namespace_depth` for these bodies was not an option: that path also routes inner declarations into `pending_namespace_members`, which expects an exported owner to attach them to, and a local namespace has none (TS2395 forbids merging a local namespace with an exported declaration of the same name).

## The fix

Earliest incorrect layer is extraction. `ModuleInfoExtractor` gains a separate `local_namespace_depth` counter (documented on the field, issue #2356). `visit_ts_module_declaration` raises it for an identifier-named namespace reached while `namespace_depth == 0` and `ambient_module_depth == 0`, which is exactly a namespace without an exported owner: `export namespace Foo` raises `namespace_depth` before its declaration is walked, and `declare module '...'` raises `ambient_module_depth`. While the counter is non-zero, `visit_export_named_declaration` walks the statement without recording an export and without queueing namespace members, so imports referenced inside the body keep their credit and nested namespaces still reach the module-declaration arm. `namespace_depth` is untouched, so the scope-binding helpers treat the inner statements exactly as before.

Exported namespaces keep their existing member extraction, `declare module '<specifier>'` bodies keep the #2349 behaviour, and direct `declare global { export ... }` bodies keep today's behaviour (`declare global` is its own AST node and never enters the namespace arm). A namespace nested inside `declare global` (`declare global { namespace NodeJS { export interface ProcessEnv {} } }`) reaches the arm with no exported owner and now follows the local rule; previously `ProcessEnv` was reported as an unused type in a `.ts` file.

## Behavior change

Narrowing only: local namespace members stop producing `unused-export` and `unused-type` findings and their remove-export actions. Existing `fallow-ignore` suppressions placed above these declarations as a workaround surface as stale-suppression findings and can be removed. Genuinely unused exports next to a local namespace and unused exported namespaces keep reporting.

## Cache invalidation

Both cache layers are bumped with doc comments naming #2356:

- extract `CACHE_VERSION` 273 -> 274, so warm extraction caches re-extract the export set;
- `GRAPH_CACHE_VERSION` 35 -> 36, because unused-export verdicts are read off the persisted export set.

Warm-cache proof on the fixture, two debug binaries sharing one `.fallow` directory:

1. origin/main binary, cold run: reports `inner`, `value`, `viaSpecifier`, `unusedSibling`, `Exported` and writes the cache.
2. patched binary on that warm cache: reports only `unusedSibling` and `Exported`.
3. second warm run of the patched binary: identical.
4. origin/main binary again on the patched cache: its version gate rejects the newer cache and it replays its own stale result, confirming the verdict is version-gated rather than accidental.

## How it was tested

- Extract-level tests (all failed before the fix): the issue snippet, `declare namespace` with const/interface/type/function/class/enum members, legacy `module Foo {}`, dotted `namespace A.B.C {}`, `namespace A { export namespace B { ... } }` staying entirely local, body references keeping value and type import credit, and a namespace nested inside `declare global`.
- Pins written before the code change: `export namespace Foo { ... }` still records one export with members `x`, `Bar`, `y`; direct `declare global { export ... }` bodies still record file-level exports.
- Integration test on fixture `issue-2356-local-namespace`: `inner`, `viaSpecifier`, and `value` are not reported; `unusedSibling` and the unused exported namespace `Exported` still report; `helper` (only referenced inside a local namespace body) keeps its credit and `helper.ts` stays reachable.
- Mutation matrix: with the non-test source hunks stashed, the seven extract repro tests and the integration test fail; the two pins pass by design.
- CLI run of the issue's exact snippet with the patched binary: no findings (baseline reported `inner` with an auto-fixable remove-export action).
- Real-project smokes: `dead-code --format json` with the baseline and patched binaries on the in-repo viz-frontend and editors/vscode projects, both complete cleanly with no finding differences (neither project declares a non-exported namespace).
- Gates: cargo fmt check, clippy workspace with warnings denied, workspace tests (`--lib --bins --tests --examples`), bench check, cargo doc with warnings denied, typos, hidden-unicode scan, and comment-quality check.

Fixes #2356
