### PR TITLE
fix(ci): initialize Windows pnpm cache store

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -184,6 +184,12 @@ jobs:
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.33.0
+      - name: Initialize pnpm store on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $store = pnpm store path --silent
+          New-Item -ItemType Directory -Force -Path $store | Out-Null
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -369,6 +369,10 @@ test("release runs Windows correctness and lifecycle verification without creden
   assert.match(job, /cargo fmt --all -- --check/);
   assert.match(job, /npm run publish:prepare/);
   assert.match(job, /cd crates\/napi && npm test/);
+  assert.match(
+    vscodeTargetJob,
+    /name: Initialize pnpm store on Windows[\s\S]*if: runner\.os == 'Windows'[\s\S]*pnpm store path --silent[\s\S]*New-Item -ItemType Directory -Force -Path \$store/,
+  );
   assert.match(vscodeTargetJob, /verify:vsix/);
   assert.match(vscodeTargetJob, /FALLOW_LSP_BIN:/);
   assert.match(vscodePackageJob, /name: validation-vscode-targets/);


### PR DESCRIPTION
## Summary

- create the Windows pnpm store before `actions/setup-node` registers it as a cache path
- keep the existing pnpm cache enabled on every release-validation host
- pin the Windows initialization contract in workflow policy tests

## Cause

The Windows VS Code host smoke itself passed, but the job failed during post-job cleanup because the pnpm cache path did not exist when `setup-node` tried to save it.

## Validation

- workflow policy and repository policy tests
- actionlint
- YAML parsing
- zizmor workflow security audit
