### PR TITLE
fix(mcp): keep Code Mode refusals free of process-cleanup noise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "windows-sys 0.61.2",
 ]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -32,6 +32,7 @@ serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 schemars.workspace = true
 tempfile.workspace = true
+tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]

--- a/crates/mcp/src/tools/code_mode_subprocess.rs
+++ b/crates/mcp/src/tools/code_mode_subprocess.rs
@@ -85,7 +85,7 @@ pub(super) fn run_fallow_sync(
 
         if Instant::now() >= deadline {
             let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
-            return Err(with_cleanup_errors(
+            return Err(with_cleanup_context(
                 "code mode execution timed out while running fallow".to_string(),
                 &cleanup.errors,
             ));
@@ -99,7 +99,7 @@ pub(super) fn run_fallow_sync(
         };
         if stdout_len > max_output_bytes as u64 {
             let cleanup = cleanup_std_child(Some(&process_tree), &mut child);
-            return Err(with_cleanup_errors(
+            return Err(with_cleanup_context(
                 format!("code mode host output exceeded {max_output_bytes} bytes"),
                 &cleanup.errors,
             ));
@@ -132,6 +132,39 @@ fn spawn_managed_child(
     Ok((child, process_tree))
 }
 
+/// Messages the snippet acts on and the response envelope documents. They are
+/// part of the Code Mode contract, so they must read the same on every run.
+fn is_contract_refusal(message: &str) -> bool {
+    message.starts_with("code mode host output exceeded")
+        || message == "code mode execution timed out while running fallow"
+}
+
+/// Report best-effort teardown failures without letting them reach the caller.
+/// Killing the process group is a cleanup concern, not part of the host call's
+/// outcome, and on macOS it fails whenever the leader has already become an
+/// unreaped zombie. Folding that into a contract refusal would make a message
+/// the agent reads depend on how the kernel scheduled the child's exit.
+fn log_cleanup_errors(context: &str, cleanup_errors: &[String]) {
+    if cleanup_errors.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        context,
+        errors = cleanup_errors.join("; "),
+        "fallow subprocess cleanup reported errors"
+    );
+}
+
+/// Attach cleanup context to an error, except when the error is a contract
+/// refusal, which keeps its exact wording and logs the cleanup instead.
+fn with_cleanup_context(message: String, cleanup_errors: &[String]) -> String {
+    if is_contract_refusal(&message) {
+        log_cleanup_errors(&message, cleanup_errors);
+        return message;
+    }
+    with_cleanup_errors(message, cleanup_errors)
+}
+
 fn with_cleanup_errors(message: String, cleanup_errors: &[String]) -> String {
     if cleanup_errors.is_empty() {
         message
@@ -156,6 +189,10 @@ fn with_completed_cleanup<T>(
 
 fn with_structured_cleanup_errors(error: String, cleanup_errors: &[String]) -> String {
     if cleanup_errors.is_empty() {
+        return error;
+    }
+    if is_contract_refusal(&error) {
+        log_cleanup_errors(&error, cleanup_errors);
         return error;
     }
 
@@ -429,5 +466,48 @@ $child.Id | Set-Content -NoNewline -LiteralPath $DescendantPidPath
             wait_for_process_exit(descendant_pid),
             "completed subprocess descendant {descendant_pid} survived"
         );
+    }
+
+    #[test]
+    fn contract_refusals_keep_their_exact_wording_when_cleanup_fails() {
+        let cleanup = vec![
+            "failed to terminate subprocess tree: Operation not permitted (os error 1)".to_string(),
+        ];
+        for message in [
+            "code mode host output exceeded 500 bytes",
+            "code mode execution timed out while running fallow",
+        ] {
+            assert_eq!(
+                with_cleanup_context(message.to_string(), &cleanup),
+                message,
+                "a message the snippet acts on must not depend on teardown timing"
+            );
+            assert_eq!(
+                with_structured_cleanup_errors(message.to_string(), &cleanup),
+                message
+            );
+        }
+    }
+
+    #[test]
+    fn operational_failures_still_carry_their_cleanup_context() {
+        let cleanup = vec!["failed to reap direct subprocess after retry: boom".to_string()];
+        let joined = with_cleanup_context(
+            "failed to configure fallow subprocess tree: nope".to_string(),
+            &cleanup,
+        );
+        assert!(joined.contains("failed to configure fallow subprocess tree: nope"));
+        assert!(joined.contains("cleanup errors: failed to reap direct subprocess after retry"));
+    }
+
+    #[test]
+    fn structured_programmatic_errors_still_gain_cleanup_errors() {
+        let cleanup = vec!["failed to terminate subprocess tree: boom".to_string()];
+        let error = with_structured_cleanup_errors(
+            r#"{"error":true,"code":"config-invalid"}"#.to_string(),
+            &cleanup,
+        );
+        let value: serde_json::Value = serde_json::from_str(&error).expect("structured error");
+        assert_eq!(value["cleanup_errors"][0], cleanup[0]);
     }
 }


### PR DESCRIPTION
Follow-up to #2498, and a correction to a claim in it.

## The defect

`code mode host output exceeded N bytes` and `code mode execution timed out while running fallow` are contract strings: the snippet acts on them and the `code_execute` response envelope documents them. Both were built through `with_cleanup_errors`, which appends best-effort process-teardown diagnostics. On macOS, `killpg` returns `EPERM` whenever the leader has already become an unreaped zombie, so the refusal intermittently read:

```
code mode host output exceeded 500 bytes; cleanup errors: failed to terminate subprocess tree: Operation not permitted (os error 1)
```

Terminating the process group is a cleanup concern, not part of the host call's outcome. Folding it into the refusal made a published, agent-facing string depend on how the kernel scheduled the child's exit.

Those two messages now keep their exact wording and the cleanup errors go to `tracing::warn` instead. Operational failures (cannot configure the subprocess tree, cannot reap the child) still carry their cleanup context inline, and structured programmatic errors still gain their `cleanup_errors` field, so nothing is lost from a channel where it belongs. Three unit tests pin the split.

## Correction

#2498 said its `crates/process` change took the flake from 1 failure in 15 runs to 0 in 15. That measurement was invalid: the load generators from the first half leaked and were still running during the second, so the two halves ran under different load. The description of #2498 has been corrected.

Re-measured properly, both variants prebuilt and alternated under one constant load:

| variant | failures |
|---|---|
| before the `crates/process` change | 3 / 20 |
| after it | 2 / 20 |
| after it, plus this change | 0 / 25 |
| its own baseline, this change absent | 1 / 25 |

The `crates/process` change stands on its own merit, asking the kernel at the moment of failure rather than trusting a cached observation, but it does not close the window. The 0/25 here is corroboration, not proof: the proof is that the message can no longer vary by construction, which the unit tests hold.

## Validation

`cargo test --workspace --tests`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `npm run verify:fast`: all clean.
