### PR TITLE
fix(cli): stop mutating the process environment from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schema, the `fallow://tools` resource, and `capabilities.json`, so an agent
   reads reachability from data instead of parsing a tool description.
 
+- **An intermittent CI failure in Fallow's own test suite is fixed.** The MCP
+  test binary links its unit tests and its end-to-end tests together, so they run
+  as threads in one process sharing one environment. One unit test set and then
+  removed `FALLOW_BIN`, the variable the end-to-end tests read to locate the
+  binary they spawn, and the coverage workflow sets exactly that variable for the
+  whole workspace run. Every environment read in `crates/cli` and `crates/mcp`
+  now happens once in a thin wrapper, with the value passed to the function under
+  test, so no test mutates state another test is reading. A guard test walks the
+  workspace and fails on a new mutation, naming the file and the pattern to use
+  instead, because serializing such tests hides the race rather than removing it.
+
 ### Security
 
 - **The Code Mode sandbox no longer leaves the `Function` constructor

--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -107,8 +107,13 @@ impl fmt::Display for ApiClientError {
 impl std::error::Error for ApiClientError {}
 
 fn tls_config_from_env() -> Result<Option<TlsConfig>, ApiClientError> {
-    let Some(path) = std::env::var(CA_BUNDLE_ENV)
-        .ok()
+    tls_config_from_path(std::env::var(CA_BUNDLE_ENV).ok().as_deref())
+}
+
+/// [`tls_config_from_env`] over an injected value, so bundle parsing and its
+/// error reporting are testable without mutating the process environment.
+fn tls_config_from_path(raw: Option<&str>) -> Result<Option<TlsConfig>, ApiClientError> {
+    let Some(path) = raw
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
     else {
@@ -143,10 +148,15 @@ fn tls_config_from_env() -> Result<Option<TlsConfig>, ApiClientError> {
 /// Honors `FALLOW_API_URL` for staging/local development. Trailing slashes on
 /// the base are trimmed so `/v1/...` paths never double-slash.
 pub fn api_url(path: &str) -> String {
-    let base = std::env::var("FALLOW_API_URL")
-        .ok()
+    api_url_with_base(std::env::var("FALLOW_API_URL").ok().as_deref(), path)
+}
+
+/// [`api_url`] over an injected base, so the override and default precedence is
+/// testable without mutating the process environment.
+fn api_url_with_base(base: Option<&str>, path: &str) -> String {
+    let base = base
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| DEFAULT_API_URL.to_owned());
+        .unwrap_or(DEFAULT_API_URL);
     format!("{}{path}", base.trim_end_matches('/'))
 }
 
@@ -610,27 +620,12 @@ mod tests {
     }
 
     #[test]
-    #[expect(unsafe_code, reason = "env var mutation requires unsafe")]
     fn ca_bundle_read_errors_are_reported_as_client_setup_errors() {
-        let prior = std::env::var(CA_BUNDLE_ENV).ok();
-        // SAFETY: This test owns the CA_BUNDLE_ENV mutation and restores the
-        // previous value before returning.
-        unsafe {
-            std::env::set_var(CA_BUNDLE_ENV, "/definitely/missing/fallow-ca.pem");
-        }
-        let err = try_api_agent().expect_err("missing bundle should fail");
+        let err = tls_config_from_path(Some("/definitely/missing/fallow-ca.pem"))
+            .expect_err("missing bundle should fail");
         let message = err.to_string();
         assert!(message.contains(CA_BUNDLE_ENV));
         assert!(message.contains("failed to read PEM bundle"));
-        // SAFETY: Restore the process environment to the value captured before
-        // the test mutation.
-        unsafe {
-            if let Some(value) = prior {
-                std::env::set_var(CA_BUNDLE_ENV, value);
-            } else {
-                std::env::remove_var(CA_BUNDLE_ENV);
-            }
-        }
     }
 
     #[test]
@@ -819,37 +814,18 @@ mod tests {
     }
 
     #[test]
-    #[expect(unsafe_code, reason = "env var mutation requires unsafe")]
     fn api_url_respects_env_override_and_default() {
-        let prior = std::env::var("FALLOW_API_URL").ok();
-
-        // SAFETY: This test owns the FALLOW_API_URL mutation while validating
-        // default URL behavior.
-        unsafe {
-            std::env::remove_var("FALLOW_API_URL");
-        }
         assert_eq!(
-            api_url("/v1/coverage/repo/inventory"),
+            api_url_with_base(None, "/v1/coverage/repo/inventory"),
             "https://api.fallow.cloud/v1/coverage/repo/inventory",
         );
-
-        // SAFETY: Set a scoped override for this test case only.
-        unsafe {
-            std::env::set_var("FALLOW_API_URL", "http://127.0.0.1:3000/");
-        }
         assert_eq!(
-            api_url("/v1/coverage/a/inventory"),
+            api_url_with_base(Some("   "), "/v1/coverage/repo/inventory"),
+            "https://api.fallow.cloud/v1/coverage/repo/inventory",
+        );
+        assert_eq!(
+            api_url_with_base(Some("http://127.0.0.1:3000/"), "/v1/coverage/a/inventory"),
             "http://127.0.0.1:3000/v1/coverage/a/inventory",
         );
-
-        // SAFETY: Restore the process environment to the value captured before
-        // the test mutation.
-        unsafe {
-            if let Some(value) = prior {
-                std::env::set_var("FALLOW_API_URL", value);
-            } else {
-                std::env::remove_var("FALLOW_API_URL");
-            }
-        }
     }
 }

--- a/crates/cli/src/architecture_boundaries.rs
+++ b/crates/cli/src/architecture_boundaries.rs
@@ -2215,6 +2215,70 @@ fn diagnostics_outputs_use_stage_owned_lists_after_the_session_fold() {
     }
 }
 
+/// No crate may mutate the process environment, in production or in tests.
+///
+/// `set_var` and `remove_var` are process-global and unsound while any other
+/// thread reads the environment. Cargo's harness runs a crate's tests as
+/// parallel threads in one binary, so a test that sets a variable races every
+/// reader in that binary, including the ones spawning real subprocesses from a
+/// resolved path.
+///
+/// Read an environment variable on a single line in a thin outer function and
+/// move every branch into an inner function that takes the value as an
+/// argument, then point the test at the inner function. `resolve_typed_coverage_inputs`
+/// in `crates/mcp/src/tools/api_runtime.rs` is the reference shape. Passing a
+/// value to a child process with `Command::env` is unaffected and stays the
+/// way to cover a production read end to end.
+#[test]
+fn workspace_sources_never_mutate_the_process_environment() {
+    let allowed = ["crates/cli/src/architecture_boundaries.rs"];
+    let crates_dir = workspace_root().join("crates");
+    let mut sources = Vec::new();
+    for entry in std::fs::read_dir(&crates_dir).expect("read crates directory") {
+        let entry = entry.expect("read crates directory entry");
+        let crate_dir = entry.path();
+        if !crate_dir.is_dir() {
+            continue;
+        }
+        let crate_name = entry.file_name();
+        let crate_name = crate_name.to_string_lossy();
+        for subdirectory in ["src", "tests"] {
+            let root = crate_dir.join(subdirectory);
+            if !root.is_dir() {
+                continue;
+            }
+            collect_rust_sources(
+                &root,
+                &format!("crates/{crate_name}/{subdirectory}"),
+                &mut sources,
+            );
+        }
+    }
+    sources.sort();
+    assert!(
+        !sources.is_empty(),
+        "environment mutation guard walked no sources"
+    );
+
+    for source_path in sources {
+        if allowed.contains(&source_path.as_str()) {
+            continue;
+        }
+        let source = read_source_without_line_comments(&source_path)
+            .unwrap_or_else(|error| panic!("read {source_path}: {error}"));
+        for forbidden in ["env::set_var", "env::remove_var"] {
+            assert!(
+                !source.contains(forbidden),
+                "{source_path} must not call {forbidden}: process-global environment mutation is \
+                 unsound under the parallel test harness. Read the variable on one line in a thin \
+                 outer function and take the value as an argument in the inner function the test \
+                 drives, as resolve_typed_coverage_inputs does in \
+                 crates/mcp/src/tools/api_runtime.rs"
+            );
+        }
+    }
+}
+
 fn read_source_without_line_comments(path: &str) -> std::io::Result<String> {
     let source = std::fs::read_to_string(workspace_root().join(path))?;
     Ok(source

--- a/crates/cli/src/architecture_boundaries.rs
+++ b/crates/cli/src/architecture_boundaries.rs
@@ -2266,14 +2266,20 @@ fn workspace_sources_never_mutate_the_process_environment() {
         }
         let source = read_source_without_line_comments(&source_path)
             .unwrap_or_else(|error| panic!("read {source_path}: {error}"));
-        for forbidden in ["env::set_var", "env::remove_var"] {
+        // Both the path form and the call form. The path alone misses
+        // `use std::env::*` and `use std::env::{self, set_var}`, which put the
+        // call in scope without ever writing `env::set_var`. The call form alone
+        // would miss a re-exported alias. The bare identifier is not usable as a
+        // needle: `reset_variants` in crates/core/src/plugins/sveltekit.rs
+        // contains it.
+        for forbidden in ["env::set_var", "env::remove_var", "set_var(", "remove_var("] {
             assert!(
                 !source.contains(forbidden),
-                "{source_path} must not call {forbidden}: process-global environment mutation is \
-                 unsound under the parallel test harness. Read the variable on one line in a thin \
-                 outer function and take the value as an argument in the inner function the test \
-                 drives, as resolve_typed_coverage_inputs does in \
-                 crates/mcp/src/tools/api_runtime.rs"
+                "{source_path} mutates the process environment (matched {forbidden:?}), which is \
+                 unsound under the parallel test harness: the whole workspace shares one \
+                 environment across test threads. Read the variable on one line in a thin outer \
+                 function and take the value as an argument in the inner function the test drives, \
+                 as resolve_typed_coverage_inputs does in crates/mcp/src/tools/api_runtime.rs"
             );
         }
     }

--- a/crates/cli/src/ci.rs
+++ b/crates/cli/src/ci.rs
@@ -721,6 +721,8 @@ fn load_github_state(
     target: Option<&str>,
     opts: ReconcileOptions<'_>,
 ) -> Result<ProviderState, String> {
+    let bot_login_var = std::env::var("FALLOW_BOT_LOGIN");
+    let bot_login = BotLogin::from_var(&bot_login_var);
     let pr = require_target("GitHub pull request", target)?;
     let repo = opts
         .repo
@@ -766,10 +768,10 @@ fn load_github_state(
     // after every page is loaded so their markers can be tied to a root even
     // if provider ordering or pagination places the reply first.
     for (position, comment) in review_comments.iter().enumerate() {
-        record_github_review_root(&mut state, comment, opts.review_id, position)?;
+        record_github_review_root(&mut state, comment, opts.review_id, position, bot_login)?;
     }
     for (position, comment) in review_comments.iter().enumerate() {
-        record_github_resolution_marker(&mut state, comment, opts.review_id, position)?;
+        record_github_resolution_marker(&mut state, comment, opts.review_id, position, bot_login)?;
     }
 
     load_github_review_threads(
@@ -792,9 +794,10 @@ fn record_github_review_root(
     comment: &Value,
     review_id: Option<&ReviewId>,
     provider_position: usize,
+    bot_login: BotLogin<'_>,
 ) -> Result<(), String> {
     let body = comment.get("body").and_then(Value::as_str).unwrap_or("");
-    if is_github_bot_comment(comment)
+    if is_github_bot_comment(comment, bot_login)
         && let Some(fingerprint) = extract_fallow_fingerprint(body)
     {
         if fallow_output::parse_review_id_marker(body)?.as_ref() != review_id {
@@ -832,9 +835,10 @@ fn record_github_resolution_marker(
     comment: &Value,
     review_id: Option<&ReviewId>,
     provider_position: usize,
+    bot_login: BotLogin<'_>,
 ) -> Result<(), String> {
     let body = comment.get("body").and_then(Value::as_str).unwrap_or("");
-    if is_github_bot_comment(comment) {
+    if is_github_bot_comment(comment, bot_login) {
         let Some(marker) = parse_resolution_marker(body)? else {
             return Ok(());
         };
@@ -1393,6 +1397,8 @@ fn load_gitlab_state(
     target: Option<&str>,
     opts: ReconcileOptions<'_>,
 ) -> Result<ProviderState, String> {
+    let bot_login_var = std::env::var("FALLOW_BOT_LOGIN");
+    let bot_login = BotLogin::from_var(&bot_login_var);
     let mr = require_target("GitLab merge request", target)?;
     let project_id = opts
         .project_id
@@ -1434,7 +1440,7 @@ fn load_gitlab_state(
             );
         }
     }
-    let authenticated_user = if needs_gitlab_authenticated_user(&all_discussions) {
+    let authenticated_user = if needs_gitlab_authenticated_user(&all_discussions, bot_login) {
         Some(load_gitlab_authenticated_user(&agent, &api, &token)?)
     } else {
         None
@@ -1445,16 +1451,14 @@ fn load_gitlab_state(
             discussion,
             opts.review_id,
             authenticated_user.as_ref(),
+            bot_login,
         )?;
     }
     Ok(state)
 }
 
-fn needs_gitlab_authenticated_user(discussions: &[Value]) -> bool {
-    if !matches!(
-        std::env::var("FALLOW_BOT_LOGIN"),
-        Err(std::env::VarError::NotPresent)
-    ) {
+fn needs_gitlab_authenticated_user(discussions: &[Value], bot_login: BotLogin<'_>) -> bool {
+    if !matches!(bot_login, BotLogin::Unset) {
         return false;
     }
     discussions
@@ -1504,6 +1508,7 @@ fn collect_gitlab_discussion_fingerprints(
     discussion: &Value,
     review_id: Option<&ReviewId>,
     authenticated_user: Option<&GitlabAuthenticatedUser>,
+    bot_login: BotLogin<'_>,
 ) -> Result<(), String> {
     let discussion_id = discussion
         .get("id")
@@ -1521,7 +1526,7 @@ fn collect_gitlab_discussion_fingerprints(
         .ok_or_else(|| format!("GitLab discussion {discussion_id} did not contain a root note"))?;
     {
         let body = root.get("body").and_then(Value::as_str).unwrap_or("");
-        if is_gitlab_bot_note(root, authenticated_user)
+        if is_gitlab_bot_note(root, authenticated_user, bot_login)
             && let Some(fingerprint) = extract_fallow_fingerprint(body)
         {
             if fallow_output::parse_review_id_marker(body)?.as_ref() != review_id {
@@ -1550,7 +1555,7 @@ fn collect_gitlab_discussion_fingerprints(
             let mut has_resolution_marker = false;
             for note in notes {
                 let note_body = note.get("body").and_then(Value::as_str).unwrap_or("");
-                if !is_gitlab_bot_note(note, authenticated_user) {
+                if !is_gitlab_bot_note(note, authenticated_user, bot_login) {
                     continue;
                 }
                 let Some(marker) = parse_resolution_marker(note_body)? else {
@@ -2145,6 +2150,30 @@ fn read_json_response(
         .map_err(|e| format!("{provider} response was not valid JSON: {e}"))
 }
 
+/// Resolved `FALLOW_BOT_LOGIN` state, read once per provider load and threaded
+/// down to the ownership checks.
+///
+/// The three cases are behaviorally distinct and cannot collapse into an
+/// `Option`: an unset variable falls back to native bot metadata, a
+/// non-unicode value trusts nothing, and a set value narrows ownership to that
+/// exact login (an empty or whitespace-only one trusting nothing).
+#[derive(Clone, Copy)]
+enum BotLogin<'a> {
+    Unset,
+    NonUnicode,
+    Configured(&'a str),
+}
+
+impl<'a> BotLogin<'a> {
+    fn from_var(var: &'a Result<String, std::env::VarError>) -> Self {
+        match var {
+            Ok(value) => Self::Configured(value),
+            Err(std::env::VarError::NotUnicode(_)) => Self::NonUnicode,
+            Err(std::env::VarError::NotPresent) => Self::Unset,
+        }
+    }
+}
+
 /// Determine whether a GitHub PR review comment was authored by a bot account.
 ///
 /// We trust resolved-fingerprint markers only from bot identities so a human
@@ -2156,16 +2185,16 @@ fn read_json_response(
 /// is the compatibility trust boundary. Setting `FALLOW_BOT_LOGIN` narrows
 /// ownership to that exact posting login and also supports PAT-backed human
 /// accounts that lack native bot metadata.
-fn is_github_bot_comment(comment: &Value) -> bool {
+fn is_github_bot_comment(comment: &Value, bot_login: BotLogin<'_>) -> bool {
     let user = comment.get("user");
     let login = user.and_then(|u| u.get("login")).and_then(Value::as_str);
-    match std::env::var("FALLOW_BOT_LOGIN") {
-        Ok(allow) => {
+    match bot_login {
+        BotLogin::Configured(allow) => {
             let allow = allow.trim();
             return !allow.is_empty() && login == Some(allow);
         }
-        Err(std::env::VarError::NotUnicode(_)) => return false,
-        Err(std::env::VarError::NotPresent) => {}
+        BotLogin::NonUnicode => return false,
+        BotLogin::Unset => {}
     }
     user.and_then(|u| u.get("type")).and_then(Value::as_str) == Some("Bot")
 }
@@ -2175,18 +2204,22 @@ fn is_github_bot_comment(comment: &Value) -> bool {
 /// Without an explicit login, GitLab's native bot metadata and the identity
 /// returned for the authenticated token are trusted. Setting
 /// `FALLOW_BOT_LOGIN` narrows ownership to that exact username.
-fn is_gitlab_bot_note(note: &Value, authenticated_user: Option<&GitlabAuthenticatedUser>) -> bool {
+fn is_gitlab_bot_note(
+    note: &Value,
+    authenticated_user: Option<&GitlabAuthenticatedUser>,
+    bot_login: BotLogin<'_>,
+) -> bool {
     let author = note.get("author");
     let username = author
         .and_then(|a| a.get("username"))
         .and_then(Value::as_str);
-    match std::env::var("FALLOW_BOT_LOGIN") {
-        Ok(allow) => {
+    match bot_login {
+        BotLogin::Configured(allow) => {
             let allow = allow.trim();
             return !allow.is_empty() && username == Some(allow);
         }
-        Err(std::env::VarError::NotUnicode(_)) => return false,
-        Err(std::env::VarError::NotPresent) => {}
+        BotLogin::NonUnicode => return false,
+        BotLogin::Unset => {}
     }
     if gitlab_note_has_native_bot_metadata(note) {
         return true;
@@ -2499,79 +2532,50 @@ mod tests {
 
     #[test]
     fn github_bot_check_accepts_bot_user_type() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "Bot", "login": "github-actions[bot]" },
         });
-        assert!(is_github_bot_comment(&comment));
+        assert!(is_github_bot_comment(&comment, BotLogin::Unset));
     }
 
     #[test]
     fn github_bot_check_rejects_human_user_type() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "alice" },
             "body": "<!-- fallow-resolved-fingerprint: abc123 -->",
         });
-        assert!(!is_github_bot_comment(&comment));
+        assert!(!is_github_bot_comment(&comment, BotLogin::Unset));
     }
 
-    // Serializes the FALLOW_BOT_LOGIN env-mutating tests so the GitHub and
-    // GitLab override cases cannot overwrite each other's value when run in
-    // parallel (which raced and failed on Windows CI).
-    static BOT_LOGIN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
-    )]
     fn github_bot_check_accepts_explicit_login_override() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "fallow-bot-account" },
         });
-        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
-        unsafe {
-            std::env::set_var("FALLOW_BOT_LOGIN", "fallow-bot-account");
-        }
-        assert!(is_github_bot_comment(&comment));
-        // SAFETY: Restore the process environment after the scoped override.
-        unsafe {
-            std::env::remove_var("FALLOW_BOT_LOGIN");
-        }
+        assert!(is_github_bot_comment(
+            &comment,
+            BotLogin::Configured("fallow-bot-account")
+        ));
     }
 
     #[test]
     fn gitlab_bot_check_accepts_system_and_bot_flag() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let system_note = serde_json::json!({ "system": true });
-        assert!(is_gitlab_bot_note(&system_note, None));
+        assert!(is_gitlab_bot_note(&system_note, None, BotLogin::Unset));
         let bot_author = serde_json::json!({
             "system": false,
             "author": { "bot": true, "username": "project-bot" },
         });
-        assert!(is_gitlab_bot_note(&bot_author, None));
+        assert!(is_gitlab_bot_note(&bot_author, None, BotLogin::Unset));
     }
 
     #[test]
     fn gitlab_bot_check_rejects_human_author() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let human = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "alice" },
         });
-        assert!(!is_gitlab_bot_note(&human, None));
+        assert!(!is_gitlab_bot_note(&human, None, BotLogin::Unset));
     }
 
     #[test]
@@ -2920,6 +2924,7 @@ mod tests {
             }),
             None,
             0,
+            BotLogin::Unset,
         )
         .unwrap();
         collect_github_thread_fingerprints(&mut state, &thread, None).unwrap();
@@ -2963,6 +2968,7 @@ mod tests {
             }),
             None,
             0,
+            BotLogin::Unset,
         )
         .unwrap();
         collect_github_thread_fingerprints(&mut state, &thread, None).unwrap();
@@ -2988,6 +2994,7 @@ mod tests {
             }),
             None,
             0,
+            BotLogin::Unset,
         )
         .unwrap();
         record_github_resolution_marker(
@@ -3000,6 +3007,7 @@ mod tests {
             }),
             None,
             1,
+            BotLogin::Unset,
         )
         .unwrap();
         finalize_github_state(&mut state);
@@ -3021,6 +3029,7 @@ mod tests {
             }),
             None,
             1,
+            BotLogin::Unset,
         )
         .unwrap_err();
 
@@ -3041,6 +3050,7 @@ mod tests {
             }),
             None,
             1,
+            BotLogin::Unset,
         )
         .unwrap_err();
 
@@ -3072,8 +3082,14 @@ mod tests {
             ]
         });
         let mut state = ProviderState::default();
-        let error = collect_gitlab_discussion_fingerprints(&mut state, &discussion, None, None)
-            .unwrap_err();
+        let error = collect_gitlab_discussion_fingerprints(
+            &mut state,
+            &discussion,
+            None,
+            None,
+            BotLogin::Unset,
+        )
+        .unwrap_err();
         assert!(error.contains("string id"));
         assert!(state.fingerprints.is_empty());
     }
@@ -3087,7 +3103,14 @@ mod tests {
             ]
         });
         let mut state = ProviderState::default();
