### PR TITLE
fix(extract): count branching that lives outside every function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Branching outside every function is now counted.** No frame was pushed for
+  a module body, so a top-level `if` ladder, an environment guard, or a
+  conditional export scored nothing at all, and hoisting a branch out of a
+  function lowered a file's complexity without removing any branching. Such
+  code now lands on a synthetic `<module>` unit, in the same family as
+  `<template>`. The unit is emitted only when the module body actually
+  branches, so a file that gains no information gains no unit, and it is
+  excluded from the CRAP dimension because an Istanbul function map can never
+  contain it. Measured across four real projects, this adds between 0.1 and 0.5
+  percent more units and moves no health aggregate at one decimal place
+  ([#2503](https://github.com/fallow-rs/fallow/issues/2503)).
+
 - **Release publication is gated on the curated release metadata**
   (Closes [#2414](https://github.com/fallow-rs/fallow/issues/2414)). The rules
   for a release title and its notes lived only in the maintainer runbook, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function lowered a file's complexity without removing any branching. Such
   code now lands on a synthetic `<module>` unit, in the same family as
   `<template>`. The unit is emitted only when the module body actually
-  branches, so a file that gains no information gains no unit, and it is
-  excluded from the CRAP dimension because an Istanbul function map can never
-  contain it. Measured across four real projects, this adds between 0.1 and 0.5
-  percent more units and moves no health aggregate at one decimal place
+  branches, so a file that gains no information gains no unit. It is not an
+  authored function, so it stays out of the CRAP dimension, the large-function
+  list, the unit-size and parameter distributions, and the component rollup,
+  and its suppression action points at the branching statement rather than at a
+  function declaration that does not exist. On four real projects this added
+  between 0.1 and 0.5 percent more units and moved no health aggregate at one
+  decimal place; a file whose module body branches heavily will see its own
+  numbers change
   ([#2503](https://github.com/fallow-rs/fallow/issues/2503)).
 
 - **Release publication is gated on the curated release metadata**

--- a/crates/engine/src/health/component_rollup.rs
+++ b/crates/engine/src/health/component_rollup.rs
@@ -205,7 +205,7 @@ fn component_template_owner(
 
 fn is_component_class_finding(finding: &ComplexityViolation) -> bool {
     finding.name != COMPONENT_ROLLUP_NAME
-        && !fallow_types::extract::is_synthetic_template_unit(&finding.name)
+        && !fallow_types::extract::is_synthetic_unit(&finding.name)
         && finding
             .path
             .extension()

--- a/crates/engine/src/health/large_functions.rs
+++ b/crates/engine/src/health/large_functions.rs
@@ -52,6 +52,11 @@ pub(super) fn collect_large_functions(
             continue;
         }
         for func in &module.complexity {
+            // A module body's line count is the whole file, which is not a
+            // function length and must not be reported as one.
+            if fallow_types::extract::is_synthetic_unit(&func.name) {
+                continue;
+            }
             let max_unit_size = input
                 .thresholds
                 .effective_max_unit_size(relative, func.name.as_str());

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -421,11 +421,12 @@ fn compute_crap_scores_istanbul(
     let mut total = 0usize;
     let mut per_function = Vec::with_capacity(complexity.len());
     for f in complexity {
-        // Synthetic template-family units carry no measurable coverage (an
-        // Istanbul fnMap can never contain them), so they are excluded from
-        // the CRAP dimension entirely: no per-function entry, no max /
-        // above-threshold contribution, no match-statistics slot.
-        if fallow_types::extract::is_synthetic_template_unit(&f.name) {
+        // Units an Istanbul fnMap can never contain carry no measurable
+        // coverage, so they are excluded from the CRAP dimension entirely: no
+        // per-function entry, no max / above-threshold contribution, no
+        // match-statistics slot. That is the template family plus the module
+        // body, whose code runs at import time and belongs to no function.
+        if fallow_types::extract::is_coverage_exempt_unit(&f.name) {
             continue;
         }
         total += 1;

--- a/crates/engine/src/health/scoring.rs
+++ b/crates/engine/src/health/scoring.rs
@@ -426,7 +426,7 @@ fn compute_crap_scores_istanbul(
         // per-function entry, no max / above-threshold contribution, no
         // match-statistics slot. That is the template family plus the module
         // body, whose code runs at import time and belongs to no function.
-        if fallow_types::extract::is_coverage_exempt_unit(&f.name) {
+        if fallow_types::extract::is_synthetic_unit(&f.name) {
             continue;
         }
         total += 1;
@@ -547,10 +547,11 @@ fn compute_crap_scores_estimated(
     let mut signals = CrapThresholdSignals::default();
     let mut per_function = Vec::with_capacity(complexity.len());
     for f in complexity {
-        // Template-family units leave the CRAP dimension: their name never
-        // appears in `test_referenced_exports`, so the estimate could only
-        // ever restate the file's reachability as a disguised cyclomatic gate.
-        if fallow_types::extract::is_synthetic_template_unit(&f.name) {
+        // Units that are not an authored function leave the CRAP dimension:
+        // their name never appears in `test_referenced_exports`, so the
+        // estimate could only ever restate the file's reachability as a
+        // disguised cyclomatic gate.
+        if fallow_types::extract::is_synthetic_unit(&f.name) {
             continue;
         }
         let cc = f64::from(f.cyclomatic);

--- a/crates/engine/src/vital_signs.rs
+++ b/crates/engine/src/vital_signs.rs
@@ -152,8 +152,22 @@ fn selected_module_metrics(input: &VitalSignsInput<'_>) -> SelectedModuleMetrics
 
     for module in input.selected_modules() {
         total_loc += module.line_offsets.len() as u64;
-        line_counts.extend(module.complexity.iter().map(|c| c.line_count));
-        param_counts.extend(module.complexity.iter().map(|c| c.param_count));
+        // Unit-size and parameter distributions describe authored functions.
+        // A module body has the file's length and no parameter list.
+        line_counts.extend(
+            module
+                .complexity
+                .iter()
+                .filter(|c| !fallow_types::extract::is_synthetic_unit(&c.name))
+                .map(|c| c.line_count),
+        );
+        param_counts.extend(
+            module
+                .complexity
+                .iter()
+                .filter(|c| !fallow_types::extract::is_synthetic_unit(&c.name))
+                .map(|c| c.param_count),
+        );
     }
 
     SelectedModuleMetrics {

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -1017,7 +1017,7 @@ use crate::MemberKind;
 /// Bumped to 284 for issue #2448: complexity units now persist private-member
 /// provenance separately from their display name. Warm 283 caches cannot
 /// distinguish an ECMAScript private member from a public quoted `#` name.
-pub(super) const CACHE_VERSION: u32 = 284;
+pub(super) const CACHE_VERSION: u32 = 285;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/complexity.rs
+++ b/crates/extract/src/complexity.rs
@@ -742,6 +742,15 @@ fn is_hook_callee(name: &str) -> bool {
 }
 
 /// Compute per-function complexity metrics from a parsed Oxc program.
+/// Name of the synthetic unit holding a module body's own branching.
+///
+/// Part of the `<...>` synthetic family alongside `<template>`, and excluded
+/// from the CRAP dimension for the same reason: it carries no directly
+/// measurable test coverage. It does count towards cyclomatic and cognitive
+/// totals, because its branching runs at import time and is exactly what the
+/// per-function view was missing.
+pub const MODULE_UNIT_NAME: &str = "<module>";
+
 pub fn compute_complexity(
     program: &Program<'_>,
     source: &str,
@@ -749,7 +758,34 @@ pub fn compute_complexity(
 ) -> Vec<FunctionComplexity> {
     let mut visitor = ComplexityVisitor::new(source, line_offsets);
 
+    // A frame for the module body itself. Without it every increment outside a
+    // function is dropped: `push_contribution` and `inc_cyclomatic` write to
+    // the innermost frame and there was none, so a top-level `if` ladder or an
+    // environment guard scored nothing at all, and hoisting a branch out of a
+    // function lowered the file's total without removing any branching
+    // (#2503).
+    visitor.push_function(
+        FunctionIdentity::public(MODULE_UNIT_NAME),
+        program.span,
+        0,
+        0,
+    );
     visitor.visit_program(program);
+    visitor.pop_function();
+
+    // The module unit is kept only when the module body actually branches.
+    // Emitting it for every file would add a unit to every denominator in the
+    // product, moving averages and percentiles on projects that gained no new
+    // information.
+    if let Some(index) = visitor
+        .results
+        .iter()
+        .position(|unit| unit.name == MODULE_UNIT_NAME)
+        && visitor.results[index].cyclomatic <= 1
+        && visitor.results[index].cognitive == 0
+    {
+        visitor.results.remove(index);
+    }
 
     visitor.results
 }
@@ -1286,9 +1322,71 @@ mod tests {
     }
 
     #[test]
-    fn top_level_code_not_reported() {
+    fn top_level_branching_lands_on_the_module_unit() {
+        // Previously dropped entirely: no frame was pushed for the module body,
+        // so this scored nothing (#2503).
         let results = analyze("if (true) { console.log('hello'); }");
-        assert!(results.is_empty());
+        let module = find_fn(&results, MODULE_UNIT_NAME);
+        assert_eq!(module.cyclomatic, 2, "base 1 plus the top-level if");
+        assert_eq!(module.cognitive, 1);
+    }
+
+    #[test]
+    fn every_increment_family_counts_at_module_scope() {
+        // One fixture per syntactic form, since the module frame is a new
+        // context for constructs that were only ever exercised inside a
+        // function.
+        for (source, cyclomatic) in [
+            ("if (a) { b(); }", 2),
+            ("if (a) { b(); } else if (c) { d(); }", 3),
+            ("for (const x of xs) { use(x); }", 2),
+            ("while (a) { b(); }", 2),
+            ("const v = a ? 1 : 2;", 2),
+            ("const v = a && b;", 2),
+            ("const v = a ?? b;", 2),
+            ("switch (a) { case 1: b(); break; default: c(); }", 2),
+            ("try { a(); } catch (e) { b(); }", 2),
+            ("const v = a?.b;", 2),
+        ] {
+            let results = analyze(source);
+            let module = find_fn(&results, MODULE_UNIT_NAME);
+            assert_eq!(
+                module.cyclomatic, cyclomatic,
+                "module-scope cyclomatic for `{source}`"
+            );
+            assert_conservation(source);
+        }
+    }
+
+    #[test]
+    fn a_function_declared_at_module_scope_keeps_its_own_unit() {
+        // The module frame must not swallow the functions inside it.
+        let results = analyze(
+            "if (flag) { setup(); }
+             export function handle(a) { if (a) { return 1; } return 0; }",
+        );
+
+        let module = find_fn(&results, MODULE_UNIT_NAME);
+        let handle = find_fn(&results, "handle");
+        assert_eq!(module.cyclomatic, 2, "the top-level if only");
+        assert_eq!(handle.cyclomatic, 2, "its own if only");
+    }
+
+    #[test]
+    fn a_module_without_branching_emits_no_module_unit() {
+        // Emitting one per file would add a unit to every denominator in the
+        // product without adding information.
+        for source in [
+            "export const a = 1;",
+            "import { x } from './x';\nexport default x;",
+            "function f(a) { if (a) { return 1; } return 0; }",
+        ] {
+            let results = analyze(source);
+            assert!(
+                !results.iter().any(|unit| unit.name == MODULE_UNIT_NAME),
+                "unexpected module unit for `{source}`"
+            );
+        }
     }
 
     #[test]
@@ -1859,11 +1957,10 @@ mod tests {
     }
 
     #[test]
-    fn hoisting_a_branch_to_module_scope_hides_it() {
-        // Documented blind spot, asserted so a future frame change is visible.
-        // `push_function` runs only for functions and arrows, and both
-        // `push_contribution` and `inc_cyclomatic` write to the innermost
-        // frame, so a top-level branch contributes nothing at all.
+    fn hoisting_a_branch_to_module_scope_keeps_it_counted() {
+        // The branch moves from a function to the module body and stays in the
+        // total. Before #2503 the hoisted form scored zero, so hoisting looked
+        // like removal.
         let inside = assert_conservation("const f = (a) => { if (a) { return 1; } return 0; };");
         let hoisted = assert_conservation(
             "let value = 0;
@@ -1872,8 +1969,8 @@ mod tests {
         );
         assert_eq!(inside.branch_points, 1);
         assert_eq!(
-            hoisted.branch_points, 0,
-            "module-scope branching is invisible, so a fall in branch_points is not proof of removal"
+            hoisted.branch_points, 1,
+            "the branch is still counted once it runs at import time"
         );
     }
 }

--- a/crates/output/src/audit_branching.rs
+++ b/crates/output/src/audit_branching.rs
@@ -56,9 +56,9 @@ pub enum CognitiveAttribution {
     /// left.
     NestingReset,
     /// The branch-point count fell. Deliberately a statement about the count
-    /// and not about the program: increments outside every function are
-    /// invisible here, which is the same reason there is no "branching
-    /// removed" verdict.
+    /// and not about the program: a fall can also come from code leaving the
+    /// accounting set, which is the same reason this section names no
+    /// changeset-level verdict.
     FewerBranchPoints,
     /// Both moved, or neither did. The second case is cognitive falling while
     /// branching and nesting both held, where naming either cause would assert

--- a/crates/output/src/health_findings.rs
+++ b/crates/output/src/health_findings.rs
@@ -137,6 +137,7 @@ pub fn build_health_finding_actions(
 
     let inherited_from = violation.inherited_from.as_deref();
     if includes_crap
+        && !fallow_types::extract::is_synthetic_unit(name)
         && let Some(action) = build_crap_coverage_action(
             name,
             violation.coverage_tier,
@@ -282,6 +283,15 @@ fn build_suppress_action(
     is_component: bool,
 ) -> HealthFindingAction {
     let extension = violation.path.extension().and_then(|ext| ext.to_str());
+    // A module body has no declaration to place a comment above; the finding is
+    // anchored at the first line of the file.
+    if violation.name == "<module>" {
+        return suppress_line_action(
+            "Suppress with an inline comment above the branching statement",
+            DEFAULT_SUPPRESS_COMMENT,
+            "above-module-statement",
+        );
+    }
     if is_template && extension.is_some_and(|ext| ext.eq_ignore_ascii_case("html")) {
         return suppress_file_action(
             "Suppress with an HTML comment at the top of the template",

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1003,6 +1003,18 @@ pub fn is_synthetic_template_unit(name: &str) -> bool {
     name == "<template>" || name.starts_with("<snippet:")
 }
 
+/// Units an Istanbul `fnMap` can never contain, so no coverage can be matched
+/// to them.
+///
+/// The template family plus the module body: module-scope code runs at import
+/// time and belongs to no function, so a coverage report has no entry for it.
+/// Wider than [`is_synthetic_template_unit`], which stays template-specific for
+/// the rendering paths that speak about templates.
+#[must_use]
+pub fn is_coverage_exempt_unit(name: &str) -> bool {
+    is_synthetic_template_unit(name) || name == "<module>"
+}
+
 /// Branching totals for one file: the quantity that survives extraction, and
 /// the number of units now holding it.
 ///

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -1003,15 +1003,19 @@ pub fn is_synthetic_template_unit(name: &str) -> bool {
     name == "<template>" || name.starts_with("<snippet:")
 }
 
-/// Units an Istanbul `fnMap` can never contain, so no coverage can be matched
-/// to them.
+/// Units that are not an authored function.
 ///
-/// The template family plus the module body: module-scope code runs at import
-/// time and belongs to no function, so a coverage report has no entry for it.
+/// The template family plus the module body. Nothing here has a signature, a
+/// parameter list, a length a reader would call a function length, or an entry
+/// in an Istanbul function map. Consumers that treat a unit as a function must
+/// skip these: a module body's line count is the whole file, and asking for
+/// test coverage of code that belongs to no function is asking for something
+/// that cannot exist.
+///
 /// Wider than [`is_synthetic_template_unit`], which stays template-specific for
 /// the rendering paths that speak about templates.
 #[must_use]
-pub fn is_coverage_exempt_unit(name: &str) -> bool {
+pub fn is_synthetic_unit(name: &str) -> bool {
     is_synthetic_template_unit(name) || name == "<module>"
 }
 
@@ -1026,11 +1030,9 @@ pub fn is_coverage_exempt_unit(name: &str) -> bool {
 /// `functions` rises. Reporting the two terms separately is what distinguishes
 /// branching that left from branching that only moved.
 ///
-/// Known blind spot: increments outside every function are invisible here.
-/// `push_contribution` and `inc_cyclomatic` both write to the innermost frame
-/// and no frame is pushed at module scope, so a branch hoisted to the top level
-/// of a module lowers `branch_points` without removing any branching. Consumers
-/// must not read a fall in `branch_points` as proof that branching was removed.
+/// Module-scope increments are included: they land on a synthetic `<module>`
+/// unit, so a branch hoisted out of a function to the top level of a module
+/// stays counted rather than vanishing from the total.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, bitcode::Encode, bitcode::Decode)]
 pub struct FileBranching {
     /// Summed weight of `Cyclomatic` contributions. The conserved quantity.

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -24727,7 +24727,7 @@
         {
           "type": "string",
           "const": "fewer-branch-points",
-          "description": "The branch-point count fell. Deliberately a statement about the count\nand not about the program: increments outside every function are\ninvisible here, which is the same reason there is no \"branching\nremoved\" verdict."
+          "description": "The branch-point count fell. Deliberately a statement about the count\nand not about the program: a fall can also come from code leaving the\naccounting set, which is the same reason this section names no\nchangeset-level verdict."
         },
         {
           "type": "string",


### PR DESCRIPTION
## Problem

No frame was pushed for a module body. `push_contribution` and `inc_cyclomatic` both write to the innermost frame, and at module scope there was none, so every increment outside a function was dropped from the counter and from the per-increment breakdown together.

Consequences, in rising order:

1. Module-scope branching was unmeasured. Top-level `if` ladders, environment guards and conditional exports scored nothing.
2. Every aggregate built on those numbers inherited the blind spot: `average_cyclomatic`, `critical_complexity_pct`, `p90_cyclomatic`, `FileHealthScore.total_cyclomatic`.
3. Hoisting a branch out of a function lowered a file's total without removing any branching, so a fall in the count was not evidence of removal.

The identity `sum(cyclomatic) == functions + branch points` still held throughout, because both sides dropped in step. The branching was simply invisible.

## Approach

Module-scope code lands on a synthetic `<module>` unit, in the same family as `<template>`.

Two choices keep the blast radius proportional to the information gained:

- The unit is emitted only when the module body actually branches. Emitting one per file would add a unit to every denominator in the product without adding information.
- It is not an authored function, so every consumer that treats a unit as one skips it: both CRAP filter sites, the large-function list, the unit-size and parameter distributions, and the component rollup. Its suppression action points at the branching statement rather than at a function declaration it does not have, and it is offered no coverage action, because coverage of code belonging to no function cannot exist. That needed a predicate of its own (`is_synthetic_unit`), since the template-specific one is also used by rendering paths that speak about templates.

`CACHE_VERSION` moves to 285: extraction semantics changed.

## Measured effect

Four real projects, unit counts before and after:

| project | before | after | module units |
|---|---|---|---|
| A | 693 | 695 | 2 |
| B | 4965 | 4972 | 7 |
| C | 2043 | 2053 | 10 |
| D | 596 | 597 | 1 |

Between 0.1 and 0.5 percent more units. `avg_cyclomatic`, `p90_cyclomatic`, `critical_complexity_pct` and `maintainability_avg` do not move on any of them, not even at one decimal place. That is four application codebases, where nearly everything lives in a function; a file whose module body branches heavily will see its own numbers change, which is the point.

Worth stating plainly: this tempers the urgency of the original report. The gap is real, and it is rarely bitten in application code, where nearly everything lives in a function. It matters most for the third consequence above, which is a correctness property rather than a scoring one.

## Found in review

The first pass exempted the module unit from one of the two CRAP filter sites and nothing else, so it still scored on CRAP through the second, entered the large-function list with the whole file as its length, drove the unit-size and parameter distributions, could be reported as an Angular component's worst class method, and was offered a suppression comment above a declaration it does not have plus a request for test coverage that cannot exist. All reproduced against a real binary and fixed, and the changelog claim about the CRAP exemption was corrected: it was not true when written.

## Validation

- A fixture per syntactic form at module scope: `if`, `else if`, `for...of`, `while`, ternary, logical and nullish operators, `switch`, `try`/`catch`, optional chaining, each also asserting the conservation identity
- A test that the module frame does not swallow the functions declared inside it
- Two tests that pinned the old behavior are inverted, including the one added alongside the branching section to document the gap
- Full workspace suite green, `cargo clippy --workspace --all-targets -- -D warnings` clean, schema drift gate and contract generation green
- Real-consumer smoke: `fallow health` runs clean on four real projects, which is where the numbers above come from

Closes #2503

