### PR TITLE
fix(extract): record a bare namespace-import reference as a whole-object use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A namespace import handed over whole (a call argument, a JSX attribute
+  value, an alias, an initializer) now credits every export of its target**
+  (Closes [#2377](https://github.com/fallow-rs/fallow/issues/2377)). The
+  visitor recorded a whole-object use for an allow-list of positions only:
+  `Object.keys/values/entries/getOwnPropertyNames(NS)`, a spread, `for ... in`,
+  a computed non-string access, a rest destructure, and a few type positions.
+  Every other reference to an `import * as NS` local left no trace, so a
+  consumer that also wrote one dotted access narrowed to that member alone and
+  reported every sibling the receiver can still reach: `register(NS)`,
+  `<Callout icons={NS} />`, `const alias = NS`, `[NS]`, `{ icons: NS }` handed
+  to a callee, `export const all = NS`, `slot = NS`, `return NS`, and
+  `typeof NS`. A reference the parser resolves to one member is unchanged and
+  keeps narrowing: `NS.member`, `NS?.member`, `NS['member']`, a JSX member tag
+  `<NS.Card />`, a dotted type name `NS.Type`, a destructure, and a namespace
+  placed in an object literal bound to a local whose path is read
+  (`const api = { NS }` plus `api.NS.member`, the shape the namespace-object
+  alias phase follows precisely). A bare reference to that local
+  (`hand(api)`) now hands the namespace on as well. `export { NS }` is
+  unchanged: the graph already credits every export there. The rule is scoped
+  to `import * as` locals, so named imports, and namespace objects bound by
+  `require` or a dynamic import, keep the behavior they had. Since Astro and
+  MDX consumers got this guarantee from their whole-file completeness guard,
+  only `.ts` / `.tsx` / `.js` / `.jsx` consumers change. **Repositories using
+  any of these shapes will see fewer unused-export findings**, and an export
+  credited for the first time also becomes reachable, so member-level
+  detectors can report on it where the unused-export finding used to stand in
+  its place. The record is also deduplicated now: a name recorded opaquely
+  many times is one entry. Warm caches invalidate (`CACHE_VERSION` 277 to 278,
+  `GRAPH_CACHE_VERSION` 41 to 42).
+
 - **A `default` import or re-export specifier now credits the target's default
   export** (Closes
   [#2374](https://github.com/fallow-rs/fallow/issues/2374)). `default` is one

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -267,6 +267,8 @@ mod issue_2348_jsx_namespace_member;
 mod issue_2355_astro_mdx_member_tags;
 #[path = "integration_test/issue_2376_mdx_import_prose.rs"]
 mod issue_2376_mdx_import_prose;
+#[path = "integration_test/issue_2377_whole_object_use.rs"]
+mod issue_2377_whole_object_use;
 #[path = "integration_test/issue_346_static_factory_method.rs"]
 mod issue_346_static_factory_method;
 #[path = "integration_test/issue_604_vite_rollup_path_helpers.rs"]

--- a/crates/core/tests/integration_test/issue_2377_whole_object_use.rs
+++ b/crates/core/tests/integration_test/issue_2377_whole_object_use.rs
@@ -1,0 +1,51 @@
+use crate::common::{create_config, fixture_path};
+
+/// Issue #2377: a namespace import handed over whole must credit every export
+/// of its target, whatever position hands it over. Before the fix the visitor
+/// recorded a whole-object use for an allow-list of positions only
+/// (`Object.keys(NS)`, spread, `for ... in`, computed non-string access, rest
+/// destructuring), so a consumer that also wrote one dotted access narrowed to
+/// that member and reported every sibling the receiver can still reach.
+///
+/// The fixture pins one consumer per handover shape, each against its own
+/// namespace target so a miscredit cannot be masked by a sibling shape:
+/// - a JSX attribute value (`<Callout icons={AttributeIcons} />`),
+/// - a call argument (`register(ArgumentIcons)`),
+/// - an alias (`const alias = AliasIcons`),
+/// - an array literal element (`[ArrayIcons]`),
+/// - an object literal value (`{ icons: ObjectIcons }`),
+/// - a return value (`return ReturnIcons`),
+///
+/// plus the precision control: a namespace used only through dotted accesses
+/// still narrows, so its genuinely unused sibling keeps reporting.
+#[test]
+fn whole_object_namespace_pass_credits_every_export() {
+    let root = fixture_path("issue-2377-whole-object-use");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_export_names: Vec<&str> = results
+        .unused_exports
+        .iter()
+        .map(|e| e.export.export_name.as_str())
+        .collect();
+
+    for (shape, sibling) in [
+        ("a JSX attribute value", "AttributeMoon"),
+        ("a call argument", "ArgumentMoon"),
+        ("an alias", "AliasMoon"),
+        ("an array literal element", "ArrayMoon"),
+        ("an object literal value", "ObjectMoon"),
+        ("a return value", "ReturnMoon"),
+    ] {
+        assert!(
+            !unused_export_names.contains(&sibling),
+            "a namespace handed over as {shape} must credit every export: {unused_export_names:?}"
+        );
+    }
+
+    assert!(
+        unused_export_names.contains(&"DottedMoon"),
+        "a namespace used only through dotted accesses must still narrow: {unused_export_names:?}"
+    );
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -971,7 +971,14 @@ use crate::MemberKind;
 /// Warm 276 caches hold the import-less module for every MDX file whose prose
 /// opens with the word "import" (or that carries any other rejected statement
 /// line), so its imported modules would stay reported as unused.
-pub(super) const CACHE_VERSION: u32 = 277;
+///
+/// Bumped to 278 for issue #2377: a reference to an `import * as NS` local the
+/// visitor cannot resolve to one member (a call argument, a JSX attribute
+/// value, an alias, an array or object literal element, an initializer, an
+/// assignment right-hand side, a return value) is recorded as a whole-object
+/// use. Warm 277 caches hold the narrower record, so the siblings such a
+/// consumer can still reach would stay reported as unused.
+pub(super) const CACHE_VERSION: u32 = 278;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -338,6 +338,23 @@ pub(crate) struct ModuleInfoExtractor {
     handled_require_spans: FxHashSet<Span>,
     handled_import_spans: FxHashSet<Span>,
     namespace_binding_names: Vec<String>,
+    /// The `import * as NS from '...'` locals of this program, pre-registered
+    /// from the top-level statement list before the body walk: an import
+    /// declaration is legal after the code that reads it, so walk order cannot
+    /// answer whether a reference names a namespace object. See issue #2377.
+    namespace_import_locals: FxHashSet<String>,
+    /// Spans of references to those locals that a more precise pass already
+    /// resolved to a member, so `visit_identifier_reference` leaves them alone:
+    /// the object of a static or string-computed access, the root of a JSX
+    /// member tag, and the left side of a dotted type name, plus a re-export
+    /// specifier local the graph already treats as a whole-object observation.
+    /// See issue #2377.
+    structured_namespace_reference_spans: FxHashSet<Span>,
+    /// `(root local, namespace local)` for a namespace placed in an object
+    /// literal bound to that root (`const api = { ns }`). The placement itself
+    /// is precise, so a bare reference to the root is what hands the namespace
+    /// object on. See issue #2377.
+    object_literal_namespace_placements: Vec<(String, String)>,
     binding_target_names: FxHashMap<String, BindingTarget>,
     /// The class each binding name most recently named at this point in the walk,
     /// never poisoned to `Ambiguous`. `binding_target_names` is module-flat, so a

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -319,9 +319,16 @@ fn into_module_info_transfers_require_calls() {
 #[test]
 fn into_module_info_transfers_whole_object_uses() {
     let info = parse(
-        "import { Status } from './types';\nObject.values(Status);\nconst y = { ...Status };",
+        "import { Status } from './types';\nimport { Role } from './role';\n\
+         Object.values(Status);\nconst y = { ...Role };\nconst z = { ...Status };",
     );
-    assert!(info.whole_object_uses.len() >= 2);
+    let mut uses = info.whole_object_uses.to_vec();
+    uses.sort();
+    assert_eq!(
+        uses,
+        vec!["Role".to_string(), "Status".to_string()],
+        "one entry per name; a name recorded twice is not repeated"
+    );
 }
 
 fn has_member_access(info: &crate::ModuleInfo, object: &str, member: &str) -> bool {
@@ -2103,6 +2110,149 @@ fn spread_marks_whole_use() {
 fn dynamic_computed_access_marks_whole_use() {
     let info = parse("import { E } from './e';\nconst k = 'x';\nE[k];");
     assert!(info.whole_object_uses.contains(&"E".to_string()));
+}
+
+/// Issue #2377: a namespace-import local handed over whole is a whole-object
+/// use in every position the visitor cannot resolve to one member.
+#[test]
+fn bare_namespace_reference_marks_whole_use() {
+    for (label, source) in [
+        ("call argument", "register(NS);"),
+        ("alias", "const alias = NS;"),
+        ("array literal", "const all = [NS];"),
+        ("object literal argument", "register({ icons: NS });"),
+        (
+            "object literal bound and handed on",
+            "const api = { icons: NS };\nregister(api);",
+        ),
+        ("return value", "export const get = () => NS;"),
+        ("assignment right-hand side", "let slot; slot = NS;"),
+        ("type query", "export type All = typeof NS;"),
+    ] {
+        let info = parse(&format!(
+            "import * as NS from './ns';\nNS.Star();\n{source}"
+        ));
+        assert!(
+            info.whole_object_uses.contains(&"NS".to_string()),
+            "{label} must record a whole-object use: {:?}",
+            info.whole_object_uses
+        );
+        assert!(
+            info.member_accesses
+                .iter()
+                .any(|access| access.object == "NS" && access.member == "Star"),
+            "{label} must keep the dotted access: {:?}",
+            info.member_accesses
+        );
+    }
+}
+
+/// Issue #2377: a namespace-import local the visitor resolved to a member is
+/// not a whole-object use, so the graph keeps narrowing it.
+#[test]
+fn resolved_namespace_reference_keeps_narrowing() {
+    for (label, source) in [
+        ("static access", "NS.Star();"),
+        ("optional access", "NS?.Star;"),
+        ("string-computed access", "NS['Star'];"),
+        ("dotted type name", "export const s: NS.Star = 1;"),
+        ("re-export specifier", "export { NS };"),
+    ] {
+        let info = parse(&format!("import * as NS from './ns';\n{source}"));
+        assert!(
+            !info.whole_object_uses.contains(&"NS".to_string()),
+            "{label} must not record a whole-object use: {:?}",
+            info.whole_object_uses
+        );
+    }
+}
+
+/// Issue #2377: a JSX member tag is the JSX spelling of `NS.Card`, while a
+/// namespace passed as an attribute value is a whole-object pass. The closing
+/// tag must not undo the exclusion the opening tag set up.
+#[test]
+fn jsx_namespace_positions_split_member_tag_from_attribute_pass() {
+    let tag_only = crate::tests::parse_tsx(
+        "import * as NS from './ns';\nexport const A = () => <NS.Card>text</NS.Card>;",
+    );
+    assert!(
+        !tag_only.whole_object_uses.contains(&"NS".to_string()),
+        "a member tag must stay narrowed: {:?}",
+        tag_only.whole_object_uses
+    );
+
+    let attribute_pass = crate::tests::parse_tsx(
+        "import * as NS from './ns';\nimport { Callout } from './callout';\n\
+         export const A = () => <div><NS.Card /><Callout icons={NS} /></div>;",
+    );
+    assert!(
+        attribute_pass.whole_object_uses.contains(&"NS".to_string()),
+        "a namespace passed as an attribute value must record a whole-object use: {:?}",
+        attribute_pass.whole_object_uses
+    );
+}
+
+/// Issue #2377: the local is registered from the statement list, not from walk
+/// order, so a body that reads the namespace above its own import declaration
+/// still records the pass. One entry is recorded however many times the local
+/// is mentioned.
+#[test]
+fn bare_namespace_reference_is_hoisted_and_deduplicated() {
+    let info = parse(
+        "export const first = () => register(NS);\n\
+         export const second = () => register(NS);\n\
+         import * as NS from './ns';",
+    );
+    assert_eq!(
+        info.whole_object_uses
+            .iter()
+            .filter(|name| *name == "NS")
+            .count(),
+        1,
+        "one deduplicated entry expected: {:?}",
+        info.whole_object_uses
+    );
+}
+
+/// Issue #2377: a namespace placed in an object literal bound to a local is
+/// resolved by the object-binding path (`api.ns.member`), which issue #2372
+/// keeps off the whole-module closure on purpose, so the placement alone stays
+/// narrowed. A destructure names its members and stays narrowed too.
+#[test]
+fn resolved_namespace_placement_keeps_narrowing() {
+    for (label, source) in [
+        (
+            "object literal read through its path",
+            "const api = { icons: NS };\nexport const used = api.icons.Star;",
+        ),
+        ("destructure", "const { Star } = NS;\nStar();"),
+    ] {
+        let info = parse(&format!("import * as NS from './ns';\n{source}"));
+        assert!(
+            !info.whole_object_uses.contains(&"NS".to_string()),
+            "{label} must not record a whole-object use: {:?}",
+            info.whole_object_uses
+        );
+    }
+
+    let rest = parse("import * as NS from './ns';\nconst { Star, ...others } = NS;");
+    assert!(
+        rest.whole_object_uses.contains(&"NS".to_string()),
+        "a rest element keeps its own whole-object use: {:?}",
+        rest.whole_object_uses
+    );
+}
+
+/// Issue #2377: the rule is scoped to namespace-import locals, so a named
+/// import passed whole keeps the recording allow-list it had.
+#[test]
+fn bare_named_import_reference_is_not_a_whole_use() {
+    let info = parse("import { E } from './e';\nregister(E);");
+    assert!(
+        !info.whole_object_uses.contains(&"E".to_string()),
+        "a named import is out of scope: {:?}",
+        info.whole_object_uses
+    );
 }
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -731,16 +731,171 @@ impl ModuleInfoExtractor {
         }
     }
 
+    /// Pre-register every `import * as NS from '...'` local of the program.
+    ///
+    /// [`ModuleInfoExtractor::record_bare_namespace_reference`] needs the answer
+    /// at every reference, and an import declaration is legal after the code
+    /// that reads it (a function body hoisted above its own import), so the
+    /// walk-order `namespace_binding_names` cannot be asked. Namespace objects
+    /// bound by `require` or a dynamic import keep their walk-order registry:
+    /// they are not statements the language hoists. See issue #2377.
+    fn record_program_namespace_import_locals(&mut self, program: &Program<'_>) {
+        for statement in &program.body {
+            let Statement::ImportDeclaration(decl) = statement else {
+                continue;
+            };
+            let Some(specifiers) = &decl.specifiers else {
+                continue;
+            };
+            for specifier in specifiers {
+                if let ImportDeclarationSpecifier::ImportNamespaceSpecifier(namespace) = specifier {
+                    self.namespace_import_locals
+                        .insert(namespace.local.name.to_string());
+                }
+            }
+        }
+    }
+
+    /// Mark a reference the visitor resolved to a specific member, so
+    /// [`ModuleInfoExtractor::record_bare_namespace_reference`] does not turn it
+    /// into a whole-object use (issue #2377).
+    fn mark_structured_namespace_reference(&mut self, ident: &IdentifierReference<'_>) {
+        if self.carries_namespace_object(ident.name.as_str()) {
+            self.structured_namespace_reference_spans.insert(ident.span);
+        }
+    }
+
+    /// Whether a bare reference to `name` hands a namespace object on: the
+    /// namespace-import local itself, or a local whose object literal holds one
+    /// (`const api = { ns }`).
+    fn carries_namespace_object(&self, name: &str) -> bool {
+        self.namespace_import_locals.contains(name)
+            || self
+                .object_literal_namespace_placements
+                .iter()
+                .any(|(root, _)| root == name)
+    }
+
+    /// Record a namespace-import local placed in an object literal bound to
+    /// `root_name`, and exclude the placement itself from the bare-reference
+    /// rule (issue #2377).
+    pub(super) fn record_object_literal_namespace_placement(
+        &mut self,
+        root_name: &str,
+        value: &IdentifierReference<'_>,
+    ) {
+        if !self.namespace_import_locals.contains(value.name.as_str()) {
+            return;
+        }
+        self.structured_namespace_reference_spans.insert(value.span);
+        let placement = (root_name.to_string(), value.name.to_string());
+        if !self
+            .object_literal_namespace_placements
+            .contains(&placement)
+        {
+            self.object_literal_namespace_placements.push(placement);
+        }
+    }
+
+    /// Mark the root identifier of a JSX member-expression tag (`<NS.Card />`),
+    /// which is the JSX spelling of `NS.Card`, not a bare pass of `NS`.
+    fn mark_jsx_member_tag_root(&mut self, name: Option<&JSXElementName<'_>>) {
+        let Some(JSXElementName::MemberExpression(member)) = name else {
+            return;
+        };
+        let mut current = member;
+        loop {
+            match &current.object {
+                JSXMemberExpressionObject::MemberExpression(inner) => current = inner,
+                JSXMemberExpressionObject::IdentifierReference(root) => {
+                    self.mark_structured_namespace_reference(root);
+                    return;
+                }
+                JSXMemberExpressionObject::ThisExpression(_) => return,
+            }
+        }
+    }
+
+    /// A namespace-import local mentioned anywhere the visitor cannot resolve to
+    /// one member hands the whole namespace object over: a call argument, a JSX
+    /// attribute value, an alias (`const N = NS`), an array or object literal
+    /// element, an initializer, an assignment right-hand side, a return value,
+    /// or `typeof NS`. The callee (or the reader of the alias) can reach every
+    /// export, so narrowing to the dotted accesses alone reports the siblings it
+    /// still uses. Recording a whole-object use puts the binding back on the
+    /// graph's mark-all path, which over-credits instead (issue #2377).
+    ///
+    /// The precise positions record their own member access and are excluded
+    /// through `structured_namespace_reference_spans`. That includes the
+    /// string-computed access `NS['Moon']`, which the parser resolves exactly;
+    /// the Astro and MDX text guards cannot and leave it on mark-all.
+    ///
+    /// The local of the binding's own `import * as NS` is a binding identifier,
+    /// never a reference, so the import declaration needs no exclusion.
+    fn record_bare_namespace_reference(&mut self, ident: &IdentifierReference<'_>) {
+        // Every identifier reference of every file reaches here; a file without
+        // a namespace import has nothing to answer.
+        if self.namespace_import_locals.is_empty()
+            && self.object_literal_namespace_placements.is_empty()
+        {
+            return;
+        }
+        if self
+            .structured_namespace_reference_spans
+            .contains(&ident.span)
+        {
+            return;
+        }
+        let name = ident.name.as_str();
+        if self.namespace_import_locals.contains(name) {
+            self.record_whole_object_identifier_use(name);
+            return;
+        }
+        self.record_object_literal_namespace_pass(name);
+    }
+
+    /// A bare reference to a local whose object literal holds a namespace
+    /// (`const api = { ns }; hand(api)`) hands that namespace on with the
+    /// object. Placing it there is precise on its own: the object-binding
+    /// resolver follows `api.ns.<member>`, and issue #2372 keeps such a binding
+    /// off the whole-module closure for exactly that reason. See issue #2377.
+    fn record_object_literal_namespace_pass(&mut self, root_name: &str) {
+        if self.object_literal_namespace_placements.is_empty() {
+            return;
+        }
+        let passed: Vec<String> = self
+            .object_literal_namespace_placements
+            .iter()
+            .filter(|(root, _)| root == root_name)
+            .map(|(_, namespace)| namespace.clone())
+            .collect();
+        for namespace in passed {
+            self.record_whole_object_identifier_use(&namespace);
+        }
+    }
+
     fn record_whole_object_identifier_use(&mut self, name: &str) {
         if name == "loaderData" || self.route_loader_data_bindings.contains(name) {
-            self.whole_object_uses
-                .push(ROUTE_LOADER_DATA_OBJECT.to_string());
+            self.push_whole_object_use(ROUTE_LOADER_DATA_OBJECT.to_string());
         }
         // A `this.<field>` reflective use (`Object.keys(this.opts.c)`) is keyed
         // per class so it resolves against the same class's binding, then
         // stripped back to `this.` before emission (issue #1821).
         let qualified = self.qualify_this_scope(name);
-        self.whole_object_uses.push(qualified);
+        self.push_whole_object_use(qualified);
+    }
+
+    /// Record one name in the whole-object set, skipping a repeat.
+    ///
+    /// Every consumer asks membership, never a count, and the record is
+    /// persisted, so a name mentioned opaquely many times (a namespace handed
+    /// to several callees) stays one entry. `extend_whole_object_uses` applies
+    /// the same rule to the Astro and MDX template passes.
+    fn push_whole_object_use(&mut self, name: String) {
+        if self.whole_object_uses.contains(&name) {
+            return;
+        }
+        self.whole_object_uses.push(name);
     }
 }
 
@@ -1850,6 +2005,13 @@ impl<'a> ModuleInfoExtractor {
                 .iter()
                 .any(|n| n == ident.name.as_str())
         {
+            // A destructure names its members: `handle_namespace_destructuring`
+            // records them (or the whole object, for a rest element), so the
+            // initializer is not a bare pass (issue #2377). A plain
+            // `const alias = NS` binds the object itself and is one.
+            if matches!(declarator.id, BindingPattern::ObjectPattern(_)) {
+                self.mark_structured_namespace_reference(ident);
+            }
             self.handle_namespace_destructuring(declarator, &ident.name);
             return;
         }
@@ -2151,6 +2313,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             self.directives
                 .push(directive.directive.as_str().to_string());
         }
+        self.record_program_namespace_import_locals(program);
         self.record_program_function_type_aliases(program);
         self.record_program_prologue(program);
         self.record_program_sanitizer_functions(program);
@@ -2413,6 +2576,16 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
     }
 
     fn visit_export_named_declaration(&mut self, decl: &ExportNamedDeclaration<'a>) {
+        // `export { NS }` hands the namespace object to consumers the graph
+        // cannot enumerate, and `narrow_namespace_references` already puts that
+        // binding on mark-all through its own re-export test (issue #2373), so
+        // the specifier local is not a bare pass to record again (issue #2377).
+        for specifier in &decl.specifiers {
+            if let ModuleExportName::IdentifierReference(local) = &specifier.local {
+                self.mark_structured_namespace_reference(local);
+            }
+        }
+
         let is_namespace = matches!(&decl.declaration, Some(Declaration::TSModuleDeclaration(_)));
 
         // Exports inside a namespace declared without the `export` keyword are
@@ -3056,6 +3229,9 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 member: expr.property.name.to_string(),
             });
         }
+        if let Expression::Identifier(object) = &expr.object {
+            self.mark_structured_namespace_reference(object);
+        }
         walk::walk_static_member_expression(self, expr);
     }
 
@@ -3087,6 +3263,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     object: obj.name.to_string(),
                     member: lit.value.to_string(),
                 });
