### PR TITLE
fix(dead-code): collapse React Native platform families in duplicate-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status bar and a statusline wrapper can retry with a current binary. Corrupt
   or unreadable stores keep the `data unavailable` line.
 
+### Fixed
+
+- **React Native and Expo platform-extension families are no longer reported
+  as duplicate exports** (Closes
+  [#2407](https://github.com/fallow-rs/fallow/issues/2407)). Since 3.11.0 an
+  import of `./UserMenu` credits every member of a Metro family
+  (`UserMenu.tsx`, `UserMenu.ios.tsx`, `UserMenu.web.tsx`, ...), which made
+  the siblings share an importer and surface in `duplicate-exports` as a pair.
+  With the `react-native` or `expo` plugin active, `dead-code` now folds each
+  family into one representative (the base file when present, otherwise the
+  lowest path) before duplicate detection. A genuine duplicate in an unrelated
+  file is still reported and names that file next to the family
+  representative. Projects without those plugins keep the previous output.
+
 ## [3.18.0] - 2026-08-25
 
 ### Added

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -11,6 +11,7 @@ use crate::graph::{
     AmbiguityParticipants, EffectiveExportResolution, ExportNamespace, ExportSymbol, ModuleGraph,
     ModuleNode,
 };
+use crate::resolve::{has_react_native_plugin, platform_family_key};
 use crate::results::{
     DuplicateExport, DuplicateLocation, ExportUsage, PrivateTypeLeak, ReferenceLocation,
     StaleSuppression, SuppressionOrigin, UnusedExport,
@@ -73,6 +74,13 @@ fn is_tanstack_router_active(
             .iter()
             .any(|plugin| plugin == TANSTACK_ROUTER_PLUGIN_NAME)
     })
+}
+
+/// Whether Metro platform-extension resolution is in effect, which is the only
+/// situation where sibling `<stem>.<platform><ext>` files are one module
+/// selected per platform rather than independent duplicates.
+fn is_react_native_active(plugin_result: Option<&crate::plugins::AggregatedPluginResult>) -> bool {
+    plugin_result.is_some_and(|pr| has_react_native_plugin(&pr.active_plugins))
 }
 
 struct CompiledUsedExportRule<'a> {
@@ -1067,6 +1075,7 @@ pub(super) fn find_duplicate_exports_with_plugins(
     let dynamic_re_export_sources = build_dynamic_re_export_source_map(graph, resolved_modules);
     let export_locations =
         collect_duplicate_export_locations(graph, config, suppressions, plugin_result);
+    let collapse_platform_families = is_react_native_active(plugin_result);
 
     let mut sorted_locations: Vec<_> = export_locations.into_iter().collect();
     sorted_locations.sort_by(|a, b| a.0.cmp(&b.0));
@@ -1080,6 +1089,7 @@ pub(super) fn find_duplicate_exports_with_plugins(
                 &dynamic_re_export_sources,
                 graph,
                 line_offsets_by_file,
+                collapse_platform_families,
             )
         })
         .collect()
@@ -1238,14 +1248,16 @@ fn is_css_module_path(path: &std::path::Path) -> bool {
 }
 
 /// Evaluate one same-name export group into an optional duplicate finding:
-/// strip re-export chain members, partition the remaining origins into
-/// importer-connected components, and collect the surviving locations.
+/// strip re-export chain members, collapse Metro platform-extension families
+/// when `collapse_platform_families` is set, partition the remaining origins
+/// into importer-connected components, and collect the surviving locations.
 fn evaluate_duplicate_export_group(
     name: String,
     locations: Vec<ExportEntry>,
     dynamic_re_export_sources: &DynamicReExportSources,
     graph: &ModuleGraph,
     line_offsets_by_file: &LineOffsetsMap<'_>,
+    collapse_platform_families: bool,
 ) -> Option<DuplicateExport> {
     if locations.len() <= 1 {
         return None;
@@ -1266,6 +1278,14 @@ fn evaluate_duplicate_export_group(
             )
         })
         .collect();
