### PR TITLE
fix(deps): credit packages hoisted for a bundled private sibling workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   splitting cannot deliver.** It now says that splitting relocates branching, so
   it lowers the function's own score without lowering the total.
 
-### Fixed
-
 - **A package hoisted for a private sibling workspace is no longer reported as
   unused** (Refs
   [discussion #2244](https://github.com/fallow-rs/fallow/discussions/2244)). A
@@ -100,8 +98,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   NL Design System Utrecht monorepo, where a documentation site declares a
   Storybook workspace that only its private Astro sibling imports: that finding
   is gone, every other dependency finding is unchanged, and three further real
-  monorepos report identically before and after. Thanks
-  [@simmo](https://github.com/simmo) for the report.
+  monorepos report identically before and after. If you previously removed a
+  hoisted package on this advice and hit an unresolved import at build time, or
+  added one to `ignoreDependencies` to quiet it, that entry is no longer needed
+  and can be dropped. Thanks [@simmo](https://github.com/simmo) for the report.
+
+### Fixed
 
 - **Two audits running at once no longer fail with a base worktree that
   "already exists".** The temporary base view was named from the process id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A package hoisted for a private sibling workspace is no longer reported as
+  unused** (Refs
+  [discussion #2244](https://github.com/fallow-rs/fallow/discussions/2244)). A
+  workspace that is never published is not installed from a registry, so a
+  consumer that depends on it inlines its source, and the package manager then
+  has to resolve that sibling's own packages from the consumer's manifest.
+  Hoisting them there is what makes the build work, but nothing in the consumer
+  imports them, so each one was reported as an unused dependency, with
+  `move-dependency` as the suggested action. Following that advice breaks the
+  build, and the only escape was repo-global `ignoreDependencies`, which
+  silences the package everywhere. Fallow now walks the private-sibling
+  closure, transitively and cycle-safe, and credits the packages those siblings
+  import. A published sibling brings its own dependency tree and is
+  deliberately not followed, so a genuine finding still fires there. Only what
+  a sibling both imports and declares in `dependencies`,
+  `optionalDependencies`, or `peerDependencies` counts: a sibling's
+  `devDependencies` are its own build-time needs and never reach a consumer. A
+  package that nothing imports anywhere is unaffected. Measured on the public
+  NL Design System Utrecht monorepo, where a documentation site declares a
+  Storybook workspace that only its private Astro sibling imports: that finding
+  is gone, every other dependency finding is unchanged, and three further real
+  monorepos report identically before and after. Thanks
+  [@simmo](https://github.com/simmo) for the report.
+
 - **Two audits running at once no longer fail with a base worktree that
   "already exists".** The temporary base view was named from the process id
   plus a wall-clock reading. That reading is not monotonic and repeats across

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -160,15 +160,163 @@ fn deepest_matching_workspace<'a>(path: &Path, workspace_roots: &[&'a Path]) -> 
         .max_by_key(|root| root.components().count())
 }
 
-fn dependency_owning_workspace_roots<'a>(
+/// One workspace manifest, read once for the whole unused-dependency pass.
+///
+/// The per-workspace pass reads `package.json` again to locate declaration
+/// lines, but the cross-workspace indices need only the fields below, so they
+/// are collected up front instead of inside the parallel per-workspace map.
+struct WorkspaceManifest<'a> {
+    /// Workspace root, the key every usage index is built against.
+    root: &'a Path,
+    /// Manifest `name`, falling back to the discovered workspace name. This is
+    /// the string a sibling workspace writes in its own dependency map.
+    name: String,
+    /// `"private": true`. The offline, deterministic signal that a workspace is
+    /// never published, so consumers inline its source instead of installing it
+    /// from a registry.
+    is_private: bool,
+    /// Every declared dependency name, in any category. Used to follow edges to
+    /// private siblings: a sibling's source reaches this workspace whether it is
+    /// pulled in for the shipped build or only for the local one.
+    declared: FxHashSet<String>,
+    /// Names declared in a category that travels with the package:
+    /// `dependencies`, `optionalDependencies`, and `peerDependencies`.
+    /// `devDependencies` are build-time needs of this workspace alone and are
+    /// never inlined into a consumer, so they are deliberately excluded.
+    shipped: FxHashSet<String>,
+}
+
+/// Names a workspace carries into anything that inlines its source.
+///
+/// `peerDependencies` count because a peer is by definition supplied by the
+/// consumer, and `optionalDependencies` count because an optional package that
+/// is present is loaded from the consumer's tree like any other.
+fn shipped_dependency_names(pkg: &PackageJson) -> FxHashSet<String> {
+    pkg.production_dependency_names()
+        .into_iter()
+        .chain(pkg.optional_dependency_names())
+        .chain(
+            pkg.peer_dependencies
+                .iter()
+                .flat_map(|peers| peers.keys().cloned()),
+        )
+        .collect()
+}
+
+/// Read every workspace manifest once, in parallel, dropping workspaces whose
+/// `package.json` is missing, unparsable, or covered by `ignorePatterns`.
+fn read_workspace_manifests<'a>(
     workspaces: &'a [fallow_config::WorkspaceInfo],
     config: &ResolvedConfig,
-) -> Vec<&'a Path> {
+) -> Vec<WorkspaceManifest<'a>> {
+    use rayon::prelude::*;
     workspaces
-        .iter()
-        .filter(|workspace| read_workspace_package(workspace, config).is_some())
-        .map(|workspace| workspace.root.as_path())
+        .par_iter()
+        .filter_map(|workspace| {
+            let (_, _, pkg) = read_workspace_package(workspace, config)?;
+            Some(WorkspaceManifest {
+                root: workspace.root.as_path(),
+                name: pkg.name.clone().unwrap_or_else(|| workspace.name.clone()),
+                is_private: pkg.private == Some(true),
+                declared: pkg.all_dependency_names().into_iter().collect(),
+                shipped: shipped_dependency_names(&pkg),
+            })
+        })
         .collect()
+}
+
+fn dependency_owning_workspace_roots<'a>(manifests: &[WorkspaceManifest<'a>]) -> Vec<&'a Path> {
+    manifests.iter().map(|manifest| manifest.root).collect()
+}
+
+/// Reverse index: workspace root -> third-party packages that workspace inherits
+/// from the private siblings its build inlines.
+///
+/// A private, unpublished sibling is never installed from a registry, so a
+/// consumer that depends on it bundles its source. The package manager then has
+/// to resolve that sibling's own packages from the consumer's manifest, which is
+/// why hoisting them into the consumer is correct rather than dead weight. See
+/// discussion #2244.
+///
+/// The walk follows private siblings only, transitively, because a published
+/// package brings its own dependency tree and needs no hoisting. Crediting a
+/// published sibling's packages would suppress a genuine finding. Workspace
+/// graphs can be cyclic, so each walk carries a visited set.
+fn collect_bundled_workspace_usage<'a>(
+    manifests: &[WorkspaceManifest<'a>],
+    workspace_used_packages: &FxHashMap<&'a Path, FxHashSet<&'a str>>,
+) -> FxHashMap<&'a Path, FxHashSet<&'a str>> {
+    let private_by_name: FxHashMap<&str, usize> = manifests
+        .iter()
+        .enumerate()
+        .filter(|(_, manifest)| manifest.is_private)
+        .map(|(index, manifest)| (manifest.name.as_str(), index))
+        .collect();
+    if private_by_name.is_empty() {
+        return FxHashMap::default();
+    }
+
+    use rayon::prelude::*;
+    manifests
+        .par_iter()
+        .enumerate()
+        .map(|(index, consumer)| {
+            let bundled = bundled_packages_for(
+                index,
+                consumer,
+                manifests,
+                &private_by_name,
+                workspace_used_packages,
+            );
+            (consumer.root, bundled)
+        })
+        .filter(|(_, bundled)| !bundled.is_empty())
+        .collect()
+}
+
+/// Walk the private-sibling closure reachable from one consumer workspace and
+/// return the packages those siblings actually import.
+///
+/// A package is credited only when the sibling both imports it and declares it
+/// in a shipped category, so a sibling's own unused declaration cannot mask a
+/// finding in the consumer, and a sibling's `devDependencies` stay out.
+fn bundled_packages_for<'a>(
+    consumer_index: usize,
+    consumer: &WorkspaceManifest<'a>,
+    manifests: &[WorkspaceManifest<'a>],
+    private_by_name: &FxHashMap<&str, usize>,
+    workspace_used_packages: &FxHashMap<&'a Path, FxHashSet<&'a str>>,
+) -> FxHashSet<&'a str> {
+    let private_siblings = |manifest: &WorkspaceManifest<'a>| -> Vec<usize> {
+        manifest
+            .declared
+            .iter()
+            .filter_map(|dep| private_by_name.get(dep.as_str()).copied())
+            .collect()
+    };
+
+    let mut bundled: FxHashSet<&str> = FxHashSet::default();
+    let mut visited: FxHashSet<usize> = FxHashSet::default();
+    visited.insert(consumer_index);
+    let mut pending = private_siblings(consumer);
+
+    while let Some(index) = pending.pop() {
+        if !visited.insert(index) {
+            continue;
+        }
+        let sibling = &manifests[index];
+        if let Some(imported) = workspace_used_packages.get(&sibling.root) {
+            bundled.extend(
+                imported
+                    .iter()
+                    .copied()
+                    .filter(|package| sibling.shipped.contains(*package)),
+            );
+        }
+        pending.extend(private_siblings(sibling));
+    }
+
+    bundled
 }
 
 /// Reverse index: workspace root -> packages with ANY file under that root using