-        collect_gitlab_discussion_fingerprints(&mut state, &discussion, None, None).unwrap();
+        collect_gitlab_discussion_fingerprints(
+            &mut state,
+            &discussion,
+            None,
+            None,
+            BotLogin::Unset,
+        )
+        .unwrap();
         assert!(state.fingerprints.contains("fp-gitlab"));
         let lifecycle = &state.gitlab_discussions_by_fingerprint["fp-gitlab"][0];
         assert_eq!(lifecycle.discussion_id, "disc-99");
@@ -3107,7 +3130,14 @@ mod tests {
             ]
         });
         let mut state = ProviderState::default();
-        collect_gitlab_discussion_fingerprints(&mut state, &discussion, None, None).unwrap();
+        collect_gitlab_discussion_fingerprints(
+            &mut state,
+            &discussion,
+            None,
+            None,
+            BotLogin::Unset,
+        )
+        .unwrap();
         assert!(state.gitlab_discussions_by_fingerprint["fp-resolved"][0].has_resolution_marker);
     }
 
@@ -3125,7 +3155,14 @@ mod tests {
             ]
         });
         let mut state = ProviderState::default();
-        collect_gitlab_discussion_fingerprints(&mut state, &discussion, None, None).unwrap();
+        collect_gitlab_discussion_fingerprints(
+            &mut state,
+            &discussion,
+            None,
+            None,
+            BotLogin::Unset,
+        )
+        .unwrap();
         assert!(!state.gitlab_discussions_by_fingerprint["fp-human"][0].has_resolution_marker);
     }
 