+
+    // Collapse after the re-export strip so a barrel that re-exports from the
+    // platform winner is still recognized as a chain member of the family.
+    let independent_entries = if collapse_platform_families {
+        collapse_platform_family_entries(independent_entries)
+    } else {
+        independent_entries
+    };
 
     if independent_entries.len() <= 1 {
         return None;
@@ -1296,6 +1316,81 @@ fn evaluate_duplicate_export_group(
         export_name: name,
         locations: surviving_locations,
     })
+}
+
+/// Keep one member per Metro platform-extension family in `entries`.
+///
+/// With the React Native or Expo plugin active the resolver credits an import
+/// of `./UserMenu` to every family member, so `UserMenu.tsx` and
+/// `UserMenu.ios.tsx` share each importer and would otherwise partition into
+/// one duplicate component. The variants are one module selected per
+/// platform, not independent origins. The base file stands in for the family
+/// when present (it is Metro's fallback on every other platform), otherwise
+/// the lowest path, so a genuine duplicate elsewhere is still reported
+/// against a stable member. Entry order is preserved.
+fn collapse_platform_family_entries(entries: Vec<ExportEntry>) -> Vec<ExportEntry> {
+    let keep = platform_family_keep_mask(&entries);
+    entries
+        .into_iter()
+        .zip(keep)
+        .filter_map(|(entry, keep)| keep.then_some(entry))
+        .collect()
+}
+
+/// Mark which of `entries` survive family collapsing: every entry outside a
+/// family, and every entry of each family's representative file.
+fn platform_family_keep_mask(entries: &[ExportEntry]) -> Vec<bool> {
+    let mut families: FxHashMap<(&std::path::Path, &str), Vec<(usize, bool)>> =
+        FxHashMap::default();
+    for (i, entry) in entries.iter().enumerate() {
+        let Some(key) = platform_family_key(&entry.path) else {
+            continue;
+        };
+        families
+            .entry((key.parent, key.base))
+            .or_default()
+            .push((i, key.is_platform_variant));
+    }
+
+    let mut keep = vec![true; entries.len()];
+    for members in families.into_values() {
+        let Some(representative) = platform_family_representative(entries, &members) else {
+            continue;
+        };
+        for &(i, _) in &members {
+            if entries[i].file_id != representative {
+                keep[i] = false;
+            }
+        }
+    }
+    keep
+}
+
+/// Pick the file that stands in for one family, or `None` when `members` do
+/// not form a family: a single file (possibly with both a value and a type
+/// entry), or same-stem files without any platform variant, which Metro never
+/// treats as a family.
+fn platform_family_representative(
+    entries: &[ExportEntry],
+    members: &[(usize, bool)],
+) -> Option<FileId> {
+    let distinct_files: FxHashSet<FileId> =
+        members.iter().map(|&(i, _)| entries[i].file_id).collect();
+    if distinct_files.len() < 2 || !members.iter().any(|&(_, is_variant)| is_variant) {
+        return None;
+    }
+    let base_members = members
+        .iter()
+        .filter(|&&(_, is_variant)| !is_variant)
+        .map(|&(i, _)| &entries[i]);
+    let representative = match base_members.min_by_key(|entry| &entry.path) {
+        Some(base) => base,
+        None => members
+            .iter()
+            .map(|&(i, _)| &entries[i])
+            .min_by_key(|entry| &entry.path)?,
+    };
+    Some(representative.file_id)
 }
 
 fn is_re_export_chain_member(

--- a/crates/core/tests/integration_test/false_positive_fixes.rs
+++ b/crates/core/tests/integration_test/false_positive_fixes.rs
@@ -637,6 +637,201 @@ export const app = UserMenu;
     );
 }
 