@@ -463,6 +611,7 @@ impl<'a> UnusedDependencyScan<'a> {
             script_used: &self.script_used,
             ignore_deps: &self.ignore_deps,
             workspace_used_packages: &self.usage.workspace_used_packages,
+            bundled_workspace_usage: &self.usage.bundled_workspace_usage,
             package_workspace_usage: &self.usage.package_workspace_usage,
             root_flagged,
         }
@@ -517,6 +666,7 @@ struct DependencyUsageIndices<'a> {
     used_packages: FxHashSet<&'a str>,
     package_workspace_usage: FxHashMap<String, Vec<PathBuf>>,
     workspace_used_packages: FxHashMap<&'a Path, FxHashSet<&'a str>>,
+    bundled_workspace_usage: FxHashMap<&'a Path, FxHashSet<&'a str>>,
     root_peer_used: FxHashSet<String>,
 }
 
@@ -529,10 +679,15 @@ fn collect_dependency_usage_indices<'a>(
     let used_packages: FxHashSet<&str> = graph.package_usage.keys().map(String::as_str).collect();
     let root_peer_used = PeerDependencyResolver::new()
         .peer_dependency_closure(&config.root, used_packages.iter().copied());
-    let workspace_roots = dependency_owning_workspace_roots(workspaces, config);
+    let manifests = read_workspace_manifests(workspaces, config);
+    let workspace_roots = dependency_owning_workspace_roots(&manifests);
+    let workspace_used_packages = collect_workspace_used_packages(graph, &workspace_roots);
+    let bundled_workspace_usage =
+        collect_bundled_workspace_usage(&manifests, &workspace_used_packages);
     DependencyUsageIndices {
         package_workspace_usage: collect_package_workspace_usage(graph, &workspace_roots),
-        workspace_used_packages: collect_workspace_used_packages(graph, &workspace_roots),
+        workspace_used_packages,
+        bundled_workspace_usage,
         used_packages,
         root_peer_used,
     }