@@ -3137,6 +3174,7 @@ mod tests {
             &serde_json::json!({ "id": "disc-empty", "notes": [] }),
             None,
             None,
+            BotLogin::Unset,
         )
         .unwrap_err();
 
@@ -3157,6 +3195,7 @@ mod tests {
             }),
             None,
             None,
+            BotLogin::Unset,
         )
         .unwrap_err();
 
@@ -3428,92 +3467,79 @@ mod tests {
     }
 
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
-    )]
     fn empty_configured_bot_login_trusts_no_native_bot() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
-        unsafe {
-            std::env::set_var("FALLOW_BOT_LOGIN", "   ");
-        }
-        assert!(!is_github_bot_comment(&serde_json::json!({
-            "user": { "type": "Bot", "login": "foreign[bot]" }
-        })));
+        assert!(!is_github_bot_comment(
+            &serde_json::json!({
+                "user": { "type": "Bot", "login": "foreign[bot]" }
+            }),
+            BotLogin::Configured("   ")
+        ));
         assert!(!is_gitlab_bot_note(
             &serde_json::json!({
                 "system": false,
                 "author": { "bot": true, "username": "foreign-bot" }
             }),
-            None
+            None,
+            BotLogin::Configured("   ")
         ));
-        // SAFETY: Restore the process environment after the scoped override.
-        unsafe {
-            std::env::remove_var("FALLOW_BOT_LOGIN");
-        }
+    }
+
+    #[test]
+    fn non_unicode_bot_login_trusts_no_native_bot() {
+        assert!(!is_github_bot_comment(
+            &serde_json::json!({
+                "user": { "type": "Bot", "login": "foreign[bot]" }
+            }),
+            BotLogin::NonUnicode
+        ));
+        assert!(!is_gitlab_bot_note(
+            &serde_json::json!({
+                "system": true,
+                "author": { "bot": true, "username": "foreign-bot" }
+            }),
+            None,
+            BotLogin::NonUnicode
+        ));
     }
 
     // --- is_github_bot_comment: missing branch (line 1323-1331) ---
 
     #[test]
     fn github_bot_check_returns_false_when_no_user_field() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({ "body": "no user" });
