### PR TITLE
perf(trace): omit redundant namespace evidence

### DIFF
--- a/crates/engine/src/trace_impl.rs
+++ b/crates/engine/src/trace_impl.rs
@@ -287,17 +287,17 @@ fn crediting_export_references(
             graph.effective_bindings_share_declaration_group(candidate.binding(), surface.binding())
         });
     if !same_binding {
-        return (
-            namespace,
-            references.clone(),
-            vec![namespaced_references(namespace, references)],
-        );
+        return (namespace, references, Vec::new());
     }
     let other_references = direct_export_references(graph, root, file_id, export_name, other);
-    let by_namespace = vec![
-        namespaced_references(namespace, references.clone()),
-        namespaced_references(other, other_references.clone()),
-    ];
+    let by_namespace = if references.is_empty() || other_references.is_empty() {
+        Vec::new()
+    } else {
+        vec![
+            namespaced_references(namespace, references.clone()),
+            namespaced_references(other, other_references.clone()),
+        ]
+    };
     if references.is_empty() && !other_references.is_empty() {
         (other, other_references, by_namespace)
     } else {
@@ -1762,6 +1762,23 @@ mod tests {
         );
         assert_eq!(trace.direct_references[0].kind, "named import");
         assert_eq!(trace.reason, "Used by 1 file(s)");
+    }
+
+    #[test]
+    fn trace_omits_redundant_single_namespace_evidence() {
+        let graph = source_consumer_graph(vec![named_foo_export(false)], false, false, Vec::new());
+
+        let trace = trace_export(&graph, Path::new("/project"), "src/source.ts", "Foo")
+            .expect("value export exists");
+
+        assert_eq!(
+            trace.namespace,
+            fallow_types::semantic::SemanticNamespace::Value
+        );
+        assert_eq!(trace.direct_references.len(), 1);
+        assert!(trace.direct_references_by_namespace.is_empty());
+        let json = serde_json::to_value(&trace).expect("serialize trace");
+        assert!(json.get("direct_references_by_namespace").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- omit `direct_references_by_namespace` when the selected trace lane already contains all direct references
- preserve explicit per-namespace evidence when both value and type lanes contain references
- cover both the internal result and serialized omission contract

## Performance

The focused release Criterion WallTime benchmark improved from a 265.68 microsecond central estimate on `main` to 142.31 microseconds on a repeated optimized run. CodSpeed Simulation confirms a 31% improvement for the same trace benchmark on matching runners, with the other comparable benchmarks unchanged. The benchmark workload and fixture are unchanged.

## Validation

- focused trace regression tests
- complete repository verification
- CLI smoke against the issue fixture
- CLI smoke against the public `srcmap` repository
- CodSpeed Simulation on matching runners and local matching-environment WallTime validation
