### PR TITLE
ci(dependabot): stop reporting a refused auto-merge as a failure

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,28 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: steps.meta.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge "$PR_URL" --auto --squash
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if output=$(gh pr merge "$PR_URL" --auto --squash 2>&1); then
+            exit 0
+          fi
+          # GitHub refuses to ENABLE auto-merge when there is nothing left to
+          # wait for. That happens whenever this job queues behind a burst of
+          # dependabot pull requests: by the time it runs, every required
+          # context has already reported and the pull request is mergeable, so
+          # the mutation is rejected for clean or unstable status. A pull
+          # request that closed while the job waited is the same story. Neither
+          # is a fault, and failing here paints a red check on a pull request
+          # whose own checks are green.
+          printf '%s\n' "$output"
+          case "$output" in
+            *"is in clean status"*|*"is in unstable status"*|*"Pull request is closed"*)
+              echo "auto-merge not enabled: this pull request is no longer waiting on checks."
+              ;;
+            *)
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
The dependabot auto-merge helper has failed 27 times since April, across cargo, npm and actions bumps, and every one of them painted a red check on a pull request whose own checks were green.

The failure is always the same refusal:

```
GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)
```

GitHub only lets you *enable* auto-merge on a pull request that cannot merge yet. When the helper job queues behind a burst of dependabot pull requests, every required context reports before the job gets a runner, the pull request is already mergeable, and the mutation is rejected.

Measured on the codeql-action bump today:

| Event | Time |
|---|---|
| Run created | 20:18:21 |
| Last required context reported (`CI`) | 20:46:07 |
| Helper job finally got a runner | 20:47:12 |

Twenty-nine minutes of queue behind nineteen simultaneous pull requests, and by then there was nothing left to wait for.

A refusal that means the work is already done, or that the pull request closed while the job waited, now logs the message and exits 0. Every other error still fails the job.

Deliberately not changed: this does not fall back to merging the pull request directly. A refusal for `unstable` status means the required contexts passed while some non-required check is red or pending, and whether that merges is a judgement a maintainer should keep making. This only stops the helper from reporting its own no-op as a fault.
