### PR TITLE
fix(extract): record import X = require('./x') as a CommonJS import edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   many times is one entry. Warm caches invalidate (`CACHE_VERSION` 277 to 278,
   `GRAPH_CACHE_VERSION` 41 to 42).
 
+- **`import X = require('./x')` now records an import edge** (Closes
+  [#2365](https://github.com/fallow-rs/fallow/issues/2365)). The extractor had
+  no arm for a `TSImportEqualsDeclaration` with an external module reference,
+  so the TypeScript spelling of a CommonJS require produced no import at all:
+  the target was reported as an unused file and nothing reached through the
+  binding was credited. The declaration now records exactly what a
+  `const X = require('./x')` declaration records, so the target resolves
+  through the CommonJS mechanism, member accesses through `X` narrow the
+  target's exports the way a namespace import does, and a binding used as a
+  whole object (`Object.values(X)`) credits the full namespace object,
+  including the names the target only exposes through its own `export *`
+  chain. `export import X = require('./x')` inside a namespace body records
+  the same edge. Repositories that use the form will see fewer unused-file and
+  unused-export findings, and the exports of a file that becomes reachable for
+  the first time are narrowed against the members the consumer writes, so a
+  sibling nothing accesses surfaces as an unused export where the unused-file
+  row used to stand in its place. Total finding count is not guaranteed to
+  decrease: the edge is visible to every check that reads imports, so an
+  import-equals whose specifier does not resolve now reports
+  `unresolved-import`, and a bare specifier no manifest lists reports
+  `unlisted-dependency`, exactly as the equivalent `import X from './x'`
+  already did. `import X = Some.Namespace` is deliberately unchanged: an
+  entity-name reference aliases a binding declared in the same file, not a
+  module, so it records no edge. Warm caches invalidate (extract
+  `CACHE_VERSION` 278 to 279, `GRAPH_CACHE_VERSION` 42 to 43); the first run
+  after upgrading performs one cold re-analysis.
+
 - **A `default` import or re-export specifier now credits the target's default
   export** (Closes
   [#2374](https://github.com/fallow-rs/fallow/issues/2374)). `default` is one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,11 +136,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   TypeScript erases completely, so it keeps the type-space edge but is never
   read as a runtime import: a type-only devDependency stays out of
   `dev-dependency-in-production`, matching `import type * as X from 'pkg'`.
+  A bare reference that hands the module object on (`register(X)`,
+  `const alias = X`, `return X`) credits every export the receiver can reach,
+  matching the namespace-import rule added in
+  [#2377](https://github.com/fallow-rs/fallow/issues/2377).
   `export import X = require('./x')` additionally hands the module object to
   consumers the graph cannot enumerate, so every export of the target keeps
   its credit exactly as it does behind `import * as X from './x';
   export { X }`, including on an entry point with no local member access
-  ([#2373](https://github.com/fallow-rs/fallow/issues/2373)).
+  ([#2373](https://github.com/fallow-rs/fallow/issues/2373)). That credit is
+  matched by bare name, so it is granted only when the file binds the name
+  once; a whole-object use the file genuinely wrote (`Object.values(X)`) is
+  kept either way, so a same-named function parameter no longer deletes the
+  target's credit. In the other direction a binding nothing references credits
+  nothing at all: TypeScript elides such a declaration, so the target keeps
+  every unused-export and unused-type row it earns, exactly as it does behind
+  an unreferenced `import * as X from './x'`. The edge still resolves, so the
+  target is a reachable file either way.
   Repositories that use the form will see fewer unused-file and
   unused-export findings, and the exports of a file that becomes reachable for
   the first time are narrowed against the members the consumer writes, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,11 +144,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumers the graph cannot enumerate, so every export of the target keeps
   its credit exactly as it does behind `import * as X from './x';
   export { X }`, including on an entry point with no local member access
-  ([#2373](https://github.com/fallow-rs/fallow/issues/2373)). That credit is
-  matched by bare name, so it is granted only when the file binds the name
-  once; a whole-object use the file genuinely wrote (`Object.values(X)`) is
-  kept either way, so a same-named function parameter no longer deletes the
-  target's credit. In the other direction a binding nothing references credits
+  ([#2373](https://github.com/fallow-rs/fallow/issues/2373)) and whatever else
+  the file happens to bind under that name. The two spellings still differ in
+  one place, in the conservative direction: `export { X }` is an export row, so
+  a re-export nothing imports reports as an unused export, while the
+  import-equals binding records no export row and never does.
+  In the other direction a binding nothing references credits
   nothing at all: TypeScript elides such a declaration, so the target keeps
   every unused-export and unused-type row it earns, exactly as it does behind
   an unreferenced `import * as X from './x'`. The edge still resolves, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,8 +132,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chain. Narrowing covers both semantic spaces: the binding is classified for
   type and value usage like a namespace import, so `X.SomeType` in an
   annotation credits the target's type export instead of leaving it reported
-  as an unused type. `export import X = require('./x')`, at file level or
-  inside an exported namespace body, additionally hands the module object to
+  as an unused type. `import type X = require('pkg')` is the one spelling
+  TypeScript erases completely, so it keeps the type-space edge but is never
+  read as a runtime import: a type-only devDependency stays out of
+  `dev-dependency-in-production`, matching `import type * as X from 'pkg'`.
+  `export import X = require('./x')` additionally hands the module object to
   consumers the graph cannot enumerate, so every export of the target keeps
   its credit exactly as it does behind `import * as X from './x';
   export { X }`, including on an entry point with no local member access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,8 +129,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target's exports the way a namespace import does, and a binding used as a
   whole object (`Object.values(X)`) credits the full namespace object,
   including the names the target only exposes through its own `export *`
-  chain. `export import X = require('./x')` inside a namespace body records
-  the same edge. Repositories that use the form will see fewer unused-file and
+  chain. Narrowing covers both semantic spaces: the binding is classified for
+  type and value usage like a namespace import, so `X.SomeType` in an
+  annotation credits the target's type export instead of leaving it reported
+  as an unused type. `export import X = require('./x')`, at file level or
+  inside an exported namespace body, additionally hands the module object to
+  consumers the graph cannot enumerate, so every export of the target keeps
+  its credit exactly as it does behind `import * as X from './x';
+  export { X }`, including on an entry point with no local member access
+  ([#2373](https://github.com/fallow-rs/fallow/issues/2373)).
+  Repositories that use the form will see fewer unused-file and
   unused-export findings, and the exports of a file that becomes reachable for
   the first time are narrowed against the members the consumer writes, so a
   sibling nothing accesses surfaces as an unused export where the unused-file

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -1381,6 +1381,7 @@ fn create_cache_round_trip_input() -> fallow_core::extract::ModuleInfo {
             destructured_names: vec![],
             local_name: None,
             source_span: oxc_span::Span::default(),
+            is_type_only: false,
         }],
         package_path_references: Box::default(),
         member_accesses: vec![

--- a/crates/core/src/analyze/policy/tests.rs
+++ b/crates/core/src/analyze/policy/tests.rs
@@ -254,6 +254,7 @@ fn require_call(source: &str, local: Option<&str>, destructured: &[&str]) -> Req
         source_span: oxc_span::Span::new(0, 10),
         destructured_names: destructured.iter().map(ToString::to_string).collect(),
         local_name: local.map(ToString::to_string),
+        is_type_only: false,
     }
 }
 

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -81,6 +81,8 @@ mod issue_2349_module_augmentation;
 mod issue_2356_local_namespace;
 #[path = "integration_test/issue_2357_ambient_star_reexport.rs"]
 mod issue_2357_ambient_star_reexport;
+#[path = "integration_test/issue_2365_import_equals.rs"]
+mod issue_2365_import_equals;
 #[path = "integration_test/issue_2372_star_barrel_whole_module.rs"]
 mod issue_2372_star_barrel_whole_module;
 #[path = "integration_test/issue_2373_entry_namespace_chain.rs"]

--- a/crates/core/tests/integration_test/issue_2365_import_equals.rs
+++ b/crates/core/tests/integration_test/issue_2365_import_equals.rs
@@ -1,0 +1,184 @@
+//! Issue #2365: `import X = require('./x')` is the TypeScript spelling of a
+//! CommonJS require binding. It records the same edge a
+//! `const X = require('./x')` declaration records, so the target participates
+//! in reachability and member accesses through `X` narrow the target's exports
+//! the way a namespace import does.
+//!
+//! `import X = Some.Namespace` stays out of scope: an entity-name reference
+//! names a binding declared in the same file, not a module, so it records no
+//! edge at all.
+
+use super::common::{create_config, fixture_path};
+
+const FIXTURE: &str = "issue-2365-import-equals";
+
+fn unused_files(results: &fallow_core::results::AnalysisResults) -> Vec<String> {
+    results
+        .unused_files
+        .iter()
+        .map(|f| f.file.path.to_string_lossy().replace('\\', "/"))
+        .collect()
+}
+
+fn unused_export_pairs(results: &fallow_core::results::AnalysisResults) -> Vec<(String, String)> {
+    results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.export.path.to_string_lossy().replace('\\', "/"),
+                e.export.export_name.clone(),
+            )
+        })
+        .collect()
+}
+
+/// Exports reported on one file, in report order.
+fn unused_exports_of(results: &fallow_core::results::AnalysisResults, file: &str) -> Vec<String> {
+    unused_export_pairs(results)
+        .into_iter()
+        .filter(|(path, _)| path.ends_with(file))
+        .map(|(_, name)| name)
+        .collect()
+}
+
+#[test]
+fn import_equals_require_makes_the_target_reachable() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused_files = unused_files(&results);
+
+    // Every one of these is reached through an `import X = require(...)`
+    // binding alone; the issue reported all of them as unused files.
+    for path in [
+        "src/assigned.ts",
+        "src/narrowed.ts",
+        "src/whole.ts",
+        "src/whole-deep.ts",
+        "src/inner.ts",
+    ] {
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(path)),
+            "{path} is imported through `import X = require(...)` and must be reachable; unused \
+             files: {unused_files:?}"
+        );
+    }
+
+    // The issue's own shape: a namespace exported with `export =` and consumed
+    // through the member the consumer writes.
+    assert!(
+        !unused_export_pairs(&results)
+            .iter()
+            .any(|(path, name)| path.ends_with("src/assigned.ts") && name == "viaAssignment"),
+        "the member the consumer accesses through the binding must be credited: {:?}",
+        unused_export_pairs(&results)
+    );
+}
+
+/// The binding narrows to the members the consumer writes, exactly like the
+/// equivalent `import * as ns`. Both halves of the fixture declare the same
+/// shape (one accessed export, one untouched sibling) and must report the same
+/// way: the sibling reports, the accessed export does not.
+#[test]
+fn import_equals_narrows_members_like_a_namespace_import() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+
+    assert_eq!(
+        unused_exports_of(&results, "src/narrowed.ts"),
+        vec!["unusedByNarrowing".to_string()],
+        "an `import X = require(...)` binding credits only the members it accesses"
+    );
+    assert_eq!(
+        unused_exports_of(&results, "src/narrowed-esm.ts"),
+        vec!["esmUnusedByNarrowing".to_string()],
+        "the equivalent namespace import reports the same way"
+    );
+}
+
+/// A binding used as a whole object (`Object.values(Whole)`) observes every
+/// name on the namespace object, including the names the target only exposes
+/// through its own `export *` chain, so the #2372 whole-object seed applies to
+/// this binding as it does to a namespace import.
+#[test]
+fn import_equals_used_as_a_whole_object_credits_the_star_chain() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let pairs = unused_export_pairs(&results);
+    let unused_files = unused_files(&results);
+
+    for (file, name) in [
+        ("src/whole.ts", "wholeDirect"),
+        ("src/whole-deep.ts", "wholeDeep"),
+    ] {
+        // An unreachable file stacks no unused-export rows underneath its
+        // unused-file row, so reachability is asserted first: without it the
+        // export assertion would hold vacuously.
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(file)),
+            "{file} must be reachable before its exports can be credited: {unused_files:?}"
+        );
+        assert!(
+            !pairs
+                .iter()
+                .any(|(path, export)| path.ends_with(file) && export == name),
+            "{file}: `{name}` is on the namespace object a whole-object use observes: {pairs:?}"
+        );
+    }
+}
+
+/// `export import Inner = require('./inner')` inside a namespace body is still
+/// an import of `./inner`, and it narrows the same way.
+#[test]
+fn export_import_equals_inside_a_namespace_records_the_edge() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+
+    assert_eq!(
+        unused_exports_of(&results, "src/inner.ts"),
+        vec!["innerUnused".to_string()],
+        "the member the namespace body reads is credited and its sibling keeps reporting"
+    );
+}
+
+/// Deliberate negative control: `import ShapesAlias = Shapes` names a namespace
+/// declared in the same file. It is a local alias, not a module reference, so
+/// no import edge is invented. A `Shapes` specifier would surface as an
+/// unresolved import or an unlisted dependency.
+#[test]
+fn import_equals_entity_name_is_a_local_alias_not_an_import() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+
+    let unresolved: Vec<String> = results
+        .unresolved_imports
+        .iter()
+        .map(|f| f.import.specifier.clone())
+        .collect();
+    assert!(
+        unresolved.is_empty(),
+        "an entity-name import-equals must not become a module specifier: {unresolved:?}"
+    );
+    let unlisted: Vec<String> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|f| f.dep.package_name.clone())
+        .collect();
+    assert!(
+        unlisted.is_empty(),
+        "an entity-name import-equals must not become a package dependency: {unlisted:?}"
+    );
+
+    // The file holding the alias is analyzed and its export is credited, so the
+    // control is not passing vacuously.
+    assert!(
+        !unused_files(&results)
+            .iter()
+            .any(|p| p.ends_with("src/local-alias.ts")),
+        "the aliasing file is imported and must be reachable"
+    );
+    assert!(
+        unused_exports_of(&results, "src/local-alias.ts").is_empty(),
+        "the aliasing file's only export is consumed by the entry"
+    );
+}

--- a/crates/core/tests/integration_test/issue_2365_import_equals.rs
+++ b/crates/core/tests/integration_test/issue_2365_import_equals.rs
@@ -8,9 +8,18 @@
 //! the module object to consumers the graph cannot enumerate, so it credits
 //! every export of the target exactly as `import * as X; export { X }` does.
 //!
+//! `import type X = require('pkg')` is the one spelling TypeScript erases
+//! entirely, so it keeps the type-space edge but never claims the package is
+//! imported at runtime, matching `import type * as X from 'pkg'`.
+//!
 //! `import X = Some.Namespace` stays out of scope: an entity-name reference
 //! names a binding declared in the same file, not a module, so it records no
 //! edge at all.
+//!
+//! Every shape in the fixture is TypeScript the compiler accepts. The
+//! namespace-body spelling (`namespace N { export import X = require('./x') }`)
+//! is TS1147 and therefore lives only in the extractor's lenient-parse unit
+//! test, not here.
 
 use super::common::{create_config, fixture_path};
 
@@ -75,7 +84,6 @@ fn import_equals_require_makes_the_target_reachable() {
         "src/narrowed.ts",
         "src/whole.ts",
         "src/whole-deep.ts",
-        "src/inner.ts",
     ] {
         assert!(
             !unused_files.iter().any(|p| p.ends_with(path)),
@@ -202,19 +210,16 @@ fn import_equals_destructuring_off_the_binding_narrows_like_a_namespace_import()
 /// its credit. On an entry point there is no local member access to narrow
 /// with, and without the whole-object credit `is_entry_with_no_access` would
 /// turn every export of the target into a false `unused-export` row (#2373).
-/// Both the file-level form and the exported-namespace-body form are pinned,
-/// against the `import * as X; export { X }` twin.
+/// The file-level form is pinned against the `import * as X; export { X }`
+/// twin; it is the only spelling TypeScript accepts outside a `declare module`
+/// body.
 #[test]
 fn export_import_equals_on_an_entry_point_credits_the_whole_module() {
     let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
         .expect("analysis should succeed");
     let unused_files = unused_files(&results);
 
-    for file in [
-        "src/entry-reexport.ts",
-        "src/entry-reexport-esm.ts",
-        "src/entry-ns.ts",
-    ] {
+    for file in ["src/entry-reexport.ts", "src/entry-reexport-esm.ts"] {
         // An unreachable file stacks no unused-export rows underneath its
         // unused-file row, so reachability is asserted first.
         assert!(
@@ -229,27 +234,76 @@ fn export_import_equals_on_an_entry_point_credits_the_whole_module() {
     }
 }
 
-/// `export import Inner = require('./inner')` inside a namespace body is still
-/// an import of `./inner`, and the binding is public API under `Outer.Inner`,
-/// so every export of the target is credited the way `export { Inner }` credits
-/// a namespace import. Narrowing to the members the declaring file happens to
-/// read would be unsound: a consumer holding `Outer.Inner` can reach any of
-/// them.
+/// A `declare module '...'` body is the only context outside file scope where
+/// TypeScript accepts `export import X = require('...')`, and a relative
+/// specifier is TS2439 there, so the reference names a package. The edge still
+/// has to be recorded: without it the package is a false `unused-dependency`.
 #[test]
-fn export_import_equals_inside_a_namespace_credits_the_whole_module() {
+fn export_import_equals_inside_an_ambient_module_credits_the_package() {
     let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
         .expect("analysis should succeed");
 
+    let unused: Vec<String> = results
+        .unused_dependencies
+        .iter()
+        .map(|f| f.dep.package_name.clone())
+        .collect();
     assert!(
-        !unused_files(&results)
-            .iter()
-            .any(|p| p.ends_with("src/inner.ts")),
-        "the namespace body's import edge keeps the target reachable"
+        !unused.iter().any(|name| name == "ambient-dep"),
+        "the ambient body's import edge credits the package: {unused:?}"
     );
+    let unlisted: Vec<String> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|f| f.dep.package_name.clone())
+        .collect();
     assert!(
-        unused_exports_of(&results, "src/inner.ts").is_empty(),
-        "a binding re-exported as a namespace member observes the whole object: {:?}",
-        unused_exports_of(&results, "src/inner.ts")
+        unlisted.is_empty(),
+        "the package is declared in the manifest, so nothing is unlisted: {unlisted:?}"
+    );
+}
+
+/// `import type X = require('pkg')` is erased by TypeScript: the emitted
+/// JavaScript holds no `require` call, so the package is a type-space
+/// reference and never a runtime import. It must therefore report exactly what
+/// `import type * as X from 'pkg'` reports, which is nothing, while the
+/// unerased `import X = require('pkg')` next to it still reports the
+/// devDependency as production usage.
+#[test]
+fn type_only_import_equals_is_not_a_runtime_dependency() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+
+    let in_production: Vec<String> = results
+        .dev_dependencies_in_production
+        .iter()
+        .map(|f| f.dep.package_name.clone())
+        .collect();
+    let unused_dev: Vec<String> = results
+        .unused_dev_dependencies
+        .iter()
+        .map(|f| f.dep.package_name.clone())
+        .collect();
+
+    for package in ["type-only-dep", "type-only-esm-dep"] {
+        assert!(
+            !in_production.iter().any(|name| name == package),
+            "{package} is erased at compile time and is not imported at runtime: \
+             {in_production:?}"
+        );
+        assert!(
+            !unused_dev.iter().any(|name| name == package),
+            "{package} is used in a type position and is not an unused devDependency: \
+             {unused_dev:?}"
+        );
+    }
+
+    // Positive control: the same lane on the unerased spelling still fires, so
+    // the assertions above are not passing because the lane is dead.
+    assert!(
+        in_production.iter().any(|name| name == "runtime-dep"),
+        "an unerased `import X = require('pkg')` on a devDependency is production usage: \
+         {in_production:?}"
     );
 }
 

--- a/crates/core/tests/integration_test/issue_2365_import_equals.rs
+++ b/crates/core/tests/integration_test/issue_2365_import_equals.rs
@@ -7,6 +7,12 @@
 //! The exported form, `export import X = require('./x')`, additionally hands
 //! the module object to consumers the graph cannot enumerate, so it credits
 //! every export of the target exactly as `import * as X; export { X }` does.
+//! That credit is keyed by bare name, so it is withheld when the file binds the
+//! name twice; a whole-object use the file genuinely wrote is untouched.
+//!
+//! A binding nothing references is elided by TypeScript, so it credits nothing
+//! and the target keeps every unused-export and unused-type row it earns,
+//! exactly as an unreferenced `import * as X` does.
 //!
 //! `import type X = require('pkg')` is the one spelling TypeScript erases
 //! entirely, so it keeps the type-space edge but never claims the package is
@@ -229,6 +235,67 @@ fn export_import_equals_on_an_entry_point_credits_the_whole_module() {
         assert!(
             unused_exports_of(&results, file).is_empty(),
             "{file}: every export is reachable through the re-exported binding: {:?}",
+            unused_exports_of(&results, file)
+        );
+    }
+}
+
+/// An `import X = require('./x')` binding nothing references is elided by
+/// TypeScript, so it credits nothing: the target stays reachable through the
+/// edge, and every export and type on it still reports. Crediting the whole
+/// module object there deleted rows the analyzer is right about, which is worse
+/// than the missing edge the issue started from. Pinned against the
+/// `import * as X` twin, which reports exactly the same way.
+#[test]
+fn an_unreferenced_import_equals_binding_credits_nothing() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused_files = unused_files(&results);
+
+    for (file, export, type_name) in [
+        ("src/stale-target.ts", "staleAlpha", "StaleShape"),
+        ("src/stale-esm-target.ts", "staleEsmAlpha", "StaleEsmShape"),
+    ] {
+        // The edge still resolves, so the target is reachable; an unreachable
+        // file would stack no rows underneath its unused-file row and the
+        // assertions below would hold vacuously.
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(file)),
+            "{file} is imported and must stay reachable: {unused_files:?}"
+        );
+        assert_eq!(
+            unused_exports_of(&results, file),
+            vec![export.to_string()],
+            "{file}: an unreferenced binding credits no export"
+        );
+        assert_eq!(
+            unused_types_of(&results, file),
+            vec![type_name.to_string()],
+            "{file}: an unreferenced binding credits no type either"
+        );
+    }
+}
+
+/// A whole-object use the consumer genuinely wrote survives a same-named
+/// binding elsewhere in the file. The exported form's credit is granted by
+/// name, so withdrawing it by name deleted the genuine use with it and turned
+/// every export of the target into a false `unused-export` row. The
+/// `import * as X` twin next to it writes the same `Object.values(X)` and the
+/// same shadowing parameter, and must report the same way.
+#[test]
+fn a_shadowed_export_import_equals_keeps_a_genuine_whole_object_use() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused_files = unused_files(&results);
+
+    for file in ["src/shadowed-target.ts", "src/shadowed-esm-target.ts"] {
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(file)),
+            "{file} must be reachable before its exports can be credited: {unused_files:?}"
+        );
+        assert!(
+            unused_exports_of(&results, file).is_empty(),
+            "{file}: `Object.values(...)` observes every name on the module object: {:?}",
             unused_exports_of(&results, file)
         );
     }

