### PR TITLE
fix(cli): complete the knip and jscpd migration tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Closes [#2507](https://github.com/fallow-rs/fallow/issues/2507)). The knip
   plugin table had drifted well behind both projects: it named 73 of knip's 184
   plugin config keys, so a `marko`, `pnpm` or `sveltekit` section passed through
-  the migration without a single word, and the jscpd table covered 22 of the 37
+  the migration without a single word, and the jscpd table covered 22 of the 36
   options in jscpd's own `IOptions`, so `gitignore`, `cache` and `hashFunction`
   vanished the same way. A dropped section that says nothing is worse than one
   that says it was dropped, because the reader has no way to notice. Both tables
@@ -137,10 +137,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reported as auto-detected, and a key no plugin covers is reported as having no
   equivalent rather than promising detection that will not happen. Sixteen keys
   moved from the first group to the second on that rule, among them `eleventy`,
-  `oclif`, `vue` and `xo`, which fallow has no plugin for and never did. Tests
-  now pin each table against the upstream key set, so the next round of
-  additions shows up as a failure instead of as silence. Marko itself still has
-  no fallow plugin; only the migration reporting is fixed here. Thanks
+  `oclif`, `vue` and `xo`, which fallow has no plugin for and never did.
+  Completeness is not the only guard: a key in neither table, on either side, is
+  now reported as unknown instead of being skipped, so an option added upstream
+  after this release surfaces on the first migration that uses it rather than
+  disappearing. `rules.cycles` migrates to `circular-dependencies`, which fallow
+  has, and the two knip issue types fallow genuinely has no answer for,
+  `namespaceMembers` and `catalogReferences`, are named as such instead of
+  reading like typos. A test pins the covered half of the knip table against
+  fallow's built-in plugin roster, in both directions, so renaming or removing a
+  plugin fails the build instead of shipping a promise of detection that no
+  longer happens. The five keys knip spells differently (`next`, `nest`,
+  `panda-css`, `webdriver-io`, `electron-vite`) are declared as aliases, and a
+  sixth has to be declared before that test accepts it. jscpd's `colors` is
+  covered as well; it is not declared in `IOptions`, jscpd reads it off the
+  config object for its `--colors` flag. Marko itself still has no fallow
+  plugin; only the migration reporting is fixed here. Thanks
   [@VariableVince](https://github.com/VariableVince) for the report.
 
 - **A type-aware pass that cannot finish no longer takes the whole run with it**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fallow migrate` no longer drops knip and jscpd sections in silence**
+  (Closes [#2507](https://github.com/fallow-rs/fallow/issues/2507)). The knip
+  plugin table had drifted well behind both projects: it named 73 of knip's 184
+  plugin config keys, so a `marko`, `pnpm` or `sveltekit` section passed through
+  the migration without a single word, and the jscpd table covered 22 of the 37
+  options in jscpd's own `IOptions`, so `gitignore`, `cache` and `hashFunction`
+  vanished the same way. A dropped section that says nothing is worse than one
+  that says it was dropped, because the reader has no way to notice. Both tables
+  are now complete against their upstream source, and knip keys are split by
+  what fallow can actually claim: a key a built-in fallow plugin covers is
+  reported as auto-detected, and a key no plugin covers is reported as having no
+  equivalent rather than promising detection that will not happen. Sixteen keys
+  moved from the first group to the second on that rule, among them `eleventy`,
+  `oclif`, `vue` and `xo`, which fallow has no plugin for and never did. Tests
+  now pin each table against the upstream key set, so the next round of
+  additions shows up as a failure instead of as silence. Marko itself still has
+  no fallow plugin; only the migration reporting is fixed here. Thanks
+  [@VariableVince](https://github.com/VariableVince) for the report.
+
 - **A type-aware pass that cannot finish no longer takes the whole run with it**
   (Closes [#2499](https://github.com/fallow-rs/fallow/issues/2499)). The
   semantic pass has a fixed two-minute ceiling, and a project large enough to

--- a/crates/cli/src/migrate/jscpd.rs
+++ b/crates/cli/src/migrate/jscpd.rs
@@ -7,8 +7,9 @@ const MIGRATION_DOCS_URL: &str = "https://docs.fallow.tools/migration/from-jscpd
 /// jscpd fields that cannot be mapped and generate warnings.
 ///
 /// Together with the fields `duplicate_options_from_jscpd` migrates, this covers
-/// every key of jscpd's `IOptions`, so a migration never drops a configured
-/// option without reporting it.
+/// every key of jscpd's `IOptions` plus `colors`, so a migration never drops a
+/// configured option without reporting it. `colors` is not declared in
+/// `IOptions`; jscpd reads it off the config object for its `--colors` flag.
 const JSCPD_UNMAPPABLE_FIELDS: &[(&str, &str, Option<&str>)] = &[
     ("maxLines", "No maximum line count limit in fallow", None),
     ("maxSize", "No maximum file size limit in fallow", None),
@@ -897,8 +898,10 @@ mod tests {
         assert!(config.is_empty());
     }
 
-    /// Every key of jscpd's `IOptions`. A configured option must either reach
-    /// the fallow `duplicates` block or produce a warning, never vanish.
+    /// Every key of jscpd's `IOptions`, plus `colors`, which jscpd reads off
+    /// the config object for its `--colors` flag without declaring it in
+    /// `IOptions`. A configured option must either reach the fallow
+    /// `duplicates` block or produce a warning, never vanish.
     const JSCPD_OPTIONS: &[&str] = &[
         "absolute",
         "blame",

--- a/crates/cli/src/migrate/jscpd.rs
+++ b/crates/cli/src/migrate/jscpd.rs
@@ -1,6 +1,10 @@
 use super::{MigrationWarning, string_or_array};
 
 /// jscpd fields that cannot be mapped and generate warnings.
+///
+/// Together with the fields `duplicate_options_from_jscpd` migrates, this covers
+/// every key of jscpd's `IOptions`, so a migration never drops a configured
+/// option without reporting it.
 const JSCPD_UNMAPPABLE_FIELDS: &[(&str, &str, Option<&str>)] = &[
     ("maxLines", "No maximum line count limit in fallow", None),
     ("maxSize", "No maximum file size limit in fallow", None),
@@ -61,6 +65,69 @@ const JSCPD_UNMAPPABLE_FIELDS: &[(&str, &str, Option<&str>)] = &[
         "path",
         "Source path configuration is not supported",
         Some("run fallow from the project root directory"),
+    ),
+    (
+        "config",
+        "fallow discovers its own config file",
+        Some("use --config to point at a specific fallow config"),
+    ),
+    (
+        "cache",
+        "Caching is not configured in the config file",
+        Some("caching is on by default; pass --no-cache to disable it"),
+    ),
+    ("gitignore", "fallow always respects .gitignore", None),
+    (
+        "silent",
+        "Output verbosity is not configurable in fallow",
+        Some("use --quiet to suppress progress output"),
+    ),
+    (
+        "verbose",
+        "Output verbosity is not configurable in fallow",
+        None,
+    ),
+    ("debug", "No debug output mode in fallow", None),
+    ("noTips", "fallow does not print tips", None),
+    (
+        "colors",
+        "Color output is not configurable in the config file",
+        Some("fallow follows NO_COLOR and TTY detection"),
+    ),
+    (
+        "list",
+        "Listing detected formats is not supported in fallow",
+        None,
+    ),
+    (
+        "formatsNames",
+        "Custom file name mappings are not configurable in fallow",
+        None,
+    ),
+    (
+        "storePath",
+        "Store backend is not configurable in fallow",
+        None,
+    ),
+    (
+        "reportersOptions",
+        "Reporters are not configurable in fallow",
+        Some("use --format flag instead (human/json/sarif/compact)"),
+    ),
+    (
+        "listeners",
+        "Custom listeners are not supported in fallow",
+        None,
+    ),
+    (
+        "hashFunction",
+        "The duplication hash function is not configurable in fallow",
+        None,
+    ),
+    (
+        "executionId",
+        "Execution identifiers are not supported in fallow",
+        None,
     ),
 ];
 
@@ -419,7 +486,22 @@ mod tests {
                 "tokensToSkip": ["if"],
                 "exitCode": 1,
                 "pattern": "*.ts",
-                "path": ["src/"]
+                "path": ["src/"],
+                "config": ".jscpd.json",
+                "cache": true,
+                "gitignore": true,
+                "silent": true,
+                "verbose": true,
+                "debug": true,
+                "noTips": true,
+                "colors": false,
+                "list": true,
+                "formatsNames": {"javascript": ["Jakefile"]},
+                "storePath": "./.jscpd",
+                "reportersOptions": {},
+                "listeners": ["log"],
+                "hashFunction": "md5",
+                "executionId": "run-1"
             }"#,
         )
         .unwrap();
@@ -517,7 +599,7 @@ mod tests {
     #[test]
     fn migrate_jscpd_unmappable_without_suggestions() {
         let jscpd: serde_json::Value = serde_json::from_str(
-            r#"{"maxLines": 1000, "maxSize": "50kb", "blame": true, "absolute": true, "noSymlinks": false, "ignoreCase": true, "format": ["js"], "formatsExts": {}, "store": "redis", "tokensToSkip": ["x"], "pattern": "*.ts"}"#,
+            r#"{"maxLines": 1000, "maxSize": "50kb", "blame": true, "absolute": true, "noSymlinks": false, "ignoreCase": true, "format": ["js"], "formatsExts": {}, "store": "redis", "tokensToSkip": ["x"], "pattern": "*.ts", "gitignore": true, "verbose": true, "debug": true, "noTips": true, "list": true, "formatsNames": {}, "storePath": "./.jscpd", "listeners": ["log"], "hashFunction": "md5", "executionId": "run-1"}"#,
         )
         .unwrap();
         let mut config = empty_config();
@@ -771,5 +853,104 @@ mod tests {
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].field, "(root)");
         assert!(config.is_empty());
+    }
+
+    /// Every key of jscpd's `IOptions`. A configured option must either reach
+    /// the fallow `duplicates` block or produce a warning, never vanish.
+    const JSCPD_OPTIONS: &[&str] = &[
+        "absolute",
+        "blame",
+        "cache",
+        "colors",
+        "config",
+        "debug",
+        "executionId",
+        "exitCode",
+        "format",
+        "formatsExts",
+        "formatsNames",
+        "gitignore",
+        "hashFunction",
+        "ignore",
+        "ignoreCase",
+        "ignorePattern",
+        "list",
+        "listeners",
+        "maxLines",
+        "maxSize",
+        "minLines",
+        "minTokens",
+        "mode",
+        "noSymlinks",
+        "noTips",
+        "output",
+        "path",
+        "pattern",
+        "reporters",
+        "reportersOptions",
+        "silent",
+        "skipLocal",
+        "storePath",
+        "store",
+        "threshold",
+        "tokensToSkip",
+        "verbose",
+    ];
+
+    /// Options that migrate into the fallow `duplicates` block.
+    const JSCPD_MAPPED_OPTIONS: &[&str] = &[
+        "ignore",
+        "minLines",
+        "minTokens",
+        "mode",
+        "skipLocal",
+        "threshold",
+    ];
+
+    #[test]
+    fn every_jscpd_option_is_mapped_or_reported() {
+        for option in JSCPD_OPTIONS {
+            let mapped = JSCPD_MAPPED_OPTIONS.contains(option);
+            let reported = JSCPD_UNMAPPABLE_FIELDS.iter().any(|(f, _, _)| f == option);
+            assert!(
+                mapped ^ reported,
+                "jscpd option `{option}` should be either migrated or reported, not neither or both"
+            );
+        }
+    }
+
+    #[test]
+    fn unmappable_jscpd_fields_are_real_jscpd_options() {
+        for (field, _, _) in JSCPD_UNMAPPABLE_FIELDS {
+            assert!(
+                JSCPD_OPTIONS.contains(field),
+                "JSCPD_UNMAPPABLE_FIELDS entry `{field}` is not a jscpd option"
+            );
+        }
+    }
+
+    #[test]
+    fn unmappable_jscpd_fields_have_no_duplicates() {
+        let mut seen = rustc_hash::FxHashSet::default();
+        for (field, _, _) in JSCPD_UNMAPPABLE_FIELDS {
+            assert!(
+                seen.insert(*field),
+                "JSCPD_UNMAPPABLE_FIELDS has duplicate entry `{field}`"
+            );
+        }
+    }
+
+    #[test]
+    fn newly_covered_jscpd_options_warn() {
+        let jscpd: serde_json::Value =
+            serde_json::from_str(r#"{"gitignore": true, "cache": false, "silent": true}"#).unwrap();
+        let mut config = empty_config();
+        let mut warnings = Vec::new();
+        migrate_jscpd(&jscpd, &mut config, &mut warnings);
+
+        let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
+        assert!(fields.contains(&"gitignore"), "{fields:?}");
+        assert!(fields.contains(&"cache"), "{fields:?}");
+        assert!(fields.contains(&"silent"), "{fields:?}");
     }
 }

--- a/crates/cli/src/migrate/jscpd.rs
+++ b/crates/cli/src/migrate/jscpd.rs
@@ -1,5 +1,9 @@
 use super::{MigrationWarning, string_or_array};
 
+/// Docs URL surfaced as a suggestion when a jscpd config key is unknown to the
+/// migrator (typo, or an option jscpd added after this table was written).
+const MIGRATION_DOCS_URL: &str = "https://docs.fallow.tools/migration/from-jscpd";
+
 /// jscpd fields that cannot be mapped and generate warnings.
 ///
 /// Together with the fields `duplicate_options_from_jscpd` migrates, this covers
@@ -131,6 +135,20 @@ const JSCPD_UNMAPPABLE_FIELDS: &[(&str, &str, Option<&str>)] = &[
     ),
 ];
 
+/// jscpd options that migrate into the fallow `duplicates` block, plus the
+/// `$schema` key a JSON config may carry. A key here is either translated or
+/// structural, so the unknown-key ladder in `push_unhandled_jscpd_warnings`
+/// must stay quiet about it.
+const JSCPD_MIGRATED_FIELDS: &[&str] = &[
+    "$schema",
+    "ignore",
+    "minLines",
+    "minTokens",
+    "mode",
+    "skipLocal",
+    "threshold",
+];
+
 pub(super) fn migrate_jscpd(
     jscpd: &serde_json::Value,
     config: &mut serde_json::Map<String, serde_json::Value>,
@@ -151,7 +169,7 @@ pub(super) fn migrate_jscpd(
         config.insert("duplicates".to_string(), serde_json::Value::Object(dupes));
     }
 
-    push_unmappable_jscpd_warnings(obj, warnings);
+    push_unhandled_jscpd_warnings(obj, warnings);
 }
 
 fn duplicate_options_from_jscpd(
@@ -258,7 +276,13 @@ fn insert_jscpd_ignore(
     }
 }
 
-fn push_unmappable_jscpd_warnings(
+/// Warn about every configured jscpd option the migration did not translate.
+///
+/// A documented-unmappable option is reported with its own explanation, in
+/// table order. An option in neither the migrated nor the unmappable table is
+/// reported as unknown, so a key outside both tables is never spread into
+/// nothing.
+fn push_unhandled_jscpd_warnings(
     obj: &serde_json::Map<String, serde_json::Value>,
     warnings: &mut Vec<MigrationWarning>,
 ) {
@@ -271,6 +295,24 @@ fn push_unmappable_jscpd_warnings(
                 suggestion: suggestion.map(std::string::ToString::to_string),
             });
         }
+    }
+
+    for key in obj.keys() {
+        if JSCPD_MIGRATED_FIELDS.contains(&key.as_str())
+            || JSCPD_UNMAPPABLE_FIELDS
+                .iter()
+                .any(|(field, _, _)| *field == key.as_str())
+        {
+            continue;
+        }
+        warnings.push(MigrationWarning {
+            source: "jscpd",
+            field: key.clone(),
+            message: format!("unknown jscpd option `{key}`; not migrated"),
+            suggestion: Some(format!(
+                "check for a typo or report the missing mapping at {MIGRATION_DOCS_URL}"
+            )),
+        });
     }
 }
 
@@ -897,20 +939,10 @@ mod tests {
         "verbose",
     ];
 
-    /// Options that migrate into the fallow `duplicates` block.
-    const JSCPD_MAPPED_OPTIONS: &[&str] = &[
-        "ignore",
-        "minLines",
-        "minTokens",
-        "mode",
-        "skipLocal",
-        "threshold",
-    ];
-
     #[test]
     fn every_jscpd_option_is_mapped_or_reported() {
         for option in JSCPD_OPTIONS {
-            let mapped = JSCPD_MAPPED_OPTIONS.contains(option);
+            let mapped = JSCPD_MIGRATED_FIELDS.contains(option);
             let reported = JSCPD_UNMAPPABLE_FIELDS.iter().any(|(f, _, _)| f == option);
             assert!(
                 mapped ^ reported,
@@ -938,6 +970,51 @@ mod tests {
                 "JSCPD_UNMAPPABLE_FIELDS has duplicate entry `{field}`"
             );
         }
+    }
+
+    /// `$schema` is structural rather than an option, so it is the one entry
+    /// that does not have to appear in jscpd's own option list.
+    #[test]
+    fn migrated_jscpd_fields_are_real_jscpd_options() {
+        for field in JSCPD_MIGRATED_FIELDS {
+            if *field == "$schema" {
+                continue;
+            }
+            assert!(
+                JSCPD_OPTIONS.contains(field),
+                "JSCPD_MIGRATED_FIELDS entry `{field}` is not a jscpd option"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_jscpd_option_is_reported() {
+        let jscpd: serde_json::Value =
+            serde_json::from_str(r#"{"minTokens": 50, "treatHintsAsErrors": true}"#).unwrap();
+        let mut config = empty_config();
+        let mut warnings = Vec::new();
+        migrate_jscpd(&jscpd, &mut config, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].field, "treatHintsAsErrors");
+        assert!(
+            warnings[0].message.contains("unknown jscpd option"),
+            "{}",
+            warnings[0].message
+        );
+        let dupes = config.get("duplicates").unwrap().as_object().unwrap();
+        assert_eq!(dupes.get("minTokens").unwrap(), 50);
+    }
+
+    #[test]
+    fn schema_key_is_not_reported_as_unknown() {
+        let jscpd: serde_json::Value =
+            serde_json::from_str(r#"{"$schema": "https://example.test/jscpd.json"}"#).unwrap();
+        let mut config = empty_config();
+        let mut warnings = Vec::new();
+        migrate_jscpd(&jscpd, &mut config, &mut warnings);
+
+        assert!(warnings.is_empty(), "{warnings:?}");
     }
 
     #[test]

--- a/crates/cli/src/migrate/knip.rs
+++ b/crates/cli/src/migrate/knip.rs
@@ -603,7 +603,8 @@ mod tests {
     fn migrate_knip_exclude_all_mappable_types() {
         let knip: serde_json::Value = serde_json::from_str(
             r#"{"exclude": ["files", "dependencies", "devDependencies", "exports",
-                "types", "enumMembers", "classMembers", "unlisted", "unresolved", "duplicates"]}"#,
+                "types", "enumMembers", "classMembers", "unlisted", "unresolved", "duplicates",
+                "cycles"]}"#,
         )
         .unwrap();
         let mut config = empty_config();

--- a/crates/cli/src/migrate/knip.rs
+++ b/crates/cli/src/migrate/knip.rs
@@ -2,7 +2,8 @@ use serde_json::Value;
 
 use super::knip_fields::{
     migrate_exclude, migrate_ignore, migrate_ignore_deps, migrate_ignore_exports_used_in_file,
-    migrate_include, migrate_rules, migrate_simple_field, warn_plugin_keys, warn_unmappable_fields,
+    migrate_include, migrate_rules, migrate_simple_field, warn_unhandled_root_keys,
+    warn_unmappable_fields,
 };
 #[cfg(test)]
 use super::knip_tables::KNIP_RULE_MAP;
@@ -59,7 +60,7 @@ pub(super) fn migrate_knip(
 
     warn_unmappable_fields(obj, warnings);
 
-    warn_plugin_keys(obj, warnings);
+    warn_unhandled_root_keys(obj, warnings);
 
     if let Some(workspaces) = obj.get("workspaces") {
         warn_workspace_configs(workspaces, warnings);

--- a/crates/cli/src/migrate/knip_fields.rs
+++ b/crates/cli/src/migrate/knip_fields.rs
@@ -1,8 +1,8 @@
 use serde_json::{Map, Value};
 
 use super::knip_tables::{
-    KNIP_PLUGIN_KEYS, KNIP_RULE_MAP, KNIP_UNMAPPABLE_FIELDS, KNIP_UNMAPPABLE_ISSUE_TYPES,
-    KNIP_UNSUPPORTED_PLUGIN_KEYS,
+    KNIP_MIGRATED_FIELDS, KNIP_PLUGIN_KEYS, KNIP_RULE_MAP, KNIP_UNMAPPABLE_FIELDS,
+    KNIP_UNMAPPABLE_ISSUE_TYPES, KNIP_UNSUPPORTED_PLUGIN_KEYS,
 };
 use super::{MigrationWarning, string_or_array};
 
@@ -268,12 +268,15 @@ pub(super) fn warn_unmappable_fields(obj: &JsonMap, warnings: &mut Vec<Migration
     }
 }
 
-/// Warn about knip plugin-specific config keys.
+/// Warn about every root key the migration did not translate.
 ///
 /// A key that a built-in fallow plugin covers is reported as auto-detected. A
-/// key that no fallow plugin covers is reported as unsupported rather than
-/// dropped in silence, so a migration never loses a section without saying so.
-pub(super) fn warn_plugin_keys(obj: &JsonMap, warnings: &mut Vec<MigrationWarning>) {
+/// key that no fallow plugin covers is reported as unsupported. A key in
+/// neither plugin table and in neither the migrated nor the unmappable table
+/// is reported as unknown, so a migration never loses a section without saying
+/// so. `warn_unmappable_fields` already reports the documented-unmappable
+/// keys, so they are skipped here rather than reported twice.
+pub(super) fn warn_unhandled_root_keys(obj: &JsonMap, warnings: &mut Vec<MigrationWarning>) {
     for key in obj.keys() {
         if KNIP_PLUGIN_KEYS.contains(&key.as_str()) {
             warnings.push(MigrationWarning {
@@ -297,6 +300,19 @@ pub(super) fn warn_plugin_keys(obj: &JsonMap, warnings: &mut Vec<MigrationWarnin
                      dependencies as unused"
                         .to_string(),
                 ),
+            });
+        } else if !KNIP_MIGRATED_FIELDS.contains(&key.as_str())
+            && !KNIP_UNMAPPABLE_FIELDS
+                .iter()
+                .any(|(field, _, _)| *field == key.as_str())
+        {
+            warnings.push(MigrationWarning {
+                source: "knip",
+                field: key.clone(),
+                message: format!("unknown knip config key `{key}`; not migrated"),
+                suggestion: Some(format!(
+                    "check for a typo or report the missing mapping at {MIGRATION_DOCS_URL}"
+                )),
             });
         }
     }
@@ -752,11 +768,11 @@ mod tests {
     }
 
     #[test]
-    fn warn_plugin_keys_detects_plugins() {
+    fn warn_unhandled_root_keys_detects_plugins() {
         let obj: JsonMap =
             serde_json::from_str(r#"{"eslint": {"entry": ["a.js"]}, "jest": true}"#).unwrap();
         let mut warnings = Vec::new();
-        warn_plugin_keys(&obj, &mut warnings);
+        warn_unhandled_root_keys(&obj, &mut warnings);
 
         assert_eq!(warnings.len(), 2);
         let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
@@ -768,30 +784,30 @@ mod tests {
     }
 
     #[test]
-    fn warn_plugin_keys_empty_object_no_warnings() {
+    fn warn_unhandled_root_keys_empty_object_no_warnings() {
         let obj = Map::new();
         let mut warnings = Vec::new();
-        warn_plugin_keys(&obj, &mut warnings);
+        warn_unhandled_root_keys(&obj, &mut warnings);
 
         assert!(warnings.is_empty());
     }
 
     #[test]
-    fn warn_plugin_keys_non_plugin_keys_no_warnings() {
+    fn warn_unhandled_root_keys_non_plugin_keys_no_warnings() {
         let obj: JsonMap =
             serde_json::from_str(r#"{"entry": ["x"], "ignore": ["y"], "rules": {}}"#).unwrap();
         let mut warnings = Vec::new();
-        warn_plugin_keys(&obj, &mut warnings);
+        warn_unhandled_root_keys(&obj, &mut warnings);
 
         assert!(warnings.is_empty());
     }
 
     #[test]
-    fn warn_plugin_keys_reports_unsupported_plugin() {
+    fn warn_unhandled_root_keys_reports_unsupported_plugin() {
         let obj: JsonMap = serde_json::from_str(r#"{"marko": {"entry": ["src/**/*.marko"]}}"#)
             .expect("valid json");
         let mut warnings = Vec::new();
-        warn_plugin_keys(&obj, &mut warnings);
+        warn_unhandled_root_keys(&obj, &mut warnings);
 
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].field, "marko");
@@ -804,11 +820,11 @@ mod tests {
     }
 
     #[test]
-    fn warn_plugin_keys_separates_covered_from_unsupported() {
+    fn warn_unhandled_root_keys_separates_covered_from_unsupported() {
         let obj: JsonMap =
             serde_json::from_str(r#"{"sveltekit": true, "vue": true}"#).expect("valid json");
         let mut warnings = Vec::new();
-        warn_plugin_keys(&obj, &mut warnings);
+        warn_unhandled_root_keys(&obj, &mut warnings);
 
         let sveltekit = warnings
             .iter()
@@ -821,5 +837,65 @@ mod tests {
             .find(|w| w.field == "vue")
             .expect("vue warning");
         assert!(vue.message.contains("no fallow plugin equivalent"));
+    }
+
+    #[test]
+    fn warn_unhandled_root_keys_reports_a_key_in_neither_table() {
+        let obj: JsonMap = serde_json::from_str(r#"{"cycles": true}"#).expect("valid json");
+        let mut warnings = Vec::new();
+        warn_unhandled_root_keys(&obj, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].field, "cycles");
+        assert!(
+            warnings[0].message.contains("unknown knip config key"),
+            "{}",
+            warnings[0].message
+        );
+        assert!(
+            warnings[0]
+                .suggestion
+                .as_ref()
+                .is_some_and(|s| s.contains(MIGRATION_DOCS_URL))
+        );
+    }
+
+    #[test]
+    fn warn_unhandled_root_keys_stays_quiet_about_documented_unmappable_keys() {
+        let obj: JsonMap =
+            serde_json::from_str(r#"{"treatTagHintsAsErrors": true, "$schema": "x"}"#)
+                .expect("valid json");
+        let mut warnings = Vec::new();
+        warn_unhandled_root_keys(&obj, &mut warnings);
+
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+
+    /// `warn_unmappable_fields` owns the documented-unmappable keys, so a
+    /// full migration reports `treatTagHintsAsErrors` exactly once while an
+    /// sibling in neither table still gets its own warning.
+    #[test]
+    fn documented_and_unknown_keys_each_warn_once() {
+        let obj: JsonMap =
+            serde_json::from_str(r#"{"treatTagHintsAsErrors": true, "cycles": true}"#)
+                .expect("valid json");
+        let mut warnings = Vec::new();
+        warn_unmappable_fields(&obj, &mut warnings);
+        warn_unhandled_root_keys(&obj, &mut warnings);
+
+        let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
+        assert_eq!(
+            fields
+                .iter()
+                .filter(|f| **f == "treatTagHintsAsErrors")
+                .count(),
+            1,
+            "{fields:?}"
+        );
+        assert_eq!(
+            fields.iter().filter(|f| **f == "cycles").count(),
+            1,
+            "{fields:?}"
+        );
     }
 }

--- a/crates/cli/src/migrate/knip_fields.rs
+++ b/crates/cli/src/migrate/knip_fields.rs
@@ -2,6 +2,7 @@ use serde_json::{Map, Value};
 
 use super::knip_tables::{
     KNIP_PLUGIN_KEYS, KNIP_RULE_MAP, KNIP_UNMAPPABLE_FIELDS, KNIP_UNMAPPABLE_ISSUE_TYPES,
+    KNIP_UNSUPPORTED_PLUGIN_KEYS,
 };
 use super::{MigrationWarning, string_or_array};
 
@@ -267,7 +268,11 @@ pub(super) fn warn_unmappable_fields(obj: &JsonMap, warnings: &mut Vec<Migration
     }
 }
 
-/// Warn about knip plugin-specific config keys that are auto-detected in fallow.
+/// Warn about knip plugin-specific config keys.
+///
+/// A key that a built-in fallow plugin covers is reported as auto-detected. A
+/// key that no fallow plugin covers is reported as unsupported rather than
+/// dropped in silence, so a migration never loses a section without saying so.
 pub(super) fn warn_plugin_keys(obj: &JsonMap, warnings: &mut Vec<MigrationWarning>) {
     for key in obj.keys() {
         if KNIP_PLUGIN_KEYS.contains(&key.as_str()) {
@@ -279,6 +284,17 @@ pub(super) fn warn_plugin_keys(obj: &JsonMap, warnings: &mut Vec<MigrationWarnin
                 ),
                 suggestion: Some(
                     "remove this section; fallow detects framework config automatically"
+                        .to_string(),
+                ),
+            });
+        } else if KNIP_UNSUPPORTED_PLUGIN_KEYS.contains(&key.as_str()) {
+            warnings.push(MigrationWarning {
+                source: "knip",
+                field: key.clone(),
+                message: format!("plugin config `{key}` has no fallow plugin equivalent"),
+                suggestion: Some(
+                    "remove this section; fallow may report this tool's config files or \
+                     dependencies as unused"
                         .to_string(),
                 ),
             });
@@ -768,5 +784,42 @@ mod tests {
         warn_plugin_keys(&obj, &mut warnings);
 
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn warn_plugin_keys_reports_unsupported_plugin() {
+        let obj: JsonMap = serde_json::from_str(r#"{"marko": {"entry": ["src/**/*.marko"]}}"#)
+            .expect("valid json");
+        let mut warnings = Vec::new();
+        warn_plugin_keys(&obj, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].field, "marko");
+        assert!(
+            warnings[0].message.contains("no fallow plugin equivalent"),
+            "{}",
+            warnings[0].message
+        );
+        assert!(warnings[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn warn_plugin_keys_separates_covered_from_unsupported() {
+        let obj: JsonMap =
+            serde_json::from_str(r#"{"sveltekit": true, "vue": true}"#).expect("valid json");
+        let mut warnings = Vec::new();
+        warn_plugin_keys(&obj, &mut warnings);
+
+        let sveltekit = warnings
+            .iter()
+            .find(|w| w.field == "sveltekit")
+            .expect("sveltekit warning");
+        assert!(sveltekit.message.contains("auto-detected"));
+
+        let vue = warnings
+            .iter()
+            .find(|w| w.field == "vue")
+            .expect("vue warning");
+        assert!(vue.message.contains("no fallow plugin equivalent"));
     }
 }

--- a/crates/cli/src/migrate/knip_tables.rs
+++ b/crates/cli/src/migrate/knip_tables.rs
@@ -69,6 +69,23 @@ pub(super) const KNIP_UNMAPPABLE_FIELDS: &[(&str, &str, Option<&str>)] = &[
         None,
     ),
     ("treatConfigHintsAsErrors", "No equivalent in fallow", None),
+    ("treatTagHintsAsErrors", "No equivalent in fallow", None),
+];
+
+/// Knip root keys that `migrate_knip` translates into fallow config, plus the
+/// `$schema` key every JSON config may carry. A key here is neither a plugin
+/// section nor an unmappable field, so the unknown-key ladder in
+/// `warn_unhandled_root_keys` must stay quiet about it.
+pub(super) const KNIP_MIGRATED_FIELDS: &[&str] = &[
+    "$schema",
+    "entry",
+    "exclude",
+    "ignore",
+    "ignoreDependencies",
+    "ignoreExportsUsedInFile",
+    "include",
+    "rules",
+    "workspaces",
 ];
 
 /// Knip issue type names that have no fallow equivalent.
@@ -432,6 +449,30 @@ mod tests {
             assert!(
                 !unmappable.contains(key),
                 "KNIP_PLUGIN_KEYS entry `{key}` overlaps with KNIP_UNMAPPABLE_FIELDS"
+            );
+        }
+    }
+
+    /// The unknown-root-key ladder decides by table membership, so a key that
+    /// sits in two tables would either warn twice or warn wrongly.
+    #[test]
+    fn migrated_fields_do_not_overlap_with_the_other_tables() {
+        let unmappable: FxHashSet<&str> =
+            KNIP_UNMAPPABLE_FIELDS.iter().map(|(f, _, _)| *f).collect();
+        let covered: FxHashSet<&str> = KNIP_PLUGIN_KEYS.iter().copied().collect();
+        let unsupported: FxHashSet<&str> = KNIP_UNSUPPORTED_PLUGIN_KEYS.iter().copied().collect();
+        for field in KNIP_MIGRATED_FIELDS {
+            assert!(
+                !unmappable.contains(field),
+                "KNIP_MIGRATED_FIELDS entry `{field}` overlaps with KNIP_UNMAPPABLE_FIELDS"
+            );
+            assert!(
+                !covered.contains(field),
+                "KNIP_MIGRATED_FIELDS entry `{field}` overlaps with KNIP_PLUGIN_KEYS"
+            );
+            assert!(
+                !unsupported.contains(field),
+                "KNIP_MIGRATED_FIELDS entry `{field}` overlaps with KNIP_UNSUPPORTED_PLUGIN_KEYS"
             );
         }
     }

--- a/crates/cli/src/migrate/knip_tables.rs
+++ b/crates/cli/src/migrate/knip_tables.rs
@@ -304,7 +304,26 @@ pub(super) const KNIP_UNSUPPORTED_PLUGIN_KEYS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustc_hash::FxHashSet;
+    use rustc_hash::{FxHashMap, FxHashSet};
+
+    /// Knip plugin keys whose spelling differs from the built-in fallow plugin
+    /// that covers the same tool. Every other entry of `KNIP_PLUGIN_KEYS` has
+    /// to match a registered plugin name exactly, so a sixth spelling
+    /// difference fails `plugin_keys_resolve_to_builtin_plugins` until it is
+    /// declared here.
+    const KNIP_PLUGIN_KEY_ALIASES: &[(&str, &str)] = &[
+        ("electron-vite", "electron"),
+        ("nest", "nestjs"),
+        ("next", "nextjs"),
+        ("panda-css", "pandacss"),
+        ("webdriver-io", "webdriverio"),
+    ];
+
+    fn builtin_plugins() -> FxHashSet<&'static str> {
+        fallow_engine::plugins::registry::builtin_plugin_names()
+            .into_iter()
+            .collect()
+    }
 
     #[test]
     fn rule_map_has_no_empty_keys_or_values() {
@@ -543,6 +562,53 @@ mod tests {
             !KNIP_PLUGIN_KEYS.contains(&"marko"),
             "KNIP_PLUGIN_KEYS should not claim to cover `marko`"
         );
+    }
+
+    /// The claim `KNIP_PLUGIN_KEYS` makes is that fallow auto-detects the tool,
+    /// so every key has to resolve to a plugin the built-in registry actually
+    /// registers. Renaming or removing a plugin without moving its knip key
+    /// fails here instead of shipping a migration that promises detection
+    /// fallow no longer performs.
+    #[test]
+    fn plugin_keys_resolve_to_builtin_plugins() {
+        let builtin = builtin_plugins();
+        let aliases: FxHashMap<&str, &str> = KNIP_PLUGIN_KEY_ALIASES.iter().copied().collect();
+        for key in KNIP_PLUGIN_KEYS {
+            let plugin = aliases.get(key).copied().unwrap_or(key);
+            assert!(
+                builtin.contains(plugin),
+                "KNIP_PLUGIN_KEYS entry `{key}` resolves to plugin `{plugin}`, which the built-in registry does not register; move the key to KNIP_UNSUPPORTED_PLUGIN_KEYS or declare its alias in KNIP_PLUGIN_KEY_ALIASES"
+            );
+        }
+    }
+
+    /// The other half of the same invariant: a key parked as unsupported must
+    /// not name a plugin fallow does register, or the migration understates
+    /// what fallow covers.
+    #[test]
+    fn unsupported_plugin_keys_name_no_builtin_plugin() {
+        let builtin = builtin_plugins();
+        for key in KNIP_UNSUPPORTED_PLUGIN_KEYS {
+            assert!(
+                !builtin.contains(key),
+                "KNIP_UNSUPPORTED_PLUGIN_KEYS entry `{key}` names a registered built-in plugin; move it to KNIP_PLUGIN_KEYS"
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_key_aliases_are_used_and_needed() {
+        let builtin = builtin_plugins();
+        for (key, plugin) in KNIP_PLUGIN_KEY_ALIASES {
+            assert!(
+                KNIP_PLUGIN_KEYS.contains(key),
+                "KNIP_PLUGIN_KEY_ALIASES declares `{key}`, which is not a knip plugin key"
+            );
+            assert!(
+                !builtin.contains(key),
+                "KNIP_PLUGIN_KEY_ALIASES entry `{key}` is itself a built-in plugin name; the alias to `{plugin}` is not needed"
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/migrate/knip_tables.rs
+++ b/crates/cli/src/migrate/knip_tables.rs
@@ -79,56 +79,82 @@ pub(super) const KNIP_UNMAPPABLE_ISSUE_TYPES: &[&str] = &[
     "catalog",
 ];
 
-/// Known knip plugin config keys (framework-specific). These are auto-detected by fallow plugins.
+/// Knip plugin config keys that a built-in fallow plugin covers. Fallow
+/// detects these frameworks and tools from the project itself, so the knip
+/// section has no fallow counterpart and can be dropped.
+///
+/// Keys come from the `Plugins` map in knip and from the plugin sections of
+/// knip's published JSON schema, which still accepts a few keys that the
+/// plugin map has since renamed. A key belongs here only when a plugin in
+/// `fallow_core::plugins` registers the same tool. Keys that no fallow plugin
+/// covers belong in `KNIP_UNSUPPORTED_PLUGIN_KEYS` instead.
 pub(super) const KNIP_PLUGIN_KEYS: &[&str] = &[
     "angular",
     "astro",
     "ava",
     "babel",
     "biome",
+    "bun",
+    "c8",
     "capacitor",
     "changesets",
     "commitizen",
     "commitlint",
+    "convex",
     "cspell",
     "cucumber",
     "cypress",
+    "danger",
+    "dependency-cruiser",
     "docusaurus",
     "drizzle",
-    "eleventy",
+    "electron-vite",
     "eslint",
     "expo",
+    "fumadocs",
     "gatsby",
-    "github-actions",
     "graphql-codegen",
+    "hardhat",
     "husky",
     "jest",
+    "karma",
     "knex",
     "lefthook",
     "lint-staged",
+    "lit",
     "markdownlint",
     "mocha",
-    "moonrepo",
     "msw",
     "nest",
     "next",
-    "node-test-runner",
-    "npm-package-json-lint",
+    "next-intl",
+    "nitro",
+    "nodemon",
     "nuxt",
     "nx",
     "nyc",
-    "oclif",
+    "openapi-ts",
+    "oxlint",
+    "panda-css",
+    "parcel",
     "playwright",
+    "plop",
+    "pm2",
+    "pnpm",
     "postcss",
     "prettier",
     "prisma",
-    "react-cosmos",
+    "qwik",
+    "react-native",
     "react-router",
-    "release-it",
+    "relay",
     "remark",
     "remix",
+    "rolldown",
     "rollup",
+    "rsbuild",
     "rspack",
+    "sanity",
     "semantic-release",
     "sentry",
     "simple-git-hooks",
@@ -136,24 +162,123 @@ pub(super) const KNIP_PLUGIN_KEYS: &[&str] = &[
     "storybook",
     "stryker",
     "stylelint",
-    "svelte",
+    "sveltekit",
+    "svgo",
+    "svgr",
+    "swc",
     "syncpack",
     "tailwind",
+    "tanstack-router",
+    "tsd",
+    "tsdown",
     "tsup",
-    "tsx",
     "typedoc",
     "typescript",
-    "unbuild",
     "unocss",
-    "vercel-og",
+    "vercel",
     "vite",
+    "vitepress",
     "vitest",
-    "vue",
+    "webdriver-io",
     "webpack",
-    "wireit",
     "wrangler",
+    "wxt",
+];
+
+/// Knip plugin config keys that no built-in fallow plugin covers. The section
+/// is still recognized so a migration reports it instead of dropping it in
+/// silence, but fallow makes no claim to detect the tool.
+pub(super) const KNIP_UNSUPPORTED_PLUGIN_KEYS: &[&str] = &[
+    "astro-db",
+    "astro-markdoc",
+    "astro-og-canvas",
+    "borp",
+    "bumpp",
+    "catalyst",
+    "changelogen",
+    "changelogithub",
+    "create-typescript-app",
+    "dotenv",
+    "eleventy",
+    "esbuild",
+    "eve",
+    "execa",
+    "expressive-code",
+    "fast",
+    "github-action",
+    "github-actions",
+    "glob",
+    "i18next-parser",
+    "ladle",
+    "laravel-vite-plugin",
+    "linthtml",
+    "lockfile-lint",
+    "lost-pixel",
+    "lunaria",
+    "marko",
+    "mdx",
+    "mdxlint",
+    "metro",
+    "moonrepo",
+    "nano-spawn",
+    "nano-staged",
+    "netlify",
+    "next-mdx",
+    "node",
+    "node-modules-inspector",
+    "node-test-runner",
+    "npm-package-json-lint",
+    "nuxtjs-i18n",
+    "oclif",
+    "openclaw",
+    "orval",
+    "oxfmt",
+    "payload",
+    "pino",
+    "playwright-ct",
+    "playwright-test",
+    "pre-commit",
+    "preconstruct",
+    "quasar",
+    "raycast",
+    "react-cosmos",
+    "react-email",
+    "release-it",
+    "rslib",
+    "rstest",
+    "serverless-framework",
+    "sst",
+    "starlight",
+    "stencil",
+    "svelte",
+    "sveltejs-package",
+    "tanstack-start",
+    "taskfile",
+    "tauri",
+    "temporal",
+    "travis",
+    "ts-node",
+    "tsx",
+    "unbuild",
+    "unplugin-auto-import",
+    "unplugin-icons",
+    "unplugin-vue-components",
+    "unplugin-vue-i18n",
+    "unplugin-vue-markdown",
+    "unplugin-vue-router",
+    "vercel-og",
+    "vike",
+    "vite-plugin-pages",
+    "vite-plugin-pwa",
+    "vite-plugin-vue-layouts-next",
+    "vite-plus",
+    "vite-pwa-assets-generator",
+    "vue",
+    "wireit",
     "xo",
+    "yarn",
     "yorkie",
+    "zx",
 ];
 
 #[cfg(test)]
@@ -304,6 +429,94 @@ mod tests {
             assert!(
                 !unmappable.contains(key),
                 "KNIP_PLUGIN_KEYS entry `{key}` overlaps with KNIP_UNMAPPABLE_FIELDS"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_plugin_keys_is_non_empty() {
+        assert!(
+            !KNIP_UNSUPPORTED_PLUGIN_KEYS.is_empty(),
+            "KNIP_UNSUPPORTED_PLUGIN_KEYS should not be empty"
+        );
+    }
+
+    #[test]
+    fn unsupported_plugin_keys_are_sorted() {
+        for window in KNIP_UNSUPPORTED_PLUGIN_KEYS.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "KNIP_UNSUPPORTED_PLUGIN_KEYS is not sorted: `{}` should come after `{}`",
+                window[1],
+                window[0]
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_plugin_keys_have_no_duplicates() {
+        let mut seen = FxHashSet::default();
+        for key in KNIP_UNSUPPORTED_PLUGIN_KEYS {
+            assert!(
+                seen.insert(*key),
+                "KNIP_UNSUPPORTED_PLUGIN_KEYS has duplicate entry `{key}`"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_plugin_keys_do_not_overlap_with_plugin_keys() {
+        let covered: FxHashSet<&str> = KNIP_PLUGIN_KEYS.iter().copied().collect();
+        for key in KNIP_UNSUPPORTED_PLUGIN_KEYS {
+            assert!(
+                !covered.contains(key),
+                "`{key}` is in both KNIP_PLUGIN_KEYS and KNIP_UNSUPPORTED_PLUGIN_KEYS"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_plugin_keys_do_not_overlap_with_unmappable_fields() {
+        let unmappable: FxHashSet<&str> =
+            KNIP_UNMAPPABLE_FIELDS.iter().map(|(f, _, _)| *f).collect();
+        for key in KNIP_UNSUPPORTED_PLUGIN_KEYS {
+            assert!(
+                !unmappable.contains(key),
+                "KNIP_UNSUPPORTED_PLUGIN_KEYS entry `{key}` overlaps with KNIP_UNMAPPABLE_FIELDS"
+            );
+        }
+    }
+
+    /// Fallow has no Marko plugin, so the knip `marko` section must land in the
+    /// unsupported table rather than claim auto-detection.
+    #[test]
+    fn marko_is_recognized_as_unsupported() {
+        assert!(
+            KNIP_UNSUPPORTED_PLUGIN_KEYS.contains(&"marko"),
+            "KNIP_UNSUPPORTED_PLUGIN_KEYS should contain `marko`"
+        );
+        assert!(
+            !KNIP_PLUGIN_KEYS.contains(&"marko"),
+            "KNIP_PLUGIN_KEYS should not claim to cover `marko`"
+        );
+    }
+
+    #[test]
+    fn plugin_keys_cover_recently_added_fallow_plugins() {
+        let expected = [
+            "bun",
+            "electron-vite",
+            "oxlint",
+            "panda-css",
+            "pnpm",
+            "sveltekit",
+            "tanstack-router",
+            "webdriver-io",
+        ];
+        for name in expected {
+            assert!(
+                KNIP_PLUGIN_KEYS.contains(&name),
+                "KNIP_PLUGIN_KEYS should contain `{name}`"
             );
         }
     }

--- a/crates/cli/src/migrate/knip_tables.rs
+++ b/crates/cli/src/migrate/knip_tables.rs
@@ -10,6 +10,7 @@ pub(super) const KNIP_RULE_MAP: &[(&str, &str)] = &[
     ("unlisted", "unlisted-dependencies"),
     ("unresolved", "unresolved-imports"),
     ("duplicates", "duplicate-exports"),
+    ("cycles", "circular-dependencies"),
 ];
 
 /// Knip fields that cannot be mapped and generate warnings.
@@ -77,6 +78,8 @@ pub(super) const KNIP_UNMAPPABLE_ISSUE_TYPES: &[&str] = &[
     "nsExports",
     "nsTypes",
     "catalog",
+    "catalogReferences",
+    "namespaceMembers",
 ];
 
 /// Knip plugin config keys that a built-in fallow plugin covers. Fallow


### PR DESCRIPTION
Closes #2507.

## Problem

@VariableVince reported Marko missing from the knip migration tables, and added: "There may be more missing in jscpd and Knip migrations after additions or fixes in the last months."

That second sentence was the real issue. A systematic diff against knip 6.34.0 and `@jscpd/core` 4.2.5 found **128 knip gaps and 15 jscpd gaps**.

The serious category is not the missing entries. It is **16 keys the table claimed fallow auto-detects when no fallow plugin covers them**: `eleventy`, `github-actions`, `moonrepo`, `node-test-runner`, `npm-package-json-lint`, `oclif`, `react-cosmos`, `release-it`, `svelte`, `tsx`, `unbuild`, `vercel-og`, `vue`, `wireit`, `xo`, `yorkie`. Migration was telling users their tooling was handled when it was not. Those now report honestly as unsupported.

## Coverage

`KNIP_PLUGIN_KEYS` (94) plus the new `KNIP_UNSUPPORTED_PLUGIN_KEYS` (90) is exactly the 184 real knip keys, taken as the union of knip's `Plugins` map (182) and its published JSON schema (177). jscpd is 6 mapped plus 31 reported, covering all of `IOptions` plus `colors`.

Every covered key is an exact string match against a registered fallow plugin, except five declared aliases: `next`→`nextjs`, `nest`→`nestjs`, `panda-css`→`pandacss`, `webdriver-io`→`webdriverio`, `electron-vite`→`electron`.

Rejected as plausible-but-not-real rather than padding the covered list: `metro` (only reachable through the react-native plugin, which needs react-native as its enabler), `i18next-parser` (fallow's `i18next` is the library, not the CLI), `svelte` and `vue` (fallow parses those file types, which is not plugin coverage), `esbuild`, and the `astro-*` and `tanstack-start` keys.

## The tables are now guarded, not just correct

A first pass claimed "tests pin each table against the upstream key set". They did not: they asserted sorting, uniqueness and eight hardcoded names, and consulted nothing. Renaming a plugin would have left every test green while `fallow migrate` started promising auto-detection that would not happen, which is exactly the dishonesty this change exists to remove.

`plugin_keys_resolve_to_builtin_plugins` now resolves every covered key through the alias table to `builtin_plugin_names()`, with the reverse check that no unsupported key names a registered plugin, and a third test that no alias is stale or redundant. Proven by pointing an alias at a nonexistent plugin:

```
KNIP_PLUGIN_KEYS entry `panda-css` resolves to plugin `panda-css`, which the
built-in registry does not register; move the key to KNIP_UNSUPPORTED_PLUGIN_KEYS
or declare its alias in KNIP_PLUGIN_KEY_ALIASES
```

The changelog claims the plugin-roster pin only. No in-repo source carries knip's upstream key list, so that half is not claimed.

## Unknown keys no longer vanish

Both migrators were allowlist-only with no else-branch, so a key in neither table was silently dropped. `{"entry": ["src/index.ts"], "cycles": true, "treatTagHintsAsErrors": true}` produced **zero** warnings; both are real knip root keys, and `treatConfigHintsAsErrors` was already handled, so omitting its sibling was visibly asymmetric.

Now:

```
Warnings (2):
  [knip] `treatTagHintsAsErrors`: No equivalent in fallow
  [knip] `cycles`: unknown knip config key `cycles`; not migrated (suggestion: check
    for a typo or report the missing mapping at https://docs.fallow.tools/migration/from-knip)
```

Same on the jscpd side, which previously spread the whole config object so anything outside the table disappeared.

## Also

`rules.cycles` now maps to `circular-dependencies`, which fallow has and the table missed. `namespaceMembers` and `catalogReferences` moved into the unmappable list so they stop reading as user typos.

## Marko

Fallow still has **no Marko plugin**. Only the table side is fixed here: `marko` is listed as unsupported and `marko_is_recognized_as_unsupported` pins that. A real Marko plugin is a much larger change and should be filed separately.

## Validation

- `cargo test -p fallow-cli --lib`: `test result: ok. 2894 passed; 0 failed`
- `migrate_tests`: `15 passed; 0 failed`; `snapshot_tests`: `127 passed; 0 failed`
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0
- `cargo fmt --all --check`: exit 0

## Follow-up, not blocking

`fallow_engine::plugins::registry::builtin_plugin_names()` is a hand-maintained mirror of core's registry, not derived from it, and nothing pins the two together. It has already drifted: core registers a `deno` plugin the engine list omits. The new guard binds to that mirror because the CLI has no direct `fallow-core` dependency, so a plugin renamed in core is caught only once the mirror is updated. Closing that properly fails today on `deno` and would move the `fallow schema` plugin count, so it belongs in its own change.