@@ -619,6 +774,7 @@ struct WorkspaceUnusedDependencyInputs<'a> {
     script_used: &'a FxHashSet<&'a str>,
     ignore_deps: &'a FxHashSet<&'a str>,
     workspace_used_packages: &'a FxHashMap<&'a Path, FxHashSet<&'a str>>,
+    bundled_workspace_usage: &'a FxHashMap<&'a Path, FxHashSet<&'a str>>,
     package_workspace_usage: &'a FxHashMap<String, Vec<PathBuf>>,
     root_flagged: &'a FxHashSet<String>,
 }
@@ -657,6 +813,7 @@ fn collect_workspace_unused_dependencies<'a>(
         ws_root,
         &ws_used_packages,
         inputs.package_workspace_usage,
+        inputs.bundled_workspace_usage.get(&ws_root),
         inputs.root_flagged,
     );
 
@@ -679,6 +836,9 @@ fn read_workspace_package(
 struct WorkspaceDependencyUsage<'a> {
     ws_root: &'a Path,
     ws_peer_used: FxHashSet<String>,
+    /// Packages this workspace inherits from the private siblings it bundles,
+    /// absent when the workspace bundles no private sibling.
+    bundled_used: Option<&'a FxHashSet<&'a str>>,
     package_workspace_usage: &'a FxHashMap<String, Vec<PathBuf>>,
     root_flagged: &'a FxHashSet<String>,
 }