--- a/crates/core/tests/integration_test/issue_2365_import_equals.rs
+++ b/crates/core/tests/integration_test/issue_2365_import_equals.rs
@@ -2,7 +2,11 @@
 //! CommonJS require binding. It records the same edge a
 //! `const X = require('./x')` declaration records, so the target participates
 //! in reachability and member accesses through `X` narrow the target's exports
-//! the way a namespace import does.
+//! the way a namespace import does, in type space as well as value space.
+//!
+//! The exported form, `export import X = require('./x')`, additionally hands
+//! the module object to consumers the graph cannot enumerate, so it credits
+//! every export of the target exactly as `import * as X; export { X }` does.
 //!
 //! `import X = Some.Namespace` stays out of scope: an entity-name reference
 //! names a binding declared in the same file, not a module, so it records no
@@ -39,6 +43,22 @@ fn unused_exports_of(results: &fallow_core::results::AnalysisResults, file: &str
         .into_iter()
         .filter(|(path, _)| path.ends_with(file))
         .map(|(_, name)| name)
+        .collect()
+}
+
+/// Type exports reported on one file, in report order.
+fn unused_types_of(results: &fallow_core::results::AnalysisResults, file: &str) -> Vec<String> {
+    results
+        .unused_types
+        .iter()
+        .filter(|e| {
+            e.export
+                .path
+                .to_string_lossy()
+                .replace('\\', "/")
+                .ends_with(file)
+        })
+        .map(|e| e.export.export_name.clone())
         .collect()
 }
 
@@ -127,17 +147,109 @@ fn import_equals_used_as_a_whole_object_credits_the_star_chain() {
     }
 }
 
-/// `export import Inner = require('./inner')` inside a namespace body is still
-/// an import of `./inner`, and it narrows the same way.
+/// The binding narrows in type space too. `Typed.UsedShape` in an annotation
+/// credits the interface; the untouched sibling interface still reports. The
+/// `import * as TypedEsm` half of the fixture declares the same shape and must
+/// report the same way: crediting only the value lane would invent an
+/// `unused-type` row the namespace import never produces.
 #[test]
-fn export_import_equals_inside_a_namespace_records_the_edge() {
+fn import_equals_narrows_type_members_like_a_namespace_import() {
     let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
         .expect("analysis should succeed");
 
     assert_eq!(
-        unused_exports_of(&results, "src/inner.ts"),
-        vec!["innerUnused".to_string()],
-        "the member the namespace body reads is credited and its sibling keeps reporting"
+        unused_types_of(&results, "src/typed.ts"),
+        vec!["UnusedShape".to_string()],
+        "a type reached through `Typed.UsedShape` is credited, its sibling is not"
+    );
+    assert_eq!(
+        unused_types_of(&results, "src/typed-esm.ts"),
+        vec!["EsmUnusedShape".to_string()],
+        "the equivalent namespace import reports the same way"
+    );
+
+    // The value export on the same target is credited through the same
+    // binding, so the type lane is not bought by dropping the value lane.
+    assert!(
+        unused_exports_of(&results, "src/typed.ts").is_empty(),
+        "the value member read through the binding stays credited: {:?}",
+        unused_exports_of(&results, "src/typed.ts")
+    );
+}
+
+/// Object destructuring off the binding (`const { used } = X`) resolves through
+/// the namespace binding name, so only the destructured member is credited.
+/// Without that binding name the whole target would report.
+#[test]
+fn import_equals_destructuring_off_the_binding_narrows_like_a_namespace_import() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+
+    assert_eq!(
+        unused_exports_of(&results, "src/destructured.ts"),
+        vec!["destructuredSibling".to_string()],
+        "destructuring off the binding credits the destructured member alone"
+    );
+    assert_eq!(
+        unused_exports_of(&results, "src/destructured-esm.ts"),
+        vec!["esmDestructuredSibling".to_string()],
+        "the equivalent namespace import reports the same way"
+    );
+}
+
+/// `export import X = require('./x')` hands the required module object to
+/// consumers the graph cannot enumerate, so every export of the target keeps
+/// its credit. On an entry point there is no local member access to narrow
+/// with, and without the whole-object credit `is_entry_with_no_access` would
+/// turn every export of the target into a false `unused-export` row (#2373).
+/// Both the file-level form and the exported-namespace-body form are pinned,
+/// against the `import * as X; export { X }` twin.
+#[test]
+fn export_import_equals_on_an_entry_point_credits_the_whole_module() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused_files = unused_files(&results);
+
+    for file in [
+        "src/entry-reexport.ts",
+        "src/entry-reexport-esm.ts",
+        "src/entry-ns.ts",
+    ] {
+        // An unreachable file stacks no unused-export rows underneath its
+        // unused-file row, so reachability is asserted first.
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(file)),
+            "{file} must be reachable before its exports can be credited: {unused_files:?}"
+        );
+        assert!(
+            unused_exports_of(&results, file).is_empty(),
+            "{file}: every export is reachable through the re-exported binding: {:?}",
+            unused_exports_of(&results, file)
+        );
+    }
+}
+
+/// `export import Inner = require('./inner')` inside a namespace body is still
+/// an import of `./inner`, and the binding is public API under `Outer.Inner`,
+/// so every export of the target is credited the way `export { Inner }` credits
+/// a namespace import. Narrowing to the members the declaring file happens to
+/// read would be unsound: a consumer holding `Outer.Inner` can reach any of
+/// them.
+#[test]
+fn export_import_equals_inside_a_namespace_credits_the_whole_module() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+
+    assert!(
+        !unused_files(&results)
+            .iter()
+            .any(|p| p.ends_with("src/inner.ts")),
+        "the namespace body's import edge keeps the target reachable"
+    );
+    assert!(
+        unused_exports_of(&results, "src/inner.ts").is_empty(),
+        "a binding re-exported as a namespace member observes the whole object: {:?}",
+        unused_exports_of(&results, "src/inner.ts")
     );
 }
 

--- a/crates/core/tests/integration_test/issue_2365_import_equals.rs
+++ b/crates/core/tests/integration_test/issue_2365_import_equals.rs
@@ -6,9 +6,13 @@
 //!
 //! The exported form, `export import X = require('./x')`, additionally hands
 //! the module object to consumers the graph cannot enumerate, so it credits
-//! every export of the target exactly as `import * as X; export { X }` does.
-//! That credit is keyed by bare name, so it is withheld when the file binds the
-//! name twice; a whole-object use the file genuinely wrote is untouched.
+//! every export of the target exactly as `import * as X; export { X }` does,
+//! whatever else the file binds under that name.
+//!
+//! The one place the two spellings still differ is the consumer's own export
+//! surface: `export { X }` records an export row named `X`, so an unconsumed
+//! re-export reports; the import-equals form records no export row, so it never
+//! does. That is a deliberate miss, pinned below, not an invented row.
 //!
 //! A binding nothing references is elided by TypeScript, so it credits nothing
 //! and the target keeps every unused-export and unused-type row it earns,
@@ -276,9 +280,57 @@ fn an_unreferenced_import_equals_binding_credits_nothing() {
     }
 }
 
+/// The unmasked shadowed shape: an exported import-equals whose name a
+/// parameter binds again, with no `Object.values(...)` to mask the difference.
+/// A shadow guard on the whole-object credit reported every export of the
+/// target as an auto-fixable `unused-export`, rows main never produced and rows
+/// the `import * as X; export { X }` twin next to it never produces either.
+///
+/// The two files also pin the one deviation that remains between the spellings:
+/// `export { X }` is an export row, so an unconsumed re-export reports on the
+/// consumer, while the import-equals binding records no export row and never
+/// does. That direction loses a finding, it does not invent one.
+#[test]
+fn a_shadowed_export_import_equals_keeps_the_targets_credit() {
+    let results = fallow_core::analyze(&create_config(fixture_path(FIXTURE)))
+        .expect("analysis should succeed");
+    let unused_files = unused_files(&results);
+
+    for file in [
+        "src/bare-shadowed-target.ts",
+        "src/bare-shadowed-esm-target.ts",
+    ] {
+        // An unreachable file stacks no unused-export rows underneath its
+        // unused-file row, so reachability is asserted first.
+        assert!(
+            !unused_files.iter().any(|p| p.ends_with(file)),
+            "{file} must be reachable before its exports can be credited: {unused_files:?}"
+        );
+        assert!(
+            unused_exports_of(&results, file).is_empty(),
+            "{file}: the re-exported binding hands the module object on, so every export keeps \
+             its credit: {:?}",
+            unused_exports_of(&results, file)
+        );
+    }
+
+    assert!(
+        unused_exports_of(&results, "src/bare-shadowed.ts").is_empty(),
+        "the import-equals binding is no export row, so only `parseBareShadowed` can report and \
+         the entry consumes it: {:?}",
+        unused_exports_of(&results, "src/bare-shadowed.ts")
+    );
+    assert_eq!(
+        unused_exports_of(&results, "src/bare-shadowed-esm.ts"),
+        vec!["BareShadowedEsmTarget".to_string()],
+        "the twin's `export {{ X }}` is an export row nothing imports, which is the one row the \
+         import-equals spelling does not produce"
+    );
+}
+
 /// A whole-object use the consumer genuinely wrote survives a same-named
-/// binding elsewhere in the file. The exported form's credit is granted by
-/// name, so withdrawing it by name deleted the genuine use with it and turned
+/// binding elsewhere in the file. An earlier revision withdrew the exported
+/// form's credit by name, which deleted the genuine use with it and turned
 /// every export of the target into a false `unused-export` row. The
 /// `import * as X` twin next to it writes the same `Object.values(X)` and the
 /// same shadowing parameter, and must report the same way.

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -146,6 +146,7 @@ fn cached_require_calls_to_module(
             source_span: Span::new(require_call.source_span_start, require_call.source_span_end),
             destructured_names: require_call.destructured_names.clone(),
             local_name: require_call.local_name.clone(),
+            is_type_only: require_call.is_type_only,
         })
         .collect()
 }
