### PR TITLE
fix(ci): allow cold-cache check completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true' || github.event_name == 'push' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # A cold Rust cache can leave the NAPI release build finishing just after
+    # the previous 20-minute limit on merged commits.
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -228,7 +228,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
 
   assert.doesNotMatch(workflowWithoutWindowsJobs, /windows-latest|windows-11-arm|macos-latest/);
   assert.match(checkJob, /runs-on: ubuntu-latest/);
-  assert.match(checkJob, /timeout-minutes: 20/);
+  assert.match(checkJob, /timeout-minutes: 30/);
   assert.doesNotMatch(checkJob, /matrix\.|windows-latest|macos-latest/);
   assert.match(vscodePackageTargetsJob, /runs-on: ubuntu-latest/);
   assert.match(vscodeTargetHostJob, /linux-x64[\s\S]*win32-x64[\s\S]*darwin-x64/u);


### PR DESCRIPTION
Raises the central CI job timeout so a cold-cache NAPI release build can finish on merged commits.

Adds workflow-policy coverage for the new bound.

Validation:
- `node --test scripts/workflow-policy.test.mjs`
- `actionlint .github/workflows/ci.yml`
- `npm run verify:fast`