### PR TITLE
chore: publish Fallow in the official MCP Registry

### DIFF
--- a/npm/fallow/package.json
+++ b/npm/fallow/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fallow",
   "version": "3.18.0",
+  "mcpName": "io.github.fallow-rs/fallow",
   "description": "Codebase intelligence for TypeScript and JavaScript. Free static analysis of code and styles, optional paid runtime intelligence (Fallow Runtime). Quality, risk, architecture, dependencies, duplication, and design-system drift for humans, CI, and the agents writing your code. Zero-config framework support.",
   "license": "MIT",
   "repository": {

--- a/scripts/mcp-registry.test.mjs
+++ b/scripts/mcp-registry.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+
+test("MCP Registry metadata matches the published npm package", () => {
+  const card = readJson("server.json");
+  const packageManifest = readJson("npm/fallow/package.json");
+  const [npmPackage] = card.packages;
+
+  assert.equal(
+    card.$schema,
+    "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  );
+  assert.ok(card.description.length <= 100);
+  assert.equal(card.name, packageManifest.mcpName);
+  assert.equal(card.version, packageManifest.version);
+  assert.equal(npmPackage.identifier, packageManifest.name);
+  assert.equal(npmPackage.version, packageManifest.version);
+  assert.deepEqual(npmPackage.transport, { type: "stdio" });
+  assert.deepEqual(npmPackage.packageArguments, [{ type: "positional", value: "mcp-server" }]);
+  assert.equal(card.repository.url, "https://github.com/fallow-rs/fallow");
+});

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.fallow-rs/fallow",
+  "title": "Fallow",
+  "description": "Codebase intelligence for TypeScript and JavaScript, exposed as structured MCP analysis tools.",
+  "repository": {
+    "url": "https://github.com/fallow-rs/fallow",
+    "source": "github"
+  },
+  "version": "3.18.0",
+  "websiteUrl": "https://docs.fallow.tools/integrations/mcp",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "fallow",
+      "version": "3.18.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp-server"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the official MCP Registry card and package ownership metadata for Fallow. The card installs the public `fallow` npm package and launches its existing `mcp-server` stdio command.

Verification:
- official `mcp-publisher validate server.json`: pass
- Registry metadata contract test: pass
- npm package tests: pass
- npm pack manifest inspection: pass
- published `fallow@3.18.0 mcp-server` smoke: pass
- `npm run verify:fast`: pass

Live publication must follow the first npm release containing `mcpName`. The existing public `fallow@3.18.0` manifest predates that Registry ownership proof.