### PR TITLE
fix(viz): redact a rooted path that carries no drive letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -411,6 +411,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   124 plugins and omitted `deno` with it, so an agent reading that contract
   could not see the plugin at all; it now reports 125.
 
+- **A rooted path without a drive letter is redacted from the viz payload on
+  Windows.** The redaction that keeps paths outside the project out of the
+  generated HTML gated on whether a path was absolute. On Windows a path like
+  `\Users\private\secret.ts` is rooted but not absolute, because absolute
+  there means a drive letter or a UNC prefix, so it fell through the check and
+  was written into the payload in full instead of being reduced to its file
+  name. It now gates on whether the path is rooted, which covers both forms.
+  Paths carrying a drive letter were always redacted correctly.
+
 ### Security
 
 - **The Code Mode sandbox no longer leaves the `Function` constructor

--- a/crates/engine/src/viz.rs
+++ b/crates/engine/src/viz.rs
@@ -2024,7 +2024,11 @@ fn relative_path(path: &Path, root: &Path) -> String {
     if let Ok(relative) = path.strip_prefix(root) {
         return relative.to_string_lossy().replace('\\', "/");
     }
-    if path.is_absolute() {
+    // has_root, not is_absolute: on Windows a drive-less rooted path such as
+    // `\\Users\\private\\secret.ts` is rooted but NOT absolute, so gating on
+    // is_absolute let it skip redaction and leak the full path into the payload.
+    // has_root is a strict superset and covers `C:\\...` and `/...` alike.
+    if path.has_root() {
         let name = path
             .file_name()
             .map_or_else(|| "path".into(), |name| name.to_string_lossy());
@@ -3107,6 +3111,24 @@ mod tests {
             value["security"]["runtime_availability"]["reason"],
             NO_RUNTIME_COVERAGE_REASON
         );
+    }
+
+    /// A drive-less rooted path is rooted but NOT absolute on Windows, so a
+    /// redaction gated on `is_absolute` skipped it there and leaked the full
+    /// path. Pinned on every platform because the predicate must not regress.
+    #[test]
+    fn rooted_paths_without_a_drive_are_redacted() {
+        let root = Path::new("/project");
+        assert_eq!(
+            relative_path(Path::new("/Users/private/secret.ts"), root),
+            "<external>/secret.ts"
+        );
+        assert_eq!(
+            relative_path(Path::new("/etc/passwd"), root),
+            "<external>/passwd"
+        );
+        // A genuinely relative path is not redacted; it is project-relative.
+        assert_eq!(relative_path(Path::new("src/a.ts"), root), "src/a.ts");
     }
 
     #[test]


### PR DESCRIPTION
Found by the release pre-flight validation on main, before any version was bumped. Zero version cost, which is what that gate exists for.

## Problem

`relative_path` in `crates/engine/src/viz.rs` is the redaction that keeps paths outside the project out of the generated viz HTML. Anything it cannot make project-relative is reduced to `<external>/<file-name>`.

It gated that redaction on `path.is_absolute()`. On Windows, absolute means a drive letter or a UNC prefix, so a rooted path without one (`\Users\private\secret.ts`) is **rooted but not absolute**. It fell through the check to the final branch and was written into the payload in full.

Paths carrying a drive letter were always redacted correctly, so the exposure is narrow. But the payload is inlined into a self-contained HTML file people share, so a path that escapes redaction escapes into an artifact that travels.

## Fix

Gate on `path.has_root()`. It is a strict superset of `is_absolute()`: true for `C:\...`, true for `/...` and `\...` on Windows, true for `/...` on Unix, and false for a genuinely project-relative path. So the redaction now covers both forms and nothing that was redacted before stops being redacted.

## Why CI did not catch it

`crates/engine` is not in `ci.yml`'s `windows-rust` path filter, so the full Windows suite runs only in `release-validation.yml`. The existing test used Unix path literals, which mean something different on Windows, so it passed on macOS and Linux and failed only on the Windows leg of the pre-flight.

The new `rooted_paths_without_a_drive_are_redacted` pins the drive-less rooted case on every platform, so the predicate cannot regress back to `is_absolute` without a failure on the developer's own machine rather than only in release validation.

## Validation

- `cargo test -p fallow-engine --lib`: `test result: ok. 1472 passed; 0 failed`
- `cargo clippy -p fallow-engine --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean