### PR TITLE
test(config): compare the per-instance dedupe key with a platform-native tail

### DIFF
--- a/crates/config/src/workspace/diagnostics.rs
+++ b/crates/config/src/workspace/diagnostics.rs
@@ -1055,11 +1055,17 @@ mod tests {
 
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].message, diag.message);
+        // The key embeds `diag.path` through a raw `Display`, so the expected
+        // tail carries the platform separator: the stored path is rebuilt from
+        // its components and renders with backslashes on Windows.
+        let expected_tail = Path::new("packages").join("scratch");
         assert!(
             plans[0]
                 .dedupe_key
                 .contains("::glob-matched-no-package-json::")
-                && plans[0].dedupe_key.ends_with("packages/scratch"),
+                && plans[0]
+                    .dedupe_key
+                    .ends_with(&expected_tail.display().to_string()),
             "per-instance key is `root::kind::path`, not the `-agg::pattern` form: {}",
             plans[0].dedupe_key
         );


### PR DESCRIPTION
The weekly Release Validation went red on Windows: `plan_warnings_single_match_keeps_per_instance_message_and_key` panicked with

```
per-instance key is `root::kind::path`, not the `-agg::pattern` form:
/project::glob-matched-no-package-json::\project\packages\scratch
```

`normalise_diagnostic_path` rebuilds the stored path from its components, which is a no-op on Unix but swaps forward slashes for backslashes on Windows. The per-instance dedupe key embeds that path through a raw `Display`, so its tail is `packages\scratch` there, while the test asserted the literal `packages/scratch`.

The expectation is now built with `Path::join`, so it carries whichever separator the platform uses. The other path assertions in this module are unaffected because they read `message`, which goes through `display_relative` and normalises to forward slashes for output stability.

Test-only change; the dedupe key is internal to `should_emit` and never reaches output.

Local gate: `cargo test -p fallow-config --lib`, `cargo fmt --all --check`, and `cargo clippy -p fallow-config --all-targets -- -D warnings` all green. Windows itself is unverifiable locally, so Release Validation is the real check.