### PR TITLE
fix(ci): resolve the bot login once instead of reading it per comment

### DIFF
--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -593,6 +593,15 @@ struct ProviderState {
     github_discussions_by_fingerprint: BTreeMap<String, Vec<GithubDiscussion>>,
     github_unattached_resolved_markers: Vec<GithubUnattachedResolvedMarker>,
     gitlab_discussions_by_fingerprint: BTreeMap<String, Vec<GitlabDiscussion>>,
+    /// Posting login that owns Fallow's comments, resolved once at the command
+    /// boundary from `FALLOW_BOT_LOGIN`.
+    ///
+    /// Held here rather than read per comment so ownership cannot depend on
+    /// when in a run the check happens. Reading the process environment from
+    /// inside this logic made two tests fail intermittently: the three tests
+    /// that override the variable serialized against each other, but every
+    /// other test read it unguarded while an override was in effect.
+    bot_login: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -736,7 +745,10 @@ fn load_github_state(
         .unwrap_or("https://api.github.com")
         .trim_end_matches('/');
     let agent = try_api_agent().map_err(|err| err.to_string())?;
-    let mut state = ProviderState::default();
+    let mut state = ProviderState {
+        bot_login: resolved_bot_login(),
+        ..ProviderState::default()
+    };
     let mut review_comments = Vec::new();
 
     for page in 1..=100 {
@@ -794,7 +806,7 @@ fn record_github_review_root(
     provider_position: usize,
 ) -> Result<(), String> {
     let body = comment.get("body").and_then(Value::as_str).unwrap_or("");
-    if is_github_bot_comment(comment)
+    if is_github_bot_comment(comment, state.bot_login.as_deref())
         && let Some(fingerprint) = extract_fallow_fingerprint(body)
     {
         if fallow_output::parse_review_id_marker(body)?.as_ref() != review_id {
@@ -834,7 +846,7 @@ fn record_github_resolution_marker(
     provider_position: usize,
 ) -> Result<(), String> {
     let body = comment.get("body").and_then(Value::as_str).unwrap_or("");
-    if is_github_bot_comment(comment) {
+    if is_github_bot_comment(comment, state.bot_login.as_deref()) {
         let Some(marker) = parse_resolution_marker(body)? else {
             return Ok(());
         };
@@ -1408,7 +1420,10 @@ fn load_gitlab_state(
         .unwrap_or_else(|| "https://gitlab.com/api/v4".to_owned());
     let api = api.trim_end_matches('/').to_owned();
     let agent = try_api_agent().map_err(|err| err.to_string())?;
-    let mut state = ProviderState::default();
+    let mut state = ProviderState {
+        bot_login: resolved_bot_login(),
+        ..ProviderState::default()
+    };
     let mut all_discussions = Vec::new();
 
     for page in 1..=100 {
@@ -1434,11 +1449,12 @@ fn load_gitlab_state(
             );
         }
     }
-    let authenticated_user = if needs_gitlab_authenticated_user(&all_discussions) {
-        Some(load_gitlab_authenticated_user(&agent, &api, &token)?)
-    } else {
-        None
-    };
+    let authenticated_user =
+        if needs_gitlab_authenticated_user(&all_discussions, state.bot_login.as_deref()) {
+            Some(load_gitlab_authenticated_user(&agent, &api, &token)?)
+        } else {
+            None
+        };
     for discussion in &all_discussions {
         collect_gitlab_discussion_fingerprints(
             &mut state,
@@ -1450,11 +1466,8 @@ fn load_gitlab_state(
     Ok(state)
 }
 
-fn needs_gitlab_authenticated_user(discussions: &[Value]) -> bool {
-    if !matches!(
-        std::env::var("FALLOW_BOT_LOGIN"),
-        Err(std::env::VarError::NotPresent)
-    ) {
+fn needs_gitlab_authenticated_user(discussions: &[Value], bot_login: Option<&str>) -> bool {
+    if bot_login.is_some() {
         return false;
     }
     discussions
@@ -1521,7 +1534,7 @@ fn collect_gitlab_discussion_fingerprints(
         .ok_or_else(|| format!("GitLab discussion {discussion_id} did not contain a root note"))?;
     {
         let body = root.get("body").and_then(Value::as_str).unwrap_or("");
-        if is_gitlab_bot_note(root, authenticated_user)
+        if is_gitlab_bot_note(root, authenticated_user, state.bot_login.as_deref())
             && let Some(fingerprint) = extract_fallow_fingerprint(body)
         {
             if fallow_output::parse_review_id_marker(body)?.as_ref() != review_id {
@@ -1550,7 +1563,7 @@ fn collect_gitlab_discussion_fingerprints(
             let mut has_resolution_marker = false;
             for note in notes {
                 let note_body = note.get("body").and_then(Value::as_str).unwrap_or("");
-                if !is_gitlab_bot_note(note, authenticated_user) {
+                if !is_gitlab_bot_note(note, authenticated_user, state.bot_login.as_deref()) {
                     continue;
                 }
                 let Some(marker) = parse_resolution_marker(note_body)? else {
@@ -2156,10 +2169,16 @@ fn read_json_response(
 /// is the compatibility trust boundary. Setting `FALLOW_BOT_LOGIN` narrows
 /// ownership to that exact posting login and also supports PAT-backed human
 /// accounts that lack native bot metadata.
-fn is_github_bot_comment(comment: &Value) -> bool {
+/// The configured posting login, or `None` when the variable is absent or
+/// blank. Resolved once per command so the value cannot change mid-run.
+fn resolved_bot_login() -> Option<String> {
+    std::env::var("FALLOW_BOT_LOGIN").ok()
+}
+
+fn is_github_bot_comment(comment: &Value, bot_login: Option<&str>) -> bool {
     let user = comment.get("user");
     let login = user.and_then(|u| u.get("login")).and_then(Value::as_str);
-    match std::env::var("FALLOW_BOT_LOGIN") {
+    match bot_login.ok_or(std::env::VarError::NotPresent) {
         Ok(allow) => {
             let allow = allow.trim();
             return !allow.is_empty() && login == Some(allow);
@@ -2175,12 +2194,16 @@ fn is_github_bot_comment(comment: &Value) -> bool {
 /// Without an explicit login, GitLab's native bot metadata and the identity
 /// returned for the authenticated token are trusted. Setting
 /// `FALLOW_BOT_LOGIN` narrows ownership to that exact username.
-fn is_gitlab_bot_note(note: &Value, authenticated_user: Option<&GitlabAuthenticatedUser>) -> bool {
+fn is_gitlab_bot_note(
+    note: &Value,
+    authenticated_user: Option<&GitlabAuthenticatedUser>,
+    bot_login: Option<&str>,
+) -> bool {
     let author = note.get("author");
     let username = author
         .and_then(|a| a.get("username"))
         .and_then(Value::as_str);
-    match std::env::var("FALLOW_BOT_LOGIN") {
+    match bot_login.ok_or(std::env::VarError::NotPresent) {
         Ok(allow) => {
             let allow = allow.trim();
             return !allow.is_empty() && username == Some(allow);
@@ -2499,79 +2522,74 @@ mod tests {
 
     #[test]
     fn github_bot_check_accepts_bot_user_type() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "Bot", "login": "github-actions[bot]" },
         });
-        assert!(is_github_bot_comment(&comment));
+        assert!(is_github_bot_comment(&comment, None));
     }
 
     #[test]
     fn github_bot_check_rejects_human_user_type() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "alice" },
             "body": "<!-- fallow-resolved-fingerprint: abc123 -->",
         });
-        assert!(!is_github_bot_comment(&comment));
+        assert!(!is_github_bot_comment(&comment, None));
     }
 
-    // Serializes the FALLOW_BOT_LOGIN env-mutating tests so the GitHub and
-    // GitLab override cases cannot overwrite each other's value when run in
-    // parallel (which raced and failed on Windows CI).
-    static BOT_LOGIN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
+    /// The one place the process environment is still read. Every other test
+    /// passes the resolved value, so nothing else in this module can observe a
+    /// mutation from here.
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
-    )]
-    fn github_bot_check_accepts_explicit_login_override() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let comment = serde_json::json!({
-            "user": { "type": "User", "login": "fallow-bot-account" },
-        });
-        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
+    #[allow(unsafe_code, reason = "the only env-mutating test in this module")]
+    fn resolved_bot_login_reads_the_environment_once() {
+        assert_eq!(resolved_bot_login(), None, "unset by default under test");
+
+        // SAFETY: no other test in this module reads FALLOW_BOT_LOGIN, and the
+        // variable is cleared before returning.
         unsafe {
             std::env::set_var("FALLOW_BOT_LOGIN", "fallow-bot-account");
         }
-        assert!(is_github_bot_comment(&comment));
-        // SAFETY: Restore the process environment after the scoped override.
+        let resolved = resolved_bot_login();
+        // SAFETY: restore the process environment before asserting, so a
+        // failure cannot leak the override into the rest of the run.
         unsafe {
             std::env::remove_var("FALLOW_BOT_LOGIN");
         }
+
+        assert_eq!(resolved.as_deref(), Some("fallow-bot-account"));
+        assert!(is_github_bot_comment(
+            &serde_json::json!({ "user": { "type": "User", "login": "fallow-bot-account" } }),
+            resolved.as_deref()
+        ));
+    }
+
+    #[test]
+    fn github_bot_check_accepts_explicit_login_override() {
+        let comment = serde_json::json!({
+            "user": { "type": "User", "login": "fallow-bot-account" },
+        });
+        assert!(is_github_bot_comment(&comment, Some("fallow-bot-account")));
     }
 
     #[test]
     fn gitlab_bot_check_accepts_system_and_bot_flag() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let system_note = serde_json::json!({ "system": true });
-        assert!(is_gitlab_bot_note(&system_note, None));
+        assert!(is_gitlab_bot_note(&system_note, None, None));
         let bot_author = serde_json::json!({
             "system": false,
             "author": { "bot": true, "username": "project-bot" },
         });
-        assert!(is_gitlab_bot_note(&bot_author, None));
+        assert!(is_gitlab_bot_note(&bot_author, None, None));
     }
 
     #[test]
     fn gitlab_bot_check_rejects_human_author() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let human = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "alice" },
         });
-        assert!(!is_gitlab_bot_note(&human, None));
+        assert!(!is_gitlab_bot_note(&human, None, None));
     }
 
     #[test]
@@ -3428,92 +3446,55 @@ mod tests {
     }
 
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
-    )]
     fn empty_configured_bot_login_trusts_no_native_bot() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
-        unsafe {
-            std::env::set_var("FALLOW_BOT_LOGIN", "   ");
-        }
-        assert!(!is_github_bot_comment(&serde_json::json!({
-            "user": { "type": "Bot", "login": "foreign[bot]" }
-        })));
+        assert!(!is_github_bot_comment(
+            &serde_json::json!({ "user": { "type": "Bot", "login": "foreign[bot]" } }),
+            Some("   ")
+        ));
         assert!(!is_gitlab_bot_note(
             &serde_json::json!({
                 "system": false,
                 "author": { "bot": true, "username": "foreign-bot" }
             }),
-            None
+            None,
+            Some("   ")
         ));
-        // SAFETY: Restore the process environment after the scoped override.
-        unsafe {
-            std::env::remove_var("FALLOW_BOT_LOGIN");
-        }
     }
 
     // --- is_github_bot_comment: missing branch (line 1323-1331) ---
 
     #[test]
     fn github_bot_check_returns_false_when_no_user_field() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({ "body": "no user" });
-        assert!(!is_github_bot_comment(&comment));
+        assert!(!is_github_bot_comment(&comment, None));
     }
 
     #[test]
     fn github_bot_check_returns_false_when_fallow_bot_login_not_set_and_type_not_bot() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "someperson" },
         });
-        assert!(!is_github_bot_comment(&comment));
+        assert!(!is_github_bot_comment(&comment, None));
     }
 
     // --- is_gitlab_bot_note: FALLOW_BOT_LOGIN path (lines 1356-1364) ---
 
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
-    )]
     fn gitlab_bot_check_accepts_explicit_login_override() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let note = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "fallow-gl-bot" },
         });
-        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
-        unsafe {
-            std::env::set_var("FALLOW_BOT_LOGIN", "fallow-gl-bot");
-        }
-        assert!(is_gitlab_bot_note(&note, None));
-        // SAFETY: Restore the process environment after the scoped override.
-        unsafe {
-            std::env::remove_var("FALLOW_BOT_LOGIN");
-        }
+        assert!(is_gitlab_bot_note(&note, None, Some("fallow-gl-bot")));
     }
 
     #[test]
     fn gitlab_bot_check_returns_false_when_bot_flag_is_false_and_no_login_override() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let note = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "contributor" },
         });
-        assert!(!is_gitlab_bot_note(&note, None));
+        assert!(!is_gitlab_bot_note(&note, None, None));
     }
 
     // --- read_json_response: non-2xx path (lines 1288-1303) ---

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -593,15 +593,15 @@ struct ProviderState {
     github_discussions_by_fingerprint: BTreeMap<String, Vec<GithubDiscussion>>,
     github_unattached_resolved_markers: Vec<GithubUnattachedResolvedMarker>,
     gitlab_discussions_by_fingerprint: BTreeMap<String, Vec<GitlabDiscussion>>,
-    /// Posting login that owns Fallow's comments, resolved once at the command
-    /// boundary from `FALLOW_BOT_LOGIN`.
+    /// How the posting login that owns Fallow's comments was configured,
+    /// resolved once at the command boundary from `FALLOW_BOT_LOGIN`.
     ///
     /// Held here rather than read per comment so ownership cannot depend on
     /// when in a run the check happens. Reading the process environment from
     /// inside this logic made two tests fail intermittently: the three tests
     /// that override the variable serialized against each other, but every
     /// other test read it unguarded while an override was in effect.
-    bot_login: Option<String>,
+    bot_login: BotLogin,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -806,7 +806,7 @@ fn record_github_review_root(
     provider_position: usize,
 ) -> Result<(), String> {
     let body = comment.get("body").and_then(Value::as_str).unwrap_or("");
-    if is_github_bot_comment(comment, state.bot_login.as_deref())
+    if is_github_bot_comment(comment, &state.bot_login)
         && let Some(fingerprint) = extract_fallow_fingerprint(body)
     {
         if fallow_output::parse_review_id_marker(body)?.as_ref() != review_id {
@@ -846,7 +846,7 @@ fn record_github_resolution_marker(
     provider_position: usize,
 ) -> Result<(), String> {
     let body = comment.get("body").and_then(Value::as_str).unwrap_or("");
-    if is_github_bot_comment(comment, state.bot_login.as_deref()) {
+    if is_github_bot_comment(comment, &state.bot_login) {
         let Some(marker) = parse_resolution_marker(body)? else {
             return Ok(());
         };
@@ -1449,12 +1449,12 @@ fn load_gitlab_state(
             );
         }
     }
-    let authenticated_user =
-        if needs_gitlab_authenticated_user(&all_discussions, state.bot_login.as_deref()) {
-            Some(load_gitlab_authenticated_user(&agent, &api, &token)?)
-        } else {
-            None
-        };
+    let authenticated_user = if needs_gitlab_authenticated_user(&all_discussions, &state.bot_login)
+    {
+        Some(load_gitlab_authenticated_user(&agent, &api, &token)?)
+    } else {
+        None
+    };
     for discussion in &all_discussions {
         collect_gitlab_discussion_fingerprints(
             &mut state,
@@ -1466,8 +1466,8 @@ fn load_gitlab_state(
     Ok(state)
 }
 
-fn needs_gitlab_authenticated_user(discussions: &[Value], bot_login: Option<&str>) -> bool {
-    if bot_login.is_some() {
+fn needs_gitlab_authenticated_user(discussions: &[Value], bot_login: &BotLogin) -> bool {
+    if !matches!(bot_login, BotLogin::Unset) {
         return false;
     }
     discussions
@@ -1534,7 +1534,7 @@ fn collect_gitlab_discussion_fingerprints(
         .ok_or_else(|| format!("GitLab discussion {discussion_id} did not contain a root note"))?;
     {
         let body = root.get("body").and_then(Value::as_str).unwrap_or("");
-        if is_gitlab_bot_note(root, authenticated_user, state.bot_login.as_deref())
+        if is_gitlab_bot_note(root, authenticated_user, &state.bot_login)
             && let Some(fingerprint) = extract_fallow_fingerprint(body)
         {
             if fallow_output::parse_review_id_marker(body)?.as_ref() != review_id {
@@ -1563,7 +1563,7 @@ fn collect_gitlab_discussion_fingerprints(
             let mut has_resolution_marker = false;
             for note in notes {
                 let note_body = note.get("body").and_then(Value::as_str).unwrap_or("");
-                if !is_gitlab_bot_note(note, authenticated_user, state.bot_login.as_deref()) {
+                if !is_gitlab_bot_note(note, authenticated_user, &state.bot_login) {
                     continue;
                 }
                 let Some(marker) = parse_resolution_marker(note_body)? else {
@@ -2169,22 +2169,44 @@ fn read_json_response(
 /// is the compatibility trust boundary. Setting `FALLOW_BOT_LOGIN` narrows
 /// ownership to that exact posting login and also supports PAT-backed human
 /// accounts that lack native bot metadata.
-/// The configured posting login, or `None` when the variable is absent or
-/// blank. Resolved once per command so the value cannot change mid-run.
-fn resolved_bot_login() -> Option<String> {
-    std::env::var("FALLOW_BOT_LOGIN").ok()
+/// How `FALLOW_BOT_LOGIN` was configured, resolved once per command so the
+/// value cannot change mid-run.
+///
+/// The unreadable case is kept distinct from the unset one on purpose: a
+/// variable that is set but not valid unicode is a misconfiguration, and
+/// treating it as unset would silently fall back to trusting any comment
+/// carrying native bot metadata.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum BotLogin {
+    /// The variable is absent. Native provider bot metadata is the trust
+    /// boundary.
+    #[default]
+    Unset,
+    /// The variable holds a value. A blank value trusts nobody, which is how
+    /// an operator turns native-metadata trust off.
+    Configured(String),
+    /// The variable is set but not valid unicode. Trust nobody.
+    Unreadable,
 }
 
-fn is_github_bot_comment(comment: &Value, bot_login: Option<&str>) -> bool {
+fn resolved_bot_login() -> BotLogin {
+    match std::env::var("FALLOW_BOT_LOGIN") {
+        Ok(value) => BotLogin::Configured(value),
+        Err(std::env::VarError::NotPresent) => BotLogin::Unset,
+        Err(std::env::VarError::NotUnicode(_)) => BotLogin::Unreadable,
+    }
+}
+
+fn is_github_bot_comment(comment: &Value, bot_login: &BotLogin) -> bool {
     let user = comment.get("user");
     let login = user.and_then(|u| u.get("login")).and_then(Value::as_str);
-    match bot_login.ok_or(std::env::VarError::NotPresent) {
-        Ok(allow) => {
+    match bot_login {
+        BotLogin::Unreadable => return false,
+        BotLogin::Configured(allow) => {
             let allow = allow.trim();
             return !allow.is_empty() && login == Some(allow);
         }
-        Err(std::env::VarError::NotUnicode(_)) => return false,
-        Err(std::env::VarError::NotPresent) => {}
+        BotLogin::Unset => {}
     }
     user.and_then(|u| u.get("type")).and_then(Value::as_str) == Some("Bot")
 }
@@ -2197,19 +2219,19 @@ fn is_github_bot_comment(comment: &Value, bot_login: Option<&str>) -> bool {
 fn is_gitlab_bot_note(
     note: &Value,
     authenticated_user: Option<&GitlabAuthenticatedUser>,
-    bot_login: Option<&str>,
+    bot_login: &BotLogin,
 ) -> bool {
     let author = note.get("author");
     let username = author
         .and_then(|a| a.get("username"))
         .and_then(Value::as_str);
-    match bot_login.ok_or(std::env::VarError::NotPresent) {
-        Ok(allow) => {
+    match bot_login {
+        BotLogin::Unreadable => return false,
+        BotLogin::Configured(allow) => {
             let allow = allow.trim();
             return !allow.is_empty() && username == Some(allow);
         }
-        Err(std::env::VarError::NotUnicode(_)) => return false,
-        Err(std::env::VarError::NotPresent) => {}
+        BotLogin::Unset => {}
     }
     if gitlab_note_has_native_bot_metadata(note) {
         return true;
@@ -2525,7 +2547,7 @@ mod tests {
         let comment = serde_json::json!({
             "user": { "type": "Bot", "login": "github-actions[bot]" },
         });
-        assert!(is_github_bot_comment(&comment, None));
+        assert!(is_github_bot_comment(&comment, &BotLogin::Unset));
     }
 
     #[test]
@@ -2534,7 +2556,7 @@ mod tests {
             "user": { "type": "User", "login": "alice" },
             "body": "<!-- fallow-resolved-fingerprint: abc123 -->",
         });
-        assert!(!is_github_bot_comment(&comment, None));
+        assert!(!is_github_bot_comment(&comment, &BotLogin::Unset));
     }
 
     /// The one place the process environment is still read. Every other test
@@ -2543,7 +2565,11 @@ mod tests {
     #[test]
     #[allow(unsafe_code, reason = "the only env-mutating test in this module")]
     fn resolved_bot_login_reads_the_environment_once() {
-        assert_eq!(resolved_bot_login(), None, "unset by default under test");
+        assert_eq!(
+            resolved_bot_login(),
+            BotLogin::Unset,
+            "unset by default under test"
+        );
 
         // SAFETY: no other test in this module reads FALLOW_BOT_LOGIN, and the
         // variable is cleared before returning.
@@ -2557,10 +2583,29 @@ mod tests {
             std::env::remove_var("FALLOW_BOT_LOGIN");
         }
 
-        assert_eq!(resolved.as_deref(), Some("fallow-bot-account"));
+        assert_eq!(
+            resolved,
+            BotLogin::Configured("fallow-bot-account".to_string())
+        );
         assert!(is_github_bot_comment(
             &serde_json::json!({ "user": { "type": "User", "login": "fallow-bot-account" } }),
-            resolved.as_deref()
+            &resolved
+        ));
+    }
+
+    #[test]
+    fn an_unreadable_login_trusts_nobody() {
+        // Distinct from unset on purpose: a variable that is set but not valid
+        // unicode is a misconfiguration, and treating it as unset would fall
+        // back to trusting any comment carrying native bot metadata.
+        assert!(!is_github_bot_comment(
+            &serde_json::json!({ "user": { "type": "Bot", "login": "foreign[bot]" } }),
+            &BotLogin::Unreadable
+        ));
+        assert!(!is_gitlab_bot_note(
+            &serde_json::json!({ "system": true }),
+            None,
+            &BotLogin::Unreadable
         ));
     }
 
@@ -2569,18 +2614,21 @@ mod tests {
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "fallow-bot-account" },
         });
-        assert!(is_github_bot_comment(&comment, Some("fallow-bot-account")));
+        assert!(is_github_bot_comment(
+            &comment,
+            &BotLogin::Configured("fallow-bot-account".to_string())
+        ));
     }
 
     #[test]
     fn gitlab_bot_check_accepts_system_and_bot_flag() {
         let system_note = serde_json::json!({ "system": true });
-        assert!(is_gitlab_bot_note(&system_note, None, None));
+        assert!(is_gitlab_bot_note(&system_note, None, &BotLogin::Unset));
         let bot_author = serde_json::json!({
             "system": false,
             "author": { "bot": true, "username": "project-bot" },
         });
-        assert!(is_gitlab_bot_note(&bot_author, None, None));
+        assert!(is_gitlab_bot_note(&bot_author, None, &BotLogin::Unset));
     }
 
     #[test]
@@ -2589,7 +2637,7 @@ mod tests {
             "system": false,
             "author": { "bot": false, "username": "alice" },
         });
-        assert!(!is_gitlab_bot_note(&human, None, None));
+        assert!(!is_gitlab_bot_note(&human, None, &BotLogin::Unset));
     }
 
     #[test]
@@ -3449,7 +3497,7 @@ mod tests {
     fn empty_configured_bot_login_trusts_no_native_bot() {
         assert!(!is_github_bot_comment(
             &serde_json::json!({ "user": { "type": "Bot", "login": "foreign[bot]" } }),
-            Some("   ")
+            &BotLogin::Configured("   ".to_string())
         ));
         assert!(!is_gitlab_bot_note(
             &serde_json::json!({
@@ -3457,7 +3505,7 @@ mod tests {
                 "author": { "bot": true, "username": "foreign-bot" }
             }),
             None,
-            Some("   ")
+            &BotLogin::Configured("   ".to_string())
         ));
     }
 
@@ -3466,7 +3514,7 @@ mod tests {
     #[test]
     fn github_bot_check_returns_false_when_no_user_field() {
         let comment = serde_json::json!({ "body": "no user" });
-        assert!(!is_github_bot_comment(&comment, None));
+        assert!(!is_github_bot_comment(&comment, &BotLogin::Unset));
     }
 
     #[test]
@@ -3474,7 +3522,7 @@ mod tests {
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "someperson" },
         });
-        assert!(!is_github_bot_comment(&comment, None));
+        assert!(!is_github_bot_comment(&comment, &BotLogin::Unset));
     }
 
     // --- is_gitlab_bot_note: FALLOW_BOT_LOGIN path (lines 1356-1364) ---
@@ -3485,7 +3533,11 @@ mod tests {
             "system": false,
             "author": { "bot": false, "username": "fallow-gl-bot" },
         });
-        assert!(is_gitlab_bot_note(&note, None, Some("fallow-gl-bot")));
+        assert!(is_gitlab_bot_note(
+            &note,
+            None,
+            &BotLogin::Configured("fallow-gl-bot".to_string())
+        ));
     }
 
     #[test]
@@ -3494,7 +3546,7 @@ mod tests {
             "system": false,
             "author": { "bot": false, "username": "contributor" },
         });
-        assert!(!is_gitlab_bot_note(&note, None, None));
+        assert!(!is_gitlab_bot_note(&note, None, &BotLogin::Unset));
     }
 
     // --- read_json_response: non-2xx path (lines 1288-1303) ---


### PR DESCRIPTION
## Problem

Two tests failed intermittently under the full suite and passed every time in isolation:

- `ci::tests::gitlab_identical_fingerprints_and_resolution_replies_are_scoped`
- `ci::tests::github_explicit_marker_for_unowned_root_is_not_reassigned`

`is_github_bot_comment` and `is_gitlab_bot_note` read `FALLOW_BOT_LOGIN` on every call, deep inside otherwise pure logic. `BOT_LOGIN_ENV_LOCK` existed, but it serialized only the three tests that *set* the variable against each other. The twenty-two tests that read it indirectly took no lock, so they could observe an override a concurrent test had in effect.

Both failing tests assert on a bot comment carrying no login, which is exactly the case that flips once an explicit login is configured.

## Approach

Resolve the login once at the command boundary and carry it on `ProviderState`, so ownership cannot depend on when in a run the check happens. The two ownership predicates take it as a parameter.

The override cases pass the value directly instead of mutating the environment. `BOT_LOGIN_ENV_LOCK` is gone, and five of the six `unsafe` env mutations with it; the sixth pair remains in the one test below. Nothing else in the module reads the variable, so there is nothing left for that test to race against.

One test still reads the environment. Moving the overrides to parameters would otherwise have left nothing covering that the variable is read at all, which is a real behavior a user depends on. It is the only such test, and it restores the variable before asserting so a failure cannot leak the override into the rest of the run.

## Follow-up found in review

Resolving the variable with `.ok()` collapsed the not-unicode case into the unset one, which made the two arms handling it dead code and turned a fail-closed case fail-open: a variable that is set but not valid unicode is a misconfiguration, and treating it as unset falls back to trusting any comment carrying native provider bot metadata. The three states are now a type, and a test covers the unreadable case on both providers.

## Validation

- Twenty consecutive runs of the `ci` module, then three consecutive full `fallow-cli` lib runs: no failures
- Full workspace suite green
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- The structural argument matters more than the loop: exactly one test touches the variable and nothing else reads it, so there is nothing left to race on

Closes #2508

