### PR TITLE
docs(quality-gates): list the install the NAPI gate step needs

### DIFF
--- a/docs/development/quality-gates.md
+++ b/docs/development/quality-gates.md
@@ -43,8 +43,14 @@ Install into the checkout you are working in:
 ```bash
 npm ci
 npm ci --prefix tools/type-aware-sidecar
+npm ci --prefix crates/napi
 pnpm --dir editors/vscode install
 ```
+
+`verify:full` runs `npm --prefix crates/napi run build:debug`, whose `napi`
+binary comes from that package's own devDependencies. Without the install the
+step ends in `napi: command not found` and exit 127, after every earlier gate
+has already passed.
 
 `scripts/assert-local-resolution.mjs` enforces the invariant for the
 entrypoints that load third-party modules. The JavaScript lint, format, and


### PR DESCRIPTION
`npm run verify:full` ends with a local NAPI build:

```
[verify] Local NAPI build: "npm" "--prefix" "crates/napi" "run" "build:debug"
sh: napi: command not found
[verify] Local NAPI build failed with exit code 127.
```

The `napi` binary comes from `crates/napi`'s own devDependencies, but the documented setup lists only the root install, the type-aware sidecar, and the VS Code extension. A checkout that follows the documentation therefore runs all seventeen steps, passes every earlier gate including the full workspace test suite, and stops at the last one.

Adding `npm ci --prefix crates/napi` to the documented list, with the reason next to it so the failure is recognisable if it appears anyway.

Verified on a checkout that reproduced the failure: after the install the NAPI step succeeds and `verify:full` completes with exit 0 across all seventeen steps.
