### PR TITLE
feat(lsp): add best-available Zed parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Zed now exposes the best available Fallow parity through the shared LSP
+  contract.** Teams can commit exact diagnostic codes in
+  `initialization_options.mutedCategories`, opt into inline complexity Code
+  Lens through `health.inlineComplexity`, and enable advisory security
+  candidate diagnostics through project rules. The Zed guide now separates
+  those LSP features from complete `fallow health` and `fallow security` CLI
+  runs, including their exit-code contract, and makes clear that the current
+  Zed extension API has no contribution points for a Fallow-owned sidebar or
+  status-bar item. This is editor parity where the host API supports it, not a
+  claim of full VS Code UI parity. (Closes
+  [#2542](https://github.com/fallow-rs/fallow/issues/2542).)
+
 ## [3.22.0] - 2026-09-01
 
 ### Added

--- a/crates/lsp/src/initialization.rs
+++ b/crates/lsp/src/initialization.rs
@@ -26,6 +26,7 @@ pub struct LspInitializationOptions {
     pub config_path: Option<String>,
     pub allow_remote_extends: bool,
     pub issue_types: Option<BTreeMap<String, bool>>,
+    pub muted_categories: Option<Vec<String>>,
     pub changed_since: Option<String>,
     pub duplication: Option<LspDuplicationOptions>,
     pub production: Option<bool>,
@@ -55,6 +56,15 @@ pub fn parse_initialization_options(opts: Option<&serde_json::Value>) -> LspInit
                 .filter_map(|(key, value)| value.as_bool().map(|enabled| (key.clone(), enabled)))
                 .collect::<BTreeMap<_, _>>();
             (!issue_types.is_empty()).then_some(issue_types)
+        }),
+        muted_categories: obj.get("mutedCategories").and_then(|value| {
+            let categories = value
+                .as_array()?
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+            (!categories.is_empty()).then_some(categories)
         }),
         changed_since: obj
             .get("changedSince")

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -141,13 +141,13 @@ use fallow_config::DetectionMode;
 #[cfg(test)]
 use fallow_config::DuplicatesConfig;
 use initialization::{
-    LspDuplicationOptions, LspTypeAwareOptions, initialization_config_path,
-    parse_initialization_options,
+    LspDuplicationOptions, LspInitializationOptions, LspTypeAwareOptions,
+    initialization_config_path, parse_initialization_options,
 };
 #[cfg(test)]
 use initialization::{
-    LspInitializationOptions, initialization_duplication_options,
-    initialization_inline_complexity_enabled, initialization_production_override,
+    initialization_duplication_options, initialization_inline_complexity_enabled,
+    initialization_production_override,
 };
 use path_utils::canonicalize_for_lsp;
 #[cfg(test)]
@@ -173,6 +173,30 @@ const WATCHED_FILE_GLOBS: &[&str] = &[
     "**/{package.json,package-lock.json,pnpm-lock.yaml,yarn.lock,bun.lock,bun.lockb}",
     "**/{fallow.json,fallow.jsonc,fallow.yaml,fallow.yml,fallow.toml}",
 ];
+
+fn disabled_diagnostic_codes(options: &LspInitializationOptions) -> FxHashSet<String> {
+    let muted_categories: FxHashSet<&str> = options
+        .muted_categories
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    diagnostic_issue_type_metas()
+        .filter(|issue_type| {
+            muted_categories.contains(issue_type.code)
+                || issue_type.config_key.is_some_and(|config_key| {
+                    options
+                        .issue_types
+                        .as_ref()
+                        .and_then(|issue_types| issue_types.get(config_key))
+                        == Some(&false)
+                })
+        })
+        .map(|issue_type| issue_type.code.to_string())
+        .collect()
+}
 
 #[derive(Clone)]
 struct FallowLspServer {
@@ -201,7 +225,8 @@ struct FallowLspServer {
     /// documents and project state are ready. The first open or save runs the
     /// initial analysis instead.
     startup_analysis_started: Arc<AtomicBool>,
-    /// Diagnostic codes to suppress (parsed from initializationOptions.issueTypes)
+    /// Diagnostic codes suppressed by `initializationOptions.issueTypes` or
+    /// `initializationOptions.mutedCategories`.
     disabled_diagnostic_codes: Arc<RwLock<FxHashSet<String>>>,
     /// Optional git ref from `initializationOptions.changedSince`. When set,
     /// analysis results and duplication reports are scoped to files changed
@@ -290,19 +315,8 @@ impl LanguageServer for FallowLspServer {
 
         if let Some(opts) = &params.initialization_options {
             let parsed_options = parse_initialization_options(Some(opts));
-
-            if let Some(issue_types) = &parsed_options.issue_types {
-                let mut disabled = FxHashSet::default();
-                for issue_type in diagnostic_issue_type_metas() {
-                    let Some(config_key) = issue_type.config_key else {
-                        continue;
-                    };
-                    if issue_types.get(config_key) == Some(&false) {
-                        disabled.insert(issue_type.code.to_string());
-                    }
-                }
-                *self.disabled_diagnostic_codes.write().await = disabled;
-            }
+            *self.disabled_diagnostic_codes.write().await =
+                disabled_diagnostic_codes(&parsed_options);
 
             if let Some(git_ref) = parsed_options.changed_since.as_deref() {
                 let trimmed = git_ref.trim();

--- a/crates/lsp/src/tests.rs
+++ b/crates/lsp/src/tests.rs
@@ -1083,6 +1083,7 @@ fn parse_initialization_options_reads_full_payload() {
         "issueTypes": {
             "unused-exports": false
         },
+        "mutedCategories": ["code-duplication", "unused-file"],
         "changedSince": "origin/main",
         "production": true,
         "duplication": {
@@ -1110,6 +1111,10 @@ fn parse_initialization_options_reads_full_payload() {
             .as_ref()
             .and_then(|issue_types| issue_types.get("unused-exports")),
         Some(&false)
+    );
+    assert_eq!(
+        parsed.muted_categories.as_deref(),
+        Some(["code-duplication".to_string(), "unused-file".to_string()].as_slice())
     );
     assert_eq!(parsed.changed_since.as_deref(), Some("origin/main"));
     assert_eq!(parsed.production, Some(true));
@@ -1150,15 +1155,52 @@ fn parse_initialization_options_is_permissive_for_missing_or_malformed_payload()
         parse_initialization_options(Some(&json!("not an object"))),
         LspInitializationOptions::default()
     );
+    let malformed = parse_initialization_options(Some(&json!({
+        "production": "on",
+        "mutedCategories": "code-duplication",
+        "health": {
+            "inlineComplexity": "yes"
+        }
+    })));
+    assert_eq!(malformed.production, None);
+    assert_eq!(malformed.muted_categories, None);
+
+    let parsed = parse_initialization_options(Some(&json!({
+        "mutedCategories": [
+            "code-duplication",
+            7,
+            null,
+            "unused-export"
+        ]
+    })));
     assert_eq!(
-        parse_initialization_options(Some(&json!({
-            "production": "on",
-            "health": {
-                "inlineComplexity": "yes"
-            }
-        })))
-        .production,
-        None
+        parsed.muted_categories.as_deref(),
+        Some(["code-duplication".to_string(), "unused-export".to_string()].as_slice()),
+        "malformed array entries must not discard valid category codes",
+    );
+}
+
+#[test]
+fn disabled_diagnostic_codes_union_issue_types_and_exact_muted_categories() {
+    let options = LspInitializationOptions {
+        issue_types: Some(std::collections::BTreeMap::from([
+            ("unused-exports".to_string(), false),
+            ("unused-files".to_string(), true),
+        ])),
+        muted_categories: Some(vec![
+            "code-duplication".to_string(),
+            "Code-Duplication".to_string(),
+            "future-diagnostic".to_string(),
+        ]),
+        ..LspInitializationOptions::default()
+    };
+
+    let disabled = disabled_diagnostic_codes(&options);
+
+    assert_eq!(
+        disabled,
+        FxHashSet::from_iter(["code-duplication".to_string(), "unused-export".to_string()]),
+        "muted diagnostic codes and disabled issue-type keys form a validated union",
     );
 }
 
@@ -3754,6 +3796,156 @@ async fn publish_inserts_skipped_uri_into_new_uris() {
         backend.previous_diagnostic_uris.read().await.contains(&uri),
         "skipped stale URI must still be tracked in previous_diagnostic_uris",
     );
+}
+
+fn muted_analysis_output(source: &Path) -> BlockingAnalysisOutput {
+    let results = AnalysisResults {
+        unused_files: vec![UnusedFileFinding::with_actions(UnusedFile {
+            path: source.to_path_buf(),
+        })],
+        unused_exports: vec![UnusedExportFinding::with_actions(UnusedExport {
+            path: source.to_path_buf(),
+            export_name: "unused".to_string(),
+            is_type_only: false,
+            line: 1,
+            col: 13,
+            span_start: 13,
+            is_re_export: false,
+        })],
+        ..AnalysisResults::default()
+    };
+    let duplication = DuplicationReport {
+        clone_groups: vec![CloneGroup {
+            instances: vec![CloneInstance {
+                file: source.to_path_buf(),
+                start_line: 2,
+                end_line: 2,
+                start_col: 0,
+                end_col: 27,
+                fragment: "export const duplicate = 2;".to_string(),
+            }],
+            token_count: 5,
+            line_count: 1,
+            similarity: None,
+        }],
+        stats: DuplicationStats {
+            clone_groups: 1,
+            clone_instances: 1,
+            ..DuplicationStats::default()
+        },
+        ..DuplicationReport::default()
+    };
+    BlockingAnalysisOutput {
+        analysis: EditorAnalysisOutput::new(results, duplication),
+        inline_complexity: Vec::new(),
+        config_messages: Vec::new(),
+        changed_message: None,
+        applied_changed_since: None,
+        changed_since_scope: None,
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn initialization_mutes_the_same_diagnostics_for_push_and_pull() {
+    use futures::StreamExt;
+
+    let (mut service, mut socket) = LspService::build(FallowLspServer::new).finish();
+    let initialize = Request::build("initialize")
+        .params(json!({
+            "capabilities": {},
+            "initializationOptions": {
+                "issueTypes": {
+                    "unused-exports": false,
+                    "unused-files": true
+                },
+                "mutedCategories": [
+                    "code-duplication",
+                    "Code-Duplication",
+                    "future-diagnostic",
+                    7
+                ]
+            }
+        }))
+        .id(1)
+        .finish();
+    service
+        .ready()
+        .await
+        .expect("service ready")
+        .call(initialize)
+        .await
+        .expect("initialize call")
+        .expect("initialize response");
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = canonicalize_for_lsp(dir.path());
+    let source = root.join("muted.ts");
+    std::fs::write(
+        &source,
+        "export const unused = 1;\nexport const duplicate = 2;\n",
+    )
+    .expect("write source");
+    let uri = Uri::from_file_path(&source).expect("source URI");
+    let backend = service.inner();
+    assert_eq!(
+        *backend.disabled_diagnostic_codes.read().await,
+        FxHashSet::from_iter(["code-duplication".to_string(), "unused-export".to_string()]),
+    );
+
+    let receive_protocol_output = async {
+        let mut pushed = None;
+        loop {
+            let message = tokio::time::timeout(Duration::from_millis(500), socket.next())
+                .await
+                .expect("protocol output must arrive")
+                .expect("client socket must stay open");
+            match message.method() {
+                "textDocument/publishDiagnostics" => pushed = Some(message),
+                "fallow/analysisComplete" => break (pushed, message),
+                _ => {}
+            }
+        }
+    };
+    let output = muted_analysis_output(&source);
+    let version_snapshot = VersionSnapshot::default();
+    let apply = backend.apply_analysis_output(output, &root, &version_snapshot);
+    let ((), (pushed, completion)) = tokio::join!(apply, receive_protocol_output);
+
+    let cached = backend.cached_diagnostics.read().await;
+    assert_eq!(cached[&uri].len(), 1);
+    assert!(matches!(
+        cached[&uri][0].code.as_ref(),
+        Some(NumberOrString::String(code)) if code == "unused-file"
+    ));
+    drop(cached);
+
+    let pushed = pushed.expect("publishDiagnostics must precede analysisComplete");
+    let params = pushed.params().expect("publishDiagnostics params");
+    assert_eq!(params["diagnostics"].as_array().map(Vec::len), Some(1));
+    assert_eq!(params["diagnostics"][0]["code"], "unused-file");
+    let completion = completion.params().expect("analysisComplete params");
+    assert_eq!(completion["unusedFiles"], 1);
+    assert_eq!(completion["unusedExports"], 1);
+    assert_eq!(completion["cloneGroups"], 1);
+
+    let pull = Request::build("textDocument/diagnostic")
+        .params(json!({
+            "textDocument": { "uri": uri.to_string() },
+            "identifier": "fallow"
+        }))
+        .id(2)
+        .finish();
+    let response = service
+        .ready()
+        .await
+        .expect("service ready")
+        .call(pull)
+        .await
+        .expect("diagnostic request")
+        .expect("diagnostic response");
+    let result = response.result().expect("pull result");
+    assert_eq!(result["items"].as_array().map(Vec::len), Some(1));
+    assert_eq!(result["items"][0]["code"], "unused-file");
 }
 
 // -------------------------------------------------------------------------

--- a/docs/reference/lsp-internals.md
+++ b/docs/reference/lsp-internals.md
@@ -30,10 +30,38 @@ lifecycle behavior.
   including clears for stale findings.
 - Diagnostics keep stable codes, `source: "fallow"`, actionable messages, and
   project-relative evidence where appropriate.
+- `initializationOptions.mutedCategories` accepts exact diagnostic codes from
+  the shared issue catalogue. Known string codes are unioned with diagnostics
+  disabled through `issueTypes: false`; unknown and non-string entries are
+  ignored so older servers remain permissive with newer clients.
+- Initialization options are read once during `initialize`. Clients must
+  restart the language server after changing `mutedCategories` or
+  `health.inlineComplexity`.
+- `health.inlineComplexity` is opt-in and supplies threshold-exceeding function
+  complexity to Code Lens. It is not a project Health report or an editor-owned
+  Health view.
+- Security candidate diagnostics remain opt-in through the project config.
+  `security-sink` and `security-client-server-leak` default to `off`, retain
+  those exact diagnostic codes, and publish at information severity because
+  candidates are not verified vulnerabilities.
 - Code actions must be safe, scoped, and derived from the current issue.
 - Initialization options and issue metadata stay aligned with generated VS
   Code contracts.
 - Shutdown must prevent late publication and clean up owned subprocess work.
+
+## Editor parity boundary
+
+The shared LSP owns diagnostics, hover, quick fixes, Code Lens, and their
+initialization contract. Host-specific sidebars, status items, full Health
+reports, and full Security reports are outside that protocol. Editors without
+custom UI contribution points should expose the shared LSP features and direct
+users to a separately installed `fallow` CLI for the complete project reports.
+
+When documenting CLI invocation from an editor, preserve the process contract:
+run from the project root, treat exit `1` as a successful analysis with
+findings, and treat exit `2` as a configuration, input, or execution error.
+`fallow security` is advisory unless `--fail-on-issues`, an error-severity
+security rule, or an explicit security gate changes its exit behavior.
 
 ## Verification
 

--- a/editors/vscode/scripts/codegen-contracts.mjs
+++ b/editors/vscode/scripts/codegen-contracts.mjs
@@ -645,6 +645,7 @@ export interface LspTypeAwareInitializationOptions {
 
 export interface LspInitializationOptions {
   readonly issueTypes: Record<string, boolean>;
+  readonly mutedCategories?: readonly string[];
   readonly changedSince: string;
   readonly configPath: string;
   readonly allowRemoteExtends: boolean;

--- a/editors/vscode/src/generated/lsp-initialization-options.d.ts
+++ b/editors/vscode/src/generated/lsp-initialization-options.d.ts
@@ -35,6 +35,7 @@ export interface LspTypeAwareInitializationOptions {
 
 export interface LspInitializationOptions {
   readonly issueTypes: Record<string, boolean>;
+  readonly mutedCategories?: readonly string[];
   readonly changedSince: string;
   readonly configPath: string;
   readonly allowRemoteExtends: boolean;

--- a/editors/vscode/test/generated-types.test.ts
+++ b/editors/vscode/test/generated-types.test.ts
@@ -66,6 +66,18 @@ describe("generated/output-contract.d.ts", () => {
     };
 
     expect(sample.issueTypes["unused-exports"]).toBe(false);
+    expect(sample.mutedCategories).toBeUndefined();
+  });
+
+  it("exposes optional muted diagnostic categories for LSP clients", () => {
+    expectTypeOf<LspInitializationOptions["mutedCategories"]>().toEqualTypeOf<
+      readonly string[] | undefined
+    >();
+
+    const sample: Pick<LspInitializationOptions, "mutedCategories"> = {
+      mutedCategories: ["code-duplication"],
+    };
+    expect(sample.mutedCategories).toEqual(["code-duplication"]);
   });
 
   it("exposes CombinedOutput with optional check/dupes/health branches", () => {

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -83,6 +83,98 @@ Fallow currently reads issue toggles from LSP initialization options:
 }
 ```
 
+`issueTypes` uses Fallow config keys, which are plural for many rules. To give
+the whole team the same quieter editor baseline, commit exact LSP diagnostic
+codes in `.zed/settings.json` instead:
+
+```json
+{
+  "lsp": {
+    "fallow": {
+      "initialization_options": {
+        "mutedCategories": [
+          "unused-file",
+          "unused-export",
+          "code-duplication",
+          "stale-suppression"
+        ]
+      }
+    }
+  }
+}
+```
+
+Diagnostic codes are singular where shown above. The security codes are
+exactly `security-sink` and `security-client-server-leak`. A mute affects only
+editor diagnostics; CLI, audit, and CI output remain unchanged. After changing
+an initialization option, run `editor: restart language server` from Zed's
+command palette.
+
+### Inline complexity
+
+Inline complexity is off by default in the editor-agnostic LSP. Enable its Code
+Lens in the same initialization options:
+
+```json
+{
+  "code_lens": "on",
+  "lsp": {
+    "fallow": {
+      "initialization_options": {
+        "health": {
+          "inlineComplexity": true
+        }
+      }
+    }
+  }
+}
+```
+
+This adds a compact complexity lens above functions that exceed Fallow's
+thresholds. Use `"code_lens": "menu"` instead if you prefer to reveal lenses
+from the editor menu. It does not run or render the complete Health report.
+
+### Security candidate diagnostics
+
+Security candidates are deliberately opt-in. Enable either or both project
+rules in `.fallowrc.json`:
+
+```json
+{
+  "rules": {
+    "security-sink": "warn",
+    "security-client-server-leak": "warn"
+  }
+}
+```
+
+The LSP reuses this project configuration and publishes matching candidates as
+information diagnostics. Setting the same keys to `true` under `issueTypes`
+does not enable rules that remain `off` in the Fallow config. Candidates are
+items to verify, not confirmed vulnerabilities.
+
+## Full Health and Security reports
+
+The Zed extension provides the shared LSP surface. For project-wide Health and
+Security reports, install the `fallow` CLI separately and run it from the
+project root, for example in Zed's terminal:
+
+```bash
+npm install --save-dev fallow
+npx fallow health
+npx fallow security --fail-on-issues
+```
+
+For these commands, exit code `0` is a successful clean run, `1` is a
+successful run with findings, and `2` is a configuration, input, or execution
+error. Without `--fail-on-issues`, `fallow security` remains advisory and can
+exit `0` with candidates.
+
+The current Zed extension API does not provide contribution points for a
+Fallow-owned sidebar tree or status-bar item. Use Zed's built-in Problems and
+LSP surfaces for diagnostics, and the CLI for the complete reports. This is the
+best available parity with the current API, not full VS Code UI parity.
+
 ## Development
 
 1. Open Zed.


### PR DESCRIPTION
## Summary

- add an optional mutedCategories LSP initialization option using exact diagnostic codes
- combine it with issueTypes filtering before both push and pull diagnostics while keeping analysisComplete and CLI results unchanged
- document Zed muting, inline Health Code Lens, opt-in Security candidate diagnostics, CLI report routes, and current native UI limits

Closes #2542

## Verification

- cargo test -p fallow-lsp
- VS Code contract check, generated-type test, lint, and build
- Zed host tests and wasm32-wasip2 build
- npm run verify:fast
- npm run verify:full
- public p-map LSP smoke: muted duplication absent from push and pull, unmuted diagnostics preserved, full findings retained in analysisComplete and CLI output