### PR TITLE
chore(hooks): skip node-dependent checks without node_modules

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,9 +4,11 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+# A fresh worktree has no node_modules; CI still runs commitlint, so skip
+# locally instead of aborting the commit with a message that reads as a warning.
 if [ ! -x node_modules/.bin/commitlint ]; then
-  echo "commitlint is not installed. Run: npm install"
-  exit 1
+  echo "commit-msg: commitlint is not installed, skipping local check (CI still enforces it). Run: npm ci" >&2
+  exit 0
 fi
 
 node_modules/.bin/commitlint --edit "$1"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -38,13 +38,12 @@ js_ts_changed=$(
 
 if [ -n "$js_ts_changed" ]; then
   if [ ! -d node_modules ]; then
-    echo "JS/TS files staged but node_modules is missing. Run \`npm install\` first." >&2
-    exit 1
+    echo "pre-commit: JS/TS files staged but node_modules is missing; skipping oxlint and oxfmt (CI still enforces them). Run: npm ci" >&2
+  else
+    echo "Running oxlint..."
+    npm run --silent lint:js
+
+    echo "Running oxfmt --check..."
+    npm run --silent fmt:js:check
   fi
-
-  echo "Running oxlint..."
-  npm run --silent lint:js
-
-  echo "Running oxfmt --check..."
-  npm run --silent fmt:js:check
 fi

--- a/editors/vscode/test/integration/runTest.ts
+++ b/editors/vscode/test/integration/runTest.ts
@@ -5,7 +5,10 @@ import { runTests } from "@vscode/test-electron";
 
 const extensionDevelopmentPath = path.resolve(__dirname, "../../..");
 const extensionTestsPath = path.resolve(__dirname, "suite/index.js");
-const vscodeTestCachePath = path.join(os.tmpdir(), "fallow-vscode-test-cache");
+const vscodeTestCachePath = path.resolve(
+  process.env["FALLOW_VSCODE_TEST_CACHE_PATH"] ??
+    path.join(os.tmpdir(), "fallow-vscode-test-cache"),
+);
 const fixtureWorkspacePath = path.resolve(
   extensionDevelopmentPath,
   "test/integration/fixtures/workspace/package.json"


### PR DESCRIPTION
A fresh worktree has no `node_modules`, so `.githooks/commit-msg` aborted the commit on missing commitlint and `.githooks/pre-commit` aborted on staged JS/TS. Both now warn and skip locally; CI still enforces commitlint, oxlint, and oxfmt. The VS Code integration test runner also honours `FALLOW_VSCODE_TEST_CACHE_PATH`, matching the real-project runner.