### PR TITLE
fix(ci): name the coverage root only when the coverage file failed to join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The CI summary points at `--coverage-root` only when the coverage file
+  failed to join.** The audit summary warned about a low match rate whenever
+  fewer than half the analyzed functions matched a record, which is ordinary:
+  a coverage file covers the files its test run touched, so a project whose
+  suite exercises part of its modules matched part of its functions and was
+  told its paths were probably wrong. The note now keys on files in the
+  coverage file that no analyzed file matched, and says how many.
+
 - **Coverage maps written by `v8-to-istanbul` are no longer rejected**
   (Closes [#2454](https://github.com/fallow-rs/fallow/issues/2454)). c8, nyc in
   v8 mode, and older vitest versions write a map in which the implicit else of

--- a/crates/cli/src/report/github_summary.rs
+++ b/crates/cli/src/report/github_summary.rs
@@ -2029,6 +2029,29 @@ fn audit_complexity_section(env: &Value) -> String {
     )
 }
 
+/// Point at the coverage root only when the coverage file failed to join.
+///
+/// A low function match rate is ordinary: a coverage file covers the files its
+/// test run touched, so a project whose suite exercises a fraction of its
+/// modules matches a fraction of its functions with nothing wrong. The signal
+/// that a path is misconfigured is files in the coverage file that no analyzed
+/// file matched.
+fn audit_coverage_join_suffix(summary: &Value) -> String {
+    let matched = summary
+        .get("istanbul_files_matched")
+        .and_then(Value::as_u64);
+    let total = summary.get("istanbul_files_total").and_then(Value::as_u64);
+    match (matched, total) {
+        (Some(matched), Some(total)) if total > 0 && matched == 0 => format!(
+            ", from a coverage file describing {total} files that none of the analyzed files matched; check `--coverage-root` is correct for this checkout."
+        ),
+        (Some(matched), Some(total)) if total > 0 && matched < total => format!(
+            ", from {matched} of {total} files in the coverage file; the rest matched no analyzed file."
+        ),
+        _ => ".".to_owned(),
+    }
+}
+
 fn audit_coverage_model_note(complexity: &Value) -> String {
     let summary = complexity.get("summary").cloned().unwrap_or(Value::Null);
     let model = summary.get("coverage_model").and_then(Value::as_str);
@@ -2038,13 +2061,9 @@ fn audit_coverage_model_note(complexity: &Value) -> String {
             let total = summary.get("istanbul_total").and_then(Value::as_u64);
             match (matched, total) {
                 (Some(matched), Some(total)) if total > 0 => {
-                    let suffix = if matched * 100 / total < 50 {
-                        ". Low match rate; check `--coverage-root` is correct for this checkout."
-                    } else {
-                        "."
-                    };
                     format!(
-                        "\n\n*Coverage model: istanbul. Matched {matched}/{total} functions{suffix}*"
+                        "\n\n*Coverage model: istanbul. Matched {matched}/{total} functions{}*",
+                        audit_coverage_join_suffix(&summary)
                     )
                 }
                 _ => "\n\n*Coverage model: istanbul (exact, from `--coverage`).*".to_owned(),

--- a/crates/cli/tests/github_format_tests.rs
+++ b/crates/cli/tests/github_format_tests.rs
@@ -207,7 +207,7 @@ fn audit_envelope() -> Value {
             "findings": [
                 { "path": "src/gnarly.ts", "line": 88, "name": "bigSwitch", "severity": "high", "cyclomatic": 24, "cognitive": 18, "crap": 42.5, "coverage_tier": "partial", "introduced": true }
             ],
-            "summary": { "coverage_model": "istanbul", "istanbul_matched": 12, "istanbul_total": 40 }
+            "summary": { "coverage_model": "istanbul", "istanbul_matched": 12, "istanbul_total": 40, "istanbul_files_matched": 5, "istanbul_files_total": 5 }
         },
         "duplication": {
             "clone_groups": [
@@ -793,6 +793,39 @@ fn github_summary_health_snapshot() {
         &LinkContext::default(),
     );
     insta::assert_snapshot!("github_summary_health", rendered);
+}
+
+/// A coverage file covers the files its test run touched, so matching a
+/// fraction of a project's functions is ordinary. The signal that a path is
+/// wrong is files in the coverage file that no analyzed file matched, and the
+/// note points at `--coverage-root` for that case alone.
+#[test]
+fn audit_summary_names_the_coverage_root_only_when_the_join_failed() {
+    let with_join_failure = |matched: u64, total: u64| {
+        let mut envelope = audit_envelope();
+        envelope["complexity"]["summary"] = serde_json::json!({
+            "coverage_model": "istanbul",
+            "istanbul_matched": 12,
+            "istanbul_total": 40,
+            "istanbul_files_matched": matched,
+            "istanbul_files_total": total,
+        });
+        render_summary(EnvelopeKind::Audit, &envelope, &LinkContext::default())
+    };
+
+    let joined = with_join_failure(5, 5);
+    assert!(joined.contains("Matched 12/40 functions."), "{joined}");
+    assert!(!joined.contains("--coverage-root"), "{joined}");
+
+    let unjoined = with_join_failure(0, 5);
+    assert!(unjoined.contains("--coverage-root"), "{unjoined}");
+    assert!(
+        unjoined.contains("5 files that none of the analyzed files matched"),
+        "{unjoined}"
+    );
+
+    let partial = with_join_failure(2, 5);
+    assert!(partial.contains("from 2 of 5 files"), "{partial}");
 }
 
 #[test]

--- a/crates/cli/tests/snapshots/github_format_tests__github_summary_audit.snap
+++ b/crates/cli/tests/snapshots/github_format_tests__github_summary_audit.snap
@@ -27,7 +27,7 @@ expression: rendered
 |:-----|:---------|:-------|:---------|:-----------|:----------|:---------|:-----|
 | `src/gnarly.ts:88` | `bigSwitch` | new | high | 24 | 18 | partial | 42.5 |
 
-*Coverage model: istanbul. Matched 12/40 functions. Low match rate; check `--coverage-root` is correct for this checkout.*
+*Coverage model: istanbul. Matched 12/40 functions.*
 
 ### Duplication
 


### PR DESCRIPTION
The audit CI summary warned about a low match rate whenever fewer than half the analyzed functions matched a coverage record:

```
*Coverage model: istanbul. Matched 12/40 functions. Low match rate; check `--coverage-root` is correct for this checkout.*
```

That fraction is ordinary. A coverage file covers the files its test run touched, so a project whose suite exercises part of its modules matches part of its functions with nothing misconfigured. On a real project here, 750 of 2427 functions matched while every one of the 46 files in the coverage file joined, and the summary still told the reader their coverage root was probably wrong.

The condition a coverage root explains is files in the coverage file that no analyzed file matched, which the summary can now see through `istanbul_files_matched` and `istanbul_files_total`. The note keys on that instead and reports the count:

- complete join: `Matched 12/40 functions.`
- nothing joined: `..., from a coverage file describing 5 files that none of the analyzed files matched; check --coverage-root is correct for this checkout.`
- partial join: `..., from 2 of 5 files in the coverage file; the rest matched no analyzed file.`

The audit snapshot fixture now carries a complete join, so it stops asserting the false warning, and a new test covers all three states.
