### PR TITLE
fix(graph): credit star and namespace chains behind whole-module consumers and entry namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,16 +154,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing else, and a binding placed in an exported object literal
   (`export const API = { ns }`) keeps the precise `API.ns.<member>` crediting
   of the alias phase unless it is also used as a whole object or exported
-  under its own name. A barrel no entry point reaches keeps reporting: it is
-  already an unused file, so its chain is not credited and no unused-export
-  row is stacked underneath that row. A whole-object use inside an unreachable
-  file still suppresses the reachable target's chain, exactly as it already
-  suppressed that target's direct exports, so deleting the unused file the
-  report names brings the chain back on the next run. Fewer unused-export
-  findings for star barrels consumed as whole objects, through a named
-  namespace binding, or through dynamic-import patterns. The graph cache
-  version was bumped, so the first run after upgrading performs one cold
-  re-analysis.
+  under its own name. A barrel no entry point reaches keeps reporting when one
+  of these five consumers is what observes it: that consumer is unreachable
+  too, the barrel is already an unused file, and crediting its chain would
+  only stack unused-export rows underneath that row. The ambient-module star
+  form is deliberately not gated that way, because the module id it declares
+  is imported from outside the graph: an unreachable `declare module` shim
+  keeps crediting its chain, which routinely runs back into modules an entry
+  point imports directly. A whole-object use inside an unreachable file still
+  suppresses the reachable target's chain, exactly as it already suppressed
+  that target's direct exports, so deleting the unused file the report names
+  brings the chain back on the next run.
+
+  Two properties of the seed are worth naming. `export type { ns }` seeds the
+  closure exactly like `export { ns }` and credits the chain in the value
+  namespace as well, because `typeof ns.member` keeps a value declaration
+  reachable through a type-only re-export. And a namespace binding exported
+  under its own name seeds the closure whether or not that export has a
+  consumer, so a report can call `m.ts:ns` unused while crediting the whole
+  chain behind it, the same self-inconsistency the unreachable-observer case
+  has. Fewer unused-export findings for star barrels consumed as whole
+  objects, through a named namespace binding, or through dynamic-import
+  patterns. The graph cache version was bumped, so the first run after
+  upgrading performs one cold re-analysis.
 
 - **`export * as sub` on the entry-point surface now credits sub's own
   `export *` and `export * as` chains** (Closes
@@ -197,9 +210,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `export * from './barrel'` whose barrel does `export * from './mid'` over a
   `mid` that does `export * as default from './target'` now reports target's
   exports. That includes the ambient form from
-  [#2357](https://github.com/fallow-rs/fallow/issues/2357): the issue-2357
-  behaviour is otherwise unchanged, and an `export * as default` declared
-  directly on the ambient star's own target still credits its chain.
+  [#2357](https://github.com/fallow-rs/fallow/issues/2357), where an
+  `export * as default` declared directly on the ambient star's own target
+  still credits its chain. Nothing else in the issue-2357 behaviour moves: an
+  ambient chain is seeded and walked at any reachability, exactly as it was.
 
 - **Star re-exports inside `declare module '...'` bodies credit the full ES
   star surface of their target without adding to the declaring file's export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the environment-variable docs no longer tell MCP callers to pass the inputs
   explicitly.
 
+- **Whole-module consumers of a barrel now credit the exports the barrel only
+  exposes through its own `export *` and `export * as` chains** (Closes
+  [#2372](https://github.com/fallow-rs/fallow/issues/2372)). A namespace
+  import the graph cannot narrow to member accesses (`import * as ns from
+  './barrel'` used as a whole object in `Object.values(ns)`, a spread, or a
+  destructure with rest, handed on without any member access, or re-exported
+  from a non-entry module) and a dynamic-import pattern match (`import()` with
+  a template, `import.meta.glob`, `require.context`) credited the target's
+  direct exports only, so a name that reached the barrel through
+  `export * from './deep'` or `export * as sub from './sub'` was reported as
+  unused even though the consumer observes every name on the namespace
+  object. These consumers now seed the same closure the ambient-module star
+  form from [#2357](https://github.com/fallow-rs/fallow/issues/2357) uses:
+  the barrel's `export *` sources credit their named exports (never
+  `default`, which a plain `export *` does not forward), its `export * as sub`
+  sources credit every export (`default` included, because `sub.default` is
+  on the object), and both rules recurse through sub's own chains. A
+  member-narrowed namespace import (`ns.one()`) keeps narrowing to the
+  accessed members and credits nothing else. Fewer unused-export findings for
+  star barrels consumed as whole objects or through dynamic-import patterns.
+  The graph cache version was bumped, so the first run after upgrading
+  performs one cold re-analysis.
+
+- **`export * as sub` on the entry-point surface now credits sub's own
+  `export *` and `export * as` chains** (Closes
+  [#2373](https://github.com/fallow-rs/fallow/issues/2373)). For
+  `export * as sub from './sub'` on an entry point, or on a barrel the entry
+  reaches through plain `export *`, every direct export of `sub.ts` was
+  credited but neither its `export * from './deep'` sources nor its
+  `export * as sub2` sources were: the entry star closure walked plain
+  `export *` edges only, and only entry points counted as exposing a
+  namespace object. Every name on sub's namespace object is reachable through
+  the entry, so sub now joins the same closure: deep's named exports are
+  credited (never deep's `default`), every export of sub2 is credited
+  (`default` included), and the rules recurse through any further level. A
+  namespace re-export on a reachable non-entry barrel that is off the entry
+  surface and has no consumer still exposes nothing, and the entry's plain
+  `export *` still never forwards the barrel's own `default`. Fewer
+  unused-export findings for nested namespace re-exports behind an entry
+  point.
+
 - **Star re-exports inside `declare module '...'` bodies credit the full ES
   star surface of their target without adding to the declaring file's export
   surface** (Closes [#2357](https://github.com/fallow-rs/fallow/issues/2357)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,33 +130,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Whole-module consumers of a barrel now credit the exports the barrel only
   exposes through its own `export *` and `export * as` chains** (Closes
-  [#2372](https://github.com/fallow-rs/fallow/issues/2372)). A namespace
-  import the graph cannot narrow to member accesses (`import * as ns from
-  './barrel'` used as a whole object in `Object.values(ns)`, a spread, or a
-  destructure with rest, handed on without any member access, or re-exported
-  from a non-entry module), a dynamic-import pattern match (`import()` with
-  a template, `import.meta.glob`, `require.context`), and a bare side-effect
-  `require('./barrel')` credited the target's
-  direct exports only, so a name that reached the barrel through
-  `export * from './deep'` or `export * as sub from './sub'` was reported as
-  unused even though the consumer observes every name on the namespace
-  object. These consumers now seed the same closure the ambient-module star
-  form from [#2357](https://github.com/fallow-rs/fallow/issues/2357) uses:
-  the barrel's `export *` sources credit their named exports (never
-  `default`, which a plain `export *` does not forward), its `export * as sub`
-  sources credit every export (`default` included, because `sub.default` is
-  on the object), and both rules recurse through sub's own chains. A
-  member-narrowed namespace import (`ns.one()`) keeps narrowing to the
-  accessed members and credits nothing else, and a binding placed in an
-  exported object literal (`export const API = { ns }`) keeps the precise
-  `API.ns.<member>` crediting of the alias phase. A barrel no entry point
-  reaches keeps reporting: it is already an unused file, so its chain is not
-  credited and no unused-export row is stacked underneath that row. Fewer
-  unused-export findings for
-  star barrels consumed as whole objects or through dynamic-import patterns,
-  and never more.
-  The graph cache version was bumped, so the first run after upgrading
-  performs one cold re-analysis.
+  [#2372](https://github.com/fallow-rs/fallow/issues/2372)). Five consumer
+  shapes credited the target's direct exports only: a namespace import the
+  graph cannot narrow to member accesses (`import * as ns from './barrel'`
+  used as a whole object in `Object.values(ns)`, a spread, or a destructure
+  with rest, or handed on without any member access), a namespace binding
+  exported under its own name (`export { ns }`, on an entry point as much as
+  on any other module), an `export * as sub` binding imported by name and used
+  as a whole object (`import { sub } from './barrel'` plus
+  `Object.values(sub)`), a dynamic-import pattern match (`import()` with a
+  template, `import.meta.glob`, `require.context`), and a bare side-effect
+  `require('./barrel')` with no binding. A name that reached the barrel
+  through `export * from './deep'` or `export * as sub from './sub'` was
+  reported as unused even though the consumer observes every name on the
+  namespace object. These consumers now seed the same closure the
+  ambient-module star form from
+  [#2357](https://github.com/fallow-rs/fallow/issues/2357) uses: the barrel's
+  `export *` sources credit their named exports (never `default`, which a
+  plain `export *` does not forward), its `export * as sub` sources credit
+  every export (`default` included, because `sub.default` is on the object),
+  and both rules recurse through sub's own chains. A member-narrowed namespace
+  import (`ns.one()`) keeps narrowing to the accessed members and credits
+  nothing else, and a binding placed in an exported object literal
+  (`export const API = { ns }`) keeps the precise `API.ns.<member>` crediting
+  of the alias phase unless it is also used as a whole object or exported
+  under its own name. A barrel no entry point reaches keeps reporting: it is
+  already an unused file, so its chain is not credited and no unused-export
+  row is stacked underneath that row. A whole-object use inside an unreachable
+  file still suppresses the reachable target's chain, exactly as it already
+  suppressed that target's direct exports, so deleting the unused file the
+  report names brings the chain back on the next run. Fewer unused-export
+  findings for star barrels consumed as whole objects, through a named
+  namespace binding, or through dynamic-import patterns. The graph cache
+  version was bumped, so the first run after upgrading performs one cold
+  re-analysis.
 
 - **`export * as sub` on the entry-point surface now credits sub's own
   `export *` and `export * as` chains** (Closes
@@ -173,15 +180,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sub2 is credited (`default` included), and the rules recurse through any
   further level. The entry surface is tracked by name, so a barrel the entry
   reaches only through `export { one } from './barrel'` still exposes `one`
-  and nothing else; a barrel that declares its own `sub` shadows a
-  star-forwarded `sub` and stops the chain there; a namespace re-export on a
-  reachable non-entry barrel that
-  is off the entry surface and has no consumer still exposes nothing; and the
-  entry's plain `export *` still never forwards the barrel's own `default`,
-  so `export * as default` on such a barrel keeps reporting while the same
-  declaration on the entry point itself is credited.
+  and nothing else; a barrel that declares its own `sub`, or that receives
+  `sub` from two `export *` sources at once, exports a different binding under
+  that name and stops the chain there, whether the entry names the barrel or
+  reaches it through a plain `export *`; a namespace re-export on a reachable
+  non-entry barrel that is off the entry surface and has no consumer still
+  exposes nothing; and the entry's plain `export *` still never forwards the
+  barrel's own `default`, so `export * as default` on such a barrel keeps
+  reporting while the same declaration on the entry point itself is credited.
   Fewer unused-export findings for nested namespace re-exports behind an entry
   point.
+
+  One shape reports one finding more. A plain `export *` hop inside a chain no
+  longer carries a downstream `export * as default` onward, because that star
+  never forwards `default`, so an
+  `export * from './barrel'` whose barrel does `export * from './mid'` over a
+  `mid` that does `export * as default from './target'` now reports target's
+  exports. That includes the ambient form from
+  [#2357](https://github.com/fallow-rs/fallow/issues/2357): the issue-2357
+  behaviour is otherwise unchanged, and an `export * as default` declared
+  directly on the ambient star's own target still credits its chain.
 
 - **Star re-exports inside `declare module '...'` bodies credit the full ES
   star surface of their target without adding to the declaring file's export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources credit every export (`default` included, because `sub.default` is
   on the object), and both rules recurse through sub's own chains. A
   member-narrowed namespace import (`ns.one()`) keeps narrowing to the
-  accessed members and credits nothing else. Fewer unused-export findings for
+  accessed members and credits nothing else, and a binding placed in an
+  exported object literal (`export const API = { ns }`) keeps the precise
+  `API.ns.<member>` crediting of the alias phase. Fewer unused-export findings for
   star barrels consumed as whole objects or through dynamic-import patterns.
   The graph cache version was bumped, so the first run after upgrading
   performs one cold re-analysis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,8 +134,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   import the graph cannot narrow to member accesses (`import * as ns from
   './barrel'` used as a whole object in `Object.values(ns)`, a spread, or a
   destructure with rest, handed on without any member access, or re-exported
-  from a non-entry module) and a dynamic-import pattern match (`import()` with
-  a template, `import.meta.glob`, `require.context`) credited the target's
+  from a non-entry module), a dynamic-import pattern match (`import()` with
+  a template, `import.meta.glob`, `require.context`), and a bare side-effect
+  `require('./barrel')` credited the target's
   direct exports only, so a name that reached the barrel through
   `export * from './deep'` or `export * as sub from './sub'` was reported as
   unused even though the consumer observes every name on the namespace
@@ -148,8 +149,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   member-narrowed namespace import (`ns.one()`) keeps narrowing to the
   accessed members and credits nothing else, and a binding placed in an
   exported object literal (`export const API = { ns }`) keeps the precise
-  `API.ns.<member>` crediting of the alias phase. Fewer unused-export findings for
-  star barrels consumed as whole objects or through dynamic-import patterns.
+  `API.ns.<member>` crediting of the alias phase. A barrel no entry point
+  reaches keeps reporting: it is already an unused file, so its chain is not
+  credited and no unused-export row is stacked underneath that row. Fewer
+  unused-export findings for
+  star barrels consumed as whole objects or through dynamic-import patterns,
+  and never more.
   The graph cache version was bumped, so the first run after upgrading
   performs one cold re-analysis.
 
@@ -168,9 +173,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sub2 is credited (`default` included), and the rules recurse through any
   further level. The entry surface is tracked by name, so a barrel the entry
   reaches only through `export { one } from './barrel'` still exposes `one`
-  and nothing else; a namespace re-export on a reachable non-entry barrel that
+  and nothing else; a barrel that declares its own `sub` shadows a
+  star-forwarded `sub` and stops the chain there; a namespace re-export on a
+  reachable non-entry barrel that
   is off the entry surface and has no consumer still exposes nothing; and the
-  entry's plain `export *` still never forwards the barrel's own `default`.
+  entry's plain `export *` still never forwards the barrel's own `default`,
+  so `export * as default` on such a barrel keeps reporting while the same
+  declaration on the entry point itself is credited.
   Fewer unused-export findings for nested namespace re-exports behind an entry
   point.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,19 +156,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`export * as sub` on the entry-point surface now credits sub's own
   `export *` and `export * as` chains** (Closes
   [#2373](https://github.com/fallow-rs/fallow/issues/2373)). For
-  `export * as sub from './sub'` on an entry point, or on a barrel the entry
-  reaches through plain `export *`, every direct export of `sub.ts` was
-  credited but neither its `export * from './deep'` sources nor its
-  `export * as sub2` sources were: the entry star closure walked plain
-  `export *` edges only, and only entry points counted as exposing a
-  namespace object. Every name on sub's namespace object is reachable through
-  the entry, so sub now joins the same closure: deep's named exports are
-  credited (never deep's `default`), every export of sub2 is credited
-  (`default` included), and the rules recurse through any further level. A
-  namespace re-export on a reachable non-entry barrel that is off the entry
-  surface and has no consumer still exposes nothing, and the entry's plain
-  `export *` still never forwards the barrel's own `default`. Fewer
-  unused-export findings for nested namespace re-exports behind an entry
+  `export * as sub from './sub'` on an entry point, on a barrel the entry
+  reaches through plain `export *`, or named by the entry through a chain of
+  named re-exports (`export { sub } from './barrel'`, renames included), every
+  direct export of `sub.ts` was credited but neither its
+  `export * from './deep'` sources nor its `export * as sub2` sources were:
+  the entry star closure walked plain `export *` edges only, and only entry
+  points counted as exposing a namespace object. Every name on sub's namespace
+  object is reachable through the entry, so sub now joins the same closure:
+  deep's named exports are credited (never deep's `default`), every export of
+  sub2 is credited (`default` included), and the rules recurse through any
+  further level. The entry surface is tracked by name, so a barrel the entry
+  reaches only through `export { one } from './barrel'` still exposes `one`
+  and nothing else; a namespace re-export on a reachable non-entry barrel that
+  is off the entry surface and has no consumer still exposes nothing; and the
+  entry's plain `export *` still never forwards the barrel's own `default`.
+  Fewer unused-export findings for nested namespace re-exports behind an entry
   point.
 
 - **Star re-exports inside `declare module '...'` bodies credit the full ES

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -81,6 +81,10 @@ mod issue_2349_module_augmentation;
 mod issue_2356_local_namespace;
 #[path = "integration_test/issue_2357_ambient_star_reexport.rs"]
 mod issue_2357_ambient_star_reexport;
+#[path = "integration_test/issue_2372_star_barrel_whole_module.rs"]
+mod issue_2372_star_barrel_whole_module;
+#[path = "integration_test/issue_2373_entry_namespace_chain.rs"]
+mod issue_2373_entry_namespace_chain;
 #[path = "integration_test/issue_546_storybook_runtime_resources.rs"]
 mod issue_546_storybook_runtime_resources;
 #[path = "integration_test/issue_914_pnpm_bare_binary.rs"]

--- a/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
+++ b/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
@@ -453,3 +453,78 @@ fn whole_module_credit_is_routed_through_the_chain() {
         "sub2-deep.ts:default is not part of sub2.ts's `export *` surface"
     );
 }
+
+#[test]
+fn plain_star_members_of_the_closure_do_not_forward_a_default_namespace() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // barrel.ts `export * from './star-default'`: the star carries
+    // star-default.ts's named exports onto the observed namespace object and
+    // leaves its `default` behind, so `export * as default` there hands its
+    // target to nobody.
+    assert_credited(
+        &unused,
+        "src/star-default.ts",
+        "starDefaultOne",
+        "a plain `export *` forwards every named export",
+    );
+    assert_reported(
+        &unused,
+        "src/star-default.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
+    assert_reported(
+        &unused,
+        "src/star-default-sub.ts",
+        "starDefaultSubOne",
+        "the namespace object named `default` is not on the barrel's namespace object",
+    );
+    assert_reported(
+        &unused,
+        "src/star-default-deep.ts",
+        "starDefaultDeepOne",
+        "nothing behind the `default` namespace object is reachable",
+    );
+}
+
+#[test]
+fn a_whole_object_use_in_an_unreachable_file_credits_no_chain() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+    let unused_files: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.file.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+
+    // dead-consumer.ts observes dead-barrel.ts's whole namespace object, but
+    // no entry point reaches either file. The report already calls all four
+    // files unused, so crediting the chain would only stack unused-export
+    // rows underneath those rows.
+    for path in [
+        "src/dead-consumer.ts",
+        "src/dead-barrel.ts",
+        "src/dead-deep.ts",
+        "src/dead-sub.ts",
+    ] {
+        assert!(
+            unused_files.iter().any(|p| p.ends_with(path)),
+            "{path} must stay an unused file: {unused_files:?}"
+        );
+    }
+    for (path, name) in [
+        ("src/dead-deep.ts", "deadDeepOne"),
+        ("src/dead-sub.ts", "deadSubOne"),
+        ("src/dead-sub.ts", "default"),
+    ] {
+        assert!(
+            !is_reported(&unused, path, name),
+            "{path}:{name} must not be reported on top of the unused-file row; \
+             unused exports: {unused:?}"
+        );
+    }
+}

--- a/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
+++ b/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
@@ -332,6 +332,37 @@ fn member_narrowed_namespace_imports_do_not_seed_the_closure() {
 }
 
 #[test]
+fn alias_sourced_namespace_bindings_do_not_seed_the_closure() {
+    // Regression pin: alias.ts places `aliasNs` in `export const aliasApi =
+    // { aliasNs }` without touching it otherwise. The direct-export mark-all
+    // still fires for that unnarrowed binding (as before), but the namespace
+    // object alias phase follows `aliasApi.aliasNs.aliasOne` precisely, so the
+    // star chain behind the aliased barrel stays narrowed.
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    assert_credited(
+        &unused,
+        "src/alias-barrel.ts",
+        "aliasDirect",
+        "a direct export behind an unnarrowed binding",
+    );
+    assert_credited(
+        &unused,
+        "src/alias-deep.ts",
+        "aliasOne",
+        "accessed as `aliasApi.aliasNs.aliasOne`",
+    );
+    assert_reported(
+        &unused,
+        "src/alias-deep.ts",
+        "aliasTwo",
+        "never accessed through the alias",
+    );
+}
+
+#[test]
 fn star_chains_that_re_export_themselves_terminate() {
     // cycle-a.ts `export * from './cycle-b'`; cycle-b.ts `export * as cycleNs
     // from './cycle-a'`. `Object.keys(cyc)` on cycle-a.ts sees `cycleA`,

--- a/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
+++ b/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
@@ -1,0 +1,424 @@
+//! Issue #2372: a consumer that observes a whole namespace object sees every
+//! name on it, including the names the target only exposes through its own
+//! `export *` and `export * as ns` chains. Two consumer shapes used to credit
+//! the target's direct exports only: a namespace import the graph cannot
+//! narrow (a whole-object use such as `Object.values(ns)`, a binding handed on
+//! without member access, or a binding re-exported from a non-entry module)
+//! and a dynamic-import pattern match (`import()` with a template,
+//! `import.meta.glob`, `require.context`).
+//!
+//! ES semantics apply exactly: the namespace object includes the target's
+//! `default`, a plain `export *` never forwards a `default`, and an
+//! `export * as sub` exposes sub's namespace object, `default` included.
+//! Member-narrowed namespace imports keep their narrowing and never seed the
+//! closure.
+
+use super::common::{create_config, fixture_path};
+use fallow_core::graph::{ExportSymbol, ModuleNode, ReferenceKind};
+
+const FIXTURE: &str = "issue-2372-star-barrel-whole-module";
+
+fn module_named<'a>(modules: &'a [ModuleNode], suffix: &str) -> &'a ModuleNode {
+    modules
+        .iter()
+        .find(|m| {
+            m.path
+                .to_string_lossy()
+                .replace('\\', "/")
+                .ends_with(suffix)
+        })
+        .unwrap_or_else(|| panic!("{suffix} must be part of the module graph"))
+}
+
+fn export_named<'a>(module: &'a ModuleNode, name: &str) -> &'a ExportSymbol {
+    module
+        .exports
+        .iter()
+        .find(|e| e.name.matches_str(name))
+        .unwrap_or_else(|| panic!("{} must export `{name}`", module.path.display()))
+}
+
+fn unused_export_pairs(results: &fallow_core::results::AnalysisResults) -> Vec<(String, String)> {
+    results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.export.path.to_string_lossy().replace('\\', "/"),
+                e.export.export_name.clone(),
+            )
+        })
+        .collect()
+}
+
+fn is_reported(unused: &[(String, String)], path: &str, name: &str) -> bool {
+    unused.iter().any(|(p, n)| p.ends_with(path) && n == name)
+}
+
+fn assert_credited(unused: &[(String, String)], path: &str, name: &str, why: &str) {
+    assert!(
+        !is_reported(unused, path, name),
+        "{path}:{name} must be credited: {why}; unused exports: {unused:?}"
+    );
+}
+
+fn assert_reported(unused: &[(String, String)], path: &str, name: &str, why: &str) {
+    assert!(
+        is_reported(unused, path, name),
+        "{path}:{name} must keep reporting: {why}; unused exports: {unused:?}"
+    );
+}
+
+#[test]
+fn whole_object_namespace_use_credits_star_and_namespace_chains() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // `Object.values(ns)` in index.ts observes barrel.ts's namespace object:
+    // its direct exports (`default` included), the named exports of its
+    // `export *` source, and every export of its `export * as sub` source,
+    // recursively through sub.ts's own `export *` and `export * as sub2`
+    // chains (a three-level chain).
+    assert_credited(&unused, "src/barrel.ts", "direct", "a direct export");
+    assert_credited(
+        &unused,
+        "src/barrel.ts",
+        "default",
+        "`ns.default` is on the object",
+    );
+    assert_credited(
+        &unused,
+        "src/deep.ts",
+        "deepHelper",
+        "forwarded by barrel.ts's `export *`",
+    );
+    for name in ["subOne", "sub2", "default"] {
+        assert_credited(
+            &unused,
+            "src/sub.ts",
+            name,
+            "`ns.sub` is sub.ts's namespace object",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/sub-deep.ts",
+        "subDeepOne",
+        "forwarded by sub.ts's `export *`",
+    );
+    for name in ["sub2One", "default"] {
+        assert_credited(
+            &unused,
+            "src/sub2.ts",
+            name,
+            "`ns.sub.sub2` is sub2.ts's namespace",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/sub2-deep.ts",
+        "sub2DeepOne",
+        "forwarded by sub2.ts's `export *`",
+    );
+
+    // A plain `export *` never forwards `default`.
+    for path in ["src/deep.ts", "src/sub-deep.ts", "src/sub2-deep.ts"] {
+        assert_reported(
+            &unused,
+            path,
+            "default",
+            "a plain `export *` never forwards `default`",
+        );
+    }
+}
+
+#[test]
+fn every_unnarrowed_namespace_import_seeds_the_closure() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // shim.ts (reachable, not an entry point): `Object.keys(shimNs)`.
+    assert_credited(
+        &unused,
+        "src/shim-barrel.ts",
+        "shimDirect",
+        "a direct export",
+    );
+    assert_credited(
+        &unused,
+        "src/shim-deep.ts",
+        "shimDeepOne",
+        "forwarded by shim-barrel.ts's `export *` behind a non-entry whole-object use",
+    );
+    for name in ["shimSubOne", "default"] {
+        assert_credited(
+            &unused,
+            "src/shim-sub.ts",
+            name,
+            "`shimNs.shimSub` is shim-sub.ts's namespace object",
+        );
+    }
+    assert_reported(
+        &unused,
+        "src/shim-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+
+    // passer.ts: `consume(passed)` hands the binding on without any member
+    // access, so the graph cannot narrow it.
+    assert_credited(
+        &unused,
+        "src/passed-barrel.ts",
+        "passedDirect",
+        "a direct export",
+    );
+    assert_credited(
+        &unused,
+        "src/passed-deep.ts",
+        "passedDeepOne",
+        "forwarded by passed-barrel.ts's `export *` behind an unnarrowed binding",
+    );
+    assert_reported(
+        &unused,
+        "src/passed-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+
+    // re-shim.ts: `export { reNs }` hands the namespace object to consumers
+    // the graph cannot enumerate.
+    assert_credited(&unused, "src/re-barrel.ts", "reDirect", "a direct export");
+    assert_credited(
+        &unused,
+        "src/re-deep.ts",
+        "reDeepOne",
+        "forwarded by re-barrel.ts's `export *` behind a re-exported namespace binding",
+    );
+    assert_reported(
+        &unused,
+        "src/re-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+}
+
+#[test]
+fn dynamic_import_pattern_targets_credit_their_chains() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // `import.meta.glob('./mods/*.ts')` hands the consumer each matched
+    // module's namespace object.
+    assert_credited(&unused, "src/mods/a.ts", "aOwn", "a direct export");
+    for name in ["deepStarOne", "deepStarTwo"] {
+        assert_credited(
+            &unused,
+            "src/mod-deps/a-deep.ts",
+            name,
+            "forwarded by mods/a.ts's `export *`",
+        );
+    }
+    assert_reported(
+        &unused,
+        "src/mod-deps/a-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+    assert_credited(
+        &unused,
+        "src/mod-deps/a-named.ts",
+        "namedOnly",
+        "named re-export on mods/a.ts",
+    );
+    assert_reported(
+        &unused,
+        "src/mod-deps/a-named.ts",
+        "namedSibling",
+        "not forwarded by any re-export",
+    );
+    for name in ["bNsOne", "default"] {
+        assert_credited(
+            &unused,
+            "src/mod-deps/b-ns.ts",
+            name,
+            "`bNs` is b-ns.ts's namespace object",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/mod-deps/b-ns-deep.ts",
+        "bNsDeepOne",
+        "forwarded by b-ns.ts's `export *`",
+    );
+    assert_reported(
+        &unused,
+        "src/mod-deps/b-ns-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+
+    // A template `import()` and `require.context` follow the same rule.
+    assert_credited(
+        &unused,
+        "src/plugins/one.ts",
+        "pluginOne",
+        "a direct export",
+    );
+    assert_credited(
+        &unused,
+        "src/plugin-deps/one-deep.ts",
+        "pluginDeepOne",
+        "forwarded by plugins/one.ts's `export *` behind a template `import()`",
+    );
+    assert_reported(
+        &unused,
+        "src/plugin-deps/one-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+    assert_credited(&unused, "src/icons/star.ts", "starIcon", "a direct export");
+    assert_credited(
+        &unused,
+        "src/icon-deps/star-deep.ts",
+        "iconDeepOne",
+        "forwarded by icons/star.ts's `export *` behind `require.context`",
+    );
+    assert_reported(
+        &unused,
+        "src/icon-deps/star-deep.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+}
+
+#[test]
+fn member_narrowed_namespace_imports_do_not_seed_the_closure() {
+    // Regression pin: `narrow.one()` keeps narrowing to the accessed member,
+    // so nothing else behind narrow-barrel.ts is credited.
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    assert_credited(
+        &unused,
+        "src/narrow-deep.ts",
+        "one",
+        "accessed as `narrow.one`",
+    );
+    assert_reported(
+        &unused,
+        "src/narrow-deep.ts",
+        "two",
+        "never accessed on the binding",
+    );
+    assert_reported(
+        &unused,
+        "src/narrow-barrel.ts",
+        "narrowSub",
+        "never accessed on the binding",
+    );
+    for name in ["narrowSubOne", "default"] {
+        assert_reported(
+            &unused,
+            "src/narrow-sub.ts",
+            name,
+            "the `narrowSub` namespace is never accessed",
+        );
+    }
+}
+
+#[test]
+fn star_chains_that_re_export_themselves_terminate() {
+    // cycle-a.ts `export * from './cycle-b'`; cycle-b.ts `export * as cycleNs
+    // from './cycle-a'`. `Object.keys(cyc)` on cycle-a.ts sees `cycleA`,
+    // `cycleB`, and `cycleNs`; cycle-b.ts's default is on neither namespace
+    // object.
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    assert_credited(&unused, "src/cycle-a.ts", "cycleA", "a direct export");
+    for name in ["cycleB", "cycleNs"] {
+        assert_credited(
+            &unused,
+            "src/cycle-b.ts",
+            name,
+            "forwarded by cycle-a.ts's `export *`",
+        );
+    }
+    assert_reported(
+        &unused,
+        "src/cycle-b.ts",
+        "default",
+        "never forwarded by `export *`",
+    );
+}
+
+#[test]
+fn whole_module_credit_is_routed_through_the_chain() {
+    let output = fallow_core::analyze_with_trace(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let graph = output
+        .graph
+        .as_ref()
+        .expect("analyze_with_trace retains the graph");
+
+    // The `export *` source is credited through the barrel's star chain, the
+    // `export * as sub` source through the namespace object the barrel
+    // exposes, and so on down the chain.
+    let barrel = module_named(&graph.modules, "src/barrel.ts");
+    let deep_helper = export_named(module_named(&graph.modules, "src/deep.ts"), "deepHelper");
+    assert!(
+        deep_helper
+            .references
+            .iter()
+            .any(|r| r.kind == ReferenceKind::ReExport && r.from_file == barrel.file_id),
+        "deepHelper must be credited through the barrel.ts star chain, found {:?}",
+        deep_helper
+            .references
+            .iter()
+            .map(|r| (r.kind, r.namespace, r.from_file))
+            .collect::<Vec<_>>()
+    );
+    let sub = module_named(&graph.modules, "src/sub.ts");
+    for name in ["subOne", "default"] {
+        let export = export_named(sub, name);
+        assert!(
+            export
+                .references
+                .iter()
+                .any(|r| r.kind == ReferenceKind::NamespaceImport && r.from_file == barrel.file_id),
+            "sub.ts:{name} must be credited through the namespace object barrel.ts exposes, \
+             found {:?}",
+            export
+                .references
+                .iter()
+                .map(|r| (r.kind, r.namespace, r.from_file))
+                .collect::<Vec<_>>()
+        );
+    }
+    let sub2 = module_named(&graph.modules, "src/sub2.ts");
+    let sub2_default = export_named(sub2, "default");
+    assert!(
+        sub2_default
+            .references
+            .iter()
+            .any(|r| r.kind == ReferenceKind::NamespaceImport && r.from_file == sub.file_id),
+        "sub2.ts:default must be credited through the namespace object sub.ts exposes, found {:?}",
+        sub2_default
+            .references
+            .iter()
+            .map(|r| (r.kind, r.namespace, r.from_file))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        export_named(module_named(&graph.modules, "src/sub2-deep.ts"), "default")
+            .references
+            .is_empty(),
+        "sub2-deep.ts:default is not part of sub2.ts's `export *` surface"
+    );
+}

--- a/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
+++ b/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
@@ -578,6 +578,57 @@ fn an_ambient_star_chain_stops_at_a_plain_star_hop_before_a_default_namespace() 
 }
 
 #[test]
+fn an_unreachable_ambient_shim_credits_a_chain_that_re_enters_reachable_modules() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+    let unused_files: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.file.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+
+    // unreached-shim.ts holds a `declare module` body in a plain `.ts` file
+    // nothing imports, so no entry point reaches it or the barrel behind it.
+    // The module id it declares is imported from outside this graph all the
+    // same, so the chain keeps its credit.
+    for path in [
+        "src/unreached-shim.ts",
+        "src/unreached-barrel.ts",
+        "src/unreached-mid.ts",
+    ] {
+        assert!(
+            unused_files.iter().any(|p| p.ends_with(path)),
+            "{path} must stay an unused file: {unused_files:?}"
+        );
+    }
+
+    // The chain runs back into two modules the entry point imports directly,
+    // so their unused-export rows sit under no unused-file row at all.
+    for path in ["src/unreached-reentry.ts", "src/unreached-ns-reentry.ts"] {
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(path)),
+            "{path} must stay a reachable file: {unused_files:?}"
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/unreached-reentry.ts",
+        "unreachedReentryChainOnly",
+        "the ambient star surface forwards every named export of the chain, \
+         through the unreachable hop and back into a reachable module",
+    );
+    for name in ["unreachedNsChainOnly", "default"] {
+        assert_credited(
+            &unused,
+            "src/unreached-ns-reentry.ts",
+            name,
+            "`unreachedNs` is unreached-ns-reentry.ts's namespace object",
+        );
+    }
+}
+
+#[test]
 fn a_named_import_used_as_a_whole_object_credits_the_namespace_chain() {
     let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
         .expect("analysis should succeed");

--- a/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
+++ b/crates/core/tests/integration_test/issue_2372_star_barrel_whole_module.rs
@@ -528,3 +528,122 @@ fn a_whole_object_use_in_an_unreachable_file_credits_no_chain() {
         );
     }
 }
+
+#[test]
+fn an_ambient_star_chain_stops_at_a_plain_star_hop_before_a_default_namespace() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // ambient-shim.ts declares `export * from './ambient-barrel'` inside a
+    // `declare module` body, so ambient-barrel.ts joins the closure at full
+    // namespace-object exposure: its `export * as ambientNs` source is
+    // credited whole, `default` included.
+    assert_credited(
+        &unused,
+        "src/ambient-barrel.ts",
+        "ambientBarrelOne",
+        "the ambient star credits its target's whole star surface",
+    );
+    for name in ["ambientNsOne", "default"] {
+        assert_credited(
+            &unused,
+            "src/ambient-ns-target.ts",
+            name,
+            "`ambientNs` is ambient-ns-target.ts's namespace object",
+        );
+    }
+
+    // ambient-mid.ts arrives through ambient-barrel.ts's plain `export *`,
+    // which forwards named exports and never `default`, so the namespace
+    // object ambient-mid.ts names `default` reaches nobody.
+    assert_credited(
+        &unused,
+        "src/ambient-mid.ts",
+        "ambientMidOne",
+        "a plain `export *` forwards every named export",
+    );
+    assert_reported(
+        &unused,
+        "src/ambient-mid.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
+    assert_reported(
+        &unused,
+        "src/ambient-mid-target.ts",
+        "ambientMidTargetOne",
+        "the `default` namespace object never leaves ambient-mid.ts",
+    );
+}
+
+#[test]
+fn a_named_import_used_as_a_whole_object_credits_the_namespace_chain() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // index.ts `import { wholeSub } from './whole-barrel'` plus
+    // `Object.values(wholeSub)`: the binding is whole-barrel.ts's
+    // `export * as wholeSub` stub, so the consumer observes whole-sub.ts's
+    // entire namespace object and every chain behind it.
+    assert_credited(
+        &unused,
+        "src/whole-sub.ts",
+        "wholeSubOne",
+        "the whole namespace object is observed",
+    );
+    assert_credited(
+        &unused,
+        "src/whole-deep.ts",
+        "wholeDeepX",
+        "forwarded by whole-sub.ts's `export *`",
+    );
+    for name in ["wholeSub2X", "default"] {
+        assert_credited(
+            &unused,
+            "src/whole-sub2.ts",
+            name,
+            "`wholeSub.wholeSub2` is whole-sub2.ts's namespace object",
+        );
+    }
+    assert_reported(
+        &unused,
+        "src/whole-deep.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
+    assert_reported(
+        &unused,
+        "src/whole-barrel.ts",
+        "wholeBarrelOne",
+        "the consumer names `wholeSub` only, not the rest of whole-barrel.ts",
+    );
+}
+
+#[test]
+fn an_alias_source_exported_under_its_own_name_credits_the_namespace_chain() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // alias-reexport.ts puts `aliasReNs` in an exported object literal and
+    // also exports it under its own name. The named export hands the whole
+    // object to consumers the graph cannot enumerate, so the alias exclusion
+    // that keeps `alias.ts` narrowed does not apply here.
+    assert_credited(
+        &unused,
+        "src/alias-re-deep.ts",
+        "aliasReOne",
+        "the binding is exported under its own name",
+    );
+
+    // Negative control: alias.ts places its binding in an object literal only,
+    // so the alias phase keeps following `aliasApi.aliasNs.<member>` exactly.
+    assert_reported(
+        &unused,
+        "src/alias-deep.ts",
+        "aliasTwo",
+        "an object-literal alias alone stays narrowed to the accessed members",
+    );
+}

--- a/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
+++ b/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
@@ -1,9 +1,10 @@
 //! Issue #2373: an `export * as sub` on the entry-point surface (on the entry
-//! itself or on a barrel the entry reaches through plain `export *`) exposes
-//! sub's whole namespace object to consumers the graph cannot enumerate. The
-//! namespace re-export phase credited sub's direct exports, but neither sub's
-//! own `export *` sources nor its own `export * as sub2` sources, so the
-//! deeper levels of the chain were reported as unused.
+//! itself, on a barrel the entry reaches through plain `export *`, or named by
+//! the entry through a chain of named re-exports) exposes sub's whole
+//! namespace object to consumers the graph cannot enumerate. The namespace
+//! re-export phase credited sub's direct exports, but neither sub's own
+//! `export *` sources nor its own `export * as sub2` sources, so the deeper
+//! levels of the chain were reported as unused.
 //!
 //! ES semantics apply exactly: a plain `export *` never forwards `default`, a
 //! namespace object exposes its target's `default`, and a namespace re-export
@@ -141,6 +142,75 @@ fn entry_namespace_chain_credits_nested_star_and_namespace_sources() {
             "a plain `export *` never forwards `default`",
         );
     }
+}
+
+#[test]
+fn entry_named_re_export_of_a_namespace_credits_nested_star_and_namespace_sources() {
+    // index.ts `export { named } from './named'`; named.ts `export * as named
+    // from './named-sub'`. The entry exposes the namespace object by name
+    // rather than through a plain star, so named-sub's own `export *` and
+    // `export * as namedSub2` chains are reachable the same way.
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    for name in ["namedSubOne", "namedSub2", "default"] {
+        assert_credited(
+            &unused,
+            "src/named-sub.ts",
+            name,
+            "`named` is re-exported by name from the entry",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/named-deep.ts",
+        "namedDeepX",
+        "forwarded by named-sub.ts's `export *`",
+    );
+    for name in ["namedSub2X", "default"] {
+        assert_credited(
+            &unused,
+            "src/named-sub2.ts",
+            name,
+            "`named.namedSub2` is named-sub2.ts's namespace object",
+        );
+    }
+    assert_reported(
+        &unused,
+        "src/named-deep.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
+    assert_reported(
+        &unused,
+        "src/named.ts",
+        "namedBarrelOne",
+        "the entry names `named` only, not the rest of named.ts",
+    );
+
+    // The same chain through a rename hop: index.ts `export { renamed } from
+    // './rename-mid'`; rename-mid.ts `export { rn as renamed } from
+    // './rename-barrel'`; rename-barrel.ts `export * as rn from
+    // './rename-sub'`.
+    assert_credited(
+        &unused,
+        "src/rename-sub.ts",
+        "renameSubOne",
+        "`rn` reaches the entry as `renamed`",
+    );
+    assert_credited(
+        &unused,
+        "src/rename-deep.ts",
+        "renameDeepX",
+        "forwarded by rename-sub.ts's `export *`",
+    );
+    assert_reported(
+        &unused,
+        "src/rename-deep.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
 }
 
 #[test]

--- a/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
+++ b/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
@@ -1,0 +1,271 @@
+//! Issue #2373: an `export * as sub` on the entry-point surface (on the entry
+//! itself or on a barrel the entry reaches through plain `export *`) exposes
+//! sub's whole namespace object to consumers the graph cannot enumerate. The
+//! namespace re-export phase credited sub's direct exports, but neither sub's
+//! own `export *` sources nor its own `export * as sub2` sources, so the
+//! deeper levels of the chain were reported as unused.
+//!
+//! ES semantics apply exactly: a plain `export *` never forwards `default`, a
+//! namespace object exposes its target's `default`, and a namespace re-export
+//! off the entry surface with no consumer exposes nothing.
+
+use super::common::{create_config, fixture_path};
+use fallow_core::graph::{ExportSymbol, ModuleNode, ReferenceKind};
+
+const FIXTURE: &str = "issue-2373-entry-namespace-chain";
+
+fn module_named<'a>(modules: &'a [ModuleNode], suffix: &str) -> &'a ModuleNode {
+    modules
+        .iter()
+        .find(|m| {
+            m.path
+                .to_string_lossy()
+                .replace('\\', "/")
+                .ends_with(suffix)
+        })
+        .unwrap_or_else(|| panic!("{suffix} must be part of the module graph"))
+}
+
+fn export_named<'a>(module: &'a ModuleNode, name: &str) -> &'a ExportSymbol {
+    module
+        .exports
+        .iter()
+        .find(|e| e.name.matches_str(name))
+        .unwrap_or_else(|| panic!("{} must export `{name}`", module.path.display()))
+}
+
+fn unused_export_pairs(results: &fallow_core::results::AnalysisResults) -> Vec<(String, String)> {
+    results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.export.path.to_string_lossy().replace('\\', "/"),
+                e.export.export_name.clone(),
+            )
+        })
+        .collect()
+}
+
+fn is_reported(unused: &[(String, String)], path: &str, name: &str) -> bool {
+    unused.iter().any(|(p, n)| p.ends_with(path) && n == name)
+}
+
+fn assert_credited(unused: &[(String, String)], path: &str, name: &str, why: &str) {
+    assert!(
+        !is_reported(unused, path, name),
+        "{path}:{name} must be credited: {why}; unused exports: {unused:?}"
+    );
+}
+
+fn assert_reported(unused: &[(String, String)], path: &str, name: &str, why: &str) {
+    assert!(
+        is_reported(unused, path, name),
+        "{path}:{name} must keep reporting: {why}; unused exports: {unused:?}"
+    );
+}
+
+#[test]
+fn entry_namespace_chain_credits_nested_star_and_namespace_sources() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // index.ts `export * from './barrel'`; barrel.ts `export * as sub`: the
+    // entry surface forwards `sub`, whose namespace object exposes sub.ts's
+    // direct exports (credited before this fix), the named exports of its
+    // `export *` source, and every export of its `export * as sub2` source,
+    // recursively through sub2.ts's own `export *` and `export * as sub3`.
+    for name in ["subOne", "sub2", "default"] {
+        assert_credited(&unused, "src/sub.ts", name, "`sub` is on the entry surface");
+    }
+    assert_credited(
+        &unused,
+        "src/deep.ts",
+        "deepX",
+        "forwarded by sub.ts's `export *`",
+    );
+    for name in ["sub2X", "sub3", "default"] {
+        assert_credited(
+            &unused,
+            "src/sub2.ts",
+            name,
+            "`sub.sub2` is sub2.ts's namespace object",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/sub2-deep.ts",
+        "sub2DeepX",
+        "forwarded by sub2.ts's `export *`",
+    );
+    for name in ["sub3X", "default"] {
+        assert_credited(
+            &unused,
+            "src/sub3.ts",
+            name,
+            "`sub.sub2.sub3` is sub3.ts's namespace object",
+        );
+    }
+
+    // index.ts `export * as top from './top'`: the entry exposes top's
+    // namespace object directly, so top.ts's `export *` source is credited.
+    for name in ["topOne", "default"] {
+        assert_credited(
+            &unused,
+            "src/top.ts",
+            name,
+            "`top` is exposed by the entry point",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/top-deep.ts",
+        "topDeepX",
+        "forwarded by top.ts's `export *`",
+    );
+
+    // A plain `export *` never forwards `default`: the entry's star does not
+    // forward barrel.ts's default, and sub.ts's, sub2.ts's, and top.ts's
+    // stars do not forward their sources' defaults.
+    for path in [
+        "src/barrel.ts",
+        "src/deep.ts",
+        "src/sub2-deep.ts",
+        "src/top-deep.ts",
+    ] {
+        assert_reported(
+            &unused,
+            path,
+            "default",
+            "a plain `export *` never forwards `default`",
+        );
+    }
+}
+
+#[test]
+fn namespace_re_exports_off_the_entry_surface_expose_nothing() {
+    // Regression pin: shim.ts is reachable but not on the entry surface, and
+    // nothing consumes `hidden`, so hidden.ts and its chain keep reporting.
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    assert_credited(
+        &unused,
+        "src/shim.ts",
+        "shimOne",
+        "re-exported by name from the entry",
+    );
+    assert_reported(
+        &unused,
+        "src/shim.ts",
+        "hidden",
+        "no consumer observes the namespace",
+    );
+    for name in ["hiddenOne", "default"] {
+        assert_reported(
+            &unused,
+            "src/hidden.ts",
+            name,
+            "no consumer observes the namespace",
+        );
+    }
+    for name in ["hiddenDeepX", "default"] {
+        assert_reported(
+            &unused,
+            "src/hidden-deep.ts",
+            name,
+            "no consumer observes the namespace",
+        );
+    }
+}
+
+#[test]
+fn entry_star_chains_that_re_export_themselves_terminate() {
+    // Regression pin: index.ts `export * from './cycle-a'`; cycle-a.ts
+    // `export * as cycleNs from './cycle-b'`; cycle-b.ts `export * from
+    // './cycle-a'`. The closure terminates and the cycle stays fully credited.
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    assert_credited(
+        &unused,
+        "src/cycle-a.ts",
+        "cycleA",
+        "forwarded by the entry's `export *`",
+    );
+    for name in ["cycleB", "default"] {
+        assert_credited(
+            &unused,
+            "src/cycle-b.ts",
+            name,
+            "`cycleNs` is on the entry surface",
+        );
+    }
+}
+
+#[test]
+fn entry_namespace_credit_is_routed_through_the_chain() {
+    let output = fallow_core::analyze_with_trace(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let graph = output
+        .graph
+        .as_ref()
+        .expect("analyze_with_trace retains the graph");
+
+    // sub.ts's `export *` source is credited through sub.ts's star chain and
+    // its `export * as sub2` source through the namespace object sub.ts
+    // exposes; sub2.ts's own chain follows the same two rules.
+    let sub = module_named(&graph.modules, "src/sub.ts");
+    let deep_x = export_named(module_named(&graph.modules, "src/deep.ts"), "deepX");
+    assert!(
+        deep_x
+            .references
+            .iter()
+            .any(|r| r.kind == ReferenceKind::ReExport && r.from_file == sub.file_id),
+        "deepX must be credited through the sub.ts star chain, found {:?}",
+        deep_x
+            .references
+            .iter()
+            .map(|r| (r.kind, r.namespace, r.from_file))
+            .collect::<Vec<_>>()
+    );
+    let sub2 = module_named(&graph.modules, "src/sub2.ts");
+    for name in ["sub2X", "default"] {
+        let export = export_named(sub2, name);
+        assert!(
+            export
+                .references
+                .iter()
+                .any(|r| r.kind == ReferenceKind::NamespaceImport && r.from_file == sub.file_id),
+            "sub2.ts:{name} must be credited through the namespace object sub.ts exposes, \
+             found {:?}",
+            export
+                .references
+                .iter()
+                .map(|r| (r.kind, r.namespace, r.from_file))
+                .collect::<Vec<_>>()
+        );
+    }
+    let sub3_default = export_named(module_named(&graph.modules, "src/sub3.ts"), "default");
+    assert!(
+        sub3_default
+            .references
+            .iter()
+            .any(|r| r.kind == ReferenceKind::NamespaceImport && r.from_file == sub2.file_id),
+        "sub3.ts:default must be credited through the namespace object sub2.ts exposes, found {:?}",
+        sub3_default
+            .references
+            .iter()
+            .map(|r| (r.kind, r.namespace, r.from_file))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        export_named(module_named(&graph.modules, "src/deep.ts"), "default")
+            .references
+            .is_empty(),
+        "deep.ts:default is not part of sub.ts's `export *` surface"
+    );
+}

--- a/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
+++ b/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
@@ -431,3 +431,83 @@ fn a_locally_shadowed_star_name_does_not_carry_a_namespace_to_the_surface() {
         );
     }
 }
+
+#[test]
+fn a_plain_star_hop_does_not_carry_a_shadowed_or_ambiguous_namespace_to_the_surface() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // index.ts `export * from './star-shadow-barrel'`: sitting on the entry's
+    // plain-`export *` closure is not proof the name survives to the entry.
+    // star-shadow-barrel.ts declares its own `starShadowNs`, so the entry's
+    // `starShadowNs` is that number and the namespace object stops there.
+    for (path, name) in [
+        ("src/star-shadow-source.ts", "starShadowNs"),
+        ("src/star-shadow-target.ts", "starShadowTargetOne"),
+        ("src/star-shadow-deep.ts", "starShadowDeepX"),
+    ] {
+        assert_reported(
+            &unused,
+            path,
+            name,
+            "a local declaration shadows the star-forwarded name",
+        );
+    }
+
+    // index.ts `export * from './ambig-barrel'`, whose two stars both carry
+    // `ambigNs`: the name is ambiguous on the barrel, so neither namespace
+    // object reaches the entry surface.
+    for (path, name) in [
+        ("src/ambig-s1.ts", "ambigNs"),
+        ("src/ambig-s2.ts", "ambigNs"),
+        ("src/ambig-target1.ts", "ambigTarget1One"),
+        ("src/ambig-target2.ts", "ambigTarget2One"),
+        ("src/ambig-deep1.ts", "ambigDeep1X"),
+        ("src/ambig-deep2.ts", "ambigDeep2X"),
+    ] {
+        assert_reported(
+            &unused,
+            path,
+            name,
+            "two stars carry the same name onto the barrel",
+        );
+    }
+}
+
+#[test]
+fn an_entry_that_re_exports_a_namespace_binding_credits_its_chain() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // index.ts `import * as bindNs from './bind-barrel'` plus
+    // `export { bindNs }`: the namespace object is the entry point's public
+    // API, so bind-barrel.ts's own `export * as bindSub` chain follows.
+    for name in ["bindBarrelOne", "bindSub"] {
+        assert_credited(
+            &unused,
+            "src/bind-barrel.ts",
+            name,
+            "the entry point exports the namespace binding",
+        );
+    }
+    assert_credited(
+        &unused,
+        "src/bind-sub.ts",
+        "bindSubOne",
+        "`bindNs.bindSub` is bind-sub.ts's namespace object",
+    );
+    assert_credited(
+        &unused,
+        "src/bind-deep.ts",
+        "bindDeepX",
+        "forwarded by bind-sub.ts's `export *`",
+    );
+    assert_reported(
+        &unused,
+        "src/bind-deep.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
+}

--- a/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
+++ b/crates/core/tests/integration_test/issue_2373_entry_namespace_chain.rs
@@ -339,3 +339,95 @@ fn entry_namespace_credit_is_routed_through_the_chain() {
         "deep.ts:default is not part of sub.ts's `export *` surface"
     );
 }
+
+#[test]
+fn a_default_named_namespace_reaches_the_surface_only_through_the_entry_itself() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // index.ts `export * as default from './entry-default-sub'`: the entry
+    // point's own `default` is public API, so the chain behind it is credited.
+    assert_credited(
+        &unused,
+        "src/entry-default-sub.ts",
+        "entryDefaultSubOne",
+        "the entry point exposes its own `default`",
+    );
+    assert_credited(
+        &unused,
+        "src/entry-default-deep.ts",
+        "entryDefaultDeepX",
+        "forwarded by entry-default-sub.ts's `export *`",
+    );
+
+    // index.ts `export * from './star-default'`: the star leaves
+    // star-default.ts's `default` behind, so the namespace object it names is
+    // off the entry surface.
+    assert_credited(
+        &unused,
+        "src/star-default.ts",
+        "starDefaultOne",
+        "a plain `export *` forwards every named export",
+    );
+    assert_reported(
+        &unused,
+        "src/star-default.ts",
+        "default",
+        "a plain `export *` never forwards `default`",
+    );
+    for (path, name) in [
+        ("src/star-default-sub.ts", "starDefaultSubOne"),
+        ("src/star-default-deep.ts", "starDefaultDeepX"),
+    ] {
+        assert_reported(
+            &unused,
+            path,
+            name,
+            "the `default` namespace object never reaches the entry surface",
+        );
+    }
+
+    // index.ts `export * from './named-default-mid'`, whose named re-export
+    // renames the namespace to `default`: the same star drops it again.
+    assert_reported(
+        &unused,
+        "src/named-default-barrel.ts",
+        "defaultNs",
+        "the rename lands on a `default` the entry's star does not forward",
+    );
+    for (path, name) in [
+        ("src/named-default-sub.ts", "namedDefaultSubOne"),
+        ("src/named-default-deep.ts", "namedDefaultDeepX"),
+    ] {
+        assert_reported(
+            &unused,
+            path,
+            name,
+            "nothing behind the renamed `default` namespace object is reachable",
+        );
+    }
+}
+
+#[test]
+fn a_locally_shadowed_star_name_does_not_carry_a_namespace_to_the_surface() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused = unused_export_pairs(&results);
+
+    // shadow-barrel.ts declares its own `shadowNs`, which shadows the one
+    // shadow-source.ts star-forwards, so the entry's `shadowNs` is that number
+    // and shadow-target.ts's namespace object is unreachable.
+    for (path, name) in [
+        ("src/shadow-source.ts", "shadowNs"),
+        ("src/shadow-target.ts", "shadowTargetOne"),
+        ("src/shadow-deep.ts", "shadowDeepX"),
+    ] {
+        assert_reported(
+            &unused,
+            path,
+            name,
+            "a local declaration shadows the star-forwarded name",
+        );
+    }
+}

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -144,7 +144,16 @@ pub use store::GraphCacheStore;
 /// caches carry the old empty accessed-members verdict for those consumers, so
 /// exports rendered only in Astro or MDX markup would stay reported as unused
 /// on upgrade.
-pub const GRAPH_CACHE_VERSION: u32 = 38;
+///
+/// Bumped to 39 for issues #2372 and #2373: a consumer that observes a whole
+/// namespace object (a whole-object namespace use, a dynamic-import pattern
+/// match) and an `export * as ns` chain on the entry-point surface now credit
+/// the names the target only exposes through its own `export *` and
+/// `export * as` chains, and those references are baked into the persisted
+/// graph. Warm 38 caches carry only the direct-export credit, so the
+/// star-forwarded and nested-namespace exports would stay reported as unused
+/// on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 39;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -146,13 +146,17 @@ pub use store::GraphCacheStore;
 /// on upgrade.
 ///
 /// Bumped to 39 for issues #2372 and #2373: a consumer that observes a whole
-/// namespace object (a whole-object namespace use, a dynamic-import pattern
-/// match) and an `export * as ns` chain on the entry-point surface now credit
-/// the names the target only exposes through its own `export *` and
-/// `export * as` chains, and those references are baked into the persisted
-/// graph. Warm 38 caches carry only the direct-export credit, so the
-/// star-forwarded and nested-namespace exports would stay reported as unused
-/// on upgrade.
+/// namespace object (a whole-object namespace use of an `import * as` or of an
+/// `export * as` binding imported by name, a dynamic-import pattern match) and
+/// an `export * as ns` chain an entry point exposes now credit the names the
+/// target only exposes through its own `export *` and `export * as` chains,
+/// and those references are baked into the persisted graph. Warm 38 caches
+/// carry only the direct-export credit, so the star-forwarded and
+/// nested-namespace exports would stay reported as unused on upgrade. The same
+/// version covers the one direction that moves the other way: a plain
+/// `export *` hop no longer carries a downstream `export * as default` onward,
+/// so a chain behind such a namespace object can report one finding more than
+/// a warm 38 cache holds.
 pub const GRAPH_CACHE_VERSION: u32 = 39;
 
 /// Cached form of a resolved target.

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -419,12 +419,17 @@ impl ModuleGraph {
     /// Walks every edge and attaches `SymbolReference` entries to the target
     /// module's exports. Includes namespace import narrowing (member access
     /// tracking) and CSS Module default-import narrowing.
+    ///
+    /// Returns the targets whose whole namespace object a consumer observed
+    /// (the seeds of `ModuleGraph::collect_exposed_namespace_targets`), so the
+    /// namespace re-export and star propagation phases can credit the names
+    /// those targets only expose through their own re-export chains.
     pub(super) fn populate_references(
         &mut self,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
         entry_point_ids: &FxHashSet<FileId>,
         reference_paths: &mut ReferencePathInterner,
-    ) {
+    ) -> FxHashSet<FileId> {
         // Both maps are transient acceleration state for this pass: the name
         // index gives O(1) export lookup per imported symbol instead of a scan
         // over all target exports, and the dedup index keeps duplicate-
@@ -432,6 +437,7 @@ impl ModuleGraph {
         // keeps `references` as the only durable storage.
         let mut dedup = ReferenceDedup::default();
         let mut export_indices: FxHashMap<usize, ExportNameIndex> = FxHashMap::default();
+        let mut whole_module_targets: FxHashSet<FileId> = FxHashSet::default();
         for edge_idx in 0..self.edges.len() {
             let source_id = self.edges[edge_idx].source;
             let target_id = self.edges[edge_idx].target;
@@ -464,10 +470,12 @@ impl ModuleGraph {
                         export_index,
                         effective_exports: &self.effective_exports,
                         dedup: &mut dedup,
+                        whole_module_targets: &mut whole_module_targets,
                     },
                 );
             }
         }
+        whole_module_targets
     }
 }
 

--- a/crates/graph/src/graph/build.rs
+++ b/crates/graph/src/graph/build.rs
@@ -429,7 +429,7 @@ impl ModuleGraph {
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
         entry_point_ids: &FxHashSet<FileId>,
         reference_paths: &mut ReferencePathInterner,
-    ) -> FxHashSet<FileId> {
+    ) -> super::re_exports::WholeModuleObservations {
         // Both maps are transient acceleration state for this pass: the name
         // index gives O(1) export lookup per imported symbol instead of a scan
         // over all target exports, and the dedup index keeps duplicate-
@@ -437,7 +437,7 @@ impl ModuleGraph {
         // keeps `references` as the only durable storage.
         let mut dedup = ReferenceDedup::default();
         let mut export_indices: FxHashMap<usize, ExportNameIndex> = FxHashMap::default();
-        let mut whole_module_targets: FxHashSet<FileId> = FxHashSet::default();
+        let mut whole_module_targets = super::re_exports::WholeModuleObservations::default();
         for edge_idx in 0..self.edges.len() {
             let source_id = self.edges[edge_idx].source;
             let target_id = self.edges[edge_idx].target;

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -549,6 +549,7 @@ fn propagate_namespace_references(
     graph: &mut ModuleGraph,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     features: build::NamespaceFeatures,
+    whole_module_targets: &FxHashSet<FileId>,
     reference_paths: &mut ReferencePathInterner,
 ) {
     let indexes = namespace_indexes::NamespacePropagationIndexes::new(graph, module_by_id);
@@ -561,7 +562,12 @@ fn propagate_namespace_references(
         );
     }
     if features.has_re_exports {
-        namespace_re_exports::propagate_namespace_re_exports(graph, &indexes, reference_paths);
+        namespace_re_exports::propagate_namespace_re_exports(
+            graph,
+            &indexes,
+            whole_module_targets,
+            reference_paths,
+        );
     }
 }
 
@@ -671,13 +677,15 @@ impl ModuleGraph {
 
         let mut reference_paths =
             ReferencePathInterner::new(test_reachability_plan.requires_reference_provenance());
-        graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
+        let whole_module_targets =
+            graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
 
         if namespace_features.has_aliases || namespace_features.has_re_exports {
             propagate_namespace_references(
                 &mut graph,
                 &module_by_id,
                 namespace_features,
+                &whole_module_targets,
                 &mut reference_paths,
             );
         }
@@ -689,8 +697,11 @@ impl ModuleGraph {
             total_capacity,
         );
 
-        graph.re_export_cycles =
-            graph.resolve_re_export_chains(&module_by_id, &mut reference_paths);
+        graph.re_export_cycles = graph.resolve_re_export_chains(
+            &module_by_id,
+            &whole_module_targets,
+            &mut reference_paths,
+        );
         let finalized_paths = reference_paths.finalize(&mut graph.modules);
         graph.reference_paths = finalized_paths.paths;
         graph.reference_routes = finalized_paths.routes;

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -684,8 +684,11 @@ impl ModuleGraph {
         // namespace closure needs it to stay off modules the report already
         // calls unused files.
         let entry_reachable = graph.collect_reachable(&entry_point_ids, total_capacity);
-        let exposed_namespace_targets =
-            graph.collect_exposed_namespace_targets(&whole_module_targets, &entry_reachable);
+        let exposed_namespace_targets = graph.collect_exposed_namespace_targets(
+            &whole_module_targets,
+            &entry_reachable,
+            &module_by_id,
+        );
 
         if namespace_features.has_aliases || namespace_features.has_re_exports {
             propagate_namespace_references(

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -549,7 +549,7 @@ fn propagate_namespace_references(
     graph: &mut ModuleGraph,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     features: build::NamespaceFeatures,
-    exposed_namespace_targets: &FxHashSet<FileId>,
+    exposed_namespace_targets: &re_exports::ExposedNamespaceTargets,
     reference_paths: &mut ReferencePathInterner,
 ) {
     let indexes = namespace_indexes::NamespacePropagationIndexes::new(graph, module_by_id);
@@ -679,8 +679,13 @@ impl ModuleGraph {
             ReferencePathInterner::new(test_reachability_plan.requires_reference_provenance());
         let whole_module_targets =
             graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
+        // Entry-point reachability depends on edges alone, so it is available
+        // here and is reused verbatim by `mark_reachable` below. The exposed
+        // namespace closure needs it to stay off modules the report already
+        // calls unused files.
+        let entry_reachable = graph.collect_reachable(&entry_point_ids, total_capacity);
         let exposed_namespace_targets =
-            graph.collect_exposed_namespace_targets(&whole_module_targets);
+            graph.collect_exposed_namespace_targets(&whole_module_targets, &entry_reachable);
 
         if namespace_features.has_aliases || namespace_features.has_re_exports {
             propagate_namespace_references(
@@ -693,6 +698,7 @@ impl ModuleGraph {
         }
 
         graph.mark_reachable(
+            &entry_reachable,
             &entry_point_ids,
             &runtime_entry_point_ids,
             test_reachability_plan,

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -549,7 +549,7 @@ fn propagate_namespace_references(
     graph: &mut ModuleGraph,
     module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     features: build::NamespaceFeatures,
-    whole_module_targets: &FxHashSet<FileId>,
+    exposed_namespace_targets: &FxHashSet<FileId>,
     reference_paths: &mut ReferencePathInterner,
 ) {
     let indexes = namespace_indexes::NamespacePropagationIndexes::new(graph, module_by_id);
@@ -565,7 +565,7 @@ fn propagate_namespace_references(
         namespace_re_exports::propagate_namespace_re_exports(
             graph,
             &indexes,
-            whole_module_targets,
+            exposed_namespace_targets,
             reference_paths,
         );
     }
@@ -679,13 +679,15 @@ impl ModuleGraph {
             ReferencePathInterner::new(test_reachability_plan.requires_reference_provenance());
         let whole_module_targets =
             graph.populate_references(&module_by_id, &entry_point_ids, &mut reference_paths);
+        let exposed_namespace_targets =
+            graph.collect_exposed_namespace_targets(&whole_module_targets);
 
         if namespace_features.has_aliases || namespace_features.has_re_exports {
             propagate_namespace_references(
                 &mut graph,
                 &module_by_id,
                 namespace_features,
-                &whole_module_targets,
+                &exposed_namespace_targets,
                 &mut reference_paths,
             );
         }
@@ -699,7 +701,7 @@ impl ModuleGraph {
 
         graph.re_export_cycles = graph.resolve_re_export_chains(
             &module_by_id,
-            &whole_module_targets,
+            &exposed_namespace_targets,
             &mut reference_paths,
         );
         let finalized_paths = reference_paths.finalize(&mut graph.modules);

--- a/crates/graph/src/graph/namespace_indexes.rs
+++ b/crates/graph/src/graph/namespace_indexes.rs
@@ -446,7 +446,16 @@ fn consumer_import_namespaces(
     namespaces
 }
 
-fn uniquely_forwards_binding(
+/// Whether `barrel_file` re-exports under `barrel_name`, in `namespace`, the
+/// very binding `source_file` exports under `source_name`.
+///
+/// A local declaration on the barrel, or the same name arriving from two stars
+/// at once, resolves to a different binding and the name never travels
+/// further. Phase 2c walks with this per namespace edge, and the exposed
+/// namespace closure's own outward search calls it through
+/// `ModuleGraph::forwards_binding`, so both agree on every hop by
+/// construction.
+pub(super) fn uniquely_forwards_binding(
     graph: &ModuleGraph,
     source_file: FileId,
     source_name: &str,

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -23,10 +23,12 @@
 //! Whole-object uses (`Object.values(Foo)`, spread, destructure-with-rest)
 //! credit every target export. Barrels that expose the namespace through an
 //! entry point also credit every target export, mirroring the entry-point
-//! semantics of `propagate_entry_point_star`, as do barrels an ambient-module
-//! star re-export reaches (`ModuleGraph::collect_ambient_star_targets`, issue
-//! #2357): the declared module name exposes the namespace object to consumers
-//! the graph cannot enumerate.
+//! semantics of `propagate_entry_point_star`, as does every member of the
+//! exposed namespace closure (`ModuleGraph::collect_exposed_namespace_targets`,
+//! issues #2357, #2372, #2373): a barrel whose whole namespace object reaches
+//! consumers the graph cannot enumerate, through an ambient-module star, a
+//! dynamic-import pattern, a whole-object namespace use, or an `export * as`
+//! chain on the entry-point surface.
 //!
 //! Runs after Phase 2b (cross-package alias propagation) and before Phase 3
 //! (reachability) so credits attached here participate in reachability and
@@ -72,9 +74,13 @@ struct PendingCredit {
 }
 
 /// Phase 2c: credit `export * as Foo from './bar'` member accesses onto `./bar`.
+///
+/// `whole_module_targets` are the targets whose whole namespace object Phase 2
+/// observed; they seed the exposed namespace closure.
 pub(super) fn propagate_namespace_re_exports(
     graph: &mut ModuleGraph,
     indexes: &NamespacePropagationIndexes<'_>,
+    whole_module_targets: &FxHashSet<FileId>,
     reference_paths: &mut ReferencePathInterner,
 ) {
     let ns_edges: Vec<(FileId, FileId, String, bool)> = graph
@@ -102,8 +108,8 @@ pub(super) fn propagate_namespace_re_exports(
     }
 
     let mut pending: Vec<PendingCredit> = Vec::new();
-    let ambient_star_targets = graph.collect_ambient_star_targets();
-    let credits_unseen_consumers = !ambient_star_targets.is_empty()
+    let exposed_namespace_targets = graph.collect_exposed_namespace_targets(whole_module_targets);
+    let credits_unseen_consumers = !exposed_namespace_targets.is_empty()
         || graph
             .modules
             .iter()
@@ -136,7 +142,7 @@ pub(super) fn propagate_namespace_re_exports(
             );
 
             for export in reachable.iter().filter(|export| {
-                exposes_namespace_object(graph, &ambient_star_targets, export.file_id)
+                exposes_namespace_object(graph, &exposed_namespace_targets, export.file_id)
             }) {
                 let path = routes.entry_path(export, reference_paths);
                 pending.push(PendingCredit {
@@ -163,16 +169,16 @@ pub(super) fn propagate_namespace_re_exports(
 }
 
 /// Whether a barrel hands its namespace re-export to consumers the graph
-/// cannot enumerate: an entry point, or a member of the ambient star closure
-/// (issue #2357), whose every export is reachable through a declared module
-/// name. Both credit every export of the namespace target, `default`
-/// included, because the namespace object exposes it.
+/// cannot enumerate: an entry point, or a member of the exposed namespace
+/// closure (issues #2357, #2372, #2373), whose whole namespace object some
+/// consumer observes. Both credit every export of the namespace target,
+/// `default` included, because the namespace object exposes it.
 fn exposes_namespace_object(
     graph: &ModuleGraph,
-    ambient_star_targets: &FxHashSet<FileId>,
+    exposed_namespace_targets: &FxHashSet<FileId>,
     file_id: FileId,
 ) -> bool {
-    ambient_star_targets.contains(&file_id)
+    exposed_namespace_targets.contains(&file_id)
         || graph
             .modules
             .get(file_id.0 as usize)

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -34,7 +34,7 @@
 //! (reachability) so credits attached here participate in reachability and
 //! Phase 4 chain propagation downstream. See issue #324.
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use super::namespace_indexes::{
     NamespacePropagationIndexes, NamespaceReferenceRoutes, ReachableNamespaceExports,
@@ -44,6 +44,7 @@ use super::narrowing::{
     create_synthetic_exports_for_star_re_exports_at_site, mark_all_exports_referenced_at_site,
     mark_member_exports_referenced_at_site,
 };
+use super::re_exports::ExposedNamespaceTargets;
 use super::types::{ReferenceKind, ReferencePathId, ReferencePathInterner};
 use super::{ExportNamespace, ModuleGraph};
 use fallow_types::discover::FileId;
@@ -81,7 +82,7 @@ struct PendingCredit {
 pub(super) fn propagate_namespace_re_exports(
     graph: &mut ModuleGraph,
     indexes: &NamespacePropagationIndexes<'_>,
-    exposed_namespace_targets: &FxHashSet<FileId>,
+    exposed_namespace_targets: &ExposedNamespaceTargets,
     reference_paths: &mut ReferencePathInterner,
 ) {
     let ns_edges: Vec<(FileId, FileId, String, bool)> = graph
@@ -142,7 +143,12 @@ pub(super) fn propagate_namespace_re_exports(
             );
 
             for export in reachable.iter().filter(|export| {
-                exposes_namespace_object(graph, exposed_namespace_targets, export.file_id)
+                exposes_namespace_object(
+                    graph,
+                    exposed_namespace_targets,
+                    export.file_id,
+                    &export.exported_name,
+                )
             }) {
                 let path = routes.entry_path(export, reference_paths);
                 pending.push(PendingCredit {
@@ -168,17 +174,23 @@ pub(super) fn propagate_namespace_re_exports(
     apply_pending_credits(graph, &pending);
 }
 
-/// Whether a barrel hands its namespace re-export to consumers the graph
-/// cannot enumerate: an entry point, or a member of the exposed namespace
-/// closure (issues #2357, #2372, #2373), whose whole namespace object some
-/// consumer observes. Both credit every export of the namespace target,
-/// `default` included, because the namespace object exposes it.
+/// Whether a barrel hands the namespace re-export it exports under
+/// `exported_name` to consumers the graph cannot enumerate: an entry point, or
+/// a member of the exposed namespace closure (issues #2357, #2372, #2373)
+/// whose whole namespace object some consumer observes. Both credit every
+/// export of the namespace target, `default` included, because the namespace
+/// object exposes it.
+///
+/// The name matters for a closure member reached through a plain `export *`:
+/// that star never forwarded the member's `default`, so an
+/// `export * as default` on it reaches nobody.
 fn exposes_namespace_object(
     graph: &ModuleGraph,
-    exposed_namespace_targets: &FxHashSet<FileId>,
+    exposed_namespace_targets: &ExposedNamespaceTargets,
     file_id: FileId,
+    exported_name: &str,
 ) -> bool {
-    exposed_namespace_targets.contains(&file_id)
+    exposed_namespace_targets.exposes_name(file_id, exported_name)
         || graph
             .modules
             .get(file_id.0 as usize)
@@ -339,6 +351,8 @@ struct GroupState {
 
 #[cfg(test)]
 mod tests {
+    use rustc_hash::FxHashSet;
+
     use super::*;
     use crate::graph::ModuleGraph;
     use crate::resolve::{

--- a/crates/graph/src/graph/namespace_re_exports.rs
+++ b/crates/graph/src/graph/namespace_re_exports.rs
@@ -75,12 +75,13 @@ struct PendingCredit {
 
 /// Phase 2c: credit `export * as Foo from './bar'` member accesses onto `./bar`.
 ///
-/// `whole_module_targets` are the targets whose whole namespace object Phase 2
-/// observed; they seed the exposed namespace closure.
+/// `exposed_namespace_targets` is the exposed namespace closure
+/// (`ModuleGraph::collect_exposed_namespace_targets`), computed once per build
+/// and shared with Phase 4.
 pub(super) fn propagate_namespace_re_exports(
     graph: &mut ModuleGraph,
     indexes: &NamespacePropagationIndexes<'_>,
-    whole_module_targets: &FxHashSet<FileId>,
+    exposed_namespace_targets: &FxHashSet<FileId>,
     reference_paths: &mut ReferencePathInterner,
 ) {
     let ns_edges: Vec<(FileId, FileId, String, bool)> = graph
@@ -108,7 +109,6 @@ pub(super) fn propagate_namespace_re_exports(
     }
 
     let mut pending: Vec<PendingCredit> = Vec::new();
-    let exposed_namespace_targets = graph.collect_exposed_namespace_targets(whole_module_targets);
     let credits_unseen_consumers = !exposed_namespace_targets.is_empty()
         || graph
             .modules
@@ -142,7 +142,7 @@ pub(super) fn propagate_namespace_re_exports(
             );
 
             for export in reachable.iter().filter(|export| {
-                exposes_namespace_object(graph, &exposed_namespace_targets, export.file_id)
+                exposes_namespace_object(graph, exposed_namespace_targets, export.file_id)
             }) {
                 let path = routes.entry_path(export, reference_paths);
                 pending.push(PendingCredit {

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -57,6 +57,13 @@ pub(super) struct AttachContext<'a> {
     pub(super) export_index: &'a ExportNameIndex,
     pub(super) effective_exports: &'a super::effective_exports::EffectiveExportIndex,
     pub(super) dedup: &'a mut ReferenceDedup,
+    /// Targets whose whole namespace object a consumer observed in this pass
+    /// (issues #2357, #2372, #2373): every site that credits all exports of a
+    /// namespace target instead of narrowing to accessed members. Seeds
+    /// `ModuleGraph::collect_exposed_namespace_targets`, which extends the
+    /// credit to the names the target only exposes through its own `export *`
+    /// and `export * as ns` chains.
+    pub(super) whole_module_targets: &'a mut FxHashSet<FileId>,
 }
 
 impl AttachContext<'_> {
@@ -67,6 +74,7 @@ impl AttachContext<'_> {
             export_index: self.export_index,
             effective_exports: self.effective_exports,
             dedup: self.dedup,
+            whole_module_targets: self.whole_module_targets,
         }
     }
 }
@@ -458,6 +466,19 @@ fn narrow_namespace_references(
         && !is_whole_object
         && ctx.entry_point_ids.contains(&site.from_file);
 
+    // The consumer observes the whole namespace object (a whole-object use,
+    // no member access the graph can narrow to, or a binding re-exported to
+    // consumers it cannot enumerate): every name on the object is credited,
+    // including the names the target only exposes through its own `export *`
+    // and `export * as ns` chains, which the exposed-namespace closure
+    // handles downstream (issue #2372).
+    let observes_whole_module = is_whole_object
+        || (!is_entry_with_no_access
+            && (accessed_members.is_empty() || is_re_exported_from_non_entry));
+    if observes_whole_module {
+        ctx.whole_module_targets.insert(module.file_id);
+    }
+
     for (namespace, is_used) in [
         (ExportNamespace::Type, namespaces.0),
         (ExportNamespace::Value, namespaces.1),
@@ -473,10 +494,7 @@ fn narrow_namespace_references(
             effective_exports: ctx.effective_exports,
             dedup: ctx.dedup,
         };
-        if is_whole_object
-            || (!is_entry_with_no_access
-                && (accessed_members.is_empty() || is_re_exported_from_non_entry))
-        {
+        if observes_whole_module {
             mark_all_exports_referenced_at_site(&mut module.exports, &mut mark);
         } else {
             let found_members = mark_member_exports_referenced_at_site(
@@ -745,6 +763,10 @@ pub(super) fn attach_symbol_reference(
             // (issue #2357), which forwards the ES star surface: every named
             // export and never `default`. The `export * as ns` form records
             // the namespace object's `default` member as a separate import.
+            // Both observe the whole module, so the target's own `export *`
+            // and `export * as ns` chains are credited downstream through the
+            // exposed-namespace closure (issue #2372 for the runtime form).
+            ctx.whole_module_targets.insert(target_module.file_id);
             let namespaces = desired_import_namespaces(sym, source_mod).namespaces();
             for (namespace, is_used) in [
                 (ExportNamespace::Type, namespaces.0),

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -59,10 +59,11 @@ pub(super) struct AttachContext<'a> {
     pub(super) dedup: &'a mut ReferenceDedup,
     /// Targets whose whole namespace object a consumer observed in this pass
     /// (issues #2357, #2372, #2373): every site that credits all exports of a
-    /// namespace target instead of narrowing to accessed members. Seeds
-    /// `ModuleGraph::collect_exposed_namespace_targets`, which extends the
-    /// credit to the names the target only exposes through its own `export *`
-    /// and `export * as ns` chains.
+    /// namespace target instead of narrowing to accessed members, except a
+    /// binding the namespace-object alias phase narrows on the consumer's
+    /// behalf. Seeds `ModuleGraph::collect_exposed_namespace_targets`, which
+    /// extends the credit to the names the target only exposes through its
+    /// own `export *` and `export * as ns` chains.
     pub(super) whole_module_targets: &'a mut FxHashSet<FileId>,
 }
 
@@ -471,11 +472,20 @@ fn narrow_namespace_references(
     // consumers it cannot enumerate): every name on the object is credited,
     // including the names the target only exposes through its own `export *`
     // and `export * as ns` chains, which the exposed-namespace closure
-    // handles downstream (issue #2372).
+    // handles downstream (issue #2372). A binding placed in an exported
+    // object literal (`export const API = { ns }`) keeps the direct-export
+    // credit but never seeds that closure: the namespace-object alias phase
+    // follows `API.ns.<member>` accesses precisely, so the chain behind it
+    // stays narrowed unless the binding is also used as a whole object.
     let observes_whole_module = is_whole_object
         || (!is_entry_with_no_access
             && (accessed_members.is_empty() || is_re_exported_from_non_entry));
-    if observes_whole_module {
+    let is_alias_source = source_mod.is_some_and(|m| {
+        m.namespace_object_aliases
+            .iter()
+            .any(|alias| alias.namespace_local == sym_local_name)
+    });
+    if observes_whole_module && (is_whole_object || !is_alias_source) {
         ctx.whole_module_targets.insert(module.file_id);
     }
 

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -68,6 +68,17 @@ pub(super) struct AttachContext<'a> {
 }
 
 impl AttachContext<'_> {
+    /// Record that a consumer observed `target`'s whole namespace object.
+    ///
+    /// Every namespace mark-all site must call this so the exposed namespace
+    /// closure sees the same seed set the marks credited; the one deliberate
+    /// exception is a binding the namespace-object alias phase narrows on the
+    /// consumer's behalf. The seed is namespace-agnostic on purpose: the
+    /// object exposes the same names in the type and value namespaces.
+    fn observe_whole_namespace_object(&mut self, target: FileId) {
+        self.whole_module_targets.insert(target);
+    }
+
     fn reborrow(&mut self) -> AttachContext<'_> {
         AttachContext {
             module_by_id: self.module_by_id,
@@ -480,13 +491,15 @@ fn narrow_namespace_references(
     let observes_whole_module = is_whole_object
         || (!is_entry_with_no_access
             && (accessed_members.is_empty() || is_re_exported_from_non_entry));
-    let is_alias_source = source_mod.is_some_and(|m| {
-        m.namespace_object_aliases
-            .iter()
-            .any(|alias| alias.namespace_local == sym_local_name)
-    });
-    if observes_whole_module && (is_whole_object || !is_alias_source) {
-        ctx.whole_module_targets.insert(module.file_id);
+    let is_alias_source = || {
+        source_mod.is_some_and(|m| {
+            m.namespace_object_aliases
+                .iter()
+                .any(|alias| alias.namespace_local == sym_local_name)
+        })
+    };
+    if observes_whole_module && (is_whole_object || !is_alias_source()) {
+        ctx.observe_whole_namespace_object(module.file_id);
     }
 
     for (namespace, is_used) in [
@@ -776,7 +789,7 @@ pub(super) fn attach_symbol_reference(
             // Both observe the whole module, so the target's own `export *`
             // and `export * as ns` chains are credited downstream through the
             // exposed-namespace closure (issue #2372 for the runtime form).
-            ctx.whole_module_targets.insert(target_module.file_id);
+            ctx.observe_whole_namespace_object(target_module.file_id);
             let namespaces = desired_import_namespaces(sym, source_mod).namespaces();
             for (namespace, is_used) in [
                 (ExportNamespace::Type, namespaces.0),

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -64,19 +64,33 @@ pub(super) struct AttachContext<'a> {
     /// behalf. Seeds `ModuleGraph::collect_exposed_namespace_targets`, which
     /// extends the credit to the names the target only exposes through its
     /// own `export *` and `export * as ns` chains.
-    pub(super) whole_module_targets: &'a mut FxHashSet<FileId>,
+    pub(super) whole_module_targets: &'a mut super::re_exports::WholeModuleObservations,
 }
 
 impl AttachContext<'_> {
-    /// Record that a consumer observed `target`'s whole namespace object.
+    /// Record that a consumer in this graph observed `target`'s whole
+    /// namespace object.
     ///
-    /// Every namespace mark-all site must call this so the exposed namespace
-    /// closure sees the same seed set the marks credited; the one deliberate
-    /// exception is a binding the namespace-object alias phase narrows on the
-    /// consumer's behalf. The seed is namespace-agnostic on purpose: the
-    /// object exposes the same names in the type and value namespaces.
+    /// Every namespace mark-all site must call this or
+    /// [`AttachContext::observe_ambient_namespace_object`] so the exposed
+    /// namespace closure sees the same seed set the marks credited; the one
+    /// deliberate exception is a binding the namespace-object alias phase
+    /// narrows on the consumer's behalf. The seed is namespace-agnostic on
+    /// purpose: the object exposes the same names in the type and value
+    /// namespaces, and `typeof ns.member` keeps a value declaration reachable
+    /// through a type-only observation.
     fn observe_whole_namespace_object(&mut self, target: FileId) {
-        self.whole_module_targets.insert(target);
+        self.whole_module_targets.observe(target);
+    }
+
+    /// Record that an ambient `declare module '...'` body re-exports every
+    /// name of `target` under an external module id (issue #2357).
+    ///
+    /// Separate from [`AttachContext::observe_whole_namespace_object`]
+    /// because the observers live outside this graph: the seed stands however
+    /// the shim and the target sit in it.
+    fn observe_ambient_namespace_object(&mut self, target: FileId) {
+        self.whole_module_targets.observe_ambient(target);
     }
 
     fn reborrow(&mut self) -> AttachContext<'_> {
@@ -793,7 +807,14 @@ pub(super) fn attach_symbol_reference(
             // Both observe the whole module, so the target's own `export *`
             // and `export * as ns` chains are credited downstream through the
             // exposed-namespace closure (issue #2372 for the runtime form).
-            ctx.observe_whole_namespace_object(target_module.file_id);
+            // The ambient form seeds that closure at any reachability: its
+            // observers are importers of the declared module id, not files in
+            // this graph.
+            if sym.is_ambient_star() {
+                ctx.observe_ambient_namespace_object(target_module.file_id);
+            } else {
+                ctx.observe_whole_namespace_object(target_module.file_id);
+            }
             let namespaces = desired_import_namespaces(sym, source_mod).namespaces();
             for (namespace, is_used) in [
                 (ExportNamespace::Type, namespaces.0),

--- a/crates/graph/src/graph/narrowing.rs
+++ b/crates/graph/src/graph/narrowing.rs
@@ -468,14 +468,18 @@ fn narrow_namespace_references(
     let is_whole_object =
         source_mod.is_some_and(|m| m.whole_object_uses.iter().any(|n| n == sym_local_name));
 
-    let is_re_exported_from_non_entry = source_mod.is_some_and(|m| {
+    // `export { ns }` hands the namespace object itself to consumers the graph
+    // cannot enumerate, on an entry point as much as on any other module: the
+    // binding is the public API there (issue #2373).
+    let is_re_exported = source_mod.is_some_and(|m| {
         m.exports
             .iter()
             .any(|e| e.local_name.as_deref() == Some(sym_local_name))
-    }) && !ctx.entry_point_ids.contains(&site.from_file);
+    });
 
     let is_entry_with_no_access = accessed_members.is_empty()
         && !is_whole_object
+        && !is_re_exported
         && ctx.entry_point_ids.contains(&site.from_file);
 
     // The consumer observes the whole namespace object (a whole-object use,
@@ -487,10 +491,10 @@ fn narrow_namespace_references(
     // object literal (`export const API = { ns }`) keeps the direct-export
     // credit but never seeds that closure: the namespace-object alias phase
     // follows `API.ns.<member>` accesses precisely, so the chain behind it
-    // stays narrowed unless the binding is also used as a whole object.
+    // stays narrowed unless the binding is also used as a whole object or
+    // exported under its own name.
     let observes_whole_module = is_whole_object
-        || (!is_entry_with_no_access
-            && (accessed_members.is_empty() || is_re_exported_from_non_entry));
+        || (!is_entry_with_no_access && (accessed_members.is_empty() || is_re_exported));
     let is_alias_source = || {
         source_mod.is_some_and(|m| {
             m.namespace_object_aliases
@@ -498,7 +502,7 @@ fn narrow_namespace_references(
                 .any(|alias| alias.namespace_local == sym_local_name)
         })
     };
-    if observes_whole_module && (is_whole_object || !is_alias_source()) {
+    if observes_whole_module && (is_whole_object || is_re_exported || !is_alias_source()) {
         ctx.observe_whole_namespace_object(module.file_id);
     }
 

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -200,24 +200,13 @@ struct NameForwarders<'a> {
     stars: FxHashMap<FileId, Vec<FileId>>,
 }
 
-/// What [`NameForwarders::reaches_surface`] measures a state against.
-struct SurfaceReach {
-    /// Entry points plus every barrel they reach through plain `export *`.
-    star_surface: FxHashSet<FileId>,
-    /// Every module some star-surface module re-exports from, transitively,
-    /// names ignored.
-    ///
-    /// A name can only travel from a module to the entry surface along
-    /// forwarding edges, so a module outside this set answers the search in
-    /// constant time however deep its own chains run.
-    may_reach: FxHashSet<FileId>,
-}
-
-/// Reusable state for [`NameForwarders::reaches_surface`].
+/// Reusable state for [`ExposedNameSearch::reaches_exposure`].
 ///
-/// `failed` outlives a single search: an exhausted search proves that every
-/// state it visited fails too, so a forwarding chain shared by many namespace
-/// edges is walked once instead of once per edge.
+/// `failed` outlives a single search within one round: an exhausted search
+/// proves that every state it visited fails too, so a forwarding chain shared
+/// by many namespace edges is walked once instead of once per edge. A round
+/// that widens the closure clears it, because a state that failed against the
+/// smaller closure can succeed against the wider one.
 #[derive(Default)]
 struct NameSearchScratch<'a> {
     visited: FxHashSet<(FileId, &'a str)>,
@@ -248,39 +237,128 @@ impl<'a> NameForwarders<'a> {
         }
         Self { named, stars }
     }
+}
 
-    /// Whether `name`, as exported by `file`, reaches the entry point's own
-    /// export surface through named and plain-star re-exports.
+/// The outward search that decides whether one `export * as ns` edge hands its
+/// target's namespace object to consumers the graph cannot enumerate.
+///
+/// A name reaches such a consumer when it arrives, through named and plain-star
+/// re-exports, at an entry point's own export surface, at a module already in
+/// the exposed namespace closure, or at a name some importer uses as a whole
+/// object. The three are the same three decisions Phase 2c makes for the
+/// namespace edges it credits, so seeding from them keeps the closure and
+/// Phase 2c from disagreeing about which objects are observed.
+struct ExposedNameSearch<'a> {
+    forwarders: NameForwarders<'a>,
+    /// Per target file, the imported names whose local binding some importer
+    /// uses as a whole object (`Object.values(ns)`, a spread, a
+    /// destructure-with-rest). Named imports only: a namespace import is
+    /// already a `whole_module_targets` seed.
+    whole_object_names: FxHashMap<FileId, Vec<String>>,
+    /// Every module some acceptance point re-exports from, transitively, names
+    /// ignored.
+    ///
+    /// A name can only travel from a module to an acceptance point along
+    /// forwarding edges, so a module outside this set answers the search in
+    /// constant time however deep its own chains run. Recomputed per round,
+    /// because a round that widens the closure adds acceptance points.
+    may_reach: FxHashSet<FileId>,
+    scratch: NameSearchScratch<'a>,
+}
+
+impl<'a> ExposedNameSearch<'a> {
+    fn build(
+        modules: &'a [super::types::ModuleNode],
+        module_by_id: &FxHashMap<FileId, &ResolvedModule>,
+    ) -> Self {
+        let mut whole_object_names: FxHashMap<FileId, Vec<String>> = FxHashMap::default();
+        for consumer in module_by_id.values() {
+            if consumer.whole_object_uses.is_empty() {
+                continue;
+            }
+            for import in &consumer.resolved_imports {
+                let Some(target) = import.target.internal_file_id() else {
+                    continue;
+                };
+                let imported_name = match &import.info.imported_name {
+                    fallow_types::extract::ImportedName::Named(name) => name.as_str(),
+                    fallow_types::extract::ImportedName::Default => "default",
+                    _ => continue,
+                };
+                let local_name = import.info.local_name.as_str();
+                if local_name.is_empty()
+                    || !consumer
+                        .whole_object_uses
+                        .iter()
+                        .any(|used| used == local_name)
+                {
+                    continue;
+                }
+                let names = whole_object_names.entry(target).or_default();
+                if !names.iter().any(|name| name == imported_name) {
+                    names.push(imported_name.to_string());
+                }
+            }
+        }
+
+        Self {
+            forwarders: NameForwarders::build(modules),
+            whole_object_names,
+            may_reach: FxHashSet::default(),
+            scratch: NameSearchScratch::default(),
+        }
+    }
+
+    /// Rebuild the reachability prune and drop the memoised failures for a new
+    /// round against a wider closure.
+    fn refresh(&mut self, graph: &ModuleGraph, closure: &ExposedNamespaceTargets) {
+        let mut seeds: FxHashSet<FileId> = graph
+            .modules
+            .iter()
+            .filter(|m| m.is_entry_point())
+            .map(|m| m.file_id)
+            .collect();
+        seeds.extend(closure.members.keys().copied());
+        seeds.extend(self.whole_object_names.keys().copied());
+        self.may_reach = graph.collect_forwarding_sources(&seeds);
+        self.scratch.failed.clear();
+    }
+
+    /// Whether `name`, as exported by `file`, reaches an acceptance point
+    /// through named and plain-star re-exports.
     ///
     /// Each hop must really forward the binding: a barrel that declares its
     /// own `name`, or that receives it from two stars at once, exports a
-    /// different binding under that name and the chain stops there. A plain
+    /// different binding under that name and the chain stops there. Being on
+    /// an entry point's plain-`export *` closure is not on its own proof that
+    /// the name survives to the entry, so no hop is skipped for it. A plain
     /// `export *` also never carries `default`, so a `default`-named state
     /// takes named hops only.
-    fn reaches_surface(
-        &self,
+    fn reaches_exposure(
+        &mut self,
         graph: &ModuleGraph,
+        closure: &ExposedNamespaceTargets,
         file: FileId,
         name: &'a str,
-        surfaces: &SurfaceReach,
-        scratch: &mut NameSearchScratch<'a>,
     ) -> bool {
-        let SurfaceReach {
-            star_surface,
-            may_reach,
-        } = surfaces;
-        if !may_reach.contains(&file) || scratch.failed.contains(&(file, name)) {
+        if !self.may_reach.contains(&file) || self.scratch.failed.contains(&(file, name)) {
             return false;
         }
+        let Self {
+            forwarders,
+            whole_object_names,
+            may_reach,
+            scratch,
+        } = self;
         scratch.visited.clear();
         scratch.frontier.clear();
         scratch.visited.insert((file, name));
         scratch.frontier.push((file, name));
         while let Some((current, current_name)) = scratch.frontier.pop() {
-            if graph.surface_exposes(star_surface, current, current_name) {
+            if exposes_here(graph, closure, whole_object_names, current, current_name) {
                 return true;
             }
-            if let Some(barrels) = self.named.get(&(current, current_name)) {
+            if let Some(barrels) = forwarders.named.get(&(current, current_name)) {
                 for &(barrel, exported_name) in barrels {
                     if may_reach.contains(&barrel)
                         && graph.forwards_binding(current, current_name, barrel, exported_name)
@@ -294,7 +372,7 @@ impl<'a> NameForwarders<'a> {
             if current_name == "default" {
                 continue;
             }
-            if let Some(barrels) = self.stars.get(&current) {
+            if let Some(barrels) = forwarders.stars.get(&current) {
                 for &barrel in barrels {
                     if may_reach.contains(&barrel)
                         && graph.forwards_binding(current, current_name, barrel, current_name)
@@ -309,6 +387,26 @@ impl<'a> NameForwarders<'a> {
         scratch.failed.extend(scratch.visited.iter().copied());
         false
     }
+}
+
+/// Whether the module that exports `name` already hands it to a consumer the
+/// graph cannot enumerate, with no further re-export hop needed.
+///
+/// An entry point exposes every name it exports, `default` included: it is the
+/// public API. A closure member exposes what its own exposure allows. A name
+/// some importer uses as a whole object is observed in full by that importer.
+fn exposes_here(
+    graph: &ModuleGraph,
+    closure: &ExposedNamespaceTargets,
+    whole_object_names: &FxHashMap<FileId, Vec<String>>,
+    file: FileId,
+    name: &str,
+) -> bool {
+    graph.is_entry_point_file(file)
+        || closure.exposes_name(file, name)
+        || whole_object_names
+            .get(&file)
+            .is_some_and(|names| names.iter().any(|candidate| candidate == name))
 }
 
 struct ReExportFixpointInput<'a> {
@@ -459,24 +557,33 @@ impl ModuleGraph {
     ///
     /// The seeds are the targets whose whole namespace object Phase 2
     /// observed (`whole_module_targets`: an ambient-module star, a
-    /// dynamic-import pattern match, or a namespace import the graph could not
-    /// narrow because it is used as a whole object, handed on without member
-    /// access, or re-exported from a non-entry module) plus the `export * as
-    /// ns` sources an entry point's own export surface exposes. Every such
-    /// consumer sees every name on the namespace object, including the names
-    /// that only arrive through the target's own `export *` and
-    /// `export * as ns` chains, and per-name propagation cannot credit those
-    /// because no name is ever imported. The closure therefore follows both
-    /// chain forms: star propagation treats each member like an entry barrel
-    /// for its `export *` sources (named exports, never `default`), and
-    /// namespace re-export propagation credits every export of each member's
-    /// `export * as ns` sources (`default` included, because the namespace
-    /// object exposes it).
+    /// dynamic-import pattern match, a bindingless side-effect `require()`, or
+    /// a namespace import the graph could not narrow because it is used as a
+    /// whole object, handed on without member access, or re-exported from a
+    /// non-entry module) plus every `export * as ns` source whose name reaches
+    /// an entry point's own export surface, an existing closure member, or an
+    /// importer that uses the binding as a whole object. Every such consumer
+    /// sees every name on the namespace object, including the names that only
+    /// arrive through the target's own `export *` and `export * as ns` chains,
+    /// and per-name propagation cannot credit those because no name is ever
+    /// imported. The closure therefore follows both chain forms: star
+    /// propagation treats each member like an entry barrel for its `export *`
+    /// sources (named exports, never `default`), and namespace re-export
+    /// propagation credits every export of each member's `export * as ns`
+    /// sources (`default` included, because the namespace object exposes it).
     ///
     /// A member reached through a plain `export *` carries the weaker
     /// [`Exposure::StarSurface`]: the star forwarded its named exports and not
     /// its `default`, so an `export * as default` declared on it exposes
     /// nothing and stops the walk.
+    ///
+    /// The namespace-edge seeds and the closure walk run to a fixpoint against
+    /// each other: a target that joins the closure can itself expose a name a
+    /// further `export * as ns` edge forwards to it, and that edge only
+    /// qualifies once the target is a member. The rounds are the same
+    /// exposure decision Phase 2c makes per namespace edge, so the closure
+    /// Phase 2c reads already contains every target Phase 2c would credit in
+    /// full, instead of stopping one namespace level short of it.
     ///
     /// `entry_reachable` is the entry-point reachability bitset. A module no
     /// entry point reaches is already reported as an unused file, so crediting
@@ -484,25 +591,75 @@ impl ModuleGraph {
     /// only consumers left to observe it are unreachable themselves.
     ///
     /// Computed once per graph build and threaded into both phases that read
-    /// it; it depends only on `re_exports`, the entry-point flags, and
-    /// reachability, none of which any later phase mutates.
+    /// it; it depends only on `re_exports`, the entry-point flags, the
+    /// consumers' whole-object uses, and reachability, none of which any later
+    /// phase mutates.
     pub(in crate::graph) fn collect_exposed_namespace_targets(
         &self,
         whole_module_targets: &FxHashSet<FileId>,
         entry_reachable: &FixedBitSet,
+        module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     ) -> ExposedNamespaceTargets {
-        let mut seeds = whole_module_targets.clone();
-        self.seed_entry_exposed_namespaces(&mut seeds);
-
         let mut closure = ExposedNamespaceTargets {
             members: FxHashMap::default(),
         };
         let mut stack: Vec<(FileId, Exposure)> = Vec::new();
-        for seed in seeds {
+        for &seed in whole_module_targets {
             if entry_reachable.contains(seed.0 as usize) {
                 closure.record(&mut stack, seed, Exposure::NamespaceObject);
             }
         }
+
+        let mut pending: Vec<(FileId, &str, FileId)> = self
+            .modules
+            .iter()
+            .flat_map(|m| {
+                m.re_exports
+                    .iter()
+                    .filter(|re| is_namespace_re_export(re))
+                    .map(move |re| (m.file_id, re.exported_name.as_str(), re.source_file))
+            })
+            .filter(|(_, _, source)| entry_reachable.contains(source.0 as usize))
+            .collect();
+        let mut search =
+            (!pending.is_empty()).then(|| ExposedNameSearch::build(&self.modules, module_by_id));
+
+        loop {
+            self.extend_exposure_walk(&mut closure, &mut stack, entry_reachable);
+            let Some(search) = search.as_mut() else { break };
+            if pending.is_empty() {
+                break;
+            }
+            search.refresh(self, &closure);
+            let mut widened = false;
+            let mut still_pending = Vec::with_capacity(pending.len());
+            for (barrel, exported_name, source) in std::mem::take(&mut pending) {
+                if closure.members.get(&source) == Some(&Exposure::NamespaceObject) {
+                    continue;
+                }
+                if search.reaches_exposure(self, &closure, barrel, exported_name) {
+                    closure.record(&mut stack, source, Exposure::NamespaceObject);
+                    widened = true;
+                } else {
+                    still_pending.push((barrel, exported_name, source));
+                }
+            }
+            pending = still_pending;
+            if !widened {
+                break;
+            }
+        }
+        closure
+    }
+
+    /// Drain the closure's work stack, carrying each member's exposure along
+    /// its own `export *` and `export * as ns` edges.
+    fn extend_exposure_walk(
+        &self,
+        closure: &mut ExposedNamespaceTargets,
+        stack: &mut Vec<(FileId, Exposure)>,
+        entry_reachable: &FixedBitSet,
+    ) {
         while let Some((file_id, exposure)) = stack.pop() {
             let Some(module) = self.modules.get(file_id.0 as usize) else {
                 continue;
@@ -518,92 +675,19 @@ impl ModuleGraph {
                 } else {
                     continue;
                 };
-                closure.record(&mut stack, re.source_file, next);
-            }
-        }
-        closure
-    }
-
-    /// Add every `export * as ns` source whose namespace object an entry
-    /// point's own export surface exposes.
-    ///
-    /// The surface is tracked by name, so a barrel that only forwards one
-    /// binding never exposes the rest of its module. `ns` reaches an entry
-    /// point three ways: the namespace re-export sits on the entry point
-    /// itself, it sits on a barrel the entry reaches through plain `export *`
-    /// (the star forwards `ns` along with every other name), or an entry
-    /// point re-exports `ns` by name through a chain of named and star
-    /// re-exports, renames included (`export { sub } from './barrel'`). All
-    /// three hand `ns` to consumers the graph cannot enumerate, so the
-    /// target's own chains must be credited. `export * as default` is the one
-    /// name a plain `export *` leaves behind, so it only counts on an entry
-    /// point itself or through a named hop that mentions it.
-    ///
-    /// The search runs outward from each namespace edge rather than inward
-    /// from every entry-point export, so its cost scales with the number of
-    /// `export * as` edges (usually a handful) instead of with the number of
-    /// names an entry point re-exports.
-    fn seed_entry_exposed_namespaces(&self, targets: &mut FxHashSet<FileId>) {
-        let namespace_edges: Vec<(FileId, &str, FileId)> = self
-            .modules
-            .iter()
-            .flat_map(|m| {
-                m.re_exports
-                    .iter()
-                    .filter(|re| is_namespace_re_export(re))
-                    .map(move |re| (m.file_id, re.exported_name.as_str(), re.source_file))
-            })
-            .collect();
-        if namespace_edges.is_empty() {
-            return;
-        }
-
-        let mut star_surface: FxHashSet<FileId> = self
-            .modules
-            .iter()
-            .filter(|m| m.is_entry_point())
-            .map(|m| m.file_id)
-            .collect();
-        self.extend_plain_star_closure(&mut star_surface);
-
-        let mut off_surface: Vec<(FileId, &str, FileId)> = Vec::new();
-        for (barrel, exported_name, source) in namespace_edges {
-            if self.surface_exposes(&star_surface, barrel, exported_name) {
-                targets.insert(source);
-            } else {
-                off_surface.push((barrel, exported_name, source));
-            }
-        }
-        if off_surface.is_empty() {
-            return;
-        }
-
-        let surfaces = SurfaceReach {
-            may_reach: self.collect_surface_forwarding_sources(&star_surface),
-            star_surface,
-        };
-        let forwarders = NameForwarders::build(&self.modules);
-        let mut search = NameSearchScratch::default();
-        for (barrel, exported_name, source) in off_surface {
-            if !targets.contains(&source)
-                && forwarders.reaches_surface(self, barrel, exported_name, &surfaces, &mut search)
-            {
-                targets.insert(source);
+                closure.record(stack, re.source_file, next);
             }
         }
     }
 
-    /// Every module a star-surface module re-exports from, transitively,
-    /// following named and plain-star edges and ignoring names.
+    /// Every module one of `seeds` re-exports from, transitively, following
+    /// named and plain-star edges and ignoring names.
     ///
     /// `export * as ns` is left out: it bundles its source's names into one
     /// object instead of forwarding them, so it never carries a name outward.
-    fn collect_surface_forwarding_sources(
-        &self,
-        star_surface: &FxHashSet<FileId>,
-    ) -> FxHashSet<FileId> {
-        let mut may_reach = star_surface.clone();
-        let mut stack: Vec<FileId> = star_surface.iter().copied().collect();
+    fn collect_forwarding_sources(&self, seeds: &FxHashSet<FileId>) -> FxHashSet<FileId> {
+        let mut may_reach = seeds.clone();
+        let mut stack: Vec<FileId> = seeds.iter().copied().collect();
         while let Some(barrel) = stack.pop() {
             let Some(module) = self.modules.get(barrel.0 as usize) else {
                 continue;
@@ -615,22 +699,6 @@ impl ModuleGraph {
             }
         }
         may_reach
-    }
-
-    /// Whether a module on the entry-point star surface really exposes `name`
-    /// on that surface.
-    ///
-    /// An entry point exposes every name it exports, `default` included: it is
-    /// the public API. A barrel an entry point only reaches through plain
-    /// `export *` exposes every name except `default`, which no plain
-    /// `export *` forwards.
-    fn surface_exposes(
-        &self,
-        star_surface: &FxHashSet<FileId>,
-        file_id: FileId,
-        name: &str,
-    ) -> bool {
-        star_surface.contains(&file_id) && (name != "default" || self.is_entry_point_file(file_id))
     }
 
     /// Whether `barrel` re-exports under `barrel_name` the very binding

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -16,7 +16,7 @@ use crate::resolve::ResolvedModule;
 use fallow_types::discover::FileId;
 
 use super::types::{ReferencePathInterner, RoutedReferenceKey};
-use super::{Edge, ImportedSymbol, ModuleGraph};
+use super::{Edge, ModuleGraph};
 
 use propagate::{
     EffectiveDeclarationRouteCache, ImportBindingUsageIndex, NamedPropagationScratch,
@@ -110,6 +110,25 @@ struct ReExportContext<'a> {
     reference_paths: &'a mut ReferencePathInterner,
 }
 
+/// Which re-export chains `ModuleGraph::extend_star_closure` follows.
+#[derive(Clone, Copy)]
+enum StarChains {
+    /// Plain `export *` only: the surface a star forwards by name.
+    Plain,
+    /// Plain `export *` and `export * as ns`: everything a namespace object
+    /// exposes, recursively.
+    PlainAndNamespace,
+}
+
+impl StarChains {
+    fn follows(self, re: &super::types::ReExportEdge) -> bool {
+        match self {
+            Self::Plain => re.exported_name == "*",
+            Self::PlainAndNamespace => re.imported_name == "*",
+        }
+    }
+}
+
 struct ReExportFixpointInput<'a> {
     re_export_info: &'a [ReExportTuple],
     entry_star_targets: &'a FxHashSet<FileId>,
@@ -190,6 +209,7 @@ impl ModuleGraph {
     pub(super) fn resolve_re_export_chains(
         &mut self,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
+        whole_module_targets: &FxHashSet<FileId>,
         reference_paths: &mut ReferencePathInterner,
     ) -> Vec<GraphReExportCycle> {
         let re_export_info = self.collect_re_export_tuples();
@@ -200,7 +220,7 @@ impl ModuleGraph {
 
         let cycles = find_re_export_cycles(&self.modules, &re_export_info);
 
-        let entry_star_targets = self.collect_entry_star_targets();
+        let entry_star_targets = self.collect_entry_star_targets(whole_module_targets);
         let edges_by_target = self.build_edges_by_target();
 
         self.run_re_export_fixpoint(ReExportFixpointInput {
@@ -231,10 +251,14 @@ impl ModuleGraph {
     }
 
     /// Compute the transitive closure of `export *` source files whose every
-    /// named export is credited: star sources of entry-point barrels, plus the
-    /// ambient star closure of `collect_ambient_star_targets`.
-    fn collect_entry_star_targets(&self) -> FxHashSet<FileId> {
-        let mut entry_star_targets = self.collect_ambient_star_targets();
+    /// named export is credited: star sources of entry-point barrels, closed
+    /// over plain `export *` chains, plus every member of the exposed
+    /// namespace closure (`collect_exposed_namespace_targets`).
+    fn collect_entry_star_targets(
+        &self,
+        whole_module_targets: &FxHashSet<FileId>,
+    ) -> FxHashSet<FileId> {
+        let mut entry_star_targets = self.collect_exposed_namespace_targets(whole_module_targets);
         entry_star_targets.extend(self.modules.iter().filter(|m| m.is_entry_point()).flat_map(
             |m| {
                 m.re_exports
@@ -243,64 +267,72 @@ impl ModuleGraph {
                     .map(|re| re.source_file)
             },
         ));
-        let mut entry_star_stack: Vec<FileId> = entry_star_targets.iter().copied().collect();
-        while let Some(file_id) = entry_star_stack.pop() {
-            let idx = file_id.0 as usize;
-            if idx >= self.modules.len() {
-                continue;
-            }
-
-            for re in self.modules[idx]
-                .re_exports
-                .iter()
-                .filter(|re| re.exported_name == "*")
-            {
-                if entry_star_targets.insert(re.source_file) {
-                    entry_star_stack.push(re.source_file);
-                }
-            }
-        }
+        self.extend_star_closure(&mut entry_star_targets, StarChains::Plain);
         entry_star_targets
     }
 
-    /// Every module whose full ES star surface an ambient-module star
-    /// re-export reaches (issue #2357).
+    /// Every module whose full namespace object is handed to consumers the
+    /// graph cannot enumerate per name (issues #2357, #2372, #2373).
     ///
-    /// `export *` and `export * as ns` inside a `declare module '...'` body
-    /// arrive as a type-only namespace symbol with no local binding. They state
-    /// that every name the target exposes is reachable through the declared
-    /// module, including names that only arrive through the target's own
-    /// `export *` and `export * as ns` chains, and per-name propagation cannot
-    /// credit those because the consumer never imports a name. The closure
-    /// therefore follows both chain forms: star propagation treats each member
-    /// like an entry barrel for its `export *` sources (named exports, never
-    /// `default`), and namespace re-export propagation credits every export of
-    /// each member's `export * as ns` sources (`default` included, because the
-    /// namespace object exposes it). Runtime whole-module edges (dynamic-import
-    /// patterns) are not seeds and keep their direct-export credit only.
-    pub(in crate::graph) fn collect_ambient_star_targets(&self) -> FxHashSet<FileId> {
-        let mut targets: FxHashSet<FileId> = self
-            .edges
+    /// The seeds are the targets whose whole namespace object Phase 2
+    /// observed (`whole_module_targets`: an ambient-module star, a
+    /// dynamic-import pattern match, or a namespace import the graph could not
+    /// narrow because it is used as a whole object, handed on without member
+    /// access, or re-exported from a non-entry module) plus the `export * as
+    /// ns` sources on the entry-point surface, meaning those of every entry
+    /// point and of every barrel an entry point reaches through plain
+    /// `export *`, because the entry's star surface forwards `ns` itself.
+    /// Every such consumer sees every name on the namespace object, including
+    /// the names that only arrive through the target's own `export *` and
+    /// `export * as ns` chains, and per-name propagation cannot credit those
+    /// because no name is ever imported. The closure therefore follows both
+    /// chain forms: star propagation treats each member like an entry barrel
+    /// for its `export *` sources (named exports, never `default`), and
+    /// namespace re-export propagation credits every export of each member's
+    /// `export * as ns` sources (`default` included, because the namespace
+    /// object exposes it).
+    pub(in crate::graph) fn collect_exposed_namespace_targets(
+        &self,
+        whole_module_targets: &FxHashSet<FileId>,
+    ) -> FxHashSet<FileId> {
+        let mut entry_surface: FxHashSet<FileId> = self
+            .modules
             .iter()
-            .filter(|edge| edge.symbols.iter().any(ImportedSymbol::is_ambient_star))
-            .map(|edge| edge.target)
+            .filter(|m| m.is_entry_point())
+            .map(|m| m.file_id)
             .collect();
+        self.extend_star_closure(&mut entry_surface, StarChains::Plain);
+
+        let mut targets = whole_module_targets.clone();
+        targets.extend(
+            entry_surface
+                .iter()
+                .filter_map(|file_id| self.modules.get(file_id.0 as usize))
+                .flat_map(|m| {
+                    m.re_exports
+                        .iter()
+                        .filter(|re| re.imported_name == "*" && re.exported_name != "*")
+                        .map(|re| re.source_file)
+                }),
+        );
+        self.extend_star_closure(&mut targets, StarChains::PlainAndNamespace);
+        targets
+    }
+
+    /// Extend `targets` with every module its members reach through the
+    /// selected re-export chains, transitively.
+    fn extend_star_closure(&self, targets: &mut FxHashSet<FileId>, chains: StarChains) {
         let mut stack: Vec<FileId> = targets.iter().copied().collect();
         while let Some(file_id) = stack.pop() {
             let Some(module) = self.modules.get(file_id.0 as usize) else {
                 continue;
             };
-            for re in module
-                .re_exports
-                .iter()
-                .filter(|re| re.imported_name == "*")
-            {
+            for re in module.re_exports.iter().filter(|re| chains.follows(re)) {
                 if targets.insert(re.source_file) {
                     stack.push(re.source_file);
                 }
             }
         }
-        targets
     }
 
     /// Index every edge by its target file for fast star-propagation lookups.

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -111,6 +111,54 @@ struct ReExportContext<'a> {
     reference_paths: &'a mut ReferencePathInterner,
 }
 
+/// The targets whose whole namespace object Phase 2 saw observed, split by
+/// whether the observation survives the target being unreachable.
+///
+/// An ambient `declare module 'pkg' { export * from './impl' }` states the
+/// shape of an external module id (issue #2357). Whoever imports that id
+/// observes the whole surface, and the shim file only stores the declaration,
+/// so neither the shim's nor the target's place in this graph says anything
+/// about who looks: the observation stands at any reachability, and the chain
+/// behind the target can re-enter modules an entry point does reach.
+///
+/// Every other observer is a real consumer in this graph (a whole-object
+/// namespace use, a dynamic-import pattern match, a bindingless side-effect
+/// `require()`, a namespace binding re-exported under its own name). A target
+/// no entry point reaches has no observer left that any entry point reaches
+/// either, and the report already calls it an unused file, so crediting its
+/// chain would only stack unused-export rows underneath that row.
+#[derive(Default)]
+pub(in crate::graph) struct WholeModuleObservations {
+    /// Targets an ambient module body re-exports from, at any reachability.
+    ambient: FxHashSet<FileId>,
+    /// Targets a consumer in this graph observes as a whole object.
+    observed: FxHashSet<FileId>,
+}
+
+impl WholeModuleObservations {
+    /// Record a whole-object observation made by a consumer in this graph.
+    pub(in crate::graph) fn observe(&mut self, target: FileId) {
+        self.observed.insert(target);
+    }
+
+    /// Record the target of an `export *` or `export * as ns` inside a
+    /// `declare module '...'` body.
+    pub(in crate::graph) fn observe_ambient(&mut self, target: FileId) {
+        self.ambient.insert(target);
+    }
+
+    /// The closure seeds: every ambient target, plus the observed targets an
+    /// entry point reaches.
+    fn seeds<'a>(&'a self, entry_reachable: &'a FixedBitSet) -> impl Iterator<Item = FileId> + 'a {
+        self.ambient.iter().copied().chain(
+            self.observed
+                .iter()
+                .copied()
+                .filter(|target| entry_reachable.contains(target.0 as usize)),
+        )
+    }
+}
+
 /// How much of a closure member the consumers that cannot be enumerated see.
 ///
 /// The two differ on `default` alone, because a plain `export *` forwards
@@ -239,6 +287,36 @@ impl<'a> NameForwarders<'a> {
     }
 }
 
+/// Extend `may_reach` with every module `seeds` re-exports from, transitively,
+/// following named and plain-star edges and ignoring names.
+///
+/// `export * as ns` is left out: it bundles its source's names into one object
+/// instead of forwarding them, so it never carries a name outward.
+///
+/// A seed already in `may_reach` is skipped with its whole subtree, which is
+/// what lets the closure fixpoint widen the prune round by round instead of
+/// rebuilding it from scratch.
+fn extend_forwarding_sources(
+    modules: &[super::types::ModuleNode],
+    may_reach: &mut FxHashSet<FileId>,
+    seeds: impl IntoIterator<Item = FileId>,
+) {
+    let mut stack: Vec<FileId> = seeds
+        .into_iter()
+        .filter(|seed| may_reach.insert(*seed))
+        .collect();
+    while let Some(barrel) = stack.pop() {
+        let Some(module) = modules.get(barrel.0 as usize) else {
+            continue;
+        };
+        for re in &module.re_exports {
+            if !is_namespace_re_export(re) && may_reach.insert(re.source_file) {
+                stack.push(re.source_file);
+            }
+        }
+    }
+}
+
 /// The outward search that decides whether one `export * as ns` edge hands its
 /// target's namespace object to consumers the graph cannot enumerate.
 ///
@@ -301,26 +379,41 @@ impl<'a> ExposedNameSearch<'a> {
             }
         }
 
+        let mut may_reach = FxHashSet::default();
+        extend_forwarding_sources(
+            modules,
+            &mut may_reach,
+            modules
+                .iter()
+                .filter(|m| m.is_entry_point())
+                .map(|m| m.file_id)
+                .chain(whole_object_names.keys().copied()),
+        );
+
         Self {
             forwarders: NameForwarders::build(modules),
             whole_object_names,
-            may_reach: FxHashSet::default(),
+            may_reach,
             scratch: NameSearchScratch::default(),
         }
     }
 
-    /// Rebuild the reachability prune and drop the memoised failures for a new
-    /// round against a wider closure.
-    fn refresh(&mut self, graph: &ModuleGraph, closure: &ExposedNamespaceTargets) {
-        let mut seeds: FxHashSet<FileId> = graph
-            .modules
-            .iter()
-            .filter(|m| m.is_entry_point())
-            .map(|m| m.file_id)
-            .collect();
-        seeds.extend(closure.members.keys().copied());
-        seeds.extend(self.whole_object_names.keys().copied());
-        self.may_reach = graph.collect_forwarding_sources(&seeds);
+    /// Widen the reachability prune with the members the last round added and
+    /// drop the memoised failures for a round against the wider closure.
+    ///
+    /// The prune only ever grows, so the members already walked keep their
+    /// subtree and each re-export edge is visited at most once across every
+    /// round instead of once per round.
+    fn refresh(
+        &mut self,
+        modules: &'a [super::types::ModuleNode],
+        closure: &ExposedNamespaceTargets,
+    ) {
+        extend_forwarding_sources(
+            modules,
+            &mut self.may_reach,
+            closure.members.keys().copied(),
+        );
         self.scratch.failed.clear();
     }
 
@@ -585,10 +678,14 @@ impl ModuleGraph {
     /// Phase 2c reads already contains every target Phase 2c would credit in
     /// full, instead of stopping one namespace level short of it.
     ///
-    /// `entry_reachable` is the entry-point reachability bitset. A module no
-    /// entry point reaches is already reported as an unused file, so crediting
-    /// its chain would only add unused-export rows underneath that row; the
-    /// only consumers left to observe it are unreachable themselves.
+    /// `entry_reachable` is the entry-point reachability bitset. It gates the
+    /// two seed kinds issues #2372 and #2373 add (an observed whole-object
+    /// target and an `export * as ns` source), and nothing else: withholding
+    /// those can only withhold credit the pre-existing closure never gave.
+    /// The ambient seeds and the walk stay ungated, because a chain that
+    /// starts at an unreachable shim routinely re-enters a module an entry
+    /// point imports directly, and gating it would report exports on files
+    /// the report calls reachable.
     ///
     /// Computed once per graph build and threaded into both phases that read
     /// it; it depends only on `re_exports`, the entry-point flags, the
@@ -596,7 +693,7 @@ impl ModuleGraph {
     /// phase mutates.
     pub(in crate::graph) fn collect_exposed_namespace_targets(
         &self,
-        whole_module_targets: &FxHashSet<FileId>,
+        whole_module_targets: &WholeModuleObservations,
         entry_reachable: &FixedBitSet,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
     ) -> ExposedNamespaceTargets {
@@ -604,10 +701,8 @@ impl ModuleGraph {
             members: FxHashMap::default(),
         };
         let mut stack: Vec<(FileId, Exposure)> = Vec::new();
-        for &seed in whole_module_targets {
-            if entry_reachable.contains(seed.0 as usize) {
-                closure.record(&mut stack, seed, Exposure::NamespaceObject);
-            }
+        for seed in whole_module_targets.seeds(entry_reachable) {
+            closure.record(&mut stack, seed, Exposure::NamespaceObject);
         }
 
         let mut pending: Vec<(FileId, &str, FileId)> = self
@@ -625,12 +720,12 @@ impl ModuleGraph {
             (!pending.is_empty()).then(|| ExposedNameSearch::build(&self.modules, module_by_id));
 
         loop {
-            self.extend_exposure_walk(&mut closure, &mut stack, entry_reachable);
+            self.extend_exposure_walk(&mut closure, &mut stack);
             let Some(search) = search.as_mut() else { break };
             if pending.is_empty() {
                 break;
             }
-            search.refresh(self, &closure);
+            search.refresh(&self.modules, &closure);
             let mut widened = false;
             let mut still_pending = Vec::with_capacity(pending.len());
             for (barrel, exported_name, source) in std::mem::take(&mut pending) {
@@ -654,18 +749,22 @@ impl ModuleGraph {
 
     /// Drain the closure's work stack, carrying each member's exposure along
     /// its own `export *` and `export * as ns` edges.
+    ///
+    /// No hop is dropped for reachability. A re-export edge makes its source
+    /// reachable whenever the barrel is, so only the ambient seeds can ever
+    /// walk from an unreachable member, and their chains routinely re-enter
+    /// modules an entry point imports directly.
     fn extend_exposure_walk(
         &self,
         closure: &mut ExposedNamespaceTargets,
         stack: &mut Vec<(FileId, Exposure)>,
-        entry_reachable: &FixedBitSet,
     ) {
         while let Some((file_id, exposure)) = stack.pop() {
             let Some(module) = self.modules.get(file_id.0 as usize) else {
                 continue;
             };
             for re in &module.re_exports {
-                if re.imported_name != "*" || !entry_reachable.contains(re.source_file.0 as usize) {
+                if re.imported_name != "*" {
                     continue;
                 }
                 let next = if re.exported_name == "*" {
@@ -680,37 +779,15 @@ impl ModuleGraph {
         }
     }
 
-    /// Every module one of `seeds` re-exports from, transitively, following
-    /// named and plain-star edges and ignoring names.
-    ///
-    /// `export * as ns` is left out: it bundles its source's names into one
-    /// object instead of forwarding them, so it never carries a name outward.
-    fn collect_forwarding_sources(&self, seeds: &FxHashSet<FileId>) -> FxHashSet<FileId> {
-        let mut may_reach = seeds.clone();
-        let mut stack: Vec<FileId> = seeds.iter().copied().collect();
-        while let Some(barrel) = stack.pop() {
-            let Some(module) = self.modules.get(barrel.0 as usize) else {
-                continue;
-            };
-            for re in &module.re_exports {
-                if !is_namespace_re_export(re) && may_reach.insert(re.source_file) {
-                    stack.push(re.source_file);
-                }
-            }
-        }
-        may_reach
-    }
-
     /// Whether `barrel` re-exports under `barrel_name` the very binding
     /// `source` exports under `source_name`.
     ///
-    /// A local declaration on the barrel, or the same name arriving from two
-    /// stars at once, shadows a star-forwarded name: the barrel then exports a
-    /// different binding and the name never travels further. The value
-    /// namespace decides whenever the source exports the name there (a
-    /// namespace object is a value binding); a type-only surface falls back to
-    /// the type namespace. Phase 2c's own walk applies the same rule through
-    /// `uniquely_forwards_binding`.
+    /// Only the namespace choice lives here: the value namespace decides
+    /// whenever the source exports the name there (a namespace object is a
+    /// value binding), and a type-only surface falls back to the type
+    /// namespace. The per-namespace comparison itself is Phase 2c's own
+    /// `uniquely_forwards_binding`, so the closure's outward search and the
+    /// phase it pre-computes for cannot drift apart on what a hop forwards.
     fn forwards_binding(
         &self,
         source: FileId,
@@ -719,14 +796,19 @@ impl ModuleGraph {
         barrel_name: &str,
     ) -> bool {
         for namespace in [super::ExportNamespace::Value, super::ExportNamespace::Type] {
-            let super::EffectiveExportResolution::Unique(origin) =
-                self.resolve_export(source, source_name, namespace)
-            else {
+            if !matches!(
+                self.resolve_export(source, source_name, namespace),
+                super::EffectiveExportResolution::Unique(_)
+            ) {
                 continue;
-            };
-            return matches!(
-                self.resolve_export(barrel, barrel_name, namespace),
-                super::EffectiveExportResolution::Unique(forwarded) if forwarded == origin
+            }
+            return super::namespace_indexes::uniquely_forwards_binding(
+                self,
+                source,
+                source_name,
+                barrel,
+                barrel_name,
+                namespace,
             );
         }
         false

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -7,6 +7,7 @@ mod tests;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 
+use fixedbitset::FixedBitSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 #[cfg(test)]
@@ -110,21 +111,72 @@ struct ReExportContext<'a> {
     reference_paths: &'a mut ReferencePathInterner,
 }
 
-/// Which re-export chains `ModuleGraph::extend_star_closure` follows.
-#[derive(Clone, Copy)]
-enum StarChains {
-    /// Plain `export *` only: the surface a star forwards by name.
-    Plain,
-    /// Plain `export *` and `export * as ns`: everything a namespace object
-    /// exposes, recursively.
-    PlainAndNamespace,
+/// How much of a closure member the consumers that cannot be enumerated see.
+///
+/// The two differ on `default` alone, because a plain `export *` forwards
+/// every named export of its source and never the source's `default`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Exposure {
+    /// Reached through a plain `export *`: every export except `default`.
+    StarSurface,
+    /// The whole namespace object is observed: every export, `default`
+    /// included.
+    NamespaceObject,
 }
 
-impl StarChains {
-    fn follows(self, re: &super::types::ReExportEdge) -> bool {
-        match self {
-            Self::Plain => re.imported_name == "*" && re.exported_name == "*",
-            Self::PlainAndNamespace => re.imported_name == "*",
+/// The exposed namespace closure: every module whose names reach consumers
+/// the graph cannot enumerate, with the part of its export surface they see.
+///
+/// Built by [`ModuleGraph::collect_exposed_namespace_targets`], computed once
+/// per graph build and read by Phase 2c (namespace re-export propagation) and
+/// Phase 4 (the entry-star seed).
+pub(in crate::graph) struct ExposedNamespaceTargets {
+    members: FxHashMap<FileId, Exposure>,
+}
+
+impl ExposedNamespaceTargets {
+    /// Whether the closure has no members at all.
+    pub(in crate::graph) fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// Whether the member exposes `exported_name`.
+    ///
+    /// A member reached through a plain `export *` does not expose `default`:
+    /// the star that carried its names onward never forwards it, so an
+    /// `export * as default` declared on such a member hands its target's
+    /// namespace object to nobody.
+    pub(in crate::graph) fn exposes_name(&self, file_id: FileId, exported_name: &str) -> bool {
+        match self.members.get(&file_id) {
+            Some(Exposure::NamespaceObject) => true,
+            Some(Exposure::StarSurface) => exported_name != "default",
+            None => false,
+        }
+    }
+
+    /// Every member, at either exposure.
+    ///
+    /// Phase 4 star propagation credits the named exports of a member's
+    /// `export *` sources and never their `default`, which both exposures
+    /// forward alike, so it reads the membership alone.
+    fn files(&self) -> impl Iterator<Item = FileId> + '_ {
+        self.members.keys().copied()
+    }
+
+    /// Record a member, re-walking it when a wider exposure than a previous
+    /// visit arrives. Each member is walked at most twice.
+    fn record(&mut self, stack: &mut Vec<(FileId, Exposure)>, file_id: FileId, exposure: Exposure) {
+        match self.members.entry(file_id) {
+            std::collections::hash_map::Entry::Occupied(mut slot) => {
+                if *slot.get() == Exposure::StarSurface && exposure == Exposure::NamespaceObject {
+                    slot.insert(exposure);
+                    stack.push((file_id, exposure));
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(exposure);
+                stack.push((file_id, exposure));
+            }
         }
     }
 }
@@ -148,11 +200,29 @@ struct NameForwarders<'a> {
     stars: FxHashMap<FileId, Vec<FileId>>,
 }
 
-/// Reusable visited set and stack for [`NameForwarders::reaches_surface`].
+/// What [`NameForwarders::reaches_surface`] measures a state against.
+struct SurfaceReach {
+    /// Entry points plus every barrel they reach through plain `export *`.
+    star_surface: FxHashSet<FileId>,
+    /// Every module some star-surface module re-exports from, transitively,
+    /// names ignored.
+    ///
+    /// A name can only travel from a module to the entry surface along
+    /// forwarding edges, so a module outside this set answers the search in
+    /// constant time however deep its own chains run.
+    may_reach: FxHashSet<FileId>,
+}
+
+/// Reusable state for [`NameForwarders::reaches_surface`].
+///
+/// `failed` outlives a single search: an exhausted search proves that every
+/// state it visited fails too, so a forwarding chain shared by many namespace
+/// edges is walked once instead of once per edge.
 #[derive(Default)]
 struct NameSearchScratch<'a> {
     visited: FxHashSet<(FileId, &'a str)>,
     frontier: Vec<(FileId, &'a str)>,
+    failed: FxHashSet<(FileId, &'a str)>,
 }
 
 impl<'a> NameForwarders<'a> {
@@ -179,38 +249,64 @@ impl<'a> NameForwarders<'a> {
         Self { named, stars }
     }
 
-    /// Whether `name`, as exported by `file`, reaches a module on the entry
-    /// point's star surface through named and plain-star re-exports.
+    /// Whether `name`, as exported by `file`, reaches the entry point's own
+    /// export surface through named and plain-star re-exports.
+    ///
+    /// Each hop must really forward the binding: a barrel that declares its
+    /// own `name`, or that receives it from two stars at once, exports a
+    /// different binding under that name and the chain stops there. A plain
+    /// `export *` also never carries `default`, so a `default`-named state
+    /// takes named hops only.
     fn reaches_surface(
         &self,
+        graph: &ModuleGraph,
         file: FileId,
         name: &'a str,
-        star_surface: &FxHashSet<FileId>,
+        surfaces: &SurfaceReach,
         scratch: &mut NameSearchScratch<'a>,
     ) -> bool {
+        let SurfaceReach {
+            star_surface,
+            may_reach,
+        } = surfaces;
+        if !may_reach.contains(&file) || scratch.failed.contains(&(file, name)) {
+            return false;
+        }
         scratch.visited.clear();
         scratch.frontier.clear();
         scratch.visited.insert((file, name));
         scratch.frontier.push((file, name));
         while let Some((current, current_name)) = scratch.frontier.pop() {
-            if star_surface.contains(&current) {
+            if graph.surface_exposes(star_surface, current, current_name) {
                 return true;
             }
             if let Some(barrels) = self.named.get(&(current, current_name)) {
                 for &(barrel, exported_name) in barrels {
-                    if scratch.visited.insert((barrel, exported_name)) {
+                    if may_reach.contains(&barrel)
+                        && graph.forwards_binding(current, current_name, barrel, exported_name)
+                        && !scratch.failed.contains(&(barrel, exported_name))
+                        && scratch.visited.insert((barrel, exported_name))
+                    {
                         scratch.frontier.push((barrel, exported_name));
                     }
                 }
             }
+            if current_name == "default" {
+                continue;
+            }
             if let Some(barrels) = self.stars.get(&current) {
                 for &barrel in barrels {
-                    if scratch.visited.insert((barrel, current_name)) {
+                    if may_reach.contains(&barrel)
+                        && graph.forwards_binding(current, current_name, barrel, current_name)
+                        && !scratch.failed.contains(&(barrel, current_name))
+                        && scratch.visited.insert((barrel, current_name))
+                    {
                         scratch.frontier.push((barrel, current_name));
                     }
                 }
             }
         }
+        scratch.failed.extend(scratch.visited.iter().copied());
         false
     }
 }
@@ -295,7 +391,7 @@ impl ModuleGraph {
     pub(super) fn resolve_re_export_chains(
         &mut self,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
-        exposed_namespace_targets: &FxHashSet<FileId>,
+        exposed_namespace_targets: &ExposedNamespaceTargets,
         reference_paths: &mut ReferencePathInterner,
     ) -> Vec<GraphReExportCycle> {
         let re_export_info = self.collect_re_export_tuples();
@@ -343,9 +439,9 @@ impl ModuleGraph {
     /// per build and threaded in).
     fn collect_entry_star_targets(
         &self,
-        exposed_namespace_targets: &FxHashSet<FileId>,
+        exposed_namespace_targets: &ExposedNamespaceTargets,
     ) -> FxHashSet<FileId> {
-        let mut entry_star_targets = exposed_namespace_targets.clone();
+        let mut entry_star_targets: FxHashSet<FileId> = exposed_namespace_targets.files().collect();
         entry_star_targets.extend(self.modules.iter().filter(|m| m.is_entry_point()).flat_map(
             |m| {
                 m.re_exports
@@ -354,7 +450,7 @@ impl ModuleGraph {
                     .map(|re| re.source_file)
             },
         ));
-        self.extend_star_closure(&mut entry_star_targets, StarChains::Plain);
+        self.extend_plain_star_closure(&mut entry_star_targets);
         entry_star_targets
     }
 
@@ -377,17 +473,55 @@ impl ModuleGraph {
     /// `export * as ns` sources (`default` included, because the namespace
     /// object exposes it).
     ///
+    /// A member reached through a plain `export *` carries the weaker
+    /// [`Exposure::StarSurface`]: the star forwarded its named exports and not
+    /// its `default`, so an `export * as default` declared on it exposes
+    /// nothing and stops the walk.
+    ///
+    /// `entry_reachable` is the entry-point reachability bitset. A module no
+    /// entry point reaches is already reported as an unused file, so crediting
+    /// its chain would only add unused-export rows underneath that row; the
+    /// only consumers left to observe it are unreachable themselves.
+    ///
     /// Computed once per graph build and threaded into both phases that read
-    /// it; it depends only on `re_exports` and the entry-point flags, which
-    /// no later phase mutates.
+    /// it; it depends only on `re_exports`, the entry-point flags, and
+    /// reachability, none of which any later phase mutates.
     pub(in crate::graph) fn collect_exposed_namespace_targets(
         &self,
         whole_module_targets: &FxHashSet<FileId>,
-    ) -> FxHashSet<FileId> {
-        let mut targets = whole_module_targets.clone();
-        self.seed_entry_exposed_namespaces(&mut targets);
-        self.extend_star_closure(&mut targets, StarChains::PlainAndNamespace);
-        targets
+        entry_reachable: &FixedBitSet,
+    ) -> ExposedNamespaceTargets {
+        let mut seeds = whole_module_targets.clone();
+        self.seed_entry_exposed_namespaces(&mut seeds);
+
+        let mut closure = ExposedNamespaceTargets {
+            members: FxHashMap::default(),
+        };
+        let mut stack: Vec<(FileId, Exposure)> = Vec::new();
+        for seed in seeds {
+            if entry_reachable.contains(seed.0 as usize) {
+                closure.record(&mut stack, seed, Exposure::NamespaceObject);
+            }
+        }
+        while let Some((file_id, exposure)) = stack.pop() {
+            let Some(module) = self.modules.get(file_id.0 as usize) else {
+                continue;
+            };
+            for re in &module.re_exports {
+                if re.imported_name != "*" || !entry_reachable.contains(re.source_file.0 as usize) {
+                    continue;
+                }
+                let next = if re.exported_name == "*" {
+                    Exposure::StarSurface
+                } else if exposure == Exposure::NamespaceObject || re.exported_name != "default" {
+                    Exposure::NamespaceObject
+                } else {
+                    continue;
+                };
+                closure.record(&mut stack, re.source_file, next);
+            }
+        }
+        closure
     }
 
     /// Add every `export * as ns` source whose namespace object an entry
@@ -401,7 +535,9 @@ impl ModuleGraph {
     /// point re-exports `ns` by name through a chain of named and star
     /// re-exports, renames included (`export { sub } from './barrel'`). All
     /// three hand `ns` to consumers the graph cannot enumerate, so the
-    /// target's own chains must be credited.
+    /// target's own chains must be credited. `export * as default` is the one
+    /// name a plain `export *` leaves behind, so it only counts on an entry
+    /// point itself or through a named hop that mentions it.
     ///
     /// The search runs outward from each namespace edge rather than inward
     /// from every entry-point export, so its cost scales with the number of
@@ -428,11 +564,11 @@ impl ModuleGraph {
             .filter(|m| m.is_entry_point())
             .map(|m| m.file_id)
             .collect();
-        self.extend_star_closure(&mut star_surface, StarChains::Plain);
+        self.extend_plain_star_closure(&mut star_surface);
 
         let mut off_surface: Vec<(FileId, &str, FileId)> = Vec::new();
         for (barrel, exported_name, source) in namespace_edges {
-            if star_surface.contains(&barrel) {
+            if self.surface_exposes(&star_surface, barrel, exported_name) {
                 targets.insert(source);
             } else {
                 off_surface.push((barrel, exported_name, source));
@@ -442,26 +578,112 @@ impl ModuleGraph {
             return;
         }
 
+        let surfaces = SurfaceReach {
+            may_reach: self.collect_surface_forwarding_sources(&star_surface),
+            star_surface,
+        };
         let forwarders = NameForwarders::build(&self.modules);
         let mut search = NameSearchScratch::default();
         for (barrel, exported_name, source) in off_surface {
             if !targets.contains(&source)
-                && forwarders.reaches_surface(barrel, exported_name, &star_surface, &mut search)
+                && forwarders.reaches_surface(self, barrel, exported_name, &surfaces, &mut search)
             {
                 targets.insert(source);
             }
         }
     }
 
-    /// Extend `targets` with every module its members reach through the
-    /// selected re-export chains, transitively.
-    fn extend_star_closure(&self, targets: &mut FxHashSet<FileId>, chains: StarChains) {
+    /// Every module a star-surface module re-exports from, transitively,
+    /// following named and plain-star edges and ignoring names.
+    ///
+    /// `export * as ns` is left out: it bundles its source's names into one
+    /// object instead of forwarding them, so it never carries a name outward.
+    fn collect_surface_forwarding_sources(
+        &self,
+        star_surface: &FxHashSet<FileId>,
+    ) -> FxHashSet<FileId> {
+        let mut may_reach = star_surface.clone();
+        let mut stack: Vec<FileId> = star_surface.iter().copied().collect();
+        while let Some(barrel) = stack.pop() {
+            let Some(module) = self.modules.get(barrel.0 as usize) else {
+                continue;
+            };
+            for re in &module.re_exports {
+                if !is_namespace_re_export(re) && may_reach.insert(re.source_file) {
+                    stack.push(re.source_file);
+                }
+            }
+        }
+        may_reach
+    }
+
+    /// Whether a module on the entry-point star surface really exposes `name`
+    /// on that surface.
+    ///
+    /// An entry point exposes every name it exports, `default` included: it is
+    /// the public API. A barrel an entry point only reaches through plain
+    /// `export *` exposes every name except `default`, which no plain
+    /// `export *` forwards.
+    fn surface_exposes(
+        &self,
+        star_surface: &FxHashSet<FileId>,
+        file_id: FileId,
+        name: &str,
+    ) -> bool {
+        star_surface.contains(&file_id) && (name != "default" || self.is_entry_point_file(file_id))
+    }
+
+    /// Whether `barrel` re-exports under `barrel_name` the very binding
+    /// `source` exports under `source_name`.
+    ///
+    /// A local declaration on the barrel, or the same name arriving from two
+    /// stars at once, shadows a star-forwarded name: the barrel then exports a
+    /// different binding and the name never travels further. The value
+    /// namespace decides whenever the source exports the name there (a
+    /// namespace object is a value binding); a type-only surface falls back to
+    /// the type namespace. Phase 2c's own walk applies the same rule through
+    /// `uniquely_forwards_binding`.
+    fn forwards_binding(
+        &self,
+        source: FileId,
+        source_name: &str,
+        barrel: FileId,
+        barrel_name: &str,
+    ) -> bool {
+        for namespace in [super::ExportNamespace::Value, super::ExportNamespace::Type] {
+            let super::EffectiveExportResolution::Unique(origin) =
+                self.resolve_export(source, source_name, namespace)
+            else {
+                continue;
+            };
+            return matches!(
+                self.resolve_export(barrel, barrel_name, namespace),
+                super::EffectiveExportResolution::Unique(forwarded) if forwarded == origin
+            );
+        }
+        false
+    }
+
+    /// Whether the file is an entry point of this graph.
+    fn is_entry_point_file(&self, file_id: FileId) -> bool {
+        self.modules
+            .get(file_id.0 as usize)
+            .is_some_and(super::types::ModuleNode::is_entry_point)
+    }
+
+    /// Extend `targets` with every module its members reach through plain
+    /// `export *` chains, transitively.
+    fn extend_plain_star_closure(&self, targets: &mut FxHashSet<FileId>) {
         let mut stack: Vec<FileId> = targets.iter().copied().collect();
         while let Some(file_id) = stack.pop() {
             let Some(module) = self.modules.get(file_id.0 as usize) else {
                 continue;
             };
-            for re in module.re_exports.iter().filter(|re| chains.follows(re)) {
+            for re in module
+                .re_exports
+                .iter()
+                .filter(|re| re.imported_name == "*" && re.exported_name == "*")
+            {
                 if targets.insert(re.source_file) {
                     stack.push(re.source_file);
                 }

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -123,10 +123,16 @@ enum StarChains {
 impl StarChains {
     fn follows(self, re: &super::types::ReExportEdge) -> bool {
         match self {
-            Self::Plain => re.exported_name == "*",
+            Self::Plain => re.imported_name == "*" && re.exported_name == "*",
             Self::PlainAndNamespace => re.imported_name == "*",
         }
     }
+}
+
+/// `export * as ns from './x'`: the barrel exposes x's namespace object under
+/// a single name instead of forwarding x's names.
+fn is_namespace_re_export(re: &super::types::ReExportEdge) -> bool {
+    re.imported_name == "*" && re.exported_name != "*"
 }
 
 struct ReExportFixpointInput<'a> {
@@ -209,7 +215,7 @@ impl ModuleGraph {
     pub(super) fn resolve_re_export_chains(
         &mut self,
         module_by_id: &FxHashMap<FileId, &ResolvedModule>,
-        whole_module_targets: &FxHashSet<FileId>,
+        exposed_namespace_targets: &FxHashSet<FileId>,
         reference_paths: &mut ReferencePathInterner,
     ) -> Vec<GraphReExportCycle> {
         let re_export_info = self.collect_re_export_tuples();
@@ -220,7 +226,7 @@ impl ModuleGraph {
 
         let cycles = find_re_export_cycles(&self.modules, &re_export_info);
 
-        let entry_star_targets = self.collect_entry_star_targets(whole_module_targets);
+        let entry_star_targets = self.collect_entry_star_targets(exposed_namespace_targets);
         let edges_by_target = self.build_edges_by_target();
 
         self.run_re_export_fixpoint(ReExportFixpointInput {
@@ -253,12 +259,13 @@ impl ModuleGraph {
     /// Compute the transitive closure of `export *` source files whose every
     /// named export is credited: star sources of entry-point barrels, closed
     /// over plain `export *` chains, plus every member of the exposed
-    /// namespace closure (`collect_exposed_namespace_targets`).
+    /// namespace closure (`collect_exposed_namespace_targets`, computed once
+    /// per build and threaded in).
     fn collect_entry_star_targets(
         &self,
-        whole_module_targets: &FxHashSet<FileId>,
+        exposed_namespace_targets: &FxHashSet<FileId>,
     ) -> FxHashSet<FileId> {
-        let mut entry_star_targets = self.collect_exposed_namespace_targets(whole_module_targets);
+        let mut entry_star_targets = exposed_namespace_targets.clone();
         entry_star_targets.extend(self.modules.iter().filter(|m| m.is_entry_point()).flat_map(
             |m| {
                 m.re_exports
@@ -279,11 +286,9 @@ impl ModuleGraph {
     /// dynamic-import pattern match, or a namespace import the graph could not
     /// narrow because it is used as a whole object, handed on without member
     /// access, or re-exported from a non-entry module) plus the `export * as
-    /// ns` sources on the entry-point surface, meaning those of every entry
-    /// point and of every barrel an entry point reaches through plain
-    /// `export *`, because the entry's star surface forwards `ns` itself.
-    /// Every such consumer sees every name on the namespace object, including
-    /// the names that only arrive through the target's own `export *` and
+    /// ns` sources an entry point's own export surface exposes. Every such
+    /// consumer sees every name on the namespace object, including the names
+    /// that only arrive through the target's own `export *` and
     /// `export * as ns` chains, and per-name propagation cannot credit those
     /// because no name is ever imported. The closure therefore follows both
     /// chain forms: star propagation treats each member like an entry barrel
@@ -291,32 +296,94 @@ impl ModuleGraph {
     /// namespace re-export propagation credits every export of each member's
     /// `export * as ns` sources (`default` included, because the namespace
     /// object exposes it).
+    ///
+    /// Computed once per graph build and threaded into both phases that read
+    /// it; it depends only on `re_exports` and the entry-point flags, which
+    /// no later phase mutates.
     pub(in crate::graph) fn collect_exposed_namespace_targets(
         &self,
         whole_module_targets: &FxHashSet<FileId>,
     ) -> FxHashSet<FileId> {
-        let mut entry_surface: FxHashSet<FileId> = self
+        let mut targets = whole_module_targets.clone();
+        self.seed_entry_exposed_namespaces(&mut targets);
+        self.extend_star_closure(&mut targets, StarChains::PlainAndNamespace);
+        targets
+    }
+
+    /// Add every `export * as ns` source whose namespace object an entry
+    /// point's own export surface exposes.
+    ///
+    /// The surface is tracked by name, so a barrel that only forwards one
+    /// binding never exposes the rest of its module. `ns` reaches an entry
+    /// point three ways: the namespace re-export sits on the entry point
+    /// itself, it sits on a barrel the entry reaches through plain `export *`
+    /// (the star forwards `ns` along with every other name), or an entry
+    /// point re-exports `ns` by name through a chain of named and star
+    /// re-exports, renames included (`export { sub } from './barrel'`). All
+    /// three hand `ns` to consumers the graph cannot enumerate, so the
+    /// target's own chains must be credited.
+    fn seed_entry_exposed_namespaces(&self, targets: &mut FxHashSet<FileId>) {
+        if !self
+            .modules
+            .iter()
+            .any(|m| m.re_exports.iter().any(is_namespace_re_export))
+        {
+            return;
+        }
+
+        let mut star_surface: FxHashSet<FileId> = self
             .modules
             .iter()
             .filter(|m| m.is_entry_point())
             .map(|m| m.file_id)
             .collect();
-        self.extend_star_closure(&mut entry_surface, StarChains::Plain);
+        self.extend_star_closure(&mut star_surface, StarChains::Plain);
 
-        let mut targets = whole_module_targets.clone();
-        targets.extend(
-            entry_surface
-                .iter()
-                .filter_map(|file_id| self.modules.get(file_id.0 as usize))
-                .flat_map(|m| {
-                    m.re_exports
-                        .iter()
-                        .filter(|re| re.imported_name == "*" && re.exported_name != "*")
-                        .map(|re| re.source_file)
-                }),
-        );
-        self.extend_star_closure(&mut targets, StarChains::PlainAndNamespace);
-        targets
+        let mut named_surface: FxHashSet<(FileId, &str)> = FxHashSet::default();
+        let mut frontier: Vec<(FileId, &str)> = Vec::new();
+        for module in star_surface
+            .iter()
+            .filter_map(|file_id| self.modules.get(file_id.0 as usize))
+        {
+            for re in &module.re_exports {
+                if is_namespace_re_export(re) {
+                    targets.insert(re.source_file);
+                } else if re.imported_name != "*"
+                    && named_surface.insert((re.source_file, re.imported_name.as_str()))
+                {
+                    frontier.push((re.source_file, re.imported_name.as_str()));
+                }
+            }
+        }
+
+        while let Some((file_id, name)) = frontier.pop() {
+            let Some(module) = self.modules.get(file_id.0 as usize) else {
+                continue;
+            };
+            for re in &module.re_exports {
+                let inward = if re.imported_name == "*" {
+                    if re.exported_name == "*" {
+                        // A plain star is one of the places `name` can arrive
+                        // from, so the search continues under the same name.
+                        Some(name)
+                    } else {
+                        if re.exported_name == name {
+                            targets.insert(re.source_file);
+                        }
+                        None
+                    }
+                } else if re.exported_name == name {
+                    Some(re.imported_name.as_str())
+                } else {
+                    None
+                };
+                if let Some(inward_name) = inward
+                    && named_surface.insert((re.source_file, inward_name))
+                {
+                    frontier.push((re.source_file, inward_name));
+                }
+            }
+        }
     }
 
     /// Extend `targets` with every module its members reach through the

--- a/crates/graph/src/graph/re_exports/mod.rs
+++ b/crates/graph/src/graph/re_exports/mod.rs
@@ -135,6 +135,86 @@ fn is_namespace_re_export(re: &super::types::ReExportEdge) -> bool {
     re.imported_name == "*" && re.exported_name != "*"
 }
 
+/// Reverse index of the re-export edges that carry one exported name outward,
+/// from the module that declares it toward the barrels that forward it.
+///
+/// A namespace re-export (`export * as ns`) is not a forwarder: it bundles the
+/// source's names into one object instead of passing them along.
+struct NameForwarders<'a> {
+    /// `(source, imported name)` to the barrels re-exporting it, each with the
+    /// name it exports it under, so renames are followed exactly.
+    named: FxHashMap<(FileId, &'a str), Vec<(FileId, &'a str)>>,
+    /// Source file to the barrels that re-export all of its names.
+    stars: FxHashMap<FileId, Vec<FileId>>,
+}
+
+/// Reusable visited set and stack for [`NameForwarders::reaches_surface`].
+#[derive(Default)]
+struct NameSearchScratch<'a> {
+    visited: FxHashSet<(FileId, &'a str)>,
+    frontier: Vec<(FileId, &'a str)>,
+}
+
+impl<'a> NameForwarders<'a> {
+    fn build(modules: &'a [super::types::ModuleNode]) -> Self {
+        let mut named: FxHashMap<(FileId, &'a str), Vec<(FileId, &'a str)>> = FxHashMap::default();
+        let mut stars: FxHashMap<FileId, Vec<FileId>> = FxHashMap::default();
+        for module in modules {
+            for re in &module.re_exports {
+                if re.imported_name == "*" {
+                    if re.exported_name == "*" {
+                        stars
+                            .entry(re.source_file)
+                            .or_default()
+                            .push(module.file_id);
+                    }
+                } else {
+                    named
+                        .entry((re.source_file, re.imported_name.as_str()))
+                        .or_default()
+                        .push((module.file_id, re.exported_name.as_str()));
+                }
+            }
+        }
+        Self { named, stars }
+    }
+
+    /// Whether `name`, as exported by `file`, reaches a module on the entry
+    /// point's star surface through named and plain-star re-exports.
+    fn reaches_surface(
+        &self,
+        file: FileId,
+        name: &'a str,
+        star_surface: &FxHashSet<FileId>,
+        scratch: &mut NameSearchScratch<'a>,
+    ) -> bool {
+        scratch.visited.clear();
+        scratch.frontier.clear();
+        scratch.visited.insert((file, name));
+        scratch.frontier.push((file, name));
+        while let Some((current, current_name)) = scratch.frontier.pop() {
+            if star_surface.contains(&current) {
+                return true;
+            }
+            if let Some(barrels) = self.named.get(&(current, current_name)) {
+                for &(barrel, exported_name) in barrels {
+                    if scratch.visited.insert((barrel, exported_name)) {
+                        scratch.frontier.push((barrel, exported_name));
+                    }
+                }
+            }
+            if let Some(barrels) = self.stars.get(&current) {
+                for &barrel in barrels {
+                    if scratch.visited.insert((barrel, current_name)) {
+                        scratch.frontier.push((barrel, current_name));
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
 struct ReExportFixpointInput<'a> {
     re_export_info: &'a [ReExportTuple],
     entry_star_targets: &'a FxHashSet<FileId>,
@@ -322,12 +402,23 @@ impl ModuleGraph {
     /// re-exports, renames included (`export { sub } from './barrel'`). All
     /// three hand `ns` to consumers the graph cannot enumerate, so the
     /// target's own chains must be credited.
+    ///
+    /// The search runs outward from each namespace edge rather than inward
+    /// from every entry-point export, so its cost scales with the number of
+    /// `export * as` edges (usually a handful) instead of with the number of
+    /// names an entry point re-exports.
     fn seed_entry_exposed_namespaces(&self, targets: &mut FxHashSet<FileId>) {
-        if !self
+        let namespace_edges: Vec<(FileId, &str, FileId)> = self
             .modules
             .iter()
-            .any(|m| m.re_exports.iter().any(is_namespace_re_export))
-        {
+            .flat_map(|m| {
+                m.re_exports
+                    .iter()
+                    .filter(|re| is_namespace_re_export(re))
+                    .map(move |re| (m.file_id, re.exported_name.as_str(), re.source_file))
+            })
+            .collect();
+        if namespace_edges.is_empty() {
             return;
         }
 
@@ -339,49 +430,25 @@ impl ModuleGraph {
             .collect();
         self.extend_star_closure(&mut star_surface, StarChains::Plain);
 
-        let mut named_surface: FxHashSet<(FileId, &str)> = FxHashSet::default();
-        let mut frontier: Vec<(FileId, &str)> = Vec::new();
-        for module in star_surface
-            .iter()
-            .filter_map(|file_id| self.modules.get(file_id.0 as usize))
-        {
-            for re in &module.re_exports {
-                if is_namespace_re_export(re) {
-                    targets.insert(re.source_file);
-                } else if re.imported_name != "*"
-                    && named_surface.insert((re.source_file, re.imported_name.as_str()))
-                {
-                    frontier.push((re.source_file, re.imported_name.as_str()));
-                }
+        let mut off_surface: Vec<(FileId, &str, FileId)> = Vec::new();
+        for (barrel, exported_name, source) in namespace_edges {
+            if star_surface.contains(&barrel) {
+                targets.insert(source);
+            } else {
+                off_surface.push((barrel, exported_name, source));
             }
         }
+        if off_surface.is_empty() {
+            return;
+        }
 
-        while let Some((file_id, name)) = frontier.pop() {
-            let Some(module) = self.modules.get(file_id.0 as usize) else {
-                continue;
-            };
-            for re in &module.re_exports {
-                let inward = if re.imported_name == "*" {
-                    if re.exported_name == "*" {
-                        // A plain star is one of the places `name` can arrive
-                        // from, so the search continues under the same name.
-                        Some(name)
-                    } else {
-                        if re.exported_name == name {
-                            targets.insert(re.source_file);
-                        }
-                        None
-                    }
-                } else if re.exported_name == name {
-                    Some(re.imported_name.as_str())
-                } else {
-                    None
-                };
-                if let Some(inward_name) = inward
-                    && named_surface.insert((re.source_file, inward_name))
-                {
-                    frontier.push((re.source_file, inward_name));
-                }
+        let forwarders = NameForwarders::build(&self.modules);
+        let mut search = NameSearchScratch::default();
+        for (barrel, exported_name, source) in off_surface {
+            if !targets.contains(&source)
+                && forwarders.reaches_surface(barrel, exported_name, &star_surface, &mut search)
+            {
+                targets.insert(source);
             }
         }
     }

--- a/crates/graph/src/graph/re_exports/tests.rs
+++ b/crates/graph/src/graph/re_exports/tests.rs
@@ -4278,3 +4278,157 @@ fn merged_exports(
         .expect("value export should exist");
     (type_export, value_export)
 }
+
+/// A `ResolvedReExport` that renames the binding on the way out.
+fn renaming_re_export(
+    source: &str,
+    imported_name: &str,
+    exported_name: &str,
+    target: ResolveResult,
+) -> ResolvedReExport {
+    ResolvedReExport {
+        info: fallow_types::extract::ReExportInfo {
+            source: source.to_string(),
+            imported_name: imported_name.to_string(),
+            exported_name: exported_name.to_string(),
+            is_type_only: false,
+            span: oxc_span::Span::default(),
+            statement_span: oxc_span::Span::default(),
+            source_span: oxc_span::Span::default(),
+        },
+        target,
+    }
+}
+
+fn star_re_export(source: &str, target: ResolveResult) -> ResolvedReExport {
+    plain_re_export(source, "*", target)
+}
+
+/// leaf/other declare `one`; the three barrels forward it, shadow it and
+/// receive it twice.
+fn graph_for_forwarding_shapes() -> ModuleGraph {
+    let files = vec![
+        discovered_file(0, "/project/leaf.ts"),
+        discovered_file(1, "/project/other.ts"),
+        discovered_file(2, "/project/rename.ts"),
+        discovered_file(3, "/project/shadow.ts"),
+        discovered_file(4, "/project/ambiguous.ts"),
+        discovered_file(5, "/project/consumer.ts"),
+    ];
+    let resolved_modules = vec![
+        ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/project/leaf.ts"),
+            exports: vec![named_export("one", false)].into(),
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(1),
+            path: PathBuf::from("/project/other.ts"),
+            exports: vec![named_export("one", false)].into(),
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(2),
+            path: PathBuf::from("/project/rename.ts"),
+            re_exports: vec![renaming_re_export(
+                "./leaf",
+                "one",
+                "renamed",
+                ResolveResult::InternalModule(FileId(0)),
+            )],
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(3),
+            path: PathBuf::from("/project/shadow.ts"),
+            exports: vec![named_export("one", false)].into(),
+            re_exports: vec![star_re_export(
+                "./leaf",
+                ResolveResult::InternalModule(FileId(0)),
+            )],
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(4),
+            path: PathBuf::from("/project/ambiguous.ts"),
+            re_exports: vec![
+                star_re_export("./leaf", ResolveResult::InternalModule(FileId(0))),
+                star_re_export("./other", ResolveResult::InternalModule(FileId(1))),
+            ],
+            ..Default::default()
+        },
+        ResolvedModule {
+            file_id: FileId(5),
+            path: PathBuf::from("/project/consumer.ts"),
+            ..Default::default()
+        },
+    ];
+    let entry_points = vec![EntryPoint {
+        path: PathBuf::from("/project/consumer.ts"),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+    ModuleGraph::build(&resolved_modules, &entry_points, &files)
+}
+
+#[test]
+fn forwards_binding_agrees_with_phase_2c_on_rename_shadow_and_ambiguity() {
+    let graph = graph_for_forwarding_shapes();
+    let (leaf, other) = (FileId(0), FileId(1));
+    let (rename, shadow, ambiguous) = (FileId(2), FileId(3), FileId(4));
+
+    // A rename hop forwards the leaf binding; a local declaration on the
+    // barrel and the same name arriving from two stars both stop the chain.
+    for (source, source_name, barrel, barrel_name, expected, why) in [
+        (
+            leaf,
+            "one",
+            rename,
+            "renamed",
+            true,
+            "a rename hop forwards",
+        ),
+        (
+            leaf,
+            "one",
+            shadow,
+            "one",
+            false,
+            "a local declaration shadows",
+        ),
+        (
+            leaf,
+            "one",
+            ambiguous,
+            "one",
+            false,
+            "two stars carry the name at once",
+        ),
+        (
+            other,
+            "one",
+            ambiguous,
+            "one",
+            false,
+            "the second star is ambiguous too",
+        ),
+    ] {
+        assert_eq!(
+            graph.forwards_binding(source, source_name, barrel, barrel_name),
+            expected,
+            "the closure search must agree that {why}"
+        );
+        assert_eq!(
+            crate::graph::namespace_indexes::uniquely_forwards_binding(
+                &graph,
+                source,
+                source_name,
+                barrel,
+                barrel_name,
+                ExportNamespace::Value,
+            ),
+            expected,
+            "Phase 2c's own walk must agree that {why}"
+        );
+    }
+}

--- a/crates/graph/src/graph/reachability.rs
+++ b/crates/graph/src/graph/reachability.rs
@@ -306,7 +306,12 @@ impl ProfileWorklist {
 }
 
 impl ModuleGraph {
-    fn collect_reachable(
+    /// BFS over the edge list from `entry_points`.
+    ///
+    /// Reads edges only, so the result is stable from the moment
+    /// `populate_edges` finishes; the graph build calls it once and hands the
+    /// same bitset to the exposed namespace closure and to `mark_reachable`.
+    pub(super) fn collect_reachable(
         &self,
         entry_points: &FxHashSet<FileId>,
         total_capacity: usize,
@@ -375,15 +380,16 @@ impl ModuleGraph {
     /// Mark modules reachable from overall, runtime, and test entry points via BFS.
     ///
     /// Skips redundant BFS passes when entry point sets are identical or empty.
+    /// `visited` is the overall entry-point pass, already computed by the
+    /// caller through [`ModuleGraph::collect_reachable`].
     pub(super) fn mark_reachable(
         &mut self,
+        visited: &FixedBitSet,
         entry_points: &FxHashSet<FileId>,
         runtime_entry_points: &FxHashSet<FileId>,
         test_reachability_plan: TestReachabilityPlan<'_>,
         total_capacity: usize,
     ) {
-        let visited = self.collect_reachable(entry_points, total_capacity);
-
         let runtime_same = runtime_entry_points == entry_points;
         let runtime_visited = if runtime_same {
             None

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -96,21 +96,27 @@ error by suppressing a downstream detector.
   dynamic-import pattern match through `import()`, `import.meta.glob`, or
   `require.context`, a bare side-effect `require('./barrel')` with no binding,
   and a namespace import the graph cannot narrow: a whole-object use, a
-  binding handed on without member access, or a binding re-exported from a
-  non-entry module) plus the `export * as ns` sources an entry point's own
-  export surface exposes: on the entry point itself, on a barrel the entry
-  reaches through plain `export *`, or named by the entry through a chain of
-  named and star re-exports, renames included. That surface is tracked by
-  name, so a barrel an entry point reaches only through
-  `export { one } from './barrel'` exposes `one` and nothing else. Every hop
-  of that name chain must uniquely forward the binding, the same rule the
-  Phase 2c walk applies, so a barrel that declares its own `ns` shadows a
-  star-forwarded `ns` and the chain stops there. That check reads the value
-  namespace whenever the source exports the name there and the type namespace
-  otherwise, so `export type { ns } from './barrel'` on an entry point does
-  not put the value namespace object on the surface. Plain-star hops and the
-  closure's own chain walk stay namespace-agnostic, like the pre-existing
-  entry-star closure.
+  binding handed on without member access, or a binding exported under its own
+  name from any module, entry point included) plus every `export * as ns`
+  source whose name reaches a consumer the graph cannot enumerate.
+- A name reaches such a consumer three ways, and the closure applies the same
+  test to all three: it arrives on an entry point's own export surface (the
+  public API, `default` included), on a module already in the closure (which
+  exposes what its own exposure allows), or at a name some importer uses as a
+  whole object (`import { sub } from './barrel'` plus `Object.values(sub)`).
+  The search runs outward from each namespace edge along named and plain-star
+  re-exports, so its cost scales with the number of `export * as` edges rather
+  than with the number of names an entry point re-exports. Every hop must
+  uniquely forward the binding, the same rule the Phase 2c walk applies, so a
+  barrel that declares its own `ns`, or that receives `ns` from two stars at
+  once, exports a different binding under that name and the chain stops there.
+  Sitting on an entry point's plain-`export *` closure is not on its own proof
+  that a name survives to the entry, so no hop is skipped for it. The forwarding
+  check reads the value namespace whenever the source exports the name there and
+  the type namespace otherwise, so `export type { ns } from './barrel'` on an
+  entry point does not put the value namespace object on the surface. Plain-star
+  hops and the closure's own chain walk stay namespace-agnostic, like the
+  pre-existing entry-star closure.
 - The closure follows `export *` and `export * as` chains from each member,
   and carries how much of each member is exposed. A member whose whole
   namespace object is observed exposes every export; a member reached through
@@ -122,28 +128,41 @@ error by suppressing a downstream detector.
   name that `export * as` uses. `export * as default` therefore only carries a
   namespace object onward from an entry point itself or from a member whose
   whole namespace object is observed.
+- The namespace-edge seeds and the chain walk run to a fixpoint against each
+  other: a target that joins the closure can itself expose the name a further
+  `export * as ns` edge forwards to it, and that edge only qualifies once the
+  target is a member. Each round widens the closure or stops, so the walk
+  terminates, and the closure Phase 2c reads already contains every target
+  Phase 2c would credit in full instead of stopping one namespace level short
+  of it.
 - A member-narrowed namespace import (`ns.one()`) never seeds the closure, a
   binding placed in an exported object literal (`export const API = { ns }`)
-  seeds it only when it is also used as a whole object (the namespace-object
-  alias phase follows `API.ns.<member>` precisely while the direct-export
-  mark-all stays as before), and a namespace re-export on a barrel off the
-  entry surface with no consumer exposes nothing. The seed's own credit keeps
-  its shape: a runtime whole-module edge credits the namespace object,
-  `default` included; the ambient star form credits the star surface without
-  `default`. A module no entry point reaches is never a member: the report
-  already calls it an unused file, and the only consumers left to observe it
-  are unreachable themselves, so crediting its chain would only stack
-  unused-export rows underneath the unused-file rows. The mark-all sites that
-  feed the closure keep crediting the target's own direct exports as before,
-  reachable or not; reference-level reachability filters those at reporting
-  time.
+  seeds it only when it is also used as a whole object or exported under its
+  own name (the namespace-object alias phase follows `API.ns.<member>`
+  precisely while the direct-export mark-all stays as before), and a namespace
+  re-export on a barrel off the entry surface with no consumer exposes nothing.
+  The seed's own credit keeps its shape: a runtime whole-module edge credits
+  the namespace object, `default` included; the ambient star form credits the
+  star surface without `default`.
+- A module no entry point reaches is never a member: the report already calls
+  it an unused file, and the only consumers left to observe it are unreachable
+  themselves, so crediting its chain would only stack unused-export rows
+  underneath the unused-file rows. The reachability test applies to the seed,
+  not to the observer, so a whole-object use inside an unreachable file still
+  suppresses the reachable target's whole chain, the same way the pre-existing
+  mark-all already suppresses the target's direct exports from such a file.
+  Deleting the unused file the report names therefore brings the chain back as
+  unused exports on the next run. The mark-all sites that feed the closure keep
+  crediting the target's own direct exports as before, reachable or not;
+  reference-level reachability filters those at reporting time.
 - The exposed namespace closure is computed once per graph build, in
   `ModuleGraph::build`, and threaded into both phases that read it (Phase 2c
   namespace re-export propagation and the Phase 4 entry-star seed). It depends
-  only on `ModuleNode::re_exports`, the entry-point flags, and entry-point
-  reachability, none of which any phase after Phase 2 mutates. Reachability
-  reads the edge list alone, so the build computes it once, before the
-  closure, and hands the same bitset to `mark_reachable`.
+  only on `ModuleNode::re_exports`, the entry-point flags, the consumers'
+  whole-object uses, and entry-point reachability, none of which any phase
+  after Phase 2 mutates. Reachability reads the edge list alone, so the build
+  computes it once, before the closure, and hands the same bitset to
+  `mark_reachable`.
 - Styling and CSS-in-JS extraction must preserve source line mapping.
 - Duplication token or normalization changes require the duplication cache
   version to move with the changed semantics.

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -103,8 +103,12 @@ error by suppressing a downstream detector.
   its `export *` sources (named exports in both namespaces, never `default`)
   and namespace re-export propagation credits every export of its
   `export * as` sources (`default` included). A member-narrowed namespace
-  import (`ns.one()`) never seeds it, and a namespace re-export on a barrel
-  off the entry surface with no consumer exposes nothing. The seed's own
+  import (`ns.one()`) never seeds it, a binding placed in an exported object
+  literal (`export const API = { ns }`) seeds it only when it is also used as
+  a whole object (the namespace-object alias phase follows `API.ns.<member>`
+  precisely while the direct-export mark-all stays as before), and a
+  namespace re-export on a barrel off the entry surface with no consumer
+  exposes nothing. The seed's own
   credit keeps its shape: a runtime whole-module edge credits the namespace
   object, `default` included; the ambient star form credits the star surface
   without `default`.

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -80,18 +80,34 @@ error by suppressing a downstream detector.
   `declare module '...'` body, recorded as a type-only namespace import
   without a local binding) credits the full ES star surface of its target:
   every named export in both the type and the value namespace, never the
-  target's `default`, and, through the ambient star closure
-  (`ModuleGraph::collect_ambient_star_targets`), the same surface of every
-  module the target reaches through its own `export *` chain plus every
-  export (`default` included) of each `export * as sub` source along that
-  chain, recursively. `export * as ns` adds a type-only default import for
-  `ns.default`. Every other type-only import credits type space only: a bound
-  `import type { x }`, the ambient named re-export (#2349), explicitly
-  type-only ambient re-exports, and `import()` type references in TypeScript
-  and JSDoc, so the value half of a same-name type and value pair reached only
-  that way still reports. Runtime whole-module edges (dynamic-import patterns)
-  credit the module namespace object, `default` included, and only the
-  target's direct exports.
+  target's `default`, and, through the exposed namespace closure below, the
+  same surface of every module the target reaches through its own `export *`
+  chain plus every export (`default` included) of each `export * as sub`
+  source along that chain, recursively. `export * as ns` adds a type-only
+  default import for `ns.default`. Every other type-only import credits type
+  space only: a bound `import type { x }`, the ambient named re-export
+  (#2349), explicitly type-only ambient re-exports, and `import()` type
+  references in TypeScript and JSDoc, so the value half of a same-name type
+  and value pair reached only that way still reports.
+- The exposed namespace closure
+  (`ModuleGraph::collect_exposed_namespace_targets`, issues #2357, #2372,
+  #2373) is seed-agnostic. Its seeds are every target whose whole namespace
+  object a consumer observes in Phase 2 (an ambient-module star, a
+  dynamic-import pattern match through `import()`, `import.meta.glob`, or
+  `require.context`, and a namespace import the graph cannot narrow: a
+  whole-object use, a binding handed on without member access, or a binding
+  re-exported from a non-entry module) plus the `export * as ns` sources on
+  the entry-point surface (entry points and every barrel they reach through
+  plain `export *`). The closure follows `export *` and `export * as` chains
+  from each member: star propagation treats a member like an entry barrel for
+  its `export *` sources (named exports in both namespaces, never `default`)
+  and namespace re-export propagation credits every export of its
+  `export * as` sources (`default` included). A member-narrowed namespace
+  import (`ns.one()`) never seeds it, and a namespace re-export on a barrel
+  off the entry surface with no consumer exposes nothing. The seed's own
+  credit keeps its shape: a runtime whole-module edge credits the namespace
+  object, `default` included; the ambient star form credits the star surface
+  without `default`.
 - Styling and CSS-in-JS extraction must preserve source line mapping.
 - Duplication token or normalization changes require the duplication cache
   version to move with the changed semantics.

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -94,19 +94,35 @@ error by suppressing a downstream detector.
   #2373) is seed-agnostic. Its seeds are every target whose whole namespace
   object a consumer observes in Phase 2 (an ambient-module star, a
   dynamic-import pattern match through `import()`, `import.meta.glob`, or
-  `require.context`, and a namespace import the graph cannot narrow: a
-  whole-object use, a binding handed on without member access, or a binding
-  re-exported from a non-entry module) plus the `export * as ns` sources an
-  entry point's own export surface exposes: on the entry point itself, on a
-  barrel the entry reaches through plain `export *`, or named by the entry
-  through a chain of named and star re-exports, renames included. That surface
-  is tracked by name, so a barrel an entry point reaches only through
-  `export { one } from './barrel'` exposes `one` and nothing else. The closure
-  follows `export *` and `export * as` chains from each member: star
-  propagation treats a member like an entry barrel for its `export *` sources
-  (named exports in both namespaces, never `default`) and namespace re-export
-  propagation credits every export of its `export * as` sources (`default`
-  included). A member-narrowed namespace import (`ns.one()`) never seeds it, a
+  `require.context`, a bare side-effect `require('./barrel')` with no binding,
+  and a namespace import the graph cannot narrow: a whole-object use, a
+  binding handed on without member access, or a binding re-exported from a
+  non-entry module) plus the `export * as ns` sources an entry point's own
+  export surface exposes: on the entry point itself, on a barrel the entry
+  reaches through plain `export *`, or named by the entry through a chain of
+  named and star re-exports, renames included. That surface is tracked by
+  name, so a barrel an entry point reaches only through
+  `export { one } from './barrel'` exposes `one` and nothing else. Every hop
+  of that name chain must uniquely forward the binding, the same rule the
+  Phase 2c walk applies, so a barrel that declares its own `ns` shadows a
+  star-forwarded `ns` and the chain stops there. That check reads the value
+  namespace whenever the source exports the name there and the type namespace
+  otherwise, so `export type { ns } from './barrel'` on an entry point does
+  not put the value namespace object on the surface. Plain-star hops and the
+  closure's own chain walk stay namespace-agnostic, like the pre-existing
+  entry-star closure.
+- The closure follows `export *` and `export * as` chains from each member,
+  and carries how much of each member is exposed. A member whose whole
+  namespace object is observed exposes every export; a member reached through
+  a plain `export *` exposes every export except `default`, which no plain
+  `export *` forwards. Star propagation treats a member like an entry barrel
+  for its `export *` sources (named exports in both namespaces, never
+  `default`) and namespace re-export propagation credits every export of its
+  `export * as` sources (`default` included) whenever the member exposes the
+  name that `export * as` uses. `export * as default` therefore only carries a
+  namespace object onward from an entry point itself or from a member whose
+  whole namespace object is observed.
+- A member-narrowed namespace import (`ns.one()`) never seeds the closure, a
   binding placed in an exported object literal (`export const API = { ns }`)
   seeds it only when it is also used as a whole object (the namespace-object
   alias phase follows `API.ns.<member>` precisely while the direct-export
@@ -114,15 +130,20 @@ error by suppressing a downstream detector.
   entry surface with no consumer exposes nothing. The seed's own credit keeps
   its shape: a runtime whole-module edge credits the namespace object,
   `default` included; the ambient star form credits the star surface without
-  `default`. Seeding runs before reachability, like the mark-all sites that
-  feed it, so a whole-object use inside a file the same report calls unused
-  still credits its target's chain; deleting that file is what re-reports the
-  chain.
+  `default`. A module no entry point reaches is never a member: the report
+  already calls it an unused file, and the only consumers left to observe it
+  are unreachable themselves, so crediting its chain would only stack
+  unused-export rows underneath the unused-file rows. The mark-all sites that
+  feed the closure keep crediting the target's own direct exports as before,
+  reachable or not; reference-level reachability filters those at reporting
+  time.
 - The exposed namespace closure is computed once per graph build, in
   `ModuleGraph::build`, and threaded into both phases that read it (Phase 2c
   namespace re-export propagation and the Phase 4 entry-star seed). It depends
-  only on `ModuleNode::re_exports` and the entry-point flags, neither of which
-  any phase after Phase 2 mutates.
+  only on `ModuleNode::re_exports`, the entry-point flags, and entry-point
+  reachability, none of which any phase after Phase 2 mutates. Reachability
+  reads the edge list alone, so the build computes it once, before the
+  closure, and hands the same bitset to `mark_reachable`.
 - Styling and CSS-in-JS extraction must preserve source line mapping.
 - Duplication token or normalization changes require the duplication cache
   version to move with the changed semantics.

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -96,22 +96,33 @@ error by suppressing a downstream detector.
   dynamic-import pattern match through `import()`, `import.meta.glob`, or
   `require.context`, and a namespace import the graph cannot narrow: a
   whole-object use, a binding handed on without member access, or a binding
-  re-exported from a non-entry module) plus the `export * as ns` sources on
-  the entry-point surface (entry points and every barrel they reach through
-  plain `export *`). The closure follows `export *` and `export * as` chains
-  from each member: star propagation treats a member like an entry barrel for
-  its `export *` sources (named exports in both namespaces, never `default`)
-  and namespace re-export propagation credits every export of its
-  `export * as` sources (`default` included). A member-narrowed namespace
-  import (`ns.one()`) never seeds it, a binding placed in an exported object
-  literal (`export const API = { ns }`) seeds it only when it is also used as
-  a whole object (the namespace-object alias phase follows `API.ns.<member>`
-  precisely while the direct-export mark-all stays as before), and a
-  namespace re-export on a barrel off the entry surface with no consumer
-  exposes nothing. The seed's own
-  credit keeps its shape: a runtime whole-module edge credits the namespace
-  object, `default` included; the ambient star form credits the star surface
-  without `default`.
+  re-exported from a non-entry module) plus the `export * as ns` sources an
+  entry point's own export surface exposes: on the entry point itself, on a
+  barrel the entry reaches through plain `export *`, or named by the entry
+  through a chain of named and star re-exports, renames included. That surface
+  is tracked by name, so a barrel an entry point reaches only through
+  `export { one } from './barrel'` exposes `one` and nothing else. The closure
+  follows `export *` and `export * as` chains from each member: star
+  propagation treats a member like an entry barrel for its `export *` sources
+  (named exports in both namespaces, never `default`) and namespace re-export
+  propagation credits every export of its `export * as` sources (`default`
+  included). A member-narrowed namespace import (`ns.one()`) never seeds it, a
+  binding placed in an exported object literal (`export const API = { ns }`)
+  seeds it only when it is also used as a whole object (the namespace-object
+  alias phase follows `API.ns.<member>` precisely while the direct-export
+  mark-all stays as before), and a namespace re-export on a barrel off the
+  entry surface with no consumer exposes nothing. The seed's own credit keeps
+  its shape: a runtime whole-module edge credits the namespace object,
+  `default` included; the ambient star form credits the star surface without
+  `default`. Seeding runs before reachability, like the mark-all sites that
+  feed it, so a whole-object use inside a file the same report calls unused
+  still credits its target's chain; deleting that file is what re-reports the
+  chain.
+- The exposed namespace closure is computed once per graph build, in
+  `ModuleGraph::build`, and threaded into both phases that read it (Phase 2c
+  namespace re-export propagation and the Phase 4 entry-star seed). It depends
+  only on `ModuleNode::re_exports` and the entry-point flags, neither of which
+  any phase after Phase 2 mutates.
 - Styling and CSS-in-JS extraction must preserve source line mapping.
 - Duplication token or normalization changes require the duplication cache
   version to move with the changed semantics.

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -109,14 +109,18 @@ error by suppressing a downstream detector.
   than with the number of names an entry point re-exports. Every hop must
   uniquely forward the binding, the same rule the Phase 2c walk applies, so a
   barrel that declares its own `ns`, or that receives `ns` from two stars at
-  once, exports a different binding under that name and the chain stops there.
-  Sitting on an entry point's plain-`export *` closure is not on its own proof
-  that a name survives to the entry, so no hop is skipped for it. The forwarding
-  check reads the value namespace whenever the source exports the name there and
-  the type namespace otherwise, so `export type { ns } from './barrel'` on an
-  entry point does not put the value namespace object on the surface. Plain-star
-  hops and the closure's own chain walk stay namespace-agnostic, like the
-  pre-existing entry-star closure.
+  once, exports a different binding under that name and the chain stops
+  there. That rule is not restated: `ModuleGraph::forwards_binding` picks the
+  namespace and then calls Phase 2c's own `uniquely_forwards_binding`, so the
+  closure and the phase it pre-computes for cannot drift apart on what a hop
+  forwards. Sitting on an entry point's plain-`export *` closure is not on its
+  own proof that a name survives to the entry, so no hop is skipped for it.
+  The forwarding check reads the value namespace whenever the source exports
+  the name there and the type namespace otherwise, so
+  `export type { ns } from './barrel'` on an entry point does not put the
+  value namespace object on the surface. Plain-star hops and the closure's own
+  chain walk stay namespace-agnostic, like the pre-existing entry-star
+  closure.
 - The closure follows `export *` and `export * as` chains from each member,
   and carries how much of each member is exposed. A member whose whole
   namespace object is observed exposes every export; a member reached through
@@ -134,7 +138,12 @@ error by suppressing a downstream detector.
   target is a member. Each round widens the closure or stops, so the walk
   terminates, and the closure Phase 2c reads already contains every target
   Phase 2c would credit in full instead of stopping one namespace level short
-  of it.
+  of it. The reachability prune the search uses only grows, so a round extends
+  it from the members the previous round added instead of rebuilding it, and
+  each re-export edge is walked at most once across all rounds. The rest of a
+  round is a rescan of the namespace edges still pending, which a chain shaped
+  to resolve exactly one edge per round can drive up; real barrel trees settle
+  whole subtrees per round and stay in the single digits.
 - A member-narrowed namespace import (`ns.one()`) never seeds the closure, a
   binding placed in an exported object literal (`export const API = { ns }`)
   seeds it only when it is also used as a whole object or exported under its
@@ -144,17 +153,37 @@ error by suppressing a downstream detector.
   The seed's own credit keeps its shape: a runtime whole-module edge credits
   the namespace object, `default` included; the ambient star form credits the
   star surface without `default`.
-- A module no entry point reaches is never a member: the report already calls
-  it an unused file, and the only consumers left to observe it are unreachable
-  themselves, so crediting its chain would only stack unused-export rows
-  underneath the unused-file rows. The reachability test applies to the seed,
-  not to the observer, so a whole-object use inside an unreachable file still
-  suppresses the reachable target's whole chain, the same way the pre-existing
-  mark-all already suppresses the target's direct exports from such a file.
-  Deleting the unused file the report names therefore brings the chain back as
-  unused exports on the next run. The mark-all sites that feed the closure keep
-  crediting the target's own direct exports as before, reachable or not;
-  reference-level reachability filters those at reporting time.
+- Reachability gates the seeds issues #2372 and #2373 add, and nothing else.
+  A target no entry point reaches, observed only by a consumer in this graph,
+  is not seeded: that consumer is unreachable too, the report already calls
+  the target an unused file, and crediting its chain would only stack
+  unused-export rows underneath the unused-file rows. The same holds for an
+  `export * as ns` source no entry point reaches. The test applies to the
+  seed, not to the observer, so a whole-object use inside an unreachable file
+  still suppresses the reachable target's whole chain, the same way the
+  pre-existing mark-all already suppresses the target's direct exports from
+  such a file; deleting the unused file the report names brings the chain back
+  as unused exports on the next run.
+- The ambient seeds are not gated, and neither is the chain walk. A
+  `declare module 'pkg'` body states the shape of an external module id: its
+  observers are importers of that id, outside this graph, so where the shim
+  and its target sit inside the graph says nothing about who looks. The chain
+  behind an unreachable shim routinely re-enters a module an entry point
+  imports directly, and gating it reported exports on files the report calls
+  reachable. A re-export edge makes its source reachable whenever the barrel
+  is, so only an ambient chain can ever walk out of an unreachable member in
+  the first place; a hop that lands on an unreachable module credits it
+  through a re-export reference the unused-export detector already discounts
+  when nothing reachable reads it. The mark-all sites that feed the closure
+  keep crediting the target's own direct exports as before, reachable or not.
+- Two seed properties are deliberate and visible in reports. The seed is
+  namespace-agnostic, so `export type { ns }` seeds it exactly like
+  `export { ns }` and the chain is credited in the value namespace as well:
+  `typeof ns.member` keeps a value declaration reachable through a type-only
+  re-export. And the seed does not ask whether the re-export itself has a
+  consumer, so a namespace binding exported under its own name credits the
+  chain behind it even when the report calls that very export unused, the same
+  self-inconsistency the unreachable-observer case has.
 - The exposed namespace closure is computed once per graph build, in
   `ModuleGraph::build`, and threaded into both phases that read it (Phase 2c
   namespace re-export propagation and the Phase 4 entry-star seed). It depends

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/package.json
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-2372-star-barrel-whole-module",
+  "type": "module",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-barrel.ts
@@ -1,0 +1,2 @@
+export * from './alias-deep';
+export const aliasDirect = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-deep.ts
@@ -1,0 +1,2 @@
+export const aliasOne = 1;
+export const aliasTwo = 2;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-re-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-re-barrel.ts
@@ -1,0 +1,2 @@
+export * from './alias-re-deep';
+export const aliasReDirect = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-re-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-re-deep.ts
@@ -1,0 +1,1 @@
+export const aliasReOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-reexport.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias-reexport.ts
@@ -1,0 +1,7 @@
+import * as aliasReNs from './alias-re-barrel';
+
+// The binding is both an object-literal alias source and exported under its
+// own name: the named export hands the whole object to consumers the graph
+// cannot enumerate, so the chain behind it is credited.
+export const aliasReApi = { aliasReNs };
+export { aliasReNs };

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/alias.ts
@@ -1,0 +1,5 @@
+import * as aliasNs from './alias-barrel';
+
+// A namespace binding placed in an exported object literal: consumers reach
+// it as `aliasApi.aliasNs.<member>`, which the alias phase follows precisely.
+export const aliasApi = { aliasNs };

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-barrel.ts
@@ -1,0 +1,3 @@
+export * from './ambient-mid';
+export * as ambientNs from './ambient-ns-target';
+export const ambientBarrelOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-mid-target.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-mid-target.ts
@@ -1,0 +1,1 @@
+export const ambientMidTargetOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-mid.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-mid.ts
@@ -1,0 +1,4 @@
+// Reached through ambient-barrel's plain `export *`, which forwards named
+// exports and never `default`, so this namespace object exposes nothing.
+export * as default from './ambient-mid-target';
+export const ambientMidOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-ns-target.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-ns-target.ts
@@ -1,0 +1,2 @@
+export const ambientNsOne = 1;
+export default function ambientNsDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-shim.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/ambient-shim.ts
@@ -1,0 +1,8 @@
+// An ambient star hands the whole ES star surface of its target to the
+// declared module's consumers, so ambient-barrel joins the exposed namespace
+// closure at full namespace-object exposure.
+declare module 'ambient-star' {
+  export * from './ambient-barrel';
+}
+
+export {};

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/barrel.ts
@@ -1,4 +1,5 @@
 export * from './deep';
+export * from './star-default';
 export * as sub from './sub';
 export const direct = (): number => 1;
 export default function barrelDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/barrel.ts
@@ -1,0 +1,4 @@
+export * from './deep';
+export * as sub from './sub';
+export const direct = (): number => 1;
+export default function barrelDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/cycle-a.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/cycle-a.ts
@@ -1,0 +1,2 @@
+export * from './cycle-b';
+export const cycleA = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/cycle-b.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/cycle-b.ts
@@ -1,0 +1,3 @@
+export * as cycleNs from './cycle-a';
+export const cycleB = 1;
+export default function cycleBDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-barrel.ts
@@ -1,0 +1,2 @@
+export * from './dead-deep';
+export * as deadSub from './dead-sub';

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-consumer.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-consumer.ts
@@ -1,0 +1,6 @@
+import * as deadNs from './dead-barrel';
+
+// No entry point reaches this file: the report already calls it unused, so
+// its whole-object use must not credit the barrel's chain and turn the dead
+// subtree into unused-export rows underneath the unused-file rows.
+export const deadAll = Object.values(deadNs);

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-deep.ts
@@ -1,0 +1,1 @@
+export const deadDeepOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-sub.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/dead-sub.ts
@@ -1,0 +1,2 @@
+export const deadSubOne = 1;
+export default function deadSubDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/deep.ts
@@ -1,0 +1,2 @@
+export const deepHelper = (): number => 2;
+export default function deepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/icon-deps/star-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/icon-deps/star-deep.ts
@@ -1,0 +1,2 @@
+export const iconDeepOne = 1;
+export default function iconDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/icons/star.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/icons/star.ts
@@ -1,0 +1,2 @@
+export * from '../icon-deps/star-deep';
+export const starIcon = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
@@ -7,6 +7,8 @@ import { reNs } from './re-shim';
 import { aliasApi } from './alias';
 import { aliasReApi, aliasReNs } from './alias-reexport';
 import { wholeSub } from './whole-barrel';
+import { unreachedReentryUsed } from './unreached-reentry';
+import { unreachedNsUsed } from './unreached-ns-reentry';
 
 import './ambient-shim';
 
@@ -34,6 +36,10 @@ export const wholeAll = Object.values(wholeSub);
 export const cycleAll = Object.keys(cyc);
 
 export const shims = [shimAll, passedOn, reNs, aliasReNs];
+
+// unreached-shim.ts is an unused file, but its ambient chain runs back into
+// these two modules, which the entry point imports directly.
+export const reentry = unreachedReentryUsed + unreachedNsUsed;
 
 // Dynamic-import pattern targets hand the consumer each matched module's
 // namespace object.

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
@@ -4,6 +4,7 @@ import * as cyc from './cycle-a';
 import { shimAll } from './shim';
 import { passedOn } from './passer';
 import { reNs } from './re-shim';
+import { aliasApi } from './alias';
 
 // Whole-object use of a namespace import observes every name on the barrel's
 // namespace object, including names that only arrive through the barrel's
@@ -12,6 +13,10 @@ export const all = Object.values(ns);
 
 // Member access only: narrowing credits `one` and nothing else.
 export const narrowOne = narrow.one();
+
+// Access through an object-literal alias: the alias phase credits `aliasOne`
+// and nothing else behind the aliased namespace.
+export const aliasOne = aliasApi.aliasNs.aliasOne;
 
 // Whole-object use of a barrel that re-exports itself through a chain.
 export const cycleAll = Object.keys(cyc);

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
@@ -1,0 +1,30 @@
+import * as ns from './barrel';
+import * as narrow from './narrow-barrel';
+import * as cyc from './cycle-a';
+import { shimAll } from './shim';
+import { passedOn } from './passer';
+import { reNs } from './re-shim';
+
+// Whole-object use of a namespace import observes every name on the barrel's
+// namespace object, including names that only arrive through the barrel's
+// own `export *` and `export * as` chains.
+export const all = Object.values(ns);
+
+// Member access only: narrowing credits `one` and nothing else.
+export const narrowOne = narrow.one();
+
+// Whole-object use of a barrel that re-exports itself through a chain.
+export const cycleAll = Object.keys(cyc);
+
+export const shims = [shimAll, passedOn, reNs];
+
+// Dynamic-import pattern targets hand the consumer each matched module's
+// namespace object.
+const mods = import.meta.glob('./mods/*.ts');
+export const app = Object.keys(mods).length;
+
+const pluginName = 'one';
+export const plugin = import(`./plugins/${pluginName}.ts`);
+
+const icons = require.context('./icons', false);
+export const iconKeys = icons.keys();

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/index.ts
@@ -5,6 +5,10 @@ import { shimAll } from './shim';
 import { passedOn } from './passer';
 import { reNs } from './re-shim';
 import { aliasApi } from './alias';
+import { aliasReApi, aliasReNs } from './alias-reexport';
+import { wholeSub } from './whole-barrel';
+
+import './ambient-shim';
 
 // Whole-object use of a namespace import observes every name on the barrel's
 // namespace object, including names that only arrive through the barrel's
@@ -18,10 +22,18 @@ export const narrowOne = narrow.one();
 // and nothing else behind the aliased namespace.
 export const aliasOne = aliasApi.aliasNs.aliasOne;
 
+// The same alias shape, but the binding is also exported under its own name,
+// which does hand the whole object on.
+export const aliasReDirect = aliasReApi.aliasReNs.aliasReDirect;
+
+// Whole-object use of an `export * as` binding imported by name: the same
+// closure seed as a whole-object namespace import.
+export const wholeAll = Object.values(wholeSub);
+
 // Whole-object use of a barrel that re-exports itself through a chain.
 export const cycleAll = Object.keys(cyc);
 
-export const shims = [shimAll, passedOn, reNs];
+export const shims = [shimAll, passedOn, reNs, aliasReNs];
 
 // Dynamic-import pattern targets hand the consumer each matched module's
 // namespace object.

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/a-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/a-deep.ts
@@ -1,0 +1,3 @@
+export const deepStarOne = 1;
+export const deepStarTwo = 2;
+export default function aDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/a-named.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/a-named.ts
@@ -1,0 +1,2 @@
+export const namedOnly = 1;
+export const namedSibling = 2;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/b-ns-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/b-ns-deep.ts
@@ -1,0 +1,2 @@
+export const bNsDeepOne = 1;
+export default function bNsDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/b-ns.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/mod-deps/b-ns.ts
@@ -1,0 +1,3 @@
+export * from './b-ns-deep';
+export const bNsOne = 1;
+export default function bNsDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/mods/a.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/mods/a.ts
@@ -1,0 +1,3 @@
+export * from '../mod-deps/a-deep';
+export { namedOnly } from '../mod-deps/a-named';
+export const aOwn = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/mods/b.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/mods/b.ts
@@ -1,0 +1,2 @@
+export * as bNs from '../mod-deps/b-ns';
+export const bOwn = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/narrow-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/narrow-barrel.ts
@@ -1,0 +1,2 @@
+export * from './narrow-deep';
+export * as narrowSub from './narrow-sub';

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/narrow-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/narrow-deep.ts
@@ -1,0 +1,2 @@
+export const one = (): number => 1;
+export const two = (): number => 2;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/narrow-sub.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/narrow-sub.ts
@@ -1,0 +1,2 @@
+export const narrowSubOne = 1;
+export default function narrowSubDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/passed-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/passed-barrel.ts
@@ -1,0 +1,2 @@
+export * from './passed-deep';
+export const passedDirect = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/passed-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/passed-deep.ts
@@ -1,0 +1,2 @@
+export const passedDeepOne = 1;
+export default function passedDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/passer.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/passer.ts
@@ -1,0 +1,9 @@
+import * as passed from './passed-barrel';
+
+// A namespace binding handed on without any member access: the graph cannot
+// narrow it, so it credits the whole namespace object.
+export const passedOn = consume(passed);
+
+function consume(value: unknown): unknown {
+  return value;
+}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/plugin-deps/one-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/plugin-deps/one-deep.ts
@@ -1,0 +1,2 @@
+export const pluginDeepOne = 1;
+export default function pluginDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/plugins/one.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/plugins/one.ts
@@ -1,0 +1,2 @@
+export * from '../plugin-deps/one-deep';
+export const pluginOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/re-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/re-barrel.ts
@@ -1,0 +1,2 @@
+export * from './re-deep';
+export const reDirect = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/re-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/re-deep.ts
@@ -1,0 +1,2 @@
+export const reDeepOne = 1;
+export default function reDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/re-shim.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/re-shim.ts
@@ -1,0 +1,5 @@
+import * as reNs from './re-barrel';
+
+// A namespace binding re-exported from a non-entry module reaches consumers
+// the graph cannot enumerate, so it credits the whole namespace object.
+export { reNs };

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim-barrel.ts
@@ -1,0 +1,3 @@
+export * from './shim-deep';
+export * as shimSub from './shim-sub';
+export const shimDirect = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim-deep.ts
@@ -1,0 +1,2 @@
+export const shimDeepOne = 1;
+export default function shimDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim-sub.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim-sub.ts
@@ -1,0 +1,2 @@
+export const shimSubOne = 1;
+export default function shimSubDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/shim.ts
@@ -1,0 +1,4 @@
+import * as shimNs from './shim-barrel';
+
+// Whole-object use in a reachable non-entry module.
+export const shimAll = Object.keys(shimNs);

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/star-default-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/star-default-deep.ts
@@ -1,0 +1,1 @@
+export const starDefaultDeepOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/star-default-sub.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/star-default-sub.ts
@@ -1,0 +1,2 @@
+export * from './star-default-deep';
+export const starDefaultSubOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/star-default.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/star-default.ts
@@ -1,0 +1,4 @@
+// A plain `export *` never forwards `default`, so this namespace object is
+// not on the barrel's namespace object and its chain stays reported.
+export * as default from './star-default-sub';
+export const starDefaultOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub-deep.ts
@@ -1,0 +1,2 @@
+export const subDeepOne = 1;
+export default function subDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub.ts
@@ -1,0 +1,4 @@
+export * from './sub-deep';
+export * as sub2 from './sub2';
+export const subOne = 1;
+export default function subDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub2-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub2-deep.ts
@@ -1,0 +1,2 @@
+export const sub2DeepOne = 1;
+export default function sub2DeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub2.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/sub2.ts
@@ -1,0 +1,3 @@
+export * from './sub2-deep';
+export const sub2One = 1;
+export default function sub2Default(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-barrel.ts
@@ -1,0 +1,1 @@
+export * from './unreached-mid';

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-mid.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-mid.ts
@@ -1,0 +1,6 @@
+// A hop no entry point reaches, sitting between the unreachable shim and the
+// modules the entry point imports directly. Both chain forms leave from here.
+export * from './unreached-reentry';
+export * as unreachedNs from './unreached-ns-reentry';
+
+export const unreachedMidOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-ns-reentry.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-ns-reentry.ts
@@ -1,0 +1,3 @@
+export const unreachedNsUsed = 1;
+export const unreachedNsChainOnly = 2;
+export default function unreachedNsDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-reentry.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-reentry.ts
@@ -1,0 +1,2 @@
+export const unreachedReentryUsed = 1;
+export const unreachedReentryChainOnly = 2;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-shim.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/unreached-shim.ts
@@ -1,0 +1,7 @@
+// A `declare module` body in a plain `.ts` file nothing imports. The shim is
+// an unused file, but the module id it declares is imported from outside this
+// graph, so the chain behind it keeps its credit and re-enters modules the
+// entry point imports directly.
+declare module 'unreached-star' {
+  export * from './unreached-barrel';
+}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-barrel.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-barrel.ts
@@ -1,0 +1,2 @@
+export * as wholeSub from './whole-sub';
+export const wholeBarrelOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-deep.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-deep.ts
@@ -1,0 +1,2 @@
+export const wholeDeepX = 1;
+export default function wholeDeepDefault(): void {}

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-sub.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-sub.ts
@@ -1,0 +1,3 @@
+export * from './whole-deep';
+export * as wholeSub2 from './whole-sub2';
+export const wholeSubOne = 1;

--- a/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-sub2.ts
+++ b/tests/fixtures/issue-2372-star-barrel-whole-module/src/whole-sub2.ts
@@ -1,0 +1,2 @@
+export const wholeSub2X = 1;
+export default function wholeSub2Default(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/package.json
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "issue-2373-entry-namespace-chain",
+  "type": "module",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-barrel.ts
@@ -1,0 +1,4 @@
+// Two stars carry `ambigNs` onto this barrel at once, so the name is
+// ambiguous here and neither namespace object reaches the entry surface.
+export * from './ambig-s1';
+export * from './ambig-s2';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-deep1.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-deep1.ts
@@ -1,0 +1,1 @@
+export const ambigDeep1X = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-deep2.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-deep2.ts
@@ -1,0 +1,1 @@
+export const ambigDeep2X = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-s1.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-s1.ts
@@ -1,0 +1,1 @@
+export * as ambigNs from './ambig-target1';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-s2.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-s2.ts
@@ -1,0 +1,1 @@
+export * as ambigNs from './ambig-target2';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-target1.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-target1.ts
@@ -1,0 +1,2 @@
+export * from './ambig-deep1';
+export const ambigTarget1One = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-target2.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/ambig-target2.ts
@@ -1,0 +1,2 @@
+export * from './ambig-deep2';
+export const ambigTarget2One = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/barrel.ts
@@ -1,0 +1,3 @@
+export * as sub from './sub';
+export const direct = 1;
+export default function barrelDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/bind-barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/bind-barrel.ts
@@ -1,0 +1,2 @@
+export * as bindSub from './bind-sub';
+export const bindBarrelOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/bind-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/bind-deep.ts
@@ -1,0 +1,2 @@
+export const bindDeepX = 1;
+export default function bindDeepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/bind-sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/bind-sub.ts
@@ -1,0 +1,2 @@
+export * from './bind-deep';
+export const bindSubOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/cycle-a.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/cycle-a.ts
@@ -1,0 +1,2 @@
+export * as cycleNs from './cycle-b';
+export const cycleA = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/cycle-b.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/cycle-b.ts
@@ -1,0 +1,3 @@
+export * from './cycle-a';
+export const cycleB = 1;
+export default function cycleBDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/deep.ts
@@ -1,0 +1,2 @@
+export const deepX = 1;
+export default function deepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/entry-default-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/entry-default-deep.ts
@@ -1,0 +1,1 @@
+export const entryDefaultDeepX = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/entry-default-sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/entry-default-sub.ts
@@ -1,0 +1,2 @@
+export * from './entry-default-deep';
+export const entryDefaultSubOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/hidden-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/hidden-deep.ts
@@ -1,0 +1,2 @@
+export const hiddenDeepX = 1;
+export default function hiddenDeepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/hidden.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/hidden.ts
@@ -1,0 +1,3 @@
+export * from './hidden-deep';
+export const hiddenOne = 1;
+export default function hiddenDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
@@ -1,10 +1,16 @@
 // The entry surface forwards `sub` (a namespace object) through plain
 // `export *`, exposes `top` directly, names `named` and the renamed `rn`
-// through named re-export chains, and reaches a barrel that re-exports itself
-// through an `export *` / `export * as` cycle. It also reaches two barrels
-// whose namespace object is named `default`, which no plain `export *`
-// forwards, and one barrel whose star-forwarded name is shadowed locally.
+// through named re-export chains, re-exports an imported namespace binding
+// under its own name, and reaches a barrel that re-exports itself through an
+// `export *` / `export * as` cycle. It also reaches two barrels whose
+// namespace object is named `default`, which no plain `export *` forwards,
+// and three barrels whose star-forwarded name is shadowed or ambiguous.
+import * as bindNs from './bind-barrel';
+
 export * from './barrel';
+export * from './star-shadow-barrel';
+export * from './ambig-barrel';
+export { bindNs };
 export * as top from './top';
 export * as default from './entry-default-sub';
 export * from './cycle-a';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
@@ -1,7 +1,10 @@
 // The entry surface forwards `sub` (a namespace object) through plain
-// `export *`, exposes `top` directly, and reaches a barrel that re-exports
-// itself through an `export *` / `export * as` cycle.
+// `export *`, exposes `top` directly, names `named` and the renamed `rn`
+// through named re-export chains, and reaches a barrel that re-exports itself
+// through an `export *` / `export * as` cycle.
 export * from './barrel';
 export * as top from './top';
 export * from './cycle-a';
 export { shimOne } from './shim';
+export { named } from './named';
+export { renamed } from './rename-mid';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
@@ -1,0 +1,7 @@
+// The entry surface forwards `sub` (a namespace object) through plain
+// `export *`, exposes `top` directly, and reaches a barrel that re-exports
+// itself through an `export *` / `export * as` cycle.
+export * from './barrel';
+export * as top from './top';
+export * from './cycle-a';
+export { shimOne } from './shim';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/index.ts
@@ -1,10 +1,16 @@
 // The entry surface forwards `sub` (a namespace object) through plain
 // `export *`, exposes `top` directly, names `named` and the renamed `rn`
 // through named re-export chains, and reaches a barrel that re-exports itself
-// through an `export *` / `export * as` cycle.
+// through an `export *` / `export * as` cycle. It also reaches two barrels
+// whose namespace object is named `default`, which no plain `export *`
+// forwards, and one barrel whose star-forwarded name is shadowed locally.
 export * from './barrel';
 export * as top from './top';
+export * as default from './entry-default-sub';
 export * from './cycle-a';
+export * from './star-default';
+export * from './named-default-mid';
 export { shimOne } from './shim';
 export { named } from './named';
 export { renamed } from './rename-mid';
+export { shadowNs } from './shadow-barrel';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-deep.ts
@@ -1,0 +1,2 @@
+export const namedDeepX = 1;
+export default function namedDeepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-barrel.ts
@@ -1,0 +1,1 @@
+export * as defaultNs from './named-default-sub';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-deep.ts
@@ -1,0 +1,1 @@
+export const namedDefaultDeepX = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-mid.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-mid.ts
@@ -1,0 +1,3 @@
+// The rename lands on `default`, which the entry's plain `export *` leaves
+// behind, so the namespace object stays off the entry surface.
+export { defaultNs as default } from './named-default-barrel';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-default-sub.ts
@@ -1,0 +1,2 @@
+export * from './named-default-deep';
+export const namedDefaultSubOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-sub.ts
@@ -1,0 +1,4 @@
+export * from './named-deep';
+export * as namedSub2 from './named-sub2';
+export const namedSubOne = 1;
+export default function namedSubDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named-sub2.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named-sub2.ts
@@ -1,0 +1,2 @@
+export const namedSub2X = 1;
+export default function namedSub2Default(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/named.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/named.ts
@@ -1,0 +1,4 @@
+// Reached from the entry by name, not by a plain star: only `named` is on the
+// entry surface, so `namedBarrelOne` keeps reporting.
+export * as named from './named-sub';
+export const namedBarrelOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-barrel.ts
@@ -1,0 +1,1 @@
+export * as rn from './rename-sub';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-deep.ts
@@ -1,0 +1,2 @@
+export const renameDeepX = 1;
+export default function renameDeepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-mid.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-mid.ts
@@ -1,0 +1,1 @@
+export { rn as renamed } from './rename-barrel';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/rename-sub.ts
@@ -1,0 +1,2 @@
+export * from './rename-deep';
+export const renameSubOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-barrel.ts
@@ -1,0 +1,4 @@
+// The local `shadowNs` shadows the star-forwarded one, so the entry's
+// `shadowNs` is this number and shadow-source's namespace object is unreachable.
+export * from './shadow-source';
+export const shadowNs = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-deep.ts
@@ -1,0 +1,1 @@
+export const shadowDeepX = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-source.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-source.ts
@@ -1,0 +1,1 @@
+export * as shadowNs from './shadow-target';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-target.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/shadow-target.ts
@@ -1,0 +1,2 @@
+export * from './shadow-deep';
+export const shadowTargetOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/shim.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/shim.ts
@@ -1,0 +1,4 @@
+// A reachable non-entry barrel: its namespace re-export is not on the entry
+// surface and nothing consumes `hidden`, so none of hidden.ts is credited.
+export * as hidden from './hidden';
+export const shimOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-default-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-default-deep.ts
@@ -1,0 +1,1 @@
+export const starDefaultDeepX = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-default-sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-default-sub.ts
@@ -1,0 +1,2 @@
+export * from './star-default-deep';
+export const starDefaultSubOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-default.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-default.ts
@@ -1,0 +1,5 @@
+// The entry reaches this barrel through a plain `export *`, which forwards
+// every name except `default`, so this namespace object never lands on the
+// entry surface.
+export * as default from './star-default-sub';
+export const starDefaultOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-barrel.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-barrel.ts
@@ -1,0 +1,5 @@
+// The entry reaches this barrel through a plain `export *`. The barrel
+// declares its own `starShadowNs`, which shadows the star-forwarded one, so
+// star-shadow-target's namespace object never reaches the entry surface.
+export * from './star-shadow-source';
+export const starShadowNs = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-deep.ts
@@ -1,0 +1,1 @@
+export const starShadowDeepX = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-source.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-source.ts
@@ -1,0 +1,1 @@
+export * as starShadowNs from './star-shadow-target';

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-target.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/star-shadow-target.ts
@@ -1,0 +1,2 @@
+export * from './star-shadow-deep';
+export const starShadowTargetOne = 1;

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/sub.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/sub.ts
@@ -1,0 +1,4 @@
+export * from './deep';
+export * as sub2 from './sub2';
+export const subOne = 1;
+export default function subDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/sub2-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/sub2-deep.ts
@@ -1,0 +1,2 @@
+export const sub2DeepX = 1;
+export default function sub2DeepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/sub2.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/sub2.ts
@@ -1,0 +1,4 @@
+export * from './sub2-deep';
+export * as sub3 from './sub3';
+export const sub2X = 1;
+export default function sub2Default(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/sub3.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/sub3.ts
@@ -1,0 +1,2 @@
+export const sub3X = 1;
+export default function sub3Default(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/top-deep.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/top-deep.ts
@@ -1,0 +1,2 @@
+export const topDeepX = 1;
+export default function topDeepDefault(): void {}

--- a/tests/fixtures/issue-2373-entry-namespace-chain/src/top.ts
+++ b/tests/fixtures/issue-2373-entry-namespace-chain/src/top.ts
@@ -1,0 +1,3 @@
+export * from './top-deep';
+export const topOne = 1;
+export default function topDefault(): void {}


### PR DESCRIPTION
## What was broken

Several consumer shapes observe every name on a module's namespace object but credited only the module's direct exports, so names the module only exposes through its own `export * from './deep'` or `export * as sub from './sub'` were reported as unused (#2372):

- A namespace import the graph cannot narrow: `import * as ns from './barrel'` used as a whole object (`Object.values(ns)`, a spread, a destructure with rest), handed on without any member access, or exported under its own name.
- An `export * as sub` binding imported by name and used as a whole object: `import { sub } from './barrel'` plus `Object.values(sub)`.
- A dynamic-import pattern match: `import()` with a template, `import.meta.glob`, `require.context`.
- A bare side-effect `require('./barrel')` with no binding.

For a real entry point, `export * as sub from './sub'` on the entry, on a barrel the entry reaches through plain `export *`, or named by the entry through a chain of named re-exports (`export { sub } from './barrel'`, or `import * as ns` plus `export { ns }`) credited every direct export of `sub.ts`, but neither sub's own `export * from './deep'` sources nor its own `export * as sub2` sources (#2373).

## Root cause

Phase 2 credits a whole-module consumer through `mark_all_exports_referenced_at_site`, which walks the target's direct export list only. The two phases that credit chains, star propagation (Phase 4, seeded by `collect_entry_star_targets`) and namespace re-export propagation (Phase 2c, gated by `exposes_namespace_object`), knew two seeds: entry points and the ambient-module star closure that #2357 added. `collect_entry_star_targets` also walked plain `export *` edges only, so an `export * as sub` source behind an entry was never treated as exposing a namespace object of its own.

## The fix

One seed-agnostic closure replaces `collect_ambient_star_targets`:

- `populate_references` (Phase 2) returns every target whose whole namespace object a consumer observed: the empty-local-name namespace branch of `attach_symbol_reference` (ambient stars, dynamic-import pattern matches, and a bare side-effect `require('./barrel')` with no binding) and every mark-all branch of `narrow_namespace_references` (whole-object use, no member access outside an entry point, binding exported under its own name). Both sites record the seed through `AttachContext::observe_whole_namespace_object`, which carries the invariant.
- `ModuleGraph::collect_exposed_namespace_targets` seeds with those targets plus every `export * as ns` source whose name reaches a consumer the graph cannot enumerate, then closes over both `export *` and `export * as` chains. Phase 2c treats a member as exposing its `export * as` sources; Phase 4 unions the closure into `entry_star_targets`, so every member is treated like an entry barrel for its `export *` sources (named exports, never `default`).
- A name reaches such a consumer three ways, and the closure applies **the same test Phase 2c applies**: it arrives on an entry point's own export surface, on a module already in the closure, or at a name some importer uses as a whole object. The namespace-edge seeds and the chain walk therefore run to a fixpoint against each other, because a target that joins the closure can itself expose the name a further `export * as ns` edge forwards to it. Each round widens the closure or stops, so the walk terminates, and the closure Phase 2c reads no longer stops one namespace level short of what Phase 2c credits.
- Each member carries **how much of it is exposed**. A member whose whole namespace object is observed exposes every export, `default` included. A member reached through a plain `export *` exposes every export except `default`, because that is the one name a plain `export *` never forwards, so an `export * as default` declared on such a member hands its target's namespace object to nobody. An entry point exposes its own `default`: it is public API.
- The surface is matched **by name**, and every hop must uniquely forward the binding. That rule is not restated: `ModuleGraph::forwards_binding` picks the namespace and then calls Phase 2c's own `uniquely_forwards_binding`, so the closure and the phase it pre-computes for cannot drift apart on what a hop forwards. A barrel that declares its own `ns`, or that receives `ns` from two `export *` sources at once, exports a different binding under that name and the chain stops there. Sitting on an entry point's plain-`export *` closure is not on its own proof that a name survives to the entry, so no hop is skipped for it: the shortcut applies to an entry point itself only. The check reads the value namespace whenever the source exports the name there and the type namespace otherwise, so `export type { ns } from './barrel'` on an entry point does not put the value namespace object on the surface.
- Entry-point reachability gates the seeds this PR adds, and nothing else. A target observed by a consumer in this graph, where no entry point reaches the target, is not seeded: that consumer is unreachable too, the report already calls the target an unused file, and crediting its chain would only stack unused-export rows underneath the unused-file rows. The same holds for an `export * as ns` source no entry point reaches. Withholding those can only withhold credit the pre-existing closure never gave.
- The ambient seeds from #2357 are deliberately **not** gated, and neither is the chain walk. A `declare module 'pkg'` body states the shape of an external module id: its observers are importers of that id, outside this graph, so where the shim and its target sit inside the graph says nothing about who looks. The chain behind an unreachable shim routinely re-enters a module an entry point imports directly, and gating it reported unused exports on files the report calls reachable. A re-export edge makes its source reachable whenever the barrel is, so only an ambient chain can ever walk out of an unreachable member in the first place. Entry-point reachability reads the edge list alone, so `ModuleGraph::build` computes it once, before the closure, and hands the same bitset to `mark_reachable`.
- Two seed properties are deliberate and visible in reports, and both are written down in the CHANGELOG and `docs/reference/detection-internals.md`. The seed is namespace-agnostic, so `export type { ns }` seeds the closure exactly like `export { ns }` and credits the chain in the value namespace as well: `typeof ns.member` keeps a value declaration reachable through a type-only re-export. And the seed does not ask whether the re-export itself has a consumer, so a namespace binding exported under its own name credits the chain behind it even when the report calls that very export unused, the same self-inconsistency the unreachable-observer case has.

The closure is computed once in `ModuleGraph::build` and threaded into Phase 2c and Phase 4 instead of each phase rebuilding it; it reads only `re_exports`, the entry-point flags, the consumers' whole-object uses, and that reachability bitset, none of which a later phase mutates. Seeding short-circuits when the project has no `export * as` edge at all.

## Performance

The name search runs outward from each `export * as` edge toward the acceptance points, over a reverse index of the edges that forward a single name, rather than inward from every name an entry point re-exports. Two cutoffs keep a pathological chain cheap: a module that no forwarding edge connects to an acceptance point answers in constant time however deep its own chains run, and an exhausted search remembers every state it visited within a round, so a forwarding chain shared by many namespace edges is walked once instead of once per edge.

Debug-build minimum over repeated full `dead-code --no-cache` runs, identical output everywhere:

| project | baseline (main) | this branch |
| --- | --- | --- |
| vitest monorepo (12 runs each) | 2426 ms | 2507 ms |
| 400 namespace barrels behind a 20-link plain-star chain | 145 ms | 152 ms |
| 400 namespace barrels behind a 400-link plain-star chain | 374 ms | 430 ms |

The last row is the accepted cost of the shadowing fix: an on-surface namespace edge no longer takes a shortcut, so its name walks up the plain-star chain with a uniqueness check per hop. Realistic chain depths are within noise; the inward-by-name search variant measured roughly twice the baseline on the vitest monorepo, which is why the search direction is what it is.

The seed's own credit keeps its shape: a runtime whole-module edge credits the namespace object, `default` included; the ambient star form credits the star surface without `default`. Member-narrowed namespace imports (`ns.one()`) never seed the closure. A binding placed in an exported object literal (`export const API = { ns }`) keeps the direct-export mark-all it had on main but seeds the closure only when it is also used as a whole object or exported under its own name: the namespace-object alias phase follows `API.ns.<member>` accesses precisely, and the existing `issue-310` multi-hop alias test pins that `unusedQuery` stays reported.

The mark-all sites that feed the closure keep crediting their target's own direct exports as before, reachable or not; reference-level reachability filters those at reporting time. This matches the pre-existing mark-all model and is stated in `docs/reference/detection-internals.md`, along with what an unreachable whole-object observer suppresses.

The closure fixpoint does not rebuild its reachability prune per round. The prune only grows, so a round extends it from the members the previous round added and each re-export edge is walked at most once across all rounds. What is left per round is a rescan of the namespace edges still pending, which a chain shaped to resolve exactly one edge per round can drive up. On the pathological alternating named/namespace chain a reviewer built for that shape, minimum of 11 debug runs on a loaded box: N=1200 baseline 283 ms against 310 ms here (down from the +77% measured before the prune became incremental), N=2000 baseline 428 ms against 619 ms here (down from +160%). Real projects are flat: `viz-frontend` 191 ms against 182 ms, `editors/vscode` 228 ms against 227 ms, minimum of 9.

## Behavior change

- Whole-object namespace uses, unnarrowed namespace bindings, a namespace binding exported under its own name, an `export * as` binding imported by name and used as a whole object, dynamic-import pattern matches, a bindingless `require()`, and `export * as` chains an entry point exposes now credit the full namespace object of their target: direct exports, the named exports of `export *` sources (never their `default`), and every export of `export * as` sources (`default` included), recursively. Fewer unused-export findings for star barrels consumed those ways. A barrel that one of those consumers observes and no entry point reaches keeps reporting as an unused file with nothing stacked underneath it; an ambient `declare module` shim keeps crediting its chain whatever its reachability.
- **One shape reports one finding more.** A plain `export *` hop inside a chain no longer carries a downstream `export * as default` onward, because that star never forwards `default`. An `export * from './barrel'` whose barrel does `export * from './mid'` over a `mid` that does `export * as default from './target'` now reports target's exports. That includes the ambient form: the `issue-2357-ambient-star-reexport` fixture is byte-identical between the baseline and this branch, but an ambient chain with a plain-star hop before an `export * as default` is not. An `export * as default` declared directly on the ambient star's own target still credits its chain. Nothing else in the issue-2357 behaviour moves: an ambient chain is seeded and walked at any reachability, exactly as it was.
- A namespace re-export on a reachable non-entry barrel that is off the entry surface and has no consumer still exposes nothing; a barrel that declares its own copy of a star-forwarded name, or that receives the same name from two stars at once, stops the chain, whether the entry names the barrel or reaches it through a plain `export *`; a plain `export *` still never forwards `default`, so `export * as default` behind one keeps reporting while the same declaration on the entry point itself is credited.

## Cache invalidation

- `GRAPH_CACHE_VERSION` 38 -> 39: the new references are baked into the persisted graph and a graph-cache hit skips the build entirely. Warm 38 caches carry only the direct-export credit, and they also predate the one direction that moves the other way. Version 39 is unreleased (main is at 38), so it still invalidates every warm cache a user can have.
- Extraction is untouched; the extract cache version stays at 276.

Warm-cache proof on a scratch copy of the `issue-2373-entry-namespace-chain` fixture: the baseline binary (main, graph 38) runs cold and writes the cache; this branch (graph 39) on that warm cache reports exactly its own cold `--no-cache` output, and a second warm run is identical.

## How it was tested

- Integration fixture `issue-2372-star-barrel-whole-module`: whole-object use in the entry point over a barrel with `export *` plus a three-level `export * as` chain; a non-entry whole-object shim; a binding handed on without member access; a binding re-exported from a non-entry module; an `export * as` binding imported by name and used as a whole object, with a name-precision control on the same barrel; a binding that is both an object-literal alias source and exported under its own name, against the object-literal-only negative control; an ambient `declare module` star whose target exposes an `export * as ns` (credited whole, `default` included) and whose plain-star hop drops a downstream `export * as default` (reported); `import.meta.glob`, a template `import()`, and `require.context` targets with star, named, and `export * as` re-exports; a member-narrowed namespace import as a negative control; a barrel that re-exports itself through an `export *` / `export * as` cycle; an `export * as default` on a plain-star member, whose chain stays reported; a whole-object use inside an unreachable file, whose dead subtree stays unused-file rows with no unused-export rows underneath; reference-shape assertions that the credit is routed through the barrel's star chain and the exposed namespace object.
- Integration fixture `issue-2373-entry-namespace-chain`: the issue repro plus a third `export * as sub3` level and sub2's own `export *`, an `export * as top` directly on the entry, a namespace named by the entry through `export { named } from './named'` and through a rename hop, an `import * as bindNs` plus `export { bindNs }` on the entry, a name-precision control, an off-surface `export * as hidden` on a reachable non-entry barrel, an entry star cycle, `export * as default` on the entry itself (credited) against the same declaration on a plain-star barrel and behind an `export { x as default }` rename (both reported), a star-forwarded namespace name shadowed by a local declaration on the barrel in both the named-hop and the plain-star entry form, the same name arriving from two `export *` sources at once, and reference-shape assertions.
- Fixture `issue-2372-star-barrel-whole-module` also pins the shape the reachability split exists for: `unreached-shim.ts` holds a `declare module` body in a plain `.ts` file nothing imports, `unreached-barrel.ts` and `unreached-mid.ts` behind it are unused files, and `unreached-reentry.ts` and `unreached-ns-reentry.ts` are imported directly by the entry point, so the chain's names must stay credited on modules that carry no unused-file row at all. Re-gating the seed makes that test fail.
- Graph unit test `forwards_binding_agrees_with_phase_2c_on_rename_shadow_and_ambiguity`: a rename hop forwards, a local declaration on the barrel shadows, and the same name arriving from two `export *` sources is ambiguous, asserted for both `ModuleGraph::forwards_binding` and `uniquely_forwards_binding`.
- Mutation matrix. With the whole branch's `crates/graph/src` reverted to main, fourteen of the twenty-one tests fail; the seven that pass are the declared negative controls (member narrowing, object-literal alias, unreachable observer, off-surface namespace, the two cycle pins, and the shadow/ambiguity pin, which guards a regression this branch introduced rather than a gap on main). With only this round's `crates/graph/src` reverted, the four tests this round adds for its own fixes fail (the plain-star shadow and ambiguity pin, the entry namespace binding pin, the whole-object named-import pin, and the alias-plus-named-export pin) while the ambient pin passes, since that behaviour landed in the branch's preceding commit and bites against main instead.
- Exact issue repros through both binaries: #2372 case 1 reports `src/deep.ts:deepHelper` on the baseline and nothing with the fix; #2373 reports only `barrel.ts:default` and `deep.ts:default` with the fix (baseline added `deep.ts:deepX`, `sub2.ts:sub2X`, `sub2.ts:default`).
- Adversarial probes replayed from review, all now matching ES semantics: a locally shadowed `export * as ns` behind a plain-star entry and behind a named hop; two `export *` sources exporting the same `ns`; `export * as default` behind an entry star, behind a plain star from a whole-object seed, behind an `export { ns as default }` rename, and on the entry point itself; an ambient chain with a plain-star hop before an `export * as default`.
- Real-project smokes with the baseline and branch binaries, normalized `dead-code --format json --no-cache` output identical everywhere: the in-repo `viz-frontend` and `editors/vscode`, the vitest monorepo, a design-system monorepo, and a large product monorepo. The `issue-2357`, `issue-310`, `issue-2348`, `issue-269`, `issue-303`, `issue-324`, `issue-328`, and `issue-1373` namespace fixtures are also identical to main.
- Gates on the rebased tree: cargo fmt check, clippy workspace all-targets with warnings denied, full workspace test suite (with the type-aware sidecar installed), bench check, cargo doc with warnings denied, typos, hidden-unicode scan, and comment-quality check.

## Review round 2

The entry-reachability gate the previous round added narrowed the pre-existing #2357 closure: when the `declare module` shim is an unreachable non-`.d.ts` file, the branch stopped crediting the ambient star's chain and reported new unused exports on files an entry point imports directly. Three shapes a reviewer executed are byte-identical to the pre-change binary again:

1. An unreachable shim over `impl.ts` -> `impl-deep.ts` where the entry point imports `implDeepOne` from `impl-deep.ts`: `impl-deep.ts:implDeepTwo` is no longer reported.
2. The same in namespace form (`export * as ns` over a reachable `ns-target.ts`): `ns-target.ts:nsTwo` and `ns-target.ts:default` are no longer reported.
3. A fully dead island: `impl-deep.ts:implDeepOne` is reported again, as on main.

Fixed by splitting the closure seeds (ambient targets ungated, in-graph observers gated) and dropping the reachability test from the chain walk, plus the incremental reachability prune, the `forwards_binding` delegation, and the CHANGELOG and detection-internals corrections described above.

Rebased onto `dc03fd148`.

Fixes #2372
Fixes #2373

