### PR TITLE
fix: eliminate remaining Istanbul static fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Istanbul coverage now matches uniquely attributable anonymous callbacks
-  whose extracted start falls between the producer's declaration and body
-  positions** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448),
-  [#2449](https://github.com/fallow-rs/fallow/pull/2449)). Some callback
-  arguments in multi-line calls are recorded with a declaration start at the
-  surrounding call expression and a body start after the callback itself.
-  Fallow now uses that header span as a fallback only when exactly one anonymous
-  function contains the extracted start. Established anonymous matches keep
-  priority, while overlapping fallback spans remain unmatched.
+- **Istanbul coverage now matches uniquely attributable functions whose
+  extracted start falls between the producer's declaration and body positions**
+  (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448),
+  [#2449](https://github.com/fallow-rs/fallow/pull/2449)). A callback argument
+  in a multi-line call, and a class method carrying decorators and a wrapped
+  parameter list, are recorded with a declaration start above the function and
+  a body start below it. Fallow now reads that header span when no established
+  matcher resolves the position, including when the anonymous aliases collide,
+  which is what curried arrows formatted one per line produce. Established
+  matches keep priority. The span is used only when exactly one anonymous
+  record covers the position and no other function is declared inside it,
+  because a signature can carry a default parameter value or a decorator
+  argument that is a different function with unrelated coverage. Thanks to
+  [@PrinceD96](https://github.com/PrinceD96) for the report and the
+  implementation.
+
+- **Private class members no longer take coverage from the function that
+  encloses them** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448)).
+  No instrumenter records a `#member` in its function map, so every candidate
+  one could reach belongs to some enclosing function. Such a member could be
+  reported as fully covered while it never ran. It now uses the static estimate
+  instead, and it is recorded under its own `#name` rather than `<anonymous>`,
+  so it is identifiable in complexity output.
 
 ## [3.20.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - **Coverage matching no longer rescans a file for every unmatched function.**
-  A file whose coverage map does not join paid a full scan per lookup, twice
-  over once header spans were added. Aliases and header spans are now indexed
-  by line, which bounds each fallback to the few records that can reach the
-  position. A 4518-function file whose coverage never joins went from 231 ms to
-  146 ms, and a 6000-function one from 337 ms to 203 ms.
+  Aliases and header spans are now indexed by line, which bounds each fallback
+  to the records that can reach the target position.
 
 ## [3.20.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   neither does the member keeps the static estimate instead of a measured
   number that belongs to different code.
 
+- **A coverage map with project-relative keys now joins from any working
+  directory** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448)).
+  nyc and some Jest setups record keys relative to the project. Fallow resolved
+  them against the process directory, so a run from anywhere but the project
+  root lost the whole map at once and every function silently fell back to its
+  static estimate. They now resolve against the project root, the way the
+  coverage file path already does.
+
 - **Private class members no longer take coverage from the function that
   encloses them** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448)).
   No instrumenter records a `#member` in its function map, so every candidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Istanbul coverage now matches uniquely attributable functions whose
-  extracted start falls between the producer's declaration and body positions**
+- **Istanbul coverage now matches functions whose extracted position falls
+  between the producer's declaration and its body**
   (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448),
