### PR TITLE
fix(core): analyze package.json resolutions as a bun dependency-override source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `workspace_diagnostics[].kind` union; consumers that exhaustively match on
   `kind` should treat unknown kinds as informational.
 
+- **bun repositories that pin transitive versions under Yarn-style
+  `resolutions` now get `unused-dependency-overrides` and
+  `misconfigured-dependency-overrides` findings for those entries** (Closes
+  [#2367](https://github.com/fallow-rs/fallow/issues/2367)). bun reads
+  `resolutions` as an alias of `overrides`, but the override analyzer only
+  parsed the top-level `overrides` object and `pnpm.overrides`, so a bun
+  repository whose root `package.json` used `resolutions` was never
+  analyzed: no findings with any lockfile, and next to a `bun.lockb` no
+  `bun-lockb-override-resolution-skipped` diagnostic either, because no
+  override state was gathered. When the root `packageManager` names bun, or
+  no recognised `packageManager` is declared and a `bun.lock` or `bun.lockb`
+  sits at the root, the `resolutions` entries now run through the same
+  analysis as `overrides`: resolved against the text `bun.lock`, reported
+  with `source: "package.json"` and the entry's line, and carrying the bun
+  hint, which names `resolutions` so the entry is easy to locate. bun's key
+  dialect is honoured: `pkg`, `@scope/pkg`, `pkg@<2`, the yarn paths
+  `parent/child`, `**/child`, and `parent/**/child`, and the pnpm
+  `parent>child` form all parse; paths deeper than one parent and non-string
+  values, which bun warns about and skips, are reported as misconfigured.
+  bun consults `resolutions` only when the manifest has no `overrides` key,
+  so a manifest carrying both is analyzed for `overrides` alone. A
+  `resolutions`-only manifest next to a `bun.lockb` without a parseable text
+  lockfile now records the skip diagnostic. yarn, npm, and pnpm repositories
+  are unchanged: `resolutions` is not an override source there, and the yarn
+  hint for inert `overrides` entries stays as it was. Suppress an entry with
+  `ignoreDependencyOverrides: [{ "package": "...", "source": "package.json"
+  }]`. The JSON contract is unchanged; only the `source` field description
+  mentions the new origin.
+
 - **The VS Code extension now publishes platform-specific packages for macOS,
   Linux, and Windows.** Each targeted VSIX carries only its matching semantic
   backend, reducing normal extension downloads by roughly 82 to 84 percent.

--- a/crates/cli/tests/check_tests.rs
+++ b/crates/cli/tests/check_tests.rs
@@ -1025,3 +1025,46 @@ fn bun_lockb_only_override_skip_surfaces_in_json_and_human_output() {
         human.stderr
     );
 }
+
+/// Issue #2367: a bun repo that pins versions under Yarn-style `resolutions`
+/// gets unused-override findings in JSON output, sourced to `package.json`
+/// with the bun hint naming `resolutions`.
+#[test]
+fn bun_resolutions_surface_as_unused_overrides_in_json_output() {
+    let output = run_fallow(
+        "dead-code",
+        "issue-2367-bun-resolutions",
+        &["--format", "json", "--quiet", "--no-cache"],
+    );
+    let json = parse_json(&output);
+    let findings = json["unused_dependency_overrides"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let mut keys: Vec<&str> = findings
+        .iter()
+        .filter_map(|finding| finding["raw_key"].as_str())
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec!["**/trim-newlines", "left-pad"],
+        "the two unresolved resolutions pins are reported: {findings:?}"
+    );
+    for finding in &findings {
+        assert_eq!(finding["source"], "package.json");
+        assert_eq!(finding["path"], "package.json");
+        let hint = finding["hint"].as_str().unwrap_or_default();
+        assert!(
+            hint.contains("resolutions") && hint.contains("bun install --frozen-lockfile"),
+            "the bun hint names the resolutions origin: {hint}"
+        );
+    }
+    assert!(
+        json["workspace_diagnostics"]
+            .as_array()
+            .is_none_or(Vec::is_empty),
+        "a parseable bun.lock resolves normally: {}",
+        json["workspace_diagnostics"]
+    );
+}

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -25,7 +25,7 @@ pub use diagnostics::{
     stash_workspace_diagnostics, workspace_diagnostics_for,
 };
 use diagnostics::{emit_diagnostics, is_skip_listed_dir};
-pub use npm_overrides::parse_npm_package_json_overrides;
+pub use npm_overrides::{parse_bun_package_json_resolutions, parse_npm_package_json_overrides};
 pub use package_json::{NapiConfig, PackageJson};
 pub use parsers::parse_tsconfig_root_dir;
 use parsers::{

--- a/crates/config/src/workspace/npm_overrides.rs
+++ b/crates/config/src/workspace/npm_overrides.rs
@@ -27,10 +27,23 @@
 //! shape the pnpm parser produces (joining nesting levels with `>`), so the
 //! unused-override and misconfigured-override detectors can analyze npm and
 //! pnpm overrides through one code path.
+//!
+//! bun reads the same top-level `overrides` object and, as a Yarn migration
+//! aid, a top-level `resolutions` object with flat string entries whose keys
+//! may use yarn's dependency-path spelling (`parent/child`, `**/child`).
+//! [`parse_bun_package_json_resolutions`] maps that dialect onto the shared
+//! entry shape so bun repositories get the same two findings for
+//! `resolutions` (issue #2367).
 
 use super::pnpm_overrides::{
-    ParsedOverrideKey, PnpmOverrideData, PnpmOverrideEntry, split_pkg_and_selector,
+    ParsedOverrideKey, PnpmOverrideData, PnpmOverrideEntry, parse_override_key,
+    split_pkg_and_selector,
 };
+
+const OVERRIDES_KEY: &str = "overrides";
+const RESOLUTIONS_KEY: &str = "resolutions";
+const YARN_GLOB_SEGMENT: &str = "**";
+const YARN_COMMENT_KEY_PREFIX: &str = "//";
 
 /// Parse the top-level `overrides` section of a root `package.json`. Returns
 /// an empty `PnpmOverrideData` when the file has no overrides, when the JSON
@@ -41,15 +54,133 @@ pub fn parse_npm_package_json_overrides(source: &str) -> PnpmOverrideData {
         Ok(v) => v,
         Err(_) => return PnpmOverrideData::default(),
     };
-    let Some(overrides) = value.get("overrides").and_then(|o| o.as_object()) else {
+    let Some(overrides) = value.get(OVERRIDES_KEY).and_then(|o| o.as_object()) else {
         return PnpmOverrideData::default();
     };
 
-    let mut line_index = NpmOverridesLineIndex::build(source);
+    let mut line_index = NpmOverridesLineIndex::build(source, OVERRIDES_KEY, true);
     let mut entries = Vec::new();
     let mut path: Vec<String> = Vec::new();
     flatten_overrides(overrides, &mut path, &mut line_index, &mut entries);
     PnpmOverrideData { entries }
+}
+
+/// Parse the Yarn-style top-level `resolutions` object of a root
+/// `package.json` the way bun reads it (issue #2367). bun treats
+/// `resolutions` as an alias of `overrides` with flat string entries: a key
+/// is a bare package (`left-pad`, `@scope/pkg`, `pkg@<2`), a yarn dependency
+/// path (`parent/child`, `**/child`, `parent/**/child`, where `@scope/name`
+/// spans two path segments), or the pnpm `parent>child` form. Paths deeper
+/// than one parent and non-string values are kept as entries without a
+/// parsed key or value so the misconfigured-override detector reports them,
+/// matching the warning bun prints before skipping such entries. Keys that
+/// start with `//` are comments and skipped. Returns empty data when the
+/// file has no `resolutions` object or the JSON is malformed. Callers decide
+/// whether the repository installs with bun and whether an `overrides` key
+/// shadows the section.
+#[must_use]
+pub fn parse_bun_package_json_resolutions(source: &str) -> PnpmOverrideData {
+    let value: serde_json::Value = match serde_json::from_str(source) {
+        Ok(v) => v,
+        Err(_) => return PnpmOverrideData::default(),
+    };
+    let Some(resolutions) = value.get(RESOLUTIONS_KEY).and_then(|o| o.as_object()) else {
+        return PnpmOverrideData::default();
+    };
+
+    let mut line_index = NpmOverridesLineIndex::build(source, RESOLUTIONS_KEY, false);
+    let mut entries = Vec::with_capacity(resolutions.len());
+    for (key, value) in resolutions {
+        let line = line_index.next_line_for(key);
+        if key.starts_with(YARN_COMMENT_KEY_PREFIX) {
+            continue;
+        }
+        let raw_value = match value {
+            serde_json::Value::String(s) => Some(s.clone()),
+            _ => None,
+        };
+        let Some(line) = line else {
+            continue;
+        };
+        entries.push(PnpmOverrideEntry {
+            raw_key: key.clone(),
+            parsed_key: parse_resolution_key(key),
+            raw_value,
+            line,
+        });
+    }
+    PnpmOverrideData { entries }
+}
+
+/// Parse a `resolutions` key into the shared override key shape. The pnpm
+/// `parent>child` spelling is delegated to the pnpm key parser; everything
+/// else is a yarn dependency path where `**` segments match any depth,
+/// `@scope/name` spans two segments, and at most one parent precedes the
+/// target. Returns `None` for the shapes bun rejects: an empty segment, a
+/// bare scope, a trailing `**`, or more than one parent level.
+fn parse_resolution_key(key: &str) -> Option<ParsedOverrideKey> {
+    let trimmed = key.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(delimiter) = pnpm_delimiter(trimmed) {
+        if pnpm_delimiter(&trimmed[delimiter + 1..]).is_some() {
+            return None;
+        }
+        return parse_override_key(trimmed);
+    }
+
+    let mut segments: Vec<String> = Vec::with_capacity(2);
+    let mut tokens = trimmed.split('/').peekable();
+    while let Some(token) = tokens.next() {
+        if token.is_empty() {
+            return None;
+        }
+        if token == YARN_GLOB_SEGMENT {
+            tokens.peek()?;
+            continue;
+        }
+        let segment = if token.starts_with('@') {
+            let name = tokens.next().filter(|name| !name.is_empty())?;
+            format!("{token}/{name}")
+        } else {
+            token.to_string()
+        };
+        if segments.len() == 2 {
+            return None;
+        }
+        segments.push(segment);
+    }
+
+    let (parent, target) = match segments.as_slice() {
+        [target] => (None, target),
+        [parent, target] => (Some(parent), target),
+        _ => return None,
+    };
+    let (target_package, target_version_selector) = split_pkg_and_selector(target)?;
+    let (parent_package, parent_version_selector) = match parent {
+        Some(parent) => {
+            let (package, selector) = split_pkg_and_selector(parent)?;
+            (Some(package), selector)
+        }
+        None => (None, None),
+    };
+    Some(ParsedOverrideKey {
+        parent_package,
+        parent_version_selector,
+        target_package,
+        target_version_selector,
+    })
+}
+
+/// Byte offset of the pnpm `parent>child` delimiter as bun recognises it:
+/// the first `>` past the first byte that is not preceded by a space, `|`,
+/// or `@`, so `pkg@>=1` keeps its version selector intact.
+fn pnpm_delimiter(key: &str) -> Option<usize> {
+    let bytes = key.as_bytes();
+    bytes.iter().enumerate().skip(1).find_map(|(index, byte)| {
+        (*byte == b'>' && !matches!(bytes[index - 1], b' ' | b'|' | b'@')).then_some(index)
+    })
 }
 
 /// Depth-first flattening of the (possibly nested) overrides object into flat
@@ -136,8 +267,9 @@ fn build_npm_key(path: &[String], key: &str) -> (String, Option<ParsedOverrideKe
     )
 }
 
-/// Ordered `(key, line)` pairs for every key inside the top-level `overrides`
-/// object, consumed by a forward-only cursor during flattening.
+/// Ordered `(key, line)` pairs for every key inside one top-level section
+/// object (`overrides` or `resolutions`), consumed by a forward-only cursor
+/// during flattening.
 struct NpmOverridesLineIndex {
     entries: Vec<(String, u32)>,
     cursor: usize,
@@ -157,10 +289,13 @@ impl NpmOverridesLineIndex {
     }
 
     /// Walk the raw source with a brace-depth scanner and record every key
-    /// (at any nesting depth) inside the top-level `overrides` object,
-    /// paired with its 1-based line number.
-    fn build(source: &str) -> Self {
-        let mut scan = NpmOverridesJsonScan::default();
+    /// inside the top-level `section` object, paired with its 1-based line
+    /// number. With `nested` set, keys at any depth inside the section are
+    /// recorded (npm scopes overrides by nesting); otherwise only the
+    /// section's direct keys are, so a nested object value bun rejects cannot
+    /// shift the cursor onto a later key of the same name.
+    fn build(source: &str, section: &'static str, nested: bool) -> Self {
+        let mut scan = NpmOverridesJsonScan::new(section, nested);
         let mut current_line = 1u32;
 
         for ch in source.chars() {
@@ -182,15 +317,16 @@ impl NpmOverridesLineIndex {
     }
 }
 
-/// Char-by-char brace-depth scanner state for the top-level `overrides` line
-/// index. Mirrors the pnpm `pnpm.overrides` scanner, but records keys at every
-/// nesting depth inside the overrides object because npm scopes overrides by
-/// nesting rather than by `parent>child` keys.
-#[derive(Default)]
+/// Char-by-char brace-depth scanner state for a top-level section line
+/// index. Mirrors the pnpm `pnpm.overrides` scanner, but can record keys at
+/// every nesting depth inside the section object because npm scopes
+/// overrides by nesting rather than by `parent>child` keys.
 struct NpmOverridesJsonScan {
+    section: &'static str,
+    nested: bool,
     entries: Vec<(String, u32)>,
     depth: i32,
-    overrides_depth: Option<i32>,
+    section_depth: Option<i32>,
     in_string: bool,
     escape: bool,
     last_key: Option<String>,
@@ -199,6 +335,21 @@ struct NpmOverridesJsonScan {
 }
 
 impl NpmOverridesJsonScan {
+    fn new(section: &'static str, nested: bool) -> Self {
+        Self {
+            section,
+            nested,
+            entries: Vec::new(),
+            depth: 0,
+            section_depth: None,
+            in_string: false,
+            escape: false,
+            last_key: None,
+            key_buf: String::new(),
+            collecting_key: false,
+        }
+    }
+
     fn consume_in_string_char(&mut self, ch: char) {
         if self.escape {
             if self.collecting_key {
@@ -236,10 +387,10 @@ impl NpmOverridesJsonScan {
             }
             '{' => self.depth += 1,
             '}' => {
-                // The overrides object closes when depth returns to the level
-                // where the `overrides` key was seen.
-                if self.overrides_depth == Some(self.depth - 1) {
-                    self.overrides_depth = None;
+                // The section object closes when depth returns to the level
+                // where its key was seen.
+                if self.section_depth == Some(self.depth - 1) {
+                    self.section_depth = None;
                 }
                 self.depth -= 1;
             }
@@ -255,10 +406,11 @@ impl NpmOverridesJsonScan {
         let Some(key) = self.last_key.take() else {
             return;
         };
-        if self.overrides_depth.is_none() && self.depth == 1 && key == "overrides" {
-            self.overrides_depth = Some(self.depth);
-        } else if let Some(d) = self.overrides_depth
+        if self.section_depth.is_none() && self.depth == 1 && key == self.section {
+            self.section_depth = Some(self.depth);
+        } else if let Some(d) = self.section_depth
             && self.depth > d
+            && (self.nested || self.depth == d + 1)
         {
             self.entries.push((key, current_line));
         }
@@ -409,5 +561,175 @@ mod tests {
     fn malformed_json_returns_no_entries() {
         let data = parse_npm_package_json_overrides("{not valid json");
         assert!(data.entries.is_empty());
+    }
+
+    // Issue #2367: bun reads Yarn-style `resolutions` as an `overrides` alias.
+
+    fn parsed(entry: &PnpmOverrideEntry) -> &ParsedOverrideKey {
+        entry
+            .parsed_key
+            .as_ref()
+            .unwrap_or_else(|| panic!("{} should parse", entry.raw_key))
+    }
+
+    #[test]
+    fn resolutions_flat_entries_parse_with_lines() {
+        let json = r#"{
+  "name": "root",
+  "resolutions": {
+    "ws": "^8.21.0",
+    "left-pad": "^1.3.0"
+  }
+}"#;
+        let data = parse_bun_package_json_resolutions(json);
+        assert_eq!(data.entries.len(), 2);
+        assert_eq!(data.entries[0].raw_key, "ws");
+        assert_eq!(data.entries[0].line, 4);
+        assert_eq!(data.entries[1].raw_key, "left-pad");
+        assert_eq!(data.entries[1].raw_value.as_deref(), Some("^1.3.0"));
+        assert_eq!(data.entries[1].line, 5);
+        let left_pad = parsed(&data.entries[1]);
+        assert_eq!(left_pad.target_package, "left-pad");
+        assert!(left_pad.parent_package.is_none());
+    }
+
+    #[test]
+    fn resolutions_yarn_path_keys_map_to_parent_and_target() {
+        let json = r#"{
+  "resolutions": {
+    "**/left-pad": "^1.3.0",
+    "react/left-pad": "^1.3.0",
+    "react/**/left-pad": "^1.3.0",
+    "@scope/parent/left-pad": "^1.3.0",
+    "@scope/parent/@scope/child": "^1.3.0",
+    "react@^18/left-pad": "^1.3.0",
+    "@types/react@<18": "18.0.0"
+  }
+}"#;
+        let data = parse_bun_package_json_resolutions(json);
+        assert_eq!(data.entries.len(), 7);
+
+        let glob = parsed(&data.entries[0]);
+        assert_eq!(data.entries[0].raw_key, "**/left-pad");
+        assert_eq!(glob.target_package, "left-pad");
+        assert!(glob.parent_package.is_none());
+        assert_eq!(data.entries[0].line, 3);
+
+        let scoped_parent = parsed(&data.entries[1]);
+        assert_eq!(scoped_parent.parent_package.as_deref(), Some("react"));
+        assert_eq!(scoped_parent.target_package, "left-pad");
+
+        let glob_between = parsed(&data.entries[2]);
+        assert_eq!(glob_between.parent_package.as_deref(), Some("react"));
+        assert_eq!(glob_between.target_package, "left-pad");
+
+        let scoped = parsed(&data.entries[3]);
+        assert_eq!(scoped.parent_package.as_deref(), Some("@scope/parent"));
+        assert_eq!(scoped.target_package, "left-pad");
+
+        let both_scoped = parsed(&data.entries[4]);
+        assert_eq!(both_scoped.parent_package.as_deref(), Some("@scope/parent"));
+        assert_eq!(both_scoped.target_package, "@scope/child");
+
+        let ranged_parent = parsed(&data.entries[5]);
+        assert_eq!(ranged_parent.parent_package.as_deref(), Some("react"));
+        assert_eq!(
+            ranged_parent.parent_version_selector.as_deref(),
+            Some("^18")
+        );
+        assert_eq!(ranged_parent.target_package, "left-pad");
+
+        let selector = parsed(&data.entries[6]);
+        assert_eq!(selector.target_package, "@types/react");
+        assert_eq!(selector.target_version_selector.as_deref(), Some("<18"));
+        assert_eq!(data.entries[6].line, 9);
+    }
+
+    #[test]
+    fn resolutions_pnpm_delimiter_keys_parse_like_overrides() {
+        let json = r#"{"resolutions": {"react>left-pad": "^1.3.0", "pkg@>=1": "^2.0.0"}}"#;
+        let data = parse_bun_package_json_resolutions(json);
+        assert_eq!(data.entries.len(), 2);
+        let chained = parsed(&data.entries[0]);
+        assert_eq!(chained.parent_package.as_deref(), Some("react"));
+        assert_eq!(chained.target_package, "left-pad");
+        // `@>` is a version selector, not the pnpm delimiter.
+        let selector = parsed(&data.entries[1]);
+        assert!(selector.parent_package.is_none());
+        assert_eq!(selector.target_package, "pkg");
+        assert_eq!(selector.target_version_selector.as_deref(), Some(">=1"));
+    }
+
+    #[test]
+    fn resolutions_shapes_bun_rejects_are_unparsable_or_valueless() {
+        let json = r#"{
+  "resolutions": {
+    "a/b/c": "^1.0.0",
+    "a>b>c": "^1.0.0",
+    "@scope": "^1.0.0",
+    "left-pad/**": "^1.0.0",
+    "nested": { "left-pad": "^1.3.0" },
+    "left-pad": "^1.3.0"
+  }
+}"#;
+        let data = parse_bun_package_json_resolutions(json);
+        assert_eq!(data.entries.len(), 6);
+        for entry in &data.entries[..4] {
+            assert!(
+                entry.parsed_key.is_none(),
+                "{} is deeper than one parent or malformed and must not parse",
+                entry.raw_key
+            );
+        }
+        assert_eq!(data.entries[4].raw_key, "nested");
+        assert!(data.entries[4].parsed_key.is_some());
+        assert!(
+            data.entries[4].raw_value.is_none(),
+            "bun only honours string resolution values"
+        );
+        // The nested object's inner key must not steal the line of the later
+        // top-level entry with the same name.
+        assert_eq!(data.entries[5].raw_key, "left-pad");
+        assert_eq!(data.entries[5].line, 8);
+    }
+
+    #[test]
+    fn resolutions_comment_keys_are_skipped_without_shifting_lines() {
+        let json = r#"{
+  "resolutions": {
+    "//": "pin for CVE-2024-0001",
+    "left-pad": "^1.3.0"
+  }
+}"#;
+        let data = parse_bun_package_json_resolutions(json);
+        assert_eq!(data.entries.len(), 1);
+        assert_eq!(data.entries[0].raw_key, "left-pad");
+        assert_eq!(data.entries[0].line, 4);
+    }
+
+    #[test]
+    fn resolutions_parser_ignores_overrides_and_nested_sections() {
+        assert!(
+            parse_bun_package_json_resolutions(r#"{"overrides": {"left-pad": "^1.3.0"}}"#)
+                .entries
+                .is_empty()
+        );
+        assert!(
+            parse_bun_package_json_resolutions(
+                r#"{"config": {"resolutions": {"left-pad": "^1.3.0"}}}"#
+            )
+            .entries
+            .is_empty()
+        );
+        assert!(
+            parse_npm_package_json_overrides(r#"{"resolutions": {"left-pad": "^1.3.0"}}"#)
+                .entries
+                .is_empty()
+        );
+        assert!(
+            parse_bun_package_json_resolutions("{not valid json")
+                .entries
+                .is_empty()
+        );
     }
 }

--- a/crates/core/src/analyze/unused_overrides.rs
+++ b/crates/core/src/analyze/unused_overrides.rs
@@ -12,7 +12,19 @@
 //! npm parser flattens nested objects into the shared entry shape, so all
 //! three sources run through one analysis path. bun declares overrides through
 //! the same top-level `overrides` key, so bun repos are analyzed via the npm
-//! parser and resolved against `bun.lock`. yarn `resolutions` is out of scope.
+//! parser and resolved against `bun.lock`.
+//!
+//! bun also honours Yarn's top-level `resolutions` object as an alias of
+//! `overrides` (issue #2367). In a bun repository (the root `packageManager`
+//! names bun, or no recognised `packageManager` is declared and a `bun.lock`
+//! or `bun.lockb` sits at the root) the `resolutions` entries run through the
+//! same two detectors, reported with `source: "package.json"`. bun reads
+//! `overrides` first and never consults `resolutions` once an `overrides` key
+//! exists, so a manifest carrying both is analyzed for `overrides` alone.
+//! yarn repositories stay out of scope: yarn never applies `overrides`, the
+//! inert entries keep the "declare the pin under `resolutions`" hint, and
+//! yarn's own `resolutions` semantics (glob paths, `yarn.lock`) are not
+//! modelled.
 //!
 //! Two findings are emitted:
 //!
@@ -46,9 +58,9 @@
 use fallow_config::{
     CompiledIgnoreDependencyOverrideRule, PackageJson, PnpmOverrideData, ResolvedConfig,
     WorkspaceDiagnostic, WorkspaceDiagnosticKind, WorkspaceInfo,
-    override_misconfig_reason as parser_misconfig_reason, parse_npm_package_json_overrides,
-    parse_pnpm_package_json_overrides, parse_pnpm_workspace_overrides,
-    record_workspace_diagnostics,
+    override_misconfig_reason as parser_misconfig_reason, parse_bun_package_json_resolutions,
+    parse_npm_package_json_overrides, parse_pnpm_package_json_overrides,
+    parse_pnpm_workspace_overrides, record_workspace_diagnostics,
 };
 use fallow_types::results::{
     DependencyOverrideMisconfigReason, DependencyOverrideSource, MisconfiguredDependencyOverride,
@@ -65,12 +77,14 @@ const BUN_LOCKB_FILE: &str = "bun.lockb";
 const YARN_LOCK_FILE: &str = "yarn.lock";
 const NODE_MODULES_SEGMENT: &str = "node_modules/";
 const ROOT_PACKAGE_JSON: &str = "package.json";
+const OVERRIDES_KEY: &str = "overrides";
 const SOURCE_LABEL_YAML: &str = "pnpm-workspace.yaml";
 const SOURCE_LABEL_JSON: &str = "package.json";
 const HINT_MAY_BE_TRANSITIVE_PNPM: &str =
     "may target a transitive dependency; pnpm install --frozen-lockfile is the ground truth";
 const HINT_MAY_BE_TRANSITIVE_BUN: &str =
     "may target a transitive dependency; bun install --frozen-lockfile is the ground truth";
+const HINT_MAY_BE_TRANSITIVE_BUN_RESOLUTIONS: &str = "declared under `resolutions`, which bun applies as an alias of `overrides`; may target a transitive dependency; bun install --frozen-lockfile is the ground truth";
 const HINT_MAY_BE_TRANSITIVE_NPM: &str =
     "may target a transitive dependency; npm ci is the ground truth";
 const HINT_OVERRIDES_IGNORED_BY_YARN: &str =
@@ -82,7 +96,7 @@ const LOCKFILE_DEPENDENCY_SECTIONS: &[&str] = &[
     "peerDependencies",
 ];
 
-/// Combined override state across both sources, plus the set of packages
+/// Combined override state across every source, plus the set of packages
 /// declared in any workspace `package.json` dep section.
 pub struct PnpmOverrideState {
     /// Entries from `pnpm-workspace.yaml`'s `overrides:` map. Empty when the
@@ -95,6 +109,11 @@ pub struct PnpmOverrideState {
     /// `overrides` object. Empty when the file is missing, has no overrides
     /// section, or fails to parse.
     npm_package_json_data: PnpmOverrideData,
+    /// Flat entries from `<root>/package.json`'s Yarn-style top-level
+    /// `resolutions` object. Populated only for bun repositories whose
+    /// manifest has no `overrides` key (bun ignores `resolutions` otherwise);
+    /// empty for every other package manager (issue #2367).
+    bun_resolutions_data: PnpmOverrideData,
     /// Every package name that appears in `dependencies` / `devDependencies` /
     /// `peerDependencies` / `optionalDependencies` of any workspace
     /// `package.json` (root + members).
@@ -115,8 +134,8 @@ pub struct PnpmOverrideState {
     transitive_hint: &'static str,
 }
 
-/// Read both override sources and walk workspace `package.json` files to build
-/// shared analysis state. Returns `None` when neither source carries any
+/// Read every override source and walk workspace `package.json` files to
+/// build shared analysis state. Returns `None` when no source carries any
 /// entries; callers should skip both override detectors in that case.
 #[must_use]
 pub fn gather_pnpm_override_state(
@@ -140,6 +159,9 @@ pub fn gather_pnpm_override_state(
 
     let root_pkg_path = config.root.join(ROOT_PACKAGE_JSON);
     let root_pkg_source = std::fs::read_to_string(&root_pkg_path).ok();
+    let root_manifest: Option<serde_json::Value> = root_pkg_source
+        .as_deref()
+        .and_then(|source| serde_json::from_str(source).ok());
     let package_json_data = root_pkg_source
         .as_deref()
         .map(parse_pnpm_package_json_overrides)
@@ -149,20 +171,39 @@ pub fn gather_pnpm_override_state(
         .map(parse_npm_package_json_overrides)
         .unwrap_or_default();
 
+    let declared_manager = declared_package_manager(root_manifest.as_ref());
+    // bun's `OverrideMap::parse_append` (src/install/lockfile/OverrideMap.rs)
+    // takes the `overrides` property when it exists, whatever its value, and
+    // falls through to `resolutions` only when `overrides` is absent, so a
+    // manifest with both keys is analyzed for `overrides` alone.
+    let manifest_declares_overrides = root_manifest
+        .as_ref()
+        .is_some_and(|manifest| manifest.get(OVERRIDES_KEY).is_some());
+    let bun_resolutions_data = match root_pkg_source.as_deref() {
+        Some(source)
+            if uses_bun(declared_manager, &config.root) && !manifest_declares_overrides =>
+        {
+            parse_bun_package_json_resolutions(source)
+        }
+        _ => PnpmOverrideData::default(),
+    };
+
     if workspace_yaml_data.entries.is_empty()
         && package_json_data.entries.is_empty()
         && npm_package_json_data.entries.is_empty()
+        && bun_resolutions_data.entries.is_empty()
     {
         return None;
     }
 
     let declared_packages = collect_declared_packages(config, workspaces);
-    let lockfile_resolution = collect_lockfile_packages(config, root_pkg_source.as_deref());
+    let lockfile_resolution = collect_lockfile_packages(config, declared_manager);
 
     Some(PnpmOverrideState {
         workspace_yaml_data,
         package_json_data,
         npm_package_json_data,
+        bun_resolutions_data,
         declared_packages,
         lockfile_packages: lockfile_resolution.packages,
         lockfile_resolution_unavailable: lockfile_resolution.resolution_unavailable,
@@ -226,7 +267,7 @@ struct LockfileResolution {
 /// instead of flagging every transitive-only override.
 fn collect_lockfile_packages(
     config: &ResolvedConfig,
-    root_pkg_source: Option<&str>,
+    declared_manager: Option<DeclaredPackageManager>,
 ) -> LockfileResolution {
     let mut packages = FxHashSet::default();
 
@@ -258,7 +299,7 @@ fn collect_lockfile_packages(
     let has_bun_lockb = config.root.join(BUN_LOCKB_FILE).exists();
     let has_yarn_lock = config.root.join(YARN_LOCK_FILE).exists();
 
-    let transitive_hint = match declared_package_manager(root_pkg_source) {
+    let transitive_hint = match declared_manager {
         Some(DeclaredPackageManager::Bun) => HINT_MAY_BE_TRANSITIVE_BUN,
         Some(DeclaredPackageManager::Npm) => HINT_MAY_BE_TRANSITIVE_NPM,
         Some(DeclaredPackageManager::Yarn) => HINT_OVERRIDES_IGNORED_BY_YARN,
@@ -292,13 +333,14 @@ enum DeclaredPackageManager {
 }
 
 /// Read the corepack `packageManager` field (`"bun@1.3.2"` names bun) from
-/// the root `package.json` source. Mirrors the packageManager-first probes in
+/// the parsed root `package.json`. Mirrors the packageManager-first probes in
 /// the CLI package-manager detectors so the transitive hint cannot name a
 /// package manager the repository does not use, for example a bun repo whose
 /// lockfile is not committed yet.
-fn declared_package_manager(root_pkg_source: Option<&str>) -> Option<DeclaredPackageManager> {
-    let value: serde_json::Value = serde_json::from_str(root_pkg_source?).ok()?;
-    let field = value.get("packageManager")?.as_str()?;
+fn declared_package_manager(
+    root_manifest: Option<&serde_json::Value>,
+) -> Option<DeclaredPackageManager> {
+    let field = root_manifest?.get("packageManager")?.as_str()?;
     let name = field.split('@').next().unwrap_or(field);
     match name {
         "npm" => Some(DeclaredPackageManager::Npm),
@@ -306,6 +348,20 @@ fn declared_package_manager(root_pkg_source: Option<&str>) -> Option<DeclaredPac
         "yarn" => Some(DeclaredPackageManager::Yarn),
         "bun" => Some(DeclaredPackageManager::Bun),
         _ => None,
+    }
+}
+
+/// Whether the repository installs with bun, which decides if the root
+/// manifest's `resolutions` object is an override source. The corepack
+/// `packageManager` field wins when it names a known manager; without one, a
+/// `bun.lock` or `bun.lockb` at the root counts. A manifest naming npm, pnpm,
+/// or yarn is never a bun repository, even next to a leftover bun lockfile,
+/// mirroring the packageManager-first rule the transitive hint uses.
+fn uses_bun(declared_manager: Option<DeclaredPackageManager>, root: &std::path::Path) -> bool {
+    match declared_manager {
+        Some(DeclaredPackageManager::Bun) => true,
+        Some(_) => false,
+        None => root.join(BUN_LOCK_FILE).exists() || root.join(BUN_LOCKB_FILE).exists(),
     }
 }
 
@@ -549,6 +605,16 @@ pub fn find_unused_dependency_overrides(
         ignore_rules: &config.compiled_ignore_dependency_overrides,
         findings: &mut findings,
     });
+    collect_unused_from_source(&mut UnusedOverrideSourceInput {
+        data: &state.bun_resolutions_data,
+        source: DependencyOverrideSource::PnpmPackageJson,
+        source_path: &json_path,
+        declared: &state.declared_packages,
+        resolved: &state.lockfile_packages,
+        hint: HINT_MAY_BE_TRANSITIVE_BUN_RESOLUTIONS,
+        ignore_rules: &config.compiled_ignore_dependency_overrides,
+        findings: &mut findings,
+    });
     findings
 }
 
@@ -649,6 +715,13 @@ pub fn find_misconfigured_dependency_overrides(
     );
     collect_misconfigured_from_source(
         &state.npm_package_json_data,
+        DependencyOverrideSource::PnpmPackageJson,
+        &json_path,
+        &config.compiled_ignore_dependency_overrides,
+        &mut findings,
+    );
+    collect_misconfigured_from_source(
+        &state.bun_resolutions_data,
         DependencyOverrideSource::PnpmPackageJson,
         &json_path,
         &config.compiled_ignore_dependency_overrides,
@@ -1122,6 +1195,288 @@ mod tests {
         assert!(
             bun_lockb_skip_diagnostics(root).is_empty(),
             "the diagnostic is specific to bun.lockb, not to a missing lockfile"
+        );
+    }
+
+    // Issue #2367: bun honours Yarn-style `resolutions` as an `overrides`
+    // alias, so a bun manifest that pins versions there must reach the same
+    // detectors and the same bun.lockb skip diagnostic.
+
+    fn write_manifest(
+        root: &std::path::Path,
+        package_manager: Option<&str>,
+        overrides: Option<&str>,
+        resolutions: Option<&str>,
+    ) {
+        let package_manager_field = package_manager
+            .map(|value| format!(",\n  \"packageManager\": \"{value}\""))
+            .unwrap_or_default();
+        let overrides_field = overrides
+            .map(|value| format!(",\n  \"overrides\": {value}"))
+            .unwrap_or_default();
+        let resolutions_field = resolutions
+            .map(|value| format!(",\n  \"resolutions\": {value}"))
+            .unwrap_or_default();
+        std::fs::write(
+            root.join(ROOT_PACKAGE_JSON),
+            format!(
+                r#"{{
+  "name": "issue-2367-bun-resolutions",
+  "private": true,
+  "devDependencies": {{ "happy-dom": "^20.10.6" }}{package_manager_field}{overrides_field}{resolutions_field}
+}}"#
+            ),
+        )
+        .expect("write package.json");
+    }
+
+    #[expect(
+        deprecated,
+        reason = "the detector helper is deprecated for external callers; the unit test exercises the internal resolutions path"
+    )]
+    fn run_misconfigured_override_detector(
+        config: &ResolvedConfig,
+    ) -> Option<Vec<MisconfiguredDependencyOverride>> {
+        let state = gather_pnpm_override_state(config, &[])?;
+        Some(find_misconfigured_dependency_overrides(&state, config))
+    }
+
+    fn flagged_targets(findings: &[UnusedDependencyOverride]) -> Vec<&str> {
+        findings
+            .iter()
+            .map(|finding| finding.target_package.as_str())
+            .collect()
+    }
+
+    const RESOLUTIONS_WS_AND_LEFT_PAD: &str = r#"{ "ws": "^8.21.0", "left-pad": "^1.3.0" }"#;
+    const RESOLUTIONS_LEFT_PAD: &str = r#"{ "left-pad": "^1.3.0" }"#;
+
+    #[test]
+    fn bun_resolutions_only_next_to_bun_lockb_records_skip_diagnostic_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write_manifest(
+            root,
+            Some("bun@1.3.2"),
+            None,
+            Some(RESOLUTIONS_WS_AND_LEFT_PAD),
+        );
+        std::fs::write(root.join(BUN_LOCKB_FILE), BUN_LOCKB_PLACEHOLDER).expect("write bun.lockb");
+        let config = resolve_config(root);
+
+        let findings = run_unused_override_detector(&config)
+            .expect("resolutions are override state in a bun repository");
+        assert!(
+            findings.is_empty(),
+            "bun.lockb is unreadable; the check must stay skipped: {findings:?}"
+        );
+        let diagnostics = bun_lockb_skip_diagnostics(root);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "a resolutions-only manifest announces the skip like an overrides one: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].path, root.join(ROOT_PACKAGE_JSON));
+
+        let _ = run_unused_override_detector(&config);
+        assert_eq!(
+            bun_lockb_skip_diagnostics(root).len(),
+            1,
+            "the registry dedupes on kind + path"
+        );
+    }
+
+    #[test]
+    fn bun_resolutions_resolve_against_text_bun_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write_manifest(
+            root,
+            Some("bun@1.3.2"),
+            None,
+            Some(RESOLUTIONS_WS_AND_LEFT_PAD),
+        );
+        std::fs::write(root.join(BUN_LOCK_FILE), BUN_LOCK_REAL_SHAPE).expect("write bun.lock");
+        let config = resolve_config(root);
+
+        let findings = run_unused_override_detector(&config)
+            .expect("resolutions are override state in a bun repository");
+        assert_eq!(
+            flagged_targets(&findings),
+            vec!["left-pad"],
+            "bun.lock resolves ws transitively; left-pad stays unresolved"
+        );
+        let finding = &findings[0];
+        assert_eq!(finding.raw_key, "left-pad");
+        assert_eq!(finding.source, DependencyOverrideSource::PnpmPackageJson);
+        assert_eq!(finding.path, root.join(ROOT_PACKAGE_JSON));
+        assert_eq!(finding.line, 6, "the resolutions object sits on line 6");
+        let hint = finding.hint.as_deref().unwrap_or_default();
+        assert!(
+            hint.contains("resolutions") && hint.contains("bun install --frozen-lockfile"),
+            "the bun hint names the resolutions origin: {hint}"
+        );
+        assert!(
+            bun_lockb_skip_diagnostics(root).is_empty(),
+            "a parseable bun.lock means resolution ran"
+        );
+    }
+
+    #[test]
+    fn bun_overrides_key_shadows_resolutions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write_manifest(
+            root,
+            Some("bun@1.3.2"),
+            Some(r#"{ "ws": "^8.21.0" }"#),
+            Some(RESOLUTIONS_LEFT_PAD),
+        );
+        std::fs::write(root.join(BUN_LOCK_FILE), BUN_LOCK_REAL_SHAPE).expect("write bun.lock");
+        let config = resolve_config(root);
+
+        let findings = run_unused_override_detector(&config).expect("overrides are declared");
+        assert!(
+            findings.is_empty(),
+            "bun never reads resolutions once an overrides key exists: {findings:?}"
+        );
+
+        let empty_dir = tempfile::tempdir().expect("tempdir");
+        let empty_root = empty_dir.path();
+        write_manifest(
+            empty_root,
+            Some("bun@1.3.2"),
+            Some("{}"),
+            Some(RESOLUTIONS_LEFT_PAD),
+        );
+        std::fs::write(empty_root.join(BUN_LOCK_FILE), BUN_LOCK_REAL_SHAPE)
+            .expect("write bun.lock");
+        let config = resolve_config(empty_root);
+        assert!(
+            run_unused_override_detector(&config).is_none(),
+            "an empty overrides object still shadows resolutions, so no override state exists"
+        );
+    }
+
+    #[derive(Debug)]
+    struct NonBunRepository {
+        package_manager: Option<&'static str>,
+        lockfile: Option<(&'static str, &'static str)>,
+    }
+
+    #[test]
+    fn resolutions_are_ignored_outside_bun_repositories() {
+        let cases = [
+            NonBunRepository {
+                package_manager: Some("yarn@4.5.0"),
+                lockfile: Some((YARN_LOCK_FILE, "# yarn lockfile v1\n")),
+            },
+            // A declared package manager wins over a leftover bun lockfile.
+            NonBunRepository {
+                package_manager: Some("npm@10.9.0"),
+                lockfile: Some((BUN_LOCK_FILE, BUN_LOCK_REAL_SHAPE)),
+            },
+            NonBunRepository {
+                package_manager: None,
+                lockfile: Some((PNPM_LOCK_FILE, "lockfileVersion: '9.0'\n")),
+            },
+            NonBunRepository {
+                package_manager: None,
+                lockfile: None,
+            },
+        ];
+        for case in cases {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let root = dir.path();
+            write_manifest(root, case.package_manager, None, Some(RESOLUTIONS_LEFT_PAD));
+            if let Some((name, content)) = case.lockfile {
+                std::fs::write(root.join(name), content).expect("write lockfile");
+            }
+            let config = resolve_config(root);
+            assert!(
+                run_unused_override_detector(&config).is_none(),
+                "{case:?}: resolutions are not an override source outside bun repositories"
+            );
+        }
+    }
+
+    #[test]
+    fn bun_lockfile_without_package_manager_field_enables_resolutions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write_manifest(root, None, None, Some(RESOLUTIONS_WS_AND_LEFT_PAD));
+        std::fs::write(root.join(BUN_LOCK_FILE), BUN_LOCK_REAL_SHAPE).expect("write bun.lock");
+        let config = resolve_config(root);
+        let findings = run_unused_override_detector(&config)
+            .expect("a root bun.lock marks the repository as bun");
+        assert_eq!(flagged_targets(&findings), vec!["left-pad"]);
+
+        let lockb_dir = tempfile::tempdir().expect("tempdir");
+        let lockb_root = lockb_dir.path();
+        write_manifest(lockb_root, None, None, Some(RESOLUTIONS_WS_AND_LEFT_PAD));
+        std::fs::write(lockb_root.join(BUN_LOCKB_FILE), BUN_LOCKB_PLACEHOLDER)
+            .expect("write bun.lockb");
+        let config = resolve_config(lockb_root);
+        let findings = run_unused_override_detector(&config)
+            .expect("a root bun.lockb marks the repository as bun");
+        assert!(findings.is_empty(), "bun.lockb is unreadable: {findings:?}");
+        assert_eq!(
+            bun_lockb_skip_diagnostics(lockb_root).len(),
+            1,
+            "the skip is announced for the resolutions-only manifest"
+        );
+    }
+
+    #[test]
+    fn bun_resolutions_yarn_path_keys_credit_parents_and_flag_rejected_shapes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        write_manifest(
+            root,
+            Some("bun@1.3.2"),
+            None,
+            Some(
+                r#"{
+    "**/ws": "^8.21.0",
+    "happy-dom/left-pad": "^1.3.0",
+    "**/left-pad": "^1.3.0",
+    "a/b/c": "^1.0.0",
+    "nested": { "left-pad": "^1.3.0" }
+  }"#,
+            ),
+        );
+        std::fs::write(root.join(BUN_LOCK_FILE), BUN_LOCK_REAL_SHAPE).expect("write bun.lock");
+        let config = resolve_config(root);
+
+        let unused = run_unused_override_detector(&config).expect("resolutions are declared");
+        let flagged: Vec<(&str, &str)> = unused
+            .iter()
+            .map(|finding| (finding.raw_key.as_str(), finding.target_package.as_str()))
+            .collect();
+        assert_eq!(
+            flagged,
+            vec![("**/left-pad", "left-pad")],
+            "ws resolves through bun.lock, happy-dom/left-pad is credited through its declared parent, and the shapes bun rejects never reach the unused check"
+        );
+
+        let misconfigured =
+            run_misconfigured_override_detector(&config).expect("resolutions are declared");
+        let reasons: Vec<(&str, DependencyOverrideMisconfigReason)> = misconfigured
+            .iter()
+            .map(|finding| (finding.raw_key.as_str(), finding.reason))
+            .collect();
+        assert_eq!(
+            reasons,
+            vec![
+                ("a/b/c", DependencyOverrideMisconfigReason::UnparsableKey),
+                ("nested", DependencyOverrideMisconfigReason::EmptyValue),
+            ],
+            "a path deeper than one parent and a non-string value are the shapes bun warns about and skips"
+        );
+        assert!(
+            misconfigured
+                .iter()
+                .all(|finding| finding.source == DependencyOverrideSource::PnpmPackageJson)
         );
     }
 }

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -313,6 +313,8 @@ mod issue_2019_cli_flag_convention_table;
 mod issue_2069_npm_overrides;
 #[path = "integration_test/issue_2358_bun_lockb_diagnostic.rs"]
 mod issue_2358_bun_lockb_diagnostic;
+#[path = "integration_test/issue_2367_bun_resolutions.rs"]
+mod issue_2367_bun_resolutions;
 #[path = "integration_test/issue_317_namespace_barrel_ignore_exports.rs"]
 mod issue_317_namespace_barrel_ignore_exports;
 #[path = "integration_test/issue_329_pnpm_catalog.rs"]

--- a/crates/core/tests/integration_test/issue_2367_bun_resolutions.rs
+++ b/crates/core/tests/integration_test/issue_2367_bun_resolutions.rs
@@ -1,0 +1,118 @@
+//! Integration test for Yarn-style `resolutions` as a bun override source
+//! (issue #2367).
+//!
+//! Fixture under `tests/fixtures/issue-2367-bun-resolutions/` is a bun
+//! repository (`packageManager: bun@1.3.2`, text `bun.lock`) whose root
+//! `package.json` declares no `overrides` and pins three packages under
+//! `resolutions`: `ws` (declared and resolved, USED), `left-pad` (absent
+//! everywhere, UNUSED), and the yarn glob form `**/trim-newlines` (absent,
+//! UNUSED). The lockfile resolves `ws` only.
+
+use fallow_config::{
+    FallowConfig, IgnoreDependencyOverrideRule, OutputFormat, WorkspaceDiagnosticKind,
+};
+use fallow_types::results::DependencyOverrideSource;
+
+use super::common::fixture_path;
+
+const FIXTURE: &str = "issue-2367-bun-resolutions";
+
+fn config_for_fixture(ignore: Vec<IgnoreDependencyOverrideRule>) -> fallow_config::ResolvedConfig {
+    FallowConfig {
+        ignore_dependency_overrides: ignore,
+        ..Default::default()
+    }
+    .resolve(
+        fixture_path(FIXTURE),
+        OutputFormat::Human,
+        4,
+        true,
+        true,
+        None,
+    )
+}
+
+#[test]
+fn bun_resolutions_entries_are_reported_as_unused_overrides() {
+    let root = fixture_path(FIXTURE);
+    let config = config_for_fixture(vec![]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let mut flagged: Vec<(&str, &str, u32)> = results
+        .unused_dependency_overrides
+        .iter()
+        .map(|finding| {
+            (
+                finding.entry.raw_key.as_str(),
+                finding.entry.target_package.as_str(),
+                finding.entry.line,
+            )
+        })
+        .collect();
+    flagged.sort_unstable();
+    assert_eq!(
+        flagged,
+        vec![
+            ("**/trim-newlines", "trim-newlines", 12),
+            ("left-pad", "left-pad", 11),
+        ],
+        "ws is declared and resolved; the two unresolved pins report at their resolutions lines"
+    );
+
+    let expected_path = root
+        .join("package.json")
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    for finding in &results.unused_dependency_overrides {
+        assert_eq!(
+            finding.entry.source,
+            DependencyOverrideSource::PnpmPackageJson,
+            "resolutions live in package.json"
+        );
+        assert_eq!(
+            finding.entry.path.display().to_string().replace('\\', "/"),
+            expected_path
+        );
+        let hint = finding.entry.hint.as_deref().unwrap_or_default();
+        assert!(
+            hint.contains("resolutions") && hint.contains("bun install --frozen-lockfile"),
+            "the bun hint names the resolutions origin: {hint}"
+        );
+    }
+
+    assert!(
+        results.misconfigured_dependency_overrides.is_empty(),
+        "every key in the fixture is a shape bun honours: {:?}",
+        results.misconfigured_dependency_overrides
+    );
+    assert!(
+        fallow_config::workspace_diagnostics_for(&root)
+            .iter()
+            .all(|diagnostic| !matches!(
+                diagnostic.kind,
+                WorkspaceDiagnosticKind::BunLockbOverrideResolutionSkipped
+            )),
+        "a parseable bun.lock means resolution ran, so no skip diagnostic"
+    );
+}
+
+#[test]
+fn ignore_rule_suppresses_bun_resolutions_entry() {
+    let config = config_for_fixture(vec![IgnoreDependencyOverrideRule {
+        package: "left-pad".to_string(),
+        source: Some("package.json".to_string()),
+    }]);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let flagged: Vec<&str> = results
+        .unused_dependency_overrides
+        .iter()
+        .map(|finding| finding.entry.target_package.as_str())
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["trim-newlines"],
+        "the package.json source label suppresses a resolutions entry"
+    );
+}

--- a/crates/types/src/results.rs
+++ b/crates/types/src/results.rs
@@ -3109,7 +3109,8 @@ pub enum DependencyOverrideSource {
     /// Top-level `overrides:` key in `pnpm-workspace.yaml`.
     #[serde(rename = "pnpm-workspace.yaml")]
     PnpmWorkspaceYaml,
-    /// `pnpm.overrides` or the top-level npm `overrides` object in a root
+    /// `pnpm.overrides`, the top-level npm `overrides` object, or (in a bun
+    /// repository) the Yarn-style top-level `resolutions` object in a root
     /// `package.json`.
     #[serde(rename = "package.json")]
     PnpmPackageJson,
@@ -3134,11 +3135,13 @@ impl std::fmt::Display for DependencyOverrideSource {
 }
 
 /// An entry in pnpm's `overrides:` map (or the legacy `pnpm.overrides` in
-/// `package.json`), or in npm's top-level `overrides` object in
-/// `package.json`, whose target package is not declared in any workspace
-/// `package.json` and is not present in `pnpm-lock.yaml` or
-/// `package-lock.json`. Projects without a readable lockfile fall back to
-/// package manifest checks; the `hint` field flags that conservative mode.
+/// `package.json`), in npm's top-level `overrides` object in `package.json`,
+/// or (in a bun repository) in the Yarn-style top-level `resolutions` object
+/// in `package.json`, whose target package is not declared in any workspace
+/// `package.json` and is not present in `pnpm-lock.yaml`,
+/// `package-lock.json`, or `bun.lock`. Projects without a readable lockfile
+/// fall back to package manifest checks; the `hint` field flags that
+/// conservative mode.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct UnusedDependencyOverride {

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -5147,7 +5147,7 @@
         "path",
         "line"
       ],
-      "description": "An entry in pnpm's `overrides:` map (or the legacy `pnpm.overrides` in\n`package.json`), or in npm's top-level `overrides` object in\n`package.json`, whose target package is not declared in any workspace\n`package.json` and is not present in `pnpm-lock.yaml` or\n`package-lock.json`. Projects without a readable lockfile fall back to\npackage manifest checks; the `hint` field flags that conservative mode."
+      "description": "An entry in pnpm's `overrides:` map (or the legacy `pnpm.overrides` in\n`package.json`), in npm's top-level `overrides` object in `package.json`,\nor (in a bun repository) in the Yarn-style top-level `resolutions` object\nin `package.json`, whose target package is not declared in any workspace\n`package.json` and is not present in `pnpm-lock.yaml`,\n`package-lock.json`, or `bun.lock`. Projects without a readable lockfile\nfall back to package manifest checks; the `hint` field flags that\nconservative mode."
     },
     "MisconfiguredDependencyOverride": {
       "type": "object",
@@ -6683,7 +6683,7 @@
         {
           "type": "string",
           "const": "package.json",
-          "description": "`pnpm.overrides` or the top-level npm `overrides` object in a root\n`package.json`."
+          "description": "`pnpm.overrides`, the top-level npm `overrides` object, or (in a bun\nrepository) the Yarn-style top-level `resolutions` object in a root\n`package.json`."
         }
       ],
       "description": "Where an override entry was declared. Serialized as the filename label\n(`\"pnpm-workspace.yaml\"` or `\"package.json\"`) so the value in JSON output\nmatches the value users write in `ignoreDependencyOverrides[].source`."

--- a/tests/fixtures/issue-2367-bun-resolutions/bun.lock
+++ b/tests/fixtures/issue-2367-bun-resolutions/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "issue-2367-bun-resolutions",
+      "dependencies": {
+        "ws": "^8.21.0",
+      },
+    },
+  },
+  "overrides": {
+    "ws": "^8.21.0",
+    "left-pad": "^1.3.0",
+    "trim-newlines": "^3.0.1",
+  },
+  "packages": {
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-20"],
+  }
+}

--- a/tests/fixtures/issue-2367-bun-resolutions/package.json
+++ b/tests/fixtures/issue-2367-bun-resolutions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "issue-2367-bun-resolutions",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "bun@1.3.2",
+  "dependencies": {
+    "ws": "^8.21.0"
+  },
+  "resolutions": {
+    "ws": "^8.21.0",
+    "left-pad": "^1.3.0",
+    "**/trim-newlines": "^3.0.1"
+  }
+}

--- a/tests/fixtures/issue-2367-bun-resolutions/src/index.ts
+++ b/tests/fixtures/issue-2367-bun-resolutions/src/index.ts
@@ -1,0 +1,1 @@
+export const root = 1;


### PR DESCRIPTION
## What was broken

bun honours Yarn-style `resolutions` in `package.json` as an alias of `overrides`, but the dependency-override analyzer only read the top-level `overrides` object, `pnpm.overrides`, and `pnpm-workspace.yaml`. A bun repository that pins transitive versions under `resolutions` was never analyzed: no `unused-dependency-overrides` or `misconfigured-dependency-overrides` findings with any lockfile, and since #2362 no `bun-lockb-override-resolution-skipped` diagnostic next to a `bun.lockb` either, because no override state was gathered. Both repros from the issue (a `resolutions` manifest next to a `bun.lockb`, and a `resolutions` manifest next to a text `bun.lock` that resolves only `ws`) produced nothing: no findings, no diagnostic, no stderr warning.

## Root cause

`gather_pnpm_override_state` builds its state from three parsers (`pnpm-workspace.yaml`, `pnpm.overrides`, and the npm `overrides` object) and returns `None` when all three are empty, so the detectors and the bun.lockb skip path never ran for a `resolutions`-only manifest. The npm parser also hard-codes the `overrides` key and flattens nested objects, and it does not understand yarn's `parent/child` and `**/child` path keys, which bun accepts under `resolutions`.

## The fix

- `fallow_config::parse_bun_package_json_resolutions` parses the top-level `resolutions` object through the shared override entry shape. It reuses the npm line scanner (now parameterised by section key, recording only direct keys for `resolutions` so a nested object bun rejects cannot shift a later key's line) and maps bun's key dialect: bare packages, `@scope/pkg`, `pkg@<2`, the yarn paths `parent/child`, `**/child`, and `parent/**/child` (with `@scope/name` spanning two segments), and the pnpm `parent>child` form, using bun's delimiter rule so `pkg@>=1` keeps its selector. Shapes bun warns about and skips (more than one parent level, a bare scope, a trailing `**`, a non-string value) stay entries without a parsed key or value so the misconfigured detector reports them. `//` comment keys are skipped.
- The core analyzer gathers `resolutions` only for bun repositories: the root `packageManager` names bun, or no recognised `packageManager` is declared and a `bun.lock` or `bun.lockb` sits at the root (a manifest naming npm, pnpm, or yarn is never a bun repository, even next to a leftover bun lockfile, mirroring the packageManager-first rule the transitive hint already uses).
- bun precedence, cited in a code comment: `OverrideMap::parse_append` in bun's `src/install/lockfile/OverrideMap.rs` takes the `overrides` property when it exists, whatever its value, and falls through to `resolutions` only when `overrides` is absent. The analyzer therefore ignores `resolutions` whenever the manifest has an `overrides` key, including an empty one.
- `resolutions` entries run through both detectors with `source: "package.json"` (the declaring-file label the field is documented as), the entry's line, and a bun hint that names `resolutions`: `declared under `resolutions`, which bun applies as an alias of `overrides`; may target a transitive dependency; bun install --frozen-lockfile is the ground truth`. A `resolutions`-only manifest next to a `bun.lockb` without a parseable text lockfile now records the existing skip diagnostic.
- yarn repositories keep the current stance, documented in the module docs: `resolutions` is not parsed, and the inert-`overrides` hint is unchanged.
- The root manifest is parsed once in `gather_pnpm_override_state` and the declared package manager is passed into `collect_lockfile_packages` instead of being re-derived from the source string.

## Behavior change

Additive findings only, for bun repositories that declare `resolutions` without `overrides`: new `unused-dependency-overrides` and `misconfigured-dependency-overrides` entries, and the `bun-lockb-override-resolution-skipped` diagnostic next to a `bun.lockb`. npm, pnpm, and yarn repositories, and bun repositories with an `overrides` key, are unchanged. No contract change: `DependencyOverrideSource` keeps its two values (the policy in `docs/backwards-compatibility.md` bumps the envelope for a value added to an existing enum-valued required field, and `source` is documented as the declaring-file label, which `package.json` already is), so only the rustdoc descriptions of `DependencyOverrideSource::PnpmPackageJson` and `UnusedDependencyOverride` changed and `docs/output-schema.json` was regenerated from them. Suppression works with the existing `ignoreDependencyOverrides: [{ "package": "...", "source": "package.json" }]` rule.

## Cache invalidation

None. Override analysis reads the manifest and lockfiles on every run; nothing about it is persisted in the extract or graph caches. Warm-cache proof on the fixture: baseline binary cold run writes `.fallow` and reports nothing, the fixed binary on that warm cache reports `left-pad` and `**/trim-newlines`, and a second warm run is stable.

## How it was tested

- Config unit tests (`npm_overrides::tests`): flat entries with lines; every yarn path shape and the pnpm delimiter form; shapes bun rejects are unparsable or valueless and a nested object does not shift a later key's line; comment keys are skipped; the `resolutions` parser ignores `overrides` and nested `resolutions`, and the npm parser ignores `resolutions`.
- Core unit tests (`unused_overrides::tests`, mirroring the #2362 set): resolutions-only next to `bun.lockb` records the skip diagnostic once and stays deduplicated; resolutions resolve against a text `bun.lock` (left-pad flagged, `source`, `path`, line, hint); an `overrides` key (even empty) shadows `resolutions`; yarn, npm (with a leftover `bun.lock`), pnpm, and lockfile-less repositories ignore `resolutions`; a root bun lockfile without a `packageManager` field enables them; yarn path keys credit a declared parent and the shapes bun rejects reach the misconfigured detector.
- Integration test on fixture `tests/fixtures/issue-2367-bun-resolutions` (bun repo, `resolutions` with `ws`, `left-pad`, and `**/trim-newlines`, text `bun.lock` resolving `ws`): both unresolved pins report at their lines with the `package.json` source and the resolutions hint, no misconfigured findings, no skip diagnostic; the `ignoreDependencyOverrides` rule with `source: "package.json"` suppresses an entry.
- CLI test: `dead-code --format json` on the fixture carries both findings with `source` and `path` `package.json` and the resolutions hint, and no workspace diagnostics.
- Issue repros through the baseline binary (built from e65a9083e) and the fixed binary: the `bun.lockb` repro reports the skip diagnostic in JSON and on stderr on the fixed binary only; the text `bun.lock` repro reports `left-pad` with the bun hint on the fixed binary only; a manifest with both `overrides` and `resolutions` reports nothing on either.
- Real-project parity: `dead-code --format json --no-cache` on the in-repo `viz-frontend` (package-lock.json) and `editors/vscode` (pnpm-lock.yaml); outputs identical apart from `analysis_run_id` and `elapsed_ms`, stderr identical apart from timestamps.
- Mutation matrix: with the non-test hunks of `unused_overrides.rs` reverted, the core unit tests, the integration test, and the CLI test fail; with the non-test hunks of the config parser reverted, the config tests and the core crate fail to compile on the missing parser.
- Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `cargo check --workspace --benches`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `typos`, the hidden-unicode scan, the comment-quality check, and `npm run generate:contracts:check`.

Fixes #2367
