### PR TITLE
test(config): prove every listed rule name is reachable

### DIFF
--- a/crates/config/src/config/rules.rs
+++ b/crates/config/src/config/rules.rs
@@ -1582,6 +1582,34 @@ mod tests {
         assert_eq!(KNOWN_RULE_NAMES.len(), 98);
     }
 
+    /// The reverse of `known_rule_names_covers_every_struct_field`. That one
+    /// proves every real rule is listed; this one proves every listed name is
+    /// real. A stale entry is not inert: `closest_known_rule_name` suggests
+    /// from this list, so a removed or renamed rule left behind here gets
+    /// offered to a user as the fix for their typo.
+    #[test]
+    fn known_rule_names_holds_no_unreachable_entry() {
+        let serialized =
+            serde_json::to_value(RulesConfig::default()).expect("RulesConfig serializes");
+        let canonical = serialized
+            .as_object()
+            .expect("RulesConfig serializes to an object");
+        let source = include_str!("rules.rs");
+
+        let unreachable: Vec<&&str> = KNOWN_RULE_NAMES
+            .iter()
+            .filter(|name| !canonical.contains_key(**name))
+            .filter(|name| !source.contains(&format!("alias = \"{name}\"")))
+            .collect();
+
+        assert!(
+            unreachable.is_empty(),
+            "KNOWN_RULE_NAMES entries that are neither a serialized rule nor a declared \
+             serde alias: {unreachable:?}. closest_known_rule_name suggests from this list, \
+             so each one can be offered to a user as a rule that does not exist."
+        );
+    }
+
     #[test]
     fn known_rule_names_has_no_duplicates() {
         let mut sorted: Vec<&str> = KNOWN_RULE_NAMES.to_vec();


### PR DESCRIPTION
## What I set out to do, and why most of it was unnecessary

I went in believing `KNOWN_RULE_NAMES` was unpinned, because `known_rule_names_list_length_is_pinned` asserts a literal `98` and consults nothing. That was wrong, and worth stating plainly: two genuine guards already exist beside it.

- `known_rule_names_covers_every_struct_field` serializes `RulesConfig::default()` and asserts every key is listed. `RulesConfig` has zero `skip_serializing_if`, so no field can hide from it. Sound.
- `known_rule_names_covers_every_serde_alias_in_source` scans the source for `alias = "..."` and asserts each is listed.

So the forward direction was covered the whole time, and a schema-derived version I prototyped turned out to be a strict duplicate of the first. I dropped it.

Provenance, since it was never written down: the 98 entries are exactly the 53 canonical kebab-case names (54 fields minus one `#[serde(skip)]`) unioned with the 53 declared aliases.

## What was actually missing

The reverse direction. Nothing asserted that a listed name still corresponds to something real, so a removed or renamed rule left in the list stayed there silently.

That is not inert. `closest_known_rule_name` draws its suggestions from this list, so a stale entry gets offered to a user as the fix for their typo, pointing them at a rule that no longer exists.

`known_rule_names_holds_no_unreachable_entry` closes it: every entry must be either a serialized field or a declared alias. Proved by planting a stale name and watching it fail:

```
KNOWN_RULE_NAMES entries that are neither a serialized rule nor a declared serde alias:
["removed-rule-left-behind"]. closest_known_rule_name suggests from this list, so each one
can be offered to a user as a rule that does not exist.
```

## Validation

- `cargo test -p fallow-config --lib known_rule_names`: `test result: ok. 5 passed; 0 failed`
- `cargo clippy -p fallow-config --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean

The `98` length assertion stays as-is. With both directions now guarded it is redundant rather than misleading, and #2536 already corrected its name and doc comment to describe what it actually does.