### PR TITLE
test(cli): stop copying a fixture's cache directory into the copy

### DIFF
--- a/crates/cli/tests/fix_tests.rs
+++ b/crates/cli/tests/fix_tests.rs
@@ -748,6 +748,11 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
+        // A fixture's cache directory is not part of the fixture, and another
+        // test in this binary may be writing it while this copy walks it.
+        if entry.file_name() == ".fallow" {
+            continue;
+        }
         let ty = entry.file_type()?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -26,6 +26,15 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).expect("create destination directory");
     for entry in std::fs::read_dir(src).expect("read source directory") {
         let entry = entry.expect("read source entry");
+        // A fixture's cache directory is not part of the fixture. Another test
+        // in this binary runs the real binary against the shared fixture as its
+        // root, which writes and renames cache files there, so copying that
+        // directory races the writer: the entry is read, the writer renames its
+        // temp file over the old one, and the copy fails with a not-found for a
+        // file the caller never asked for. The copy also wants a cold cache.
+        if entry.file_name() == ".fallow" {
+            continue;
+        }
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         let file_type = entry.file_type().expect("read source entry type");


### PR DESCRIPTION
A dependabot pull request that bumped a devDependency in the VS Code extension failed the Rust `Check` job:

```
test health_coverage_gaps_suppressed_file_excluded ... FAILED
panicked at crates/cli/tests/health_tests.rs:35:49:
copy file: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Nothing about that bump touches Rust. The failure is a race between two tests in the same binary that share `tests/fixtures/coverage-gaps`:

- `health_coverage_gaps_flag_reports_runtime_gaps` runs the real binary with the shared fixture directory as its root, so the binary writes and renames cache files under `tests/fixtures/coverage-gaps/.fallow/`.
- `health_coverage_gaps_suppressed_file_excluded` copies that same fixture into a temp directory, walking every entry it finds.

The copy reads a cache entry, the writer renames its temp file over that path, and `std::fs::copy` fails with a not-found for a file no test ever asked for. It only fires when the two land in the same window, which is why it shows up as an unrelated red check on someone else's pull request.

A fixture's cache directory is not part of the fixture, and a copied project wants a cold cache anyway, so both copy helpers now skip `.fallow`. The same helper exists in `fix_tests.rs` with the same exposure, so it is fixed there too.

## Verification

Both suites pass, and six concurrent runs of the suite that raced produced zero failures. Nothing in `tests/fixtures/**/.fallow` is tracked, so no fixture loses content it was supposed to carry.

This is one instance of the isolation problem described in #2460, not the whole of it: the telemetry spool lock case there is unrelated to fixture copying.
