### PR TITLE
fix(vscode): close the downloaded binary before executing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--version` against it. Unix refuses to execute a file that any process holds
   open for writing, so a first install could fail with `Text file busy` on
   Linux. The download now resolves only after the descriptor is really closed,
-  and a close that fails still rejects the download exactly once.
+  and a close that fails still rejects the download exactly once. A socket that
+  fails after the body is already on disk no longer deletes that file either,
+  which used to turn a keep-alive teardown into a failed install.
 
 ## [3.21.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that re-run the Fallow binary, now waits the condition out for up to a second
   before reporting it. A spawn that never meets it is unchanged.
 
+- **The VS Code extension no longer starts a binary it may still hold open.** A
+  download resolved on the write stream's `finish` event, which fires once the
+  bytes reach the operating system and not once the descriptor is released;
+  closing it is queued on a background thread. The extension then marked the
+  file executable, renamed it into place, which keeps the same inode and so the
+  same open descriptor, and started it as the language server or ran
+  `--version` against it. Unix refuses to execute a file that any process holds
+  open for writing, so a first install could fail with `Text file busy` on
+  Linux. The download now resolves only after the descriptor is really closed,
+  and a close that fails still rejects the download exactly once.
+
 ## [3.21.0] - 2026-08-31
 
 ### Added

--- a/docs/reference/vscode-internals.md
+++ b/docs/reference/vscode-internals.md
@@ -27,6 +27,10 @@ Do not duplicate the full setting list in durable prose.
 - Binary resolution follows the documented priority: explicit user path,
   workspace dependency, system path, managed binary, then auto-download.
 - Validate managed downloads before execution.
+- A managed download is complete only once its file descriptor is closed.
+  Stream completion is not enough: Unix refuses to execute a file that any
+  process still holds open for writing, and the extension chmods, renames,
+  and spawns what it just downloaded.
 - Keep LSP analysis, health, audit, security, and runtime coverage as separate
   lazy workflows unless a measured UX change justifies combining them.
 - Configuration changes restart only the surfaces whose initialization state

--- a/editors/vscode/src/download.ts
+++ b/editors/vscode/src/download.ts
@@ -177,9 +177,23 @@ export const httpsDownload = (url: string, dest: string, signal?: AbortSignal): 
           reject(err);
         });
         response.pipe(file);
+        // 'finish' only means the bytes reached the OS; the descriptor is still
+        // open, and `close()` merely queues fs.close(fd) on the libuv
+        // threadpool. Unix refuses to exec a file that any process holds open
+        // for writing (ETXTBSY), and this very file is chmod'ed, renamed into
+        // place and then spawned by the same extension host. Resolve from the
+        // close callback so the descriptor is gone before the caller runs.
         file.on("finish", () => {
-          file.close();
-          resolve();
+          file.close((err) => {
+            // A failed close also reaches the 'error' handler below, which
+            // unlinks the partial file; whichever settles first wins, so the
+            // download still rejects exactly once.
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve();
+          });
         });
         file.on("error", (err) => {
           fs.unlink(dest, () => {});

--- a/editors/vscode/src/download.ts
+++ b/editors/vscode/src/download.ts
@@ -167,11 +167,22 @@ export const httpsDownload = (url: string, dest: string, signal?: AbortSignal): 
     async (response) =>
       await new Promise<void>((resolve, reject) => {
         const file = fs.createWriteStream(dest);
+        // Set once the whole body has reached disk, leaving only the descriptor
+        // close outstanding. A socket error after that point describes a
+        // connection this download is already done with.
+        let bodyWritten = false;
         // Guard the readable (response) stream as well: `pipe()` does not forward
         // a readable's errors to the writable, so a mid-download socket drop would
         // emit an unhandled `error` on `response` and crash the whole extension
         // host. Tear down the write stream, drop the partial file, and reject.
         response.on("error", (err) => {
+          // A keep-alive socket can fail after the body is complete. Deleting a
+          // finished download there would fail an install that had already
+          // succeeded, so only report an error that truncated the file. The
+          // listener stays attached: an unhandled 'error' would crash the host.
+          if (bodyWritten) {
+            return;
+          }
           file.destroy();
           fs.unlink(dest, () => {});
           reject(err);
@@ -184,6 +195,7 @@ export const httpsDownload = (url: string, dest: string, signal?: AbortSignal): 
         // place and then spawned by the same extension host. Resolve from the
         // close callback so the descriptor is gone before the caller runs.
         file.on("finish", () => {
+          bodyWritten = true;
           file.close((err) => {
             // A failed close also reaches the 'error' handler below, which
             // unlinks the partial file; whichever settles first wins, so the

--- a/editors/vscode/src/download.ts
+++ b/editors/vscode/src/download.ts
@@ -197,9 +197,12 @@ export const httpsDownload = (url: string, dest: string, signal?: AbortSignal): 
         file.on("finish", () => {
           bodyWritten = true;
           file.close((err) => {
-            // A failed close also reaches the 'error' handler below, which
-            // unlinks the partial file; whichever settles first wins, so the
-            // download still rejects exactly once.
+            // Measured on Node 22: a failed `fs.close` emits 'error' on the
+            // stream first and only then runs this callback, with no error
+            // argument. So a close failure rejects through the 'error' handler
+            // below, which must stay for that reason, and this branch never
+            // fires there. It remains as a guard for a runtime that reports the
+            // failure here instead.
             if (err) {
               reject(err);
               return;

--- a/editors/vscode/test/download-stream.test.ts
+++ b/editors/vscode/test/download-stream.test.ts
@@ -81,11 +81,12 @@ describe("httpsDownload stream-error handling", () => {
     fsState.pendingClose = null;
   });
 
-  /** Run the pending fs.close(fd) completion, optionally as a failure. */
-  const releaseDescriptor = (err?: Error): void => {
+  /** Run the pending fs.close(fd) completion. A real stream passes no error
+   *  argument here even when the close failed; it emits 'error' instead. */
+  const releaseDescriptor = (): void => {
     const done = fsState.pendingClose;
     fsState.pendingClose = null;
-    done?.(err ?? null);
+    done?.();
   };
 
   /** Let queued microtasks and the macrotask queue drain. */
@@ -132,14 +133,21 @@ describe("httpsDownload stream-error handling", () => {
 
   it("rejects once when releasing the descriptor fails", async () => {
     const pending = httpsDownload("https://example.test/bin", "/tmp/badfd");
+    const settled: string[] = [];
+    void pending.then(
+      () => settled.push("resolved"),
+      () => settled.push("rejected"),
+    );
+
     fsState.writeStream.emit("finish");
-    // A real stream reports this both on 'error' and through the close
-    // callback; the promise must settle as a rejection either way.
-    const err = new Error("EBADF");
-    fsState.writeStream.emit("error", err);
-    releaseDescriptor(err);
+    // Order a real fs.WriteStream produces for a failed close: 'error' carries
+    // the failure, then the close callback runs with nothing. The resolve in
+    // that callback must not undo the rejection.
+    fsState.writeStream.emit("error", new Error("EBADF"));
+    releaseDescriptor();
 
     await expect(pending).rejects.toThrow("EBADF");
+    expect(settled).toEqual(["rejected"]);
     expect(fsState.unlinked).toContain("/tmp/badfd");
   });
 

--- a/editors/vscode/test/download-stream.test.ts
+++ b/editors/vscode/test/download-stream.test.ts
@@ -11,7 +11,7 @@ type FakeStream = EventEmitter & {
   resume?: () => void;
   pipe?: () => void;
   destroy?: (err?: Error) => void;
-  close?: () => void;
+  close?: (cb?: (err?: Error | null) => void) => void;
 };
 
 const httpsState = vi.hoisted(() => ({
@@ -24,6 +24,9 @@ const httpsState = vi.hoisted(() => ({
 const fsState = vi.hoisted(() => ({
   writeStream: null as unknown as FakeStream,
   unlinked: [] as string[],
+  // The callback fs.WriteStream.close() invokes once fs.close(fd) has really
+  // run on the libuv threadpool. Held here so a test drives that release.
+  pendingClose: null as ((err?: Error | null) => void) | null,
 }));
 
 vi.mock("node:https", () => ({
@@ -67,11 +70,28 @@ describe("httpsDownload stream-error handling", () => {
     httpsState.onRequestTimeout = null;
     const ws = Object.assign(new EventEmitter(), {
       destroy: vi.fn(),
-      close: vi.fn(),
+      // Real fs write streams only queue fs.close(fd) here; the callback fires
+      // later, once the descriptor is actually released.
+      close: vi.fn((cb?: (err?: Error | null) => void) => {
+        fsState.pendingClose = cb ?? null;
+      }),
     });
     fsState.writeStream = ws;
     fsState.unlinked = [];
+    fsState.pendingClose = null;
   });
+
+  /** Run the pending fs.close(fd) completion, optionally as a failure. */
+  const releaseDescriptor = (err?: Error): void => {
+    const done = fsState.pendingClose;
+    fsState.pendingClose = null;
+    done?.(err ?? null);
+  };
+
+  /** Let queued microtasks and the macrotask queue drain. */
+  const flush = async (): Promise<void> => {
+    await new Promise((done) => setImmediate(done));
+  };
 
   it("rejects, destroys the write stream, and unlinks the partial on a response error", async () => {
     const pending = httpsDownload("https://example.test/bin", "/tmp/partial");
@@ -88,9 +108,39 @@ describe("httpsDownload stream-error handling", () => {
   it("still resolves on the normal finish path", async () => {
     const pending = httpsDownload("https://example.test/bin", "/tmp/ok");
     fsState.writeStream.emit("finish");
+    releaseDescriptor();
     await expect(pending).resolves.toBeUndefined();
     expect((fsState.writeStream.close as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
     expect(fsState.unlinked).not.toContain("/tmp/ok");
+  });
+
+  it("stays pending until the file descriptor is released", async () => {
+    // 'finish' fires once the bytes reach the OS, with the descriptor still
+    // open. Resolving there lets the caller chmod, rename and exec a file this
+    // process still holds open for writing, which Unix rejects with ETXTBSY.
+    const pending = httpsDownload("https://example.test/bin", "/tmp/busy");
+    const settled = vi.fn();
+    void pending.then(settled, settled);
+
+    fsState.writeStream.emit("finish");
+    await flush();
+    expect(settled).not.toHaveBeenCalled();
+
+    releaseDescriptor();
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("rejects once when releasing the descriptor fails", async () => {
+    const pending = httpsDownload("https://example.test/bin", "/tmp/badfd");
+    fsState.writeStream.emit("finish");
+    // A real stream reports this both on 'error' and through the close
+    // callback; the promise must settle as a rejection either way.
+    const err = new Error("EBADF");
+    fsState.writeStream.emit("error", err);
+    releaseDescriptor(err);
+
+    await expect(pending).rejects.toThrow("EBADF");
+    expect(fsState.unlinked).toContain("/tmp/badfd");
   });
 
   it("rejects and cleans up when the response stalls mid-body", async () => {
@@ -109,6 +159,7 @@ describe("httpsDownload stream-error handling", () => {
     const pending = httpsDownload("https://example.test/bin", "/tmp/done");
     httpsState.response.complete = true;
     fsState.writeStream.emit("finish");
+    releaseDescriptor();
     await expect(pending).resolves.toBeUndefined();
 
     // A keep-alive socket can fire the inactivity timeout after the download

--- a/editors/vscode/test/download-stream.test.ts
+++ b/editors/vscode/test/download-stream.test.ts
@@ -143,6 +143,20 @@ describe("httpsDownload stream-error handling", () => {
     expect(fsState.unlinked).toContain("/tmp/badfd");
   });
 
+  it("keeps a finished download when the socket fails afterwards", async () => {
+    // A keep-alive socket can fail once the body is complete and the write
+    // stream has finished. Unlinking there would fail an install whose file is
+    // already whole.
+    const pending = httpsDownload("https://example.test/bin", "/tmp/late");
+    fsState.writeStream.emit("finish");
+    httpsState.response.emit("error", new Error("socket hang up"));
+    releaseDescriptor();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(fsState.unlinked).not.toContain("/tmp/late");
+    expect((fsState.writeStream.destroy as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
   it("rejects and cleans up when the response stalls mid-body", async () => {
     const pending = httpsDownload("https://example.test/bin", "/tmp/stalled");
     // The socket goes idle with an incomplete body; the inactivity timeout


### PR DESCRIPTION
## Problem

The extension resolved a binary download from the write stream's `finish`
event, which fires when the bytes reach the operating system, not when the
descriptor is released. `WriteStream.close()` only queues `fs.close(fd)` on the
libuv threadpool.

The same extension host then chmods that file, renames it into place, which
preserves the inode and so any lingering descriptor, and spawns it: as the LSP
server (`client.ts`), from the run-analysis command (`commands.ts`), and through
the `--version` probe (`download.ts`). Unix refuses to exec a file that any
process holds open for writing, so a first install could fail with ETXTBSY
("Text file busy") on Linux.

This is the TypeScript half of the exposure fixed on the Rust side in #2496,
which has since merged.

## Changes

**Resolve after the descriptor is closed.** The download now resolves from the
`close` callback, which Node invokes only after `fs.close(fd)` has run. Verified
on Node 22: `fstat` on the captured descriptor returns EBADF inside that
callback. A close that fails still rejects, and since the stream also emits
`error` for it, whichever settles first wins and the promise settles once.

**Keep a finished download when the socket fails afterwards.** The response
error handler unlinked the destination whatever state the download was in. Once
the body is on disk that is the wrong response, and the first commit widens that
window from nothing to one `fs.close` round trip, so a keep-alive teardown could
delete a file that was already whole and fail the install. The handler now
reports only an error that truncated the body. The listener stays attached,
because an unhandled `error` on the response would crash the extension host.
This is the same reasoning the inactivity timeout already applies one layer up
with its `complete` check.

`docs/reference/vscode-internals.md` gains the matching invariant, since the
existing list required validating a managed download before executing it and
said nothing about when the file stops being held open.

`httpsDownload` is the only place in the extension that writes a file
asynchronously and later executes it. The install lock and the signature and
digest sidecars use synchronous writes, whose descriptors are closed before the
call returns; `scripts/package-type-aware.mjs` uses `cpSync` and never spawns.

## Tests

Three cases in `test/download-stream.test.ts`, each failing against the code it
guards: the download stays pending until the descriptor is released, a failed
release rejects rather than resolves, and a socket error after `finish` neither
unlinks the file nor rejects. The write-stream fake now holds the close callback
the way a real stream does.

## Validation

- `pnpm --dir editors/vscode run lint` (both tsconfigs), `test:unit`, and
  `run build` as a bundle compile check: all clean.
- `npm run lint:js` and `npm run fmt:js:check` with the pinned oxlint 1.79.0 and
  oxfmt 0.64.0: clean.

The underlying failure does not reproduce on macOS, where an open write
descriptor does not block exec, which is the same limitation noted on #2496.
Validation is therefore the ordering tests plus a real-fs run of the download
path, not an observed live ETXTBSY.