-        assert!(!is_github_bot_comment(&comment));
+        assert!(!is_github_bot_comment(&comment, BotLogin::Unset));
     }
 
     #[test]
     fn github_bot_check_returns_false_when_fallow_bot_login_not_set_and_type_not_bot() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let comment = serde_json::json!({
             "user": { "type": "User", "login": "someperson" },
         });
-        assert!(!is_github_bot_comment(&comment));
+        assert!(!is_github_bot_comment(&comment, BotLogin::Unset));
     }
 
     // --- is_gitlab_bot_note: FALLOW_BOT_LOGIN path (lines 1356-1364) ---
 
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "test-only env mutation, serialized via BOT_LOGIN_ENV_LOCK"
-    )]
     fn gitlab_bot_check_accepts_explicit_login_override() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let note = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "fallow-gl-bot" },
         });
-        // SAFETY: serialized by BOT_LOGIN_ENV_LOCK; cleared before returning.
-        unsafe {
-            std::env::set_var("FALLOW_BOT_LOGIN", "fallow-gl-bot");
-        }
-        assert!(is_gitlab_bot_note(&note, None));
-        // SAFETY: Restore the process environment after the scoped override.
-        unsafe {
-            std::env::remove_var("FALLOW_BOT_LOGIN");
-        }
+        assert!(is_gitlab_bot_note(
+            &note,
+            None,
+            BotLogin::Configured("fallow-gl-bot")
+        ));
     }
 
     #[test]
     fn gitlab_bot_check_returns_false_when_bot_flag_is_false_and_no_login_override() {
-        let _env = BOT_LOGIN_ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let note = serde_json::json!({
             "system": false,
             "author": { "bot": false, "username": "contributor" },
         });
-        assert!(!is_gitlab_bot_note(&note, None));
+        assert!(!is_gitlab_bot_note(&note, None, BotLogin::Unset));
     }
 
     // --- read_json_response: non-2xx path (lines 1288-1303) ---
