### PR TITLE
ci: cover the config and types unit tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
               - 'crates/mcp/src/tools/mod.rs'
               - 'crates/mcp/src/tools/process_tree.rs'
               - 'crates/mcp/Cargo.toml'
+              - 'crates/config/**'
+              - 'crates/types/**'
               - '.github/actions/setup-rust/**'
               - '.github/workflows/ci.yml'
               - 'scripts/workflow-policy.test.mjs'
@@ -382,6 +384,8 @@ jobs:
         run: cargo test -p fallow-mcp completed_success_cleans_descendant_process_tree
       - name: Test CLI subprocess cleanup
         run: cargo test -p fallow-cli windows_job_object_terminates_descendants_without_taskkill_lookup
+      - name: Test config and workspace diagnostic path handling
+        run: cargo test -p fallow-config -p fallow-types --lib
       - name: Clippy platform-specific paths
         run: cargo clippy -p fallow-cli -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings
 

--- a/scripts/workflow-policy.test.mjs
+++ b/scripts/workflow-policy.test.mjs
@@ -244,6 +244,11 @@ test("regular CI keeps affected checks on Ubuntu", () => {
   assert.ok(windowsRustPaths.includes("crates/cli/src/signal/**"));
   assert.ok(windowsRustPaths.includes("crates/cli/src/type_aware.rs"));
   assert.ok(windowsRustPaths.includes("crates/lsp/**"));
+  // Path rendering lives across both crates (`Display`, `join`, `components`),
+  // and a separator regression there is invisible until the weekly Release
+  // Validation runs the full suite on Windows.
+  assert.ok(windowsRustPaths.includes("crates/config/**"));
+  assert.ok(windowsRustPaths.includes("crates/types/**"));
   assert.match(windowsRustJob, /cargo test -p fallow-engine changed_files::tests/);
   assert.match(windowsRustJob, /cargo test -p fallow-engine churn::tests/);
   assert.match(windowsRustJob, /cargo test -p fallow-engine repo_refs::tests/);
@@ -260,6 +265,7 @@ test("regular CI keeps affected checks on Ubuntu", () => {
     windowsRustJob,
     /cargo test -p fallow-cli windows_job_object_terminates_descendants_without_taskkill_lookup/,
   );
+  assert.match(windowsRustJob, /^[ \t]+run: cargo test -p fallow-config -p fallow-types --lib$/m);
   assert.match(
     windowsRustJob,
     /^[ \t]+run: cargo clippy -p fallow-cli -p fallow-core -p fallow-engine -p fallow-lsp -p fallow-mcp --all-targets -- -D warnings$/m,


### PR DESCRIPTION
`crates/config` and `crates/types` were absent from the `windows-rust` paths filter, so a change confined to them ran no Windows job at all. The only Windows run of the full suite is the weekly Release Validation, which means a separator regression in those crates stays invisible on main for up to a week.

That is not hypothetical: `normalise_diagnostic_path` landed in `crates/types/src/workspace.rs` on 24 August and broke a `crates/config` assertion on Windows only. Neither file was in the filter, so nothing Windows-side ran before it merged; the weekly cron happened to fire nineteen minutes later and caught it (fixed in #2398). The `release-validation.yml` header records v3.4.0 and v3.4.1 being burned by the same class of failure.

This adds `crates/config/**` and `crates/types/**` to the filter and runs `cargo test -p fallow-config -p fallow-types --lib` in the existing Windows job, with matching assertions in `scripts/workflow-policy.test.mjs` so the coverage cannot be dropped silently.

Both crates are already compiled by that job's other steps, so the added work is linking and running two test binaries. On the last hundred commits, twelve touch these crates while fifteen already trigger the job, so the trigger rate grows by roughly a tenth rather than doubling. Path handling is spread across twenty-six files in the two crates, which is why this is a crate-level glob rather than the file-level entries used elsewhere in the filter.

Local gate: `cargo test -p fallow-config -p fallow-types --lib` green (917 and 305 passed), and the full `node --test scripts/*.test.mjs` policy suite green. This PR edits `ci.yml`, which is itself in the filter, so the job runs here and exercises the new step on Windows.