@@ -355,6 +356,7 @@ fn module_require_calls_to_cached(
             source_span_end: require_call.source_span.end,
             destructured_names: require_call.destructured_names.clone(),
             local_name: require_call.local_name.clone(),
+            is_type_only: require_call.is_type_only,
         })
         .collect()
 }

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -1163,6 +1163,7 @@ fn module_to_cached_roundtrip_dynamic_imports() {
             destructured_names: Vec::new(),
             local_name: None,
             source_span: oxc_span::Span::default(),
+            is_type_only: false,
         }],
         package_path_references: Box::default(),
         member_accesses: vec![MemberAccess {
@@ -3688,6 +3689,7 @@ fn module_to_cached_roundtrip_require_with_destructured() {
             destructured_names: vec!["readFile".to_string(), "writeFile".to_string()],
             local_name: None,
             source_span: oxc_span::Span::default(),
+            is_type_only: false,
         }],
         package_path_references: Box::default(),
         member_accesses: vec![].into(),

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -984,9 +984,11 @@ use crate::MemberKind;
 /// namespace binding that narrows `X.member`, its type-space and value-space
 /// binding classification, the unused-binding verdict for an unreferenced
 /// non-exported one, and the whole-object use the exported form
-/// (`export import X = require('./x')`) hands to consumers. Warm 278 caches hold
-/// the module without that require call and without those facts, so the target
-/// would stay reported as an unused file on upgrade.
+/// (`export import X = require('./x')`) hands to consumers, plus the type-only
+/// flag that keeps the erased `import type X = require('./x')` spelling out of
+/// runtime dependency classification. Warm 278 caches hold the module without
+/// that require call and without those facts, so the target would stay
+/// reported as an unused file on upgrade.
 pub(super) const CACHE_VERSION: u32 = 279;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
@@ -1066,7 +1068,7 @@ assert_cached_type_size!(CachedUnknownSuppressionKind, 56);
 assert_cached_type_size!(CachedExport, 136);
 assert_cached_type_size!(CachedImport, 96);
 assert_cached_type_size!(CachedDynamicImport, 88);
-assert_cached_type_size!(CachedRequireCall, 88);
+assert_cached_type_size!(CachedRequireCall, 96);
 assert_cached_type_size!(CachedReExport, 104);
 assert_cached_type_size!(CachedMember, 64);
 assert_cached_type_size!(CachedDynamicImportPattern, 64);
@@ -1471,6 +1473,8 @@ pub struct CachedRequireCall {
     pub(crate) destructured_names: Vec<String>,
     /// Local variable name for namespace requires.
     pub(crate) local_name: Option<String>,
+    /// `true` for the type-erased `import type X = require('...')` spelling.
+    pub(crate) is_type_only: bool,
 }
 
 /// Cached re-export data.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -981,9 +981,12 @@ use crate::MemberKind;
 ///
 /// Bumped to 279 for issue #2365: `import X = require('./x')` now records the
 /// same require call a `const X = require('./x')` declaration records, plus the
-/// namespace binding that narrows `X.member` and the unused-binding verdict for
-/// an unreferenced one. Warm 278 caches hold the module without that require
-/// call, so the target would stay reported as an unused file on upgrade.
+/// namespace binding that narrows `X.member`, its type-space and value-space
+/// binding classification, the unused-binding verdict for an unreferenced
+/// non-exported one, and the whole-object use the exported form
+/// (`export import X = require('./x')`) hands to consumers. Warm 278 caches hold
+/// the module without that require call and without those facts, so the target
+/// would stay reported as an unused file on upgrade.
 pub(super) const CACHE_VERSION: u32 = 279;
 
 /// Duplication token cache version. Bump when duplicate tokenization,

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -978,7 +978,13 @@ use crate::MemberKind;
 /// assignment right-hand side, a return value) is recorded as a whole-object
 /// use. Warm 277 caches hold the narrower record, so the siblings such a
 /// consumer can still reach would stay reported as unused.
-pub(super) const CACHE_VERSION: u32 = 278;
+///
+/// Bumped to 279 for issue #2365: `import X = require('./x')` now records the
+/// same require call a `const X = require('./x')` declaration records, plus the
+/// namespace binding that narrows `X.member` and the unused-binding verdict for
+/// an unreferenced one. Warm 278 caches hold the module without that require
+/// call, so the target would stay reported as an unused file on upgrade.
+pub(super) const CACHE_VERSION: u32 = 279;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -1136,9 +1136,14 @@ pub struct SemanticUsage {
     pub declaration_merges: Vec<fallow_types::extract::DeclarationMergeFact>,
     pub(crate) mock_api_reference_spans: MockApiReferenceSpans,
     pub(crate) module_binding_reference_spans: rustc_hash::FxHashSet<Span>,
+    /// `import X = require('./x')` bindings nothing in the file references.
+    /// Moved into `import_binding_usage.unused` by
+    /// [`compute_semantic_usage_for_extractor`], which is the layer that knows
+    /// which of them the exported form declares.
+    pub(crate) unreferenced_import_equals_bindings: Vec<String>,
     /// `import X = require('./x')` binding names the file also binds somewhere
     /// else. Name-keyed credit for those is unsafe, so the exported form's
-    /// whole-object mark is withdrawn for them.
+    /// whole-object mark is withheld for them.
     pub(crate) shadowed_import_equals_bindings: Vec<String>,
 }
 
@@ -1162,7 +1167,7 @@ pub fn compute_semantic_usage_for_extractor(
     template_used: &rustc_hash::FxHashSet<String>,
 ) -> SemanticUsage {
     let computed_enum_key_spans = extractor.computed_enum_key_reference_spans();
-    let semantic_usage = compute_semantic_usage_with_candidates(
+    let mut semantic_usage = compute_semantic_usage_with_candidates(
         program,
         &extractor.imports,
         &extractor.import_equals_bindings,
@@ -1170,10 +1175,45 @@ pub fn compute_semantic_usage_for_extractor(
         &computed_enum_key_spans,
     );
     extractor.resolve_computed_enum_key_uses(&semantic_usage.module_binding_reference_spans);
-    extractor.drop_shadowed_import_equals_whole_object_uses(
+    extractor.credit_unshadowed_import_equals_whole_object_uses(
         &semantic_usage.shadowed_import_equals_bindings,
     );
+    report_unreferenced_import_equals_bindings(
+        &mut semantic_usage,
+        &extractor.exported_import_equals_names,
+    );
     semantic_usage
+}
+
+/// Move every unreferenced `import X = require('./x')` binding into the unused
+/// import-binding list, except the ones the exported form declares.
+///
+/// TypeScript elides an import-equals binding nothing references, exactly as it
+/// elides an unreferenced `import * as X from './x'`, so such a binding must
+/// not credit the target's exports; leaving it out deleted every unused-export
+/// and unused-type row on the target (issue #2365). The edge itself stays, so
+/// the target is still a reachable file, which is what the namespace-import
+/// twin does.
+///
+/// `export import X = require('./x')` is exempt: the binding is the file's
+/// public API and has no local reference by construction, so it keeps the
+/// whole-object credit issue #2373 gives the `import * as X; export { X }`
+/// twin.
+fn report_unreferenced_import_equals_bindings(
+    semantic_usage: &mut SemanticUsage,
+    exported_import_equals_names: &[String],
+) {
+    let unreferenced = std::mem::take(&mut semantic_usage.unreferenced_import_equals_bindings);
+    if unreferenced.is_empty() {
+        return;
+    }
+    let unused = &mut semantic_usage.import_binding_usage.unused;
+    unused.extend(unreferenced.into_iter().filter(|name| {
+        !exported_import_equals_names
+            .iter()
+            .any(|exported| exported == name)
+    }));
+    unused.sort_unstable();
 }
 
 fn compute_semantic_usage_with_candidates(
@@ -1226,10 +1266,11 @@ fn compute_semantic_usage_with_candidates(
         }
     }
 
-    let shadowed_import_equals_bindings = classify_import_equals_bindings(
+    let import_equals = classify_import_equals_bindings(
         scoping,
         root_scope,
         import_equals_bindings,
+        template_used,
         &mut type_referenced_bindings,
         &mut value_referenced_bindings,
     );
@@ -1277,37 +1318,52 @@ fn compute_semantic_usage_with_candidates(
         declaration_merges,
         mock_api_reference_spans,
         module_binding_reference_spans,
-        shadowed_import_equals_bindings,
+        unreferenced_import_equals_bindings: import_equals.unreferenced,
+        shadowed_import_equals_bindings: import_equals.shadowed,
     }
 }
 
+/// Verdicts [`classify_import_equals_bindings`] reaches per binding name.
+#[derive(Default)]
+struct ImportEqualsClassification {
+    /// Names with no resolved reference anywhere in the file.
+    unreferenced: Vec<String>,
+    /// Names the file binds more than once.
+    shadowed: Vec<String>,
+}
+
 /// Classify `import X = require('./y')` bindings for type and value usage, and
-/// report which of their names the file binds more than once.
+/// report which of their names are unreferenced and which the file binds more
+/// than once.
 ///
 /// The binding lives in both the type and the value namespace, the same way
 /// `import * as X from './y'` does, but the require path records it outside
 /// `imports`, so the caller's `imports` loop never sees it. Without a
 /// type-space entry, `X.SomeType` in an annotation leaves the target's type
-/// exports uncredited (issue #2365). An unreferenced binding is deliberately
-/// left out of the unused-binding list: the require path has never reported
-/// one, and the exported form (`export import X = require('./y')`)
-/// legitimately has no local reference.
+/// exports uncredited (issue #2365).
+///
+/// A name with no resolved reference is returned as unreferenced, the same
+/// verdict the `imports` loop reaches for an unreferenced `import * as X`: the
+/// declaration is erased by TypeScript, so it must not buy the target a
+/// whole-object credit. A name used only by a framework template is referenced,
+/// matching the `template_used` skip the `imports` loop applies.
 ///
 /// A name bound by a second symbol anywhere in the file is returned as
 /// shadowed. `whole_object_uses` is keyed by bare name, so the exported form's
-/// mark has to be withdrawn there: crediting an unrelated same-named binding
-/// as a whole object would silently delete real findings. Only names with a
-/// root binding are considered; one declared inside a namespace or
-/// ambient-module body has no module-flat identity to protect.
+/// mark is withheld there: crediting an unrelated same-named binding as a whole
+/// object would silently delete real findings. Only names with a root binding
+/// are considered; one declared inside a namespace or ambient-module body has
+/// no module-flat identity to protect.
 fn classify_import_equals_bindings(
     scoping: &oxc_semantic::Scoping,
     root_scope: oxc_semantic::ScopeId,
     import_equals_bindings: &[String],
+    template_used: &rustc_hash::FxHashSet<String>,
     type_referenced_bindings: &mut rustc_hash::FxHashSet<String>,
     value_referenced_bindings: &mut rustc_hash::FxHashSet<String>,
-) -> Vec<String> {
+) -> ImportEqualsClassification {
     if import_equals_bindings.is_empty() {
-        return Vec::new();
+        return ImportEqualsClassification::default();
     }
 
     let candidates: rustc_hash::FxHashSet<&str> = import_equals_bindings
@@ -1322,7 +1378,7 @@ fn classify_import_equals_bindings(
         }
     }
 
-    let mut shadowed = Vec::new();
+    let mut classification = ImportEqualsClassification::default();
     for local_name in import_equals_bindings {
         if local_name.is_empty() {
             continue;
@@ -1335,13 +1391,21 @@ fn classify_import_equals_bindings(
             .get(local_name.as_str())
             .is_some_and(|count| *count > 1)
         {
-            shadowed.push(local_name.clone());
+            classification.shadowed.push(local_name.clone());
         }
+        let mut has_references = false;
         let mut has_type_references = false;
         let mut has_value_references = false;
         for reference in scoping.get_resolved_references(symbol_id) {
+            has_references = true;
             has_type_references |= reference.is_type();
             has_value_references |= reference.is_value();
+        }
+        if !has_references {
+            if !template_used.contains(local_name) {
+                classification.unreferenced.push(local_name.clone());
+            }
+            continue;
         }
         if has_type_references {
             type_referenced_bindings.insert(local_name.clone());
@@ -1350,7 +1414,7 @@ fn classify_import_equals_bindings(
             value_referenced_bindings.insert(local_name.clone());
         }
     }
-    shadowed
+    classification
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -1146,6 +1146,7 @@ pub fn compute_semantic_usage(
     compute_semantic_usage_with_candidates(
         program,
         imports,
+        &[],
         template_used,
         &rustc_hash::FxHashSet::default(),
     )
@@ -1160,6 +1161,7 @@ pub fn compute_semantic_usage_for_extractor(
     let semantic_usage = compute_semantic_usage_with_candidates(
         program,
         &extractor.imports,
+        &extractor.import_equals_bindings,
         template_used,
         &computed_enum_key_spans,
     );
@@ -1170,6 +1172,7 @@ pub fn compute_semantic_usage_for_extractor(
 fn compute_semantic_usage_with_candidates(
     program: &Program<'_>,
     imports: &[ImportInfo],
+    import_equals_bindings: &[String],
     template_used: &rustc_hash::FxHashSet<String>,
     module_binding_candidates: &rustc_hash::FxHashSet<Span>,
 ) -> SemanticUsage {
@@ -1213,6 +1216,36 @@ fn compute_semantic_usage_with_candidates(
             if has_value_references {
                 value_referenced_bindings.insert(import.local_name.clone());
             }
+        }
+    }
+
+    // `import X = require('./y')` binds `X` in both the type and the value
+    // namespace, the same way `import * as X from './y'` does, but the require
+    // path records it outside `imports`, so the loop above never sees it.
+    // Classify it here: without a type-space entry `X.SomeType` in an
+    // annotation leaves the target's type exports uncredited (issue #2365). An
+    // unreferenced binding is deliberately kept out of `unused`: the require
+    // path has never reported an unused binding, and the exported form
+    // (`export import X = require('./y')`) legitimately has no local reference.
+    for local_name in import_equals_bindings {
+        if local_name.is_empty() {
+            continue;
+        }
+        let name = oxc_str::Ident::from(local_name.as_str());
+        let Some(symbol_id) = scoping.get_binding(root_scope, name) else {
+            continue;
+        };
+        let mut has_type_references = false;
+        let mut has_value_references = false;
+        for reference in scoping.get_resolved_references(symbol_id) {
+            has_type_references |= reference.is_type();
+            has_value_references |= reference.is_value();
+        }
+        if has_type_references {
+            type_referenced_bindings.insert(local_name.clone());
+        }
+        if has_value_references {
+            value_referenced_bindings.insert(local_name.clone());
         }
     }
 

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -1136,6 +1136,10 @@ pub struct SemanticUsage {
     pub declaration_merges: Vec<fallow_types::extract::DeclarationMergeFact>,
     pub(crate) mock_api_reference_spans: MockApiReferenceSpans,
     pub(crate) module_binding_reference_spans: rustc_hash::FxHashSet<Span>,
+    /// `import X = require('./x')` binding names the file also binds somewhere
+    /// else. Name-keyed credit for those is unsafe, so the exported form's
+    /// whole-object mark is withdrawn for them.
+    pub(crate) shadowed_import_equals_bindings: Vec<String>,
 }
 
 pub fn compute_semantic_usage(
@@ -1166,6 +1170,9 @@ pub fn compute_semantic_usage_for_extractor(
         &computed_enum_key_spans,
     );
     extractor.resolve_computed_enum_key_uses(&semantic_usage.module_binding_reference_spans);
+    extractor.drop_shadowed_import_equals_whole_object_uses(
+        &semantic_usage.shadowed_import_equals_bindings,
+    );
     semantic_usage
 }
 
@@ -1219,35 +1226,13 @@ fn compute_semantic_usage_with_candidates(
         }
     }
 
-    // `import X = require('./y')` binds `X` in both the type and the value
-    // namespace, the same way `import * as X from './y'` does, but the require
-    // path records it outside `imports`, so the loop above never sees it.
-    // Classify it here: without a type-space entry `X.SomeType` in an
-    // annotation leaves the target's type exports uncredited (issue #2365). An
-    // unreferenced binding is deliberately kept out of `unused`: the require
-    // path has never reported an unused binding, and the exported form
-    // (`export import X = require('./y')`) legitimately has no local reference.
-    for local_name in import_equals_bindings {
-        if local_name.is_empty() {
-            continue;
-        }
-        let name = oxc_str::Ident::from(local_name.as_str());
-        let Some(symbol_id) = scoping.get_binding(root_scope, name) else {
-            continue;
-        };
-        let mut has_type_references = false;
-        let mut has_value_references = false;
-        for reference in scoping.get_resolved_references(symbol_id) {
-            has_type_references |= reference.is_type();
-            has_value_references |= reference.is_value();
-        }
-        if has_type_references {
-            type_referenced_bindings.insert(local_name.clone());
-        }
-        if has_value_references {
-            value_referenced_bindings.insert(local_name.clone());
-        }
-    }
+    let shadowed_import_equals_bindings = classify_import_equals_bindings(
+        scoping,
+        root_scope,
+        import_equals_bindings,
+        &mut type_referenced_bindings,
+        &mut value_referenced_bindings,
+    );
 
     unused.sort_unstable();
 
@@ -1292,7 +1277,80 @@ fn compute_semantic_usage_with_candidates(
         declaration_merges,
         mock_api_reference_spans,
         module_binding_reference_spans,
+        shadowed_import_equals_bindings,
     }
+}
+
+/// Classify `import X = require('./y')` bindings for type and value usage, and
+/// report which of their names the file binds more than once.
+///
+/// The binding lives in both the type and the value namespace, the same way
+/// `import * as X from './y'` does, but the require path records it outside
+/// `imports`, so the caller's `imports` loop never sees it. Without a
+/// type-space entry, `X.SomeType` in an annotation leaves the target's type
+/// exports uncredited (issue #2365). An unreferenced binding is deliberately
+/// left out of the unused-binding list: the require path has never reported
+/// one, and the exported form (`export import X = require('./y')`)
+/// legitimately has no local reference.
+///
+/// A name bound by a second symbol anywhere in the file is returned as
+/// shadowed. `whole_object_uses` is keyed by bare name, so the exported form's
+/// mark has to be withdrawn there: crediting an unrelated same-named binding
+/// as a whole object would silently delete real findings. Only names with a
+/// root binding are considered; one declared inside a namespace or
+/// ambient-module body has no module-flat identity to protect.
+fn classify_import_equals_bindings(
+    scoping: &oxc_semantic::Scoping,
+    root_scope: oxc_semantic::ScopeId,
+    import_equals_bindings: &[String],
+    type_referenced_bindings: &mut rustc_hash::FxHashSet<String>,
+    value_referenced_bindings: &mut rustc_hash::FxHashSet<String>,
+) -> Vec<String> {
+    if import_equals_bindings.is_empty() {
+        return Vec::new();
+    }
+
+    let candidates: rustc_hash::FxHashSet<&str> = import_equals_bindings
+        .iter()
+        .map(String::as_str)
+        .filter(|name| !name.is_empty())
+        .collect();
+    let mut name_counts: rustc_hash::FxHashMap<&str, usize> = rustc_hash::FxHashMap::default();
+    for symbol_id in scoping.symbol_ids() {
+        if let Some(name) = candidates.get(scoping.symbol_name(symbol_id)) {
+            *name_counts.entry(*name).or_default() += 1;
+        }
+    }
+
+    let mut shadowed = Vec::new();
+    for local_name in import_equals_bindings {
+        if local_name.is_empty() {
+            continue;
+        }
+        let name = oxc_str::Ident::from(local_name.as_str());
+        let Some(symbol_id) = scoping.get_binding(root_scope, name) else {
+            continue;
+        };
+        if name_counts
+            .get(local_name.as_str())
+            .is_some_and(|count| *count > 1)
+        {
+            shadowed.push(local_name.clone());
+        }
+        let mut has_type_references = false;
+        let mut has_value_references = false;
+        for reference in scoping.get_resolved_references(symbol_id) {
+            has_type_references |= reference.is_type();
+            has_value_references |= reference.is_value();
+        }
+        if has_type_references {
+            type_referenced_bindings.insert(local_name.clone());
+        }
+        if has_value_references {
+            value_referenced_bindings.insert(local_name.clone());
+        }
+    }
+    shadowed
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -1141,24 +1141,6 @@ pub struct SemanticUsage {
     /// [`compute_semantic_usage_for_extractor`], which is the layer that knows
     /// which of them the exported form declares.
     pub(crate) unreferenced_import_equals_bindings: Vec<String>,
-    /// `import X = require('./x')` binding names the file also binds somewhere
-    /// else. Name-keyed credit for those is unsafe, so the exported form's
-    /// whole-object mark is withheld for them.
-    pub(crate) shadowed_import_equals_bindings: Vec<String>,
-}
-
-pub fn compute_semantic_usage(
-    program: &Program<'_>,
-    imports: &[ImportInfo],
-    template_used: &rustc_hash::FxHashSet<String>,
-) -> SemanticUsage {
-    compute_semantic_usage_with_candidates(
-        program,
-        imports,
-        &[],
-        template_used,
-        &rustc_hash::FxHashSet::default(),
-    )
 }
 
 pub fn compute_semantic_usage_for_extractor(
@@ -1175,9 +1157,6 @@ pub fn compute_semantic_usage_for_extractor(
         &computed_enum_key_spans,
     );
     extractor.resolve_computed_enum_key_uses(&semantic_usage.module_binding_reference_spans);
-    extractor.credit_unshadowed_import_equals_whole_object_uses(
-        &semantic_usage.shadowed_import_equals_bindings,
-    );
     report_unreferenced_import_equals_bindings(
         &mut semantic_usage,
         &extractor.exported_import_equals_names,
@@ -1213,7 +1192,11 @@ fn report_unreferenced_import_equals_bindings(
             .iter()
             .any(|exported| exported == name)
     }));
+    // One name, one row: the same binding name reaches this list twice when a
+    // file declares it both at root and inside a namespace body, and the graph
+    // reads membership rather than a count.
     unused.sort_unstable();
+    unused.dedup();
 }
 
 fn compute_semantic_usage_with_candidates(
@@ -1319,7 +1302,6 @@ fn compute_semantic_usage_with_candidates(
         mock_api_reference_spans,
         module_binding_reference_spans,
         unreferenced_import_equals_bindings: import_equals.unreferenced,
-        shadowed_import_equals_bindings: import_equals.shadowed,
     }
 }
 
@@ -1328,13 +1310,10 @@ fn compute_semantic_usage_with_candidates(
 struct ImportEqualsClassification {
     /// Names with no resolved reference anywhere in the file.
     unreferenced: Vec<String>,
-    /// Names the file binds more than once.
-    shadowed: Vec<String>,
 }
 
-/// Classify `import X = require('./y')` bindings for type and value usage, and
-/// report which of their names are unreferenced and which the file binds more
-/// than once.
+/// Classify `import X = require('./y')` bindings for type and value usage and
+/// report which of their names nothing in the file references.
 ///
 /// The binding lives in both the type and the value namespace, the same way
 /// `import * as X from './y'` does, but the require path records it outside
@@ -1348,12 +1327,10 @@ struct ImportEqualsClassification {
 /// whole-object credit. A name used only by a framework template is referenced,
 /// matching the `template_used` skip the `imports` loop applies.
 ///
-/// A name bound by a second symbol anywhere in the file is returned as
-/// shadowed. `whole_object_uses` is keyed by bare name, so the exported form's
-/// mark is withheld there: crediting an unrelated same-named binding as a whole
-/// object would silently delete real findings. Only names with a root binding
-/// are considered; one declared inside a namespace or ambient-module body has
-/// no module-flat identity to protect.
+/// Only names with a root binding are classified, the same restriction the
+/// `imports` loop next to it has: one declared inside a namespace or
+/// ambient-module body is left value-only, exactly as an `import * as X`
+/// binding in that position is.
 fn classify_import_equals_bindings(
     scoping: &oxc_semantic::Scoping,
     root_scope: oxc_semantic::ScopeId,
@@ -1366,18 +1343,6 @@ fn classify_import_equals_bindings(
         return ImportEqualsClassification::default();
     }
 
-    let candidates: rustc_hash::FxHashSet<&str> = import_equals_bindings
-        .iter()
-        .map(String::as_str)
-        .filter(|name| !name.is_empty())
-        .collect();
-    let mut name_counts: rustc_hash::FxHashMap<&str, usize> = rustc_hash::FxHashMap::default();
-    for symbol_id in scoping.symbol_ids() {
-        if let Some(name) = candidates.get(scoping.symbol_name(symbol_id)) {
-            *name_counts.entry(*name).or_default() += 1;
-        }
-    }
-
     let mut classification = ImportEqualsClassification::default();
     for local_name in import_equals_bindings {
         if local_name.is_empty() {
@@ -1387,12 +1352,6 @@ fn classify_import_equals_bindings(
         let Some(symbol_id) = scoping.get_binding(root_scope, name) else {
             continue;
         };
-        if name_counts
-            .get(local_name.as_str())
-            .is_some_and(|count| *count > 1)
-        {
-            classification.shadowed.push(local_name.clone());
-        }
         let mut has_references = false;
         let mut has_type_references = false;
         let mut has_value_references = false;
@@ -1616,12 +1575,30 @@ fn compute_auto_import_candidates_from_semantic(scoping: &oxc_semantic::Scoping)
 /// references. A value import used only as a type annotation (`const x: Foo`)
 /// will have a type-position reference and will NOT appear in the unused list.
 /// This is correct: `import { Foo }` (without `type`) may be needed at runtime.
+///
+/// `import_equals_bindings` carries the `import X = require('./x')` locals the
+/// extractor collected for the same program. They live outside `imports`, so
+/// without them the require-derived lane would be absent on this path and such
+/// a binding would keep crediting its target on a script the caller re-parses
+/// (a Vue `generic="..."` block). Pass `&[]` when the program has none.
 pub fn compute_import_binding_usage(
     program: &Program<'_>,
     imports: &[ImportInfo],
+    import_equals_bindings: &[String],
     template_used: &rustc_hash::FxHashSet<String>,
 ) -> ImportBindingUsage {
-    compute_semantic_usage(program, imports, template_used).import_binding_usage
+    let mut semantic_usage = compute_semantic_usage_with_candidates(
+        program,
+        imports,
+        import_equals_bindings,
+        template_used,
+        &rustc_hash::FxHashSet::default(),
+    );
+    // The exported form is exempt, exactly as it is on the extractor path, but
+    // `export import X = require('./x')` is not a `<script setup>` spelling: no
+    // name is exempted here.
+    report_unreferenced_import_equals_bindings(&mut semantic_usage, &[]);
+    semantic_usage.import_binding_usage
 }
 
 #[cfg(test)]

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -604,7 +604,13 @@ fn merge_script_into_module(input: &mut SfcScriptMergeInput<'_>) {
     extractor.remap_spans_with(|span| extraction.remap_span(span));
     extractor.resolve_typed_destructure_bindings();
 
-    merge_script_binding_usage(input, &allocator, &extractor.imports, semantic_usage);
+    merge_script_binding_usage(
+        input,
+        &allocator,
+        &extractor.imports,
+        &extractor.import_equals_bindings,
+        semantic_usage,
+    );
     if input.need_complexity {
         input
             .combined
@@ -654,10 +660,17 @@ fn merge_script_into_module(input: &mut SfcScriptMergeInput<'_>) {
 /// value-referenced) plus auto-import candidates into `combined`. A
 /// `generic="..."` attribute re-parses an augmented body so a type-only import
 /// consumed solely inside the constraint stays classified as type-referenced.
+///
+/// The re-parse recomputes the whole verdict, so it is handed the
+/// `import X = require('./x')` locals as well: those live outside `imports`,
+/// and without them such a binding would keep crediting its target on a
+/// `generic="..."` script while the plain `<script setup>` next to it reports
+/// (issue #2365).
 fn merge_script_binding_usage(
     input: &mut SfcScriptMergeInput<'_>,
     allocator: &Allocator,
     imports: &[ImportInfo],
+    import_equals_bindings: &[String],
     semantic_usage: crate::parse::SemanticUsage,
 ) {
     let augmented_body = build_generic_attr_probe_source(input.script);
@@ -667,7 +680,12 @@ fn merge_script_binding_usage(
         let augmented_return =
             Parser::new(allocator, augmented, source_type_for_script(input.script)).parse();
         (
-            compute_import_binding_usage(&augmented_return.program, imports, &empty_template_used),
+            compute_import_binding_usage(
+                &augmented_return.program,
+                imports,
+                import_equals_bindings,
+                &empty_template_used,
+            ),
             semantic_usage.auto_import_candidates,
         )
     } else {

--- a/crates/extract/src/sfc_props.rs
+++ b/crates/extract/src/sfc_props.rs
@@ -508,7 +508,7 @@ fn bind_define_props_target(
 
 /// Resolve which of the destructured prop locals have at least one resolved
 /// reference in the program (via `oxc_semantic`), mirroring the import-binding
-/// usage check in `parse.rs::compute_semantic_usage`.
+/// usage check in `parse.rs::compute_semantic_usage_with_candidates`.
 fn resolve_used_locals(
     program: &Program<'_>,
     destructured_locals: &FxHashSet<String>,

--- a/crates/extract/src/tests/js_ts/cjs.rs
+++ b/crates/extract/src/tests/js_ts/cjs.rs
@@ -167,15 +167,46 @@ fn import_equals_require_records_member_accesses_through_the_binding() {
     );
 }
 
-/// `export import X = require('./y')` inside a namespace body is still an
-/// import of `./y`.
+/// A `declare module '...'` body is the only context outside file scope where
+/// TypeScript accepts `export import X = require('...')`. The edge is recorded
+/// there too, so the package is not a false unused dependency.
 #[test]
-fn export_import_equals_require_inside_a_namespace_records_the_require_call() {
-    let info =
-        parse_source("export namespace Outer {\n  export import Inner = require('./inner');\n}");
+fn export_import_equals_require_inside_an_ambient_module_records_the_require_call() {
+    let info = parse_source(
+        "declare module 'virtual:api' {\n  export import Inner = require('inner-pkg');\n}",
+    );
     assert_eq!(info.require_calls.len(), 1);
-    assert_eq!(info.require_calls[0].source, "./inner");
+    assert_eq!(info.require_calls[0].source, "inner-pkg");
     assert_eq!(info.require_calls[0].local_name.as_deref(), Some("Inner"));
+}
+
+/// `import type X = require('pkg')` is the one require spelling TypeScript
+/// erases: the emitted JavaScript holds no `require` call, so the edge is
+/// type-only and dependency classification must not read it as runtime usage.
+/// The unerased spelling next to it stays a runtime require.
+#[test]
+fn import_type_equals_require_records_a_type_only_require_call() {
+    let erased = parse_source("import type T = require('pkg');\nexport type Alias = T.Shape;");
+    assert_eq!(erased.require_calls.len(), 1);
+    assert_eq!(erased.require_calls[0].source, "pkg");
+    assert!(
+        erased.require_calls[0].is_type_only,
+        "`import type X = require(...)` emits no require call at runtime"
+    );
+
+    let runtime = parse_source("import T = require('pkg');\nconsole.log(T.value);");
+    assert_eq!(runtime.require_calls.len(), 1);
+    assert!(
+        !runtime.require_calls[0].is_type_only,
+        "`import X = require(...)` does emit a require call"
+    );
+
+    let variable = parse_source("const T = require('pkg');\nconsole.log(T.value);");
+    assert_eq!(variable.require_calls.len(), 1);
+    assert!(
+        !variable.require_calls[0].is_type_only,
+        "`const X = require(...)` has no type-only spelling"
+    );
 }
 
 /// Deliberate negative control: `import X = Some.Namespace` names an entity
@@ -264,10 +295,9 @@ fn import_equals_require_never_reports_an_unused_import_binding() {
     );
 }
 
-/// `export import X = require('./x')` hands the module object to consumers the
-/// graph cannot enumerate, so the binding is recorded as a whole-object use and
-/// every export of the target keeps its credit. Both the file-level form and
-/// the exported-namespace-body form record it.
+/// `export import X = require('./x')` at file level hands the module object to
+/// consumers the graph cannot enumerate, so the binding is recorded as a
+/// whole-object use and every export of the target keeps its credit.
 #[test]
 fn export_import_equals_require_records_a_whole_object_use() {
     let file_level = parse_source("export import Users = require('./users');");
@@ -279,22 +309,31 @@ fn export_import_equals_require_records_a_whole_object_use() {
         "file-level whole-object uses: {:?}",
         file_level.whole_object_uses
     );
+}
 
-    let in_namespace =
+/// Lenient-parse pin, deliberately non-compiling input: TypeScript rejects
+/// `export import X = require('...')` inside a namespace body with TS1147, so
+/// no compiling project reaches this arm. fallow parses leniently and still
+/// has to behave, which is what this pins. The valid spellings are covered by
+/// the file-level and ambient-module tests above.
+#[test]
+fn export_import_equals_inside_a_namespace_body_is_a_lenient_parse_pin() {
+    let info =
         parse_source("export namespace Outer {\n  export import Inner = require('./inner');\n}");
+    assert_eq!(info.require_calls.len(), 1);
+    assert_eq!(info.require_calls[0].source, "./inner");
+    assert_eq!(info.require_calls[0].local_name.as_deref(), Some("Inner"));
     assert!(
-        in_namespace
-            .whole_object_uses
-            .iter()
-            .any(|name| name == "Inner"),
+        info.whole_object_uses.iter().any(|name| name == "Inner"),
         "namespace-body whole-object uses: {:?}",
-        in_namespace.whole_object_uses
+        info.whole_object_uses
     );
 }
 
 /// Deliberate negative controls for the whole-object mark: an unexported
-/// binding is narrowable through its member accesses, and the entity-name form
-/// is a local alias with no module object behind it.
+/// binding is narrowable through its member accesses, a binding inside a
+/// `declare module` body augments that module rather than this file's public
+/// API, and the entity-name form is a local alias with no module object.
 #[test]
 fn import_equals_without_export_records_no_whole_object_use() {
     let plain = parse_source("import Users = require('./users');\nconsole.log(Users.alpha);");
@@ -304,16 +343,13 @@ fn import_equals_without_export_records_no_whole_object_use() {
         plain.whole_object_uses
     );
 
-    let local_namespace = parse_source(
-        "namespace Local {\n  export import Inner = require('./inner');\n}\nconsole.log(Local);",
+    let ambient = parse_source(
+        "declare module 'virtual:api' {\n  export import Inner = require('inner-pkg');\n}",
     );
     assert!(
-        !local_namespace
-            .whole_object_uses
-            .iter()
-            .any(|name| name == "Inner"),
-        "a binding inside an unexported namespace is not public API: {:?}",
-        local_namespace.whole_object_uses
+        ambient.whole_object_uses.is_empty(),
+        "an ambient-module member is not this file's public API: {:?}",
+        ambient.whole_object_uses
     );
 
     let entity_name = parse_source(
@@ -323,5 +359,40 @@ fn import_equals_without_export_records_no_whole_object_use() {
         entity_name.whole_object_uses.is_empty(),
         "an entity-name alias has no module object: {:?}",
         entity_name.whole_object_uses
+    );
+}
+
+/// `whole_object_uses` is keyed by bare name, so the mark is only safe while
+/// the name resolves to the one binding. A same-named local in another scope
+/// would otherwise be read as a whole-object use and credit every member of
+/// whatever it holds, deleting real findings.
+#[test]
+fn export_import_equals_whole_object_use_is_withdrawn_when_the_name_is_shadowed() {
+    let shadowed = parse_source(
+        "export import Session = require('./beta');\nexport const run = (): void => {\n  const \
+         Session = makeSession();\n  Session.start();\n};\n",
+    );
+    assert!(
+        !shadowed
+            .whole_object_uses
+            .iter()
+            .any(|name| name == "Session"),
+        "a shadowed name cannot carry a bare-name whole-object mark: {:?}",
+        shadowed.whole_object_uses
+    );
+
+    // Positive control: the identical declaration keeps its mark when nothing
+    // else in the file binds the name.
+    let unshadowed = parse_source(
+        "export import Session = require('./beta');\nexport const run = (): void => {\n  const \
+         local = makeSession();\n  local.start();\n};\n",
+    );
+    assert!(
+        unshadowed
+            .whole_object_uses
+            .iter()
+            .any(|name| name == "Session"),
+        "an unshadowed name keeps its mark: {:?}",
+        unshadowed.whole_object_uses
     );
 }

--- a/crates/extract/src/tests/js_ts/cjs.rs
+++ b/crates/extract/src/tests/js_ts/cjs.rs
@@ -198,3 +198,130 @@ fn import_equals_entity_name_records_no_require_call() {
         info.imports
     );
 }
+
+/// The binding lives in both the type and the value namespace, exactly like an
+/// `import * as X` namespace import. The graph reads these two vectors to
+/// decide which namespaces a member access credits, so a binding used in a type
+/// annotation has to land in `type_referenced_import_bindings`.
+#[test]
+fn import_equals_require_classifies_type_and_value_usage() {
+    let info = parse_source(
+        "import T = require('./t');\nconsole.log(T.val);\nexport const f = (v: T.Shape): number => \
+         v.n;",
+    );
+    assert!(
+        info.type_referenced_import_bindings
+            .iter()
+            .any(|binding| binding == "T"),
+        "`T.Shape` in an annotation is a type reference: {:?}",
+        info.type_referenced_import_bindings
+    );
+    assert!(
+        info.value_referenced_import_bindings
+            .iter()
+            .any(|binding| binding == "T"),
+        "`T.val` in an expression is a value reference: {:?}",
+        info.value_referenced_import_bindings
+    );
+}
+
+/// A binding used only in type position credits type space alone, so the value
+/// exports of the target stay narrowable.
+#[test]
+fn import_equals_require_used_only_in_type_position_stays_out_of_value_space() {
+    let info =
+        parse_source("import T = require('./t');\nexport const f = (v: T.Shape): number => v.n;");
+    assert!(
+        info.type_referenced_import_bindings
+            .iter()
+            .any(|binding| binding == "T"),
+        "type usage: {:?}",
+        info.type_referenced_import_bindings
+    );
+    assert!(
+        !info
+            .value_referenced_import_bindings
+            .iter()
+            .any(|binding| binding == "T"),
+        "no expression reads the binding: {:?}",
+        info.value_referenced_import_bindings
+    );
+}
+
+/// An unreferenced import-equals binding is never reported as an unused import
+/// binding: the require path has never done that, and the exported form
+/// legitimately has no local reference.
+#[test]
+fn import_equals_require_never_reports_an_unused_import_binding() {
+    let info = parse_source("import Unused = require('./unused');");
+    assert!(
+        !info
+            .unused_import_bindings
+            .iter()
+            .any(|binding| binding == "Unused"),
+        "unused import bindings: {:?}",
+        info.unused_import_bindings
+    );
+}
+
+/// `export import X = require('./x')` hands the module object to consumers the
+/// graph cannot enumerate, so the binding is recorded as a whole-object use and
+/// every export of the target keeps its credit. Both the file-level form and
+/// the exported-namespace-body form record it.
+#[test]
+fn export_import_equals_require_records_a_whole_object_use() {
+    let file_level = parse_source("export import Users = require('./users');");
+    assert!(
+        file_level
+            .whole_object_uses
+            .iter()
+            .any(|name| name == "Users"),
+        "file-level whole-object uses: {:?}",
+        file_level.whole_object_uses
+    );
+
+    let in_namespace =
+        parse_source("export namespace Outer {\n  export import Inner = require('./inner');\n}");
+    assert!(
+        in_namespace
+            .whole_object_uses
+            .iter()
+            .any(|name| name == "Inner"),
+        "namespace-body whole-object uses: {:?}",
+        in_namespace.whole_object_uses
+    );
+}
+
+/// Deliberate negative controls for the whole-object mark: an unexported
+/// binding is narrowable through its member accesses, and the entity-name form
+/// is a local alias with no module object behind it.
+#[test]
+fn import_equals_without_export_records_no_whole_object_use() {
+    let plain = parse_source("import Users = require('./users');\nconsole.log(Users.alpha);");
+    assert!(
+        plain.whole_object_uses.is_empty(),
+        "an unexported binding stays narrowable: {:?}",
+        plain.whole_object_uses
+    );
+
+    let local_namespace = parse_source(
+        "namespace Local {\n  export import Inner = require('./inner');\n}\nconsole.log(Local);",
+    );
+    assert!(
+        !local_namespace
+            .whole_object_uses
+            .iter()
+            .any(|name| name == "Inner"),
+        "a binding inside an unexported namespace is not public API: {:?}",
+        local_namespace.whole_object_uses
+    );
+
+    let entity_name = parse_source(
+        "namespace Shapes {\n  export const box = 1;\n}\nexport import Alias = Shapes;",
+    );
+    assert!(
+        entity_name.whole_object_uses.is_empty(),
+        "an entity-name alias has no module object: {:?}",
+        entity_name.whole_object_uses
+    );
+}

--- a/crates/extract/src/tests/js_ts/cjs.rs
+++ b/crates/extract/src/tests/js_ts/cjs.rs
@@ -117,3 +117,84 @@ fn require_with_non_require_callee_not_captured() {
         "Only functions named 'require' should be captured"
     );
 }
+
+/// Issue #2365: `import X = require('./y')` is the TypeScript spelling of a
+/// CommonJS require binding and records the same require call as
+/// `const X = require('./y')`.
+#[test]
+fn import_equals_require_records_a_non_destructured_require_call() {
+    let info = parse_source("import Assigned = require('./assigned');");
+    assert_eq!(info.require_calls.len(), 1);
+    assert_eq!(info.require_calls[0].source, "./assigned");
+    assert_eq!(
+        info.require_calls[0].local_name.as_deref(),
+        Some("Assigned")
+    );
+    assert!(info.require_calls[0].destructured_names.is_empty());
+}
+
+/// The specifier span anchors the `unresolved-import` squiggly under `'./y'`
+/// rather than under the whole declaration.
+#[test]
+fn import_equals_require_anchors_the_specifier_span() {
+    let source = "import Assigned = require('./assigned');";
+    let info = parse_source(source);
+    assert_eq!(info.require_calls.len(), 1);
+    let call = &info.require_calls[0];
+    assert_eq!(
+        &source[call.source_span.start as usize..call.source_span.end as usize],
+        "'./assigned'"
+    );
+    assert_eq!(
+        &source[call.span.start as usize..call.span.end as usize],
+        "require('./assigned')"
+    );
+}
+
+/// `X.member` narrows the target's exports the way a namespace import does, so
+/// the member access and the binding name both have to be recorded.
+#[test]
+fn import_equals_require_records_member_accesses_through_the_binding() {
+    let info = parse_source(
+        "import Assigned = require('./assigned');\nconsole.log(Assigned.viaAssignment);",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Assigned" && access.member == "viaAssignment"),
+        "member accesses: {:?}",
+        info.member_accesses
+    );
+}
+
+/// `export import X = require('./y')` inside a namespace body is still an
+/// import of `./y`.
+#[test]
+fn export_import_equals_require_inside_a_namespace_records_the_require_call() {
+    let info =
+        parse_source("export namespace Outer {\n  export import Inner = require('./inner');\n}");
+    assert_eq!(info.require_calls.len(), 1);
+    assert_eq!(info.require_calls[0].source, "./inner");
+    assert_eq!(info.require_calls[0].local_name.as_deref(), Some("Inner"));
+}
+
+/// Deliberate negative control: `import X = Some.Namespace` names an entity
+/// declared in this file, not a module, so it stays a local alias and records
+/// no edge.
+#[test]
+fn import_equals_entity_name_records_no_require_call() {
+    let info = parse_source(
+        "namespace Some {\n  export namespace Nested {\n    export const value = 1;\n  }\n}\nimport \
+         Alias = Some;\nimport Deep = Some.Nested;",
+    );
+    assert!(
+        info.require_calls.is_empty(),
+        "an entity-name import-equals is a local alias: {:?}",
+        info.require_calls
+    );
+    assert!(
+        info.imports.is_empty(),
+        "an entity-name import-equals records no import: {:?}",
+        info.imports
+    );
+}

--- a/crates/extract/src/tests/js_ts/cjs.rs
+++ b/crates/extract/src/tests/js_ts/cjs.rs
@@ -368,8 +368,10 @@ fn export_import_equals_require_records_a_whole_object_use() {
 /// Lenient-parse pin, deliberately non-compiling input: TypeScript rejects
 /// `export import X = require('...')` inside a namespace body with TS1147, so
 /// no compiling project reaches this arm. fallow parses leniently and still
-/// has to behave, which is what this pins. The valid spellings are covered by
-/// the file-level and ambient-module tests above.
+/// has to behave, which is what this pins: the edge is recorded and the
+/// binding is credited, the same conservative direction the file-level form
+/// takes. The valid spellings are covered by the file-level and
+/// ambient-module tests above.
 #[test]
 fn export_import_equals_inside_a_namespace_body_is_a_lenient_parse_pin() {
     let info =
@@ -416,27 +418,31 @@ fn import_equals_without_export_records_no_whole_object_use() {
     );
 }
 
-/// `whole_object_uses` is keyed by bare name, so the mark is only safe while
-/// the name resolves to the one binding. A same-named local in another scope
-/// would otherwise be read as a whole-object use and credit every member of
-/// whatever it holds, deleting real findings.
+/// The mark is granted whatever else the file binds under that name. A
+/// same-named local in a nested scope is not a reason to withhold it: the
+/// `import * as X; export { X }` twin has no such condition, and withholding
+/// reported every export of the real target as an auto-fixable unused export.
+///
+/// The twin carries no whole-object mark of its own here, so the two extraction
+/// records differ; the target credit does not, because `export { X }` puts the
+/// twin's binding on mark-all through the graph's re-export test instead
+/// (issue #2373). `a_shadowed_export_import_equals_keeps_the_targets_credit` in
+/// the integration suite pins that the two report identically end to end.
 #[test]
-fn export_import_equals_whole_object_use_is_withheld_when_the_name_is_shadowed() {
+fn export_import_equals_whole_object_use_survives_a_shadowed_name() {
     let shadowed = parse_source(
         "export import Session = require('./beta');\nexport const run = (): void => {\n  const \
          Session = makeSession();\n  Session.start();\n};\n",
     );
     assert!(
-        !shadowed
+        shadowed
             .whole_object_uses
             .iter()
             .any(|name| name == "Session"),
-        "a shadowed name cannot carry a bare-name whole-object mark: {:?}",
+        "a shadowed name keeps the mark the exported form earns: {:?}",
         shadowed.whole_object_uses
     );
 
-    // Positive control: the identical declaration keeps its mark when nothing
-    // else in the file binds the name.
     let unshadowed = parse_source(
         "export import Session = require('./beta');\nexport const run = (): void => {\n  const \
          local = makeSession();\n  local.start();\n};\n",
@@ -449,12 +455,26 @@ fn export_import_equals_whole_object_use_is_withheld_when_the_name_is_shadowed()
         "an unshadowed name keeps its mark: {:?}",
         unshadowed.whole_object_uses
     );
+
+    // One name yields one entry whether or not it is shadowed, so the grant
+    // never stacks a second copy on the genuine one (issue #2377).
+    assert_eq!(
+        shadowed
+            .whole_object_uses
+            .iter()
+            .filter(|name| *name == "Session")
+            .count(),
+        1,
+        "whole-object uses: {:?}",
+        shadowed.whole_object_uses
+    );
 }
 
-/// The mark the exported form earns is granted after the semantic pass, never
-/// pushed and then withdrawn, so a whole-object use the file genuinely wrote
-/// survives a shadowed name. Withdrawing by name deleted it and turned every
-/// export of the target into a false `unused-export` row.
+/// A whole-object use the file genuinely wrote survives a shadowed name, and
+/// the record matches the `import * as X; export { X }` twin exactly: both
+/// hold the one `Object.values(X)` entry. An earlier revision withdrew the
+/// exported form's mark by name, which deleted the genuine entry with it and
+/// turned every export of the target into a false `unused-export` row.
 #[test]
 fn a_genuine_whole_object_use_survives_a_shadowed_export_import_equals() {
     let source = "export import Config = require('./config');\nexport const read = (): number => \
@@ -476,19 +496,6 @@ fn a_genuine_whole_object_use_survives_a_shadowed_export_import_equals() {
         shadowed.whole_object_uses.to_vec(),
         esm_twin.whole_object_uses.to_vec(),
         "the namespace-import twin records the same whole-object uses"
-    );
-
-    // One name yields one entry: the granted mark deduplicates against the
-    // genuine one rather than stacking a second copy (issue #2377).
-    assert_eq!(
-        shadowed
-            .whole_object_uses
-            .iter()
-            .filter(|n| *n == "Config")
-            .count(),
-        1,
-        "whole-object uses: {:?}",
-        shadowed.whole_object_uses
     );
 }
 
@@ -524,5 +531,26 @@ fn a_bare_import_equals_reference_is_a_whole_object_use() {
         dotted.whole_object_uses.is_empty(),
         "a resolved member access is not a handover: {:?}",
         dotted.whole_object_uses
+    );
+}
+
+/// One name yields one unused-import-binding row. A file that declares the
+/// same name at root and inside a namespace body pushes two entries into the
+/// candidate list, both resolving to the one root binding, and the graph reads
+/// membership rather than a count.
+#[test]
+fn a_repeated_import_equals_name_reports_one_unused_import_binding() {
+    let info = parse_source(
+        "import Dup = require('./dup');\nexport namespace Outer {\n  import Dup = \
+         require('./dup-inner');\n}\nexport const other = 1;",
+    );
+    assert_eq!(
+        info.unused_import_bindings
+            .iter()
+            .filter(|binding| *binding == "Dup")
+            .count(),
+        1,
+        "unused import bindings: {:?}",
+        info.unused_import_bindings
     );
 }

--- a/crates/extract/src/tests/js_ts/cjs.rs
+++ b/crates/extract/src/tests/js_ts/cjs.rs
@@ -279,19 +279,73 @@ fn import_equals_require_used_only_in_type_position_stays_out_of_value_space() {
     );
 }
 
-/// An unreferenced import-equals binding is never reported as an unused import
-/// binding: the require path has never done that, and the exported form
-/// legitimately has no local reference.
+/// An unreferenced import-equals binding is an unused import binding, exactly
+/// as the `import * as X` spelling of the same binding is. TypeScript elides
+/// both, so neither may buy the target a whole-object credit: crediting one
+/// deleted every unused-export and unused-type row on the target.
 #[test]
-fn import_equals_require_never_reports_an_unused_import_binding() {
-    let info = parse_source("import Unused = require('./unused');");
+fn unreferenced_import_equals_reports_an_unused_import_binding() {
+    let info = parse_source("import Unused = require('./unused');\nexport const other = 1;");
     assert!(
-        !info
-            .unused_import_bindings
+        info.unused_import_bindings
             .iter()
             .any(|binding| binding == "Unused"),
         "unused import bindings: {:?}",
         info.unused_import_bindings
+    );
+
+    let esm_twin = parse_source("import * as Unused from './unused';\nexport const other = 1;");
+    assert_eq!(
+        info.unused_import_bindings, esm_twin.unused_import_bindings,
+        "the namespace-import twin reports the same way"
+    );
+
+    // The erased spelling is elided just as completely, and its twin is
+    // `import type * as X`.
+    let type_only =
+        parse_source("import type Unused = require('./unused');\nexport const other = 1;");
+    let type_only_esm_twin =
+        parse_source("import type * as Unused from './unused';\nexport const other = 1;");
+    assert_eq!(
+        type_only.unused_import_bindings, type_only_esm_twin.unused_import_bindings,
+        "the type-only namespace-import twin reports the same way"
+    );
+    assert!(
+        type_only
+            .unused_import_bindings
+            .iter()
+            .any(|binding| binding == "Unused"),
+        "unused import bindings: {:?}",
+        type_only.unused_import_bindings
+    );
+
+    // Positive control: a binding anything references is not reported, so the
+    // assertion above is not passing because every binding lands there.
+    let referenced = parse_source("import Used = require('./used');\nconsole.log(Used.alpha);");
+    assert!(
+        referenced.unused_import_bindings.is_empty(),
+        "a referenced binding is not unused: {:?}",
+        referenced.unused_import_bindings
+    );
+}
+
+/// `export import X = require('./x')` is exempt: the binding is the file's
+/// public API and has no local reference by construction, so reporting it
+/// unused would withdraw the whole-object credit issue #2373 gives its
+/// `import * as X; export { X }` twin.
+#[test]
+fn exported_import_equals_is_not_an_unused_import_binding() {
+    let info = parse_source("export import Users = require('./users');");
+    assert!(
+        info.unused_import_bindings.is_empty(),
+        "unused import bindings: {:?}",
+        info.unused_import_bindings
+    );
+
+    let esm_twin = parse_source("import * as Users from './users';\nexport { Users };");
+    assert_eq!(
+        info.unused_import_bindings, esm_twin.unused_import_bindings,
+        "the re-exported namespace-import twin reports the same way"
     );
 }
 
@@ -367,7 +421,7 @@ fn import_equals_without_export_records_no_whole_object_use() {
 /// would otherwise be read as a whole-object use and credit every member of
 /// whatever it holds, deleting real findings.
 #[test]
-fn export_import_equals_whole_object_use_is_withdrawn_when_the_name_is_shadowed() {
+fn export_import_equals_whole_object_use_is_withheld_when_the_name_is_shadowed() {
     let shadowed = parse_source(
         "export import Session = require('./beta');\nexport const run = (): void => {\n  const \
          Session = makeSession();\n  Session.start();\n};\n",
@@ -394,5 +448,81 @@ fn export_import_equals_whole_object_use_is_withdrawn_when_the_name_is_shadowed(
             .any(|name| name == "Session"),
         "an unshadowed name keeps its mark: {:?}",
         unshadowed.whole_object_uses
+    );
+}
+
+/// The mark the exported form earns is granted after the semantic pass, never
+/// pushed and then withdrawn, so a whole-object use the file genuinely wrote
+/// survives a shadowed name. Withdrawing by name deleted it and turned every
+/// export of the target into a false `unused-export` row.
+#[test]
+fn a_genuine_whole_object_use_survives_a_shadowed_export_import_equals() {
+    let source = "export import Config = require('./config');\nexport const read = (): number => \
+                  Object.values(Config).length;\nexport const parse = (Config: { n: number }): \
+                  number => Config.n;\n";
+    let shadowed = parse_source(source);
+    assert!(
+        shadowed.whole_object_uses.iter().any(|n| n == "Config"),
+        "`Object.values(Config)` is a whole-object use the file wrote: {:?}",
+        shadowed.whole_object_uses
+    );
+
+    let esm_twin = parse_source(
+        "import * as Config from './config';\nexport { Config };\nexport const read = (): number \
+         => Object.values(Config).length;\nexport const parse = (Config: { n: number }): number \
+         => Config.n;\n",
+    );
+    assert_eq!(
+        shadowed.whole_object_uses.to_vec(),
+        esm_twin.whole_object_uses.to_vec(),
+        "the namespace-import twin records the same whole-object uses"
+    );
+
+    // One name yields one entry: the granted mark deduplicates against the
+    // genuine one rather than stacking a second copy (issue #2377).
+    assert_eq!(
+        shadowed
+            .whole_object_uses
+            .iter()
+            .filter(|n| *n == "Config")
+            .count(),
+        1,
+        "whole-object uses: {:?}",
+        shadowed.whole_object_uses
+    );
+}
+
+/// A bare reference that hands the module object on (a call argument, an alias,
+/// a return value) credits every export the receiver can reach, exactly as the
+/// `import * as X` spelling does since issue #2377. Without it a file with one
+/// dotted access plus one handover narrows to that member and reports every
+/// sibling the receiver still uses.
+#[test]
+fn a_bare_import_equals_reference_is_a_whole_object_use() {
+    let handed = parse_source(
+        "import Icons = require('./icons');\nconsole.log(Icons.Star);\nregister(Icons);\n",
+    );
+    assert!(
+        handed.whole_object_uses.iter().any(|name| name == "Icons"),
+        "a call argument hands the module object on: {:?}",
+        handed.whole_object_uses
+    );
+
+    let esm_twin = parse_source(
+        "import * as Icons from './icons';\nconsole.log(Icons.Star);\nregister(Icons);\n",
+    );
+    assert_eq!(
+        handed.whole_object_uses.to_vec(),
+        esm_twin.whole_object_uses.to_vec(),
+        "the namespace-import twin records the same whole-object uses"
+    );
+
+    // Negative control: a dotted-only binding keeps narrowing, so the rule does
+    // not credit every import-equals binding wholesale.
+    let dotted = parse_source("import Icons = require('./icons');\nconsole.log(Icons.Star);\n");
+    assert!(
+        dotted.whole_object_uses.is_empty(),
+        "a resolved member access is not a handover: {:?}",
+        dotted.whole_object_uses
     );
 }

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -984,6 +984,71 @@ const items = ref<T[]>([]);
     assert_eq!(info.imports[0].source, "vue");
 }
 
+/// The `generic="..."` attribute re-parses an augmented body and recomputes the
+/// whole binding verdict, so the `import X = require('./x')` lane has to travel
+/// with it. Without that the binding kept crediting its target on a
+/// `generic="..."` script while the plain `<script setup>` next to it reported,
+/// which made the verdict depend on which parse path the file happened to take
+/// (issue #2365).
+#[test]
+fn vue_generic_attr_reports_an_unreferenced_import_equals_binding() {
+    let generic = parse_sfc(
+        r#"
+<script setup lang="ts" generic="T extends { id: string }">
+import GenTarget = require('./gen-target');
+defineProps<{ item: T }>();
+</script>
+"#,
+        "Generic.vue",
+    );
+    assert!(
+        generic
+            .unused_import_bindings
+            .contains(&"GenTarget".to_string()),
+        "an unreferenced import-equals binding reports on the generic= path too, got: {:?}",
+        generic.unused_import_bindings,
+    );
+
+    // The plain `<script setup>` twin takes the other parse path and must reach
+    // the same verdict.
+    let plain = parse_sfc(
+        r#"
+<script setup lang="ts">
+import PlainTarget = require('./plain-target');
+defineProps<{ item: string }>();
+</script>
+"#,
+        "Plain.vue",
+    );
+    assert!(
+        plain
+            .unused_import_bindings
+            .contains(&"PlainTarget".to_string()),
+        "the plain script path reports the same way, got: {:?}",
+        plain.unused_import_bindings,
+    );
+
+    // Positive control: a referenced binding is not reported on either path, so
+    // the assertions above are not passing because every binding lands there.
+    let referenced = parse_sfc(
+        r#"
+<script setup lang="ts" generic="T extends { id: string }">
+import UsedTarget = require('./used-target');
+defineProps<{ item: T }>();
+console.log(UsedTarget.alpha);
+</script>
+"#,
+        "Used.vue",
+    );
+    assert!(
+        !referenced
+            .unused_import_bindings
+            .contains(&"UsedTarget".to_string()),
+        "a referenced binding is not unused, got: {:?}",
+        referenced.unused_import_bindings,
+    );
+}
+
 #[test]
 fn vue_generic_attr_marks_type_only_import_as_type_referenced() {
     let info = parse_sfc(

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -97,7 +97,12 @@ impl ModuleInfoExtractor {
             Declaration::TSModuleDeclaration(module) => {
                 self.extract_module_declaration_export(module, is_type_only);
             }
-            _ => {}
+            Declaration::TSImportEqualsDeclaration(import_equals) => {
+                self.record_exported_import_equals(import_equals);
+            }
+            // `export declare global { ... }` augments the global scope; it
+            // declares no export of this file.
+            Declaration::TSGlobalDeclaration(_) => {}
         }
     }
 
@@ -317,7 +322,12 @@ impl ModuleInfoExtractor {
                     self.push_namespace_member(lit.value.to_string(), lit.span);
                 }
             },
-            _ => {}
+            Declaration::TSImportEqualsDeclaration(import_equals) => {
+                self.record_exported_import_equals(import_equals);
+            }
+            // `declare global { ... }` inside a namespace body augments the
+            // global scope; it contributes no namespace member.
+            Declaration::TSGlobalDeclaration(_) => {}
         }
     }
 
@@ -379,12 +389,20 @@ impl ModuleInfoExtractor {
     }
 
     /// Handle `import X = require('./y')`, the TypeScript spelling of a
-    /// CommonJS require binding. It records exactly what
-    /// `const X = require('./y')` records through
-    /// [`Self::handle_require_declaration`]: one non-destructured require call
-    /// plus the namespace binding name, so the target keeps its edge and
-    /// `X.member` narrows the target's exports the way a namespace import does
-    /// (issue #2365).
+    /// CommonJS require binding. It records the same shape the
+    /// `BindingIdentifier` arm of [`Self::handle_require_declaration`] records
+    /// for `const X = require('./y')`: one non-destructured require call plus
+    /// the namespace binding name, so the target keeps its edge and `X.member`
+    /// narrows the target's exports the way a namespace import does (issue
+    /// #2365). The two paths run in parallel rather than one calling the other,
+    /// because a `TSExternalModuleReference` carries a `StringLiteral` where the
+    /// variable form carries a `CallExpression`; the `handled_require_spans`
+    /// insert is therefore deliberately absent, since `record_bare_require_call`
+    /// only ever sees call expressions.
+    ///
+    /// The binding is also recorded in `import_equals_bindings` so the semantic
+    /// pass classifies its type and value usage: without that, `X.SomeType` in
+    /// type position would leave the target's type exports uncredited.
     ///
     /// `import X = Some.Namespace` names an entity declared in this file rather
     /// than a module, so it records nothing.
@@ -397,6 +415,7 @@ impl ModuleInfoExtractor {
         };
         let local = decl.id.name.to_string();
         self.namespace_binding_names.push(local.clone());
+        self.import_equals_bindings.push(local.clone());
         self.require_calls.push(RequireCallInfo {
             source: reference.expression.value.to_string(),
             // The `require('./y')` reference, matching the call span a
@@ -406,6 +425,27 @@ impl ModuleInfoExtractor {
             destructured_names: Vec::new(),
             local_name: Some(local),
         });
+    }
+
+    /// Record the exported form, `export import X = require('./y')`, at file
+    /// level or inside an exported namespace body.
+    ///
+    /// The declaration hands the required module object to consumers the graph
+    /// cannot enumerate, exactly as `import * as X from './y'; export { X }`
+    /// does, so the binding is marked a whole-object use. Without it an entry
+    /// point that only re-exports the binding has no member access to narrow
+    /// with, `is_entry_with_no_access` fires, and every export of the target
+    /// turns into a false `unused-export` row (issues #2365, #2373).
+    ///
+    /// The entity-name form stays out of scope: `export import X = Some.Ns`
+    /// aliases a local declaration, not a module.
+    fn record_exported_import_equals(&mut self, decl: &TSImportEqualsDeclaration<'_>) {
+        if matches!(
+            &decl.module_reference,
+            TSModuleReference::ExternalModuleReference(_)
+        ) {
+            self.whole_object_uses.push(decl.id.name.to_string());
+        }
     }
 
     /// Handle namespace destructuring: `const { a, b } = ns` where `ns` is a namespace

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -437,20 +437,30 @@ impl ModuleInfoExtractor {
         });
     }
 
-    /// Note the exported form, `export import X = require('./y')`, at file
-    /// level or inside an exported namespace body.
+    /// Credit the exported form, `export import X = require('./y')`, with a
+    /// whole-object use of its binding.
     ///
     /// The declaration hands the required module object to consumers the graph
     /// cannot enumerate, exactly as `import * as X from './y'; export { X }`
-    /// does, so the binding earns a whole-object use. Without it an entry point
-    /// that only re-exports the binding has no member access to narrow with,
-    /// `is_entry_with_no_access` fires, and every export of the target turns
-    /// into a false `unused-export` row (issues #2365, #2373).
+    /// does, so every export of the target is credited. Without it an entry
+    /// point that only re-exports the binding has no member access to narrow
+    /// with, `is_entry_with_no_access` fires, and every export of the target
+    /// turns into a false `unused-export` row (issues #2365, #2373).
     ///
-    /// Only the name is recorded here.
-    /// [`Self::credit_unshadowed_import_equals_whole_object_uses`] grants the
-    /// whole-object use once the semantic pass has confirmed the file binds the
-    /// name only once.
+    /// The credit is unconditional, matching the twin, which has no condition
+    /// either: `narrow_namespace_references` matches `whole_object_uses`
+    /// against the local name of an import edge of this same file, and a
+    /// file-level `import X = require(...)` owns that name outright, because a
+    /// second root binding of it is a TypeScript duplicate-identifier error.
+    /// The one shape that can still collide is a same-named require inside a
+    /// nested scope (`const X = require('./other')` in a function body), which
+    /// over-credits `./other`; that direction loses a finding and never invents
+    /// one, whereas withholding the credit reported every export of the real
+    /// target as unused.
+    ///
+    /// [`Self::push_whole_object_use`] deduplicates, so a whole-object use the
+    /// walk records for the same name (a genuine `Object.values(X)`) stays one
+    /// entry.
     ///
     /// The entity-name form stays out of scope: `export import X = Some.Ns`
     /// aliases a local declaration, not a module.
@@ -466,38 +476,7 @@ impl ModuleInfoExtractor {
         ) {
             self.exported_import_equals_names
                 .push(decl.id.name.to_string());
-        }
-    }
-
-    /// Grant the whole-object use to every `export import X = require('./x')`
-    /// binding whose name the file binds exactly once.
-    ///
-    /// Called from the semantic pass, which is the first place scope
-    /// information exists. The credit is only safe while the name resolves to
-    /// this one binding: `whole_object_uses` is keyed by bare name, so a
-    /// same-named local in any other scope would otherwise be read as a
-    /// whole-object use and every member of whatever it holds would be
-    /// credited.
-    ///
-    /// A whole-object use the walk already recorded for the same name (a
-    /// genuine `Object.values(X)`) is untouched, and the recording site
-    /// deduplicates, so a shadowed name keeps the credit it genuinely earned
-    /// while an unearned one is never granted.
-    pub(crate) fn credit_unshadowed_import_equals_whole_object_uses(
-        &mut self,
-        shadowed: &[String],
-    ) {
-        if self.exported_import_equals_names.is_empty() {
-            return;
-        }
-        let granted: Vec<String> = self
-            .exported_import_equals_names
-            .iter()
-            .filter(|name| !shadowed.iter().any(|other| other == *name))
-            .cloned()
-            .collect();
-        for name in granted {
-            self.push_whole_object_use(name);
+            self.push_whole_object_use(decl.id.name.to_string());
         }
     }
 

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -437,24 +437,23 @@ impl ModuleInfoExtractor {
         });
     }
 
-    /// Record the exported form, `export import X = require('./y')`, at file
+    /// Note the exported form, `export import X = require('./y')`, at file
     /// level or inside an exported namespace body.
     ///
     /// The declaration hands the required module object to consumers the graph
     /// cannot enumerate, exactly as `import * as X from './y'; export { X }`
-    /// does, so the binding is marked a whole-object use. Without it an entry
-    /// point that only re-exports the binding has no member access to narrow
-    /// with, `is_entry_with_no_access` fires, and every export of the target
-    /// turns into a false `unused-export` row (issues #2365, #2373).
+    /// does, so the binding earns a whole-object use. Without it an entry point
+    /// that only re-exports the binding has no member access to narrow with,
+    /// `is_entry_with_no_access` fires, and every export of the target turns
+    /// into a false `unused-export` row (issues #2365, #2373).
+    ///
+    /// Only the name is recorded here.
+    /// [`Self::credit_unshadowed_import_equals_whole_object_uses`] grants the
+    /// whole-object use once the semantic pass has confirmed the file binds the
+    /// name only once.
     ///
     /// The entity-name form stays out of scope: `export import X = Some.Ns`
     /// aliases a local declaration, not a module.
-    ///
-    /// `whole_object_uses` is matched by bare name, so the mark is provisional:
-    /// [`Self::drop_shadowed_import_equals_whole_object_uses`] withdraws it
-    /// when the file binds the same name somewhere else, where crediting every
-    /// member of an unrelated same-named binding would silently delete real
-    /// findings.
     ///
     /// The namespace-body call site (`namespace N { export import X =
     /// require('./x') }`) is defensive leniency only: TypeScript rejects that
@@ -465,31 +464,41 @@ impl ModuleInfoExtractor {
             &decl.module_reference,
             TSModuleReference::ExternalModuleReference(_)
         ) {
-            let name = decl.id.name.to_string();
-            self.exported_import_equals_names.push(name.clone());
-            self.whole_object_uses.push(name);
+            self.exported_import_equals_names
+                .push(decl.id.name.to_string());
         }
     }
 
-    /// Withdraw the provisional whole-object mark from every `export import X =
-    /// require('./x')` binding whose name the file binds more than once.
+    /// Grant the whole-object use to every `export import X = require('./x')`
+    /// binding whose name the file binds exactly once.
     ///
     /// Called from the semantic pass, which is the first place scope
-    /// information exists. A mark is only safe while the name resolves to this
-    /// one binding: `whole_object_uses` is keyed by bare name, so a same-named
-    /// local in any other scope would otherwise be read as a whole-object use
-    /// and every member of whatever it holds would be credited.
-    pub(crate) fn drop_shadowed_import_equals_whole_object_uses(&mut self, shadowed: &[String]) {
-        if shadowed.is_empty() || self.exported_import_equals_names.is_empty() {
+    /// information exists. The credit is only safe while the name resolves to
+    /// this one binding: `whole_object_uses` is keyed by bare name, so a
+    /// same-named local in any other scope would otherwise be read as a
+    /// whole-object use and every member of whatever it holds would be
+    /// credited.
+    ///
+    /// A whole-object use the walk already recorded for the same name (a
+    /// genuine `Object.values(X)`) is untouched, and the recording site
+    /// deduplicates, so a shadowed name keeps the credit it genuinely earned
+    /// while an unearned one is never granted.
+    pub(crate) fn credit_unshadowed_import_equals_whole_object_uses(
+        &mut self,
+        shadowed: &[String],
+    ) {
+        if self.exported_import_equals_names.is_empty() {
             return;
         }
-        self.whole_object_uses.retain(|name| {
-            !(shadowed.iter().any(|other| other == name)
-                && self
-                    .exported_import_equals_names
-                    .iter()
-                    .any(|other| other == name))
-        });
+        let granted: Vec<String> = self
+            .exported_import_equals_names
+            .iter()
+            .filter(|name| !shadowed.iter().any(|other| other == *name))
+            .cloned()
+            .collect();
+        for name in granted {
+            self.push_whole_object_use(name);
+        }
     }
 
     /// Handle namespace destructuring: `const { a, b } = ns` where `ns` is a namespace

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -5,7 +5,8 @@
 
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Declaration, Expression, ImportExpression,
-    TSEnumMemberName, TSModuleDeclarationName, VariableDeclarator,
+    TSEnumMemberName, TSImportEqualsDeclaration, TSModuleDeclarationName, TSModuleReference,
+    VariableDeclarator,
 };
 
 use crate::{
@@ -375,6 +376,36 @@ impl ModuleInfoExtractor {
             }
             _ => {}
         }
+    }
+
+    /// Handle `import X = require('./y')`, the TypeScript spelling of a
+    /// CommonJS require binding. It records exactly what
+    /// `const X = require('./y')` records through
+    /// [`Self::handle_require_declaration`]: one non-destructured require call
+    /// plus the namespace binding name, so the target keeps its edge and
+    /// `X.member` narrows the target's exports the way a namespace import does
+    /// (issue #2365).
+    ///
+    /// `import X = Some.Namespace` names an entity declared in this file rather
+    /// than a module, so it records nothing.
+    pub(super) fn handle_import_equals_declaration(
+        &mut self,
+        decl: &TSImportEqualsDeclaration<'_>,
+    ) {
+        let TSModuleReference::ExternalModuleReference(reference) = &decl.module_reference else {
+            return;
+        };
+        let local = decl.id.name.to_string();
+        self.namespace_binding_names.push(local.clone());
+        self.require_calls.push(RequireCallInfo {
+            source: reference.expression.value.to_string(),
+            // The `require('./y')` reference, matching the call span a
+            // `const X = require('./y')` declaration records.
+            span: reference.span,
+            source_span: reference.expression.span,
+            destructured_names: Vec::new(),
+            local_name: Some(local),
+        });
     }
 
     /// Handle namespace destructuring: `const { a, b } = ns` where `ns` is a namespace

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -369,6 +369,7 @@ impl ModuleInfoExtractor {
                     source_span,
                     destructured_names: names,
                     local_name: None,
+                    is_type_only: false,
                 });
                 self.handled_require_spans.insert(call.span);
             }
@@ -381,6 +382,7 @@ impl ModuleInfoExtractor {
                     source_span,
                     destructured_names: Vec::new(),
                     local_name: Some(local),
+                    is_type_only: false,
                 });
                 self.handled_require_spans.insert(call.span);
             }
@@ -404,6 +406,13 @@ impl ModuleInfoExtractor {
     /// pass classifies its type and value usage: without that, `X.SomeType` in
     /// type position would leave the target's type exports uncredited.
     ///
+    /// `import type X = require('./y')` is the one spelling TypeScript erases
+    /// completely: the emitted JavaScript holds no `require` call at all. It
+    /// keeps the edge, because the target is still a type-space reference, but
+    /// carries `is_type_only`, so dependency classification treats it the way
+    /// it treats `import type * as X from './y'` instead of claiming the
+    /// package is imported at runtime.
+    ///
     /// `import X = Some.Namespace` names an entity declared in this file rather
     /// than a module, so it records nothing.
     pub(super) fn handle_import_equals_declaration(
@@ -424,6 +433,7 @@ impl ModuleInfoExtractor {
             source_span: reference.expression.span,
             destructured_names: Vec::new(),
             local_name: Some(local),
+            is_type_only: decl.import_kind.is_type(),
         });
     }
 
@@ -439,13 +449,47 @@ impl ModuleInfoExtractor {
     ///
     /// The entity-name form stays out of scope: `export import X = Some.Ns`
     /// aliases a local declaration, not a module.
+    ///
+    /// `whole_object_uses` is matched by bare name, so the mark is provisional:
+    /// [`Self::drop_shadowed_import_equals_whole_object_uses`] withdraws it
+    /// when the file binds the same name somewhere else, where crediting every
+    /// member of an unrelated same-named binding would silently delete real
+    /// findings.
+    ///
+    /// The namespace-body call site (`namespace N { export import X =
+    /// require('./x') }`) is defensive leniency only: TypeScript rejects that
+    /// spelling with TS1147, so no compiling project reaches it. The file-level
+    /// form is the one real code writes.
     fn record_exported_import_equals(&mut self, decl: &TSImportEqualsDeclaration<'_>) {
         if matches!(
             &decl.module_reference,
             TSModuleReference::ExternalModuleReference(_)
         ) {
-            self.whole_object_uses.push(decl.id.name.to_string());
+            let name = decl.id.name.to_string();
+            self.exported_import_equals_names.push(name.clone());
+            self.whole_object_uses.push(name);
         }
+    }
+
+    /// Withdraw the provisional whole-object mark from every `export import X =
+    /// require('./x')` binding whose name the file binds more than once.
+    ///
+    /// Called from the semantic pass, which is the first place scope
+    /// information exists. A mark is only safe while the name resolves to this
+    /// one binding: `whole_object_uses` is keyed by bare name, so a same-named
+    /// local in any other scope would otherwise be read as a whole-object use
+    /// and every member of whatever it holds would be credited.
+    pub(crate) fn drop_shadowed_import_equals_whole_object_uses(&mut self, shadowed: &[String]) {
+        if shadowed.is_empty() || self.exported_import_equals_names.is_empty() {
+            return;
+        }
+        self.whole_object_uses.retain(|name| {
+            !(shadowed.iter().any(|other| other == name)
+                && self
+                    .exported_import_equals_names
+                    .iter()
+                    .any(|other| other == name))
+        });
     }
 
     /// Handle namespace destructuring: `const { a, b } = ns` where `ns` is a namespace

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -366,12 +366,11 @@ pub(crate) struct ModuleInfoExtractor {
     /// module '...'` body is not classified and stays value-only, exactly as
     /// an `import * as X` binding in that position does.
     pub(crate) import_equals_bindings: Vec<String>,
-    /// Names declared by `export import X = require('./y')`. The whole-object
-    /// use they earn is granted only after the semantic pass confirms the file
-    /// binds the name once; `whole_object_uses` is keyed by bare name, so a
-    /// same-named binding in another scope would otherwise be credited too. The
-    /// same list exempts them from the unused-import-binding verdict: the
-    /// exported form has no local reference by construction.
+    /// Names declared by `export import X = require('./y')`. The walk credits
+    /// each one with a whole-object use as it records it, the same credit
+    /// `export { X }` earns for a namespace import. The list exempts them from
+    /// the unused-import-binding verdict: the exported form is the file's
+    /// public API and has no local reference by construction.
     pub(crate) exported_import_equals_names: Vec<String>,
     binding_target_names: FxHashMap<String, BindingTarget>,
     /// The class each binding name most recently named at this point in the walk,

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -366,11 +366,13 @@ pub(crate) struct ModuleInfoExtractor {
     /// module '...'` body is not classified and stays value-only, exactly as
     /// an `import * as X` binding in that position does.
     pub(crate) import_equals_bindings: Vec<String>,
-    /// Names marked as whole-object uses by `export import X = require('./y')`.
-    /// The mark is provisional until the semantic pass confirms the file binds
-    /// the name only once; `whole_object_uses` is keyed by bare name, so a
-    /// same-named binding in another scope would otherwise be credited too.
-    exported_import_equals_names: Vec<String>,
+    /// Names declared by `export import X = require('./y')`. The whole-object
+    /// use they earn is granted only after the semantic pass confirms the file
+    /// binds the name once; `whole_object_uses` is keyed by bare name, so a
+    /// same-named binding in another scope would otherwise be credited too. The
+    /// same list exempts them from the unused-import-binding verdict: the
+    /// exported form has no local reference by construction.
+    pub(crate) exported_import_equals_names: Vec<String>,
     binding_target_names: FxHashMap<String, BindingTarget>,
     /// The class each binding name most recently named at this point in the walk,
     /// never poisoned to `Ambiguous`. `binding_target_names` is module-flat, so a

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -360,7 +360,17 @@ pub(crate) struct ModuleInfoExtractor {
     /// type and the value namespace exactly like an ESM namespace import, so
     /// the semantic pass classifies them alongside `imports` and `X.Member`
     /// narrows the target's type exports too (issue #2365).
+    ///
+    /// Classification reads the root scope only, the same restriction the
+    /// `imports` loop next to it has: a binding declared inside a `declare
+    /// module '...'` body is not classified and stays value-only, exactly as
+    /// an `import * as X` binding in that position does.
     pub(crate) import_equals_bindings: Vec<String>,
+    /// Names marked as whole-object uses by `export import X = require('./y')`.
+    /// The mark is provisional until the semantic pass confirms the file binds
+    /// the name only once; `whole_object_uses` is keyed by bare name, so a
+    /// same-named binding in another scope would otherwise be credited too.
+    exported_import_equals_names: Vec<String>,
     binding_target_names: FxHashMap<String, BindingTarget>,
     /// The class each binding name most recently named at this point in the walk,
     /// never poisoned to `Ambiguous`. `binding_target_names` is module-flat, so a

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -355,6 +355,12 @@ pub(crate) struct ModuleInfoExtractor {
     /// is precise, so a bare reference to the root is what hands the namespace
     /// object on. See issue #2377.
     object_literal_namespace_placements: Vec<(String, String)>,
+    /// Local bindings introduced by `import X = require('./y')`. The require
+    /// path records them outside `imports`, but the binding lives in both the
+    /// type and the value namespace exactly like an ESM namespace import, so
+    /// the semantic pass classifies them alongside `imports` and `X.Member`
+    /// narrows the target's type exports too (issue #2365).
+    pub(crate) import_equals_bindings: Vec<String>,
     binding_target_names: FxHashMap<String, BindingTarget>,
     /// The class each binding name most recently named at this point in the walk,
     /// never poisoned to `Ambiguous`. `binding_target_names` is module-flat, so a

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -713,6 +713,7 @@ impl ModuleInfoExtractor {
                 source_span: lit.span,
                 destructured_names: Vec::new(),
                 local_name: None,
+                is_type_only: false,
             });
         }
     }

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -2575,6 +2575,11 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
     }
 
+    fn visit_ts_import_equals_declaration(&mut self, decl: &TSImportEqualsDeclaration<'a>) {
+        self.handle_import_equals_declaration(decl);
+        walk::walk_ts_import_equals_declaration(self, decl);
+    }
+
     fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
         // `export { NS }` hands the namespace object to consumers the graph
         // cannot enumerate, and `narrow_namespace_references` already puts that

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -732,7 +732,9 @@ impl ModuleInfoExtractor {
         }
     }
 
-    /// Pre-register every `import * as NS from '...'` local of the program.
+    /// Pre-register every namespace-import local of the program: an
+    /// `import * as NS from '...'` specifier, and the `import NS =
+    /// require('...')` spelling of the same binding (issue #2365).
     ///
     /// [`ModuleInfoExtractor::record_bare_namespace_reference`] needs the answer
     /// at every reference, and an import declaration is legal after the code
@@ -742,18 +744,47 @@ impl ModuleInfoExtractor {
     /// they are not statements the language hoists. See issue #2377.
     fn record_program_namespace_import_locals(&mut self, program: &Program<'_>) {
         for statement in &program.body {
-            let Statement::ImportDeclaration(decl) = statement else {
-                continue;
-            };
-            let Some(specifiers) = &decl.specifiers else {
-                continue;
-            };
-            for specifier in specifiers {
-                if let ImportDeclarationSpecifier::ImportNamespaceSpecifier(namespace) = specifier {
-                    self.namespace_import_locals
-                        .insert(namespace.local.name.to_string());
+            match statement {
+                Statement::ImportDeclaration(decl) => {
+                    let Some(specifiers) = &decl.specifiers else {
+                        continue;
+                    };
+                    for specifier in specifiers {
+                        if let ImportDeclarationSpecifier::ImportNamespaceSpecifier(namespace) =
+                            specifier
+                        {
+                            self.namespace_import_locals
+                                .insert(namespace.local.name.to_string());
+                        }
+                    }
                 }
+                Statement::TSImportEqualsDeclaration(decl) => {
+                    self.record_import_equals_namespace_local(decl);
+                }
+                Statement::ExportNamedDeclaration(decl) => {
+                    if let Some(Declaration::TSImportEqualsDeclaration(inner)) = &decl.declaration {
+                        self.record_import_equals_namespace_local(inner);
+                    }
+                }
+                _ => {}
             }
+        }
+    }
+
+    /// Register the local of an `import X = require('...')` declaration as a
+    /// namespace-import local, so a bare reference that hands the module object
+    /// on credits every export the receiver can reach, exactly as the
+    /// `import * as X from '...'` spelling does (issues #2365, #2377).
+    ///
+    /// The entity-name form (`import X = Some.Ns`) names a binding declared in
+    /// this file, not a module object, so it is not registered.
+    fn record_import_equals_namespace_local(&mut self, decl: &TSImportEqualsDeclaration<'_>) {
+        if matches!(
+            &decl.module_reference,
+            TSModuleReference::ExternalModuleReference(_)
+        ) {
+            self.namespace_import_locals
+                .insert(decl.id.name.to_string());
         }
     }
 
@@ -892,7 +923,7 @@ impl ModuleInfoExtractor {
     /// persisted, so a name mentioned opaquely many times (a namespace handed
     /// to several callees) stays one entry. `extend_whole_object_uses` applies
     /// the same rule to the Astro and MDX template passes.
-    fn push_whole_object_use(&mut self, name: String) {
+    pub(super) fn push_whole_object_use(&mut self, name: String) {
         if self.whole_object_uses.contains(&name) {
             return;
         }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -182,7 +182,12 @@ pub use store::GraphCacheStore;
 /// baked into the persisted graph. Warm 41 caches carry the narrowed verdict,
 /// so the siblings the consumer can still reach would stay reported as unused
 /// on upgrade.
-pub const GRAPH_CACHE_VERSION: u32 = 42;
+///
+/// Bumped to 43 for issue #2365: `import X = require('./x')` now resolves to a
+/// CommonJS namespace import edge, and the references it credits are baked into
+/// the persisted graph. Warm 42 caches hold the module without that edge, so
+/// the target would stay reported as an unused file on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 43;
 
 /// Cached form of a resolved target.
 ///

--- a/crates/graph/src/resolve/require_imports.rs
+++ b/crates/graph/src/resolve/require_imports.rs
@@ -5,8 +5,12 @@
 //!
 //! Destructured requires (`const { a, b } = require('./x')`) become named imports.
 //! Non-destructured requires (`const mod = require('./x')`) become namespace imports
-//! as a conservative default — the entire module binding may be used in ways that
+//! as a conservative default: the entire module binding may be used in ways that
 //! cannot be statically determined.
+//!
+//! `RequireCallInfo::is_type_only` carries through to the resolved import so
+//! the erased `import type X = require('./x')` spelling stays out of runtime
+//! dependency classification, matching `import type * as X from './x'`.
 
 use std::path::Path;
 
@@ -43,7 +47,7 @@ pub(super) fn resolve_single_require(
                 source: req.source.clone(),
                 imported_name: ImportedName::Namespace,
                 local_name: req.local_name.clone().unwrap_or_default(),
-                is_type_only: false,
+                is_type_only: req.is_type_only,
                 from_style: false,
                 span: req.span,
                 source_span: req.source_span,
@@ -59,7 +63,7 @@ pub(super) fn resolve_single_require(
                 source: req.source.clone(),
                 imported_name: ImportedName::Named(name.clone()),
                 local_name: name.clone(),
-                is_type_only: false,
+                is_type_only: req.is_type_only,
                 from_style: false,
                 span: req.span,
                 source_span: req.source_span,

--- a/crates/graph/src/resolve/tests.rs
+++ b/crates/graph/src/resolve/tests.rs
@@ -147,6 +147,7 @@ fn make_require(
         destructured_names: destructured.into_iter().map(String::from).collect(),
         local_name: local_name.map(String::from),
         source_span: oxc_span::Span::default(),
+        is_type_only: false,
     }
 }
 
@@ -1422,6 +1423,7 @@ fn require_destructured_empty_names_uses_namespace() {
             destructured_names: vec![],
             local_name: None,
             source_span: oxc_span::Span::default(),
+            is_type_only: false,
         };
         let file = Path::new("/project/src/app.js");
         let result = resolve_single_require(ctx, file, &req);

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -3112,6 +3112,13 @@ pub struct RequireCallInfo {
     pub destructured_names: Vec<String>,
     /// The local variable name for `const x = require(...)`.
     pub local_name: Option<String>,
+    /// `true` for `import type X = require('...')`, the one require spelling
+    /// TypeScript erases entirely: the emitted JavaScript contains no
+    /// `require` call, so the target is a type-space reference and never a
+    /// runtime dependency. Always `false` for `const x = require(...)`, which
+    /// has no type-only spelling. Read by dependency classification so a
+    /// type-only devDependency is not reported as production usage.
+    pub is_type_only: bool,
 }
 
 /// Result of parsing all files, including incremental cache statistics.
@@ -3502,6 +3509,7 @@ mod tests {
                 source_span: span(),
                 destructured_names: Vec::new(),
                 local_name: Some("required".to_string()),
+                is_type_only: false,
             }],
             package_path_references: vec!["react".to_string()].into(),
             member_accesses: vec![MemberAccess {

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -105,10 +105,17 @@ error by suppressing a downstream detector.
   `const X = require('./x')` declaration records (issue #2365): one CommonJS
   namespace import with the local binding, which makes `X.member` narrow the
   target's exports and a whole-object use of `X` seed the exposed namespace
-  closure below. `export import X = require('./x')` inside a namespace body
-  records the same edge. `import X = Some.Namespace` is an entity-name
-  reference that aliases a binding declared in the same file, not a module, so
-  it records nothing.
+  closure below. The binding is classified for type and value usage the same
+  way an `import * as X` binding is, so `X.SomeType` in a type annotation
+  narrows the target's type exports rather than leaving them uncredited.
+  `export import X = require('./x')`, at file level or inside an exported
+  namespace body, is recorded as a whole-object use of the binding: the module
+  object reaches consumers the graph cannot enumerate, so every export of the
+  target is credited the way `export { X }` credits a namespace import, which
+  is what keeps an entry point that only re-exports the binding from reporting
+  the target's whole surface (issue #2373). `import X = Some.Namespace` is an
+  entity-name reference that aliases a binding declared in the same file, not
+  a module, so it records nothing.
 - An ambient-module star re-export (`export *` or `export * as ns` inside a
   `declare module '...'` body, recorded as a type-only namespace import
   without a local binding) credits the full ES star surface of its target:

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -107,20 +107,29 @@ error by suppressing a downstream detector.
   target's exports and a whole-object use of `X` seed the exposed namespace
   closure below. The binding is classified for type and value usage the same
   way an `import * as X` binding is, so `X.SomeType` in a type annotation
-  narrows the target's type exports rather than leaving them uncredited.
+  narrows the target's type exports rather than leaving them uncredited, and it
+  is registered as a namespace-import local, so a bare reference that hands the
+  module object on records a whole-object use exactly as it does for
+  `import * as X` (issue #2377). A binding nothing references is reported as an
+  unused import binding, the same verdict an unreferenced `import * as X` gets:
+  TypeScript elides the declaration, so it must not credit the target's
+  exports, while the edge itself keeps the target reachable.
   `import type X = require('./x')` is the one spelling TypeScript erases
   completely, so the require call carries `is_type_only` and dependency
   classification treats it exactly as it treats `import type * as X from
   './x'` rather than claiming the package is imported at runtime.
-  `export import X = require('./x')` at file level is recorded as a
-  whole-object use of the binding: the module object reaches consumers the
-  graph cannot enumerate, so every export of the target is credited the way
-  `export { X }` credits a namespace import, which is what keeps an entry point
-  that only re-exports the binding from reporting the target's whole surface
-  (issue #2373). That mark is keyed by bare name, so the semantic pass
-  withdraws it when the file binds the same name in another scope, where
-  crediting an unrelated same-named binding would delete real findings. The
-  same mark inside a namespace body is defensive leniency only: TypeScript
+  `export import X = require('./x')` at file level earns a whole-object use of
+  the binding: the module object reaches consumers the graph cannot enumerate,
+  so every export of the target is credited the way `export { X }` credits a
+  namespace import, which is what keeps an entry point that only re-exports the
+  binding from reporting the target's whole surface (issue #2373). It is also
+  exempt from the unused-import-binding verdict above, since it has no local
+  reference by construction. The credit is keyed by bare name, so the semantic
+  pass grants it only when the file binds that name once; a whole-object use
+  the file genuinely wrote (`Object.values(X)`) is recorded by the walk and is
+  never touched, so a shadowed name keeps the credit it earned and only the
+  unearned one is withheld. The same credit inside a namespace body is
+  defensive leniency only: TypeScript
   rejects `namespace N { export import X = require('./x') }` with TS1147.
   `import X = Some.Namespace` is an entity-name reference that aliases a
   binding declared in the same file, not a module, so it records nothing.

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -108,14 +108,22 @@ error by suppressing a downstream detector.
   closure below. The binding is classified for type and value usage the same
   way an `import * as X` binding is, so `X.SomeType` in a type annotation
   narrows the target's type exports rather than leaving them uncredited.
-  `export import X = require('./x')`, at file level or inside an exported
-  namespace body, is recorded as a whole-object use of the binding: the module
-  object reaches consumers the graph cannot enumerate, so every export of the
-  target is credited the way `export { X }` credits a namespace import, which
-  is what keeps an entry point that only re-exports the binding from reporting
-  the target's whole surface (issue #2373). `import X = Some.Namespace` is an
-  entity-name reference that aliases a binding declared in the same file, not
-  a module, so it records nothing.
+  `import type X = require('./x')` is the one spelling TypeScript erases
+  completely, so the require call carries `is_type_only` and dependency
+  classification treats it exactly as it treats `import type * as X from
+  './x'` rather than claiming the package is imported at runtime.
+  `export import X = require('./x')` at file level is recorded as a
+  whole-object use of the binding: the module object reaches consumers the
+  graph cannot enumerate, so every export of the target is credited the way
+  `export { X }` credits a namespace import, which is what keeps an entry point
+  that only re-exports the binding from reporting the target's whole surface
+  (issue #2373). That mark is keyed by bare name, so the semantic pass
+  withdraws it when the file binds the same name in another scope, where
+  crediting an unrelated same-named binding would delete real findings. The
+  same mark inside a namespace body is defensive leniency only: TypeScript
+  rejects `namespace N { export import X = require('./x') }` with TS1147.
+  `import X = Some.Namespace` is an entity-name reference that aliases a
+  binding declared in the same file, not a module, so it records nothing.
 - An ambient-module star re-export (`export *` or `export * as ns` inside a
   `declare module '...'` body, recorded as a type-only namespace import
   without a local binding) credits the full ES star surface of its target:

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -100,6 +100,15 @@ error by suppressing a downstream detector.
   narrowing gate `is_css_module_path` stays on the narrower `.css` / `.scss`
   pair, so `.less` and `.sass` class maps keep their default slot empty without
   gaining member narrowing.
+- `import X = require('./x')` is the TypeScript spelling of a CommonJS require
+  binding, so the extractor records the same non-destructured require call a
+  `const X = require('./x')` declaration records (issue #2365): one CommonJS
+  namespace import with the local binding, which makes `X.member` narrow the
+  target's exports and a whole-object use of `X` seed the exposed namespace
+  closure below. `export import X = require('./x')` inside a namespace body
+  records the same edge. `import X = Some.Namespace` is an entity-name
+  reference that aliases a binding declared in the same file, not a module, so
+  it records nothing.
 - An ambient-module star re-export (`export *` or `export * as ns` inside a
   `declare module '...'` body, recorded as a type-only namespace import
   without a local binding) credits the full ES star surface of its target:

--- a/docs/reference/detection-internals.md
+++ b/docs/reference/detection-internals.md
@@ -124,13 +124,21 @@ error by suppressing a downstream detector.
   namespace import, which is what keeps an entry point that only re-exports the
   binding from reporting the target's whole surface (issue #2373). It is also
   exempt from the unused-import-binding verdict above, since it has no local
-  reference by construction. The credit is keyed by bare name, so the semantic
-  pass grants it only when the file binds that name once; a whole-object use
-  the file genuinely wrote (`Object.values(X)`) is recorded by the walk and is
-  never touched, so a shadowed name keeps the credit it earned and only the
-  unearned one is withheld. The same credit inside a namespace body is
-  defensive leniency only: TypeScript
+  reference by construction. The credit is unconditional, matching the twin,
+  which has no condition either: `narrow_namespace_references` matches
+  `whole_object_uses` against the local name of an import edge of the same
+  file, and a file-level `import X = require(...)` owns that name outright,
+  because a second root binding of it is a duplicate-identifier error. A
+  same-named require in a nested scope (`const X = require('./other')` inside a
+  function) can still collect the mark, which over-credits `./other`; that
+  direction loses a finding and never invents one, whereas withholding the
+  credit reported every export of the real target as unused. The credit inside
+  a namespace body is defensive leniency only: TypeScript
   rejects `namespace N { export import X = require('./x') }` with TS1147.
+  What the exported form does not record is an export row for the binding
+  itself, so unlike `export { X }` it never surfaces as an unused export; the
+  target credit is identical either way, and the missing row is a deliberate
+  miss rather than an invented one.
   `import X = Some.Namespace` is an entity-name reference that aliases a
   binding declared in the same file, not a module, so it records nothing.
 - An ambient-module star re-export (`export *` or `export * as ns` inside a

--- a/tests/fixtures/issue-2365-import-equals/package.json
+++ b/tests/fixtures/issue-2365-import-equals/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "issue-2365-import-equals",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/tests/fixtures/issue-2365-import-equals/package.json
+++ b/tests/fixtures/issue-2365-import-equals/package.json
@@ -1,7 +1,13 @@
 {
   "name": "issue-2365-import-equals",
   "main": "src/index.ts",
+  "dependencies": {
+    "ambient-dep": "^1.0.0"
+  },
   "devDependencies": {
+    "runtime-dep": "^1.0.0",
+    "type-only-dep": "^1.0.0",
+    "type-only-esm-dep": "^1.0.0",
     "typescript": "^5.9.3"
   }
 }

--- a/tests/fixtures/issue-2365-import-equals/src/ambient.d.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/ambient.d.ts
@@ -1,0 +1,3 @@
+declare module 'virtual:ambient-api' {
+  export import AmbientDep = require('ambient-dep');
+}

--- a/tests/fixtures/issue-2365-import-equals/src/assigned.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/assigned.ts
@@ -1,0 +1,5 @@
+namespace Assigned {
+  export const viaAssignment = 1;
+}
+
+export = Assigned;

--- a/tests/fixtures/issue-2365-import-equals/src/bare-shadowed-esm-target.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/bare-shadowed-esm-target.ts
@@ -1,0 +1,3 @@
+export const bareShadowedEsmAlpha = 1;
+
+export const bareShadowedEsmBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/bare-shadowed-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/bare-shadowed-esm.ts
@@ -1,0 +1,8 @@
+// Twin of `bare-shadowed.ts`: the same re-exported namespace binding, the same
+// shadowing parameter, no whole-object use.
+import * as BareShadowedEsmTarget from './bare-shadowed-esm-target';
+
+export { BareShadowedEsmTarget };
+
+export const parseBareShadowedEsm = (BareShadowedEsmTarget: { n: number }): number =>
+  BareShadowedEsmTarget.n;

--- a/tests/fixtures/issue-2365-import-equals/src/bare-shadowed-target.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/bare-shadowed-target.ts
@@ -1,0 +1,3 @@
+export const bareShadowedAlpha = 1;
+
+export const bareShadowedBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/bare-shadowed.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/bare-shadowed.ts
@@ -1,0 +1,7 @@
+// The shape the shadow guard used to report: an exported import-equals whose
+// name a function parameter binds again, and no `Object.values(...)` anywhere
+// to mask the difference. `bare-shadowed-esm.ts` is the twin.
+export import BareShadowedTarget = require('./bare-shadowed-target');
+
+export const parseBareShadowed = (BareShadowedTarget: { n: number }): number =>
+  BareShadowedTarget.n;

--- a/tests/fixtures/issue-2365-import-equals/src/deps.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/deps.ts
@@ -1,0 +1,9 @@
+import type TypeOnlyDep = require('type-only-dep');
+import type * as TypeOnlyEsm from 'type-only-esm-dep';
+import RuntimeDep = require('runtime-dep');
+
+export const readTypeOnly = (value: TypeOnlyDep.Shape): number => value.n;
+
+export const readTypeOnlyEsm = (value: TypeOnlyEsm.Shape): number => value.n;
+
+export const readRuntime = (): number => Object.keys(RuntimeDep).length;

--- a/tests/fixtures/issue-2365-import-equals/src/destructured-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/destructured-esm.ts
@@ -1,0 +1,3 @@
+export const esmDestructuredUsed = 1;
+
+export const esmDestructuredSibling = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/destructured.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/destructured.ts
@@ -1,0 +1,3 @@
+export const destructuredUsed = 1;
+
+export const destructuredSibling = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/entry-ns.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/entry-ns.ts
@@ -1,0 +1,3 @@
+export const nsAlpha = 1;
+
+export const nsBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/entry-ns.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/entry-ns.ts
@@ -1,3 +1,0 @@
-export const nsAlpha = 1;
-
-export const nsBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/entry-reexport-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/entry-reexport-esm.ts
@@ -1,0 +1,3 @@
+export const esmEntryAlpha = 1;
+
+export const esmEntryBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/entry-reexport.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/entry-reexport.ts
@@ -1,0 +1,3 @@
+export const entryAlpha = 1;
+
+export const entryBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/index.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/index.ts
@@ -1,0 +1,14 @@
+import Assigned = require('./assigned');
+import Narrowed = require('./narrowed');
+import Whole = require('./whole');
+
+import * as NarrowedEsm from './narrowed-esm';
+import { Outer } from './ns-reexport';
+import { aliasedMember } from './local-alias';
+
+console.log(Assigned.viaAssignment);
+console.log(Narrowed.used);
+console.log(NarrowedEsm.esmUsed);
+console.log(Object.values(Whole));
+console.log(Outer.outerValue);
+console.log(aliasedMember);

--- a/tests/fixtures/issue-2365-import-equals/src/index.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/index.ts
@@ -1,10 +1,32 @@
 import Assigned = require('./assigned');
 import Narrowed = require('./narrowed');
+import Typed = require('./typed');
 import Whole = require('./whole');
+import Destructured = require('./destructured');
 
 import * as NarrowedEsm from './narrowed-esm';
+import * as TypedEsm from './typed-esm';
+import * as DestructuredEsm from './destructured-esm';
+import * as EntryReexportEsm from './entry-reexport-esm';
 import { Outer } from './ns-reexport';
 import { aliasedMember } from './local-alias';
+
+// The entry re-exports the binding itself, so consumers the graph cannot
+// enumerate reach every name on the required module object.
+export import EntryReexport = require('./entry-reexport');
+
+export namespace EntryApi {
+  export import EntryNs = require('./entry-ns');
+}
+
+export { EntryReexportEsm };
+
+const { destructuredUsed } = Destructured;
+const { esmDestructuredUsed } = DestructuredEsm;
+
+export const readTyped = (shape: Typed.UsedShape): number => shape.n + Typed.typedValue;
+export const readTypedEsm = (shape: TypedEsm.EsmUsedShape): number =>
+  shape.n + TypedEsm.esmTypedValue;
 
 console.log(Assigned.viaAssignment);
 console.log(Narrowed.used);
@@ -12,3 +34,4 @@ console.log(NarrowedEsm.esmUsed);
 console.log(Object.values(Whole));
 console.log(Outer.outerValue);
 console.log(aliasedMember);
+console.log(destructuredUsed, esmDestructuredUsed);

--- a/tests/fixtures/issue-2365-import-equals/src/index.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/index.ts
@@ -14,6 +14,8 @@ import { staleMarker } from './stale';
 import { staleEsmMarker } from './stale-esm';
 import { parseShadowed, readShadowed } from './shadowed';
 import { parseShadowedEsm, readShadowedEsm } from './shadowed-esm';
+import { parseBareShadowed } from './bare-shadowed';
+import { parseBareShadowedEsm } from './bare-shadowed-esm';
 
 // The entry re-exports the binding itself, so consumers the graph cannot
 // enumerate reach every name on the required module object.
@@ -38,3 +40,4 @@ console.log(destructuredUsed, esmDestructuredUsed);
 console.log(staleMarker, staleEsmMarker);
 console.log(readShadowed(), parseShadowed({ n: 1 }));
 console.log(readShadowedEsm(), parseShadowedEsm({ n: 1 }));
+console.log(parseBareShadowed({ n: 1 }), parseBareShadowedEsm({ n: 1 }));

--- a/tests/fixtures/issue-2365-import-equals/src/index.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/index.ts
@@ -8,16 +8,12 @@ import * as NarrowedEsm from './narrowed-esm';
 import * as TypedEsm from './typed-esm';
 import * as DestructuredEsm from './destructured-esm';
 import * as EntryReexportEsm from './entry-reexport-esm';
-import { Outer } from './ns-reexport';
+import { readRuntime, readTypeOnly, readTypeOnlyEsm } from './deps';
 import { aliasedMember } from './local-alias';
 
 // The entry re-exports the binding itself, so consumers the graph cannot
 // enumerate reach every name on the required module object.
 export import EntryReexport = require('./entry-reexport');
-
-export namespace EntryApi {
-  export import EntryNs = require('./entry-ns');
-}
 
 export { EntryReexportEsm };
 
@@ -32,6 +28,6 @@ console.log(Assigned.viaAssignment);
 console.log(Narrowed.used);
 console.log(NarrowedEsm.esmUsed);
 console.log(Object.values(Whole));
-console.log(Outer.outerValue);
+console.log(readRuntime, readTypeOnly, readTypeOnlyEsm);
 console.log(aliasedMember);
 console.log(destructuredUsed, esmDestructuredUsed);

--- a/tests/fixtures/issue-2365-import-equals/src/index.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/index.ts
@@ -10,6 +10,10 @@ import * as DestructuredEsm from './destructured-esm';
 import * as EntryReexportEsm from './entry-reexport-esm';
 import { readRuntime, readTypeOnly, readTypeOnlyEsm } from './deps';
 import { aliasedMember } from './local-alias';
+import { staleMarker } from './stale';
+import { staleEsmMarker } from './stale-esm';
+import { parseShadowed, readShadowed } from './shadowed';
+import { parseShadowedEsm, readShadowedEsm } from './shadowed-esm';
 
 // The entry re-exports the binding itself, so consumers the graph cannot
 // enumerate reach every name on the required module object.
@@ -31,3 +35,6 @@ console.log(Object.values(Whole));
 console.log(readRuntime, readTypeOnly, readTypeOnlyEsm);
 console.log(aliasedMember);
 console.log(destructuredUsed, esmDestructuredUsed);
+console.log(staleMarker, staleEsmMarker);
+console.log(readShadowed(), parseShadowed({ n: 1 }));
+console.log(readShadowedEsm(), parseShadowedEsm({ n: 1 }));

--- a/tests/fixtures/issue-2365-import-equals/src/inner.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/inner.ts
@@ -1,3 +1,0 @@
-export const innerValue = 1;
-
-export const innerUnused = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/inner.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/inner.ts
@@ -1,0 +1,3 @@
+export const innerValue = 1;
+
+export const innerUnused = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/local-alias.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/local-alias.ts
@@ -1,0 +1,7 @@
+namespace Shapes {
+  export const box = 1;
+}
+
+import ShapesAlias = Shapes;
+
+export const aliasedMember = ShapesAlias.box;

--- a/tests/fixtures/issue-2365-import-equals/src/narrowed-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/narrowed-esm.ts
@@ -1,0 +1,3 @@
+export const esmUsed = 1;
+
+export const esmUnusedByNarrowing = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/narrowed.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/narrowed.ts
@@ -1,0 +1,3 @@
+export const used = 1;
+
+export const unusedByNarrowing = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/ns-reexport.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/ns-reexport.ts
@@ -1,0 +1,5 @@
+export namespace Outer {
+  export import Inner = require('./inner');
+
+  export const outerValue = Inner.innerValue;
+}

--- a/tests/fixtures/issue-2365-import-equals/src/ns-reexport.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/ns-reexport.ts
@@ -1,5 +1,0 @@
-export namespace Outer {
-  export import Inner = require('./inner');
-
-  export const outerValue = Inner.innerValue;
-}

--- a/tests/fixtures/issue-2365-import-equals/src/shadowed-esm-target.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/shadowed-esm-target.ts
@@ -1,0 +1,3 @@
+export const shadowedEsmAlpha = 1;
+
+export const shadowedEsmBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/shadowed-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/shadowed-esm.ts
@@ -1,0 +1,5 @@
+import * as ShadowedEsmTarget from './shadowed-esm-target';
+
+export const readShadowedEsm = (): number => Object.values(ShadowedEsmTarget).length;
+
+export const parseShadowedEsm = (ShadowedEsmTarget: { n: number }): number => ShadowedEsmTarget.n;

--- a/tests/fixtures/issue-2365-import-equals/src/shadowed-target.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/shadowed-target.ts
@@ -1,0 +1,3 @@
+export const shadowedAlpha = 1;
+
+export const shadowedBeta = 2;

--- a/tests/fixtures/issue-2365-import-equals/src/shadowed.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/shadowed.ts
@@ -1,0 +1,5 @@
+export import ShadowedTarget = require('./shadowed-target');
+
+export const readShadowed = (): number => Object.values(ShadowedTarget).length;
+
+export const parseShadowed = (ShadowedTarget: { n: number }): number => ShadowedTarget.n;

--- a/tests/fixtures/issue-2365-import-equals/src/stale-esm-target.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/stale-esm-target.ts
@@ -1,0 +1,5 @@
+export const staleEsmAlpha = 1;
+
+export interface StaleEsmShape {
+  n: number;
+}

--- a/tests/fixtures/issue-2365-import-equals/src/stale-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/stale-esm.ts
@@ -1,0 +1,3 @@
+import * as StaleEsmTarget from './stale-esm-target';
+
+export const staleEsmMarker = 1;

--- a/tests/fixtures/issue-2365-import-equals/src/stale-target.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/stale-target.ts
@@ -1,0 +1,5 @@
+export const staleAlpha = 1;
+
+export interface StaleShape {
+  n: number;
+}

--- a/tests/fixtures/issue-2365-import-equals/src/stale.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/stale.ts
@@ -1,0 +1,3 @@
+import StaleTarget = require('./stale-target');
+
+export const staleMarker = 1;

--- a/tests/fixtures/issue-2365-import-equals/src/typed-esm.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/typed-esm.ts
@@ -1,0 +1,9 @@
+export interface EsmUsedShape {
+  n: number;
+}
+
+export interface EsmUnusedShape {
+  u: number;
+}
+
+export const esmTypedValue = 1;

--- a/tests/fixtures/issue-2365-import-equals/src/typed.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/typed.ts
@@ -1,0 +1,9 @@
+export interface UsedShape {
+  n: number;
+}
+
+export interface UnusedShape {
+  u: number;
+}
+
+export const typedValue = 1;

--- a/tests/fixtures/issue-2365-import-equals/src/whole-deep.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/whole-deep.ts
@@ -1,0 +1,1 @@
+export const wholeDeep = 1;

--- a/tests/fixtures/issue-2365-import-equals/src/whole.ts
+++ b/tests/fixtures/issue-2365-import-equals/src/whole.ts
@@ -1,0 +1,3 @@
+export * from './whole-deep';
+
+export const wholeDirect = 1;


### PR DESCRIPTION
## What was broken

`import X = require('./x')` produced no import at all. `crates/extract/src/visitor/` had no arm for a `TSImportEqualsDeclaration` with an external module reference: only `visit_impl_structural.rs` saw the node, and only to shadow a function-type alias name. With neither an `ImportInfo` nor a require call, the target was reported as an unused file and nothing reached through the binding was credited.

Reproduction from the issue, `package.json` with `"main": "src/index.ts"`:

```ts
// src/assigned.ts
namespace Assigned {
  export const viaAssignment = 1;
}
export = Assigned;

// src/index.ts (entry)
import Assigned = require('./assigned');
console.log(Assigned.viaAssignment);
```

`fallow dead-code --format json --quiet --no-cache` reported `src/assigned.ts` as an unused file. Replacing the consumer line with `import Assigned from './assigned'` made it reachable, so the gap was specific to the import-equals form.

## The fix

A `visit_ts_import_equals_declaration` arm on the `Visit` impl hands the declaration to `handle_import_equals_declaration`, which pushes one non-destructured `RequireCallInfo` (the specifier, the `require('./x')` reference span, the specifier string span, no destructured names, the local binding) plus the local name onto `namespace_binding_names`. That is the same shape `handle_require_declaration` records for `const X = require('./x')`; the two paths run in parallel rather than one calling the other, because a `TSExternalModuleReference` carries a `StringLiteral` where the variable form carries a `CallExpression`.

Recording it as a require call rather than as a hand-rolled `ImportInfo` is the point. `resolve_single_require` already turns a non-destructured require into a `Namespace` import against a target carried through `into_commonjs_require()`, so reusing it gives the CommonJS mechanism, `narrow_namespace_references`, the whole-object namespace seeds from #2372, and the specifier-anchored `source_span`, with no second spelling of the same edge to keep in sync.

The arm sits on the visitor, so it fires wherever the declaration appears: at file scope, and inside a `declare module '...'` body.

### Both semantic namespaces

Living outside `ModuleInfo.imports` cost the binding its type/value classification: `compute_semantic_usage_with_candidates` only walked `imports`, so `type_referenced_import_bindings` never named a require-derived binding and `desired_import_namespaces` fell through to value only. A type reached through the binding was therefore left uncredited, and the target's interface surfaced as an `unused-type` row the `import * as` twin never produces.

The extractor now carries an `import_equals_bindings` vector and feeds it into the same semantic classification an ESM namespace binding gets, so `T.SomeType` in an annotation credits type space and `T.value` credits value space independently. Classification reads the root scope only, exactly the restriction the `imports` loop beside it has: a binding declared inside a `declare module '...'` body is not classified and stays value-only, the same way an `import * as X` binding in that position does.

### An unreferenced binding credits nothing

A binding with no resolved reference anywhere in the file is now reported as an unused import binding, which is the verdict the `imports` loop reaches for an unreferenced `import * as X from './x'`. TypeScript elides both declarations completely, so neither may buy the target a whole-object credit.

Crediting it was strictly worse than the missing edge this PR started from: `import Utils = require('./utils')` in a file that never mentions `Utils` again deleted every `unused-export` and `unused-type` row on `utils.ts`, rows `main` reports correctly, and `import type Shapes = require('./shapes')` deleted both lanes at once. The edge itself is untouched, so the target is still a reachable file, exactly as it is behind an unreferenced `import * as X`.

`export import X = require('./x')` is exempt: it has no local reference by construction and the binding is the file's public API.

### The erased spelling

`import type X = require('pkg')` is the one require spelling TypeScript erases completely: the emitted JavaScript holds no `require` call at all, so the package is a type-space reference and never a runtime import. `RequireCallInfo` now carries `is_type_only`, set from `decl.import_kind.is_type()` and resolved through to the `ImportInfo`, so dependency classification treats the declaration the way it treats `import type * as X from 'pkg'`.

Without that, a type-only devDependency reported `dev-dependency-in-production` with the note "production code imports this at runtime" and an auto-action telling the user to move the package into `dependencies`, where the byte-equivalent ESM twin reported nothing. The unerased `import X = require('pkg')` still reports it, and still matches its own twin.

### The exported form

`export import X = require('./x')` recorded no export either. `narrow_namespace_references` derives `is_re_exported` from an export whose `local_name` matches the binding, so it stayed false, `is_entry_with_no_access` fired on an entry point, and every export of the target became a false `unused-export` row. That is a direct coherence break with #2373 on the shape the declaration exists for.

The exported form now earns a whole-object use of the binding. That is the credit `import * as X from './x'; export { X }` already produces: the module object reaches consumers the graph cannot enumerate, so every name on it is observed, including the names the target only exposes through its own `export *` chain. No export row is invented for the binding itself, so the change adds no new finding class.

`whole_object_uses` is keyed by bare name, so the credit is only safe while the name resolves to this one binding, and the visitor cannot know that: scope information first exists in the semantic pass. The credit is therefore **granted** there, only for a name the file binds once, rather than pushed at walk time and withdrawn afterwards. Withdrawing by name deleted a whole-object use the file genuinely wrote:

```ts
export import Config = require('./config');
export const readConfig = (): number => Object.values(Config).length;
export const parseConfig = (Config: { n: number }): number => Config.n;
```

The unrelated parameter made the name shadowed, the withdrawal removed the entry `Object.values(Config)` had recorded, and both exports of `src/config.ts` turned into false `unused-export` rows with an auto-fixable remove-export action. Renaming only the parameter made them disappear, and `tsc` is clean on the file. Granting instead of withdrawing also composes with #2377, which deduplicates `whole_object_uses` at the recording site: with one entry per name, removing "the provisional one" would have removed the only one.

### A bare handover credits the whole object

The binding is registered as a namespace-import local, so a reference the visitor cannot resolve to one member (a call argument, an alias, a return value) records a whole-object use, exactly as #2377 does for `import * as X`. Without it, a consumer that writes one dotted access plus one handover narrowed to that member alone and reported every sibling the receiver still reaches:

```ts
import Icons = require('./icons');
const register = (value: unknown): number => Object.keys(value as object).length;
export const handedOver = (): number => Icons.star + register(Icons);
```

`src/icons.ts: moon` reported, where the `import * as Icons` twin reports nothing. That false positive is created by this PR (before it, the target was simply unreachable), so it is closed here rather than left to a follow-up.

`import X = Some.Namespace` keeps today's behaviour. An entity-name reference aliases a binding declared in the same file, not a module, so the require-call guard, the whole-object guard and the namespace-local registration all return before recording anything, and the qualified-name walk that credits `Some.Namespace` is untouched.

## Design decisions

1. **Reuse the require path, do not invent an `ImportInfo`.** The require path already carries the CommonJS mechanism, namespace narrowing, the whole-object seeds and the specifier span. A second spelling of the same edge would have to be kept in sync with all of it.
2. **The whole-object credit, not an `ExportInfo` row, for `export import`.** The credit reaches the outcome the fix needs (every export of the target credited on an entry point that only re-exports the binding) without adding a finding class to a fix whose purpose is to remove false rows. Recording an export row for the binding would also start reporting a re-export nothing consumes as an unused export, which is a behaviour change of its own; it is left out rather than taken here.
3. **Grant the whole-object credit in the semantic pass, never withdraw it.** Withdrawal is name-keyed and cannot tell a provisional mark from a genuine `Object.values(X)`, and #2377's deduplication leaves exactly one entry to remove. Granting is the same outcome for every unshadowed case and strictly safer for the shadowed one.
4. **The unreferenced binding follows the ESM twin, not `const X = require()`.** The declaration is spelled `import` and TypeScript elides it like an import. Following the `const` model instead deleted rows `main` reports, which is a false negative introduced by this PR rather than a pre-existing gap it inherits.
5. **The namespace-body call site stays, as leniency only.** `namespace N { export import X = require('./x') }` is TS1147, so no compiling project reaches it. fallow parses leniently and still has to behave, so the arm is kept and pinned by one clearly labelled extract test. The fixture covers the two spellings TypeScript accepts instead: file level, and inside a `declare module '...'` body.
6. **Type-only is a flag on the require call, not a separate lane.** One extra bool keeps the erased spelling on the same edge, narrowing and reachability path as the unerased one, and only changes what dependency classification concludes.

## Parity with the `import * as X` twin

Every shape this PR touches now produces the same findings as its ESM twin. Measured on one scratch project holding each import-equals shape next to a byte-equivalent `import * as` shape against its own target, `dead-code --no-cache --format json`, patched binary:

| Shape | import-equals target | `import * as` twin target |
|---|---|---|
| unreferenced binding | `utils.ts`: `a1`-`a5` + `UtilsShape` | `utils-esm.ts`: `b1`-`b5` + `UtilsEsmShape` |
| unreferenced `import type` binding | `shapes.ts`: `shapeValue` + `ShapesShape` | `shapes-esm.ts`: `shapeEsmValue` + `ShapesEsmShape` |
| exported form, genuine whole-object use, shadowed name | `config.ts`: nothing | `config-esm.ts`: nothing |
| dotted access plus bare handover | `icons.ts`: nothing | `icons-esm.ts`: nothing |
| entry-point re-export with a type export | `re.ts`: `ReShape` | `re-esm.ts`: `ReEsmShape` |

The same project on the pre-review revision of this branch, rebased onto the same `main`, reported `config.ts: alpha`, `config.ts: beta` and `icons.ts: moon` as false positives and was missing `utils.ts: a1`-`a5`, `shapes.ts: shapeValue` and `shapes.ts: ShapesShape`.

One asymmetry remains, listed below.

## Behavior change

Unused-file and unused-export findings decrease for repositories using the form. A file that becomes reachable for the first time has its exports narrowed against the members the consumer writes, so a sibling nothing accesses surfaces as an unused export where the unused-file row used to stand in its place.

A binding re-exported through `export import` credits its whole target instead of narrowing to the members the declaring file happens to read. Narrowing there was unsound: a consumer holding the re-exported module object can reach any member of the target. This matches what `export { X }` already credits for a namespace import, and it is what removes the entry-point false positives above.

A type-only devDependency reached only through `import type X = require('pkg')` is no longer reported as production usage.

Total finding count is not guaranteed to decrease. The edge is now visible to every check that reads imports, so an import-equals whose specifier does not resolve reports `unresolved-import`, and a bare specifier no manifest lists reports `unlisted-dependency`, exactly as the equivalent `import X from './x'` already did.

## Known deviation

- **No export row for the re-exported binding.** `export import X = require('./x')` records no export for `X` itself, so a re-export nothing consumes is not reported, where the `import * as X; export { X }` twin does report `X` as an unused export. Verified on the patched binary with a non-entry consumer: the twin reports `src/mid-esm.ts: ReEsm`, the import-equals form reports nothing. A miss, never a false positive, and it matches `main`. Worth a follow-up, not taken here.

The `export = <binding>` deviation listed on the previous revision no longer reproduces: with #2377 on `main`, `import T = require('./t'); export = T;` and its `import * as T` twin both credit the target in full, and both report nothing.

## Cache invalidation

- extract `CACHE_VERSION` 278 to 279: extraction records a require call, its type-only flag, a type/value binding classification, an unused-binding verdict and a whole-object use it did not record before, so a warm 278 module replays without them. `CachedRequireCall` grows by the flag, and its size assertion moves from 88 to 96.
- `GRAPH_CACHE_VERSION` 42 to 43: the edge and the references it credits are baked into the persisted graph.

Both are exactly one above `main` at 969689e6d. `DUPES_CACHE_VERSION` is untouched.

Warm-cache proof on the scratch parity project, against a binary built from that same `main` commit:

1. `main` binary (extract 278, graph 42) cold run writes `.fallow`: `src/config.ts`, `src/icons.ts`, `src/shapes.ts` and `src/utils.ts` reported as unused files, plus every ESM twin's rows.
2. Patched binary on that warm cache: the fixed verdict, byte-identical to its own cold `--no-cache` run.
3. Second patched run on the now 279/43 cache: identical to step 2.

## How it was tested

- Extract unit tests: the require call and its local binding, the require and specifier spans, member accesses through the binding, the type and value classification of the binding (both together and type-only), the unused-import-binding verdict on an unreferenced binding and on the erased `import type` spelling (each against its own `import * as` twin, with a referenced binding as the positive control), the exemption of the exported form (against its `import * as X; export { X }` twin), the type-only flag on the erased spelling against the unerased one, the require call from inside a `declare module` body, the whole-object credit for the file-level exported form, its withholding when the name is shadowed (with an unshadowed positive control), the survival of a genuine `Object.values(X)` under a shadowed name plus a one-name-one-entry assertion, the bare-handover whole-object use against its twin with a dotted-only negative control, and negative controls pinning that an unexported binding, an ambient-module member and an entity-name import-equals record no whole-object use. One test is labelled as a deliberate lenient-parse pin for the TS1147 namespace-body spelling.
- Integration tests on fixture `issue-2365-import-equals`: reachability through the binding, value narrowing and type narrowing each held against an equivalent `import * as` twin declared with the same shape, object destructuring off the binding held against its twin, a whole-object use crediting the target's own `export *` chain, the entry-point `export import` form held against the `import * as X; export { X }` twin, an unreferenced binding crediting neither exports nor types (held against its twin, reachability asserted first so the assertion cannot hold vacuously), a genuine whole-object use surviving a shadowed exported binding (held against its twin), the `declare module` body crediting its package, the type-only devDependency held against its `import type * as` twin with an unerased devDependency as the positive control, and the entity-name negative control.
- Mutation matrix for this revision's three source changes, applied one at a time to the committed tree and restored afterwards: neutralising the unreferenced-binding report fails `unreferenced_import_equals_reports_an_unused_import_binding` and `an_unreferenced_import_equals_binding_credits_nothing`; restoring the push-then-withdraw shape fails `a_genuine_whole_object_use_survives_a_shadowed_export_import_equals` and `a_shadowed_export_import_equals_keeps_a_genuine_whole_object_use` (which reports `["shadowedAlpha", "shadowedBeta"]`, the defect verbatim); dropping the namespace-local registration fails `a_bare_import_equals_reference_is_a_whole_object_use`. `exported_import_equals_is_not_an_unused_import_binding` and the other negative controls pass either way by design, since they pin behaviour the fix must preserve. The full suite is green with every hunk restored.
- Real projects, `main` at 969689e6d versus patched, `dead-code --no-cache --format json`. `viz-frontend` (0), `editors/vscode` (1), `vitest` (810), `rijkshuisstijl-community` (234), `vue-core` (160) and `next.js` (24272) are identical row for row; the two large ones differ only in a `next_steps` recommendation, which reads local run history rather than the analysis. On the TypeScript compiler repository, which carries the form throughout its test corpus, `unused_files`, `unused_exports`, `unused_types` and every other finding list are identical; only `unresolved_imports` (1453 to 1693) and `unlisted_dependencies` (201 to 300) move. Every new row sits on an `import X = require(...)` line in `tests/baselines/reference/**`, where a TypeScript emit baseline embeds the original source next to the emitted JavaScript and the specifier resolves to nothing, so an `import X from './foo'` on the same line would already report the same way.
- Rebased onto `main` at 969689e6d, which carries #2377. Conflicts in `CHANGELOG.md`, `crates/extract/src/cache/types.rs`, `crates/graph/src/cache/mod.rs` and `crates/extract/src/visitor/mod.rs` were resolved by hand, keeping both sides and stacking the cache bumps one above `main`. The `assert_cached_type_size!(CachedRequireCall, 96)` assertion still holds after the rebase.
- Gates on the rebased tree: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `cargo check --workspace --benches`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `typos`, `scripts/scan-hidden-unicode.py --mode committed --staged`, `scripts/check-comment-quality.mjs --staged`. No serde or schemars type changed, so no generated contract surface is implicated.

Fixes #2365
