### PR TITLE
docs(config): stop the rule-name guard claiming a check it does not make

### DIFF
--- a/crates/config/src/config/rules.rs
+++ b/crates/config/src/config/rules.rs
@@ -1017,8 +1017,12 @@ pub struct PartialRulesConfig {
 /// emit a `tracing::warn!` suggestion at config load time.
 ///
 /// Keep in sync with the `#[serde]` attributes on `RulesConfig` and
-/// `PartialRulesConfig`; the `known_rule_names_count_matches_struct` test
-/// fails when the lists drift.
+/// `PartialRulesConfig`. Nothing enforces that: the only guard here pins the
+/// list's length to a literal, so adding a rule to the struct and forgetting
+/// this list leaves every test green while the new name warns as an unknown
+/// key in user configs. A real pin needs the provenance of each entry, because
+/// the list also covers rule names that no `RulesConfig` field produces, so a
+/// field-count comparison would not even be correct.
 pub const KNOWN_RULE_NAMES: &[&str] = &[
     "unused-files",
     "unused-exports",
@@ -1569,8 +1573,12 @@ mod tests {
         );
     }
 
+    /// Pins the list's length only. This does NOT compare against
+    /// `RulesConfig`, so it cannot catch a rule added to the struct and
+    /// missing here. It exists to make an accidental deletion loud, nothing
+    /// more. See the note on [`KNOWN_RULE_NAMES`].
     #[test]
-    fn known_rule_names_count_matches_struct() {
+    fn known_rule_names_list_length_is_pinned() {
         assert_eq!(KNOWN_RULE_NAMES.len(), 98);
     }
 


### PR DESCRIPTION
Related to #2530, which removed a hand-kept plugin roster that had silently drifted.

## Problem

`KNOWN_RULE_NAMES` drives `find_unknown_rule_keys`, the typo detector for user configs. Its doc comment said:

> Keep in sync with the `#[serde]` attributes on `RulesConfig` and `PartialRulesConfig`; the `known_rule_names_count_matches_struct` test fails when the lists drift.

The test is `assert_eq!(KNOWN_RULE_NAMES.len(), 98)`. It never mentions `RulesConfig`. Adding a user-writable rule to the struct and forgetting this list leaves the count at 98, every test green, and the new rule name warning as an unknown key in real user configs.

**Nothing is drifted today.** The only `RulesConfig` field absent from the list is `private_type_leaks_configured`, which is `#[serde(skip)]` internal bookkeeping and correctly excluded.

## Why only the naming is fixed here

A real pin needs the provenance of all 98 entries, because the list also covers rule names that no `RulesConfig` field produces, so a field-count comparison would not even be correct. That is a bounded research task and it is deliberately not attempted here.

The false assurance is separable and costs one commit. A maintainer who adds a rule, reads the name `known_rule_names_count_matches_struct`, and sees green will reasonably conclude the guard covered them. The test is renamed to `known_rule_names_list_length_is_pinned`, and both it and the constant now say plainly what is and is not enforced.

The guard is unchanged and just as weak. It no longer claims otherwise.

## Scope

The four sibling guards whose names promise a comparison were checked and all genuinely compare sources: `script_scope_denylist_copies_stay_in_sync`, `schema_json_in_sync_with_derived`, `every_section_suppress_token_parses_and_matches_registry_file_level`, `is_file_level_only_matches_registry_for_footer_kinds`. This is an isolated case, not a pattern.

## Validation

- `cargo test -p fallow-config --lib known_rule_names`: `test result: ok. 4 passed; 0 failed`
- `cargo clippy -p fallow-config --all-targets -- -D warnings`: clean
- No stale references to the old test name remain

No changelog entry: this changes no behavior, only a test name and two doc comments.