+                self.mark_structured_namespace_reference(obj);
             } else {
                 self.record_whole_object_identifier_use(obj.name.as_str());
             }
@@ -3100,6 +3277,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 object: obj.name.to_string(),
                 member: it.right.name.to_string(),
             });
+            self.mark_structured_namespace_reference(obj);
         }
         walk::walk_ts_qualified_name(self, it);
     }
@@ -3108,14 +3286,14 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if let TSType::TSTypeReference(type_ref) = &it.constraint
             && let TSTypeName::IdentifierReference(ident) = &type_ref.type_name
         {
-            self.whole_object_uses.push(ident.name.to_string());
+            self.push_whole_object_use(ident.name.to_string());
         }
         if let TSType::TSTypeOperatorType(op) = &it.constraint
             && op.operator == TSTypeOperatorOperator::Keyof
             && let TSType::TSTypeQuery(query) = &op.type_annotation
             && let TSTypeQueryExprName::IdentifierReference(ident) = &query.expr_name
         {
-            self.whole_object_uses.push(ident.name.to_string());
+            self.push_whole_object_use(ident.name.to_string());
         }
         walk::walk_ts_mapped_type(self, it);
     }
@@ -3128,7 +3306,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             && let TSType::TSTypeReference(key_ref) = first_arg
             && let TSTypeName::IdentifierReference(key_ident) = &key_ref.type_name
         {
-            self.whole_object_uses.push(key_ident.name.to_string());
+            self.push_whole_object_use(key_ident.name.to_string());
         }
         walk::walk_ts_type_reference(self, it);
     }