+/// Write a small project whose `src/index.ts` entry imports the given files.
+/// `manifest` is the full `package.json` body so a test can opt in or out of
+/// the React Native plugin.
+fn write_platform_family_project(root: &std::path::Path, manifest: &str, files: &[(&str, &str)]) {
+    std::fs::write(root.join("package.json"), manifest).expect("package json");
+    for (relative, source) in files {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().expect("file parent")).expect("file dir");
+        std::fs::write(path, source).expect("project file");
+    }
+}
+
+const REACT_NATIVE_FAMILY_MANIFEST: &str = r#"{
+    "name": "react-native-platform-family-duplicates",
+    "private": true,
+    "main": "src/index.ts",
+    "dependencies": {
+        "react-native": "0.80.0"
+    }
+}"#;
+
+const PLAIN_FAMILY_MANIFEST: &str = r#"{
+    "name": "plain-platform-suffix-siblings",
+    "private": true,
+    "main": "src/index.ts"
+}"#;
+
+fn duplicate_locations(
+    results: &fallow_types::results::AnalysisResults,
+    name: &str,
+) -> Option<Vec<String>> {
+    results
+        .duplicate_exports
+        .iter()
+        .find(|d| d.export.export_name == name)
+        .map(|d| {
+            d.export
+                .locations
+                .iter()
+                .map(|location| location.path.to_string_lossy().replace('\\', "/"))
+                .collect()
+        })
+}
+
+#[test]
+fn react_native_platform_family_is_not_a_duplicate_export() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    write_platform_family_project(
+        root,
+        REACT_NATIVE_FAMILY_MANIFEST,
+        &[
+            (
+                "src/index.ts",
+                "import { UserMenu } from \"./components/UserMenu\";\nexport const app = UserMenu;\n",
+            ),
+            (
+                "src/components/UserMenu.tsx",
+                "export const UserMenu = 'default';\n",
+            ),
+            (
+                "src/components/UserMenu.ios.tsx",
+                "export const UserMenu = 'ios';\n",
+            ),
+        ],
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert_eq!(
+        duplicate_locations(&results, "UserMenu"),
+        None,
+        "one Metro platform-extension family is a single module selected per platform, not a duplicate"
+    );
+}
+
+#[test]
+fn react_native_web_platform_family_is_not_a_duplicate_export() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    write_platform_family_project(
+        root,
+        REACT_NATIVE_FAMILY_MANIFEST,
+        &[
+            (
+                "src/index.ts",
+                "import { UserMenu } from \"./components/UserMenu\";\nexport const app = UserMenu;\n",
+            ),
+            (
+                "src/components/UserMenu.tsx",
+                "export const UserMenu = 'native';\n",
+            ),
+            (
+                "src/components/UserMenu.web.tsx",
+                "export const UserMenu = 'web';\n",
+            ),
+        ],
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    assert_eq!(
+        duplicate_locations(&results, "UserMenu"),
+        None,
+        "a `.web` variant next to the base file is a platform family too"
+    );
+}
+
+#[test]
+fn react_native_platform_family_still_reports_unrelated_duplicate() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    write_platform_family_project(
+        root,
+        REACT_NATIVE_FAMILY_MANIFEST,
+        &[
+            (
+                "src/index.ts",
+                "import { UserMenu } from \"./components/UserMenu\";\nimport { UserMenu as LegacyUserMenu } from \"./legacy/UserMenu\";\nexport const app = [UserMenu, LegacyUserMenu];\n",
+            ),
+            (
+                "src/components/UserMenu.tsx",
+                "export const UserMenu = 'default';\n",
+            ),
+            (
+                "src/components/UserMenu.ios.tsx",
+                "export const UserMenu = 'ios';\n",
+            ),
+            (
+                "src/legacy/UserMenu.tsx",
+                "export const UserMenu = 'legacy';\n",
+            ),
+        ],
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let locations = duplicate_locations(&results, "UserMenu")
+        .expect("a genuine duplicate outside the family must still be reported");
+    assert!(
+        locations
+            .iter()
+            .any(|path| path.ends_with("src/legacy/UserMenu.tsx")),
+        "the finding must name the unrelated file: {locations:?}"
+    );
+    assert!(
+        locations
+            .iter()
+            .any(|path| path.ends_with("src/components/UserMenu.tsx")),
+        "the family is represented by its base file: {locations:?}"
+    );
+    assert!(
+        !locations
+            .iter()
+            .any(|path| path.ends_with("src/components/UserMenu.ios.tsx")),
+        "platform variants collapse into the family representative: {locations:?}"
+    );
+}
+
+#[test]
+fn platform_suffix_siblings_without_mobile_plugin_stay_duplicate_exports() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    write_platform_family_project(
+        root,
+        PLAIN_FAMILY_MANIFEST,
+        &[
+            (
+                "src/index.ts",
+                "import { Foo } from \"./components/Foo\";\nimport { Foo as IosFoo } from \"./components/Foo.ios\";\nexport const app = [Foo, IosFoo];\n",
+            ),
+            ("src/components/Foo.tsx", "export const Foo = 'default';\n"),
+            ("src/components/Foo.ios.tsx", "export const Foo = 'ios';\n"),
+        ],
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let locations = duplicate_locations(&results, "Foo")
+        .expect("without the React Native or Expo plugin a `.ios` suffix is just a file name");
+    assert!(
+        locations
+            .iter()
+            .any(|path| path.ends_with("src/components/Foo.tsx"))
+            && locations
+                .iter()
+                .any(|path| path.ends_with("src/components/Foo.ios.tsx")),
+        "both sibling files must be reported: {locations:?}"
+    );
+}
+
 #[test]
 fn missing_react_native_extends_resolves_explicit_js_alias_to_platform_source() {
     let dir = tempfile::tempdir().expect("temp dir");

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -32,6 +32,7 @@ pub use fallbacks::extract_package_name_from_node_modules_path;
 pub use path_info::{
     extract_package_name, is_bare_specifier, is_path_alias, is_valid_package_name,
 };
+pub use react_native::{PlatformFamilyKey, has_react_native_plugin, platform_family_key};
 pub use types::{
     OUTPUT_DIRS, ResolveResult, ResolvedImport, ResolvedModule, ResolvedProject, ResolvedReExport,
     ResolvedReplacedModuleTarget, ResolvedSourceEdge,

--- a/crates/graph/src/resolve/react_native.rs
+++ b/crates/graph/src/resolve/react_native.rs
@@ -8,8 +8,9 @@ use super::types::{RN_PLATFORM_PREFIXES, ResolveResult, ResolvedImport, Resolved
 use fallow_types::discover::{DiscoveredFile, FileId};
 use fallow_types::extract::{ImportInfo, ImportedName};
 
-/// Check if React Native or Expo plugins are active.
-fn has_react_native_plugin(active_plugins: &[String]) -> bool {
+/// Whether the React Native or Expo plugin is active, the gate for every
+/// Metro platform-extension behavior in the resolver and its consumers.
+pub fn has_react_native_plugin(active_plugins: &[String]) -> bool {
     active_plugins
         .iter()
         .any(|p| p == "react-native" || p == "expo")
@@ -40,6 +41,41 @@ fn strip_platform_segment(stem: &str) -> (&str, bool) {
     (stem, false)
 }
 
+/// Where a source file sits in a Metro platform-extension family: the
+/// directory and base stem shared by `<stem>.<platform><ext>` and
+/// `<stem><ext>`, plus whether this member carries a platform segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlatformFamilyKey<'a> {
+    /// Directory containing the file.
+    pub parent: &'a Path,
+    /// File stem with the source extension and any platform segment removed.
+    pub base: &'a str,
+    /// Whether the file name carries a platform segment (`.ios`, `.web`, ...).
+    pub is_platform_variant: bool,
+}
+
+/// Classify `path` by its Metro platform-extension family.
+///
+/// Membership is syntactic: files sharing `parent` and `base` belong to the
+/// same family, and the caller decides whether enough members exist for the
+/// family to matter. Returns `None` for files outside the Metro source
+/// extensions, names without a stem, and paths without a parent directory.
+pub fn platform_family_key(path: &Path) -> Option<PlatformFamilyKey<'_>> {
+    let name = path.file_name()?.to_str()?;
+    let (stem, ext) = split_source_ext(name);
+    ext?;
+    let (base, is_platform_variant) = strip_platform_segment(stem);
+    if base.is_empty() {
+        return None;
+    }
+    let parent = path.parent()?;
+    Some(PlatformFamilyKey {
+        parent,
+        base,
+        is_platform_variant,
+    })
+}
+
 /// Whether an import specifier explicitly names a platform variant
 /// (e.g. `./UserMenu.ios` or `./UserMenu.ios.tsx`), in which case the author
 /// targeted one variant and the family must not be credited as a whole.
@@ -62,24 +98,13 @@ impl PlatformFamilies {
     fn build(files: &[DiscoveredFile]) -> Self {
         let mut grouped: FxHashMap<(&Path, &str), Vec<(FileId, bool)>> = FxHashMap::default();
         for file in files {
-            let Some(name) = file.path.file_name().and_then(|n| n.to_str()) else {
-                continue;
-            };
-            let (stem, ext) = split_source_ext(name);
-            if ext.is_none() {
-                continue;
-            }
-            let (base, is_platform) = strip_platform_segment(stem);
-            if base.is_empty() {
-                continue;
-            }
-            let Some(parent) = file.path.parent() else {
+            let Some(key) = platform_family_key(&file.path) else {
                 continue;
             };
             grouped
-                .entry((parent, base))
+                .entry((key.parent, key.base))
                 .or_default()
-                .push((file.id, is_platform));
+                .push((file.id, key.is_platform_variant));
         }
 
         let mut family_of = FxHashMap::default();
@@ -411,6 +436,48 @@ mod tests {
         assert!(!specifier_names_platform_variant("./UserMenu"));
         assert!(!specifier_names_platform_variant("./UserMenu.tsx"));
         assert!(!specifier_names_platform_variant("./ios/UserMenu"));
+    }
+
+    #[test]
+    fn test_platform_family_key_marks_platform_variants() {
+        let key = platform_family_key(Path::new("src/components/UserMenu.ios.tsx"))
+            .expect("source file has a family key");
+        assert_eq!(key.parent, Path::new("src/components"));
+        assert_eq!(key.base, "UserMenu");
+        assert!(key.is_platform_variant);
+
+        let key = platform_family_key(Path::new("src/components/UserMenu.tsx"))
+            .expect("source file has a family key");
+        assert_eq!(key.parent, Path::new("src/components"));
+        assert_eq!(key.base, "UserMenu");
+        assert!(!key.is_platform_variant);
+    }
+
+    #[test]
+    fn test_platform_family_key_covers_every_platform_and_source_extension() {
+        for platform in RN_PLATFORM_PREFIXES {
+            for ext in RN_SOURCE_EXTS {
+                let path = format!("src/Button{platform}{ext}");
+                let key = platform_family_key(Path::new(&path)).expect("family key");
+                assert_eq!(key.base, "Button", "{path}");
+                assert!(key.is_platform_variant, "{path}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_platform_family_key_rejects_non_source_files() {
+        assert_eq!(platform_family_key(Path::new("src/UserMenu.css")), None);
+        assert_eq!(
+            platform_family_key(Path::new("src/UserMenu.ios.json")),
+            None
+        );
+        assert_eq!(platform_family_key(Path::new("src/UserMenu.ios")), None);
+        assert_eq!(
+            platform_family_key(Path::new("src/.ios.tsx")),
+            None,
+            "a bare platform segment has no base stem"
+        );
     }
 
     fn discovered(id: u32, path: &str) -> DiscoveredFile {


### PR DESCRIPTION
With the react-native or expo plugin active, an import of ./UserMenu credits every Metro platform-extension member, so UserMenu.tsx and UserMenu.ios.tsx shared an importer and surfaced as a duplicate pair. Each family now folds into one representative (the base file, otherwise the lowest path) before the importer partition. A genuine duplicate in an unrelated file is still reported against that representative. Without those plugins the output is unchanged.

The platform list stays defined once: the graph resolver exposes platform_family_key and has_react_native_plugin and the duplicate-export analysis consumes them.

Closes #2407