### PR TITLE
fix(extract): keep MDX prose lines that only look like statements out of the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,11 +128,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   program, so the whole file lost its imports: the imported modules were
   reported as unused files, and nothing the body rendered was credited. A line
   is now a statement only when it carries a shape a real statement has, a
-  source clause (`from '...'`), a brace specifier list, a star specifier, a
-  string-literal side-effect import, or, after `export`, a declaration keyword
-  (`const`, `let`, `var`, `function`, `class`, `async`, `type`, `interface`,
-  `enum`, `namespace`, `declare`, `abstract`, `default`), a brace list, or a
-  star. As a safety net, a statement block the parser rejects on its own is
+  source clause (`from '...'`, with any whitespace JavaScript accepts around
+  `from`), a brace specifier list, a star specifier, a string-literal
+  side-effect import, or, after `export`, a brace list, a star, or a
+  declaration keyword (`const`, `let`, `var`, `function`, `class`, `async`,
+  `default`, plus the TypeScript heads `type`, `interface`, `enum`,
+  `namespace`, `declare`, and `abstract`, which are recognised as statement
+  shapes and then handled by the fallback below rather than surviving as
+  statements). As a safety net, a statement block the parser rejects on its own is
   demoted to prose and the remaining blocks are re-parsed, so the file keeps
   the imports the rejected block used to take with it (a TS-only `import type`
   clause, which the JSX source type the MDX statement body is parsed with does
@@ -142,9 +145,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mark-all crediting instead of narrowing. Behavior change: MDX documents with
   such a line now resolve their imports, so their targets leave the unused-file
   list, the members their bodies render are credited, and their genuinely
-  unused siblings surface as unused exports. Both the extraction and graph
-  cache versions were bumped; the first run after upgrading performs one cold
-  re-analysis.
+  unused siblings surface as unused exports. The affected document's own
+  exports are read too, so an `export const` nothing consumes now reports as an
+  unused export on the `.mdx` file itself. Duplication reads the same statement
+  body, so clones inside an affected document, and the duplication share of its
+  health score, now surface where the file previously tokenized to nothing.
+  The extraction, graph, and duplication token cache versions were bumped; the
+  first run after upgrading performs one cold re-analysis.
 
 - **The MCP `audit` and `check_health` tools now honor `health.coverage`,
   `health.coverageRoot`, `FALLOW_COVERAGE`, and `FALLOW_COVERAGE_ROOT` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,14 +128,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   program, so the whole file lost its imports: the imported modules were
   reported as unused files, and nothing the body rendered was credited. A line
   is now a statement only when it carries a shape a real statement has, a
-  source clause (`from '...'`, with any whitespace JavaScript accepts around
-  `from`), a brace specifier list, a star specifier, a string-literal
+  source clause (`from` followed by its specifier quote, with any whitespace
+  JavaScript accepts in between and before the keyword), a brace specifier
+  list, a star specifier, a string-literal
   side-effect import, or, after `export`, a brace list, a star, or a
   declaration keyword (`const`, `let`, `var`, `function`, `class`, `async`,
   `default`, plus the TypeScript heads `type`, `interface`, `enum`,
   `namespace`, `declare`, and `abstract`, which are recognised as statement
   shapes and then handled by the fallback below rather than surviving as
-  statements). As a safety net, a statement block the parser rejects on its own is
+  statements), or when the line parses as JavaScript on its own, which keeps
+  valid heads no specifier pattern names (`import /* c */ './x'`, a top-level
+  dynamic `import ('./x')`) out of prose while a prose sentence, which does
+  not parse, stays there. As a safety net, a statement block the parser rejects on its own is
   demoted to prose and the remaining blocks are re-parsed, so the file keeps
   the imports the rejected block used to take with it (a TS-only `import type`
   clause, which the JSX source type the MDX statement body is parsed with does
@@ -147,7 +151,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list, the members their bodies render are credited, and their genuinely
   unused siblings surface as unused exports. The affected document's own
   exports are read too, so an `export const` nothing consumes now reports as an
-  unused export on the `.mdx` file itself. Duplication reads the same statement
+  unused export on the `.mdx` file itself. A multi-line MDX declaration whose
+  continuation line carries the word `from` inside a string (`summary:
+  'Written from scratch'`) is collected whole rather than cut one line short,
+  so that declaration parses and its unconsumed export reports as well.
+  Duplication reads the same statement
   body, so clones inside an affected document, and the duplication share of its
   health score, now surface where the file previously tokenized to nothing.
   The extraction, graph, and duplication token cache versions were bumped; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where the unused-export finding used to stand in its place. Warm graph caches
   invalidate (`GRAPH_CACHE_VERSION` 39 to 40); the extract cache is untouched.
 
+- **An MDX prose sentence that opens with the word "import" no longer drops
+  every import of the file** (Closes
+  [#2376](https://github.com/fallow-rs/fallow/issues/2376)). The MDX line scan
+  classified any line starting with `import ` / `import{` / `export ` /
+  `export{` as JavaScript, so a sentence such as `import the thing and render
+  <NS.Moon /> here.` joined the statement lines the parser reads as one
+  program. The parser aborts on the first fatal error and returns an empty
+  program, so the whole file lost its imports: the imported modules were
+  reported as unused files, and nothing the body rendered was credited. A line
+  is now a statement only when it carries a shape a real statement has, a
+  source clause (`from '...'`), a brace specifier list, a star specifier, a
+  string-literal side-effect import, or, after `export`, a declaration keyword
+  (`const`, `let`, `var`, `function`, `class`, `async`, `type`, `interface`,
+  `enum`, `namespace`, `declare`, `abstract`, `default`), a brace list, or a
+  star. As a safety net, a statement block the parser rejects on its own is
+  demoted to prose and the remaining blocks are re-parsed, so the file keeps
+  the imports the rejected block used to take with it (a TS-only `import type`
+  clause, which the JSX source type the MDX statement body is parsed with does
+  not accept, now costs only itself). Demotion works per block, so a
+  multi-line specifier list is never split, and a demoted line still feeds the
+  prose scan, so a namespace or CSS-module binding mentioned on it keeps its
+  mark-all crediting instead of narrowing. Behavior change: MDX documents with
+  such a line now resolve their imports, so their targets leave the unused-file
+  list, the members their bodies render are credited, and their genuinely
+  unused siblings surface as unused exports. Both the extraction and graph
+  cache versions were bumped; the first run after upgrading performs one cold
+  re-analysis.
+
 - **The MCP `audit` and `check_health` tools now honor `health.coverage`,
   `health.coverageRoot`, `FALLOW_COVERAGE`, and `FALLOW_COVERAGE_ROOT` on
   their typed route** (Closes

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -265,6 +265,8 @@ mod issue_2225_root_manual_mocks;
 mod issue_2348_jsx_namespace_member;
 #[path = "integration_test/issue_2355_astro_mdx_member_tags.rs"]
 mod issue_2355_astro_mdx_member_tags;
+#[path = "integration_test/issue_2376_mdx_import_prose.rs"]
+mod issue_2376_mdx_import_prose;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_2376_mdx_import_prose.rs
+++ b/crates/core/tests/integration_test/issue_2376_mdx_import_prose.rs
@@ -66,8 +66,35 @@ fn mdx_import_prose_line_keeps_the_files_imports() {
     );
 }
 
-/// Issue #2376 fallback: `rejected.mdx` carries a line the parser rejects
-/// (`import data from the API using RJ before rendering.`). The block is
+/// Issue #2376: `commented.mdx` carries the two statement shapes no specifier
+/// pattern names, a side-effect import whose keyword is followed by a block
+/// comment and a top-level dynamic import written with a space before the
+/// parenthesis. Both parse as JavaScript, so both keep their edge instead of
+/// turning their target into a false unused file. The document also carries a
+/// multi-line `export const` whose continuation line has the word `from`
+/// inside a string: the block is collected whole, so the declaration survives
+/// and its unconsumed export reports on the `.mdx` file itself.
+#[test]
+fn statement_shapes_without_a_specifier_pattern_keep_their_edges() {
+    let (files, exports) = reported();
+
+    for target in ["commented.ts", "lazy.ts"] {
+        assert!(
+            !files.iter().any(|file| file == target),
+            "{target} is imported by commented.mdx and must not be an unused file: {files:?}"
+        );
+    }
+    assert!(
+        exports
+            .iter()
+            .any(|(file, name)| file == "commented.mdx" && name == "docNote"),
+        "the multi-line export of commented.mdx must be collected whole: {exports:?}"
+    );
+}
+
+/// Issue #2376 fallback: `rejected.mdx` carries a line the classifier accepts
+/// on its source clause and the parser then rejects
+/// (`import data from './the-api' using RJ before rendering.`). The block is
 /// demoted to prose instead of dropping every import of the file, so its
 /// target is used, and the demoted line still counts as a mention of `RJ`, so
 /// the namespace keeps its mark-all crediting (issue #2355) and the sibling

--- a/crates/core/tests/integration_test/issue_2376_mdx_import_prose.rs
+++ b/crates/core/tests/integration_test/issue_2376_mdx_import_prose.rs
@@ -1,0 +1,91 @@
+use crate::common::{create_config, fixture_path};
+
+/// Run the issue #2376 fixture (Astro plugin enabled so `src/pages/**` is an
+/// entry surface) and return the reported unused files and unused exports.
+/// File names are unique across the fixture, so no path separators take part
+/// in the comparison.
+fn reported() -> (Vec<String>, Vec<(String, String)>) {
+    let root = fixture_path("issue-2376-mdx-import-prose");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let files = results
+        .unused_files
+        .iter()
+        .map(|file| {
+            file.file
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect();
+    let exports = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            let file = e
+                .export
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_string();
+            (file, e.export.export_name.clone())
+        })
+        .collect();
+    (files, exports)
+}
+
+/// Issue #2376: an MDX prose sentence that opens with the word "import"
+/// (`import the thing and render <NS.Moon /> here.`) is prose, not a
+/// statement, so the namespace import of `notes.mdx` survives, its target is
+/// not an unused file, and the members rendered in the body are credited while
+/// the genuinely unused sibling still reports.
+#[test]
+fn mdx_import_prose_line_keeps_the_files_imports() {
+    let (files, exports) = reported();
+
+    assert!(
+        !files.iter().any(|file| file == "ns.ts"),
+        "the namespace target of an MDX document must not be an unused file: {files:?}"
+    );
+    for member in ["Star", "Moon"] {
+        assert!(
+            !exports
+                .iter()
+                .any(|(file, name)| file == "ns.ts" && name == member),
+            "ns.ts:{member} is rendered in the MDX body and must stay credited: {exports:?}"
+        );
+    }
+    assert!(
+        exports
+            .iter()
+            .any(|(file, name)| file == "ns.ts" && name == "Unused"),
+        "the unrendered sibling must still report: {exports:?}"
+    );
+}
+
+/// Issue #2376 fallback: `rejected.mdx` carries a line the parser rejects
+/// (`import data from the API using RJ before rendering.`). The block is
+/// demoted to prose instead of dropping every import of the file, so its
+/// target is used, and the demoted line still counts as a mention of `RJ`, so
+/// the namespace keeps its mark-all crediting (issue #2355) and the sibling
+/// that is never rendered is not reported.
+#[test]
+fn rejected_statement_block_is_demoted_and_keeps_mark_all() {
+    let (files, exports) = reported();
+
+    assert!(
+        !files.iter().any(|file| file == "rejected.ts"),
+        "the import target behind a rejected statement line must not be an unused file: {files:?}"
+    );
+    for member in ["Kept", "KeptSibling"] {
+        assert!(
+            !exports
+                .iter()
+                .any(|(file, name)| file == "rejected.ts" && name == member),
+            "rejected.ts:{member}: a mention on the demoted line keeps the namespace on the mark-all path: {exports:?}"
+        );
+    }
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -964,7 +964,14 @@ use crate::MemberKind;
 /// member accesses for member-expression component tags (`<SC.Card />`). Warm
 /// 275 caches lack those accesses, so namespace-imported exports rendered only
 /// in Astro or MDX markup would stay reported as unused.
-pub(super) const CACHE_VERSION: u32 = 276;
+///
+/// Bumped to 277 for issue #2376: an MDX line is a statement only when it
+/// carries a real `import` / `export` shape, and a statement block the parser
+/// rejects is demoted to prose instead of dropping every import of the file.
+/// Warm 276 caches hold the import-less module for every MDX file whose prose
+/// opens with the word "import" (or that carries any other rejected statement
+/// line), so its imported modules would stay reported as unused.
+pub(super) const CACHE_VERSION: u32 = 277;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.
@@ -987,7 +994,13 @@ pub(super) const CACHE_VERSION: u32 = 276;
 ///
 /// Bumped to 10: cached duplicate token payloads now preserve function-like
 /// source spans for opt-in near-miss detection.
-pub const DUPES_CACHE_VERSION: u32 = 10;
+///
+/// Bumped to 11 for issue #2376: `extract_mdx_statements` feeds the duplication
+/// tokenizer from the same MDX scanner the statement fix narrowed, so a prose
+/// line that only looks like an `import` no longer reaches the token stream and
+/// a rejected statement block is demoted to prose. Warm v10 caches hold the old
+/// token stream for those files and must invalidate.
+pub const DUPES_CACHE_VERSION: u32 = 11;
 
 /// Default maximum cache size (256 MB). Overridable per-project via
 /// `cache.maxSizeMb` in the config file or `FALLOW_CACHE_MAX_SIZE` env var.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -995,11 +995,13 @@ pub(super) const CACHE_VERSION: u32 = 277;
 /// Bumped to 10: cached duplicate token payloads now preserve function-like
 /// source spans for opt-in near-miss detection.
 ///
-/// Bumped to 11 for issue #2376: `extract_mdx_statements` feeds the duplication
-/// tokenizer from the same MDX scanner the statement fix narrowed, so a prose
-/// line that only looks like an `import` no longer reaches the token stream and
-/// a rejected statement block is demoted to prose. Warm v10 caches hold the old
-/// token stream for those files and must invalidate.
+/// Bumped to 11 for issue #2376: the duplication tokenizer reads MDX through
+/// `extract_mdx_statements`, and an MDX line is now a statement only when it
+/// carries a real `import` / `export` shape, so MDX token streams change.
+/// Warm v10 entries hold the old stream (a prose sentence opening with the
+/// word "import" used to swallow the whole file, and a statement head the old
+/// prefix match missed used to be skipped), so clone groups inside MDX would
+/// stay hidden on upgrade.
 pub const DUPES_CACHE_VERSION: u32 = 11;
 
 /// Default maximum cache size (256 MB). Overridable per-project via

--- a/crates/extract/src/mdx.rs
+++ b/crates/extract/src/mdx.rs
@@ -173,7 +173,7 @@ impl<'a> MdxStatementScanner<'a> {
     fn push_statement_start(&mut self, line_start: usize, line: &'a str, trimmed: &str) {
         self.blocks.push(vec![(line_start, line)]);
         self.brace_depth = brace_delta(trimmed);
-        if self.brace_depth > 0 && !has_spaced_source_clause(trimmed) {
+        if self.brace_depth > 0 && !has_source_clause(trimmed) {
             self.in_multiline = true;
         }
     }
@@ -183,7 +183,7 @@ impl<'a> MdxStatementScanner<'a> {
             block.push((line_start, line));
         }
         self.brace_depth += brace_delta(trimmed);
-        if self.brace_depth <= 0 || trimmed.ends_with(';') || has_any_source_clause(trimmed) {
+        if self.brace_depth <= 0 || trimmed.ends_with(';') || has_source_clause(trimmed) {
             self.in_multiline = false;
             self.brace_depth = 0;
         }
@@ -271,6 +271,14 @@ fn collect_unexplained_statement_mentions(scan: &MdxScan<'_>, info: &ModuleInfo)
 /// The keywords a real `export` statement may put in front of its declaration.
 /// `default` covers `export default`; the rest are the value, type, and
 /// ambient declaration heads.
+///
+/// A keyword here says the line has the shape of a statement, not that it
+/// survives as one. The statement body is parsed with the JSX source type,
+/// which rejects every TS-only head (`export type`, `export interface`,
+/// `export enum`, `export namespace`, `export declare`, `export abstract`), so
+/// those blocks reach the parser and the fallback demotes them; the list keeps
+/// prose classification a statement about the language rather than about what
+/// this parser configuration happens to accept.
 const EXPORT_DECLARATION_KEYWORDS: [&str; 13] = [
     "abstract",
     "async",
@@ -337,7 +345,7 @@ fn is_import_statement_rest(rest: &str) -> bool {
     }
     // A default (or type-only) specifier followed by its source clause:
     // `import Button from './Button'`, `import type X from './x'`.
-    has_any_source_clause(rest)
+    has_source_clause(rest)
 }
 
 /// Does the text after `export` belong to a real export statement?
@@ -374,12 +382,23 @@ fn brace_delta(line: &str) -> i32 {
     opens.saturating_sub(closes)
 }
 
-fn has_spaced_source_clause(line: &str) -> bool {
-    line.contains(" from ")
-}
-
-fn has_any_source_clause(line: &str) -> bool {
-    has_spaced_source_clause(line) || line.contains(" from'") || line.contains(" from\"")
+/// Does this line carry a source clause: a `from` keyword bounded by
+/// whitespace on the left and by whitespace or the opening quote of its module
+/// specifier on the right?
+///
+/// The boundaries are character classes, not literal spaces, so every
+/// whitespace JavaScript accepts qualifies: `from\t'./x'`, `X\tfrom './x'`, a
+/// multi-space form, and a no-break space all name a source the way
+/// `from './x'` does, and classifying one of them as prose would drop the edge
+/// (issue #2376). A `from` inside a word (`fromage`, `from_the_api`) never
+/// matches.
+fn has_source_clause(line: &str) -> bool {
+    line.match_indices("from").any(|(index, keyword)| {
+        let before = line[..index].chars().next_back();
+        let after = line[index + keyword.len()..].chars().next();
+        before.is_some_and(char::is_whitespace)
+            && after.is_some_and(|ch| ch.is_whitespace() || ch == '\'' || ch == '"')
+    })
 }
 
 /// Parse the collected statement body and build the module info from it.
@@ -476,16 +495,18 @@ pub(crate) fn parse_mdx_to_module(file_id: FileId, source: &str, content_hash: u
     let mut scan = extract_mdx_source(source);
 
     let mut extraction = scan.extraction();
-    let (mut info, accepted) = parse_statement_body(
-        &extraction,
-        file_id,
-        content_hash,
-        parsed_suppressions.clone(),
-    );
+    let (mut info, accepted) =
+        parse_statement_body(&extraction, file_id, content_hash, parsed_suppressions);
     // A rejected body is an empty program, so without this the file would keep
     // none of its imports (issue #2376). Retry with the rejected blocks moved
-    // to prose; the retry can only add statements back.
+    // to prose; the retry can only add statements back. The rejected module
+    // info is discarded, so its suppressions move on to the retry instead of
+    // being cloned for every MDX file.
     if !accepted && scan.demote_rejected_blocks() {
+        let parsed_suppressions = crate::suppress::ParsedSuppressions {
+            suppressions: std::mem::take(&mut info.suppressions),
+            unknown_kinds: std::mem::take(&mut info.unknown_suppression_kinds),
+        };
         extraction = scan.extraction();
         info = parse_statement_body(&extraction, file_id, content_hash, parsed_suppressions).0;
     }
@@ -895,6 +916,68 @@ import { Visible } from './Visible'
             import_sources(source),
             vec!["./card".to_string()],
             "the runtime import must survive the rejected type-only clause"
+        );
+    }
+
+    /// Issue #2376 fallback: the retry parses the demoted body a second time,
+    /// so the suppressions parsed from the source have to reach the module
+    /// info the retry returns and not the one it replaced.
+    #[test]
+    fn suppressions_survive_the_fallback_reparse() {
+        let source = "<!-- fallow-ignore-file -->\n<!-- fallow-ignore-file not-a-real-kind -->\n\n\
+             import data from the API before you begin.\n\n\
+             import { Card } from './card'\n";
+        let info = parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0);
+        assert_eq!(
+            info.imports.len(),
+            1,
+            "the fallback has to have run for this test to pin anything"
+        );
+        assert_eq!(
+            info.suppressions.len(),
+            1,
+            "the file-level suppression must survive the retry"
+        );
+        assert_eq!(
+            info.unknown_suppression_kinds.len(),
+            1,
+            "the unknown suppression token must survive the retry"
+        );
+    }
+
+    /// Issue #2376: the source clause is recognised by character class, not by
+    /// literal spaces, so every whitespace form JavaScript accepts around
+    /// `from` still opens a statement. A `from` inside a word never does.
+    #[test]
+    fn source_clause_matches_any_whitespace_around_from() {
+        for line in [
+            "import Used from\t'./used'",
+            "import Used\tfrom './used'",
+            "import Used  from  './used'",
+            "import Used from\u{a0}'./used'",
+            "import type Meta from\t'./meta'",
+        ] {
+            assert!(is_statement_start(line), "{line:?} should be a statement");
+        }
+
+        for line in [
+            "import fromage before you begin.",
+            "import the fromage and the bread.",
+            "import data from_the_api and render it.",
+        ] {
+            assert!(!is_statement_start(line), "{line:?} should stay prose");
+        }
+    }
+
+    /// Issue #2376: a default import whose `from` is separated by a tab is
+    /// valid JavaScript, so its edge must survive rather than be lost to prose.
+    #[test]
+    fn tab_separated_source_clause_keeps_the_import() {
+        let source = "import Used from\t'./used'\n\n<Used />\n";
+        assert_eq!(
+            import_sources(source),
+            vec!["./used".to_string()],
+            "the tab-separated import must resolve like a space-separated one"
         );
     }
 

--- a/crates/extract/src/mdx.rs
+++ b/crates/extract/src/mdx.rs
@@ -27,17 +27,68 @@ use crate::visitor::{ModuleInfoExtractor, extend_member_accesses, extend_whole_o
 use crate::{ImportInfo, MemberAccess, ModuleInfo};
 use fallow_types::discover::FileId;
 
-/// Everything the MDX line scan yields: the source-mapped `import` / `export`
-/// statements the JavaScript parser consumes (and the same lines with their
-/// source offsets, for the script-side completeness guard), the prose lines
-/// whose usage is scanned once the import bindings are known, and the
-/// fenced-code lines (fence delimiters included) whose mentions only feed the
-/// completeness guard (issue #2355).
+/// One `import` / `export` statement as the line scan saw it: the line that
+/// opened it plus the continuation lines a multi-line specifier list collected.
+/// Each line keeps its byte offset in the original file, for the source map and
+/// for the script-side completeness guard.
+type StatementBlock<'a> = Vec<(usize, &'a str)>;
+
+/// Everything the MDX line scan yields: the `import` / `export` statement
+/// blocks the JavaScript parser consumes, the prose lines whose usage is
+/// scanned once the import bindings are known, and the fenced-code lines (fence
+/// delimiters included) whose mentions only feed the completeness guard
+/// (issue #2355).
 struct MdxScan<'a> {
-    statements: ExtractionResult,
-    statement_lines: Vec<(usize, &'a str)>,
-    prose_lines: Vec<&'a str>,
+    blocks: Vec<StatementBlock<'a>>,
+    prose_lines: Vec<(usize, &'a str)>,
     code_lines: Vec<&'a str>,
+}
+
+impl<'a> MdxScan<'a> {
+    /// The source-mapped statement body the JavaScript parser consumes.
+    fn extraction(&self) -> ExtractionResult {
+        let mut statements = ExtractionResult::default();
+        for &(line_start, line) in self.blocks.iter().flatten() {
+            statements.push_mapped(line, line_start);
+        }
+        statements
+    }
+
+    /// Every statement line with its source offset, for the script-side
+    /// completeness guard (issue #2355).
+    fn statement_lines(&self) -> impl Iterator<Item = (usize, &'a str)> {
+        self.blocks.iter().flatten().copied()
+    }
+
+    /// Move every statement block the parser rejects on its own to prose and
+    /// report whether anything moved (issue #2376).
+    ///
+    /// The parser reads the statement lines of the whole file as one program
+    /// and aborts on the first fatal error, so a single misclassified line
+    /// (a prose sentence opening with the word "import", an `import type`
+    /// clause the JSX source type rejects) would drop every import of the
+    /// file. Demoting the rejected blocks keeps the rest, and the demoted
+    /// lines still reach the prose scan, so a binding mentioned there keeps
+    /// its mark-all crediting (issue #2355). Blocks are demoted whole so a
+    /// multi-line specifier list is never split.
+    fn demote_rejected_blocks(&mut self) -> bool {
+        let scanned = self.blocks.len();
+        let mut kept = Vec::with_capacity(scanned);
+        for block in std::mem::take(&mut self.blocks) {
+            if statement_block_is_accepted(&block) {
+                kept.push(block);
+            } else {
+                self.prose_lines.extend(block);
+            }
+        }
+        self.blocks = kept;
+        if self.blocks.len() == scanned {
+            return false;
+        }
+        self.prose_lines
+            .sort_unstable_by_key(|&(line_start, _)| line_start);
+        true
+    }
 }
 
 /// Extract import/export statements from MDX content.
@@ -50,7 +101,7 @@ struct MdxScan<'a> {
 /// MDX import/export extraction only handles JS/TS `import`/`export` statements.
 #[must_use]
 pub fn extract_mdx_statements(source: &str) -> String {
-    extract_mdx_source(source).statements.body
+    extract_mdx_source(source).extraction().body
 }
 
 fn extract_mdx_source(source: &str) -> MdxScan<'_> {
@@ -63,8 +114,8 @@ fn extract_mdx_source(source: &str) -> MdxScan<'_> {
 
 #[derive(Default)]
 struct MdxStatementScanner<'a> {
-    statements: Vec<(usize, &'a str)>,
-    prose_lines: Vec<&'a str>,
+    blocks: Vec<StatementBlock<'a>>,
+    prose_lines: Vec<(usize, &'a str)>,
     code_lines: Vec<&'a str>,
     in_multiline: bool,
     brace_depth: i32,
@@ -96,7 +147,7 @@ impl<'a> MdxStatementScanner<'a> {
         // Statement lines are excluded so a tag inside
         // `export const X = () => <NS.Card />` records once, through the JSX
         // visitor.
-        self.prose_lines.push(line);
+        self.prose_lines.push((line_start, line));
     }
 
     fn consume_code_fence(&mut self, trimmed: &str) -> bool {
@@ -120,7 +171,7 @@ impl<'a> MdxStatementScanner<'a> {
     }
 
     fn push_statement_start(&mut self, line_start: usize, line: &'a str, trimmed: &str) {
-        self.statements.push((line_start, line));
+        self.blocks.push(vec![(line_start, line)]);
         self.brace_depth = brace_delta(trimmed);
         if self.brace_depth > 0 && !has_spaced_source_clause(trimmed) {
             self.in_multiline = true;
@@ -128,7 +179,9 @@ impl<'a> MdxStatementScanner<'a> {
     }
 
     fn push_multiline_line(&mut self, line_start: usize, line: &'a str, trimmed: &str) {
-        self.statements.push((line_start, line));
+        if let Some(block) = self.blocks.last_mut() {
+            block.push((line_start, line));
+        }
         self.brace_depth += brace_delta(trimmed);
         if self.brace_depth <= 0 || trimmed.ends_with(';') || has_any_source_clause(trimmed) {
             self.in_multiline = false;
@@ -137,13 +190,8 @@ impl<'a> MdxStatementScanner<'a> {
     }
 
     fn into_scan(self) -> MdxScan<'a> {
-        let mut statements = ExtractionResult::default();
-        for &(line_start, line) in &self.statements {
-            statements.push_mapped(line, line_start);
-        }
         MdxScan {
-            statements,
-            statement_lines: self.statements,
+            blocks: self.blocks,
             prose_lines: self.prose_lines,
             code_lines: self.code_lines,
         }
@@ -174,7 +222,7 @@ fn collect_body_usage(
     let mut accesses = Vec::new();
     let mut whole_object_uses = Vec::new();
     let import_locals = guarded_import_locals(imports);
-    for line in &scan.prose_lines {
+    for &(_, line) in &scan.prose_lines {
         scan_template_usage(
             line,
             &import_locals,
@@ -207,7 +255,7 @@ fn collect_unexplained_statement_mentions(scan: &MdxScan<'_>, info: &ModuleInfo)
     }
     let recorded = recorded_member_pairs(&info.member_accesses, &guarded);
     let excluded = import_declaration_ranges(&info.imports);
-    for &(line_start, line) in &scan.statement_lines {
+    for (line_start, line) in scan.statement_lines() {
         record_unexplained_script_mentions(
             line,
             line_start,
@@ -220,11 +268,102 @@ fn collect_unexplained_statement_mentions(scan: &MdxScan<'_>, info: &ModuleInfo)
     whole_object_uses
 }
 
+/// The keywords a real `export` statement may put in front of its declaration.
+/// `default` covers `export default`; the rest are the value, type, and
+/// ambient declaration heads.
+const EXPORT_DECLARATION_KEYWORDS: [&str; 13] = [
+    "abstract",
+    "async",
+    "class",
+    "const",
+    "declare",
+    "default",
+    "enum",
+    "function",
+    "interface",
+    "let",
+    "namespace",
+    "type",
+    "var",
+];
+
+/// Does this trimmed line open a real `import` / `export` statement?
+///
+/// MDX bodies are prose, so a sentence that happens to start with the word
+/// "import" or "export" must not reach the JavaScript parser: the statement
+/// lines of the whole file are parsed as one program, and a fatal parse error
+/// drops every import of the file (issue #2376). A candidate line therefore
+/// has to carry a shape only a real statement has: a source clause
+/// (`from '...'`), a brace specifier list, a star specifier, a string-literal
+/// side-effect import, or, after `export`, a declaration keyword. Everything
+/// else stays prose, where the body scan still credits its member accesses and
+/// counts its mentions.
 fn is_statement_start(trimmed: &str) -> bool {
-    trimmed.starts_with("import ")
-        || trimmed.starts_with("import{")
-        || trimmed.starts_with("export ")
-        || trimmed.starts_with("export{")
+    if let Some(rest) = statement_keyword_rest(trimmed, "import") {
+        return is_import_statement_rest(rest);
+    }
+    if let Some(rest) = statement_keyword_rest(trimmed, "export") {
+        return is_export_statement_rest(rest);
+    }
+    false
+}
+
+/// The text after the `keyword` at the start of the line, trimmed. The keyword
+/// has to be followed by whitespace or `{`, the two openings the line scan has
+/// always accepted (`import {`, `import{`), so `important` is not a candidate.
+fn statement_keyword_rest<'a>(trimmed: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = trimmed.strip_prefix(keyword)?;
+    let next = rest.chars().next()?;
+    (next.is_whitespace() || next == '{').then(|| rest.trim_start())
+}
+
+/// Does the text after `import` belong to a real import statement?
+fn is_import_statement_rest(rest: &str) -> bool {
+    let Some(first) = rest.chars().next() else {
+        return false;
+    };
+    // A side-effect import of a string literal: `import './global.css'`.
+    if first == '\'' || first == '"' {
+        return true;
+    }
+    // A specifier list, on this line or continued on the following ones:
+    // `import { A } from './a'`, `import Default, {`.
+    if rest.contains('{') {
+        return true;
+    }
+    // A star specifier: `import * as NS from './ns'`.
+    if first == '*' {
+        return true;
+    }
+    // A default (or type-only) specifier followed by its source clause:
+    // `import Button from './Button'`, `import type X from './x'`.
+    has_any_source_clause(rest)
+}
+
+/// Does the text after `export` belong to a real export statement?
+fn is_export_statement_rest(rest: &str) -> bool {
+    let Some(first) = rest.chars().next() else {
+        return false;
+    };
+    // A specifier list, on this line or continued on the following ones:
+    // `export { A }`, `export { A } from './a'`, `export {`.
+    if rest.contains('{') {
+        return true;
+    }
+    // A star re-export: `export * from './a'`, `export * as ns from './a'`.
+    if first == '*' {
+        return true;
+    }
+    EXPORT_DECLARATION_KEYWORDS.contains(&leading_word(rest))
+}
+
+/// The leading identifier-ish word of `text`, empty when it does not start with
+/// one. ASCII boundaries only, so the slice always lands on a char boundary.
+fn leading_word(text: &str) -> &str {
+    let end = text
+        .find(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '$')
+        .unwrap_or(text.len());
+    &text[..end]
 }
 
 fn brace_delta(line: &str) -> i32 {
@@ -241,6 +380,50 @@ fn has_spaced_source_clause(line: &str) -> bool {
 
 fn has_any_source_clause(line: &str) -> bool {
     has_spaced_source_clause(line) || line.contains(" from'") || line.contains(" from\"")
+}
+
+/// Parse the collected statement body and build the module info from it.
+///
+/// The flag reports whether the parser accepted the body. A rejected body
+/// aborts the parse and yields an empty program, which is what makes one
+/// misclassified line lose every import of the file (issue #2376); the caller
+/// retries without the offending blocks.
+fn parse_statement_body(
+    extraction: &ExtractionResult,
+    file_id: FileId,
+    content_hash: u64,
+    parsed_suppressions: crate::suppress::ParsedSuppressions,
+) -> (ModuleInfo, bool) {
+    if extraction.body.is_empty() {
+        let info =
+            ModuleInfoExtractor::new().into_module_info(file_id, content_hash, parsed_suppressions);
+        return (info, true);
+    }
+
+    let allocator = Allocator::default();
+    let parser_return = Parser::new(&allocator, &extraction.body, SourceType::jsx()).parse();
+    let accepted = !parser_return.panicked;
+    let mut extractor = ModuleInfoExtractor::new();
+    extractor.visit_program(&parser_return.program);
+    extractor.remap_spans_with(|span| extraction.remap_span(span));
+    (
+        extractor.into_module_info(file_id, content_hash, parsed_suppressions),
+        accepted,
+    )
+}
+
+/// Does the parser accept this statement block on its own? A block that only
+/// parses in context does not exist: every `import` / `export` statement is
+/// self-contained, and the multi-line lines of one statement travel together.
+fn statement_block_is_accepted(block: &[(usize, &str)]) -> bool {
+    let mut body = String::new();
+    for &(_, line) in block {
+        body.push_str(line);
+    }
+    let allocator = Allocator::default();
+    !Parser::new(&allocator, &body, SourceType::jsx())
+        .parse()
+        .panicked
 }
 
 fn lines_with_offsets(source: &str) -> impl Iterator<Item = (usize, &str)> {
@@ -290,19 +473,22 @@ pub(crate) fn is_mdx_file(path: &Path) -> bool {
 pub(crate) fn parse_mdx_to_module(file_id: FileId, source: &str, content_hash: u64) -> ModuleInfo {
     let parsed_suppressions = crate::suppress::parse_suppressions_from_source(source);
     let line_offsets = fallow_types::extract::compute_line_offsets(source);
-    let scan = extract_mdx_source(source);
+    let mut scan = extract_mdx_source(source);
 
-    let mut info = if scan.statements.body.is_empty() {
-        ModuleInfoExtractor::new().into_module_info(file_id, content_hash, parsed_suppressions)
-    } else {
-        let source_type = SourceType::jsx();
-        let allocator = Allocator::default();
-        let parser_return = Parser::new(&allocator, &scan.statements.body, source_type).parse();
-        let mut extractor = ModuleInfoExtractor::new();
-        extractor.visit_program(&parser_return.program);
-        extractor.remap_spans_with(|span| scan.statements.remap_span(span));
-        extractor.into_module_info(file_id, content_hash, parsed_suppressions)
-    };
+    let mut extraction = scan.extraction();
+    let (mut info, accepted) = parse_statement_body(
+        &extraction,
+        file_id,
+        content_hash,
+        parsed_suppressions.clone(),
+    );
+    // A rejected body is an empty program, so without this the file would keep
+    // none of its imports (issue #2376). Retry with the rejected blocks moved
+    // to prose; the retry can only add statements back.
+    if !accepted && scan.demote_rejected_blocks() {
+        extraction = scan.extraction();
+        info = parse_statement_body(&extraction, file_id, content_hash, parsed_suppressions).0;
+    }
     let (body_accesses, body_whole_object_uses) = collect_body_usage(&scan, &info.imports);
     extend_member_accesses(&mut info, body_accesses);
     extend_whole_object_uses(&mut info, body_whole_object_uses);
@@ -527,6 +713,189 @@ import { Visible } from './Visible'
     fn export_like_text_not_extracted() {
         let result = extract_mdx_statements("We are exporting goods overseas.\n");
         assert!(result.is_empty());
+    }
+
+    /// Issue #2376: a candidate line is a statement only when it carries a
+    /// shape a real `import` / `export` has. A prose sentence that opens with
+    /// the word "import" or "export" stays prose.
+    #[test]
+    fn statement_start_requires_a_real_import_or_export_shape() {
+        for line in [
+            "import './global.css'",
+            "import \"./global.css\"",
+            "import { A } from './a'",
+            "import{ A } from './a'",
+            "import Default, {",
+            "import {",
+            "import * as NS from './ns'",
+            "import Button from './Button'",
+            "import Button from'./Button'",
+            "import type { A } from './a'",
+            "export { A }",
+            "export{ A }",
+            "export * from './a'",
+            "export * as ns from './a'",
+            "export const meta = 1",
+            "export let x = 1",
+            "export var x = 1",
+            "export function render() {}",
+            "export async function render() {}",
+            "export class Card {}",
+            "export abstract class Card {}",
+            "export type Meta = string",
+            "export interface Meta {}",
+            "export enum Kind {}",
+            "export declare const x: number",
+            "export namespace Docs {}",
+            "export default () => null",
+        ] {
+            assert!(is_statement_start(line), "{line:?} should be a statement");
+        }
+
+        for line in [
+            "import the thing and render it here.",
+            "importantly, the docs ship first.",
+            "import all of your data before you start.",
+            "export the report to a spreadsheet later.",
+            "exports are documented below.",
+            "import",
+            "export",
+        ] {
+            assert!(!is_statement_start(line), "{line:?} should stay prose");
+        }
+    }
+
+    /// Issue #2376: a prose sentence opening with the word "import" never
+    /// reaches the statement parser, so the file keeps its imports.
+    #[test]
+    fn import_prose_sentence_is_not_extracted() {
+        let source = "import * as NS from './ns'\n\n<NS.Star />\n\nimport the thing and render <NS.Moon /> here.\n";
+        let result = extract_mdx_statements(source);
+        assert_eq!(
+            result.lines().count(),
+            1,
+            "only the real import should be extracted; got {result:?}"
+        );
+        assert!(result.contains("import * as NS from './ns'"));
+    }
+
+    /// Issue #2376: the same for a prose sentence opening with "export".
+    #[test]
+    fn export_prose_sentence_is_not_extracted() {
+        let source =
+            "export const meta = { title: 'x' }\n\nexport the report to a spreadsheet later.\n";
+        let result = extract_mdx_statements(source);
+        assert_eq!(
+            result.lines().count(),
+            1,
+            "only the real export should be extracted; got {result:?}"
+        );
+        assert!(result.contains("export const meta"));
+    }
+
+    fn import_sources(source: &str) -> Vec<String> {
+        parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0)
+            .imports
+            .iter()
+            .map(|import| import.source.clone())
+            .collect()
+    }
+
+    /// Issue #2376: the reproduction. A prose line opening with the word
+    /// "import" keeps the namespace import of the file, and the member tag it
+    /// carries is credited like any other body tag.
+    #[test]
+    fn mdx_import_prose_line_keeps_imports_and_credits_tags() {
+        let source = "import * as NS from '../components/ns'\n\n<NS.Star />\n\nimport the thing and render <NS.Moon /> here.\n";
+        assert_eq!(
+            import_sources(source),
+            vec!["../components/ns".to_string()],
+            "the namespace import must survive the prose line"
+        );
+        assert_eq!(
+            body_member_accesses(source),
+            vec![
+                ("NS".to_string(), "Star".to_string()),
+                ("NS".to_string(), "Moon".to_string()),
+            ],
+            "both body tags should be credited"
+        );
+        assert!(
+            body_whole_object_uses(source).is_empty(),
+            "every mention is a dotted tag, so the namespace stays precise"
+        );
+    }
+
+    /// Issue #2376 fallback: a line that carries a statement shape but that
+    /// the parser rejects (`import data from the API`) is demoted to prose
+    /// instead of dropping every import of the file. The demoted line still
+    /// feeds the prose scan, so the binding it mentions keeps its mark-all
+    /// crediting (issue #2355) while an unmentioned namespace stays precise.
+    #[test]
+    fn unparsable_statement_line_falls_back_to_prose() {
+        let source = "import * as NS from './ns'\nimport * as Other from './other'\n\n\
+             import data from the API using Other before rendering.\n\n\
+             <NS.Star />\n<Other.Star />\n";
+        assert_eq!(
+            import_sources(source),
+            vec!["./ns".to_string(), "./other".to_string()],
+            "both imports must survive the rejected line"
+        );
+        assert_eq!(
+            body_whole_object_uses(source),
+            vec!["Other".to_string()],
+            "the mention on the demoted line must keep Other on the mark-all path"
+        );
+        let accesses = body_member_accesses(source);
+        assert!(
+            accesses.contains(&("NS".to_string(), "Star".to_string()))
+                && accesses.contains(&("Other".to_string(), "Star".to_string())),
+            "the body tags should still record; got {accesses:?}"
+        );
+    }
+
+    /// Issue #2376 fallback: rejection is per block, so a multi-line statement
+    /// the parser rejects is demoted whole and the imports around it survive.
+    #[test]
+    fn unparsable_multiline_block_is_demoted_whole() {
+        let source = "import { Keep } from './keep'\n\nimport {\n  Broken from './broken'\n\nimport { Also } from './also'\n";
+        assert_eq!(
+            import_sources(source),
+            vec!["./keep".to_string(), "./also".to_string()],
+            "only the rejected block should be lost"
+        );
+    }
+
+    /// Issue #2376 fallback: a real multi-line import keeps its lines together
+    /// when a sibling block is demoted.
+    #[test]
+    fn parsable_multiline_import_survives_a_demoted_sibling() {
+        let source = "import data from the API before you begin.\n\nimport {\n  Foo,\n  Bar\n} from './module'\n";
+        let info = parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0);
+        let locals: Vec<&str> = info
+            .imports
+            .iter()
+            .map(|import| import.local_name.as_str())
+            .collect();
+        assert_eq!(
+            locals,
+            vec!["Foo", "Bar"],
+            "the multi-line import must survive whole"
+        );
+    }
+
+    /// Issue #2376 fallback: the statement body is parsed with the JSX source
+    /// type, which rejects a TS-only `import type` clause. Before the
+    /// fallback that lost every import of the file; now only the type-only
+    /// clause is dropped.
+    #[test]
+    fn type_only_import_clause_no_longer_drops_the_other_imports() {
+        let source = "import type { Meta } from './meta'\n\nimport { Card } from './card'\n";
+        assert_eq!(
+            import_sources(source),
+            vec!["./card".to_string()],
+            "the runtime import must survive the rejected type-only clause"
+        );
     }
 
     #[test]

--- a/crates/extract/src/mdx.rs
+++ b/crates/extract/src/mdx.rs
@@ -306,12 +306,22 @@ const EXPORT_DECLARATION_KEYWORDS: [&str; 13] = [
 /// side-effect import, or, after `export`, a declaration keyword. Everything
 /// else stays prose, where the body scan still credits its member accesses and
 /// counts its mentions.
+///
+/// The shape table is a fast path, not the definition of the language, so a
+/// candidate it does not recognise is asked the parser before it is sent to
+/// prose: a line that parses as JavaScript on its own is a statement whatever
+/// its shape. That keeps heads the table does not enumerate
+/// (`import /* c */ './x'`, a spaced dynamic `import ('./x')`) out of prose,
+/// where the parse fallback below could never have recovered them, and it
+/// cannot let prose through, because a sentence does not parse. The probe
+/// costs one parse of one line, and only for a line that opens with the
+/// keyword and carries no recognised shape.
 fn is_statement_start(trimmed: &str) -> bool {
     if let Some(rest) = statement_keyword_rest(trimmed, "import") {
-        return is_import_statement_rest(rest);
+        return is_import_statement_rest(rest) || parses_as_javascript(trimmed);
     }
     if let Some(rest) = statement_keyword_rest(trimmed, "export") {
-        return is_export_statement_rest(rest);
+        return is_export_statement_rest(rest) || parses_as_javascript(trimmed);
     }
     false
 }
@@ -383,21 +393,27 @@ fn brace_delta(line: &str) -> i32 {
 }
 
 /// Does this line carry a source clause: a `from` keyword bounded by
-/// whitespace on the left and by whitespace or the opening quote of its module
+/// whitespace on the left and followed by the opening quote of its module
 /// specifier on the right?
 ///
-/// The boundaries are character classes, not literal spaces, so every
-/// whitespace JavaScript accepts qualifies: `from\t'./x'`, `X\tfrom './x'`, a
-/// multi-space form, and a no-break space all name a source the way
-/// `from './x'` does, and classifying one of them as prose would drop the edge
-/// (issue #2376). A `from` inside a word (`fromage`, `from_the_api`) never
-/// matches.
+/// The left boundary is a character class, not a literal space, so every
+/// whitespace JavaScript accepts qualifies: `X\tfrom './x'`, a multi-space
+/// form, and a no-break space all name a source the way `from './x'` does, and
+/// classifying one of them as prose would drop the edge (issue #2376). On the
+/// right the specifier quote has to follow, immediately (`from'./x'`) or after
+/// whitespace, so ordinary text after the word (`'Everything from scratch'`
+/// inside a multi-line object literal) never counts as a source clause and
+/// never ends a statement block one line early. A `from` inside a word
+/// (`fromage`, `from_the_api`) matches neither side.
 fn has_source_clause(line: &str) -> bool {
     line.match_indices("from").any(|(index, keyword)| {
-        let before = line[..index].chars().next_back();
-        let after = line[index + keyword.len()..].chars().next();
-        before.is_some_and(char::is_whitespace)
-            && after.is_some_and(|ch| ch.is_whitespace() || ch == '\'' || ch == '"')
+        line[..index]
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
+            && line[index + keyword.len()..]
+                .trim_start()
+                .starts_with(['\'', '"'])
     })
 }
 
@@ -439,8 +455,18 @@ fn statement_block_is_accepted(block: &[(usize, &str)]) -> bool {
     for &(_, line) in block {
         body.push_str(line);
     }
+    parses_as_javascript(&body)
+}
+
+/// Does the JavaScript parser accept this source on its own, with the same
+/// source type the MDX statement body is parsed with?
+///
+/// "Accept" means the parse was not fatal, the criterion the whole-body parse
+/// uses: a head the parser recovers from is classified the way that parse
+/// would have treated it anyway.
+fn parses_as_javascript(source: &str) -> bool {
     let allocator = Allocator::default();
-    !Parser::new(&allocator, &body, SourceType::jsx())
+    !Parser::new(&allocator, source, SourceType::jsx())
         .parse()
         .panicked
 }
@@ -822,6 +848,14 @@ import { Visible } from './Visible'
             .collect()
     }
 
+    fn export_names(source: &str) -> Vec<String> {
+        parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0)
+            .exports
+            .iter()
+            .map(|export| export.name.to_string())
+            .collect()
+    }
+
     /// Issue #2376: the reproduction. A prose line opening with the word
     /// "import" keeps the namespace import of the file, and the member tag it
     /// carries is credited like any other body tag.
@@ -848,14 +882,15 @@ import { Visible } from './Visible'
     }
 
     /// Issue #2376 fallback: a line that carries a statement shape but that
-    /// the parser rejects (`import data from the API`) is demoted to prose
-    /// instead of dropping every import of the file. The demoted line still
-    /// feeds the prose scan, so the binding it mentions keeps its mark-all
-    /// crediting (issue #2355) while an unmentioned namespace stays precise.
+    /// the parser rejects (a real source clause with prose trailing it) is
+    /// demoted to prose instead of dropping every import of the file. The
+    /// demoted line still feeds the prose scan, so the binding it mentions
+    /// keeps its mark-all crediting (issue #2355) while an unmentioned
+    /// namespace stays precise.
     #[test]
     fn unparsable_statement_line_falls_back_to_prose() {
         let source = "import * as NS from './ns'\nimport * as Other from './other'\n\n\
-             import data from the API using Other before rendering.\n\n\
+             import data from './the-api' using Other before rendering.\n\n\
              <NS.Star />\n<Other.Star />\n";
         assert_eq!(
             import_sources(source),
@@ -891,7 +926,7 @@ import { Visible } from './Visible'
     /// when a sibling block is demoted.
     #[test]
     fn parsable_multiline_import_survives_a_demoted_sibling() {
-        let source = "import data from the API before you begin.\n\nimport {\n  Foo,\n  Bar\n} from './module'\n";
+        let source = "import data from './the-api' before you begin.\n\nimport {\n  Foo,\n  Bar\n} from './module'\n";
         let info = parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0);
         let locals: Vec<&str> = info
             .imports
@@ -925,7 +960,7 @@ import { Visible } from './Visible'
     #[test]
     fn suppressions_survive_the_fallback_reparse() {
         let source = "<!-- fallow-ignore-file -->\n<!-- fallow-ignore-file not-a-real-kind -->\n\n\
-             import data from the API before you begin.\n\n\
+             import data from './the-api' before you begin.\n\n\
              import { Card } from './card'\n";
         let info = parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0);
         assert_eq!(
@@ -979,6 +1014,98 @@ import { Visible } from './Visible'
             vec!["./used".to_string()],
             "the tab-separated import must resolve like a space-separated one"
         );
+    }
+
+    /// Issue #2376: the shape table is a fast path, so a valid statement it
+    /// does not enumerate is asked the parser before it is sent to prose. The
+    /// parse fallback only rescues lines the classifier wrongly accepted, so
+    /// without this probe a wrongly rejected line would lose its edge with no
+    /// safety net at all.
+    #[test]
+    fn a_valid_statement_the_shape_table_misses_is_recovered_by_the_parse_probe() {
+        for line in [
+            "import /* set up styles */ './global.css'",
+            "import /* c */ Button from './button'",
+            "import /* c */ * as NS from './ns'",
+            "export /* keep */ const commented = 1",
+            "export /* keep */ function render() {}",
+            "import ('./dynamic')",
+        ] {
+            assert!(is_statement_start(line), "{line:?} should be a statement");
+        }
+
+        // Every shape a scan of real MDX corpora turns up that opens with the
+        // keyword and carries no specifier pattern. None of them parses with
+        // the JSX source type, so the probe leaves them all in prose.
+        for line in [
+            "import /* the good parts */ of the library into your head.",
+            "export /* only */ what the reader needs to see.",
+            "export FALLOW_FORMAT=json",
+            "export PATH=\"$BUN_INSTALL/bin:$PATH\"",
+            "export = contents;",
+            "export being referenced.",
+            "import json, sys",
+        ] {
+            assert!(!is_statement_start(line), "{line:?} should stay prose");
+        }
+    }
+
+    /// Issue #2376: a side-effect import whose keyword is followed by a block
+    /// comment keeps its edge instead of becoming a false unused file.
+    #[test]
+    fn commented_keyword_import_keeps_its_edge() {
+        let source = "import /* set up styles */ '../styles/global.css'\n\n# Title\n";
+        assert_eq!(
+            import_sources(source),
+            vec!["../styles/global.css".to_string()],
+            "the commented side-effect import must resolve"
+        );
+    }
+
+    /// Issue #2376: the same for an export declaration whose keyword is
+    /// followed by a block comment.
+    #[test]
+    fn commented_keyword_export_stays_an_export() {
+        let source = "export /* keep */ const commented = 1\n\n# Title\n";
+        assert_eq!(
+            export_names(source),
+            vec!["commented".to_string()],
+            "the commented export declaration must survive"
+        );
+    }
+
+    /// Issue #2376: a top-level dynamic import written with a space before the
+    /// parenthesis is an expression, not a declaration, so no specifier shape
+    /// names it; the parse probe keeps its edge.
+    #[test]
+    fn spaced_dynamic_import_keeps_its_edge() {
+        let source = "import ('../components/lazy')\n\n# Title\n";
+        let sources: Vec<String> =
+            parse_mdx_to_module(fallow_types::discover::FileId(0), source, 0)
+                .dynamic_imports
+                .iter()
+                .map(|import| import.source.clone())
+                .collect();
+        assert_eq!(
+            sources,
+            vec!["../components/lazy".to_string()],
+            "the spaced dynamic import must resolve"
+        );
+    }
+
+    /// Issue #2376: a source clause needs its specifier quote, so the word
+    /// `from` inside a string on a continuation line does not end the block
+    /// one line early and drop the declaration it belongs to.
+    #[test]
+    fn a_from_inside_a_string_does_not_end_a_statement_block() {
+        for note in ["Everything\tfrom scratch", "Everything from scratch"] {
+            let source = format!("export const meta = {{\n  note: '{note}',\n}}\n\n# Title\n");
+            assert_eq!(
+                export_names(&source),
+                vec!["meta".to_string()],
+                "the multi-line export must be collected whole for {note:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -166,7 +166,15 @@ pub use store::GraphCacheStore;
 /// the target's default export, and those references are baked into the
 /// persisted graph. Warm 39 caches carry the uncredited verdict, so the
 /// default export would stay reported as unused on upgrade.
-pub const GRAPH_CACHE_VERSION: u32 = 40;
+///
+/// Bumped to 41 for issue #2376 (40 was taken by issue #2374 while this
+/// change was in review): an MDX prose line opening with the word
+/// "import" (and any other line the statement parser rejects) no longer drops
+/// every `import` of the file, so those files now resolve their imports and
+/// credit their bodies. Warm 40 caches persist the import-less module and its
+/// missing edges, so the imported modules would stay reported as unused files
+/// on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 41;
 
 /// Cached form of a resolved target.
 ///

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -102,16 +102,24 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   clause, a brace specifier list, a star specifier, a string-literal
   side-effect import, or, after `export`, a brace list, a star, or a
   declaration keyword. Prose that merely opens with the word "import" or
-  "export" stays prose. The classification is backed by a parse fallback: the
+  "export" stays prose. The shape list is a fast path, not the definition of
+  the language: a line that opens with the keyword and matches nothing in it
+  is handed to the parser on its own, and a line that parses is a statement
+  whatever its shape, which keeps heads the list does not enumerate
+  (`import /* c */ './x'`, a spaced dynamic `import ('./x')`) out of prose. A
+  sentence cannot slip through that probe, because a sentence does not parse.
+  Classification is backed by a parse fallback in the other direction: the
   scan keeps statement blocks (an opening line plus the continuation lines a
   multi-line specifier list collected), and when the parser rejects the body,
   every block it also rejects on its own is demoted to prose and the rest is
   re-parsed, so a rejected line costs only itself. Demoted lines feed the
   prose scan like any other body line, so the completeness guard above still
   sees their mentions. A source clause is a `from` bounded by whitespace on
-  the left and by whitespace or its specifier quote on the right, so every
-  whitespace form JavaScript accepts (`from\t'./x'`, a no-break space, a
-  multi-space run) names a source, while a `from` inside a word does not.
+  the left and followed by its specifier quote on the right, immediately or
+  after whitespace, so every whitespace form JavaScript accepts (`from\t'./x'`,
+  a no-break space, a multi-space run) names a source, while a `from` inside a
+  word or inside a string does not, and a multi-line block is never ended one
+  line early by prose in an object literal.
 - The parse fallback covers the dead-code path only. The duplication tokenizer
   reads MDX through `extract_mdx_statements`, which returns the classified
   statement body without a retry, so a line the classifier accepts and the

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -95,6 +95,20 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   feed the security secret-source index, so MDX prose records a dotted chain
   only when its root is an import local of the file: prose never creates
   member accesses on foreign roots such as `process.env`.
+- The MDX line scan hands the statement lines of the whole file to the parser
+  as one program, and a rejected program is an empty program, so one
+  misclassified line would drop every import of the file. A line opens a
+  statement only when it carries a shape a real statement has: a source
+  clause, a brace specifier list, a star specifier, a string-literal
+  side-effect import, or, after `export`, a brace list, a star, or a
+  declaration keyword. Prose that merely opens with the word "import" or
+  "export" stays prose. The classification is backed by a parse fallback: the
+  scan keeps statement blocks (an opening line plus the continuation lines a
+  multi-line specifier list collected), and when the parser rejects the body,
+  every block it also rejects on its own is demoted to prose and the rest is
+  re-parsed, so a rejected line costs only itself. Demoted lines feed the
+  prose scan like any other body line, so the completeness guard above still
+  sees their mentions.
 
 ## Verification
 

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -108,7 +108,16 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   every block it also rejects on its own is demoted to prose and the rest is
   re-parsed, so a rejected line costs only itself. Demoted lines feed the
   prose scan like any other body line, so the completeness guard above still
-  sees their mentions.
+  sees their mentions. A source clause is a `from` bounded by whitespace on
+  the left and by whitespace or its specifier quote on the right, so every
+  whitespace form JavaScript accepts (`from\t'./x'`, a no-break space, a
+  multi-space run) names a source, while a `from` inside a word does not.
+- The parse fallback covers the dead-code path only. The duplication tokenizer
+  reads MDX through `extract_mdx_statements`, which returns the classified
+  statement body without a retry, so a line the classifier accepts and the
+  parser then rejects still costs that MDX file its whole token stream there.
+  Duplication findings inside such a file are missing rather than wrong, and
+  the classifier is what keeps the common prose sentence out of that path.
 
 ## Verification
 

--- a/tests/fixtures/issue-2376-mdx-import-prose/package.json
+++ b/tests/fixtures/issue-2376-mdx-import-prose/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "issue-2376-mdx-import-prose-fixture",
+  "private": true,
+  "dependencies": {
+    "astro": "^4.0.0"
+  }
+}

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/components/commented.ts
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/components/commented.ts
@@ -1,0 +1,3 @@
+export const commentedSetup = () => null;
+
+commentedSetup();

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/components/lazy.ts
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/components/lazy.ts
@@ -1,0 +1,1 @@
+export const Lazy = () => null;

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/components/ns.ts
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/components/ns.ts
@@ -1,0 +1,5 @@
+export const Star = () => null;
+
+export const Moon = () => null;
+
+export const Unused = () => null;

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/components/rejected.ts
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/components/rejected.ts
@@ -1,0 +1,3 @@
+export const Kept = () => null;
+
+export const KeptSibling = () => null;

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/docs/commented.mdx
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/docs/commented.mdx
@@ -1,0 +1,9 @@
+import /* set up the page */ '../components/commented'
+
+import ('../components/lazy')
+
+export const docNote = {
+  summary: 'Written from scratch',
+}
+
+# Commented

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/docs/notes.mdx
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/docs/notes.mdx
@@ -1,0 +1,5 @@
+import * as NS from '../components/ns'
+
+<NS.Star />
+
+import the thing and render <NS.Moon /> here.

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/docs/rejected.mdx
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/docs/rejected.mdx
@@ -1,5 +1,5 @@
 import * as RJ from '../components/rejected'
 
-import data from the API using RJ before rendering.
+import data from './the-api' using RJ before rendering.
 
 <RJ.Kept />

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/docs/rejected.mdx
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/docs/rejected.mdx
@@ -1,0 +1,5 @@
+import * as RJ from '../components/rejected'
+
+import data from the API using RJ before rendering.
+
+<RJ.Kept />

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/pages/index.astro
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import Notes from '../docs/notes.mdx';
 import Rejected from '../docs/rejected.mdx';
+import Commented from '../docs/commented.mdx';
 ---
 <Notes />
 <Rejected />
+<Commented />

--- a/tests/fixtures/issue-2376-mdx-import-prose/src/pages/index.astro
+++ b/tests/fixtures/issue-2376-mdx-import-prose/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+import Notes from '../docs/notes.mdx';
+import Rejected from '../docs/rejected.mdx';
+---
+<Notes />
+<Rejected />


### PR DESCRIPTION
## What was broken

An MDX file whose prose contains a sentence opening with the word "import" or "export" lost **every** import of the file. The reproduction from the issue, an Astro page rendering

```mdx
import * as NS from '../components/ns'

<NS.Star />

import the thing and render <NS.Moon /> here.
```

reported `src/components/ns.ts` as an unused file (and therefore no unused export for its genuinely unused `Unused` sibling). The same shape hits any documentation line that starts with those words, including a paragraph that wraps onto a line beginning with "export" and a shell `export FOO=bar` outside a fenced block.

## Root cause

`is_statement_start` in `crates/extract/src/mdx.rs` accepted any trimmed line starting with `import ` / `import{` / `export ` / `export{`, so the prose sentence joined the statement lines. Those lines are concatenated into one buffer and parsed as a single program; oxc aborts on the first fatal error and returns an empty program (`panicked`), so nothing at all was extracted: no imports, no exports, no member accesses from the body.

## The fix

Three layers, all in `crates/extract/src/mdx.rs`.

1. **Classification.** A candidate line is a statement when it carries a shape only a real statement has: a source clause, a brace specifier list (on the line or continued below), a star specifier, a string-literal side-effect import (`import './x'`), or, after `export`, a brace list, a star, or a declaration keyword (`const`, `let`, `var`, `function`, `class`, `async`, `default`, plus the TypeScript heads `type`, `interface`, `enum`, `namespace`, `declare`, `abstract`). The keyword itself still has to be followed by whitespace or `{`, so `important` is not a candidate. A source clause is a `from` bounded by whitespace on the left and followed by its specifier quote on the right, immediately or after whitespace, so `from './x'`, `from'./x'`, `from` + tab, a no-break space and a multi-space run all qualify, while a `from` inside a word (`fromage`, `from_the_api`) or inside a string does not. The TypeScript heads are recognised as statement shapes; the JSX source type the statement body is parsed with rejects them, so they are handled by the fallback below rather than surviving as statements.

2. **Parse probe (false negatives).** The shape list is a fast path, not the definition of the language. A candidate line that opens with the keyword and matches nothing in the list is handed to the parser on its own, and a line that parses is a statement whatever its shape. That keeps heads no specifier pattern names out of prose: `import /* set up styles */ './global.css'`, `export /* keep */ const x = 1`, a top-level dynamic `import ('./x')`. A prose sentence cannot slip through, because a sentence does not parse. The probe costs one parse of one line, and only for a candidate the shape list does not recognise.

3. **Parse fallback (false positives).** The scan collects statement *blocks* (an opening line plus the continuation lines a multi-line specifier list collected) instead of loose lines. When the parser rejects the assembled body, every block the parser also rejects on its own is demoted to prose and the remaining blocks are re-parsed. The retry only ever adds statements back: the rejected body was an empty program to begin with. Demotion is per block, so a multi-line specifier list is never split, and demoted lines are merged back into the prose list in source order.

The #2355 completeness guard is preserved: a demoted line goes through the prose scan like any other body line, so a namespace or CSS-module binding mentioned on it records a whole-object use and keeps its mark-all crediting instead of narrowing to the tags the scan happened to see.

## Behavior change

- MDX documents with such a line resolve their imports again: their targets leave the unused-file list, the members their bodies render are credited, and their genuinely unused siblings surface as unused exports.
- The affected document's own exports are read too, so an `export const` nothing consumes now reports as an unused export on the `.mdx` file itself. Measured: a scratch Astro project whose `notes.mdx` carries `export const docsHelper` plus the prose line moves from `unused_files ['src/components/ns.ts']`, `unused_exports []` on the baseline binary to `unused_files []`, `unused_exports [('src/docs/notes.mdx', 'docsHelper')]` on the patched one.
- A multi-line MDX declaration whose continuation line carries the word `from` inside a string (`summary: 'Written from scratch'`) is collected whole rather than cut one line short, so that declaration parses and its unconsumed export reports as well. Measured on a two-document scratch project: the baseline binary reports `unused_exports [('src/docs/tab.mdx', 'meta')]` and the patched one `[('src/docs/space.mdx', 'spaced'), ('src/docs/tab.mdx', 'meta')]`. The space form of that truncation predates this branch.
- Duplication reads the same statement body, so clones inside an affected document, and the duplication share of its health score, now surface where the file previously tokenized to nothing. Measured: two MDX documents sharing a 25-key `export const meta` block under the prose line go from 0 clone groups / 0 tokens on the baseline binary to 1 group / 114 tokens / 83.9% on the patched one.
- A TS-only `import type { X } from './x'` clause, which the JSX source type the MDX statement body is parsed with does not accept, used to take the whole file's imports with it. It now costs only itself. (Parsing MDX statements with a TS-aware source type is a separate question, filed as a follow-up.)
- A line that parsed cleanly before still parses cleanly: a candidate is only sent to prose when it neither carries a statement shape nor parses as JavaScript on its own, and the block fallback only runs after a rejected parse. Verified over 6800 real `.mdx` files on this machine: the narrowed source clause changes the collected statement lines of zero of them, and the 31 distinct candidate lines the shape list rejects (shell `export VAR=value`, `export = contents;`, `import json, sys`, prose wraps) are all lines the parser rejects too, so all of them stay prose.

## Cache invalidation

- extract `CACHE_VERSION` 276 -> 277: warm caches hold the import-less module for every affected MDX file.
- `GRAPH_CACHE_VERSION` 39 -> 40: unused-file and unused-export verdicts are read off the persisted graph, and the newly resolved imports are baked into it at graph build, so a warm graph cache would replay the false positive verbatim.
- `DUPES_CACHE_VERSION` 10 -> 11: the duplication tokenizer reads MDX through `extract_mdx_statements`, so the classification change moves MDX token streams, and the token store is keyed only on `dupes-tokens-v{DUPES_CACHE_VERSION}` plus the file fingerprint.

Warm-cache proof on the issue fixture: the `origin/main` binary (276 / 39) ran cold and wrote `.fallow/` reporting `commented.ts`, `lazy.ts`, `ns.ts` and `rejected.ts` as unused files with no unused exports; the patched binary on that same cache reported the fixed set (no unused files, `ns.ts:Unused`, `commented.mdx:docNote`, `commented.ts:commentedSetup`, `lazy.ts:Lazy`), and a second warm run was stable. The `.fallow/` directory was removed afterwards.

Warm-cache proof for the token store, on a two-document fixture with `minCorpusSizeForTokenCache: 1` where one document carries a tab-separated `export` head: the baseline binary wrote a `dupes-tokens-v10` store and reported 0 clone groups / 114 tokens. Before the bump, the patched binary on that store still reported 0 groups / 114 tokens while a cold run reported 1 group / 171 tokens. After the bump the patched binary reports 1 group / 171 tokens with the v10 store still on disk, writes its own `dupes-tokens-v11`, and repeats that result on a second warm run.

## How it was tested

- **Unit tests** (`crates/extract/src/mdx.rs`): a classification table pinning real statement shapes and prose sentences; a whitespace table for the source clause (tab before and after `from`, a no-break space, a multi-space run, and negative cases where `from` is inside a word); the issue reproduction at module level (import survives, both body tags credited, namespace stays precise); the tab-separated default import resolving to an edge; the parse probe recovering the commented-keyword import, the commented-keyword export declaration and the spaced dynamic import, with every candidate shape a scan of real MDX corpora turns up pinned as prose; a `from` inside a string on a continuation line not ending the block, in both the tab and the space form; the fallback on a rejected single line (both imports survive, the mention on the demoted line keeps its namespace on mark-all, an unmentioned namespace stays precise); a rejected multi-line block demoted whole; a real multi-line import surviving a demoted sibling; the `import type` case; and the file's inline suppressions surviving the fallback re-parse.
- **Integration fixture** `tests/fixtures/issue-2376-mdx-import-prose` (Astro entry page rendering three MDX documents): `mdx_import_prose_line_keeps_the_files_imports` pins that `ns.ts` is not an unused file, `Star` / `Moon` stay credited and `Unused` reports; `rejected_statement_block_is_demoted_and_keeps_mark_all` pins that the target behind a rejected line is used and that both its exports stay credited through the mark-all guard; `statement_shapes_without_a_specifier_pattern_keep_their_edges` pins that the commented side-effect import and the spaced dynamic import keep their targets off the unused-file list and that the multi-line export with `from` inside a string surfaces.
- **Mutation matrix**: with the parse probe removed, the four probe tests fail plus the new integration test; with the source clause reverted to the round 1 character class, the string-`from` test fails plus the same integration test; with the fallback disabled, the five fallback tests fail plus `rejected_statement_block_is_demoted_and_keeps_mark_all`; with every non-test source hunk reverted to `origin/main` (main's source spliced in front of this branch's test module), twelve unit tests and all three integration tests fail. Restored tree green and clean each time.
- **Real-world evidence**, baseline vs patched, `--format json --no-cache`: the in-repo `viz-frontend` and `editors/vscode` are identical on `dead-code`, and the public documentation site of this project (73 MDX files) is identical too, in all three cases down to every field except `analysis_run_id` and `elapsed_ms`. Both reviewer reproductions from round 1 now match the baseline exactly: the commented side-effect import project reports `unused_files []` on both binaries, and the spaced dynamic import project reports `unused_files ['src/components/b.ts']`, `unused_exports [('src/components/a.ts', 'A')]` on both. A state-machine simulation of the line scanner over all 6800 local `.mdx` files finds exactly one file whose collected statement lines change, the new fixture document added by this branch.
- **Gates**: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib --bins --tests --examples` (with the type-aware sidecar installed), `cargo check --workspace --benches`, `cargo doc` with `-D warnings`, `typos`, hidden-unicode scan, comment-quality check.
- **Docs**: `docs/reference/extract-internals.md` records the classification rule, the quote-bounded source clause, the parse probe, the parse fallback, and that the fallback covers the dead-code path only, next to the MDX completeness guard.

## Review round 1

- `DUPES_CACHE_VERSION` 10 -> 11, with the live stale-cache divergence reproduced before the bump and the fix proven after it.
- The source clause is matched on whitespace boundaries instead of the literal strings with a leading space, so a valid `import X from` + tab + `'./x'` keeps its edge instead of becoming a false unused file.
- `parse_mdx_to_module` no longer clones the parsed suppressions on every MDX file; the fallback path discards the rejected module info, so its suppressions move on to the retry.
- The CHANGELOG names the two further finding movements above, both measured on the patched binary.
- The export keyword table and the extraction reference say the TypeScript heads are statement shapes handled by the parse fallback rather than surviving as statements.

## Review round 2

- **The classifier now has a false-negative safety net.** A line whose keyword is followed by a block comment (`import /* set up styles */ './global.css'`, `export /* keep */ const x = 1`) parsed on main and carried none of the recognised shapes, so round 1 sent it to prose and lost its edge or its declaration with no way back: the block fallback only rescues lines the classifier wrongly accepts. A spaced dynamic `import ('./x')` was lost the same way. Both are recovered by the parse probe, and both scratch projects now match the baseline binary exactly.
- **The source clause requires its specifier quote.** The word `from` inside a string on a continuation line no longer ends a multi-line block one line early and cost the declaration it belongs to. That also removes the space form of the same truncation, which predates this branch.
- **The stability claim is now accurate.** The "no change for files that parsed cleanly before" sentence was false against the commented-keyword shape; it is replaced by the precise rule and backed by the 6800-file corpus scan above.
- **Test inputs retargeted.** Tightening the source clause moved `import data from the API using X` out of the fallback and into plain classification, which silently cost three fallback tests and the `rejected.mdx` fixture their bite (the fallback mutation dropped from five failures to two). They now use a line carrying a real source clause with prose trailing it, which the classifier still accepts and the parser still rejects.

Fixes #2376
