### PR TITLE
fix(health): read the coverage maps other producers actually write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The health summary reports how much of a coverage file joined**
+  (Closes [#2455](https://github.com/fallow-rs/fallow/issues/2455)). A coverage
+  file written for a different root, a container path prefix, or an older
+  checkout used to read exactly like code with no tests: every function fell
+  back to its estimate and nothing said why. `istanbul_files_matched` and
+  `istanbul_files_total` now report how many files the coverage file describes
+  and how many an analyzed file matched, and the human report says so when the
+  two differ. A run whose coverage joins completely is unchanged.
+
 ### Fixed
 
 - **Coverage maps written by `v8-to-istanbul` are no longer rejected**
@@ -26,18 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   producer recorded.
 
 
-### Added
-
-- **The health summary reports how much of a coverage file joined**
-  (Closes [#2455](https://github.com/fallow-rs/fallow/issues/2455)). A coverage
-  file written for a different root, a container path prefix, or an older
-  checkout used to read exactly like code with no tests: every function fell
-  back to its estimate and nothing said why. `istanbul_files_matched` and
-  `istanbul_files_total` now report how many files the coverage file describes
-  and how many an analyzed file matched, and the human report says so when the
-  two differ. A run whose coverage joins completely is unchanged.
-
-### Fixed
 
 - **A coverage map that attributes nothing to a function no longer lowers its
   CRAP** (Closes [#2453](https://github.com/fallow-rs/fallow/issues/2453)). A
@@ -49,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes a score for a function it actually measured.
 
 
-### Fixed
 
 - **Istanbul coverage now matches functions whose extracted position falls
   between the producer's declaration and its body**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Coverage maps written by `v8-to-istanbul` are no longer rejected**
+  (Closes [#2454](https://github.com/fallow-rs/fallow/issues/2454)). c8, nyc in
+  v8 mode, and older vitest versions write a map in which the implicit else of
+  a bare `if` carries `column: -1`. Positions are unsigned, so a single
+  unplaceable coordinate in `branchMap`, a section fallow never reads, aborted
+  the run with exit 2. Such coordinates are now clamped on a retry, which only
+  runs after the strict parse has failed.
+
+- **An accessor keeps its coverage whichever way the producer named it**
+  (Closes [#2456](https://github.com/fallow-rs/fallow/issues/2456)). Raw V8
+  coverage and `oxc-coverage-instrument` record `get area` and `set area` where
+  istanbul-lib-instrument leaves the record anonymous, and fallow extracts the
+  unit as `area`. A covered accessor was reported as unmeasured under the first
+  two. A record now answers to its property name as well as to the spelling the
+  producer recorded.
+
+
 ### Added
 
 - **The health summary reports how much of a coverage file joined**

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -970,6 +970,15 @@ struct IstanbulFunctionCoverage {
 }
 
 impl IstanbulFunctionCoverage {
+    /// Whether this record answers to `name`, either as recorded or as the
+    /// property behind an accessor keyword the producer kept.
+    fn answers_to(&self, name: &str) -> bool {
+        if self.name == name {
+            return true;
+        }
+        accessor_property_name(&self.name) == Some(name)
+    }
+
     fn nearest_alias(
         &self,
         target: IstanbulPosition,
@@ -1194,6 +1203,17 @@ impl IstanbulFileCoverage {
                     ),
                     function_index,
                 );
+                // An accessor answers to its property name as well, without
+                // giving up the spelling the producer recorded.
+                if let Some(property) = accessor_property_name(&function.name) {
+                    alias_index
+                        .entry((
+                            property.to_string(),
+                            alias.position.line,
+                            alias.position.col,
+                        ))
+                        .or_insert(function_index);
+                }
             }
         }
 
@@ -1289,7 +1309,7 @@ impl IstanbulFileCoverage {
         if let Some(function) = window
             .iter()
             .copied()
-            .filter(|function_index| self.functions[*function_index].name == name)
+            .filter(|function_index| self.functions[*function_index].answers_to(name))
             .filter_map(|function_index| {
                 let function = &self.functions[function_index];
                 function
@@ -1471,7 +1491,7 @@ impl IstanbulFileCoverage {
     fn unambiguous_named_pct(&self, name: &str) -> Option<f64> {
         let mut found: Option<f64> = None;
         for function in &self.functions {
-            if function.name != name {
+            if !function.answers_to(name) {
                 continue;
             }
             match found {
@@ -1617,7 +1637,7 @@ pub(super) fn load_istanbul_coverage_for_sources(
         .map_err(|e| format!("failed to read coverage file {}: {e}", file_path.display()))?;
 
     let raw: std::collections::BTreeMap<String, oxc_coverage_instrument::FileCoverage> =
-        oxc_coverage_instrument::parse_coverage_map(&json).map_err(|e| {
+        parse_coverage_map_tolerantly(&json).map_err(|e| {
             format!(
                 "failed to parse coverage data from {}: {e}",
                 file_path.display()
@@ -1675,6 +1695,70 @@ fn read_discovered_source(
     } else {
         None
     }
+}
+
+/// Parse a coverage map, retrying once with unplaceable coordinates clamped.
+///
+/// A producer can emit a negative coordinate for a position it could not
+/// place: `v8-to-istanbul`, which is what c8 and nyc write, records
+/// `column: -1` on the implicit else of a bare `if`. Positions are unsigned,
+/// so one such coordinate rejects the entire map, and it always lands in
+/// `branchMap`, which nothing here reads. The retry costs a second parse and
+/// only runs after the strict one has already failed.
+fn parse_coverage_map_tolerantly(
+    json: &str,
+) -> Result<std::collections::BTreeMap<String, oxc_coverage_instrument::FileCoverage>, String> {
+    match oxc_coverage_instrument::parse_coverage_map(json) {
+        Ok(raw) => Ok(raw),
+        Err(strict_error) => {
+            let mut value: serde_json::Value =
+                serde_json::from_str(json).map_err(|_| strict_error.to_string())?;
+            if !clamp_negative_positions(&mut value) {
+                return Err(strict_error.to_string());
+            }
+            serde_json::from_value(value).map_err(|_| strict_error.to_string())
+        }
+    }
+}
+
+/// Clamp every negative `line` or `column` in the tree to zero, reporting
+/// whether anything changed. Zero is what the shared position type already
+/// uses for a coordinate a producer left null or absent.
+fn clamp_negative_positions(value: &mut serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(entries) => {
+            let mut clamped = false;
+            for (key, child) in entries.iter_mut() {
+                if matches!(key.as_str(), "line" | "column")
+                    && child.as_i64().is_some_and(|number| number < 0)
+                {
+                    *child = serde_json::Value::from(0);
+                    clamped = true;
+                    continue;
+                }
+                clamped |= clamp_negative_positions(child);
+            }
+            clamped
+        }
+        serde_json::Value::Array(items) => items.iter_mut().fold(false, |clamped, item| {
+            clamped | clamp_negative_positions(item)
+        }),
+        _ => false,
+    }
+}
+
+/// The property name behind an accessor record, when a producer prefixed it.
+///
+/// istanbul-lib-instrument leaves a class accessor anonymous, but raw V8
+/// coverage and `oxc-coverage-instrument` record `get area` and `set area`,
+/// while fallow extracts the unit as `area`. The prefix is the whole
+/// difference, so a record keeps its own spelling and answers to the bare
+/// property name as well.
+fn accessor_property_name(name: &str) -> Option<&str> {
+    let property = name
+        .strip_prefix("get ")
+        .or_else(|| name.strip_prefix("set "))?;
+    (!property.is_empty() && !property.contains(' ')).then_some(property)
 }
 
 /// Rebase one Istanbul file path from `coverage_root` onto `project_root`.
@@ -5790,6 +5874,101 @@ mod tests {
         );
 
         std::fs::write(coverage_path, serde_json::to_string(&root).unwrap()).unwrap();
+    }
+
+    /// `v8-to-istanbul`, which is what c8 and nyc write, records `column: -1`
+    /// for the implicit else of a bare `if`. Positions are unsigned, so the
+    /// strict parse rejected the whole map over a coordinate in a section
+    /// nothing here reads. Geometry from a map generated by running real V8
+    /// coverage through v8-to-istanbul 9.2.0.
+    #[test]
+    fn a_negative_branch_coordinate_does_not_cost_the_whole_map() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/pick.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "// geometry fixture\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        let source = source_path.to_string_lossy().into_owned();
+        std::fs::write(
+            &coverage_path,
+            serde_json::to_string(&serde_json::json!({
+                source.clone(): {
+                    "path": source,
+                    "statementMap": {},
+                    "fnMap": {
+                        "0": {
+                            "name": "pick",
+                            "line": 1,
+                            "decl": { "start": { "line": 1, "column": 16 }, "end": { "line": 1, "column": 20 } },
+                            "loc": { "start": { "line": 1, "column": 41 }, "end": { "line": 6, "column": 1 } }
+                        }
+                    },
+                    "branchMap": {
+                        "0": {
+                            "type": "branch",
+                            "line": 5,
+                            "loc": {
+                                "start": { "line": 5, "column": -1 },
+                                "end": { "line": 6, "column": 0 }
+                            },
+                            "locations": [
+                                {
+                                    "start": { "line": 5, "column": -1 },
+                                    "end": { "line": 6, "column": 0 }
+                                }
+                            ]
+                        }
+                    },
+                    "s": {},
+                    "f": { "0": 2 },
+                    "b": { "0": [1, 0] }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        assert_eq!(file_coverage.lookup("pick", 1, 16), Some(100.0));
+    }
+
+    /// Raw V8 coverage and `oxc-coverage-instrument` record an accessor as
+    /// `get area`, istanbul-lib-instrument leaves it anonymous, and fallow
+    /// extracts the unit as `area`. Both spellings must reach the record.
+    #[test]
+    fn an_accessor_answers_to_its_property_name() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_path = temp.path().join("src/box.ts");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::write(&source_path, "// geometry fixture\n").unwrap();
+
+        let coverage_path = temp.path().join("coverage-final.json");
+        write_single_file_istanbul_fixture(
+            &coverage_path,
+            &source_path,
+            &serde_json::json!({
+                "0": {
+                    "name": "get area",
+                    "line": 4,
+                    "decl": { "start": { "line": 4, "column": 6 }, "end": { "line": 4, "column": 10 } },
+                    "loc": { "start": { "line": 4, "column": 13 }, "end": { "line": 6, "column": 3 } }
+                }
+            }),
+            &serde_json::json!({ "0": 0 }),
+        );
+
+        let coverage = load_istanbul_coverage(&coverage_path, None, None, false).unwrap();
+        let canonical_source = dunce::canonicalize(&source_path).unwrap();
+        let file_coverage = coverage.get(&canonical_source).unwrap();
+
+        // Fallow extracts the accessor under the property name alone.
+        assert_eq!(file_coverage.lookup("area", 4, 6), Some(0.0));
+        // The producer's own spelling still resolves.
+        assert_eq!(file_coverage.lookup("get area", 4, 6), Some(0.0));
     }
 
     #[test]

--- a/crates/mcp/src/tools/coverage_fixture.rs
+++ b/crates/mcp/src/tools/coverage_fixture.rs
@@ -108,8 +108,8 @@ impl CoverageFixture {
                             "end": { "line": 3, "column": 16 }
                         },
                         "loc": {
-                            "start": { "line": 3, "column": 35 },
-                            "end": { "line": 11, "column": 10 }
+                            "start": { "line": 3, "column": 36 },
+                            "end": { "line": 11, "column": 1 }
                         }
                     }
                 },

--- a/crates/output/src/health_scores.rs
+++ b/crates/output/src/health_scores.rs
@@ -437,7 +437,12 @@ pub struct ComplexityViolation {
     /// Test coverage percentage (0-100) backing the CRAP score.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coverage_pct: Option<f64>,
-    /// Coverage tier bucket derived from `coverage_pct`.
+    /// Coverage tier bucket.
+    ///
+    /// Derived from `coverage_pct` when coverage was measured. When
+    /// `coverage_source` is estimated, `coverage_pct` is absent and the tier
+    /// describes the static estimate behind the CRAP score rather than an
+    /// observation, so read the two fields together.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coverage_tier: Option<CoverageTier>,
     /// Provenance of the coverage signal.

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -3107,7 +3107,7 @@
               "type": "null"
             }
           ],
-          "description": "Coverage tier bucket derived from `coverage_pct`."
+          "description": "Coverage tier bucket.\n\nDerived from `coverage_pct` when coverage was measured. When\n`coverage_source` is estimated, `coverage_pct` is absent and the tier\ndescribes the static estimate behind the CRAP score rather than an\nobservation, so read the two fields together."
         },
         "coverage_source": {
           "anyOf": [
@@ -10775,7 +10775,7 @@
               "type": "null"
             }
           ],
-          "description": "Coverage tier bucket derived from `coverage_pct`."
+          "description": "Coverage tier bucket.\n\nDerived from `coverage_pct` when coverage was measured. When\n`coverage_source` is estimated, `coverage_pct` is absent and the tier\ndescribes the static estimate behind the CRAP score rather than an\nobservation, so read the two fields together."
         },
         "coverage_source": {
           "anyOf": [

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -5442,7 +5442,12 @@ crap?: (number | null)
  */
 coverage_pct?: (number | null)
 /**
- * Coverage tier bucket derived from `coverage_pct`.
+ * Coverage tier bucket.
+ *
+ * Derived from `coverage_pct` when coverage was measured. When
+ * `coverage_source` is estimated, `coverage_pct` is absent and the tier
+ * describes the static estimate behind the CRAP score rather than an
+ * observation, so read the two fields together.
  */
 coverage_tier?: (CoverageTier | null)
 /**

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -5442,7 +5442,12 @@ crap?: (number | null)
  */
 coverage_pct?: (number | null)
 /**
- * Coverage tier bucket derived from `coverage_pct`.
+ * Coverage tier bucket.
+ *
+ * Derived from `coverage_pct` when coverage was measured. When
+ * `coverage_source` is estimated, `coverage_pct` is absent and the tier
+ * describes the static estimate behind the CRAP score rather than an
+ * observation, so read the two fields together.
  */
 coverage_tier?: (CoverageTier | null)
 /**


### PR DESCRIPTION
Two producer divergences that cost users their coverage data, both measured against real producer output.

**`v8-to-istanbul` maps were rejected outright** (#2454). c8, nyc in v8 mode, and older vitest versions write a map in which the implicit else of a bare `if` carries `column: -1`. Positions are unsigned, so one unplaceable coordinate aborted the run with exit 2, over a field in `branchMap` that nothing in the CRAP path reads. Unplaceable coordinates are now clamped on a retry that only runs after the strict parse has failed, so a map without them costs nothing.

Verified against a map generated by running real V8 coverage through `v8-to-istanbul` 9.2.0: previously `exit_code: 2`, now the file joins and its functions match.

**Accessors lost their coverage depending on the producer** (#2456). Raw V8 coverage and `oxc-coverage-instrument` record `get area` and `set area`; istanbul-lib-instrument leaves the record anonymous; fallow extracts the unit as `area`. A fully covered accessor read as unmeasured under the first two, and in a file no test reaches it drew a CRAP finding it had not earned. A record now answers to its property name as well as to the producer's spelling, so the two are interchangeable.

**The MCP coverage fixture had drifted** (part of #2457). It asserted a body span istanbul-lib-instrument does not emit for its own source, off by one column at the start and nine at the end, and the tests passed either way. Corrected against real output; the conformance harness that would have caught it stays open in #2457.

## Verification

- `npm run verify:fast` clean, `cargo test --workspace` and workspace clippy with `-D warnings` clean.
- Each fix has a test built from the producer's own output, and the c8 fixture carries the exact geometry that used to abort the run.
- Compared against 3.20.0 on six projects with their own coverage maps: 49 functions gain a real Istanbul match, none lose one, and no matched value changes.

Closes #2454
Closes #2456