@@ -3300,7 +3478,22 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if let JSXElementName::MemberExpression(member) = &element.opening_element.name {
             self.record_jsx_member_tag_accesses(member);
         }
+        // Both tags name the same member, so neither root is a bare pass of the
+        // namespace object (issue #2377). The closing tag is excluded on its own
+        // because `record_jsx_member_tag_accesses` deliberately skips it.
+        self.mark_jsx_member_tag_root(Some(&element.opening_element.name));
+        self.mark_jsx_member_tag_root(
+            element
+                .closing_element
+                .as_ref()
+                .map(|closing| &closing.name),
+        );
         walk::walk_jsx_element(self, element);
+    }
+
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        self.record_bare_namespace_reference(ident);
+        walk::walk_identifier_reference(self, ident);
     }
 }
 

--- a/crates/extract/src/visitor/visit_impl_object_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_object_bindings.rs
@@ -145,11 +145,12 @@ impl ModuleInfoExtractor {
         binding_name: &str,
         obj: &ObjectExpression<'_>,
     ) {
-        self.record_object_binding_targets_at_path(binding_name, obj);
+        self.record_object_binding_targets_at_path(binding_name, binding_name, obj);
     }
 
     fn record_object_binding_targets_at_path(
         &mut self,
+        root_name: &str,
         object_path: &str,
         obj: &ObjectExpression<'_>,
     ) {
@@ -171,13 +172,21 @@ impl ModuleInfoExtractor {
                 Expression::Identifier(ident)
                     if self.object_binding_candidates.len() < MAX_OBJECT_BINDING_CANDIDATES =>
                 {
+                    // The candidate gives this placement a precise path, which
+                    // `resolve_object_binding_candidates` turns back into
+                    // `<source>.<member>` accesses, so a namespace placed here
+                    // is resolved rather than handed over bare. What hands it
+                    // over is a bare reference to the root the object is bound
+                    // to, which `record_object_literal_namespace_pass` covers.
+                    // See issue #2377.
+                    self.record_object_literal_namespace_placement(root_name, ident);
                     self.object_binding_candidates.push(ObjectBindingCandidate {
                         binding_path,
                         source_name: ident.name.to_string(),
                     });
                 }
                 Expression::ObjectExpression(child) => {
-                    self.record_object_binding_targets_at_path(&binding_path, child);
+                    self.record_object_binding_targets_at_path(root_name, &binding_path, child);
                 }
                 _ => {}
             }

--- a/crates/graph/src/cache/mod.rs
+++ b/crates/graph/src/cache/mod.rs
@@ -174,7 +174,15 @@ pub use store::GraphCacheStore;
 /// credit their bodies. Warm 40 caches persist the import-less module and its
 /// missing edges, so the imported modules would stay reported as unused files
 /// on upgrade.
-pub const GRAPH_CACHE_VERSION: u32 = 41;
+///
+/// Bumped to 42 for issue #2377: a namespace import handed over whole (a call
+/// argument, a JSX attribute value, an alias, an array or object literal
+/// element, an initializer, an assignment right-hand side, a return value) no
+/// longer narrows to its dotted accesses, and those mark-all verdicts are
+/// baked into the persisted graph. Warm 41 caches carry the narrowed verdict,
+/// so the siblings the consumer can still reach would stay reported as unused
+/// on upgrade.
+pub const GRAPH_CACHE_VERSION: u32 = 42;
 
 /// Cached form of a resolved target.
 ///

--- a/docs/reference/extract-internals.md
+++ b/docs/reference/extract-internals.md
@@ -78,14 +78,15 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   use, which keeps the graph on mark-all for entry-point and non-entry
   consumers alike. The script side the visitor parsed (Astro frontmatter, MDX
   `import` / `export` lines) is guarded too
-  (`record_unexplained_script_mentions`), because the visitor records a bare
-  identifier as a whole-object use only for an allow-list of positions: for
-  the bindings the graph narrows exports for (namespace imports and CSS
-  module default imports) a mention outside the import declaration is
-  explained only by a static dotted access whose `(root, member)` pair the
-  visitor recorded or by a JSX tag root, so `const N = NS`, `NS as T`,
-  `pick(NS)`, `Object.assign({}, NS)`, `[NS]`, `{ all: NS }`, and
-  `export const all = NS` record a whole-object use. Class and enum bindings
+  (`record_unexplained_script_mentions`), because the text scan cannot see
+  what the parser resolved: for the bindings the graph narrows exports for
+  (namespace imports and CSS module default imports) a mention outside the
+  import declaration is explained only by a static dotted access whose
+  `(root, member)` pair the visitor recorded or by a JSX tag root, so
+  `NS['Moon']` and `NS?.Moon`, which the visitor resolves exactly, record a
+  whole-object use there. On the CSS-module side the guard is also what
+  covers `const N = styles`, `pick(styles)`, `[styles]`, and
+  `{ all: styles }`. Class and enum bindings
   are not script-guarded (a type annotation or `new` expression names them
   bare in ordinary code), so their member crediting stays at visitor parity
   with `.tsx` on the script side while the markup guard covers them. Narrowing
@@ -95,6 +96,20 @@ Shared extraction result types live in `crates/types/src/extract.rs`.
   feed the security secret-source index, so MDX prose records a dotted chain
   only when its root is an import local of the file: prose never creates
   member accesses on foreign roots such as `process.env`.
+- A reference to an `import * as NS` local that the visitor cannot resolve to
+  one member is a whole-object use, so the graph credits every export of the
+  target instead of narrowing to the dotted accesses
+  (`record_bare_namespace_reference` in
+  `crates/extract/src/visitor/visit_impl.rs`). The resolved positions are the
+  exclusions: the object of a static or string-computed access, the root of a
+  JSX member tag, the left side of a dotted type name, a destructure
+  initializer, a re-export specifier local (which the graph credits through
+  its own rule), and a placement in an object literal bound to a local, whose
+  `api.NS.member` path the object-binding resolver follows. A bare reference
+  to that local hands the namespace on in turn. The locals are pre-registered
+  from the program's statement list, because an import declaration is legal
+  after the code that reads it. Namespace objects bound by `require` or a
+  dynamic import keep the older allow-list.
 - The MDX line scan hands the statement lines of the whole file to the parser
   as one program, and a rejected program is an empty program, so one
   misclassified line would drop every import of the file. A line opens a

--- a/tests/fixtures/issue-2377-whole-object-use/package.json
+++ b/tests/fixtures/issue-2377-whole-object-use/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "issue-2377-whole-object-use-fixture",
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/issue-2377-whole-object-use/src/alias-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/alias-icons.ts
@@ -1,0 +1,3 @@
+export const AliasStar = (): null => null;
+
+export const AliasMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/alias.tsx
+++ b/tests/fixtures/issue-2377-whole-object-use/src/alias.tsx
@@ -1,0 +1,10 @@
+import * as AliasIcons from './alias-icons';
+
+const alias = AliasIcons;
+
+export const Aliased = () => (
+  <div>
+    <AliasIcons.AliasStar />
+    {alias.AliasMoon()}
+  </div>
+);

--- a/tests/fixtures/issue-2377-whole-object-use/src/argument-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/argument-icons.ts
@@ -1,0 +1,3 @@
+export const ArgumentStar = (): null => null;
+
+export const ArgumentMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/argument.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/argument.ts
@@ -1,0 +1,8 @@
+import * as ArgumentIcons from './argument-icons';
+
+const register = (all: Record<string, unknown>): number => Object.keys(all).length;
+
+export const useArgument = (): number => {
+  ArgumentIcons.ArgumentStar();
+  return register(ArgumentIcons);
+};

--- a/tests/fixtures/issue-2377-whole-object-use/src/array-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/array-icons.ts
@@ -1,0 +1,3 @@
+export const ArrayStar = (): null => null;
+
+export const ArrayMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/attribute-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/attribute-icons.ts
@@ -1,0 +1,3 @@
+export const AttributeStar = (): null => null;
+
+export const AttributeMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/attribute.tsx
+++ b/tests/fixtures/issue-2377-whole-object-use/src/attribute.tsx
@@ -1,0 +1,9 @@
+import * as AttributeIcons from './attribute-icons';
+import { Callout } from './callout';
+
+export const Attribute = () => (
+  <div>
+    <AttributeIcons.AttributeStar />
+    <Callout icons={AttributeIcons} />
+  </div>
+);

--- a/tests/fixtures/issue-2377-whole-object-use/src/callout.tsx
+++ b/tests/fixtures/issue-2377-whole-object-use/src/callout.tsx
@@ -1,0 +1,2 @@
+export const Callout = ({ icons }: { icons: Record<string, unknown> }): number =>
+  Object.keys(icons).length;

--- a/tests/fixtures/issue-2377-whole-object-use/src/collection.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/collection.ts
@@ -1,0 +1,12 @@
+import * as ArrayIcons from './array-icons';
+import * as ObjectIcons from './object-icons';
+
+const registry = [ArrayIcons];
+const lookup = { icons: ObjectIcons };
+
+export const collected = (): unknown[] => [
+  ArrayIcons.ArrayStar(),
+  ObjectIcons.ObjectStar(),
+  registry,
+  lookup,
+];

--- a/tests/fixtures/issue-2377-whole-object-use/src/dotted-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/dotted-icons.ts
@@ -1,0 +1,3 @@
+export const DottedStar = (): null => null;
+
+export const DottedMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/dotted.tsx
+++ b/tests/fixtures/issue-2377-whole-object-use/src/dotted.tsx
@@ -1,0 +1,3 @@
+import * as DottedIcons from './dotted-icons';
+
+export const Dotted = () => <DottedIcons.DottedStar />;

--- a/tests/fixtures/issue-2377-whole-object-use/src/index.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/index.ts
@@ -1,0 +1,6 @@
+export { Attribute } from './attribute';
+export { useArgument } from './argument';
+export { Aliased } from './alias';
+export { collected } from './collection';
+export { pickIcons } from './returned';
+export { Dotted } from './dotted';

--- a/tests/fixtures/issue-2377-whole-object-use/src/object-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/object-icons.ts
@@ -1,0 +1,3 @@
+export const ObjectStar = (): null => null;
+
+export const ObjectMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/return-icons.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/return-icons.ts
@@ -1,0 +1,3 @@
+export const ReturnStar = (): null => null;
+
+export const ReturnMoon = (): null => null;

--- a/tests/fixtures/issue-2377-whole-object-use/src/returned.ts
+++ b/tests/fixtures/issue-2377-whole-object-use/src/returned.ts
@@ -1,0 +1,6 @@
+import * as ReturnIcons from './return-icons';
+
+export const pickIcons = (): Record<string, unknown> => {
+  ReturnIcons.ReturnStar();
+  return ReturnIcons;
+};


### PR DESCRIPTION
## What was broken

A namespace import that is handed over whole and also read through one dotted access narrowed to that member alone, so every sibling the receiver can still reach was reported as an unused export. The reported shapes:

```tsx
// src/whole.tsx
import * as Icons from './whole-icons';
export const Whole = () => (<div><Icons.Star /><Callout icons={Icons} /></div>);
```

```ts
// src/arg.ts
import * as Icons from './arg-icons';
export const useArg = (): number => { Icons.Star(); return register(Icons); };
```

Both `Moon` exports reported, plus the same for an alias (`const N = NS`) and a statement initializer (`export const all = NS`).

## Root cause

`narrow_namespace_references` narrows a namespace binding to the members the consumer accessed unless the consumer recorded a whole-object use. The visitor recorded one for an allow-list of positions only: `Object.keys/values/entries/getOwnPropertyNames(NS)`, a spread, `for ... in`, a computed non-string access, a rest destructure, and a few type positions. Every other reference to the local left no trace at all, so a file with one dotted access and one bare pass looked exactly like a file with one dotted access.

Astro and MDX consumers were already covered: since #2360 their whole-file completeness guard turns any mention the structured passes did not classify into a whole-object use. Only `.ts` / `.tsx` / `.js` / `.jsx` consumers were affected.

## The fix

Earliest incorrect layer is extraction. A reference to an `import * as NS` local that the visitor cannot resolve to one member is now a whole-object use (`record_bare_namespace_reference` in `crates/extract/src/visitor/visit_impl.rs`), which puts the binding back on the graph's mark-all path. That is the conservative direction: it over-credits rather than reporting a used export.

The resolved positions are the exclusions, and they keep narrowing:

- the object of a static access (`NS.member`, `NS?.member`),
- the object of a string-computed access (`NS['member']`), which the parser resolves exactly even though the Astro and MDX text guards cannot,
- the root of a JSX member tag, opening and closing (`<NS.Card>` / `</NS.Card>`),
- the left side of a dotted type name (`NS.Type`),
- a destructure initializer (`const { Star } = NS`), whose members the visitor records (a rest element keeps its own whole-object use),
- a re-export specifier local (`export { NS }`), which the graph already credits in full through the rule added by #2373, so the two do not double-count,
- a placement in an object literal bound to a local (`const api = { NS }`), whose `api.NS.member` path the object-binding resolver follows and which #2372 deliberately keeps off the whole-module closure. A bare reference to that local (`hand(api)`) hands the namespace on in turn and does record the use.

The locals are pre-registered from the program's top-level statement list before the body walk, because an import declaration is legal after the code that reads it. The local of the binding's own `import * as NS` is a binding identifier, never a reference, so the import declaration needs no exclusion. The rule is scoped to `import * as` locals: named imports, and namespace objects bound by `require` or a dynamic import, keep the allow-list they had.

Side effect worth naming: `whole_object_uses` is now deduplicated at the recording site. Every consumer asks membership, never a count, and the record is persisted, so a name recorded opaquely many times is one entry instead of one per mention.

## Behavior change: fewer findings

This widens crediting for every TS and TSX consumer that hands a namespace over, so it is a finding-count **decrease** on upgrade, and it lands in regression baselines and `--max-issues` gates. An export credited for the first time also becomes reachable, so member-level detectors can report on it where the unused-export finding used to stand in its place.

Measured with `dead-code --no-cache --format json`, baseline binary built from `28b7be16f` against the patched binary:

| Project | Baseline | Fixed | Delta |
|---|---|---|---|
| in-repo `viz-frontend` | 0 | 0 | none |
| in-repo `editors/vscode` | 1 | 1 | none |
| `vuejs/core` v3.5.30 | 206 | 206 | none |
| `withastro/starlight` (main) | 34 | 32 | 2 fewer |

Both Starlight changes are true-positive removals on `packages/starlight/integrations/remark-rehype.ts`, `isUnifiedProcessor` and `remarkDirectivesRestoration`. `__tests__/markdown-processor/plugin-registration.test.ts` does `import * as unifiedIntegration from '../../integrations/remark-rehype'` and hands it over whole, both as a bare call argument (`registerDirectivesRestoration(processor, unifiedIntegration)`) and as a positional argument to `applyStarlightMarkdownPlugins`. The callees reach `unified.isUnifiedProcessor(...)` and `unified.remarkDirectivesRestoration`, so both exports are used. Nothing new is reported in any of the four projects.

## Cache invalidation

Both layers are bumped:

- extract `CACHE_VERSION` 277 -> 278, because extraction output changes (new `whole_object_uses` entries, and the deduplicated record);
- `GRAPH_CACHE_VERSION` 41 -> 42, because narrowing verdicts are baked into the persisted graph at build time; a warm graph cache would replay the narrowed verdict verbatim.

Warm-cache proof on the fixture:

1. baseline binary (extract 277, graph 41), cold run: reports all seven `*Moon` siblings and writes `.fallow`.
2. patched binary on that same warm cache: only `DottedMoon` reports, the precision control.
3. second warm run with the patched binary: identical output.

## How it was tested

- Extract-level tests: every handover position records the whole-object use while the dotted access is kept; every resolved position does not; the JSX member tag stays narrowed while a JSX attribute pass does not; a reference above its own import declaration is still recorded and one name yields one entry; a named import stays out of scope; and the object-literal placement plus the destructure keep narrowing while a rest element does not.
- Integration test on fixture `issue-2377-whole-object-use`, one consumer per handover shape (JSX attribute value, call argument, alias, array literal element, object literal value, return value), each against its own namespace target so a miscredit cannot be masked, plus the precision control that a dotted-only namespace still narrows and reports its unused sibling.
- Mutation matrix: with the non-test source hunks reverted, the four positive tests and the integration test fail; the three negative controls (`resolved_namespace_reference_keeps_narrowing`, `resolved_namespace_placement_keeps_narrowing`, `bare_named_import_reference_is_not_a_whole_use`) pass either way by design, since they pin behavior the fix must preserve. Restoring the hunks makes everything green again.
- CLI run of the issue's exact reproduction: only the one genuinely unused export remains.
- Real-project runs and warm-cache proof as above.
- Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `cargo check --workspace --benches`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `typos`, `scripts/scan-hidden-unicode.py --mode committed --staged`, `scripts/check-comment-quality.mjs --staged`, and `scripts/check-knowledge-architecture.mjs` all green.

## Known adjacent gap

A CSS module default import has the same defect shape (`import styles from './x.module.css'` plus one `styles.a` access plus a whole pass narrows to `a`). It is deliberately out of scope here and filed separately.

Fixes #2377