@@ -687,6 +847,9 @@ impl WorkspaceDependencyUsage<'_> {
     fn is_used_in_workspace(&self, dep: &str) -> bool {
         self.root_flagged.contains(dep)
             || self.ws_peer_used.contains(dep)
+            || self
+                .bundled_used
+                .is_some_and(|bundled| bundled.contains(dep))
             || self
                 .package_workspace_usage
                 .get(dep)
@@ -702,6 +865,7 @@ fn workspace_dependency_usage<'a>(
     ws_root: &'a Path,
     ws_used_packages: &FxHashSet<&str>,
     package_workspace_usage: &'a FxHashMap<String, Vec<PathBuf>>,
+    bundled_used: Option<&'a FxHashSet<&'a str>>,
     root_flagged: &'a FxHashSet<String>,
 ) -> WorkspaceDependencyUsage<'a> {
     let ws_peer_used = PeerDependencyResolver::new()
@@ -709,6 +873,7 @@ fn workspace_dependency_usage<'a>(
     WorkspaceDependencyUsage {
         ws_root,
         ws_peer_used,
+        bundled_used,
         package_workspace_usage,
         root_flagged,
     }

--- a/crates/core/tests/integration_test/dependencies.rs
+++ b/crates/core/tests/integration_test/dependencies.rs
@@ -1100,3 +1100,263 @@ fn ignore_patterns_applied_to_workspace_package_json_for_unused_deps() {
         "real unused dep `is-odd` should still be reported, got: {reported:?}"
     );
 }
