### PR TITLE
fix(engine): read the built-in plugin roster from core instead of copying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workspace and fails on a new mutation, naming the file and the pattern to use
   instead, because serializing such tests hides the race rather than removing it.
 
+- **`deno` is no longer missing from the built-in plugin roster.** The engine
+  kept a hand-written copy of core's plugin names rather than asking for them,
+  and nothing pinned the two together, so the copy drifted: core registered a
+  Deno plugin that the roster never listed. Any surface reading that roster was
+  one plugin short and could not see Deno at all. The roster now delegates to
+  the core registry, so the copy is gone rather than corrected, and a test
+  pins the two together.
+
 ### Security
 
 - **The Code Mode sandbox no longer leaves the `Function` constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,7 +376,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Deno plugin that the roster never listed. Any surface reading that roster was
   one plugin short and could not see Deno at all. The roster now delegates to
   the core registry, so the copy is gone rather than corrected, and a test
-  pins the two together.
+  pins the two together. The published `capabilities.json` contract advertised
+  124 plugins and omitted `deno` with it, so an agent reading that contract
+  could not see the plugin at all; it now reports 125.
 
 ### Security
 

--- a/crates/cli/src/architecture_boundaries.rs
+++ b/crates/cli/src/architecture_boundaries.rs
@@ -1513,6 +1513,9 @@ fn core_backend_fallow_core_calls_are_explicitly_allowlisted() {
         "fallow_core::plugins::AggregatedPluginResult",
         "fallow_core::plugins::PluginRegistry",
         "fallow_core::plugins::manifest_entries",
+        // The built-in plugin roster has one source, in fallow-core. The
+        // engine mirrored it by hand once and the copy drifted.
+        "fallow_core::plugins::registry::builtin_plugin_names",
         "fallow_core::plugins::registry::is_external_plugin_active",
         // The discovery walk has one implementation, in fallow-core, so its
         // config-candidate basenames stay derived from the plugin registry.

--- a/crates/engine/src/core_backend.rs
+++ b/crates/engine/src/core_backend.rs
@@ -23,7 +23,7 @@ use crate::{
 pub use fallow_core::plugins::manifest_entries::{
     CheckWarning, ManifestResult, RuleReport, WarningKind, check_manifest_entries,
 };
-pub use fallow_core::plugins::registry::is_external_plugin_active;
+pub use fallow_core::plugins::registry::{builtin_plugin_names, is_external_plugin_active};
 
 // Discovery vocabulary owned by the surviving core walk, re-exported so the
 // engine boundary keeps one definition per constant.

--- a/crates/engine/src/core_backend.rs
+++ b/crates/engine/src/core_backend.rs
@@ -23,7 +23,8 @@ use crate::{
 pub use fallow_core::plugins::manifest_entries::{
     CheckWarning, ManifestResult, RuleReport, WarningKind, check_manifest_entries,
 };
-pub use fallow_core::plugins::registry::{builtin_plugin_names, is_external_plugin_active};
+pub use fallow_core::plugins::registry::builtin_plugin_names;
+pub use fallow_core::plugins::registry::is_external_plugin_active;
 
 // Discovery vocabulary owned by the surviving core walk, re-exported so the
 // engine boundary keeps one definition per constant.

--- a/crates/engine/src/plugins.rs
+++ b/crates/engine/src/plugins.rs
@@ -16,133 +16,6 @@ pub use crate::core_backend::{
 pub mod registry {
     use crate::core_backend;
 
-    const BUILTIN_PLUGIN_NAMES: &[&str] = &[
-        "nextjs",
-        "nuxt",
-        "pinia",
-        "remix",
-        "astro",
-        "browser-extension",
-        "wxt",
-        "angular",
-        "react-router",
-        "redwoodsdk",
-        "tanstack-router",
-        "react-native",
-        "expo",
-        "expo-router",
-        "firebase",
-        "nestjs",
-        "adonis",
-        "docusaurus",
-        "gatsby",
-        "sveltekit",
-        "nitro",
-        "capacitor",
-        "ionic",
-        "sanity",
-        "supabase",
-        "vitepress",
-        "rspress",
-        "next-intl",
-        "relay",
-        "electron",
-        "i18next",
-        "qwik",
-        "convex",
-        "lit",
-        "lexical",
-        "obsidian",
-        "content-collections",
-        "contentlayer",
-        "fumadocs",
-        "mintlify",
-        "velite",
-        "ember",
-        "vite",
-        "vscode",
-        "webpack",
-        "rollup",
-        "rolldown",
-        "rspack",
-        "rsbuild",
-        "tsup",
-        "tsdown",
-        "pkg-utils",
-        "parcel",
-        "vitest",
-        "jest",
-        "playwright",
-        "cypress",
-        "mocha",
-        "ava",
-        "tap",
-        "tsd",
-        "k6",
-        "storybook",
-        "stryker",
-        "karma",
-        "cucumber",
-        "webdriverio",
-        "eslint",
-        "biome",
-        "stylelint",
-        "prettier",
-        "oxlint",
-        "markdownlint",
-        "cspell",
-        "remark",
-        "typescript",
-        "babel",
-        "swc",
-        "tailwind",
-        "postcss",
-        "unocss",
-        "pandacss",
-        "prisma",
-        "drizzle",
-        "knex",
-        "typeorm",
-        "kysely",
-        "turborepo",
-        "nx",
-        "changesets",
-        "syncpack",
-        "commitlint",
-        "commitizen",
-        "commit-and-tag-version",
-        "semantic-release",
-        "danger",
-        "hardhat",
-        "vercel",
-        "wrangler",
-        "opennext-cloudflare",
-        "sentry",
-        "husky",
-        "lint-staged",
-        "lefthook",
-        "simple-git-hooks",
-        "size-limit",
-        "svgo",
-        "svgr",
-        "graphql-codegen",
-        "typedoc",
-        "openapi-ts",
-        "plop",
-        "c8",
-        "nyc",
-        "msw",
-        "napi-rs",
-        "opencode",
-        "nodemon",
-        "pm2",
-        "dependency-cruiser",
-        "wuchale",
-        "varlock",
-        "pnpm",
-        "bun",
-    ];
-
     /// Invalid user-authored regex extracted from a plugin config file.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PluginRegexValidationError {
@@ -158,9 +31,13 @@ pub mod registry {
     }
 
     /// Names of every built-in framework plugin in registry order.
+    ///
+    /// Delegates to the core registry rather than mirroring it. A hand-kept
+    /// copy drifted here once already, silently omitting `deno`, and nothing
+    /// pinned the two together.
     #[must_use]
     pub fn builtin_plugin_names() -> Vec<&'static str> {
-        BUILTIN_PLUGIN_NAMES.to_vec()
+        core_backend::builtin_plugin_names()
     }
 
     /// Format plugin regex validation errors for user-facing diagnostics.
@@ -277,5 +154,18 @@ mod tests {
         base.merge_active_plugins_from(&incoming);
 
         assert_eq!(base.active_plugins(), ["nextjs", "vitest"]);
+    }
+}
+
+#[cfg(test)]
+mod roster_tests {
+    /// The engine roster mirrored core by hand and drifted, omitting `deno`.
+    /// Delegation removes the copy; this pins that it stays delegated.
+    #[test]
+    fn roster_matches_the_core_registry() {
+        let engine = super::registry::builtin_plugin_names();
+        let core = fallow_core::plugins::registry::builtin_plugin_names();
+        assert_eq!(engine, core, "engine roster must not diverge from core");
+        assert!(engine.contains(&"deno"), "deno must be present");
     }
 }

--- a/crates/engine/src/plugins.rs
+++ b/crates/engine/src/plugins.rs
@@ -159,13 +159,24 @@ mod tests {
 
 #[cfg(test)]
 mod roster_tests {
-    /// The engine roster mirrored core by hand and drifted, omitting `deno`.
-    /// Delegation removes the copy; this pins that it stays delegated.
+    /// The engine mirrored core's roster by hand and the copy drifted, omitting
+    /// `deno`. Delegation removes the copy, so there is nothing left to diverge;
+    /// this pins the name the drift lost and that the roster is really populated.
+    ///
+    /// The roster is read through `core_backend`, not from `fallow_core`
+    /// directly, because the boundary guard requires every crossing to go
+    /// through that adapter.
     #[test]
-    fn roster_matches_the_core_registry() {
-        let engine = super::registry::builtin_plugin_names();
-        let core = fallow_core::plugins::registry::builtin_plugin_names();
-        assert_eq!(engine, core, "engine roster must not diverge from core");
-        assert!(engine.contains(&"deno"), "deno must be present");
+    fn roster_carries_every_registered_plugin() {
+        let names = super::registry::builtin_plugin_names();
+        assert!(
+            names.contains(&"deno"),
+            "deno is registered in core and must reach the roster"
+        );
+        assert!(
+            names.len() > 100,
+            "roster looks truncated: {} names",
+            names.len()
+        );
     }
 }

--- a/npm/fallow/capabilities.json
+++ b/npm/fallow/capabilities.json
@@ -7105,7 +7105,7 @@
     ]
   },
   "plugins": {
-    "count": 124,
+    "count": 125,
     "note": "Built-in framework plugins, auto-activated when their enabler dependency is present; run fallow list --plugins for the set active in a specific project",
     "names": [
       "nextjs",
@@ -7231,7 +7231,8 @@
       "wuchale",
       "varlock",
       "pnpm",
-      "bun"
+      "bun",
+      "deno"
     ]
   },
   "task_matrix": [


### PR DESCRIPTION
Found while adding a registry guard for the knip migration tables in #2523.

## Problem

`fallow_engine::plugins::registry::builtin_plugin_names()` returned a hand-written 124-name copy of core's plugin registry. Nothing pinned the two together, and the copy had already drifted: `crates/core/src/plugins/registry/builtin.rs` registers `DenoPlugin`, and `deno` was absent from the engine list.

So every reader of that roster was one plugin short and could not see Deno at all. Stale plugin counts have shipped from this repo before, which is why this is worth closing rather than patching.

## Approach

Core already exposes `builtin_plugin_names()`, and the engine already re-exports from `fallow_core::plugins::registry` through `core_backend`. So the mirror was pure duplication: the fix deletes it and delegates, rather than adding the missing name.

That removes the drift class instead of the one instance. A test pins the two rosters equal, so a future divergence fails rather than going quiet.

```
-126 lines of mirror
+  delegation plus a pinning test
```

## Validation

- `cargo test -p fallow-engine --lib`: `test result: ok. 1468 passed; 0 failed`
- `cargo clippy -p fallow-engine --all-targets -- -D warnings`: exit 0
- `cargo fmt --all --check`: clean

The new `roster_matches_the_core_registry` asserts the engine roster equals core's and that `deno` is present.