### PR TITLE
fix(viz): gate every path-redaction site on rooted rather than absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,8 +417,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `\Users\private\secret.ts` is rooted but not absolute, because absolute
   there means a drive letter or a UNC prefix, so it fell through the check and
   was written into the payload in full instead of being reduced to its file
-  name. It now gates on whether the path is rooted, which covers both forms.
-  Paths carrying a drive letter were always redacted correctly.
+  name. The same test decided whether to join a path onto the project root, so
+  such a path was also reinterpreted as project-relative, which exposed its
+  components a second way. All four sites now gate on whether the path is
+  rooted, which covers both forms. Paths carrying a drive letter were always
+  redacted correctly, and a value that is not under a path key, such as a route
+  specifier, is still left alone.
 
 ### Security
 

--- a/crates/engine/src/viz.rs
+++ b/crates/engine/src/viz.rs
@@ -895,7 +895,10 @@ fn finding_from_value(
     let mut files = Vec::new();
     for raw in raw_paths {
         let raw_path = Path::new(&raw);
-        let absolute_path = if raw_path.is_absolute() {
+        // has_root, not is_absolute: joining a Windows rooted path that carries
+        // no drive letter onto root would reinterpret an external path as
+        // project-relative and expose its components instead of redacting it.
+        let absolute_path = if raw_path.has_root() {
             raw_path.to_path_buf()
         } else {
             root.join(raw_path)
@@ -911,7 +914,7 @@ fn finding_from_value(
         }
     }
     let absolute = raw_path.as_deref().map(Path::new).map(|path| {
-        if path.is_absolute() {
+        if path.has_root() {
             path.to_path_buf()
         } else {
             root.join(path)
@@ -1158,7 +1161,12 @@ fn relativize_keyed_paths(value: &mut Value, root: &Path, is_path: bool) {
     match value {
         Value::String(text) if is_path => {
             let path = Path::new(text);
-            if path.is_absolute() {
+            // has_root, not is_absolute, for the same reason as relative_path:
+            // a Windows rooted path without a drive letter is not absolute, so
+            // gating on is_absolute left it unredacted in the payload. Only
+            // values under a path key reach this arm, so a route specifier such
+            // as `/api/v1` is excluded by the key gate rather than by this test.
+            if path.has_root() {
                 *text = relative_path(path, root);
             }
         }
@@ -3129,6 +3137,17 @@ mod tests {
         );
         // A genuinely relative path is not redacted; it is project-relative.
         assert_eq!(relative_path(Path::new("src/a.ts"), root), "src/a.ts");
+
+        // The JSON layer gates on the same predicate and must agree.
+        let mut detail = serde_json::json!({ "path": "/Users/private/secret.ts" });
+        relativize_value_paths(&mut detail, root);
+        assert_eq!(detail["path"], "<external>/secret.ts");
+
+        // A value that is not under a path key is left alone regardless, so a
+        // route specifier does not get treated as a filesystem path.
+        let mut route = serde_json::json!({ "specifier": "/api/v1" });
+        relativize_value_paths(&mut route, root);
+        assert_eq!(route["specifier"], "/api/v1");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #2537, which fixed one of four sites. Found by the release pre-flight, again before any version was bumped.

## What #2537 missed

#2537 corrected `relative_path`, but three sibling sites in the same file made the same `is_absolute()` assumption, so the Windows validation still failed, on a different line of the same test.

- `relativize_keyed_paths` decides whether a JSON string under a path key gets redacted. Gated on `is_absolute()`, so a rooted path without a drive letter survived into the payload untouched.
- Two `if path.is_absolute() { path } else { root.join(path) }` decisions. Here the consequence is different and arguably worse: such a path was **joined onto the project root**, so `/Users/private/secret.ts` became `<root>/Users/private/secret.ts`, which then strips cleanly and renders as `Users/private/secret.ts`. Not redacted, and silently reinterpreted as project-relative.

All four now gate on `has_root()`.

## Why the route specifier is still safe

The obvious worry is that a broader predicate starts mangling non-path strings. It does not: `relativize_keyed_paths` only reaches the string arm for values under a path key (`is_path_key` / `is_path_collection_key`), and `specifier` is in neither list. `/api/v1` is excluded by the key gate, not by the absoluteness test, and the test pins that.

## Lesson applied

I fixed the first reported line and re-dispatched, which cost a full validation cycle to surface the second. The v3.4.x incident log says to extract every distinct failure from a Windows job before fixing. I then grepped `is_absolute()` across engine, output and api rather than only the failing line, which is how the two join-onto-root sites turned up; neither was covered by the failing assertion.

`crates/engine/src/viz.rs` now contains no `is_absolute()` at all.

## Validation

- `cargo test -p fallow-engine --lib`: `test result: ok. 1472 passed; 0 failed`
- `cargo clippy -p fallow-engine --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean

`rooted_paths_without_a_drive_are_redacted` now covers the JSON layer as well as `relative_path`, plus the route-specifier case, so a regression at any layer fails on a developer machine rather than only in release validation.