@@ -3693,8 +3719,22 @@ mod tests {
         });
         let mut state = ProviderState::default();
 
-        record_github_review_root(&mut state, &frontend_comment, Some(&frontend), 0).unwrap();
-        record_github_review_root(&mut state, &backend_comment, Some(&frontend), 1).unwrap();
+        record_github_review_root(
+            &mut state,
+            &frontend_comment,
+            Some(&frontend),
+            0,
+            BotLogin::Unset,
+        )
+        .unwrap();
+        record_github_review_root(
+            &mut state,
+            &backend_comment,
+            Some(&frontend),
+            1,
+            BotLogin::Unset,
+        )
+        .unwrap();
 
         assert_eq!(
             state.github_discussions_by_fingerprint["abcdef0123456789"][0].comment_id,
@@ -3723,8 +3763,8 @@ mod tests {
         });
         let mut state = ProviderState::default();
 
-        record_github_review_root(&mut state, &scoped, None, 0).unwrap();
-        record_github_review_root(&mut state, &reply, None, 1).unwrap();
+        record_github_review_root(&mut state, &scoped, None, 0, BotLogin::Unset).unwrap();
+        record_github_review_root(&mut state, &reply, None, 1, BotLogin::Unset).unwrap();
 
         assert!(state.fingerprints.is_empty());
     }