-  [#2449](https://github.com/fallow-rs/fallow/pull/2449)). A callback argument
-  in a multi-line call, and a class method carrying decorators and a wrapped
-  parameter list, are recorded with a declaration start above the function and
-  a body start below it. Fallow now reads that header span when no established
-  matcher resolves the position, including when the anonymous aliases collide,
-  which is what curried arrows formatted one per line produce. Established
-  matches keep priority. The span is used only when exactly one anonymous
-  record covers the position and no other function is declared inside it,
-  because a signature can carry a default parameter value or a decorator
-  argument that is a different function with unrelated coverage. Thanks to
+  [#2449](https://github.com/fallow-rs/fallow/pull/2449)). A class member
+  carrying a decorator and a wrapped parameter list is recorded with a
+  declaration on the decorator and a body below the signature, so neither
+  position identifies the member, and the innermost arrow of a curried chain
+  formatted one per line has the same shape. Fallow now reads that header span
+  when no established matcher resolves the position. Established matches keep
+  priority, and the span is read only when exactly one anonymous record covers
+  the position and no other function is declared inside it. Thanks to
   [@PrinceD96](https://github.com/PrinceD96) for the report and the
   implementation.
+
+- **A member whose parameter list holds a function no longer reports that
+  function's coverage** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448)).
+  A default value, a decorator argument, or a class expression written in a
+  signature is a function of its own, a line or two from the member that holds
+  it, and the nearest-record fallback could credit either to the other. Inside
+  a signature a record now has to sit on the position or contain it, and where
+  neither does the member keeps the static estimate instead of a measured
+  number that belongs to different code.
 
 - **Private class members no longer take coverage from the function that
   encloses them** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448)).
@@ -34,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so it is identifiable in complexity output. Private-member provenance is
   stored separately from that display name, so a public string-named method
   whose name begins with `#` remains eligible for exact coverage matching.
+
+### Performance
+
+- **Coverage matching no longer rescans a file for every unmatched function.**
+  A file whose coverage map does not join paid a full scan per lookup, twice
+  over once header spans were added. Aliases and header spans are now indexed
+  by line, which bounds each fallback to the few records that can reach the
+  position. A 4518-function file whose coverage never joins went from 231 ms to
+  146 ms, and a 6000-function one from 337 ms to 203 ms.
 
 ## [3.20.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Istanbul coverage now matches uniquely attributable anonymous callbacks
+  whose extracted start falls between the producer's declaration and body
+  positions** (Closes [#2448](https://github.com/fallow-rs/fallow/issues/2448),
+  [#2449](https://github.com/fallow-rs/fallow/pull/2449)). Some callback
+  arguments in multi-line calls are recorded with a declaration start at the
+  surrounding call expression and a body start after the callback itself.
+  Fallow now uses that header span as a fallback only when exactly one anonymous
+  function contains the extracted start. Established anonymous matches keep
+  priority, while overlapping fallback spans remain unmatched.
+
 ## [3.20.0] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one could reach belongs to some enclosing function. Such a member could be
   reported as fully covered while it never ran. It now uses the static estimate
   instead, and it is recorded under its own `#name` rather than `<anonymous>`,
-  so it is identifiable in complexity output.
+  so it is identifiable in complexity output. Private-member provenance is
+  stored separately from that display name, so a public string-named method
+  whose name begins with `#` remains eligible for exact coverage matching.
 
 ## [3.20.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead, and it is recorded under its own `#name` rather than `<anonymous>`,
   so it is identifiable in complexity output. Private-member provenance is
   stored separately from that display name, so a public string-named method
-  whose name begins with `#` remains eligible for exact coverage matching.
+  whose name begins with `#` remains eligible for exact coverage matching. The
+  rule sits at the one lookup entry point every consumer goes through, so the
+  test-covered check honours it as well.
 
 ### Performance
 

--- a/crates/cli/src/bin/stub_sidecar.rs
+++ b/crates/cli/src/bin/stub_sidecar.rs
@@ -17,6 +17,8 @@
 //! - `"malformed-stdout"`: writes non-JSON bytes, exit 0
 //! - `"empty-stdout"`: writes nothing, exit 0
 //! - `"enforce-license-gate"`: mirrors the paid-shape sidecar gate for tests
+//! - `"assert-private-member-uncovered"`: rejects a request that credits the
+//!   fixture's private class member with Istanbul coverage
 //! - `"security-hot"`: response with `src/sink.ts::render` as a hot path
 //! - `"capture-quality-short"`: clean response with a short-window
 //!   `capture_quality` (`lazy_parse_warning = true`), exit 0
@@ -66,6 +68,7 @@ fn main() -> ExitCode {
         "malformed-stdout" => emit_bytes(b"definitely not JSON\n"),
         "empty-stdout" => ExitCode::SUCCESS,
         "enforce-license-gate" => enforce_license_gate(parsed),
+        "assert-private-member-uncovered" => assert_private_member_uncovered(parsed),
         "exit-4" => {
             eprintln!("stub sidecar: simulated protocol mismatch");
             ExitCode::from(4)
@@ -83,6 +86,28 @@ fn main() -> ExitCode {
             ExitCode::from(2)
         }
     }
+}
+
+fn assert_private_member_uncovered(request: Option<Request>) -> ExitCode {
+    let Some(request) = request else {
+        eprintln!("stub sidecar: failed to parse request");
+        return ExitCode::from(5);
+    };
+    let private_member = request
+        .static_findings
+        .files
+        .iter()
+        .flat_map(|file| &file.functions)
+        .find(|function| function.name == "#wipe");
+    let Some(private_member) = private_member else {
+        eprintln!("stub sidecar: private member missing from request");
+        return ExitCode::from(5);
+    };
+    if private_member.test_covered {
+        eprintln!("stub sidecar: private member inherited foreign Istanbul coverage");
+        return ExitCode::from(5);
+    }
+    emit_clean_response(PROTOCOL_VERSION, None)
 }
 
 fn enforce_license_gate(request: Option<Request>) -> ExitCode {

--- a/crates/cli/src/health/coverage.rs
+++ b/crates/cli/src/health/coverage.rs
@@ -1100,7 +1100,7 @@ fn function_test_covered(
         && let Some(canonical_path) = canonical_path
         && let Some(coverage_pct) = coverage
             .get(canonical_path)
-            .and_then(|file| file.lookup(function.name.as_str(), function.line, function.col))
+            .and_then(|file| file.lookup_function(function))
     {
         return coverage_pct > 0.0;
     }

--- a/crates/cli/tests/runtime_coverage_tests.rs
+++ b/crates/cli/tests/runtime_coverage_tests.rs
@@ -274,6 +274,73 @@ mod gated {
     }
 
     #[test]
+    fn private_member_does_not_inherit_istanbul_coverage_in_sidecar_request() {
+        let harness = Harness::new();
+        let project_root = harness.tmp.path().join("private-member-project");
+        let source_dir = project_root.join("src");
+        fs::create_dir_all(&source_dir).expect("create fixture source directory");
+        fs::write(
+            project_root.join("package.json"),
+            r#"{"name":"private-member-fixture","version":"1.0.0","type":"module"}"#,
+        )
+        .expect("write fixture package manifest");
+        let source_path = source_dir.join("vault.js");
+        fs::write(
+            &source_path,
+            "const makeVault = (\n  Vault = class {\n    #wipe() {}\n  }\n) => Vault;\nexport { makeVault };\n",
+        )
+        .expect("write private-member fixture");
+
+        let coverage_path = project_root.join("coverage-final.json");
+        let coverage = serde_json::json!({
+            (source_path.to_string_lossy().into_owned()): {
+                "path": source_path,
+                "statementMap": {},
+                "fnMap": {
+                    "0": {
+                        "name": "(anonymous_0)",
+                        "line": 5,
+                        "decl": {
+                            "start": { "line": 1, "column": 18 },
+                            "end": { "line": 1, "column": 19 }
+                        },
+                        "loc": {
+                            "start": { "line": 5, "column": 5 },
+                            "end": { "line": 5, "column": 10 }
+                        }
+                    }
+                },
+                "branchMap": {},
+                "s": {},
+                "f": { "0": 1 },
+                "b": {}
+            }
+        });
+        fs::write(
+            &coverage_path,
+            serde_json::to_vec(&coverage).expect("serialize Istanbul fixture"),
+        )
+        .expect("write Istanbul fixture");
+
+        let mut cmd = harness.fallow();
+        cmd.env("FALLOW_STUB_MODE", "assert-private-member-uncovered");
+        cmd.arg("health")
+            .arg("--root")
+            .arg(&project_root)
+            .arg("--runtime-coverage")
+            .arg(&coverage_path)
+            .arg("--format")
+            .arg("json")
+            .arg("--quiet");
+        let (stdout, stderr, code) = run_with(cmd);
+
+        assert_eq!(
+            code, 0,
+            "private member must remain uncovered in the sidecar request; stdout={stdout}; stderr={stderr}"
+        );
+    }
+
+    #[test]
     fn coverage_analyze_benchmark_transport_matches_signed_stub_output() {
         let harness = Harness::new();
         let root = fixture_path("coverage-gaps");

--- a/crates/engine/src/health/core_pipeline.rs
+++ b/crates/engine/src/health/core_pipeline.rs
@@ -164,7 +164,7 @@ fn prepare_health_analysis_prelude<R>(
         report_coverage_gaps,
         enforce_coverage_gaps,
         istanbul_coverage,
-    } = prepare_health_coverage_settings(input.opts, input.config)?;
+    } = prepare_health_coverage_settings(input.opts, input.config, &input.scope.file_paths)?;
 
     let needs_file_scores = needs_health_file_scores(
         input.opts,

--- a/crates/engine/src/health/coverage_settings.rs
+++ b/crates/engine/src/health/coverage_settings.rs
@@ -18,13 +18,14 @@ pub(super) struct HealthCoverageSettings {
 pub(super) fn prepare_health_coverage_settings(
     opts: &HealthExecutionOptions<'_>,
     config: &ResolvedConfig,
+    file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
 ) -> Result<HealthCoverageSettings, HealthError> {
     let config_coverage_enabled = config.rules.coverage_gaps != fallow_config::Severity::Off;
     let report_coverage_gaps =
         opts.coverage_gaps || (opts.config_activates_coverage_gaps && config_coverage_enabled);
     let enforce_coverage_gaps = opts.enforce_coverage_gap_gate
         && config.rules.coverage_gaps == fallow_config::Severity::Error;
-    let istanbul_coverage = load_health_coverage(opts, config)?;
+    let istanbul_coverage = load_health_coverage(opts, config, file_paths)?;
 
     Ok(HealthCoverageSettings {
         report_coverage_gaps,
@@ -36,12 +37,16 @@ pub(super) fn prepare_health_coverage_settings(
 fn load_health_coverage(
     opts: &HealthExecutionOptions<'_>,
     config: &ResolvedConfig,
+    file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
 ) -> Result<Option<scoring::IstanbulCoverage>, HealthError> {
     if let Some(coverage_path) = opts.coverage_inputs.coverage {
-        return match scoring::load_istanbul_coverage(
+        let discovered_sources = (!opts.coverage_inputs.coverage_relocated)
+            .then(|| discovered_regular_sources(file_paths, &config.root));
+        return match scoring::load_istanbul_coverage_for_sources(
             coverage_path,
             opts.coverage_inputs.coverage_root,
             Some(&config.root),
+            discovered_sources.as_ref(),
             opts.coverage_inputs.coverage_relocated,
         ) {
             Ok(coverage) => Ok(Some(coverage)),
@@ -58,17 +63,42 @@ fn load_health_coverage(
     let Some(auto_path) = scoring::auto_detect_coverage(&config.root) else {
         return Ok(None);
     };
+    let discovered_sources = (!opts.coverage_inputs.coverage_relocated)
+        .then(|| discovered_regular_sources(file_paths, &config.root));
     if std::env::var("CI").is_ok_and(|v| !v.is_empty()) {
         eprintln!(
             "note: using auto-detected coverage at {}; pass --coverage explicitly for deterministic CI scores",
             auto_path.display()
         );
     }
-    Ok(scoring::load_istanbul_coverage(
+    Ok(scoring::load_istanbul_coverage_for_sources(
         &auto_path,
         opts.coverage_inputs.coverage_root,
         Some(&config.root),
+        discovered_sources.as_ref(),
         opts.coverage_inputs.coverage_relocated,
     )
     .ok())
+}
+
+fn discovered_regular_sources(
+    file_paths: &rustc_hash::FxHashMap<crate::discover::FileId, &std::path::PathBuf>,
+    project_root: &std::path::Path,
+) -> rustc_hash::FxHashSet<std::path::PathBuf> {
+    let Ok(canonical_root) = dunce::canonicalize(project_root) else {
+        return rustc_hash::FxHashSet::default();
+    };
+    file_paths
+        .values()
+        .filter_map(|path| {
+            let canonical = dunce::canonicalize(path).ok()?;
+            if !canonical.starts_with(&canonical_root) {
+                return None;
+            }
+            std::fs::metadata(&canonical)
+                .ok()?
+                .is_file()
+                .then_some(canonical)
+        })
+        .collect()
 }

--- a/crates/engine/src/health/execute_tests.rs
+++ b/crates/engine/src/health/execute_tests.rs
@@ -40,6 +40,7 @@ fn make_module(file_id: FileId, complexity: Vec<FunctionComplexity>) -> ModuleIn
 fn make_fc(name: &str, cyclomatic: u16, cognitive: u16, line_count: u32) -> FunctionComplexity {
     FunctionComplexity {
         name: name.to_string(),
+        is_private_member: false,
         line: 1,
         col: 0,
         cyclomatic,
@@ -1050,6 +1051,7 @@ fn collect_findings_preserves_function_metadata() {
         FileId(0),
         vec![FunctionComplexity {
             name: "processData".to_string(),
+            is_private_member: false,
             line: 42,
             col: 8,
             cyclomatic: 25,
@@ -1089,10 +1091,15 @@ fn collect_findings_preserves_function_metadata() {
 }
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "test fixture; linear setup/assert, length is not a maintainability concern"
+)]
 fn merge_crap_findings_disambiguates_same_line_functions() {
     let path = PathBuf::from("/project/src/curried.ts");
     let outer = FunctionComplexity {
         name: "handler".to_string(),
+        is_private_member: false,
         line: 1,
         col: 23,
         cyclomatic: 1,
@@ -1107,6 +1114,7 @@ fn merge_crap_findings_disambiguates_same_line_functions() {
     };
     let inner = FunctionComplexity {
         name: "<arrow>".to_string(),
+        is_private_member: false,
         line: 1,
         col: 43,
         cyclomatic: 7,
@@ -1200,6 +1208,7 @@ fn merge_crap_findings_picks_outer_when_outer_exceeds() {
     let path = PathBuf::from("/project/src/curried_outer.ts");
     let outer = FunctionComplexity {
         name: "complex".to_string(),
+        is_private_member: false,
         line: 5,
         col: 10,
         cyclomatic: 8,
@@ -1214,6 +1223,7 @@ fn merge_crap_findings_picks_outer_when_outer_exceeds() {
     };
     let inner = FunctionComplexity {
         name: "<arrow>".to_string(),
+        is_private_member: false,
         line: 5,
         col: 30,
         cyclomatic: 1,

--- a/crates/engine/src/health/react_hooks.rs
+++ b/crates/engine/src/health/react_hooks.rs
@@ -166,6 +166,7 @@ mod tests {
     ) -> FunctionComplexity {
         FunctionComplexity {
             name: name.to_string(),
+            is_private_member: false,
             line,
             col,
             cyclomatic: 1,

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -463,7 +463,7 @@ fn crap_for_function(
     fallow_output::CoverageSource,
 ) {
     let cc = f64::from(f.cyclomatic);
-    let lookup = file_coverage.and_then(|fc| fc.lookup(f.name.as_str(), f.line, f.col));
+    let lookup = file_coverage.and_then(|fc| fc.lookup_function(f));
     if let Some(cov_pct) = lookup {
         *matched += 1;
         return (
@@ -979,6 +979,13 @@ pub struct IstanbulFileCoverage {
 }
 
 impl IstanbulFileCoverage {
+    fn lookup_function(&self, function: &fallow_types::extract::FunctionComplexity) -> Option<f64> {
+        if function.is_private_member {
+            return None;
+        }
+        self.lookup(function.name.as_str(), function.line, function.col)
+    }
+
     fn new(mut functions: Vec<IstanbulFunctionCoverage>, relocated: bool) -> Self {
         let mut named_alias_counts: rustc_hash::FxHashMap<
             (String, IstanbulPosition),
@@ -1123,13 +1130,6 @@ impl IstanbulFileCoverage {
     /// the choice among them cannot matter (#2347). Same-checkout lookups
     /// keep the bounded fuzz, which protects against stale coverage data.
     pub fn lookup(&self, name: &str, line: u32, col: u32) -> Option<f64> {
-        // No producer records a private class member in `fnMap`. Istanbul's
-        // visitor has no case for one and the sidecar mirrors that, so every
-        // candidate a private member could reach belongs to some enclosing
-        // function, and crediting it reports code that never ran as covered.
-        if name.starts_with('#') {
-            return None;
-        }
         let exact_key = (name.to_string(), line, col);
         if self.ambiguous_aliases.contains(&exact_key) {
             return None;
@@ -2782,6 +2782,7 @@ mod tests {
             line_offsets: vec![0, 10, 20, 30, 40], // 5 lines
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: "doStuff".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 7,
@@ -2811,6 +2812,7 @@ mod tests {
             complexity: vec![
                 fallow_types::extract::FunctionComplexity {
                     name: "a".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 3,
@@ -2825,6 +2827,7 @@ mod tests {
                 },
                 fallow_types::extract::FunctionComplexity {
                     name: "b".into(),
+                    is_private_member: false,
                     line: 2,
                     col: 0,
                     cyclomatic: 5,
@@ -3339,6 +3342,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "foo".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 5,
@@ -3472,6 +3476,7 @@ mod tests {
                 10,
                 vec![fallow_types::extract::FunctionComplexity {
                     name: "fn_a".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 2,
@@ -3490,6 +3495,7 @@ mod tests {
                 10,
                 vec![fallow_types::extract::FunctionComplexity {
                     name: "fn_b".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 3,
@@ -3575,6 +3581,7 @@ mod tests {
                 10,
                 vec![fallow_types::extract::FunctionComplexity {
                     name: "complex_fn".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 30,
@@ -3593,6 +3600,7 @@ mod tests {
                 100,
                 vec![fallow_types::extract::FunctionComplexity {
                     name: "simple_fn".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 1,
@@ -3671,6 +3679,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "orphan".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 1,
@@ -3752,6 +3761,7 @@ mod tests {
             vec![
                 fallow_types::extract::FunctionComplexity {
                     name: "high".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 10,
@@ -3766,6 +3776,7 @@ mod tests {
                 },
                 fallow_types::extract::FunctionComplexity {
                     name: "medium".into(),
+                    is_private_member: false,
                     line: 11,
                     col: 0,
                     cyclomatic: 5,
@@ -3780,6 +3791,7 @@ mod tests {
                 },
                 fallow_types::extract::FunctionComplexity {
                     name: "low".into(),
+                    is_private_member: false,
                     line: 21,
                     col: 0,
                     cyclomatic: 2,
@@ -3794,6 +3806,7 @@ mod tests {
                 },
                 fallow_types::extract::FunctionComplexity {
                     name: "trivial".into(),
+                    is_private_member: false,
                     line: 31,
                     col: 0,
                     cyclomatic: 1,
@@ -3885,6 +3898,7 @@ mod tests {
                 10,
                 vec![fallow_types::extract::FunctionComplexity {
                     name: "fn_a".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 2,
@@ -3903,6 +3917,7 @@ mod tests {
                 10,
                 vec![fallow_types::extract::FunctionComplexity {
                     name: "fn_b".into(),
+                    is_private_member: false,
                     line: 1,
                     col: 0,
                     cyclomatic: 3,
@@ -4016,6 +4031,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "fn_a".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 1,
@@ -4186,6 +4202,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "fn_a".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 1,
@@ -4292,6 +4309,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "fn_a".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 2,
@@ -4353,6 +4371,7 @@ mod tests {
             100,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "fn".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 7,
@@ -4453,6 +4472,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "fn_a".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 2,
@@ -4515,6 +4535,7 @@ mod tests {
             10,
             vec![fallow_types::extract::FunctionComplexity {
                 name: "trivial".into(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 1,
@@ -4558,6 +4579,7 @@ mod tests {
     fn make_fn_complexity(cyclomatic: u16) -> fallow_types::extract::FunctionComplexity {
         fallow_types::extract::FunctionComplexity {
             name: "test_fn".into(),
+            is_private_member: false,
             line: 1,
             col: 0,
             cyclomatic,
@@ -4579,6 +4601,7 @@ mod tests {
     ) -> fallow_types::extract::FunctionComplexity {
         fallow_types::extract::FunctionComplexity {
             name: name.into(),
+            is_private_member: false,
             line,
             col: 0,
             cyclomatic,
@@ -5483,8 +5506,57 @@ mod tests {
 
         // `#wipe` sits in the arrow's header span and the arrow ran, but the
         // private member has no record of its own and never ran.
-        assert_eq!(file_coverage.lookup("#wipe", 3, 9), None);
+        let mut private_member = make_fn_complexity(1);
+        private_member.name = "#wipe".to_string();
+        private_member.is_private_member = true;
+        private_member.line = 3;
+        private_member.col = 9;
+        let result = istanbul_crap_default(&[private_member], Some(file_coverage), false);
+        assert_eq!(result.matched, 0);
+        assert_eq!(
+            result.per_function[0].coverage_source,
+            fallow_output::CoverageSource::Estimated
+        );
         assert_eq!(file_coverage.lookup("<arrow>", 1, 24), Some(100.0));
+    }
+
+    #[test]
+    fn quoted_hash_method_keeps_exact_istanbul_coverage() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/vault.js");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "class Vault { '#wipe'() {} }\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "#wipe",
+                    "line": 1,
+                    "decl": { "start": { "line": 1, "column": 14 }, "end": { "line": 1, "column": 21 } },
+                    "loc": { "start": { "line": 1, "column": 24 }, "end": { "line": 1, "column": 26 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        let mut quoted_public_method = make_fn_complexity(1);
+        quoted_public_method.name = "#wipe".to_string();
+        quoted_public_method.line = 1;
+        quoted_public_method.col = 14;
+        let result = istanbul_crap_default(&[quoted_public_method], Some(file_coverage), false);
+        assert_eq!(result.matched, 1);
+        assert_eq!(
+            result.per_function[0].coverage_source,
+            fallow_output::CoverageSource::Istanbul
+        );
+        assert_eq!(result.per_function[0].coverage_pct, Some(100.0));
     }
 
     /// istanbul-lib-instrument anchors a callback passed to a multi-line call
@@ -6080,6 +6152,35 @@ mod tests {
 
         assert!(file_coverage.lookup("<arrow>", 4, 11).is_none());
         assert_eq!(file_coverage.lookup("aa", 1, 11), Some(100.0));
+    }
+
+    #[test]
+    fn colliding_anonymous_alias_uses_unique_safe_header_span() {
+        let file_coverage = IstanbulFileCoverage::new(
+            vec![
+                IstanbulFunctionCoverage {
+                    name: "(anonymous_0)".to_string(),
+                    coverage_pct: 100.0,
+                    aliases: vec![primary_alias(1, 0), secondary_alias(3, 4)],
+                    decl_start: IstanbulPosition::new(1, 0),
+                    header_holds_other_fn: false,
+                    header_span: Some(body_span((1, 0), (5, 0))),
+                    body_span: Some(body_span((5, 0), (8, 0))),
+                },
+                IstanbulFunctionCoverage {
+                    name: "(anonymous_1)".to_string(),
+                    coverage_pct: 0.0,
+                    aliases: vec![primary_alias(10, 0), secondary_alias(3, 4)],
+                    decl_start: IstanbulPosition::new(10, 0),
+                    header_holds_other_fn: false,
+                    header_span: None,
+                    body_span: Some(body_span((10, 0), (12, 0))),
+                },
+            ],
+            false,
+        );
+
+        assert_eq!(file_coverage.lookup("<arrow>", 3, 4), Some(100.0));
     }
 
     /// A secondary alias that collides with another record's secondary alias

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -848,15 +848,37 @@ struct IstanbulSpan {
 }
 
 impl IstanbulSpan {
-    fn from_entry(fn_entry: &oxc_coverage_instrument::FnEntry) -> Option<Self> {
-        let start = IstanbulPosition::new(fn_entry.loc.start.line, fn_entry.loc.start.column);
-        let end = IstanbulPosition::new(fn_entry.loc.end.line, fn_entry.loc.end.column);
+    fn from_entry(
+        fn_entry: &oxc_coverage_instrument::FnEntry,
+        source_index: Option<&IstanbulSourceIndex<'_>>,
+    ) -> Option<Self> {
+        let start = normalized_istanbul_position(
+            fn_entry.loc.start.line,
+            fn_entry.loc.start.column,
+            source_index,
+        )?;
+        let end = normalized_istanbul_position(
+            fn_entry.loc.end.line,
+            fn_entry.loc.end.column,
+            source_index,
+        )?;
         (start.line > 0 && end.line > 0 && start < end).then_some(Self { start, end })
     }
 
-    fn header_from_entry(fn_entry: &oxc_coverage_instrument::FnEntry) -> Option<Self> {
-        let start = IstanbulPosition::new(fn_entry.decl.start.line, fn_entry.decl.start.column);
-        let end = IstanbulPosition::new(fn_entry.loc.start.line, fn_entry.loc.start.column);
+    fn header_from_entry(
+        fn_entry: &oxc_coverage_instrument::FnEntry,
+        source_index: Option<&IstanbulSourceIndex<'_>>,
+    ) -> Option<Self> {
+        let start = normalized_istanbul_position(
+            fn_entry.decl.start.line,
+            fn_entry.decl.start.column,
+            source_index,
+        )?;
+        let end = normalized_istanbul_position(
+            fn_entry.loc.start.line,
+            fn_entry.loc.start.column,
+            source_index,
+        )?;
         (start.line > 0 && end.line > 0 && start < end).then_some(Self { start, end })
     }
 
@@ -1265,10 +1287,6 @@ impl IstanbulFileCoverage {
             })
             .filter(|(distance, function_index)| {
                 *distance == (0, 0)
-                    || named_function_prefix_contains_target(
-                        &self.functions[*function_index],
-                        target,
-                    )
                     || !self.foreign_signature_blocks(&signature_owners, *function_index, target)
             })
             .min_by_key(|(distance, _)| *distance)
@@ -1455,25 +1473,6 @@ impl IstanbulFileCoverage {
     }
 }
 
-/// Whether `target` is the source-level start of a named function whose
-/// Istanbul declaration starts at the later identifier.
-///
-/// The fixed widths are the ASCII spellings before that identifier:
-/// `function `, `function* `, `async function `, and `async function* `.
-/// Matching an exact width avoids treating an enclosing same-named member on
-/// the same line as the nested function's own target.
-fn named_function_prefix_contains_target(
-    function: &IstanbulFunctionCoverage,
-    target: IstanbulPosition,
-) -> bool {
-    function.decl_start.line == target.line
-        && function
-            .decl_start
-            .col
-            .checked_sub(target.col)
-            .is_some_and(|width| matches!(width, 9 | 10 | 15 | 16))
-}
-
 /// Loaded Istanbul coverage data, keyed by canonical file path.
 pub struct IstanbulCoverage {
     files: rustc_hash::FxHashMap<std::path::PathBuf, IstanbulFileCoverage>,
@@ -1565,10 +1564,21 @@ pub fn resolve_relative_to_root(
 ///
 /// `relocated` marks a map recorded against a different checkout of the
 /// project; see [`IstanbulFileCoverage::lookup`].
-pub(super) fn load_istanbul_coverage(
+#[cfg(test)]
+fn load_istanbul_coverage(
     path: &std::path::Path,
     coverage_root: Option<&std::path::Path>,
     project_root: Option<&std::path::Path>,
+    relocated: bool,
+) -> Result<IstanbulCoverage, String> {
+    load_istanbul_coverage_for_sources(path, coverage_root, project_root, None, relocated)
+}
+
+pub(super) fn load_istanbul_coverage_for_sources(
+    path: &std::path::Path,
+    coverage_root: Option<&std::path::Path>,
+    project_root: Option<&std::path::Path>,
+    discovered_sources: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
     relocated: bool,
 ) -> Result<IstanbulCoverage, String> {
     super::validate_coverage_root_absolute(coverage_root)?;
@@ -1611,17 +1621,44 @@ pub(super) fn load_istanbul_coverage(
             raw_path
         };
         let canonical = dunce::canonicalize(&file_path).unwrap_or(file_path);
+        let source = read_discovered_source(&canonical, discovered_sources, relocated);
+        let source_index = source
+            .as_deref()
+            .map(|source| IstanbulSourceIndex::new(source, &canonical));
 
         let mut functions = Vec::with_capacity(file_cov.fn_map.len());
         for (fn_id, fn_entry) in &file_cov.fn_map {
             let coverage_pct = compute_function_statement_coverage(file_cov, fn_id, fn_entry);
-            functions.push(istanbul_function_coverage(fn_entry, coverage_pct));
+            if let Some(function) =
+                istanbul_function_coverage(fn_entry, coverage_pct, source_index.as_ref())
+            {
+                functions.push(function);
+            }
         }
 
         files.insert(canonical, IstanbulFileCoverage::new(functions, relocated));
     }
 
     Ok(IstanbulCoverage { files })
+}
+
+#[expect(
+    clippy::filetype_is_file,
+    reason = "coverage provenance must admit regular files and reject every special file type"
+)]
+fn read_discovered_source(
+    path: &std::path::Path,
+    discovered_sources: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
+    relocated: bool,
+) -> Option<String> {
+    if relocated || !discovered_sources.is_some_and(|sources| sources.contains(path)) {
+        return None;
+    }
+    if std::fs::symlink_metadata(path).ok()?.file_type().is_file() {
+        std::fs::read_to_string(path).ok()
+    } else {
+        None
+    }
 }
 
 /// Rebase one Istanbul file path from `coverage_root` onto `project_root`.
@@ -1650,25 +1687,34 @@ fn rebase_coverage_path(
 fn istanbul_function_coverage(
     fn_entry: &oxc_coverage_instrument::FnEntry,
     coverage_pct: f64,
-) -> IstanbulFunctionCoverage {
-    let body_span = IstanbulSpan::from_entry(fn_entry);
-    let header_span = IstanbulSpan::header_from_entry(fn_entry);
+    source_index: Option<&IstanbulSourceIndex<'_>>,
+) -> Option<IstanbulFunctionCoverage> {
+    let body_span = IstanbulSpan::from_entry(fn_entry, source_index);
+    let header_span = IstanbulSpan::header_from_entry(fn_entry, source_index);
+    let decl_start = normalized_istanbul_position(
+        fn_entry.decl.start.line,
+        fn_entry.decl.start.column,
+        source_index,
+    )?;
+    let effective_position = normalized_istanbul_position(
+        effective_istanbul_fn_line(fn_entry),
+        fn_entry.decl.start.column,
+        source_index,
+    );
     let candidates = [
-        Some(IstanbulAlias {
-            position: IstanbulPosition::new(
-                effective_istanbul_fn_line(fn_entry),
-                effective_istanbul_fn_col(fn_entry),
-            ),
+        effective_position.map(|position| IstanbulAlias {
+            position,
             primary: true,
         }),
         Some(IstanbulAlias {
-            position: IstanbulPosition::new(fn_entry.decl.start.line, fn_entry.decl.start.column),
+            position: decl_start,
             primary: true,
         }),
         body_span.map(|span| IstanbulAlias {
             position: span.start,
             primary: false,
         }),
+        named_function_syntax_alias(fn_entry, source_index),
     ];
     let mut aliases: Vec<IstanbulAlias> = Vec::with_capacity(candidates.len());
     for candidate in candidates.into_iter().flatten() {
@@ -1680,15 +1726,265 @@ fn istanbul_function_coverage(
         }
     }
 
-    IstanbulFunctionCoverage {
+    Some(IstanbulFunctionCoverage {
         name: fn_entry.name.clone(),
         coverage_pct,
         aliases,
-        decl_start: IstanbulPosition::new(fn_entry.decl.start.line, fn_entry.decl.start.column),
+        decl_start,
         header_holds_other_fn: false,
         header_span,
         body_span,
+    })
+}
+
+/// Source index used to reconcile Istanbul's UTF-16 columns with Fallow's
+/// UTF-8 byte columns and recover exact named-function syntax starts.
+struct IstanbulSourceIndex<'a> {
+    source: &'a str,
+    line_starts: Vec<usize>,
+    non_ascii_lines: rustc_hash::FxHashMap<usize, Utf16LineIndex>,
+    named_function_starts: rustc_hash::FxHashMap<usize, usize>,
+}
+
+struct Utf16LineIndex {
+    utf16_len: u32,
+    byte_len: usize,
+    checkpoints: Vec<Utf16Checkpoint>,
+}
+
+struct Utf16Checkpoint {
+    utf16_start: u32,
+    utf16_end: u32,
+    byte_end: usize,
+}
+
+impl<'a> IstanbulSourceIndex<'a> {
+    fn new(source: &'a str, path: &std::path::Path) -> Self {
+        let mut line_starts = vec![0];
+        line_starts.extend(
+            source
+                .bytes()
+                .enumerate()
+                .filter_map(|(index, byte)| (byte == b'\n').then_some(index + 1)),
+        );
+        let non_ascii_lines = utf16_line_indexes(source, &line_starts);
+
+        let named_function_starts = named_function_starts_from_clean_parse(source, path);
+
+        Self {
+            source,
+            line_starts,
+            non_ascii_lines,
+            named_function_starts,
+        }
     }
+
+    fn byte_position(&self, line: u32, utf16_column: u32) -> Option<IstanbulPosition> {
+        let line_index = usize::try_from(line.checked_sub(1)?).ok()?;
+        let line_start = *self.line_starts.get(line_index)?;
+        let line_end = self
+            .line_starts
+            .get(line_index + 1)
+            .copied()
+            .map_or(self.source.len(), |next_start| next_start - 1);
+        let line_source = self.source.get(line_start..line_end)?;
+        let byte_column = if let Some(index) = self.non_ascii_lines.get(&line_index) {
+            index.byte_column(utf16_column)?
+        } else {
+            let byte_column = usize::try_from(utf16_column).ok()?;
+            (byte_column <= line_source.len()).then_some(byte_column)?
+        };
+        Some(IstanbulPosition::new(
+            line,
+            u32::try_from(byte_column).ok()?,
+        ))
+    }
+
+    fn absolute_offset(&self, line: u32, utf16_column: u32) -> Option<usize> {
+        let position = self.byte_position(line, utf16_column)?;
+        let line_index = usize::try_from(position.line.checked_sub(1)?).ok()?;
+        self.line_starts
+            .get(line_index)?
+            .checked_add(position.col as usize)
+    }
+
+    fn position_at_offset(&self, offset: usize) -> Option<IstanbulPosition> {
+        if offset > self.source.len() {
+            return None;
+        }
+        let line_index = self.line_starts.partition_point(|start| *start <= offset) - 1;
+        Some(IstanbulPosition::new(
+            u32::try_from(line_index + 1).ok()?,
+            u32::try_from(offset.checked_sub(self.line_starts[line_index])?).ok()?,
+        ))
+    }
+
+    fn named_function_start(
+        &self,
+        fn_entry: &oxc_coverage_instrument::FnEntry,
+    ) -> Option<IstanbulPosition> {
+        let declaration_offset =
+            self.absolute_offset(fn_entry.decl.start.line, fn_entry.decl.start.column)?;
+        let syntax_offset = *self.named_function_starts.get(&declaration_offset)?;
+        self.position_at_offset(syntax_offset)
+    }
+}
+
+impl Utf16LineIndex {
+    fn byte_column(&self, utf16_column: u32) -> Option<usize> {
+        if utf16_column > self.utf16_len {
+            return None;
+        }
+        let completed = self
+            .checkpoints
+            .partition_point(|checkpoint| checkpoint.utf16_end <= utf16_column);
+        if let Some(next) = self.checkpoints.get(completed)
+            && utf16_column > next.utf16_start
+        {
+            return None;
+        }
+        let (utf16_base, byte_base) = completed
+            .checked_sub(1)
+            .and_then(|index| self.checkpoints.get(index))
+            .map_or((0, 0), |checkpoint| {
+                (checkpoint.utf16_end, checkpoint.byte_end)
+            });
+        let ascii_width = usize::try_from(utf16_column.checked_sub(utf16_base)?).ok()?;
+        let byte_column = byte_base.checked_add(ascii_width)?;
+        (byte_column <= self.byte_len).then_some(byte_column)
+    }
+}
+
+fn utf16_line_indexes(
+    source: &str,
+    line_starts: &[usize],
+) -> rustc_hash::FxHashMap<usize, Utf16LineIndex> {
+    let mut indexes = rustc_hash::FxHashMap::default();
+    for (line_index, &line_start) in line_starts.iter().enumerate() {
+        let line_end = line_starts
+            .get(line_index + 1)
+            .copied()
+            .map_or(source.len(), |next_start| next_start - 1);
+        let Some(line) = source.get(line_start..line_end) else {
+            continue;
+        };
+        if line.is_ascii() {
+            continue;
+        }
+        let mut utf16_column = 0_u32;
+        let mut checkpoints = Vec::new();
+        for (byte_column, character) in line.char_indices() {
+            let utf16_width = character.len_utf16() as u32;
+            if !character.is_ascii() {
+                checkpoints.push(Utf16Checkpoint {
+                    utf16_start: utf16_column,
+                    utf16_end: utf16_column.saturating_add(utf16_width),
+                    byte_end: byte_column.saturating_add(character.len_utf8()),
+                });
+            }
+            utf16_column = utf16_column.saturating_add(utf16_width);
+        }
+        indexes.insert(
+            line_index,
+            Utf16LineIndex {
+                utf16_len: utf16_column,
+                byte_len: line.len(),
+                checkpoints,
+            },
+        );
+    }
+    indexes
+}
+
+fn named_function_starts_from_clean_parse(
+    source: &str,
+    path: &std::path::Path,
+) -> rustc_hash::FxHashMap<usize, usize> {
+    let source_type = match path.extension().and_then(|extension| extension.to_str()) {
+        Some("gts") => oxc_span::SourceType::ts(),
+        Some("gjs") => oxc_span::SourceType::mjs(),
+        _ => oxc_span::SourceType::from_path(path).unwrap_or_default(),
+    };
+    if let Some(starts) = collect_named_function_starts(source, source_type) {
+        return starts;
+    }
+    if source_type.is_jsx() {
+        return rustc_hash::FxHashMap::default();
+    }
+    let jsx_source_type = if source_type.is_typescript() {
+        oxc_span::SourceType::tsx()
+    } else {
+        oxc_span::SourceType::jsx()
+    };
+    collect_named_function_starts(source, jsx_source_type).unwrap_or_default()
+}
+
+fn collect_named_function_starts(
+    source: &str,
+    source_type: oxc_span::SourceType,
+) -> Option<rustc_hash::FxHashMap<usize, usize>> {
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return None;
+    }
+    let mut starts = rustc_hash::FxHashMap::default();
+    let mut collector = NamedFunctionSyntaxCollector {
+        starts: &mut starts,
+    };
+    oxc_ast_visit::Visit::visit_program(&mut collector, &parsed.program);
+    Some(starts)
+}
+
+struct NamedFunctionSyntaxCollector<'a> {
+    starts: &'a mut rustc_hash::FxHashMap<usize, usize>,
+}
+
+impl<'ast> oxc_ast_visit::Visit<'ast> for NamedFunctionSyntaxCollector<'_> {
+    fn visit_function(
+        &mut self,
+        function: &oxc_ast::ast::Function<'ast>,
+        flags: oxc_syntax::scope::ScopeFlags,
+    ) {
+        if let Some(identifier) = &function.id
+            && let (Ok(identifier_start), Ok(syntax_start)) = (
+                usize::try_from(identifier.span.start),
+                usize::try_from(function.span.start),
+            )
+        {
+            self.starts.insert(identifier_start, syntax_start);
+        }
+        oxc_ast_visit::walk::walk_function(self, function, flags);
+    }
+}
+
+fn normalized_istanbul_position(
+    line: u32,
+    column: u32,
+    source_index: Option<&IstanbulSourceIndex<'_>>,
+) -> Option<IstanbulPosition> {
+    match source_index {
+        Some(index) => index.byte_position(line, column),
+        None => Some(IstanbulPosition::new(line, column)),
+    }
+}
+
+/// Exact syntax-backed alias for a named function's source start.
+///
+/// Istanbul declares a named function at its identifier, while Fallow records
+/// the containing `function` or `async` keyword. Parser tokens distinguish
+/// that real syntax across legal trivia from unrelated same-width text.
+fn named_function_syntax_alias(
+    fn_entry: &oxc_coverage_instrument::FnEntry,
+    source_index: Option<&IstanbulSourceIndex<'_>>,
+) -> Option<IstanbulAlias> {
+    if is_anonymous_istanbul_name(&fn_entry.name) {
+        return None;
+    }
+    Some(IstanbulAlias {
+        position: source_index?.named_function_start(fn_entry)?,
+        primary: true,
+    })
 }
 
 fn effective_istanbul_fn_line(fn_entry: &oxc_coverage_instrument::FnEntry) -> u32 {
@@ -1697,14 +1993,6 @@ fn effective_istanbul_fn_line(fn_entry: &oxc_coverage_instrument::FnEntry) -> u3
     } else {
         fn_entry.decl.start.line
     }
-}
-
-/// Effective 0-based start column for an Istanbul function entry. `FnEntry`
-/// has no top-level `column` field, so we always read it off
-/// `decl.start.column`. Both fallow's `FunctionComplexity.col` and Istanbul's
-/// `Position::column` are 0-based, so they match directly.
-fn effective_istanbul_fn_col(fn_entry: &oxc_coverage_instrument::FnEntry) -> u32 {
-    fn_entry.decl.start.column
 }
 
 /// Compute statement-level coverage percentage for a single function.
@@ -5804,8 +6092,16 @@ mod tests {
             &serde_json::json!({ "0": 3, "1": 0 }),
         );
 
-        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let discovered_sources = rustc_hash::FxHashSet::from_iter([canonical_source.clone()]);
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&discovered_sources),
+            false,
+        )
+        .unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
         // Inside both the member's header span and `scale`'s, so neither says
@@ -5857,6 +6153,363 @@ mod tests {
 
         assert_eq!(file_coverage.lookup("render", 3, 8), Some(100.0));
         assert_eq!(file_coverage.lookup("render", 5, 23), Some(0.0));
+    }
+
+    /// A same-line signature can place an unrelated identifier exactly one
+    /// function-expression prefix away from the member start. Column distance
+    /// alone must not make that nested function the member's coverage source.
+    #[test]
+    fn same_line_same_named_function_in_signature_does_not_supply_member_coverage() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/chart.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export class Chart {\n  @Watch(\"data\") render(x  = function  render() {}) {}\n}\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 2,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 2, "column": 52 }, "end": { "line": 2, "column": 54 } }
+                },
+                "1": {
+                    "name": "render",
+                    "line": 2,
+                    "decl": { "start": { "line": 2, "column": 39 }, "end": { "line": 2, "column": 45 } },
+                    "loc": { "start": { "line": 2, "column": 48 }, "end": { "line": 2, "column": 50 } }
+                }
+            }),
+            &serde_json::json!({ "0": 3, "1": 0 }),
+        );
+
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let discovered_sources = rustc_hash::FxHashSet::from_iter([canonical_source.clone()]);
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&discovered_sources),
+            false,
+        )
+        .unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("render", 2, 23), Some(100.0));
+        assert_eq!(file_coverage.lookup("render", 2, 29), Some(0.0));
+    }
+
+    #[test]
+    fn named_generator_alias_handles_trivia_and_utf16_columns() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/chart.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        let source_line =
+            "  render(label = \"pi: π, mushroom: 🍄\", x = function/* gap */*render() {}) {}";
+        std::fs::write(
+            &source_path,
+            format!("export class Chart {{\n{source_line}\n}}\n"),
+        )
+        .unwrap();
+
+        let utf16_column = |byte_column: usize| {
+            u32::try_from(source_line[..byte_column].encode_utf16().count()).unwrap()
+        };
+        let outer_target_column = source_line.find("render(").unwrap() + "render".len();
+        let syntax_column = source_line.find("function").unwrap();
+        let name_column = source_line.find("*render").unwrap() + 1;
+        let inner_body_column = source_line.find("{}").unwrap();
+        let outer_body_column = source_line.rfind("{}").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 2,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": {
+                        "start": { "line": 2, "column": utf16_column(outer_body_column) },
+                        "end": { "line": 2, "column": utf16_column(outer_body_column + 2) }
+                    }
+                },
+                "1": {
+                    "name": "render",
+                    "line": 2,
+                    "decl": {
+                        "start": { "line": 2, "column": utf16_column(name_column) },
+                        "end": { "line": 2, "column": utf16_column(name_column + "render".len()) }
+                    },
+                    "loc": {
+                        "start": { "line": 2, "column": utf16_column(inner_body_column) },
+                        "end": { "line": 2, "column": utf16_column(inner_body_column + 2) }
+                    }
+                }
+            }),
+            &serde_json::json!({ "0": 3, "1": 0 }),
+        );
+
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let discovered_sources = rustc_hash::FxHashSet::from_iter([canonical_source.clone()]);
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&discovered_sources),
+            false,
+        )
+        .unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(
+            file_coverage.lookup("render", 2, u32::try_from(outer_target_column).unwrap()),
+            Some(100.0)
+        );
+        assert_eq!(
+            file_coverage.lookup("render", 2, u32::try_from(syntax_column).unwrap()),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn utf16_index_is_sparse_and_rejects_surrogate_boundaries() {
+        let ascii_prefix = "a".repeat(4_096);
+        let source = format!("{ascii_prefix}🍄{}", "b".repeat(4_096));
+        let index = IstanbulSourceIndex::new(&source, std::path::Path::new("minified.js"));
+        let line_index = &index.non_ascii_lines[&0];
+
+        assert_eq!(line_index.checkpoints.len(), 1);
+        assert_eq!(
+            index.byte_position(1, 4_096),
+            Some(IstanbulPosition::new(1, 4_096))
+        );
+        assert_eq!(index.byte_position(1, 4_097), None);
+        assert_eq!(
+            index.byte_position(1, 4_098),
+            Some(IstanbulPosition::new(1, 4_100))
+        );
+        assert_eq!(
+            index.byte_position(1, 8_194),
+            Some(IstanbulPosition::new(1, 8_196))
+        );
+    }
+
+    #[test]
+    fn effective_alias_normalizes_against_its_own_unicode_line() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/render.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "/*🍄*/ const placeholder = 0;\n/*π*/ function render() {}\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "render",
+                    "line": 1,
+                    "decl": { "start": { "line": 2, "column": 15 }, "end": { "line": 2, "column": 21 } },
+                    "loc": { "start": { "line": 2, "column": 24 }, "end": { "line": 2, "column": 26 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1 }),
+        );
+
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let discovered_sources = rustc_hash::FxHashSet::from_iter([canonical_source.clone()]);
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&discovered_sources),
+            false,
+        )
+        .unwrap();
+        let function = &coverage.get(&canonical_source).unwrap().functions[0];
+
+        assert!(
+            function
+                .aliases
+                .iter()
+                .any(|alias| { alias.position == IstanbulPosition::new(1, 17) && alias.primary })
+        );
+        assert!(
+            !function
+                .aliases
+                .iter()
+                .any(|alias| alias.position == IstanbulPosition::new(1, 16))
+        );
+    }
+
+    #[test]
+    fn stale_utf16_coordinates_are_rejected_with_trusted_source() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/render.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "export function render() {}\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "render",
+                    "line": 1,
+                    "decl": { "start": { "line": 1, "column": 999 }, "end": { "line": 1, "column": 22 } },
+                    "loc": { "start": { "line": 1, "column": 25 }, "end": { "line": 1, "column": 27 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1 }),
+        );
+
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let discovered_sources = rustc_hash::FxHashSet::from_iter([canonical_source.clone()]);
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&discovered_sources),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            coverage
+                .get(&canonical_source)
+                .unwrap()
+                .lookup("render", 1, 7),
+            None
+        );
+    }
+
+    #[test]
+    fn invalid_optional_coordinates_preserve_valid_declaration_attribution() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/render.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "export function render() {}\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "render",
+                    "line": 99,
+                    "decl": { "start": { "line": 1, "column": 16 }, "end": { "line": 99, "column": 999 } },
+                    "loc": { "start": { "line": 1, "column": 999 }, "end": { "line": 99, "column": 999 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1 }),
+        );
+
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let discovered_sources = rustc_hash::FxHashSet::from_iter([canonical_source.clone()]);
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&discovered_sources),
+            false,
+        )
+        .unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+        let function = &file_coverage.functions[0];
+
+        assert_eq!(file_coverage.lookup("render", 1, 16), Some(100.0));
+        assert!(function.body_span.is_none());
+        assert!(function.header_span.is_none());
+        assert!(
+            !function
+                .aliases
+                .iter()
+                .any(|alias| { alias.position.line == 99 || alias.position.col == 999 })
+        );
+    }
+
+    #[test]
+    fn malformed_source_does_not_supply_named_function_provenance() {
+        assert!(
+            !IstanbulSourceIndex::new(
+                "export function render() {}",
+                std::path::Path::new("valid.ts"),
+            )
+            .named_function_starts
+            .is_empty()
+        );
+        let index = IstanbulSourceIndex::new(
+            "export function render() {} const broken = ;",
+            std::path::Path::new("broken.ts"),
+        );
+
+        assert!(index.named_function_starts.is_empty());
+    }
+
+    #[test]
+    fn javascript_with_jsx_uses_clean_jsx_provenance_parse() {
+        let index = IstanbulSourceIndex::new(
+            "export function render() { return <div />; }",
+            std::path::Path::new("component.js"),
+        );
+
+        assert!(!index.named_function_starts.is_empty());
+    }
+
+    #[test]
+    fn undiscovered_coverage_path_is_not_loaded_for_source_provenance() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/excluded.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "export function render() {}\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "render",
+                    "line": 1,
+                    "decl": { "start": { "line": 1, "column": 16 }, "end": { "line": 1, "column": 22 } },
+                    "loc": { "start": { "line": 1, "column": 25 }, "end": { "line": 1, "column": 27 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1 }),
+        );
+
+        let coverage = load_istanbul_coverage_for_sources(
+            &coverage_path,
+            None,
+            Some(temp.path()),
+            Some(&rustc_hash::FxHashSet::default()),
+            false,
+        )
+        .unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let function = &coverage.get(&canonical_source).unwrap().functions[0];
+
+        assert!(
+            function
+                .aliases
+                .iter()
+                .all(|alias| alias.position != IstanbulPosition::new(1, 7))
+        );
     }
 
     /// No instrumenter emits an `fnMap` identity for a private class member,

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -918,6 +918,14 @@ struct IstanbulFunctionCoverage {
     name: String,
     coverage_pct: f64,
     aliases: Vec<IstanbulAlias>,
+    /// Where the producer says the function is written. Unlike the alias set
+    /// this is never a synthesized position, so it answers "is another
+    /// function declared here" without false positives.
+    decl_start: IstanbulPosition,
+    /// Whether another function is declared inside this record's header span.
+    /// Computed once per file, because the header fallback needs it on every
+    /// unmatched lookup and recomputing it there is quadratic.
+    header_holds_other_fn: bool,
     header_span: Option<IstanbulSpan>,
     body_span: Option<IstanbulSpan>,
 }
@@ -1057,6 +1065,22 @@ impl IstanbulFileCoverage {
             }
         }
 
+        let mut declarations: Vec<IstanbulPosition> = functions
+            .iter()
+            .map(|function| function.decl_start)
+            .collect();
+        declarations.sort_unstable();
+        for function in &mut functions {
+            let Some(span) = function.header_span else {
+                continue;
+            };
+            // The record's own declaration opens its header span, so it is
+            // always in range: a second hit is what marks a foreign function.
+            let first = declarations.partition_point(|position| *position < span.start);
+            let past = declarations.partition_point(|position| *position < span.end);
+            function.header_holds_other_fn = past - first > 1;
+        }
+
         Self {
             functions,
             alias_index,
@@ -1099,6 +1123,13 @@ impl IstanbulFileCoverage {
     /// the choice among them cannot matter (#2347). Same-checkout lookups
     /// keep the bounded fuzz, which protects against stale coverage data.
     pub fn lookup(&self, name: &str, line: u32, col: u32) -> Option<f64> {
+        // No producer records a private class member in `fnMap`. Istanbul's
+        // visitor has no case for one and the sidecar mirrors that, so every
+        // candidate a private member could reach belongs to some enclosing
+        // function, and crediting it reports code that never ran as covered.
+        if name.starts_with('#') {
+            return None;
+        }
         let exact_key = (name.to_string(), line, col);
         if self.ambiguous_aliases.contains(&exact_key) {
             return None;
@@ -1128,7 +1159,7 @@ impl IstanbulFileCoverage {
             return Some(pct);
         }
         if self.ambiguous_anonymous_aliases.contains(&target) {
-            return None;
+            return self.unique_anonymous_header_match(target);
         }
 
         let mut nearest_distance: Option<(u32, u32)> = None;
@@ -1167,20 +1198,40 @@ impl IstanbulFileCoverage {
             return established_match;
         }
 
-        let mut header_match = None;
+        self.unique_anonymous_header_match(target)
+    }
+
+    /// Coverage of the one anonymous record whose header span owns `target`.
+    ///
+    /// A header span runs from `decl.start` to `loc.start`, so it covers the
+    /// signature: the parameter list, its default values, and any decorators.
+    /// A function literal written there is a different function from the one
+    /// that owns the span, and crediting it with the owner's coverage reports
+    /// never-executed code as covered. Every function is therefore checked for
+    /// containment, not just the anonymous ones, and a second containing span
+    /// abstains. Only an anonymous record can win, because a named record is
+    /// already reachable through the exact and fuzzy name paths.
+    fn unique_anonymous_header_match(&self, target: IstanbulPosition) -> Option<f64> {
+        let mut candidate = None;
         for (function_index, function) in self.functions.iter().enumerate() {
-            if !is_anonymous_istanbul_name(&function.name)
-                || !function
-                    .header_span
-                    .is_some_and(|span| span.contains(target))
+            if !function
+                .header_span
+                .is_some_and(|span| span.contains(target))
             {
                 continue;
             }
-            if header_match.replace(function_index).is_some() {
+            if !is_anonymous_istanbul_name(&function.name) {
+                return None;
+            }
+            if candidate.replace(function_index).is_some() {
                 return None;
             }
         }
-        header_match.map(|function_index| self.functions[function_index].coverage_pct)
+        let function_index = candidate?;
+        if self.functions[function_index].header_holds_other_fn {
+            return None;
+        }
+        Some(self.functions[function_index].coverage_pct)
     }
 
     fn innermost_anonymous_match(&self, tied: &[usize], target: IstanbulPosition) -> Option<f64> {
@@ -1436,6 +1487,8 @@ fn istanbul_function_coverage(
         name: fn_entry.name.clone(),
         coverage_pct,
         aliases,
+        decl_start: IstanbulPosition::new(fn_entry.decl.start.line, fn_entry.decl.start.column),
+        header_holds_other_fn: false,
         header_span,
         body_span,
     }
@@ -2390,6 +2443,8 @@ mod tests {
                     name,
                     coverage_pct,
                     aliases: vec![primary_alias(line, col)],
+                    decl_start: IstanbulPosition::new(line, col),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: None,
                 },
@@ -5352,6 +5407,86 @@ mod tests {
         assert_eq!(result.per_function[0].coverage_pct, Some(100.0));
     }
 
+    /// A default parameter can hold a whole function, so a header span can
+    /// cover code that belongs to something else. Geometry from
+    /// istanbul-lib-instrument 6 for a method whose default parameter is a
+    /// named function expression: only `run` and `recover` get records, and
+    /// the private member inside `recover` gets none. Crediting it with
+    /// `run`'s coverage would report never-executed code as fully covered,
+    /// because `recover` never ran.
+    #[test]
+    fn header_span_abstains_when_another_function_is_declared_inside_it() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/pipeline.js");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "// geometry fixture\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 14,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 5 } },
+                    "loc": { "start": { "line": 14, "column": 4 }, "end": { "line": 16, "column": 3 } }
+                },
+                "1": {
+                    "name": "recover",
+                    "line": 4,
+                    "decl": { "start": { "line": 4, "column": 22 }, "end": { "line": 4, "column": 29 } },
+                    "loc": { "start": { "line": 4, "column": 38 }, "end": { "line": 12, "column": 5 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        // Inside `run`'s header span (2:2 to 14:4), but `recover` is declared
+        // there, so the span says nothing about this position.
+        assert_eq!(file_coverage.lookup("<anonymous>", 6, 13), None);
+        // The two records themselves still resolve.
+        assert_eq!(file_coverage.lookup("recover", 4, 22), Some(0.0));
+    }
+
+    /// No instrumenter emits an `fnMap` identity for a private class member,
+    /// so any candidate one reaches belongs to an enclosing function.
+    #[test]
+    fn private_class_member_never_takes_enclosing_coverage() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/vault.js");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "// geometry fixture\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 7,
+                    "decl": { "start": { "line": 1, "column": 24 }, "end": { "line": 1, "column": 25 } },
+                    "loc": { "start": { "line": 7, "column": 5 }, "end": { "line": 7, "column": 20 } }
+                }
+            }),
+            &serde_json::json!({ "0": 1 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        // `#wipe` sits in the arrow's header span and the arrow ran, but the
+        // private member has no record of its own and never ran.
+        assert_eq!(file_coverage.lookup("#wipe", 3, 9), None);
+        assert_eq!(file_coverage.lookup("<arrow>", 1, 24), Some(100.0));
+    }
+
     /// istanbul-lib-instrument anchors a callback passed to a multi-line call
     /// at the call expression for `decl.start` and at the callback body for
     /// `loc.start`. Oxc anchors the callback itself between those positions.
@@ -5892,6 +6027,8 @@ mod tests {
                     name: "(anonymous_0)".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(10, 8), secondary_alias(10, 14)],
+                    decl_start: IstanbulPosition::new(10, 8),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((10, 14), (12, 30))),
                 },
@@ -5899,6 +6036,8 @@ mod tests {
                     name: "(anonymous_1)".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(10, 20), secondary_alias(11, 0)],
+                    decl_start: IstanbulPosition::new(10, 20),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((11, 0), (14, 0))),
                 },
@@ -5921,6 +6060,8 @@ mod tests {
                     name: "(anonymous_0)".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(4, 11), primary_alias(1, 11)],
+                    decl_start: IstanbulPosition::new(4, 11),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((4, 11), (4, 23))),
                 },
@@ -5928,6 +6069,8 @@ mod tests {
                     name: "(anonymous_1)".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(4, 11), secondary_alias(4, 18)],
+                    decl_start: IstanbulPosition::new(4, 11),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((4, 18), (4, 23))),
                 },
@@ -5949,6 +6092,8 @@ mod tests {
                     name: "(anonymous_0)".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(10, 0), secondary_alias(12, 4)],
+                    decl_start: IstanbulPosition::new(10, 0),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((12, 4), (20, 0))),
                 },
@@ -5956,6 +6101,8 @@ mod tests {
                     name: "(anonymous_1)".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(11, 0), secondary_alias(12, 4)],
+                    decl_start: IstanbulPosition::new(11, 0),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((12, 4), (18, 0))),
                 },
@@ -5976,6 +6123,8 @@ mod tests {
                     name: "handler".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(10, 0), secondary_alias(12, 4)],
+                    decl_start: IstanbulPosition::new(10, 0),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((12, 4), (20, 0))),
                 },
@@ -5983,6 +6132,8 @@ mod tests {
                     name: "handler".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(11, 0), secondary_alias(12, 4)],
+                    decl_start: IstanbulPosition::new(11, 0),
+                    header_holds_other_fn: false,
                     header_span: None,
                     body_span: Some(body_span((12, 4), (18, 0))),
                 },

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -1564,7 +1564,11 @@ pub(super) fn load_istanbul_coverage(
 
     let mut files = rustc_hash::FxHashMap::default();
     for file_cov in raw.values() {
-        let raw_path = std::path::PathBuf::from(&file_cov.path);
+        // A producer may record project-relative keys. They are relative to
+        // the project, not to wherever the process happens to run, and
+        // resolving them against the current directory fails the whole map at
+        // once with every unit silently falling back to its estimate.
+        let raw_path = resolve_relative_to_root(std::path::Path::new(&file_cov.path), project_root);
         let file_path = if let (Some(cov_root), Some(proj_root)) = (coverage_root, project_root) {
             rebase_coverage_path(raw_path, cov_root, proj_root)
         } else {
@@ -5414,6 +5418,48 @@ mod tests {
             resolved,
             std::path::PathBuf::from("coverage/coverage-final.json")
         );
+    }
+
+    /// nyc and some Jest setups record project-relative keys. Resolving one
+    /// against the process directory misses the file, and a run from anywhere
+    /// but the project root loses the whole map at once.
+    #[test]
+    fn load_istanbul_coverage_resolves_relative_map_keys_against_project_root() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/index.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "export function f(){}").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        std::fs::write(
+            &coverage_path,
+            serde_json::to_string(&serde_json::json!({
+                "src/index.ts": {
+                    "path": "src/index.ts",
+                    "statementMap": {},
+                    "fnMap": {
+                        "0": {
+                            "name": "f",
+                            "decl": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 21 } },
+                            "loc": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 21 } }
+                        }
+                    },
+                    "branchMap": {},
+                    "s": {},
+                    "f": { "0": 2 },
+                    "b": {}
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let coverage =
+            load_istanbul_coverage(&coverage_path, None, Some(temp.path()), false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("f", 1, 0), Some(100.0));
     }
 
     #[test]

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -1247,17 +1247,32 @@ impl IstanbulFileCoverage {
 
         let target = IstanbulPosition::new(line, col);
         let window = self.fuzz_window(target);
+        // A function written inside another function's signature is a
+        // different function from the one the signature belongs to, and both
+        // sit within a line or two of the same position. Proximity cannot
+        // tell them apart, so the records whose signature covers this target
+        // decide which candidates below are eligible at all.
+        let signature_owners = self.header_spans_containing(target);
         if let Some(function) = window
             .iter()
-            .map(|function_index| &self.functions[*function_index])
-            .filter(|function| function.name == name)
-            .filter_map(|function| {
+            .copied()
+            .filter(|function_index| self.functions[*function_index].name == name)
+            .filter_map(|function_index| {
+                let function = &self.functions[function_index];
                 function
                     .nearest_alias(target, None)
-                    .map(|distance| (distance, function))
+                    .map(|distance| (distance, function_index))
+            })
+            .filter(|(distance, function_index)| {
+                *distance == (0, 0)
+                    || named_function_prefix_contains_target(
+                        &self.functions[*function_index],
+                        target,
+                    )
+                    || !self.foreign_signature_blocks(&signature_owners, *function_index, target)
             })
             .min_by_key(|(distance, _)| *distance)
-            .map(|(_, function)| function)
+            .map(|(_, function_index)| &self.functions[function_index])
         {
             return Some(function.coverage_pct);
         }
@@ -1266,12 +1281,6 @@ impl IstanbulFileCoverage {
         {
             return Some(pct);
         }
-        // A function written inside another function's signature is a
-        // different function from the one the signature belongs to, and both
-        // sit within a line or two of the same position. Proximity cannot
-        // tell them apart, so the records whose signature covers this target
-        // decide below which candidates are eligible at all.
-        let signature_owners = self.header_spans_containing(target);
         if self.ambiguous_anonymous_aliases.contains(&target) {
             return self.unique_anonymous_header_match(&signature_owners);
         }
@@ -1444,6 +1453,25 @@ impl IstanbulFileCoverage {
         }
         found
     }
+}
+
+/// Whether `target` is the source-level start of a named function whose
+/// Istanbul declaration starts at the later identifier.
+///
+/// The fixed widths are the ASCII spellings before that identifier:
+/// `function `, `function* `, `async function `, and `async function* `.
+/// Matching an exact width avoids treating an enclosing same-named member on
+/// the same line as the nested function's own target.
+fn named_function_prefix_contains_target(
+    function: &IstanbulFunctionCoverage,
+    target: IstanbulPosition,
+) -> bool {
+    function.decl_start.line == target.line
+        && function
+            .decl_start
+            .col
+            .checked_sub(target.col)
+            .is_some_and(|width| matches!(width, 9 | 10 | 15 | 16))
 }
 
 /// Loaded Istanbul coverage data, keyed by canonical file path.
@@ -5786,6 +5814,49 @@ mod tests {
         // Both records still resolve.
         assert_eq!(file_coverage.lookup("scale", 5, 14), Some(0.0));
         assert_eq!(file_coverage.lookup("render", 3, 8), Some(100.0));
+    }
+
+    /// A named function in a member signature can legally reuse the member's
+    /// name. Name fuzz must not return that inner function before established
+    /// anonymous resolution preserves the member's valid attribution.
+    #[test]
+    fn same_named_function_in_signature_does_not_supply_member_coverage() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/chart.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export class Chart {\n  @Watch(\"data\")\n  render(\n    rows: number[],\n    project = function render(\n      row: number\n    ) {\n      return row * 2;\n    }\n  ) {\n    return rows.map(project);\n  }\n}\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 10,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 10, "column": 4 }, "end": { "line": 12, "column": 3 } }
+                },
+                "1": {
+                    "name": "render",
+                    "line": 7,
+                    "decl": { "start": { "line": 5, "column": 23 }, "end": { "line": 5, "column": 29 } },
+                    "loc": { "start": { "line": 7, "column": 6 }, "end": { "line": 9, "column": 5 } }
+                }
+            }),
+            &serde_json::json!({ "0": 3, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("render", 3, 8), Some(100.0));
+        assert_eq!(file_coverage.lookup("render", 5, 23), Some(0.0));
     }
 
     /// No instrumenter emits an `fnMap` identity for a private class member,

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -816,6 +816,12 @@ fn crap_formula(cc: f64, coverage_pct: f64) -> f64 {
 /// declaration alias at the typical `const x = async (` column.
 const ANONYMOUS_FALLBACK_MAX_COLUMN_DRIFT: u32 = 16;
 
+/// Maximum line drift tolerated by the name-fuzzy and anonymous fallbacks.
+/// Both reject an alias further than this from the target, which is what lets
+/// a lookup binary-search a window of `IstanbulFileCoverage::alias_lines`
+/// instead of scanning every record in the file.
+const ALIAS_FUZZ_MAX_LINE_DRIFT: u32 = 2;
+
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct IstanbulPosition {
     line: u32,
@@ -940,7 +946,7 @@ impl IstanbulFunctionCoverage {
             .iter()
             .filter_map(|alias| {
                 let distance = alias.position.distance_from(target);
-                if distance.0 > 2 {
+                if distance.0 > ALIAS_FUZZ_MAX_LINE_DRIFT {
                     return None;
                 }
                 if distance.0 > 0 && max_column_drift.is_some_and(|maximum| distance.1 > maximum) {
@@ -972,10 +978,88 @@ pub struct IstanbulFileCoverage {
     /// primary owner. Anonymous fallback abstains at these targets even when
     /// each identity has other aliases.
     ambiguous_anonymous_aliases: rustc_hash::FxHashSet<IstanbulPosition>,
+    /// `(alias line, function index)` for every retained alias, sorted.
+    /// The fuzzy and anonymous fallbacks reject any alias further than
+    /// [`ALIAS_FUZZ_MAX_LINE_DRIFT`] lines from the target, so they can search
+    /// a window of this index instead of every record in the file.
+    alias_lines: Vec<(u32, usize)>,
+    /// `(header span start line, function index)` for every record that has a
+    /// header span, sorted.
+    header_starts: Vec<(u32, usize)>,
+    /// Height in lines of the tallest header span in this file. A span reaches
+    /// no further than this below its own start, which bounds the window
+    /// searched in `header_starts`.
+    max_header_height: u32,
     /// The coverage map was recorded against a different checkout of the
     /// project, so line numbers may have drifted beyond the bounded fuzz.
     /// Enables the distance-free unambiguous-name fallback in [`Self::lookup`].
     relocated: bool,
+}
+
+/// Records whether each header span has a second function declared inside it,
+/// which makes the span say nothing about a position it contains.
+///
+/// Computed once per file because the header fallback needs the answer on
+/// every unmatched lookup and recomputing it there would be quadratic.
+fn mark_headers_holding_other_fns(functions: &mut [IstanbulFunctionCoverage]) {
+    let mut declarations: Vec<IstanbulPosition> = functions
+        .iter()
+        .map(|function| function.decl_start)
+        .collect();
+    declarations.sort_unstable();
+    for function in functions {
+        let Some(span) = function.header_span else {
+            continue;
+        };
+        // The record's own declaration opens its header span, so it is always
+        // in range: a second hit is what marks a foreign function.
+        let first = declarations.partition_point(|position| *position < span.start);
+        let past = declarations.partition_point(|position| *position < span.end);
+        function.header_holds_other_fn = past - first > 1;
+    }
+}
+
+/// Line-keyed indexes over one file's records, built once per file so the
+/// fuzzy, anonymous, and header fallbacks can binary-search a bounded window
+/// instead of rescanning every record on every unmatched lookup.
+struct IstanbulLineIndexes {
+    alias_lines: Vec<(u32, usize)>,
+    header_starts: Vec<(u32, usize)>,
+    max_header_height: u32,
+}
+
+impl IstanbulLineIndexes {
+    fn build(functions: &[IstanbulFunctionCoverage]) -> Self {
+        let mut alias_lines: Vec<(u32, usize)> = functions
+            .iter()
+            .enumerate()
+            .flat_map(|(function_index, function)| {
+                function
+                    .aliases
+                    .iter()
+                    .map(move |alias| (alias.position.line, function_index))
+            })
+            .collect();
+        alias_lines.sort_unstable();
+
+        let mut header_starts: Vec<(u32, usize)> = Vec::new();
+        let mut max_header_height = 0;
+        for (function_index, function) in functions.iter().enumerate() {
+            if let Some(span) = function.header_span {
+                header_starts.push((span.start.line, function_index));
+                // `IstanbulSpan` construction requires `start < end`, so the
+                // end line is never above the start line.
+                max_header_height = max_header_height.max(span.end.line - span.start.line);
+            }
+        }
+        header_starts.sort_unstable();
+
+        Self {
+            alias_lines,
+            header_starts,
+            max_header_height,
+        }
+    }
 }
 
 impl IstanbulFileCoverage {
@@ -1072,29 +1156,44 @@ impl IstanbulFileCoverage {
             }
         }
 
-        let mut declarations: Vec<IstanbulPosition> = functions
-            .iter()
-            .map(|function| function.decl_start)
-            .collect();
-        declarations.sort_unstable();
-        for function in &mut functions {
-            let Some(span) = function.header_span else {
-                continue;
-            };
-            // The record's own declaration opens its header span, so it is
-            // always in range: a second hit is what marks a foreign function.
-            let first = declarations.partition_point(|position| *position < span.start);
-            let past = declarations.partition_point(|position| *position < span.end);
-            function.header_holds_other_fn = past - first > 1;
-        }
+        mark_headers_holding_other_fns(&mut functions);
+        let indexes = IstanbulLineIndexes::build(&functions);
 
         Self {
             functions,
             alias_index,
             ambiguous_aliases,
             ambiguous_anonymous_aliases,
+            alias_lines: indexes.alias_lines,
+            header_starts: indexes.header_starts,
+            max_header_height: indexes.max_header_height,
             relocated,
         }
+    }
+
+    /// Indices of the records with an alias within
+    /// [`ALIAS_FUZZ_MAX_LINE_DRIFT`] lines of `target`, ascending and
+    /// deduplicated.
+    ///
+    /// This is exactly the candidate set of the fuzzy and anonymous fallbacks:
+    /// `nearest_alias` yields `None` for a record whose every alias is further
+    /// away, so a record outside the window cannot produce a distance and
+    /// cannot win either fallback. Ascending order reproduces the order of a
+    /// full `self.functions` scan, which both fallbacks' tie-breaks depend on:
+    /// `min_by_key` keeps the first minimum, and the anonymous scan appends
+    /// equal-distance records in encounter order.
+    fn fuzz_window(&self, target: IstanbulPosition) -> Vec<usize> {
+        let low = target.line.saturating_sub(ALIAS_FUZZ_MAX_LINE_DRIFT);
+        let high = target.line.saturating_add(ALIAS_FUZZ_MAX_LINE_DRIFT);
+        let first = self.alias_lines.partition_point(|(line, _)| *line < low);
+        let past = self.alias_lines.partition_point(|(line, _)| *line <= high);
+        let mut window: Vec<usize> = self.alias_lines[first..past]
+            .iter()
+            .map(|(_, function_index)| *function_index)
+            .collect();
+        window.sort_unstable();
+        window.dedup();
+        window
     }
 
     /// Look up coverage for a function by name, start line, and start column.
@@ -1139,9 +1238,10 @@ impl IstanbulFileCoverage {
         }
 
         let target = IstanbulPosition::new(line, col);
-        if let Some(function) = self
-            .functions
+        let window = self.fuzz_window(target);
+        if let Some(function) = window
             .iter()
+            .map(|function_index| &self.functions[*function_index])
             .filter(|function| function.name == name)
             .filter_map(|function| {
                 function
@@ -1164,7 +1264,8 @@ impl IstanbulFileCoverage {
 
         let mut nearest_distance: Option<(u32, u32)> = None;
         let mut nearest_functions = Vec::new();
-        for (function_index, function) in self.functions.iter().enumerate() {
+        for function_index in window {
+            let function = &self.functions[function_index];
             if !is_anonymous_istanbul_name(&function.name) {
                 continue;
             }
@@ -1212,8 +1313,18 @@ impl IstanbulFileCoverage {
     /// abstains. Only an anonymous record can win, because a named record is
     /// already reachable through the exact and fuzzy name paths.
     fn unique_anonymous_header_match(&self, target: IstanbulPosition) -> Option<f64> {
+        // A span reaches `target` only from at most `max_header_height` lines
+        // above it, so every containing span starts inside this window. Both
+        // abstain rules below are order-independent, so searching the window
+        // instead of the file cannot change the answer.
+        let low = target.line.saturating_sub(self.max_header_height);
+        let first = self.header_starts.partition_point(|(line, _)| *line < low);
+        let past = self
+            .header_starts
+            .partition_point(|(line, _)| *line <= target.line);
         let mut candidate = None;
-        for (function_index, function) in self.functions.iter().enumerate() {
+        for &(_, function_index) in &self.header_starts[first..past] {
+            let function = &self.functions[function_index];
             if !function
                 .header_span
                 .is_some_and(|span| span.contains(target))

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -1063,7 +1063,15 @@ impl IstanbulLineIndexes {
 }
 
 impl IstanbulFileCoverage {
-    fn lookup_function(&self, function: &fallow_types::extract::FunctionComplexity) -> Option<f64> {
+    /// Coverage for an extracted unit.
+    ///
+    /// The entry point callers outside this module get, because the
+    /// private-member rule has to hold for every consumer: gating it at one
+    /// call site leaves the next one free to reintroduce the bug.
+    pub fn lookup_function(
+        &self,
+        function: &fallow_types::extract::FunctionComplexity,
+    ) -> Option<f64> {
         if function.is_private_member {
             return None;
         }
@@ -1228,7 +1236,7 @@ impl IstanbulFileCoverage {
     /// between the two checkouts, and when all same-named candidates agree
     /// the choice among them cannot matter (#2347). Same-checkout lookups
     /// keep the bounded fuzz, which protects against stale coverage data.
-    pub fn lookup(&self, name: &str, line: u32, col: u32) -> Option<f64> {
+    pub(crate) fn lookup(&self, name: &str, line: u32, col: u32) -> Option<f64> {
         let exact_key = (name.to_string(), line, col);
         if self.ambiguous_aliases.contains(&exact_key) {
             return None;

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -1258,8 +1258,14 @@ impl IstanbulFileCoverage {
         {
             return Some(pct);
         }
+        // A function written inside another function's signature is a
+        // different function from the one the signature belongs to, and both
+        // sit within a line or two of the same position. Proximity cannot
+        // tell them apart, so the records whose signature covers this target
+        // decide below which candidates are eligible at all.
+        let signature_owners = self.header_spans_containing(target);
         if self.ambiguous_anonymous_aliases.contains(&target) {
-            return self.unique_anonymous_header_match(target);
+            return self.unique_anonymous_header_match(&signature_owners);
         }
 
         let mut nearest_distance: Option<(u32, u32)> = None;
@@ -1274,6 +1280,14 @@ impl IstanbulFileCoverage {
             else {
                 continue;
             };
+            // Inside a signature, proximity alone cannot tell a member from
+            // the function written in its parameter list. A candidate that
+            // neither sits on the target nor contains it is the wrong one.
+            if distance != (0, 0)
+                && self.foreign_signature_blocks(&signature_owners, function_index, target)
+            {
+                continue;
+            }
             match nearest_distance {
                 None => {
                     nearest_distance = Some(distance);
@@ -1299,50 +1313,82 @@ impl IstanbulFileCoverage {
             return established_match;
         }
 
-        self.unique_anonymous_header_match(target)
+        self.unique_anonymous_header_match(&signature_owners)
     }
 
-    /// Coverage of the one anonymous record whose header span owns `target`.
+    /// Indices of the records whose header span contains `target`, ascending.
     ///
-    /// A header span runs from `decl.start` to `loc.start`, so it covers the
-    /// signature: the parameter list, its default values, and any decorators.
-    /// A function literal written there is a different function from the one
-    /// that owns the span, and crediting it with the owner's coverage reports
-    /// never-executed code as covered. Every function is therefore checked for
-    /// containment, not just the anonymous ones, and a second containing span
-    /// abstains. Only an anonymous record can win, because a named record is
-    /// already reachable through the exact and fuzzy name paths.
-    fn unique_anonymous_header_match(&self, target: IstanbulPosition) -> Option<f64> {
-        // A span reaches `target` only from at most `max_header_height` lines
-        // above it, so every containing span starts inside this window. Both
-        // abstain rules below are order-independent, so searching the window
-        // instead of the file cannot change the answer.
+    /// A span reaches `target` from no further than `max_header_height` lines
+    /// above it, so every containing span starts inside that window.
+    fn header_spans_containing(&self, target: IstanbulPosition) -> Vec<usize> {
         let low = target.line.saturating_sub(self.max_header_height);
         let first = self.header_starts.partition_point(|(line, _)| *line < low);
         let past = self
             .header_starts
             .partition_point(|(line, _)| *line <= target.line);
-        let mut candidate = None;
-        for &(_, function_index) in &self.header_starts[first..past] {
-            let function = &self.functions[function_index];
-            if !function
-                .header_span
-                .is_some_and(|span| span.contains(target))
-            {
-                continue;
-            }
-            if !is_anonymous_istanbul_name(&function.name) {
-                return None;
-            }
-            if candidate.replace(function_index).is_some() {
-                return None;
-            }
+        self.header_starts[first..past]
+            .iter()
+            .filter(|(_, function_index)| {
+                self.functions[*function_index]
+                    .header_span
+                    .is_some_and(|span| span.contains(target))
+            })
+            .map(|(_, function_index)| *function_index)
+            .collect()
+    }
+
+    /// Whether `candidate` is the wrong record for a target inside a
+    /// signature it does not own.
+    ///
+    /// A default parameter value, a decorator argument, and a class
+    /// expression in a signature are functions of their own, written a line
+    /// or two from the member whose signature holds them. Crediting one by
+    /// proximity reports its coverage for a function that never shared its
+    /// fate. A candidate that contains the target in its own signature or
+    /// body is not that case: the target is its code, however the enclosing
+    /// signature encloses both.
+    fn foreign_signature_blocks(
+        &self,
+        owners: &[usize],
+        candidate: usize,
+        target: IstanbulPosition,
+    ) -> bool {
+        let function = &self.functions[candidate];
+        if function
+            .header_span
+            .is_some_and(|span| span.contains(target))
+            || function.body_span.is_some_and(|span| span.contains(target))
+        {
+            return false;
         }
-        let function_index = candidate?;
-        if self.functions[function_index].header_holds_other_fn {
+        owners.iter().any(|&owner| {
+            owner != candidate
+                && self.functions[owner]
+                    .header_span
+                    .is_some_and(|span| span.contains(function.decl_start))
+        })
+    }
+
+    /// Coverage of the single anonymous record whose signature owns the
+    /// target, given every record whose header span covers it.
+    ///
+    /// A header span runs from `decl.start` to `loc.start`, so it covers the
+    /// signature: the parameter list, its default values, and any decorators.
+    /// A function literal written there is a different function from the one
+    /// that owns the span, and crediting it with the owner's coverage reports
+    /// never-executed code as covered. Two containing spans therefore abstain,
+    /// as does a span with a second function declared inside it. Only an
+    /// anonymous record can win, because a named record is already reachable
+    /// through the exact and fuzzy name paths.
+    fn unique_anonymous_header_match(&self, signature_owners: &[usize]) -> Option<f64> {
+        let [function_index] = signature_owners else {
+            return None;
+        };
+        let function = &self.functions[*function_index];
+        if !is_anonymous_istanbul_name(&function.name) || function.header_holds_other_fn {
             return None;
         }
-        Some(self.functions[function_index].coverage_pct)
+        Some(function.coverage_pct)
     }
 
     fn innermost_anonymous_match(&self, tied: &[usize], target: IstanbulPosition) -> Option<f64> {
@@ -5541,17 +5587,70 @@ mod tests {
         assert_eq!(result.per_function[0].coverage_pct, Some(100.0));
     }
 
-    /// A default parameter can hold a whole function, so a header span can
-    /// cover code that belongs to something else. Geometry from
-    /// istanbul-lib-instrument 6 for a method whose default parameter is a
-    /// named function expression: only `run` and `recover` get records, and
-    /// the private member inside `recover` gets none. Crediting it with
-    /// `run`'s coverage would report never-executed code as fully covered,
-    /// because `recover` never ran.
+    /// Curried arrows written one per line put each record's body start on
+    /// the next record's declaration. The declaration is primary and wins the
+    /// position, so each arrow keeps a record of its own and the innermost one
+    /// resolves through the header span that opens at the arrow above it.
+    /// Geometry from istanbul-lib-instrument 6 for the source below, which is
+    /// what Prettier produces for a curried arrow.
     #[test]
-    fn header_span_abstains_when_another_function_is_declared_inside_it() {
+    fn curried_arrows_one_per_line_each_take_their_own_record() {
         let temp = tempfile::TempDir::new().unwrap();
-        let source_path = temp.path().join("src/pipeline.js");
+        let source_path = temp.path().join("src/adjust.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export const adjust = (base: number) =>\n  (factor: number) =>\n  (offset: number) =>\n    base * factor + offset;\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 2,
+                    "decl": { "start": { "line": 1, "column": 22 }, "end": { "line": 1, "column": 23 } },
+                    "loc": { "start": { "line": 2, "column": 2 }, "end": { "line": 4, "column": 26 } }
+                },
+                "1": {
+                    "name": "(anonymous_1)",
+                    "line": 3,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 3, "column": 2 }, "end": { "line": 4, "column": 26 } }
+                },
+                "2": {
+                    "name": "(anonymous_2)",
+                    "line": 4,
+                    "decl": { "start": { "line": 3, "column": 2 }, "end": { "line": 3, "column": 3 } },
+                    "loc": { "start": { "line": 4, "column": 4 }, "end": { "line": 4, "column": 26 } }
+                }
+            }),
+            &serde_json::json!({ "0": 2, "1": 1, "2": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("adjust", 1, 22), Some(100.0));
+        assert_eq!(file_coverage.lookup("<arrow>", 2, 2), Some(100.0));
+        // The innermost arrow never ran, and takes neither neighbour's value.
+        assert_eq!(file_coverage.lookup("<arrow>", 3, 2), Some(0.0));
+    }
+
+    /// A default value in a parameter list is inside the member's signature,
+    /// and its own record can be anchored at the parameter rather than at the
+    /// function, putting the extracted position tens of columns from the
+    /// declaration. The record still owns that position, because its own
+    /// signature span covers it. Geometry from an @vitest/coverage-istanbul
+    /// map for a constructor whose parameter carries a default arrow.
+    #[test]
+    fn a_default_value_keeps_its_own_record_inside_the_enclosing_signature() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/filter.ts");
         std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
         std::fs::write(&source_path, "// geometry fixture\n").unwrap();
 
@@ -5562,29 +5661,77 @@ mod tests {
             &serde_json::json!({
                 "0": {
                     "name": "(anonymous_0)",
-                    "line": 14,
-                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 5 } },
-                    "loc": { "start": { "line": 14, "column": 4 }, "end": { "line": 16, "column": 3 } }
+                    "line": 173,
+                    "decl": { "start": { "line": 169, "column": 2 }, "end": { "line": 170, "column": 3 } },
+                    "loc": { "start": { "line": 173, "column": 4 }, "end": { "line": 182, "column": 3 } }
                 },
                 "1": {
-                    "name": "recover",
-                    "line": 4,
-                    "decl": { "start": { "line": 4, "column": 22 }, "end": { "line": 4, "column": 29 } },
-                    "loc": { "start": { "line": 4, "column": 38 }, "end": { "line": 12, "column": 5 } }
+                    "name": "(anonymous_1)",
+                    "line": 171,
+                    "decl": { "start": { "line": 171, "column": 21 }, "end": { "line": 171, "column": 67 } },
+                    "loc": { "start": { "line": 171, "column": 67 }, "end": { "line": 171, "column": 76 } }
                 }
             }),
-            &serde_json::json!({ "0": 1, "1": 0 }),
+            &serde_json::json!({ "0": 46, "1": 0 }),
         );
 
         let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
-        // Inside `run`'s header span (2:2 to 14:4), but `recover` is declared
-        // there, so the span says nothing about this position.
-        assert_eq!(file_coverage.lookup("<anonymous>", 6, 13), None);
-        // The two records themselves still resolve.
-        assert_eq!(file_coverage.lookup("recover", 4, 22), Some(0.0));
+        // Fallow extracts the arrow at its parameter paren, 40 columns right
+        // of the record's declaration but inside the record's own span.
+        assert_eq!(file_coverage.lookup("<arrow>", 171, 61), Some(0.0));
+    }
+
+    /// A named function in a signature is a second function inside the
+    /// member's header span, so the span identifies nothing on its own. A unit
+    /// with no record of its own, such as a private member or a unit the
+    /// producer names differently, must take the estimate rather than the
+    /// coverage of whichever record happens to be near. Geometry from
+    /// istanbul-lib-instrument 6 for the source below.
+    #[test]
+    fn header_span_abstains_when_another_function_is_declared_inside_it() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/chart.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export class Chart {\n  @Watch(\"data\")\n  render(\n    rows: number[],\n    project = function scale(\n      row: number\n    ) {\n      return row * 2;\n    }\n  ) {\n    return rows.map(project);\n  }\n}\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 10,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 10, "column": 4 }, "end": { "line": 12, "column": 3 } }
+                },
+                "1": {
+                    "name": "scale",
+                    "line": 7,
+                    "decl": { "start": { "line": 5, "column": 23 }, "end": { "line": 5, "column": 28 } },
+                    "loc": { "start": { "line": 7, "column": 6 }, "end": { "line": 9, "column": 5 } }
+                }
+            }),
+            &serde_json::json!({ "0": 3, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        // Inside both the member's header span and `scale`'s, so neither says
+        // anything about this position.
+        assert_eq!(file_coverage.lookup("<anonymous>", 6, 6), None);
+        // Both records still resolve.
+        assert_eq!(file_coverage.lookup("scale", 5, 14), Some(0.0));
+        assert_eq!(file_coverage.lookup("render", 3, 8), Some(100.0));
     }
 
     /// No instrumenter emits an `fnMap` identity for a private class member,
@@ -5670,68 +5817,22 @@ mod tests {
         assert_eq!(result.per_function[0].coverage_pct, Some(100.0));
     }
 
-    /// istanbul-lib-instrument anchors a callback passed to a multi-line call
-    /// at the call expression for `decl.start` and at the callback body for
-    /// `loc.start`. Oxc anchors the callback itself between those positions.
+    /// A decorated member's `decl` opens at the decorator and its `loc` opens
+    /// at the body brace, so the extracted position sits between them with no
+    /// alias in reach: the decorator is more than
+    /// `ANONYMOUS_FALLBACK_MAX_COLUMN_DRIFT` columns to the left and the body
+    /// is more than `ALIAS_FUZZ_MAX_LINE_DRIFT` lines below. The header span
+    /// is what identifies the member. Geometry from istanbul-lib-instrument 6
+    /// for the source below, which is ordinary NestJS, Angular, and TypeORM
+    /// shape rather than a corner case.
     #[test]
-    fn anonymous_callback_matches_unique_istanbul_header_span() {
+    fn decorated_member_matches_its_istanbul_header_span() {
         let temp = tempfile::TempDir::new().unwrap();
-        let source_path = temp.path().join("src/order.ts");
+        let source_path = temp.path().join("src/users.controller.ts");
         std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
         std::fs::write(
             &source_path,
-            "export const order = (values: number[]) =>\n  [...values].toSorted(\n    (left, right) =>\n      score(left) - score(right)\n  );\n",
-        )
-        .unwrap();
-
-        let coverage_path = temp.path().join("coverage-final.json");
-        write_single_file_istanbul_fixture(
-            &coverage_path,
-            &source_path,
-            &serde_json::json!({
-                "0": {
-                    "name": "(anonymous_0)",
-                    "line": 2,
-                    "decl": {
-                        "start": { "line": 1, "column": 21 },
-                        "end": { "line": 1, "column": 22 }
-                    },
-                    "loc": {
-                        "start": { "line": 2, "column": 2 },
-                        "end": { "line": 5, "column": 3 }
-                    }
-                },
-                "1": {
-                    "name": "(anonymous_1)",
-                    "line": 4,
-                    "decl": {
-                        "start": { "line": 2, "column": 20 },
-                        "end": { "line": 2, "column": 21 }
-                    },
-                    "loc": {
-                        "start": { "line": 4, "column": 6 },
-                        "end": { "line": 4, "column": 32 }
-                    }
-                }
-            }),
-            &serde_json::json!({ "0": 1, "1": 0 }),
-        );
-
-        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
-        let canonical_source = dunce::canonicalize(&source_path).unwrap();
-        let file_coverage = coverage.get(&canonical_source).unwrap();
-
-        assert_eq!(file_coverage.lookup("<arrow>", 3, 4), Some(0.0));
-    }
-
-    #[test]
-    fn established_anonymous_match_wins_before_overlapping_header_spans() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let source_path = temp.path().join("src/ambiguous.ts");
-        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
-        std::fs::write(
-            &source_path,
-            "export const ambiguous = (value: number) =>\n  wrap(\n    (candidate) => candidate + value\n  );\n",
+            "export class UserController {\n  @Get(\":id\")\n  async findOneWithProfile(\n    id: string,\n    include: string[]\n  ) {\n    return this.service.find(id, include);\n  }\n}\n",
         )
         .unwrap();
 
@@ -5743,46 +5844,37 @@ mod tests {
                 "0": {
                     "name": "(anonymous_0)",
                     "line": 6,
-                    "decl": {
-                        "start": { "line": 1, "column": 0 },
-                        "end": { "line": 1, "column": 1 }
-                    },
-                    "loc": {
-                        "start": { "line": 6, "column": 0 },
-                        "end": { "line": 7, "column": 0 }
-                    }
-                },
-                "1": {
-                    "name": "(anonymous_1)",
-                    "line": 5,
-                    "decl": {
-                        "start": { "line": 2, "column": 0 },
-                        "end": { "line": 2, "column": 1 }
-                    },
-                    "loc": {
-                        "start": { "line": 5, "column": 0 },
-                        "end": { "line": 6, "column": 0 }
-                    }
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 6, "column": 4 }, "end": { "line": 8, "column": 3 } }
                 }
             }),
-            &serde_json::json!({ "0": 1, "1": 0 }),
+            &serde_json::json!({ "0": 3 }),
         );
 
         let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
-        assert_eq!(file_coverage.lookup("<arrow>", 3, 4), Some(0.0));
+        // Fallow extracts the member at the parameter paren, 3:26.
+        assert_eq!(
+            file_coverage.lookup("findOneWithProfile", 3, 26),
+            Some(100.0)
+        );
     }
 
+    /// A function written in a signature has a record of its own, and the
+    /// signature it sits in belongs to a different function. The record wins:
+    /// crediting the enclosing member would report the member's coverage for
+    /// a default value that never ran. Geometry from istanbul-lib-instrument 6
+    /// for the source below.
     #[test]
-    fn overlapping_header_spans_abstain_when_established_aliases_tie() {
+    fn established_alias_wins_over_the_signature_that_contains_it() {
         let temp = tempfile::TempDir::new().unwrap();
-        let source_path = temp.path().join("src/ambiguous.ts");
+        let source_path = temp.path().join("src/chart.ts");
         std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
         std::fs::write(
             &source_path,
-            "export const ambiguous = (value: number) =>\n  wrap(\n    (candidate) => candidate + value\n  );\n",
+            "export class Chart {\n  @Watch(\"data\")\n  render(\n    rows: number[],\n    project = (row: number) => row * 2\n  ) {\n    return rows.map(project);\n  }\n}\n",
         )
         .unwrap();
 
@@ -5793,37 +5885,78 @@ mod tests {
             &serde_json::json!({
                 "0": {
                     "name": "(anonymous_0)",
-                    "line": 5,
-                    "decl": {
-                        "start": { "line": 1, "column": 0 },
-                        "end": { "line": 1, "column": 1 }
-                    },
-                    "loc": {
-                        "start": { "line": 5, "column": 0 },
-                        "end": { "line": 6, "column": 0 }
-                    }
+                    "line": 6,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 6, "column": 4 }, "end": { "line": 8, "column": 3 } }
                 },
                 "1": {
                     "name": "(anonymous_1)",
                     "line": 5,
-                    "decl": {
-                        "start": { "line": 1, "column": 8 },
-                        "end": { "line": 1, "column": 9 }
-                    },
-                    "loc": {
-                        "start": { "line": 5, "column": 8 },
-                        "end": { "line": 6, "column": 8 }
-                    }
+                    "decl": { "start": { "line": 5, "column": 14 }, "end": { "line": 5, "column": 15 } },
+                    "loc": { "start": { "line": 5, "column": 31 }, "end": { "line": 5, "column": 38 } }
                 }
             }),
-            &serde_json::json!({ "0": 1, "1": 0 }),
+            &serde_json::json!({ "0": 3, "1": 0 }),
         );
 
         let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
         let canonical_source = dunce::canonicalize(&source_path).unwrap();
         let file_coverage = coverage.get(&canonical_source).unwrap();
 
-        assert!(file_coverage.lookup("<arrow>", 3, 4).is_none());
+        // The default value takes its own record, not the method's 100.
+        assert_eq!(file_coverage.lookup("<arrow>", 5, 14), Some(0.0));
+        // The method still resolves, and not to its default value.
+        assert_eq!(file_coverage.lookup("render", 3, 8), Some(100.0));
+    }
+
+    /// A member whose signature holds a function of its own has two records a
+    /// line or two apart, and the member's extracted position is closer to
+    /// the inner one. Proximity would report the default value's coverage for
+    /// the member, and the header span cannot break the tie because it
+    /// contains both. Abstaining leaves the static estimate, which is wrong by
+    /// a known amount rather than wrong while claiming to be measured.
+    /// Geometry from istanbul-lib-instrument 6 for the source below.
+    #[test]
+    fn signature_holding_a_function_abstains_instead_of_crediting_it() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/users.controller.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export class UserController {\n  @Get(\":id\")\n  async findOneWithProfile(\n    id: string,\n    transform = (row: string) => row.trim()\n  ) {\n    return transform(id);\n  }\n}\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 6,
+                    "decl": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 3 } },
+                    "loc": { "start": { "line": 6, "column": 4 }, "end": { "line": 8, "column": 3 } }
+                },
+                "1": {
+                    "name": "(anonymous_1)",
+                    "line": 5,
+                    "decl": { "start": { "line": 5, "column": 16 }, "end": { "line": 5, "column": 17 } },
+                    "loc": { "start": { "line": 5, "column": 33 }, "end": { "line": 5, "column": 43 } }
+                }
+            }),
+            &serde_json::json!({ "0": 3, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        // The member is two lines from the default value's declaration and
+        // ten columns off it, well inside the fallback's reach.
+        assert_eq!(file_coverage.lookup("findOneWithProfile", 3, 26), None);
+        // The default value itself still resolves.
+        assert_eq!(file_coverage.lookup("<arrow>", 5, 16), Some(0.0));
     }
 
     #[test]

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -848,6 +848,12 @@ impl IstanbulSpan {
         (start.line > 0 && end.line > 0 && start < end).then_some(Self { start, end })
     }
 
+    fn header_from_entry(fn_entry: &oxc_coverage_instrument::FnEntry) -> Option<Self> {
+        let start = IstanbulPosition::new(fn_entry.decl.start.line, fn_entry.decl.start.column);
+        let end = IstanbulPosition::new(fn_entry.loc.start.line, fn_entry.loc.start.column);
+        (start.line > 0 && end.line > 0 && start < end).then_some(Self { start, end })
+    }
+
     /// Half-open containment: `end` is the position just past the body.
     fn contains(self, position: IstanbulPosition) -> bool {
         self.start <= position && position < self.end
@@ -912,6 +918,7 @@ struct IstanbulFunctionCoverage {
     name: String,
     coverage_pct: f64,
     aliases: Vec<IstanbulAlias>,
+    header_span: Option<IstanbulSpan>,
     body_span: Option<IstanbulSpan>,
 }
 
@@ -1070,12 +1077,18 @@ impl IstanbulFileCoverage {
     ///    smallest `(line, col)` distance from the target. A distance tie is
     ///    resolved only when one valid body span contains the target and is
     ///    strictly inside every other tied span.
+    /// 4. Unique anonymous header-span fallback between `decl.start` and
+    ///    `loc.start`.
     ///
     /// Step 3 covers arrow-function exports where fallow extracts the binding
-    /// identifier (`const myHandler = () => {...}` yields `myHandler`) while
-    /// Istanbul records the function as anonymous. `load_istanbul_coverage`
-    /// indexes declaration aliases so standard Istanbul producers still
-    /// participate in this fallback. See issues #155, #166, #181, and #370.
+    /// identifier
+    /// (`const myHandler = () => {...}` yields `myHandler`) while Istanbul
+    /// records the function as anonymous. `load_istanbul_coverage` indexes
+    /// declaration aliases so standard Istanbul producers still participate
+    /// in this fallback. Step 4 covers multi-line callback arguments whose
+    /// extracted start falls between Istanbul's declaration and body anchors,
+    /// but only after the established anonymous resolution cannot decide. See
+    /// issues #155, #166, #181, and #370.
     ///
     /// When the map is `relocated` (recorded against a different checkout of
     /// the project, as in the audit base-worktree pass), a distance-free
@@ -1145,11 +1158,29 @@ impl IstanbulFileCoverage {
                 Some(_) => {}
             }
         }
-        match nearest_functions.as_slice() {
+        let established_match = match nearest_functions.as_slice() {
             [] => None,
             [function_index] => Some(self.functions[*function_index].coverage_pct),
             tied => self.innermost_anonymous_match(tied, target),
+        };
+        if established_match.is_some() {
+            return established_match;
         }
+
+        let mut header_match = None;
+        for (function_index, function) in self.functions.iter().enumerate() {
+            if !is_anonymous_istanbul_name(&function.name)
+                || !function
+                    .header_span
+                    .is_some_and(|span| span.contains(target))
+            {
+                continue;
+            }
+            if header_match.replace(function_index).is_some() {
+                return None;
+            }
+        }
+        header_match.map(|function_index| self.functions[function_index].coverage_pct)
     }
 
     fn innermost_anonymous_match(&self, tied: &[usize], target: IstanbulPosition) -> Option<f64> {
@@ -1373,6 +1404,7 @@ fn istanbul_function_coverage(
     coverage_pct: f64,
 ) -> IstanbulFunctionCoverage {
     let body_span = IstanbulSpan::from_entry(fn_entry);
+    let header_span = IstanbulSpan::header_from_entry(fn_entry);
     let candidates = [
         Some(IstanbulAlias {
             position: IstanbulPosition::new(
@@ -1404,6 +1436,7 @@ fn istanbul_function_coverage(
         name: fn_entry.name.clone(),
         coverage_pct,
         aliases,
+        header_span,
         body_span,
     }
 }
@@ -2357,6 +2390,7 @@ mod tests {
                     name,
                     coverage_pct,
                     aliases: vec![primary_alias(line, col)],
+                    header_span: None,
                     body_span: None,
                 },
             )
@@ -5318,6 +5352,162 @@ mod tests {
         assert_eq!(result.per_function[0].coverage_pct, Some(100.0));
     }
 
+    /// istanbul-lib-instrument anchors a callback passed to a multi-line call
+    /// at the call expression for `decl.start` and at the callback body for
+    /// `loc.start`. Oxc anchors the callback itself between those positions.
+    #[test]
+    fn anonymous_callback_matches_unique_istanbul_header_span() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/order.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export const order = (values: number[]) =>\n  [...values].toSorted(\n    (left, right) =>\n      score(left) - score(right)\n  );\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 2,
+                    "decl": {
+                        "start": { "line": 1, "column": 21 },
+                        "end": { "line": 1, "column": 22 }
+                    },
+                    "loc": {
+                        "start": { "line": 2, "column": 2 },
+                        "end": { "line": 5, "column": 3 }
+                    }
+                },
+                "1": {
+                    "name": "(anonymous_1)",
+                    "line": 4,
+                    "decl": {
+                        "start": { "line": 2, "column": 20 },
+                        "end": { "line": 2, "column": 21 }
+                    },
+                    "loc": {
+                        "start": { "line": 4, "column": 6 },
+                        "end": { "line": 4, "column": 32 }
+                    }
+                }
+            }),
+            &serde_json::json!({ "0": 1, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("<arrow>", 3, 4), Some(0.0));
+    }
+
+    #[test]
+    fn established_anonymous_match_wins_before_overlapping_header_spans() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/ambiguous.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export const ambiguous = (value: number) =>\n  wrap(\n    (candidate) => candidate + value\n  );\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 6,
+                    "decl": {
+                        "start": { "line": 1, "column": 0 },
+                        "end": { "line": 1, "column": 1 }
+                    },
+                    "loc": {
+                        "start": { "line": 6, "column": 0 },
+                        "end": { "line": 7, "column": 0 }
+                    }
+                },
+                "1": {
+                    "name": "(anonymous_1)",
+                    "line": 5,
+                    "decl": {
+                        "start": { "line": 2, "column": 0 },
+                        "end": { "line": 2, "column": 1 }
+                    },
+                    "loc": {
+                        "start": { "line": 5, "column": 0 },
+                        "end": { "line": 6, "column": 0 }
+                    }
+                }
+            }),
+            &serde_json::json!({ "0": 1, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("<arrow>", 3, 4), Some(0.0));
+    }
+
+    #[test]
+    fn overlapping_header_spans_abstain_when_established_aliases_tie() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/ambiguous.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &source_path,
+            "export const ambiguous = (value: number) =>\n  wrap(\n    (candidate) => candidate + value\n  );\n",
+        )
+        .unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "(anonymous_0)",
+                    "line": 5,
+                    "decl": {
+                        "start": { "line": 1, "column": 0 },
+                        "end": { "line": 1, "column": 1 }
+                    },
+                    "loc": {
+                        "start": { "line": 5, "column": 0 },
+                        "end": { "line": 6, "column": 0 }
+                    }
+                },
+                "1": {
+                    "name": "(anonymous_1)",
+                    "line": 5,
+                    "decl": {
+                        "start": { "line": 1, "column": 8 },
+                        "end": { "line": 1, "column": 9 }
+                    },
+                    "loc": {
+                        "start": { "line": 5, "column": 8 },
+                        "end": { "line": 6, "column": 8 }
+                    }
+                }
+            }),
+            &serde_json::json!({ "0": 1, "1": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert!(file_coverage.lookup("<arrow>", 3, 4).is_none());
+    }
+
     #[test]
     fn anonymous_record_aliases_do_not_tie_with_their_own_identity() {
         let temp = tempfile::TempDir::new().unwrap();
@@ -5702,12 +5892,14 @@ mod tests {
                     name: "(anonymous_0)".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(10, 8), secondary_alias(10, 14)],
+                    header_span: None,
                     body_span: Some(body_span((10, 14), (12, 30))),
                 },
                 IstanbulFunctionCoverage {
                     name: "(anonymous_1)".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(10, 20), secondary_alias(11, 0)],
+                    header_span: None,
                     body_span: Some(body_span((11, 0), (14, 0))),
                 },
             ],
@@ -5729,12 +5921,14 @@ mod tests {
                     name: "(anonymous_0)".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(4, 11), primary_alias(1, 11)],
+                    header_span: None,
                     body_span: Some(body_span((4, 11), (4, 23))),
                 },
                 IstanbulFunctionCoverage {
                     name: "(anonymous_1)".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(4, 11), secondary_alias(4, 18)],
+                    header_span: None,
                     body_span: Some(body_span((4, 18), (4, 23))),
                 },
             ],
@@ -5755,12 +5949,14 @@ mod tests {
                     name: "(anonymous_0)".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(10, 0), secondary_alias(12, 4)],
+                    header_span: None,
                     body_span: Some(body_span((12, 4), (20, 0))),
                 },
                 IstanbulFunctionCoverage {
                     name: "(anonymous_1)".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(11, 0), secondary_alias(12, 4)],
+                    header_span: None,
                     body_span: Some(body_span((12, 4), (18, 0))),
                 },
             ],
@@ -5780,12 +5976,14 @@ mod tests {
                     name: "handler".to_string(),
                     coverage_pct: 100.0,
                     aliases: vec![primary_alias(10, 0), secondary_alias(12, 4)],
+                    header_span: None,
                     body_span: Some(body_span((12, 4), (20, 0))),
                 },
                 IstanbulFunctionCoverage {
                     name: "handler".to_string(),
                     coverage_pct: 0.0,
                     aliases: vec![primary_alias(11, 0), secondary_alias(12, 4)],
+                    header_span: None,
                     body_span: Some(body_span((12, 4), (18, 0))),
                 },
             ],

--- a/crates/engine/src/vital_signs.rs
+++ b/crates/engine/src/vital_signs.rs
@@ -1131,6 +1131,7 @@ mod tests {
         crate::source::ModuleInfo {
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: format!("fn_{id}"),
+                is_private_member: false,
                 line: id + 1,
                 col: 0,
                 cyclomatic,

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -3617,6 +3617,7 @@ fn module_to_cached_roundtrip_complexity() {
         complexity: vec![
             FunctionComplexity {
                 name: "complex".to_string(),
+                is_private_member: true,
                 line: 5,
                 col: 0,
                 cyclomatic: 8,
@@ -3648,6 +3649,7 @@ fn module_to_cached_roundtrip_complexity() {
             },
             FunctionComplexity {
                 name: "simple".to_string(),
+                is_private_member: false,
                 line: 30,
                 col: 4,
                 cyclomatic: 1,
@@ -3723,6 +3725,7 @@ fn module_to_cached_roundtrip_complexity() {
 
     assert_eq!(restored.complexity.len(), 2);
     assert_eq!(restored.complexity[0].name, "complex");
+    assert!(restored.complexity[0].is_private_member);
     assert_eq!(restored.complexity[0].cyclomatic, 8);
     assert_eq!(restored.complexity[0].cognitive, 15);
     assert_eq!(restored.complexity[0].line_count, 20);
@@ -3738,6 +3741,7 @@ fn module_to_cached_roundtrip_complexity() {
         ]
     );
     assert_eq!(restored.complexity[1].name, "simple");
+    assert!(!restored.complexity[1].is_private_member);
     assert_eq!(restored.complexity[1].cyclomatic, 1);
     assert_eq!(restored.complexity[1].cognitive, 0);
 }

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -1009,7 +1009,13 @@ use crate::MemberKind;
 /// Bumped to 282 for issue #2442: complexity extraction no longer emits
 /// bodyless TypeScript overload and ambient declarations as runtime function
 /// units. Warm 281 caches retain those phantom complexity rows.
-pub(super) const CACHE_VERSION: u32 = 282;
+///
+/// Bumped to 283 for issue #2448: private class members are recorded under
+/// their own `#name` instead of `<anonymous>`. The name is persisted with the
+/// complexity unit and decides whether coverage matching runs at all, so a
+/// warm 282 cache would keep the anonymous name and the attribution that
+/// follows from it.
+pub(super) const CACHE_VERSION: u32 = 283;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -1011,11 +1011,13 @@ use crate::MemberKind;
 /// units. Warm 281 caches retain those phantom complexity rows.
 ///
 /// Bumped to 283 for issue #2448: private class members are recorded under
-/// their own `#name` instead of `<anonymous>`. The name is persisted with the
-/// complexity unit and decides whether coverage matching runs at all, so a
-/// warm 282 cache would keep the anonymous name and the attribution that
-/// follows from it.
-pub(super) const CACHE_VERSION: u32 = 283;
+/// their own `#name` instead of `<anonymous>`. Warm 282 caches retain the
+/// anonymous display name for those complexity units.
+///
+/// Bumped to 284 for issue #2448: complexity units now persist private-member
+/// provenance separately from their display name. Warm 283 caches cannot
+/// distinguish an ECMAScript private member from a public quoted `#` name.
+pub(super) const CACHE_VERSION: u32 = 284;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/complexity.rs
+++ b/crates/extract/src/complexity.rs
@@ -462,8 +462,12 @@ impl<'ast> Visit<'ast> for ComplexityVisitor<'_> {
     }
 
     fn visit_method_definition(&mut self, method: &MethodDefinition<'ast>) {
+        // `static_name` has no answer for a private key, so `#work` would fall
+        // through to `<anonymous>` and read as an unnamed unit in every report.
         if let Some(name) = method.key.static_name() {
             self.pending_name = Some(name.to_string());
+        } else if let PropertyKey::PrivateIdentifier(private) = &method.key {
+            self.pending_name = Some(format!("#{}", private.name));
         }
         walk::walk_method_definition(self, method);
         self.pending_name = None;

--- a/crates/extract/src/complexity.rs
+++ b/crates/extract/src/complexity.rs
@@ -38,7 +38,7 @@ use fallow_types::extract::{
 
 /// Per-function state on the scope stack.
 struct FunctionFrame {
-    name: String,
+    identity: FunctionIdentity,
     span: Span,
     cyclomatic: u16,
     cognitive: u16,
@@ -64,6 +64,27 @@ struct FunctionFrame {
     contributions: Vec<ComplexityContribution>,
 }
 
+struct FunctionIdentity {
+    name: String,
+    is_private_member: bool,
+}
+
+impl FunctionIdentity {
+    fn public(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            is_private_member: false,
+        }
+    }
+
+    fn private(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            is_private_member: true,
+        }
+    }
+}
+
 /// AST visitor that computes per-function complexity metrics.
 pub struct ComplexityVisitor<'a> {
     stack: Vec<FunctionFrame>,
@@ -73,9 +94,9 @@ pub struct ComplexityVisitor<'a> {
     /// Source text the AST was parsed from. Used to compute each function's
     /// content digest (`source_hash`) from its full-span byte slice.
     source: &'a str,
-    /// Name override from a parent node (e.g., method name from `MethodDefinition`,
-    /// variable name from `const foo = function() {}`).
-    pending_name: Option<String>,
+    /// Identity override from a parent node (e.g., method identity from
+    /// `MethodDefinition`, variable name from `const foo = function() {}`).
+    pending_identity: Option<FunctionIdentity>,
 }
 
 impl<'a> ComplexityVisitor<'a> {
@@ -85,7 +106,7 @@ impl<'a> ComplexityVisitor<'a> {
             results: Vec::new(),
             line_offsets,
             source,
-            pending_name: None,
+            pending_identity: None,
         }
     }
 
@@ -103,9 +124,15 @@ impl<'a> ComplexityVisitor<'a> {
         Some(fallow_cov_protocol::source_hash_for(slice.as_bytes()))
     }
 
-    fn push_function(&mut self, name: String, span: Span, param_count: u8, prop_count: u16) {
+    fn push_function(
+        &mut self,
+        identity: FunctionIdentity,
+        span: Span,
+        param_count: u8,
+        prop_count: u16,
+    ) {
         self.stack.push(FunctionFrame {
-            name,
+            identity,
             span,
             cyclomatic: 1,
             cognitive: 0,
@@ -132,7 +159,8 @@ impl<'a> ComplexityVisitor<'a> {
                 fallow_types::extract::byte_offset_to_line_col(self.line_offsets, frame.span.end).0;
             let source_hash = self.source_hash_for_span(frame.span);
             self.results.push(FunctionComplexity {
-                name: frame.name,
+                name: frame.identity.name,
+                is_private_member: frame.identity.is_private_member,
                 line,
                 col,
                 cyclomatic: frame.cyclomatic,
@@ -257,7 +285,7 @@ impl<'a> ComplexityVisitor<'a> {
         let react_shaped = self
             .stack
             .last()
-            .is_some_and(|frame| frame_name_is_react_shaped(&frame.name));
+            .is_some_and(|frame| frame_name_is_react_shaped(&frame.identity.name));
         if let Some(frame) = self.stack.last_mut() {
             frame.hook_count = frame.hook_count.saturating_add(1);
         }
@@ -413,15 +441,15 @@ impl<'ast> Visit<'ast> for ComplexityVisitor<'_> {
             walk::walk_function(self, func, flags);
             return;
         }
-        let name = func
+        let identity = func
             .id
             .as_ref()
             .map(|id| {
-                self.pending_name.take();
-                id.name.to_string()
+                self.pending_identity.take();
+                FunctionIdentity::public(id.name.to_string())
             })
-            .or_else(|| self.pending_name.take())
-            .unwrap_or_else(|| "<anonymous>".to_string());
+            .or_else(|| self.pending_identity.take())
+            .unwrap_or_else(|| FunctionIdentity::public("<anonymous>"));
 
         let is_nested = !self.stack.is_empty();
         if is_nested {
@@ -430,7 +458,7 @@ impl<'ast> Visit<'ast> for ComplexityVisitor<'_> {
 
         let param_count = Self::count_params(&func.params);
         let prop_count = Self::count_props(&func.params);
-        self.push_function(name, func.span, param_count, prop_count);
+        self.push_function(identity, func.span, param_count, prop_count);
         walk::walk_function(self, func, flags);
         self.pop_function();
 
@@ -440,10 +468,10 @@ impl<'ast> Visit<'ast> for ComplexityVisitor<'_> {
     }
 
     fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'ast>) {
-        let name = self
-            .pending_name
+        let identity = self
+            .pending_identity
             .take()
-            .unwrap_or_else(|| "<arrow>".to_string());
+            .unwrap_or_else(|| FunctionIdentity::public("<arrow>"));
 
         let is_nested = !self.stack.is_empty();
         if is_nested {
@@ -452,7 +480,7 @@ impl<'ast> Visit<'ast> for ComplexityVisitor<'_> {
 
         let param_count = Self::count_params(&arrow.params);
         let prop_count = Self::count_props(&arrow.params);
-        self.push_function(name, arrow.span, param_count, prop_count);
+        self.push_function(identity, arrow.span, param_count, prop_count);
         walk::walk_arrow_function_expression(self, arrow);
         self.pop_function();
 
@@ -465,42 +493,44 @@ impl<'ast> Visit<'ast> for ComplexityVisitor<'_> {
         // `static_name` has no answer for a private key, so `#work` would fall
         // through to `<anonymous>` and read as an unnamed unit in every report.
         if let Some(name) = method.key.static_name() {
-            self.pending_name = Some(name.to_string());
+            self.pending_identity = Some(FunctionIdentity::public(name.to_string()));
         } else if let PropertyKey::PrivateIdentifier(private) = &method.key {
-            self.pending_name = Some(format!("#{}", private.name));
+            self.pending_identity = Some(FunctionIdentity::private(format!("#{}", private.name)));
         }
         walk::walk_method_definition(self, method);
-        self.pending_name = None;
+        self.pending_identity = None;
     }
 
     fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'ast>) {
         if let Some(id) = decl.id.get_binding_identifier() {
-            self.pending_name = Some(id.name.to_string());
+            self.pending_identity = Some(FunctionIdentity::public(id.name.to_string()));
         }
         walk::walk_variable_declarator(self, decl);
-        self.pending_name = None;
+        self.pending_identity = None;
     }
 
     fn visit_property_definition(&mut self, prop: &PropertyDefinition<'ast>) {
         if let Some(name) = prop.key.static_name() {
-            self.pending_name = Some(name.to_string());
+            self.pending_identity = Some(FunctionIdentity::public(name.to_string()));
+        } else if let PropertyKey::PrivateIdentifier(private) = &prop.key {
+            self.pending_identity = Some(FunctionIdentity::private(format!("#{}", private.name)));
         }
         walk::walk_property_definition(self, prop);
-        self.pending_name = None;
+        self.pending_identity = None;
     }
 
     fn visit_object_property(&mut self, prop: &ObjectProperty<'ast>) {
         if let Some(name) = prop.key.static_name() {
-            self.pending_name = Some(name.to_string());
+            self.pending_identity = Some(FunctionIdentity::public(name.to_string()));
         }
         walk::walk_object_property(self, prop);
-        self.pending_name = None;
+        self.pending_identity = None;
     }
 
     fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'ast>) {
-        self.pending_name = Some("default".to_string());
+        self.pending_identity = Some(FunctionIdentity::public("default"));
         walk::walk_export_default_declaration(self, decl);
-        self.pending_name = None;
+        self.pending_identity = None;
     }
 
     fn visit_if_statement(&mut self, stmt: &IfStatement<'ast>) {
@@ -791,6 +821,21 @@ mod tests {
         assert_eq!(methods.len(), 1);
         assert_eq!(methods[0].line, 4);
         assert_eq!(methods[0].cyclomatic, 2);
+    }
+
+    #[test]
+    fn class_method_extraction_preserves_private_provenance() {
+        let results = analyze(
+            "class Vault {\n\
+               #wipe() {}\n\
+               '#archive'() {}\n\
+             }",
+        );
+        let private_method = find_fn(&results, "#wipe");
+        let quoted_public_method = find_fn(&results, "#archive");
+
+        assert!(private_method.is_private_member);
+        assert!(!quoted_public_method.is_private_member);
     }
 
     #[test]

--- a/crates/extract/src/template_complexity/mod.rs
+++ b/crates/extract/src/template_complexity/mod.rs
@@ -420,6 +420,7 @@ pub(in crate::template_complexity) fn build_unit_complexity(
 
     Some(FunctionComplexity {
         name: name.to_string(),
+        is_private_member: false,
         line,
         col,
         cyclomatic: complexity.cyclomatic,

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1008,6 +1008,11 @@ pub fn is_synthetic_template_unit(name: &str) -> bool {
 pub struct FunctionComplexity {
     /// Function name (or `"<anonymous>"` for unnamed functions/arrows).
     pub name: String,
+    /// Whether this function is an ECMAScript `#`-private class member.
+    ///
+    /// Kept separately from `name` because a public string-named method may
+    /// legally begin with `#` and remains eligible for runtime coverage.
+    pub is_private_member: bool,
     /// 1-based line number where the function starts.
     pub line: u32,
     /// 0-based byte column where the function starts.
@@ -3562,6 +3567,7 @@ mod tests {
             line_offsets: vec![0, 8],
             complexity: vec![FunctionComplexity {
                 name: "work".to_string(),
+                is_private_member: false,
                 line: 1,
                 col: 0,
                 cyclomatic: 2,
@@ -4856,6 +4862,7 @@ mod tests {
     fn function_complexity_bitcode_roundtrip() {
         let fc = FunctionComplexity {
             name: "processData".to_string(),
+            is_private_member: true,
             line: 42,
             col: 4,
             cyclomatic: 15,
@@ -4888,6 +4895,7 @@ mod tests {
         let bytes = bitcode::encode(&fc);
         let decoded: FunctionComplexity = bitcode::decode(&bytes).unwrap();
         assert_eq!(decoded.name, "processData");
+        assert!(decoded.is_private_member);
         assert_eq!(decoded.line, 42);
         assert_eq!(decoded.col, 4);
         assert_eq!(decoded.cyclomatic, 15);


### PR DESCRIPTION
## What

Match anonymous Istanbul function records when the extracted callback start lies between the producer declaration and body anchors.

The header-span fallback runs only after established anonymous alias and body matchers cannot resolve the function. It credits coverage only when one safe anonymous record contains the target. Nested declarations and genuinely overlapping candidates still abstain.

Track ECMAScript private-member provenance explicitly through extraction, cache, and scoring data. Actual private members remain on static estimates, while public quoted method names beginning with # remain eligible for exact Istanbul coverage.

Fixes #2448.

## Public regression evidence

- The unique-header fixture returns no match on the parent behavior and exact Istanbul coverage with the fallback.
- Established anonymous alias matching keeps priority over overlapping header spans.
- Tied established aliases and genuinely overlapping header spans remain unmatched.
- A colliding anonymous alias can use one uniquely safe header span.
- Direct extraction distinguishes an actual private member from a public quoted # method.
- Actual private members retain static estimates, while public quoted # methods receive exact Istanbul coverage.
- The extraction cache preserves private-member provenance across a round trip.

## Validation

- [x] cargo test -p fallow-types function_complexity_bitcode_roundtrip, 1 passed
- [x] cargo test -p fallow-extract complexity, 211 passed
- [x] cargo test -p fallow-engine health::scoring, 147 passed
- [x] npm run verify:fast
- [x] npm run verify:full

## Release intent

CHANGELOG.md records the fix under Unreleased > Fixed for the next patch release.