### PR TITLE
test(mcp): bound env route analysis threads

### DIFF
--- a/crates/mcp/tests/typed_route_env_coverage.rs
+++ b/crates/mcp/tests/typed_route_env_coverage.rs
@@ -293,6 +293,7 @@ impl McpServer {
                     "root": root.display().to_string(),
                     "complexity": true,
                     "max_crap": 10.0,
+                    "threads": 1,
                     "no_cache": true
                 }
             }
@@ -319,6 +320,7 @@ impl McpServer {
                 "name": "analyze",
                 "arguments": {
                     "root": root.display().to_string(),
+                    "threads": 1,
                     "no_cache": true
                 }
             }


### PR DESCRIPTION
## Summary

- bound the typed MCP env-route regression fixtures to one analysis thread
- keep production defaults unchanged while avoiding Windows CI oversubscription

## Validation

- focused coverage env route passed locally
- focused max-file-size env route passed locally
- Rust formatting and clippy passed

Closes the repeatable release-validation timeout on Windows.