@@ -3749,9 +3789,22 @@ mod tests {
         let mut scoped = ProviderState::default();
         let mut unscoped = ProviderState::default();
 
-        collect_gitlab_discussion_fingerprints(&mut scoped, &discussion, Some(&frontend), None)
-            .unwrap();
-        collect_gitlab_discussion_fingerprints(&mut unscoped, &discussion, None, None).unwrap();
+        collect_gitlab_discussion_fingerprints(
+            &mut scoped,
+            &discussion,
+            Some(&frontend),
+            None,
+            BotLogin::Unset,
+        )
+        .unwrap();
+        collect_gitlab_discussion_fingerprints(
+            &mut unscoped,
+            &discussion,
+            None,
+            None,
+            BotLogin::Unset,
+        )
+        .unwrap();
 
         assert!(!scoped.fingerprints.contains("abcdef0123456789"));
         assert!(

--- a/crates/mcp/src/server/mod.rs
+++ b/crates/mcp/src/server/mod.rs
@@ -57,7 +57,14 @@ impl FallowMcp {
 /// Resolve the fallow binary path.
 /// Priority: `FALLOW_BIN` env var > sibling binary next to fallow-mcp > PATH lookup.
 fn resolve_binary() -> String {
-    if let Ok(bin) = std::env::var("FALLOW_BIN") {
+    resolve_binary_from(std::env::var("FALLOW_BIN").ok())
+}
+
+/// [`resolve_binary`] over an injected override, so the resolution order is
+/// testable without mutating the process environment that concurrent tests in
+/// this binary read while spawning the real fallow executable.
+fn resolve_binary_from(override_bin: Option<String>) -> String {
+    if let Some(bin) = override_bin {
         return bin;
     }
 

--- a/crates/mcp/src/server/tests/run.rs
+++ b/crates/mcp/src/server/tests/run.rs
@@ -22,7 +22,7 @@ use crate::tools::run_fallow_with_timeout;
 #[cfg(unix)]
 use crate::tools::{run_fallow_with_output_limit, run_fallow_with_top_level_warnings, run_tool};
 
-use super::super::resolve_binary;
+use super::super::resolve_binary_from;
 
 /// Extract the text content from a `CallToolResult`.
 #[cfg(unix)]
@@ -435,22 +435,12 @@ async fn run_fallow_stderr_is_trimmed_in_error_message() {
 }
 
 #[test]
-#[expect(unsafe_code, reason = "env var mutation requires unsafe")]
 fn resolve_binary_behavior() {
-    // SAFETY: These tests intentionally mutate the process environment to
-    // prove the binary resolver respects the override and reset paths.
-    unsafe { std::env::remove_var("FALLOW_BIN") };
-    let bin = resolve_binary();
+    let bin = resolve_binary_from(None);
     assert!(bin.contains("fallow"));
 
-    // SAFETY: Restore the override to validate that resolve_binary reads the
-    // custom path and does not cache the prior unset state.
-    unsafe { std::env::set_var("FALLOW_BIN", "/custom/path/fallow") };
-    let bin = resolve_binary();
+    let bin = resolve_binary_from(Some("/custom/path/fallow".to_string()));
     assert_eq!(bin, "/custom/path/fallow");
-
-    // SAFETY: Leave the environment clean for the rest of the test suite.
-    unsafe { std::env::remove_var("FALLOW_BIN") };
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Closes #2494.

## Problem

`crates/cli` and `crates/mcp` tests called `std::env::set_var` / `remove_var` from inside `#[test]` functions. The harness runs tests as parallel threads in one process, so those calls mutate state other threads are concurrently reading.

The issue filed this on soundness grounds with no claim it was breaking anything. It is:

`crates/mcp/src/server/tests/mod.rs` declares `mod e2e;` and `mod run;` as siblings, so they link into **one** test binary. `run.rs` removed `FALLOW_BIN`, repointed it at a nonexistent `/custom/path/fallow`, and removed it again, while `e2e.rs`'s `fallow_binary()` reads that same variable on every concurrent test to resolve and spawn the binary. `.github/workflows/coverage.yml` sets `FALLOW_BIN` for `cargo llvm-cov --workspace`. That is real cross-test interference on CI, not a theoretical race.

A second hazard: `BOT_LOGIN_ENV_LOCK` in `ci.rs` was never taken by `api.rs`'s five mutations, and both compile into the same `fallow_cli` lib test binary, so there were two mutually unsynchronized `setenv` writers against 133 `env::var` readers.

The issue's stated deadline was stale. The workspace is already on edition 2024 and every site already sat inside `unsafe` with an `expect`/`allow` attribute, so there was no compile deadline, only the unsoundness.

## Approach

Serializing the tests would hide the race and leave the next parallel-test change free to reintroduce it. Instead every environment read became a thin one-line outer function delegating to a pure inner function the test drives, following `resolve_typed_coverage_inputs` in `crates/mcp/src/tools/api_runtime.rs`, which solved this once already for #2368.

`FALLOW_BOT_LOGIN` needed a tri-state rather than `Option<&str>`: its three readers distinguish "set", "set but not valid unicode", and "absent", and `needs_gitlab_authenticated_user` is stricter than the other two, returning false for both of the first two. A `BotLogin` enum preserves that asymmetry; `Option<&str>` would have collapsed it and silently changed behavior. It is resolved once per provider load rather than once per comment.

Deleting `BOT_LOGIN_ENV_LOCK` also de-flakes the five tests that assert unset behavior: they previously depended on the ambient environment not having the variable set, which the mutex could not guarantee. They now pass `BotLogin::Unset` explicitly.

## Guard

A test walks every crate's `src` and `tests` and fails on a new mutation, naming the file and pointing at the pattern to use instead. `#![forbid(unsafe_code)]` was not viable: `crates/cli` has genuine Win32 FFI.

The needle matches both the path form and the call form. The path form alone misses `use std::env::*` and `use std::env::{self, set_var}`, which put the call in scope without ever writing `env::set_var`; the bare identifier is unusable because `reset_variants` in `crates/core/src/plugins/sveltekit.rs` contains it. Proved by adding a glob-imported mutation to `crates/lsp` and confirming the guard fails naming that file.

Out-of-process `Command::env(..)` still passes, which is correct: that is the sanctioned way to pin a production env read.

## Validation

- `cargo test -p fallow-cli --lib`: `test result: ok. 2863 passed; 0 failed`
- `cargo test -p fallow-mcp`: `test result: ok. 647 passed; 0 failed`
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `grep -rn "env::set_var\|env::remove_var" crates/cli crates/mcp`: only the guard's own needle array

`FALLOW_BOT_LOGIN` semantics are byte-identical. Adds `non_unicode_bot_login_trusts_no_native_bot`, the first direct coverage of that branch.