+
+/// Write a monorepo root that discovers every directory under `packages/`.
+fn write_private_bundle_root(root: &std::path::Path) {
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "bundle-root",
+  "private": true,
+  "workspaces": ["packages/*"]
+}"#,
+    )
+    .expect("write root package.json");
+}
+
+/// Write one workspace package with a manifest and a single source file.
+fn write_bundle_workspace(root: &std::path::Path, name: &str, manifest: &str, source: &str) {
+    let ws_root = root.join("packages").join(name);
+    fs::create_dir_all(ws_root.join("src")).expect("create workspace package");
+    fs::write(ws_root.join("package.json"), manifest).expect("write workspace package.json");
+    fs::write(ws_root.join("src/index.ts"), source).expect("write workspace source");
+}
+
+fn unused_dependency_names_for(
+    results: &fallow_types::results::AnalysisResults,
+    workspace_suffix: &str,
+) -> Vec<String> {
+    results
+        .unused_dependencies
+        .iter()
+        .filter(|d| d.dep.path.ends_with(workspace_suffix))
+        .map(|d| d.dep.package_name.clone())
+        .collect()
+}
+
+/// Discussion #2244: a private, unpublished sibling workspace is inlined into
+/// its consumer's build, so the third-party packages the sibling imports have
+/// to be resolvable from the consumer's own manifest. Declaring them there is
+/// correct, not dead weight.
+#[test]
+fn private_sibling_bundled_dependency_is_credited_to_the_consumer() {
+    let root = fixture_path("private-workspace-bundled-dependencies");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let reported = unused_dependency_names_for(&results, "packages/workspace-a/package.json");
+
+    assert!(
+        !reported.iter().any(|name| name == "lodash-es"),
+        "lodash-es is bundled from the private `shared` workspace and must not be reported in workspace-a, got: {reported:?}"
+    );
+    assert!(
+        reported.iter().any(|name| name == "nothing-uses-this"),
+        "a dependency no workspace imports must still be reported, got: {reported:?}"
+    );
+}
+
+/// A published sibling is installed from the registry with its own dependency
+/// tree, so the consumer never needs the sibling's packages hoisted. Crediting
+/// them there would hide a real finding.
+#[test]
+fn published_sibling_does_not_credit_bundled_dependency() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let root = tmp.path();
+    write_private_bundle_root(root);
+    write_bundle_workspace(
+        root,
+        "shared",
+        r#"{
+  "name": "shared",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21"
+  }
+}"#,
+        "import { cloneDeep } from \"lodash-es\";\n\nexport const clone = cloneDeep;\n",
+    );
+    write_bundle_workspace(
+        root,
+        "consumer",
+        r#"{
+  "name": "consumer",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21",
+    "shared": "1.0.0"
+  }
+}"#,
+        "import { clone } from \"shared\";\n\nexport const value = clone;\n",
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let reported = unused_dependency_names_for(&results, "packages/consumer/package.json");
+    assert!(
+        reported.iter().any(|name| name == "lodash-es"),
+        "a published sibling's dependency must stay reported in the consumer, got: {reported:?}"
+    );
+}
+
+/// The bundle follows the private edge as far as it goes: a private sibling of
+/// a private sibling is inlined into the consumer too.
+#[test]
+fn transitive_private_chain_credits_the_deepest_sibling_imports() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let root = tmp.path();
+    write_private_bundle_root(root);
+    write_bundle_workspace(
+        root,
+        "deep",
+        r#"{
+  "name": "deep",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21"
+  }
+}"#,
+        "import { cloneDeep } from \"lodash-es\";\n\nexport const clone = cloneDeep;\n",
+    );
+    write_bundle_workspace(
+        root,
+        "mid",
+        r#"{
+  "name": "mid",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "deep": "1.0.0"
+  }
+}"#,
+        "import { clone } from \"deep\";\n\nexport const midClone = clone;\n",
+    );
+    write_bundle_workspace(
+        root,
+        "app",
+        r#"{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21",
+    "mid": "1.0.0",
+    "nothing-uses-this": "1.0.0"
+  }
+}"#,
+        "import { midClone } from \"mid\";\n\nexport const value = midClone;\n",
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let reported = unused_dependency_names_for(&results, "packages/app/package.json");
+    assert!(
+        !reported.iter().any(|name| name == "lodash-es"),
+        "lodash-es reaches app through mid -> deep and must not be reported, got: {reported:?}"
+    );
+    assert!(
+        reported.iter().any(|name| name == "nothing-uses-this"),
+        "a dependency outside the bundled closure must still be reported, got: {reported:?}"
+    );
+}
+
+/// Workspace dependency graphs can be cyclic. The closure must terminate and
+/// still credit what the cycle bundles.
+#[test]
+fn cyclic_private_workspace_graph_terminates() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let root = tmp.path();
+    write_private_bundle_root(root);
+    write_bundle_workspace(
+        root,
+        "alpha",
+        r#"{
+  "name": "alpha",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "beta": "1.0.0",
+    "lodash-es": "4.17.21"
+  }
+}"#,
+        "export const alpha = 1;\n",
+    );
+    write_bundle_workspace(
+        root,
+        "beta",
+        r#"{
+  "name": "beta",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "alpha": "1.0.0",
+    "lodash-es": "4.17.21"
+  }
+}"#,
+        "import { cloneDeep } from \"lodash-es\";\n\nexport const clone = cloneDeep;\n",
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let reported = unused_dependency_names_for(&results, "packages/alpha/package.json");
+    assert!(
+        !reported.iter().any(|name| name == "lodash-es"),
+        "the cycle must resolve and credit beta's import to alpha, got: {reported:?}"
+    );
+}
+
+/// A private sibling's devDependencies are build-time needs of that sibling,
+/// never inlined into the consumer's output, so they stay out of the closure.
+#[test]
+fn dev_dependency_of_a_private_sibling_is_not_credited() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let root = tmp.path();
+    write_private_bundle_root(root);
+    write_bundle_workspace(
+        root,
+        "tool",
+        r#"{
+  "name": "tool",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "devDependencies": {
+    "lodash-es": "4.17.21"
+  }
+}"#,
+        "import { cloneDeep } from \"lodash-es\";\n\nexport const clone = cloneDeep;\n",
+    );
+    write_bundle_workspace(
+        root,
+        "consumer",
+        r#"{
+  "name": "consumer",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21",
+    "tool": "1.0.0"
+  }
+}"#,
+        "import { clone } from \"tool\";\n\nexport const value = clone;\n",
+    );
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let reported = unused_dependency_names_for(&results, "packages/consumer/package.json");
+    assert!(
+        reported.iter().any(|name| name == "lodash-es"),
+        "a dev-only declaration in the private sibling must not credit the consumer, got: {reported:?}"
+    );
+}

--- a/tests/fixtures/private-workspace-bundled-dependencies/package.json
+++ b/tests/fixtures/private-workspace-bundled-dependencies/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "private-workspace-bundled-dependencies",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/tests/fixtures/private-workspace-bundled-dependencies/packages/shared/package.json
+++ b/tests/fixtures/private-workspace-bundled-dependencies/packages/shared/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "shared",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21"
+  }
+}

--- a/tests/fixtures/private-workspace-bundled-dependencies/packages/shared/src/index.ts
+++ b/tests/fixtures/private-workspace-bundled-dependencies/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+import { cloneDeep } from "lodash-es";
+
+export const cloneConfig = (config: Record<string, string>) => cloneDeep(config);

--- a/tests/fixtures/private-workspace-bundled-dependencies/packages/workspace-a/package.json
+++ b/tests/fixtures/private-workspace-bundled-dependencies/packages/workspace-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workspace-a",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "lodash-es": "4.17.21",
+    "shared": "1.0.0"
+  }
+}

