### PR TITLE
fix(check): fail on boundary violations and promoted warnings when overrides exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--fail-on-issues` now fails on boundary violations and promoted warnings
+  when per-path `overrides` exist** (Closes
+  [#2445](https://github.com/fallow-rs/fallow/issues/2445)). With any
+  `overrides` entry configured, the exit-code check switched to per-file
+  severity resolution, and that path never consulted import-direction
+  boundary violations, so an error-severity `boundary-violation` was reported
+  but exited 0. The same path also skipped the warn-to-error promotion of
+  `--fail-on-issues` (and `--ci`), so a `warn` rule plus any override exited 0
+  as well. Both now resolve per file and promote after override resolution, so
+  an explicit per-path `warn` fails a strict run just like the base rules.
+  Thanks to [@DeLuke84](https://github.com/DeLuke84) for the report.
+
 ## [3.19.0] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2437](https://github.com/fallow-rs/fallow/pull/2437)). Thanks to
   [@PatrickShaw](https://github.com/PatrickShaw) for the contribution.
 
-### Fixed
-
-- **`--fail-on-issues` now fails on boundary violations and promoted warnings
-  when per-path `overrides` exist** (Closes
+- **`--fail-on-issues` and `--ci` now fail on boundary violations and on
+  warn-severity findings when per-path `overrides` exist** (Closes
   [#2445](https://github.com/fallow-rs/fallow/issues/2445)). With any
   `overrides` entry configured, the exit-code check switched to per-file
   severity resolution, and that path never consulted import-direction
   boundary violations, so an error-severity `boundary-violation` was reported
-  but exited 0. The same path also skipped the warn-to-error promotion of
-  `--fail-on-issues` (and `--ci`), so a `warn` rule plus any override exited 0
-  as well. Both now resolve per file and promote after override resolution, so
-  an explicit per-path `warn` fails a strict run just like the base rules.
-  Thanks to [@DeLuke84](https://github.com/DeLuke84) for the report.
+  but the run exited 0. The same path also skipped the warn-to-error
+  promotion of `--fail-on-issues`, so a `warn` rule plus any override exited 0
+  as well. Both now resolve per file and promote after override resolution.
+  Because the override path handles every file once any `overrides` entry
+  exists, this affects all `warn`-severity rules in a project that configures
+  overrides, not only the rules set inside the override block: a strict run
+  that previously exited 0 now exits 1 on those findings. To keep the previous
+  outcome, set the rule to `off` rather than `warn`, or drop
+  `--fail-on-issues` and `--ci` for that job. Thanks to
+  [@DeLuke84](https://github.com/DeLuke84) for the report.
 
 ## [3.19.0] - 2026-08-26
 

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -1479,7 +1479,12 @@ fn print_unmatched_ignore_findings_note(result: &CheckResult, quiet: bool) {
 }
 
 fn issue_severity_exit_code(result: &CheckResult, effective_rules: &RulesConfig) -> ExitCode {
-    if rules::has_error_severity_issues(&result.results, effective_rules, Some(&result.config)) {
+    if rules::has_error_severity_issues(
+        &result.results,
+        effective_rules,
+        Some(&result.config),
+        result.fail_on_issues,
+    ) {
         ExitCode::from(1)
     } else {
         ExitCode::SUCCESS

--- a/crates/cli/src/check/rules.rs
+++ b/crates/cli/src/check/rules.rs
@@ -1,4 +1,5 @@
 use fallow_config::{ResolvedConfig, RulesConfig, Severity};
+use std::path::Path;
 
 /// Remove issues whose effective severity is `Off` from the results.
 ///
@@ -429,15 +430,25 @@ fn apply_boundary_override_rules(
 /// When overrides are configured, per-file rule resolution is used for
 /// file-scoped issue types to determine if any individual issue has Error
 /// severity. Circular dependencies resolve against every file in the cycle.
+///
+/// `promote_warns` mirrors `--fail-on-issues`: `rules` is expected to arrive
+/// already promoted, and the per-file override path promotes each resolved
+/// severity after override resolution so an explicit per-path `warn` fails
+/// the run just like the base rules would.
 pub fn has_error_severity_issues(
     results: &fallow_types::results::AnalysisResults,
     rules: &RulesConfig,
     config: Option<&ResolvedConfig>,
+    promote_warns: bool,
 ) -> bool {
     let has_overrides = config.is_some_and(|c| !c.overrides.is_empty());
 
     let file_scoped_errors = if let Some(config) = config.filter(|c| !c.overrides.is_empty()) {
-        has_override_file_scoped_error(results, config)
+        let resolver = OverrideSeverities {
+            config,
+            promote_warns,
+        };
+        has_override_file_scoped_error(results, &resolver)
     } else {
         has_default_file_scoped_error(results, rules)
     };
@@ -445,72 +456,92 @@ pub fn has_error_severity_issues(
     file_scoped_errors || has_project_level_error(results, rules, has_overrides)
 }
 
+/// Per-file severity source for the override path of the exit-code check.
+///
+/// Warn-to-error promotion happens after override resolution so it reaches
+/// severities set by a per-path override, not only the base rules.
+struct OverrideSeverities<'a> {
+    config: &'a ResolvedConfig,
+    promote_warns: bool,
+}
+
+impl OverrideSeverities<'_> {
+    fn effective_rules_for(&self, path: &Path) -> RulesConfig {
+        let mut rules = self.config.resolve_rules_for_path(path);
+        if self.promote_warns {
+            promote_warns_to_errors(&mut rules);
+        }
+        rules
+    }
+}
+
 fn has_override_file_scoped_error(
     results: &fallow_types::results::AnalysisResults,
-    config: &ResolvedConfig,
+    resolver: &OverrideSeverities<'_>,
 ) -> bool {
-    has_override_dead_code_error(results, config)
-        || has_override_catalog_boundary_error(results, config)
-        || has_override_framework_error(results, config)
+    has_override_dead_code_error(results, resolver)
+        || has_override_catalog_boundary_error(results, resolver)
+        || has_override_framework_error(results, resolver)
 }
 
 fn has_override_dead_code_error(
     results: &fallow_types::results::AnalysisResults,
-    config: &ResolvedConfig,
+    resolver: &OverrideSeverities<'_>,
 ) -> bool {
-    has_override_core_dead_code_error(results, config)
-        || has_override_component_dead_code_error(results, config)
+    has_override_core_dead_code_error(results, resolver)
+        || has_override_component_dead_code_error(results, resolver)
 }
 
 /// Per-file Error check for the core (non-component) dead-code issue types.
 fn has_override_core_dead_code_error(
     results: &fallow_types::results::AnalysisResults,
-    config: &ResolvedConfig,
+    resolver: &OverrideSeverities<'_>,
 ) -> bool {
     results
         .unused_files
         .iter()
-        .any(|f| config.resolve_rules_for_path(&f.file.path).unused_files == Severity::Error)
-        || results.unused_exports.iter().any(|e| {
-            config.resolve_rules_for_path(&e.export.path).unused_exports == Severity::Error
-        })
+        .any(|f| resolver.effective_rules_for(&f.file.path).unused_files == Severity::Error)
+        || results
+            .unused_exports
+            .iter()
+            .any(|e| resolver.effective_rules_for(&e.export.path).unused_exports == Severity::Error)
         || results
             .unused_types
             .iter()
-            .any(|e| config.resolve_rules_for_path(&e.export.path).unused_types == Severity::Error)
+            .any(|e| resolver.effective_rules_for(&e.export.path).unused_types == Severity::Error)
         || results.private_type_leaks.iter().any(|e| {
-            config
-                .resolve_rules_for_path(&e.leak.path)
+            resolver
+                .effective_rules_for(&e.leak.path)
                 .private_type_leaks
                 == Severity::Error
         })
         || results.unused_enum_members.iter().any(|m| {
-            config
-                .resolve_rules_for_path(&m.member.path)
+            resolver
+                .effective_rules_for(&m.member.path)
                 .unused_enum_members
                 == Severity::Error
         })
         || results.unused_class_members.iter().any(|m| {
-            config
-                .resolve_rules_for_path(&m.member.path)
+            resolver
+                .effective_rules_for(&m.member.path)
                 .unused_class_members
                 == Severity::Error
         })
         || results.unused_store_members.iter().any(|m| {
-            config
-                .resolve_rules_for_path(&m.member.path)
+            resolver
+                .effective_rules_for(&m.member.path)
                 .unused_store_members
                 == Severity::Error
         })
         || results.unprovided_injects.iter().any(|f| {
-            config
-                .resolve_rules_for_path(&f.inject.path)
+            resolver
+                .effective_rules_for(&f.inject.path)
                 .unprovided_injects
                 == Severity::Error
         })
         || results.unresolved_imports.iter().any(|i| {
-            config
-                .resolve_rules_for_path(&i.import.path)
+            resolver
+                .effective_rules_for(&i.import.path)
                 .unresolved_imports
                 == Severity::Error
         })
@@ -519,46 +550,46 @@ fn has_override_core_dead_code_error(
 /// Per-file Error check for the component-shaped dead-code issue types.
 fn has_override_component_dead_code_error(
     results: &fallow_types::results::AnalysisResults,
-    config: &ResolvedConfig,
+    resolver: &OverrideSeverities<'_>,
 ) -> bool {
     results.unrendered_components.iter().any(|c| {
-        config
-            .resolve_rules_for_path(&c.component.path)
+        resolver
+            .effective_rules_for(&c.component.path)
             .unrendered_components
             == Severity::Error
     }) || results.unused_component_props.iter().any(|p| {
-        config
-            .resolve_rules_for_path(&p.prop.path)
+        resolver
+            .effective_rules_for(&p.prop.path)
             .unused_component_props
             == Severity::Error
     }) || results.unused_component_emits.iter().any(|e| {
-        config
-            .resolve_rules_for_path(&e.emit.path)
+        resolver
+            .effective_rules_for(&e.emit.path)
             .unused_component_emits
             == Severity::Error
     }) || results.unused_component_inputs.iter().any(|i| {
-        config
-            .resolve_rules_for_path(&i.input.path)
+        resolver
+            .effective_rules_for(&i.input.path)
             .unused_component_inputs
             == Severity::Error
     }) || results.unused_component_outputs.iter().any(|o| {
-        config
-            .resolve_rules_for_path(&o.output.path)
+        resolver
+            .effective_rules_for(&o.output.path)
             .unused_component_outputs
             == Severity::Error
     }) || results.unused_svelte_events.iter().any(|e| {
-        config
-            .resolve_rules_for_path(&e.event.path)
+        resolver
+            .effective_rules_for(&e.event.path)
             .unused_svelte_events
             == Severity::Error
     }) || results.unused_server_actions.iter().any(|a| {
-        config
-            .resolve_rules_for_path(&a.action.path)
+        resolver
+            .effective_rules_for(&a.action.path)
             .unused_server_actions
             == Severity::Error
     }) || results.unused_load_data_keys.iter().any(|k| {
-        config
-            .resolve_rules_for_path(&k.key.path)
+        resolver
+            .effective_rules_for(&k.key.path)
             .unused_load_data_keys
             == Severity::Error
     })
@@ -566,69 +597,75 @@ fn has_override_component_dead_code_error(
 
 fn has_override_catalog_boundary_error(
     results: &fallow_types::results::AnalysisResults,
-    config: &ResolvedConfig,
+    resolver: &OverrideSeverities<'_>,
 ) -> bool {
     results.stale_suppressions.iter().any(|s| {
-        let rules = config.resolve_rules_for_path(&s.path);
+        let rules = resolver.effective_rules_for(&s.path);
         if s.missing_reason {
             rules.require_suppression_reason == Severity::Error
         } else {
             rules.stale_suppressions == Severity::Error
         }
     }) || results.unresolved_catalog_references.iter().any(|r| {
-        config
-            .resolve_rules_for_path(&r.reference.path)
+        resolver
+            .effective_rules_for(&r.reference.path)
             .unresolved_catalog_references
             == Severity::Error
     }) || results.empty_catalog_groups.iter().any(|g| {
-        config
-            .resolve_rules_for_path(&g.group.path)
+        resolver
+            .effective_rules_for(&g.group.path)
             .empty_catalog_groups
             == Severity::Error
+    }) || results.boundary_violations.iter().any(|v| {
+        resolver
+            .effective_rules_for(&v.violation.from_path)
+            .boundary_violation
+            == Severity::Error
     }) || results.boundary_coverage_violations.iter().any(|v| {
-        config
-            .resolve_rules_for_path(&v.violation.path)
+        resolver
+            .effective_rules_for(&v.violation.path)
             .boundary_violation
             == Severity::Error
     }) || results.boundary_call_violations.iter().any(|v| {
-        config
-            .resolve_rules_for_path(&v.violation.path)
+        resolver
+            .effective_rules_for(&v.violation.path)
             .boundary_violation
             == Severity::Error
     }) || results.circular_dependencies.iter().any(|c| {
-        c.cycle.files.iter().any(|path| {
-            config.resolve_rules_for_path(path).circular_dependencies == Severity::Error
-        })
+        c.cycle
+            .files
+            .iter()
+            .any(|path| resolver.effective_rules_for(path).circular_dependencies == Severity::Error)
     })
 }
 
 fn has_override_framework_error(
     results: &fallow_types::results::AnalysisResults,
-    config: &ResolvedConfig,
+    resolver: &OverrideSeverities<'_>,
 ) -> bool {
     results.invalid_client_exports.iter().any(|e| {
-        config
-            .resolve_rules_for_path(&e.export.path)
+        resolver
+            .effective_rules_for(&e.export.path)
             .invalid_client_export
             == Severity::Error
     }) || results.mixed_client_server_barrels.iter().any(|b| {
-        config
-            .resolve_rules_for_path(&b.barrel.path)
+        resolver
+            .effective_rules_for(&b.barrel.path)
             .mixed_client_server_barrel
             == Severity::Error
     }) || results.misplaced_directives.iter().any(|d| {
-        config
-            .resolve_rules_for_path(&d.directive_site.path)
+        resolver
+            .effective_rules_for(&d.directive_site.path)
             .misplaced_directive
             == Severity::Error
     }) || results.route_collisions.iter().any(|c| {
-        config
-            .resolve_rules_for_path(&c.collision.path)
+        resolver
+            .effective_rules_for(&c.collision.path)
             .route_collision
             == Severity::Error
     }) || results.dynamic_segment_name_conflicts.iter().any(|c| {
-        config
-            .resolve_rules_for_path(&c.conflict.path)
+        resolver
+            .effective_rules_for(&c.conflict.path)
             .dynamic_segment_name_conflict
             == Severity::Error
     })
@@ -1150,14 +1187,14 @@ mod tests {
     fn empty_results_no_error_issues() {
         let results = AnalysisResults::default();
         let rules = RulesConfig::default();
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
     fn error_severity_with_issues_returns_true() {
         let results = make_results();
         let rules = RulesConfig::default(); // all Error
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -1219,7 +1256,7 @@ mod tests {
             route_collision: Severity::Warn,
             dynamic_segment_name_conflict: Severity::Warn,
         };
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -1286,10 +1323,10 @@ mod tests {
             route_collision: Severity::Warn,
             dynamic_segment_name_conflict: Severity::Warn,
         };
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
 
         rules.unused_files = Severity::Error;
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -1308,7 +1345,7 @@ mod tests {
             unresolved_imports: Severity::Off,
             ..RulesConfig::default()
         };
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
     }
 
     /// Build a ResolvedConfig with overrides that turn off unused_exports for test files.
@@ -1646,7 +1683,7 @@ mod tests {
         let rules = &config.rules;
 
         assert!(
-            !has_error_severity_issues(&results, rules, Some(&config)),
+            !has_error_severity_issues(&results, rules, Some(&config), false),
             "test file override should suppress error"
         );
     }
@@ -1670,7 +1707,7 @@ mod tests {
         let rules = &config.rules;
 
         assert!(
-            has_error_severity_issues(&results, rules, Some(&config)),
+            has_error_severity_issues(&results, rules, Some(&config), false),
             "non-test file should still have Error severity"
         );
     }
@@ -1687,7 +1724,7 @@ mod tests {
         let rules = &config.rules;
 
         assert!(
-            !has_error_severity_issues(&results, rules, Some(&config)),
+            !has_error_severity_issues(&results, rules, Some(&config), false),
             "cycle files downgraded to Warn should not produce an Error verdict"
         );
     }
@@ -1704,7 +1741,7 @@ mod tests {
         let rules = &config.rules;
 
         assert!(
-            has_error_severity_issues(&results, rules, Some(&config)),
+            has_error_severity_issues(&results, rules, Some(&config), false),
             "a cycle touching any Error-severity file should still fail"
         );
     }
@@ -1723,8 +1760,77 @@ mod tests {
         let rules = &config.rules;
 
         assert!(
-            !has_error_severity_issues(&results, rules, Some(&config)),
+            !has_error_severity_issues(&results, rules, Some(&config), false),
             "boundary findings downgraded to Warn should not produce an Error verdict"
+        );
+    }
+
+    #[test]
+    fn has_error_with_override_boundary_violation_keeps_error_for_unmatched_file() {
+        let mut results = AnalysisResults::default();
+        results
+            .boundary_violations
+            .push(boundary_violation("/project/src/live/a.ts"));
+
+        let config = config_with_boundary_override("src/generated/**", Severity::Off);
+        let rules = &config.rules;
+
+        assert!(
+            has_error_severity_issues(&results, rules, Some(&config), false),
+            "an import-direction violation outside the override must still fail the run"
+        );
+    }
+
+    #[test]
+    fn has_error_with_override_boundary_violation_off_for_matched_file() {
+        let mut results = AnalysisResults::default();
+        results
+            .boundary_violations
+            .push(boundary_violation("/project/src/generated/a.ts"));
+
+        let config = config_with_boundary_override("src/generated/**", Severity::Off);
+        let rules = &config.rules;
+
+        assert!(
+            !has_error_severity_issues(&results, rules, Some(&config), false),
+            "a violation whose importer matches an Off override must not fail the run"
+        );
+    }
+
+    #[test]
+    fn has_error_with_override_promotes_per_path_warn_when_requested() {
+        let mut results = AnalysisResults::default();
+        results
+            .boundary_violations
+            .push(boundary_violation("/project/src/generated/a.ts"));
+
+        let config = config_with_boundary_override("src/generated/**", Severity::Warn);
+        let mut rules = config.rules.clone();
+        promote_warns_to_errors(&mut rules);
+
+        assert!(
+            !has_error_severity_issues(&results, &rules, Some(&config), false),
+            "without promotion a per-path Warn stays a warning"
+        );
+        assert!(
+            has_error_severity_issues(&results, &rules, Some(&config), true),
+            "fail-on-issues must promote a per-path Warn after override resolution"
+        );
+    }
+
+    #[test]
+    fn has_error_with_override_promotion_leaves_off_alone() {
+        let mut results = AnalysisResults::default();
+        results
+            .boundary_violations
+            .push(boundary_violation("/project/src/generated/a.ts"));
+
+        let config = config_with_boundary_override("src/generated/**", Severity::Off);
+        let rules = &config.rules;
+
+        assert!(
+            !has_error_severity_issues(&results, rules, Some(&config), true),
+            "promotion only lifts Warn; an Off override stays silent"
         );
     }
 
@@ -1919,7 +2025,7 @@ mod tests {
                 },
             ));
         let rules = RulesConfig::default();
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -1945,7 +2051,7 @@ mod tests {
             re_export_cycle: Severity::Warn,
             ..RulesConfig::default()
         };
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -1963,7 +2069,7 @@ mod tests {
                 },
             ));
         let rules = RulesConfig::default();
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -1984,7 +2090,7 @@ mod tests {
             unused_optional_dependencies: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -2000,7 +2106,7 @@ mod tests {
                 },
             ));
         let rules = RulesConfig::default();
-        assert!(!has_error_severity_issues(&results, &rules, None));
+        assert!(!has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -2019,7 +2125,7 @@ mod tests {
             type_only_dependencies: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     // -------------------------------------------------------------------------
@@ -3148,7 +3254,12 @@ mod tests {
             p.unused_types = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3169,7 +3280,12 @@ mod tests {
             p.unused_types = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3193,7 +3309,12 @@ mod tests {
             p.private_type_leaks = Some(Severity::Warn);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3213,7 +3334,12 @@ mod tests {
             p.unused_enum_members = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3233,7 +3359,12 @@ mod tests {
             p.unused_class_members = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3253,7 +3384,12 @@ mod tests {
             p.unused_store_members = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3272,7 +3408,12 @@ mod tests {
             p.unprovided_injects = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3291,7 +3432,12 @@ mod tests {
             p.unresolved_imports = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     // -------------------------------------------------------------------------
@@ -3320,7 +3466,12 @@ mod tests {
         });
         let rules = &config.rules;
         // Base default is Warn, so a non-matched file is also Warn: no error.
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3341,7 +3492,12 @@ mod tests {
             p.unused_component_props = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3362,7 +3518,12 @@ mod tests {
             p.unused_component_emits = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3383,7 +3544,12 @@ mod tests {
             p.unused_component_inputs = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3404,7 +3570,12 @@ mod tests {
             p.unused_component_outputs = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3423,7 +3594,12 @@ mod tests {
             p.unused_svelte_events = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3443,7 +3619,12 @@ mod tests {
             p.unused_server_actions = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3462,7 +3643,12 @@ mod tests {
             p.unused_load_data_keys = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     // -------------------------------------------------------------------------
@@ -3481,7 +3667,12 @@ mod tests {
             p.require_suppression_reason = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3494,7 +3685,12 @@ mod tests {
             p.require_suppression_reason = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3507,7 +3703,12 @@ mod tests {
             p.stale_suppressions = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3526,7 +3727,12 @@ mod tests {
             p.unresolved_catalog_references = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3543,7 +3749,12 @@ mod tests {
             p.empty_catalog_groups = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     // -------------------------------------------------------------------------
@@ -3568,7 +3779,12 @@ mod tests {
             p.invalid_client_export = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3589,7 +3805,12 @@ mod tests {
             p.mixed_client_server_barrel = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3609,7 +3830,12 @@ mod tests {
             p.misplaced_directive = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3628,7 +3854,12 @@ mod tests {
             p.route_collision = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     #[test]
@@ -3648,7 +3879,12 @@ mod tests {
             p.dynamic_segment_name_conflict = Some(Severity::Off);
         });
         let rules = &config.rules;
-        assert!(!has_error_severity_issues(&results, rules, Some(&config)));
+        assert!(!has_error_severity_issues(
+            &results,
+            rules,
+            Some(&config),
+            false
+        ));
     }
 
     // -------------------------------------------------------------------------
@@ -3666,7 +3902,7 @@ mod tests {
             require_suppression_reason: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -3733,7 +3969,7 @@ mod tests {
             route_collision: Severity::Warn,
             dynamic_segment_name_conflict: Severity::Warn,
         };
-        assert!(!has_error_severity_issues(&results, &all_warn, None));
+        assert!(!has_error_severity_issues(&results, &all_warn, None, false));
     }
 
     #[test]
@@ -3758,7 +3994,7 @@ mod tests {
             unused_dependency_overrides: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -3779,7 +4015,7 @@ mod tests {
             misconfigured_dependency_overrides: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -3798,7 +4034,7 @@ mod tests {
             re_export_cycle: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -3819,7 +4055,7 @@ mod tests {
             unused_catalog_entries: Severity::Error,
             ..RulesConfig::default()
         };
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     #[test]
@@ -3838,7 +4074,7 @@ mod tests {
                 },
             ));
         let rules = RulesConfig::default(); // boundary_violation is Error
-        assert!(has_error_severity_issues(&results, &rules, None));
+        assert!(has_error_severity_issues(&results, &rules, None, false));
     }
 
     // -------------------------------------------------------------------------

--- a/crates/cli/tests/check_tests.rs
+++ b/crates/cli/tests/check_tests.rs
@@ -65,6 +65,176 @@ fn check_ci_flag_implies_fail_on_issues() {
     assert_eq!(output.code, 1, "--ci should imply --fail-on-issues");
 }
 
+/// The fixture from issue #2445: an import from the `domain` zone into the
+/// `adapter` zone that both allow-nothing rules forbid, optionally with a
+/// per-path override that matches neither side of the import.
+fn boundary_violation_project(with_unrelated_override: bool) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temporary project");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src/domain")).expect("create domain directory");
+    std::fs::create_dir_all(root.join("src/adapter")).expect("create adapter directory");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"boundary-override-repro","private":true,"type":"module"}"#,
+    )
+    .expect("write package");
+    let overrides = if with_unrelated_override {
+        r#""overrides": [{ "files": ["src/other/**"], "rules": { "unused-exports": "off" } }],"#
+    } else {
+        ""
+    };
+    std::fs::write(
+        root.join(".fallowrc.json"),
+        format!(
+            r#"{{
+  "entry": ["src/main.ts"],
+  "rules": {{ "boundary-violation": "error" }},
+  {overrides}
+  "boundaries": {{
+    "zones": [
+      {{ "name": "domain", "patterns": ["src/domain/**"] }},
+      {{ "name": "adapter", "patterns": ["src/adapter/**"] }}
+    ],
+    "rules": [
+      {{ "from": "domain", "allow": [] }},
+      {{ "from": "adapter", "allow": [] }}
+    ]
+  }}
+}}"#
+        ),
+    )
+    .expect("write config");
+    std::fs::write(root.join("src/main.ts"), "import \"./domain/value.ts\";\n")
+        .expect("write entry point");
+    std::fs::write(
+        root.join("src/domain/value.ts"),
+        "import { adapterValue } from \"../adapter/value.ts\";\nconsole.log(adapterValue);\n",
+    )
+    .expect("write domain file");
+    std::fs::write(
+        root.join("src/adapter/value.ts"),
+        "export const adapterValue = 1;\n",
+    )
+    .expect("write adapter file");
+    dir
+}
+
+const BOUNDARY_FAIL_ARGS: &[&str] = &[
+    "--boundary-violations",
+    "--fail-on-issues",
+    "--no-cache",
+    "--format",
+    "json",
+    "--quiet",
+];
+
+#[test]
+fn boundary_violation_fails_on_issues_with_unrelated_override() {
+    let dir = boundary_violation_project(true);
+    let output = run_fallow_in_root("dead-code", dir.path(), BOUNDARY_FAIL_ARGS);
+    let json = parse_json(&output);
+    assert_eq!(
+        json["boundary_violations"].as_array().map(Vec::len),
+        Some(1),
+        "the domain -> adapter import should be reported; stdout: {}",
+        output.stdout
+    );
+    assert_eq!(
+        output.code, 1,
+        "an error-severity boundary violation must fail the run even when an unrelated per-path override exists"
+    );
+}
+
+#[test]
+fn boundary_violation_fails_on_issues_without_override() {
+    let dir = boundary_violation_project(false);
+    let output = run_fallow_in_root("dead-code", dir.path(), BOUNDARY_FAIL_ARGS);
+    assert_eq!(
+        output.code, 1,
+        "an error-severity boundary violation must fail the run"
+    );
+}
+
+/// A `warn` rule plus a per-path override that matches nothing relevant.
+fn warn_with_unrelated_override_project() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temporary project");
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src")).expect("create source directory");
+    std::fs::write(
+        root.join("package.json"),
+        r#"{"name":"warn-override-repro","private":true,"type":"module"}"#,
+    )
+    .expect("write package");
+    std::fs::write(
+        root.join(".fallowrc.json"),
+        r#"{
+  "entry": ["src/main.ts"],
+  "rules": { "unused-exports": "warn" },
+  "overrides": [{ "files": ["src/other/**"], "rules": { "unused-files": "off" } }]
+}"#,
+    )
+    .expect("write config");
+    std::fs::write(
+        root.join("src/main.ts"),
+        "import { used } from \"./lib.ts\";\nconsole.log(used);\n",
+    )
+    .expect("write entry point");
+    std::fs::write(
+        root.join("src/lib.ts"),
+        "export const used = 1;\nexport const unused = 2;\n",
+    )
+    .expect("write library file");
+    dir
+}
+
+#[test]
+fn warn_rule_with_unrelated_override_exits_1_with_fail_on_issues() {
+    let dir = warn_with_unrelated_override_project();
+    let output = run_fallow_in_root(
+        "dead-code",
+        dir.path(),
+        &[
+            "--unused-exports",
+            "--fail-on-issues",
+            "--no-cache",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+    );
+    assert_eq!(
+        output.code, 1,
+        "--fail-on-issues must promote a warn rule to error even when overrides exist; stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn warn_rule_with_unrelated_override_exits_0_without_fail_on_issues() {
+    let dir = warn_with_unrelated_override_project();
+    let output = run_fallow_in_root(
+        "dead-code",
+        dir.path(),
+        &[
+            "--unused-exports",
+            "--no-cache",
+            "--format",
+            "json",
+            "--quiet",
+        ],
+    );
+    let json = parse_json(&output);
+    assert!(
+        json["total_issues"].as_u64().unwrap_or(0) > 0,
+        "the unused export should be reported; stdout: {}",
+        output.stdout
+    );
+    assert_eq!(
+        output.code, 0,
+        "a warn-only run without --fail-on-issues exits 0"
+    );
+}
+
 #[test]
 fn check_json_format_produces_valid_json() {
     let output = run_fallow("check", "basic-project", &["--format", "json", "--quiet"]);

--- a/docs/backwards-compatibility.md
+++ b/docs/backwards-compatibility.md
@@ -165,6 +165,18 @@ When a stable interface needs to change:
 
 These are documented for the rare CI script that depended on the old behavior. None require a config migration.
 
+- **A strict run fails on findings the override path used to let through**
+  ([#2445](https://github.com/fallow-rs/fallow/issues/2445)). When a config
+  contains any per-path `overrides` entry, the exit code is decided by
+  per-file severity resolution. That path never consulted import-direction
+  boundary violations, and it started from unpromoted base rules, so
+  `--fail-on-issues` and `--ci` could exit 0 on an error-severity
+  `boundary-violation` and on every `warn`-severity finding. Both are fixed,
+  which means a pipeline with overrides that passed on an earlier v3 can now
+  exit 1 without any config or code change. The findings themselves are
+  unchanged; only the exit code is. To keep the previous outcome, set the rule
+  to `off` rather than `warn`, or drop the strict flag for that job.
+
 - **Review brief schema 8 adds author actions, test adjacency, independent
   slices, and dependency decisions.** All additive. A `--walkthrough-file`
   judgment may carry `action` (`block`, `address`, `consider`, `fyi`); any


### PR DESCRIPTION
## Summary

With any per-path `overrides` entry configured, the exit-code check switches to per-file severity resolution. That path never consulted import-direction boundary violations (only zone-coverage and forbidden-call findings), so an error-severity `boundary-violation` was reported but the run exited 0. The same path started from the un-promoted base rules, so the warn-to-error promotion of `--fail-on-issues` (and `--ci`) never reached it and a `warn` rule plus any override exited 0 as well.

- The override path now checks `boundary_violations` on `from_path`, mirroring the existing `off` filter.
- Per-file resolved rules are promoted after override resolution when `--fail-on-issues` is active, so an explicit per-path `warn` fails a strict run like the base rules do.
- No cache bump: the exit decision is computed on results every run.

Closes #2445

## Test plan

- Unit tests next to the existing override boundary test: unmatched boundary violation under an unrelated `off` override yields an error verdict (failed before the fix); matched `off` stays silent; per-path `warn` promotes only when requested.
- e2e in `crates/cli/tests/check_tests.rs`: the issue fixture with and without the unrelated override exits 1; `unused-exports: warn` plus an unrelated override exits 1 with `--fail-on-issues` and 0 without.
- `cargo fmt`, `cargo clippy -p fallow-cli -p fallow-config --all-targets -- -D warnings`, `cargo test -p fallow-cli`, `cargo test -p fallow-config`: clean.
- Real run of the built binary on the issue fixture: exit 1 with and without the overrides block; the `boundary-violation: warn` variant exits 1 under `--fail-on-issues` and 0 without.