--- a/tests/fixtures/private-workspace-bundled-dependencies/packages/workspace-a/package.json
+++ b/tests/fixtures/private-workspace-bundled-dependencies/packages/workspace-a/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "dependencies": {
     "lodash-es": "4.17.21",
+    "nothing-uses-this": "1.0.0",
     "shared": "1.0.0"
   }
 }

--- a/tests/fixtures/private-workspace-bundled-dependencies/packages/workspace-a/src/index.ts
+++ b/tests/fixtures/private-workspace-bundled-dependencies/packages/workspace-a/src/index.ts
@@ -1,0 +1,3 @@
+import { cloneConfig } from "shared";
+
+export const config = cloneConfig({ version: "1.0.0" });

--- a/tests/fixtures/private-workspace-bundled-dependencies/tsconfig.json
+++ b/tests/fixtures/private-workspace-bundled-dependencies/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Refs [discussion #2244](https://github.com/fallow-rs/fallow/discussions/2244).

## Problem

A monorepo has a workspace `workspace-a` and a private, unpublished sibling `shared`. `shared` is a dependency of `workspace-a`. Because `shared` is never published, it is not installed from a registry: `workspace-a`'s build inlines its source, so the package manager has to resolve `shared`'s own third-party packages from `workspace-a`'s manifest. Hoisting them there is what makes the build work.

Nothing in `workspace-a` imports them, so each was reported as an unused dependency. Reproduced before implementing anything:

```
lodash-es (packages/workspace-a/package.json; imported in packages/shared)
Listed in dependencies but never imported
```

The finding carries a softening hint (`used_in_workspaces`), but its primary machine-readable action is `move-dependency`: "Move this dependency to the workspace package.json that imports it". Following that advice **breaks the build**. The only escape was repo-global `ignoreDependencies`, which silences the package everywhere, which is exactly what the reporter asked to avoid.

Also measured: `private` was not consulted at all. Removing `"private": true` from the sibling produced a byte-identical finding, so fallow had never distinguished a private sibling from a published one. The old behavior was not conservative, it was uninformed.

## Approach

`ws_peer_used` already existed but is a *peerDependency* closure resolved through `node_modules`, so it could not serve here. This adds a bundled-private-sibling closure built manifest-side off `WorkspaceInfo`, the way `package_workspace_usage` already is.

The walk follows a private sibling through any declared category, because a sibling's source is loaded in the consumer's context either way. What gets *credited* is narrower: a package must be both imported by the sibling's files and declared in its `dependencies`, `optionalDependencies`, or `peerDependencies`. `devDependencies` are excluded, they are that sibling's own build-time needs and never travel into a consumer.

A published sibling brings its own dependency tree and is deliberately not followed, so a genuine finding still fires there.

Computed once up front from a single rayon read of every workspace manifest, replacing an existing read-and-discard pass, so there is no extra file read and nothing recomputed inside the parallel map over workspaces. `FxHashMap`/`FxHashSet` throughout.

## Validation

Tests written first against the fixture; exactly the three that need the fix failed before it:

```
test dependencies::cyclic_private_workspace_graph_terminates ... FAILED
test dependencies::transitive_private_chain_credits_the_deepest_sibling_imports ... FAILED
test dependencies::private_sibling_bundled_dependency_is_credited_to_the_consumer ... FAILED
```

The three guarding against over-crediting (published sibling, dev-dep, negative control) passed before the fix, as they must.

**Warm cache, measured both directions.** The pre-fix binary wrote `.fallow/`, then the fixed binary ran on that untouched cache and reported the corrected result, so no cache version needs to move: `read_workspace_package` reads each manifest from disk on every run, and no unused-dependency result is persisted. The reverse also works, so a mixed-version CI fleet during rollout cannot produce a poisoned third state.

**Consumers.** Suppression baselines filter findings *present in* the baseline, so a disappearing finding leaves an inert stale key. Regression gates detect increases only, so a decrease never trips them. No `schema_version` moves.

Measured on the public NL Design System Utrecht monorepo: the one affected finding is gone, every other dependency finding is unchanged, and three further real monorepos report identically before and after.

## Note on the release

This reports **fewer** findings than 3.21.0 did, so it is filed under `### Changed` with its own heading rather than in the fix list, and the entry tells anyone who already acted on the `move-dependency` advice how to recognize it.

## Follow-up, not blocking

`private_by_name` keys on the manifest `name`. Two workspaces at different paths sharing a name during a migration would credit through the wrong edge, and the map keeps the last writer. Narrow, and not a regression from today's behavior since today credits nothing at all, but worth a test.