### PR TITLE
fix: recognize class member use through object properties

### DIFF
--- a/crates/core/tests/integration_test/member_detection.rs
+++ b/crates/core/tests/integration_test/member_detection.rs
@@ -41,6 +41,15 @@ fn enum_class_members_detects_unused_members() {
         unused_class_member_names.contains(&"name"),
         "name should be detected as unused class property, found: {unused_class_member_names:?}"
     );
+
+    assert!(
+        !unused_class_member_names.contains(&"usedThroughObject"),
+        "usedThroughObject should be credited through an object property, found: {unused_class_member_names:?}"
+    );
+    assert!(
+        unused_class_member_names.contains(&"unusedThroughObject"),
+        "unusedThroughObject should remain unused, found: {unused_class_member_names:?}"
+    );
 }
 
 #[test]

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -816,7 +816,7 @@ use crate::MemberKind;
 ///
 /// Bumped to 237 (issue #1843 follow-up): object-binding and factory-return
 /// candidate recording now cap the per-module set at
-/// `MAX_OBJECT_BINDING_CANDIDATES` / `MAX_FACTORY_RETURN_CANDIDATES` (4096),
+/// `MAX_OBJECT_BINDING_TARGETS` / `MAX_FACTORY_RETURN_CANDIDATES` (4096),
 /// bounding the object-binding resolution fixed-point the same way the taint cap
 /// bounds its accumulator. A file exceeding a cap now persists fewer candidates,
 /// so its resolved `member_accesses` can change; warm 236 caches can carry
@@ -1024,7 +1024,12 @@ use crate::MemberKind;
 /// file with a top-level guard, `??` / `||` default, or `?.` access. Warm 284
 /// caches lack the unit, so vital signs, file scores, and branching
 /// conservation would keep replaying the module-scope blind spot.
-pub(super) const CACHE_VERSION: u32 = 285;
+///
+/// Bumped to 286 for issue #2546: object-literal properties initialized with a
+/// class instance now credit member accesses through the property path. Warm
+/// 285 caches lack those remapped `member_accesses` and would retain the false
+/// unused-class-member finding.
+pub(super) const CACHE_VERSION: u32 = 286;
 
 /// Duplication token cache version. Bump when duplicate tokenization,
 /// normalization, or the on-disk token cache schema changes.

--- a/crates/extract/src/tests/js_ts/dynamic_imports.rs
+++ b/crates/extract/src/tests/js_ts/dynamic_imports.rs
@@ -1237,6 +1237,18 @@ fn child_process_fork_named_import_credits_literal_runner() {
 }
 
 #[test]
+fn child_process_fork_inside_local_namespace_credits_literal_runner() {
+    let sources = dynamic_sources(
+        "import { fork } from 'node:child_process';\n\
+         namespace Workers {\n\
+           export function start() { fork('./worker.js'); }\n\
+         }",
+    );
+
+    assert!(sources.contains(&"./worker.js".to_string()));
+}
+
+#[test]
 fn child_process_fork_namespace_import_credits_literal_runner() {
     let sources = dynamic_sources(
         "import * as childProcess from 'child_process';\n\

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -34,6 +34,7 @@ use helpers::LitCustomElementDecorator;
 use helpers::array_element_type_from_type;
 
 pub(crate) const ROUTE_LOADER_DATA_OBJECT: &str = "$fallow.routeLoaderData";
+pub(crate) const MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES: usize = 8192;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum RouteLoadHarvestMode {
@@ -410,6 +411,26 @@ pub(crate) struct ModuleInfoExtractor {
     /// cached `ModuleInfo` field. See issue #1793.
     local_function_return_types: FxHashMap<String, String>,
     object_binding_candidates: Vec<ObjectBindingCandidate>,
+    /// Direct `new Class()` object-property target associations recorded during the AST
+    /// walk. Combined with `object_binding_candidates` to keep both object
+    /// binding channels under the same breadth cap.
+    direct_object_binding_target_count: usize,
+    /// Object-property paths whose value is a direct class instance. Module
+    /// targets remain available throughout the walk, while scoped targets are
+    /// pushed and popped with the matching declaration scopes.
+    module_direct_object_binding_targets: FxHashMap<String, FxHashSet<String>>,
+    module_direct_object_binding_generations: FxHashMap<String, u64>,
+    module_direct_object_binding_paths_by_root: FxHashMap<String, FxHashSet<String>>,
+    scoped_direct_object_binding_targets: Vec<FxHashMap<String, FxHashSet<String>>>,
+    scoped_direct_object_binding_generations: Vec<FxHashMap<String, u64>>,
+    scoped_direct_object_binding_paths_by_root: Vec<FxHashMap<String, FxHashSet<String>>>,
+    scoped_direct_object_binding_roots: Vec<FxHashSet<String>>,
+    direct_object_binding_member_accesses: FxHashSet<(String, String)>,
+    direct_object_binding_access_generations: FxHashMap<String, FxHashMap<String, u64>>,
+    direct_object_binding_generation: u64,
+    abstained_direct_object_binding_paths: FxHashSet<String>,
+    direct_object_binding_whole_object_uses: FxHashSet<String>,
+    deferred_function_var_binding_roots: Vec<FxHashSet<String>>,
     /// Working state for the object-binding fixed-point (issue #1843 follow-up):
     /// an ancestor-prefix index over `binding_target_names`, mapping every proper
     /// dotted prefix `P` of a key to the keys that start with `P.`. Built once per
@@ -1105,10 +1126,82 @@ impl ModuleInfoExtractor {
             .or_insert(BindingTarget::Class(target));
     }
 
+    fn direct_object_binding_targets(&self, object: &str) -> Option<(&FxHashSet<String>, u64)> {
+        let root = object.split_once('.').map_or(object, |(root, _)| root);
+        for index in (0..self.scoped_direct_object_binding_targets.len()).rev() {
+            if let Some(targets) = self.scoped_direct_object_binding_targets[index].get(object) {
+                let generation = self.scoped_direct_object_binding_generations[index]
+                    .get(object)
+                    .copied()
+                    .unwrap_or_default();
+                return Some((targets, generation));
+            }
+            if self.scoped_direct_object_binding_roots[index].contains(root) {
+                return None;
+            }
+        }
+        self.module_direct_object_binding_targets
+            .get(object)
+            .map(|targets| {
+                let generation = self
+                    .module_direct_object_binding_generations
+                    .get(object)
+                    .copied()
+                    .unwrap_or_default();
+                (targets, generation)
+            })
+    }
+
     /// Remember the class a receiver named at this point in the walk, so an
     /// access written in one scope survives the same name being rebound to a
     /// different class in a sibling scope.
-    fn record_walk_order_member_access(&mut self, object: &str, member: &str) {
+    fn record_walk_order_member_access(&mut self, object: &str, member: &str) -> bool {
+        if self.abstained_direct_object_binding_paths.contains(object)
+            && self.direct_object_binding_targets(object).is_some()
+        {
+            return true;
+        }
+        if let Some((classes, generation)) = self.direct_object_binding_targets(object) {
+            if self
+                .direct_object_binding_access_generations
+                .get(object)
+                .and_then(|members| members.get(member))
+                == Some(&generation)
+            {
+                return true;
+            }
+            if self.direct_object_binding_member_accesses.len()
+                >= MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES
+            {
+                self.abstain_direct_object_binding_path(object);
+                return true;
+            }
+            let mut classes = classes.iter().cloned().collect::<Vec<_>>();
+            classes.sort_unstable();
+            for class in classes {
+                if self.direct_object_binding_member_accesses.len()
+                    >= MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES
+                {
+                    self.abstain_direct_object_binding_path(object);
+                    return true;
+                }
+                let access = (class, member.to_string());
+                if self
+                    .direct_object_binding_member_accesses
+                    .insert(access.clone())
+                {
+                    self.member_accesses.push(MemberAccess {
+                        object: access.0,
+                        member: access.1,
+                    });
+                }
+            }
+            self.direct_object_binding_access_generations
+                .entry(object.to_string())
+                .or_default()
+                .insert(member.to_string(), generation);
+            return true;
+        }
         if let Some(class) = self.walk_order_class_bindings.get(object) {
             self.walk_order_member_accesses.push((
                 object.to_string(),
@@ -1116,6 +1209,29 @@ impl ModuleInfoExtractor {
                 member.to_string(),
             ));
         }
+        false
+    }
+
+    fn abstain_direct_object_binding_path(&mut self, object: &str) {
+        let mut classes = FxHashSet::default();
+        if let Some(module_classes) = self.module_direct_object_binding_targets.get(object) {
+            classes.extend(module_classes.iter().cloned());
+        }
+        for targets in &self.scoped_direct_object_binding_targets {
+            if let Some(scoped_classes) = targets.get(object) {
+                classes.extend(scoped_classes.iter().cloned());
+            }
+        }
+        for class in classes {
+            if self
+                .direct_object_binding_whole_object_uses
+                .insert(class.clone())
+            {
+                self.whole_object_uses.push(class);
+            }
+        }
+        self.abstained_direct_object_binding_paths
+            .insert(object.to_string());
     }
 
     /// Record member accesses for a JSX member-expression tag (`<SC.UsedStyle />`,
@@ -1130,11 +1246,12 @@ impl ModuleInfoExtractor {
                 && !self.namespace_like_binding_is_shadowed(&object_name)
             {
                 let object = self.qualify_this_scope(&object_name);
-                self.record_walk_order_member_access(&object, current.property.name.as_str());
-                self.member_accesses.push(MemberAccess {
-                    object,
-                    member: current.property.name.to_string(),
-                });
+                if !self.record_walk_order_member_access(&object, current.property.name.as_str()) {
+                    self.member_accesses.push(MemberAccess {
+                        object,
+                        member: current.property.name.to_string(),
+                    });
+                }
             }
             match &current.object {
                 JSXMemberExpressionObject::MemberExpression(inner) => current = inner,

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2502,6 +2502,650 @@ fn instance_property_access_mapped_to_class() {
 }
 
 #[test]
+fn object_property_instance_access_mapped_to_class() {
+    let info = parse(
+        r"
+            import { Foo } from './foo';
+            const holder = { property: new Foo() };
+            console.log(holder.property.bar);
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Foo" && access.member == "bar"),
+        "holder.property.bar should be mapped to Foo.bar, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn builtin_object_property_instance_is_not_mapped_to_class() {
+    let info = parse(
+        r"
+            const holder = { property: new Map() };
+            holder.property.get('key');
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Map"),
+        "built-in object-property instances should not emit class accesses, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn nested_shadow_maps_each_object_property_binding_to_its_own_class() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            function nested() {
+                const holder = { property: new Beta() };
+                holder.property.betaOnly();
+            }
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the outer holder should remain mapped to Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the nested holder should be mapped to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn function_local_object_property_instance_access_mapped_to_class() {
+    let info = parse(
+        r"
+            import { Foo } from './foo';
+            function run() {
+                const holder = { property: new Foo() };
+                holder.property.bar();
+            }
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Foo" && access.member == "bar"),
+        "a function-local holder should be mapped to Foo, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn shadowed_parameter_does_not_credit_module_object_property_binding() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            function inspect(holder: unknown) {
+                holder.property.unrelated();
+            }
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the module holder should remain mapped to Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "unrelated"),
+        "a shadowing parameter must not credit Alpha, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn forward_module_object_property_binding_survives_sibling_shadow() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+
+            function early() {
+                holder.property.alphaOnly();
+            }
+
+            function nested() {
+                const holder = { property: new Beta() };
+                holder.property.betaOnly();
+            }
+
+            const holder = { property: new Alpha() };
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the forward module access should map to Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the sibling local access should map to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn loop_initializer_object_property_binding_does_not_leak() {
+    let info = parse(
+        r"
+            import { Beta } from './services';
+
+            for (let holder = { property: new Beta() }; false;) {}
+
+            const holder = { property: { betaOnly() {} } };
+            holder.property.betaOnly();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the loop initializer target must not leak, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn switch_object_property_binding_does_not_leak_to_module_scope() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+
+            switch (value) {
+                case 1:
+                    const holder = { property: new Beta() };
+                    holder.property.betaOnly();
+                    break;
+            }
+
+            const holder = { property: new Alpha() };
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the module target should remain Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the switch-local target should map to Beta, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "alphaOnly"),
+        "the module access must not be credited to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn direct_and_identifier_object_property_bindings_do_not_cross_credit() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            function nested() {
+                const beta = new Beta();
+                const holder = { property: beta };
+                holder.property.betaOnly();
+            }
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the direct module target should map to Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the identifier-backed local target should map to Beta, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "alphaOnly"),
+        "the module access must not be credited to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn duplicate_object_property_uses_the_last_initializer() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const beta = new Beta();
+            const holder = {
+                property: new Alpha(),
+                property: beta,
+            };
+            holder.property.betaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the last property initializer should map to Beta, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "betaOnly"),
+        "the overwritten Alpha initializer must not receive the access, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn bare_identifier_assignment_replaces_direct_target() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            let holder = { property: new Alpha() };
+
+            holder.property.alphaOnly();
+            holder = { property: new Beta() };
+            holder.property.betaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the access before assignment should map to Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the replacement target should map to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn identifier_assignment_copies_nested_direct_targets() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const replacement = { property: new Beta() };
+            let holder = { property: new Alpha() };
+
+            holder = replacement;
+            holder.property.betaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the identifier assignment should copy replacement's nested target, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn function_assignment_adds_possible_module_target() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            function mutate() {
+                holder.property = new Beta();
+                holder.property.betaOnly();
+            }
+
+            holder.property.alphaOnly();
+            console.log(mutate);
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the module target should remain Alpha, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the function-local replacement should map to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn called_function_assignment_credits_possible_replacement() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            function mutate() {
+                holder.property = new Beta();
+            }
+
+            mutate();
+            holder.property.betaOnly();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the possible replacement should map the later access to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn static_block_assignment_credits_possible_replacement() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            class Example {
+                static {
+                    holder.property = new Beta();
+                }
+            }
+
+            holder.property.betaOnly();
+            console.log(Example);
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the static-block replacement should map the later access to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn namespace_assignment_credits_possible_replacement() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            namespace Example {
+                holder.property = new Beta();
+            }
+
+            holder.property.betaOnly();
+            console.log(Example);
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "betaOnly"),
+        "the namespace replacement should map the later access to Beta, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn function_var_non_class_binding_blocks_module_target_fallback() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            function inspect() {
+                var holder = { property: { unrelated() {} } };
+                holder.property.unrelated();
+            }
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "unrelated"),
+        "a function var must block module target fallback, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn static_block_var_binding_blocks_module_target_fallback() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            class Example {
+                static {
+                    var holder = { property: { unrelated() {} } };
+                    holder.property.unrelated();
+                }
+            }
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "unrelated"),
+        "a static-block var must block module target fallback, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn named_function_expression_binding_blocks_module_target_fallback() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            const inspect = function holder() {
+                holder.property.unrelated();
+            };
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "unrelated"),
+        "a named function expression must block module fallback, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn named_class_expression_binding_blocks_module_target_fallback() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            const Example = class holder {
+                static inspect() {
+                    holder.property.unrelated();
+                }
+            };
+
+            holder.property.alphaOnly();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "unrelated"),
+        "a named class expression must block module fallback, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn namespace_var_binding_does_not_escape_to_enclosing_function() {
+    let info = parse(
+        r"
+            import { Alpha, Beta } from './services';
+            const holder = { property: new Alpha() };
+
+            function inspect() {
+                namespace Inner {
+                    var holder = { property: new Beta() };
+                    holder.property.betaOnly();
+                }
+                holder.property.alphaOnly();
+            }
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the namespace var must not replace the enclosing Alpha target, found: {:?}",
+        info.member_accesses
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|access| access.object == "Beta" && access.member == "alphaOnly"),
+        "the namespace var must not escape into the enclosing function, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn namespace_can_use_unshadowed_module_object_property_target() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            namespace Consumers {
+                export function use() {
+                    holder.property.alphaOnly();
+                }
+            }
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the unshadowed module target should remain visible in the namespace, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn function_default_parameter_resolves_before_body_var_scope() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            function inspect(value = holder.property.alphaOnly()) {
+                var holder = { property: { unrelated() {} } };
+                console.log(value, holder);
+            }
+            inspect();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the default parameter should resolve the module target, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn arrow_default_parameter_resolves_before_body_var_scope() {
+    let info = parse(
+        r"
+            import { Alpha } from './services';
+            const holder = { property: new Alpha() };
+
+            const inspect = (value = holder.property.alphaOnly()) => {
+                var holder = { property: { unrelated() {} } };
+                console.log(value, holder);
+            };
+            inspect();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|access| access.object == "Alpha" && access.member == "alphaOnly"),
+        "the arrow default should resolve the module target, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
 fn injected_object_member_access_mapped_to_class() {
     let info = parse(
         r"

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -1233,17 +1233,27 @@ impl ModuleInfoExtractor {
     fn record_nested_declaration(&mut self, decl: &Declaration<'_>) {
         match decl {
             Declaration::VariableDeclaration(var) => {
+                if var.kind.is_lexical() {
+                    self.record_direct_object_binding_scope_roots(
+                        var.declarations
+                            .iter()
+                            .flat_map(|declarator| declarator.id.get_binding_identifiers())
+                            .map(|id| id.name.to_string()),
+                    );
+                }
                 for declarator in &var.declarations {
                     self.record_nested_declaration_names(declarator.id.get_binding_identifiers());
                 }
             }
             Declaration::ClassDeclaration(class) => {
                 if let Some(id) = class.id.as_ref() {
+                    self.record_direct_object_binding_scope_roots([id.name.to_string()]);
                     self.record_nested_named_declaration(id);
                 }
             }
             Declaration::FunctionDeclaration(function) => {
                 if let Some(id) = function.id.as_ref() {
+                    self.record_direct_object_binding_scope_roots([id.name.to_string()]);
                     self.record_nested_named_declaration(id);
                 }
             }
@@ -1255,6 +1265,36 @@ impl ModuleInfoExtractor {
         for statement in statements {
             if let Some(declaration) = statement.as_declaration() {
                 self.record_nested_declaration(declaration);
+            }
+        }
+    }
+
+    fn preseed_direct_object_binding_scope_roots(&mut self, statements: &[Statement<'_>]) {
+        for statement in statements {
+            let Some(declaration) = statement.as_declaration() else {
+                continue;
+            };
+            match declaration {
+                Declaration::VariableDeclaration(variable) if variable.kind.is_lexical() => {
+                    self.record_direct_object_binding_scope_roots(
+                        variable
+                            .declarations
+                            .iter()
+                            .flat_map(|declarator| declarator.id.get_binding_identifiers())
+                            .map(|id| id.name.to_string()),
+                    );
+                }
+                Declaration::ClassDeclaration(class) => {
+                    if let Some(id) = class.id.as_ref() {
+                        self.record_direct_object_binding_scope_roots([id.name.to_string()]);
+                    }
+                }
+                Declaration::FunctionDeclaration(function) => {
+                    if let Some(id) = function.id.as_ref() {
+                        self.record_direct_object_binding_scope_roots([id.name.to_string()]);
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -2605,6 +2645,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.record_program_prologue(program);
         self.record_program_sanitizer_functions(program);
         self.record_local_function_return_types(program);
+        self.preseed_direct_object_binding_targets(&program.body);
         walk::walk_program(self, program);
     }
 
@@ -2703,6 +2744,9 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.block_depth += 1;
         let type_alias_scope_pushed =
             self.namespace_depth == 0 && self.push_function_type_alias_scope(&stmt.body);
+        self.push_direct_object_binding_scope(FxHashSet::default());
+        self.preseed_direct_object_binding_scope_roots(&stmt.body);
+        self.preseed_direct_object_binding_targets(&stmt.body);
         if self.namespace_depth == 0 {
             self.nested_declaration_stack.push(FxHashSet::default());
             self.scoped_namespace_binding_names
@@ -2736,6 +2780,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             self.path_sink_binding_stack.pop();
             self.path_relative_binding_stack.pop();
         }
+        self.pop_direct_object_binding_scope();
         self.block_depth -= 1;
     }
 
@@ -2750,13 +2795,41 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
     }
 
+    fn visit_switch_cases(&mut self, cases: &oxc_allocator::Vec<'a, SwitchCase<'a>>) {
+        self.push_direct_object_binding_scope(FxHashSet::default());
+        for case in cases {
+            self.preseed_direct_object_binding_scope_roots(&case.consequent);
+            self.preseed_direct_object_binding_targets(&case.consequent);
+        }
+        walk::walk_switch_cases(self, cases);
+        self.pop_direct_object_binding_scope();
+    }
+
     fn visit_static_block(&mut self, block: &StaticBlock<'a>) {
         let type_alias_scope_pushed =
             self.namespace_depth == 0 && self.push_function_type_alias_scope(&block.body);
+        let var_roots = Self::var_binding_roots(&block.body);
+        self.push_var_owner_direct_object_binding_scope(var_roots);
+        self.preseed_direct_object_binding_scope_roots(&block.body);
+        self.preseed_direct_object_binding_targets(&block.body);
         walk::walk_static_block(self, block);
+        self.pop_direct_object_binding_scope();
         if type_alias_scope_pushed {
             self.pop_function_type_alias_scope();
         }
+    }
+
+    fn visit_catch_clause(&mut self, clause: &CatchClause<'a>) {
+        let roots = clause
+            .param
+            .as_ref()
+            .into_iter()
+            .flat_map(|param| param.pattern.get_binding_identifiers())
+            .map(|id| id.name.to_string())
+            .collect();
+        self.push_direct_object_binding_scope(roots);
+        walk::walk_catch_clause(self, clause);
+        self.pop_direct_object_binding_scope();
     }
 
     fn visit_declaration(&mut self, decl: &Declaration<'a>) {
@@ -2776,16 +2849,41 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             .as_deref()
             .is_some_and(|params| self.push_function_type_parameter_scope(params));
         self.record_scoped_typed_parameter_accesses(&func.params, func.body.as_deref());
+        let var_roots = func
+            .body
+            .as_deref()
+            .map_or_else(FxHashSet::default, |body| {
+                Self::var_binding_roots(&body.statements)
+            });
+        let self_roots = func
+            .id
+            .as_ref()
+            .map(|id| FxHashSet::from_iter([id.name.to_string()]))
+            .unwrap_or_default();
+        let mut direct_roots = self_roots;
+        for param in &func.params.items {
+            direct_roots.extend(
+                param
+                    .pattern
+                    .get_binding_identifiers()
+                    .into_iter()
+                    .map(|id| id.name.to_string()),
+            );
+        }
+        self.push_var_owner_direct_object_binding_scope(direct_roots);
         self.push_function_declaration_scope(&func.params);
+        self.deferred_function_var_binding_roots.push(var_roots);
         self.function_depth += 1;
         let component_pushed = self.react_enter_function(func);
         walk::walk_function(self, func, flags);
         self.react_exit_component(component_pushed);
         self.function_depth -= 1;
+        self.deferred_function_var_binding_roots.pop();
         if type_parameter_scope_pushed {
             self.pop_function_type_alias_scope();
         }
         self.pop_function_declaration_scope();
+        self.pop_direct_object_binding_scope();
     }
 
     fn visit_arrow_function_expression(&mut self, expr: &ArrowFunctionExpression<'a>) {
@@ -2795,21 +2893,37 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             .as_deref()
             .is_some_and(|params| self.push_function_type_parameter_scope(params));
         self.record_scoped_typed_parameter_accesses(&expr.params, Some(expr.body.as_ref()));
+        let var_roots = Self::var_binding_roots(&expr.body.statements);
+        let direct_roots = expr
+            .params
+            .items
+            .iter()
+            .flat_map(|param| param.pattern.get_binding_identifiers())
+            .map(|id| id.name.to_string())
+            .collect();
+        self.push_var_owner_direct_object_binding_scope(direct_roots);
         self.push_function_declaration_scope(&expr.params);
+        self.deferred_function_var_binding_roots.push(var_roots);
         self.function_depth += 1;
         let component_pushed = self.react_enter_arrow(expr);
         walk::walk_arrow_function_expression(self, expr);
         self.react_exit_component(component_pushed);
         self.function_depth -= 1;
+        self.deferred_function_var_binding_roots.pop();
         if type_parameter_scope_pushed {
             self.pop_function_type_alias_scope();
         }
         self.pop_function_declaration_scope();
+        self.pop_direct_object_binding_scope();
     }
 
     fn visit_function_body(&mut self, body: &FunctionBody<'a>) {
         let type_alias_scope_pushed =
             self.namespace_depth == 0 && self.push_function_type_alias_scope(&body.statements);
+        if let Some(var_roots) = self.deferred_function_var_binding_roots.last() {
+            self.record_direct_object_binding_scope_roots(var_roots.clone());
+        }
+        self.preseed_direct_object_binding_targets(&body.statements);
         if self.namespace_depth == 0 {
             self.scoped_array_binding_element_types
                 .push(FxHashMap::default());
@@ -3077,7 +3191,22 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if is_local_namespace {
             self.local_namespace_depth += 1;
         }
+        let body_statements = match decl.body.as_ref() {
+            Some(TSModuleDeclarationBody::TSModuleBlock(block)) => Some(&block.body),
+            _ => None,
+        };
+        let mut direct_roots =
+            body_statements.map_or_else(FxHashSet::default, |body| Self::var_binding_roots(body));
+        if let TSModuleDeclarationName::Identifier(id) = &decl.id {
+            direct_roots.insert(id.name.to_string());
+        }
+        self.push_var_owner_direct_object_binding_scope(direct_roots);
+        if let Some(body) = body_statements {
+            self.preseed_direct_object_binding_scope_roots(body);
+            self.preseed_direct_object_binding_targets(body);
+        }
         walk::walk_ts_module_declaration(self, decl);
+        self.pop_direct_object_binding_scope();
         if is_local_namespace {
             self.local_namespace_depth -= 1;
         }
@@ -3320,19 +3449,60 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         walk::walk_call_expression(self, expr);
     }
 
+    fn visit_for_statement(&mut self, stmt: &ForStatement<'a>) {
+        let mut roots = FxHashSet::default();
+        if let Some(ForStatementInit::VariableDeclaration(declaration)) = &stmt.init
+            && declaration.kind.is_lexical()
+        {
+            roots.extend(
+                declaration
+                    .declarations
+                    .iter()
+                    .flat_map(|declarator| declarator.id.get_binding_identifiers())
+                    .map(|id| id.name.to_string()),
+            );
+        }
+        self.push_direct_object_binding_scope(roots);
+        if let Some(ForStatementInit::VariableDeclaration(declaration)) = &stmt.init {
+            self.preseed_direct_object_binding_declaration(declaration);
+        }
+        walk::walk_for_statement(self, stmt);
+        self.pop_direct_object_binding_scope();
+    }
+
     fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
         self.bind_for_of_element(stmt);
 
-        if let Some((strings, objects)) = self.static_package_loop_bindings(stmt) {
+        let static_bindings = self.static_package_loop_bindings(stmt);
+        let has_static_bindings = static_bindings.is_some();
+        if let Some((strings, objects)) = static_bindings {
             self.loop_string_bindings.push(strings);
             self.loop_object_property_values.push(objects);
-            walk::walk_for_of_statement(self, stmt);
-            self.loop_object_property_values.pop();
-            self.loop_string_bindings.pop();
-            return;
         }
 
-        walk::walk_for_of_statement(self, stmt);
+        self.visit_for_statement_left(&stmt.left);
+        self.visit_expression(&stmt.right);
+
+        let mut roots = FxHashSet::default();
+        if let ForStatementLeft::VariableDeclaration(declaration) = &stmt.left
+            && declaration.kind.is_lexical()
+        {
+            roots.extend(
+                declaration
+                    .declarations
+                    .iter()
+                    .flat_map(|declarator| declarator.id.get_binding_identifiers())
+                    .map(|id| id.name.to_string()),
+            );
+        }
+        self.push_direct_object_binding_scope(roots);
+        self.visit_statement(&stmt.body);
+        self.pop_direct_object_binding_scope();
+
+        if has_static_bindings {
+            self.loop_object_property_values.pop();
+            self.loop_string_bindings.pop();
+        }
     }
 
     fn visit_template_literal(&mut self, tpl: &TemplateLiteral<'a>) {
@@ -3485,6 +3655,44 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
         self.capture_member_assign_sink(expr);
         walk::walk_assignment_expression(self, expr);
+
+        let is_plain_assignment = matches!(expr.operator, AssignmentOperator::Assign);
+        match &expr.left {
+            AssignmentTarget::AssignmentTargetIdentifier(ident) => {
+                self.record_direct_object_binding_assignment(
+                    ident.name.as_str(),
+                    &expr.right,
+                    is_plain_assignment,
+                );
+            }
+            AssignmentTarget::StaticMemberExpression(member) => {
+                if let Some(object_name) = static_member_object_name(&member.object) {
+                    self.record_direct_object_binding_assignment(
+                        &format!("{object_name}.{}", member.property.name),
+                        &expr.right,
+                        is_plain_assignment,
+                    );
+                }
+            }
+            AssignmentTarget::ComputedMemberExpression(member) => {
+                if let Some(object_name) = static_member_object_name(&member.object) {
+                    if let Some(property_name) = member.static_property_name() {
+                        self.record_direct_object_binding_assignment(
+                            &format!("{object_name}.{property_name}"),
+                            &expr.right,
+                            is_plain_assignment,
+                        );
+                    } else {
+                        self.record_direct_object_binding_assignment(
+                            &object_name,
+                            &expr.right,
+                            false,
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     fn visit_update_expression(&mut self, expr: &UpdateExpression<'a>) {
@@ -3561,11 +3769,12 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             // any non-`this` receiver pass through unchanged.
             if !self.namespace_like_binding_is_shadowed(&object_name) {
                 let object = self.qualify_this_scope(&object_name);
-                self.record_walk_order_member_access(&object, expr.property.name.as_str());
-                self.member_accesses.push(MemberAccess {
-                    object,
-                    member: expr.property.name.to_string(),
-                });
+                if !self.record_walk_order_member_access(&object, expr.property.name.as_str()) {
+                    self.member_accesses.push(MemberAccess {
+                        object,
+                        member: expr.property.name.to_string(),
+                    });
+                }
             }
         }
         if matches!(expr.object, Expression::Super(_))
@@ -3667,7 +3876,24 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if let Expression::Identifier(ident) = &stmt.right {
             self.record_whole_object_identifier_use(ident.name.as_str());
         }
-        walk::walk_for_in_statement(self, stmt);
+        self.visit_for_statement_left(&stmt.left);
+        self.visit_expression(&stmt.right);
+
+        let mut roots = FxHashSet::default();
+        if let ForStatementLeft::VariableDeclaration(declaration) = &stmt.left
+            && declaration.kind.is_lexical()
+        {
+            roots.extend(
+                declaration
+                    .declarations
+                    .iter()
+                    .flat_map(|declarator| declarator.id.get_binding_identifiers())
+                    .map(|id| id.name.to_string()),
+            );
+        }
+        self.push_direct_object_binding_scope(roots);
+        self.visit_statement(&stmt.body);
+        self.pop_direct_object_binding_scope();
     }
 
     fn visit_if_statement(&mut self, stmt: &IfStatement<'a>) {
@@ -3726,7 +3952,14 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         self.class_scope_counter += 1;
         let class_scope_id = self.class_scope_counter;
         self.class_scope_stack.push(class_scope_id);
+        let direct_scope_roots = class
+            .id
+            .as_ref()
+            .map(|id| FxHashSet::from_iter([id.name.to_string()]))
+            .unwrap_or_default();
+        self.push_direct_object_binding_scope(direct_scope_roots);
         walk::walk_class(self, class);
+        self.pop_direct_object_binding_scope();
         self.record_class_this_facts(
             class,
             class_scope_id,

--- a/crates/extract/src/visitor/visit_impl_object_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_object_bindings.rs
@@ -199,16 +199,15 @@ impl ModuleInfoExtractor {
         }
 
         match value {
-            Expression::NewExpression(new_expression)
-                if let Expression::Identifier(callee) = &new_expression.callee
-                    && !super::super::helpers::is_builtin_constructor(callee.name.as_str()) =>
-            {
-                self.record_direct_object_binding_target(
-                    root_name,
-                    binding_path.to_string(),
-                    callee.name.to_string(),
-                    DirectObjectBindingScope::BindingOwner,
-                );
+            Expression::NewExpression(new_expression) => {
+                if let Some(class_name) = direct_new_expression_class_name(new_expression) {
+                    self.record_direct_object_binding_target(
+                        root_name,
+                        binding_path.to_string(),
+                        class_name,
+                        DirectObjectBindingScope::BindingOwner,
+                    );
+                }
             }
             Expression::ObjectExpression(object) => {
                 self.record_direct_object_binding_targets_at_path(
@@ -400,16 +399,15 @@ impl ModuleInfoExtractor {
                 self.remove_direct_object_binding_targets_at_or_below(&binding_path, scope);
             }
             match &prop.value {
-                Expression::NewExpression(new_expr)
-                    if let Expression::Identifier(callee) = &new_expr.callee
-                        && !super::super::helpers::is_builtin_constructor(callee.name.as_str()) =>
-                {
-                    self.record_direct_object_binding_target(
-                        root_name,
-                        binding_path,
-                        callee.name.to_string(),
-                        scope,
-                    );
+                Expression::NewExpression(new_expr) => {
+                    if let Some(class_name) = direct_new_expression_class_name(new_expr) {
+                        self.record_direct_object_binding_target(
+                            root_name,
+                            binding_path,
+                            class_name,
+                            scope,
+                        );
+                    }
                 }
                 Expression::ObjectExpression(child) => {
                     self.record_direct_object_binding_targets_at_path(
@@ -558,6 +556,16 @@ fn direct_object_binding_expression_path(expression: &Expression<'_>) -> Option<
         }
         _ => None,
     }
+}
+
+fn direct_new_expression_class_name(expression: &NewExpression<'_>) -> Option<String> {
+    let Expression::Identifier(callee) = &expression.callee else {
+        return None;
+    };
+    if super::super::helpers::is_builtin_constructor(callee.name.as_str()) {
+        return None;
+    }
+    Some(callee.name.to_string())
 }
 
 #[cfg(all(test, not(miri)))]

--- a/crates/extract/src/visitor/visit_impl_object_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_object_bindings.rs
@@ -3,22 +3,26 @@
     reason = "object binding helpers use AST node shapes"
 )]
 use oxc_ast::ast::*;
+use rustc_hash::FxHashSet;
 
 use super::super::{BindingTarget, ModuleInfoExtractor, ObjectBindingCandidate};
 
-/// Per-module breadth cap on recorded object-binding candidates (issue #1843
+/// Per-module breadth cap on recorded object-binding targets (issue #1843
 /// follow-up): the companion to `MAX_TAINTED_BINDINGS_PER_MODULE` for the
-/// `const obj = { key: ident }` object-binding channel. `object_binding_candidates`
-/// grows once per identifier-valued property (recursively through nested object
-/// literals) and is resolved by a fixpoint pass whose iteration bound is the
-/// candidate count, so an O(n^2) worst case. A dense machine-generated bundle
-/// with a huge object literal drove the working set (and that fixpoint) super-
-/// linearly. Past the cap no NEW candidate is recorded, degrading an over-cap
-/// file to module-level reachability instead of an object-binding member-access
-/// claim, matching the false-negative-preferring direction of the taint caps.
-/// Deliberately a constant, not a config knob: real hand-written modules stay
-/// far below it.
-const MAX_OBJECT_BINDING_CANDIDATES: usize = 4096;
+/// `const obj = { key: ident }` and `const obj = { key: new Class() }` channels.
+/// Identifier candidates are resolved by a fixpoint pass with an O(n^2) worst
+/// case. Direct targets are preseeded into scope maps, so both channels need a
+/// bounded working set on dense machine-generated bundles. Past the cap no new
+/// target is recorded, matching the false-negative-preferring direction of the
+/// taint caps. Deliberately a constant, not a config knob: real hand-written
+/// modules stay far below it.
+const MAX_OBJECT_BINDING_TARGETS: usize = 4096;
+
+#[derive(Clone, Copy)]
+enum DirectObjectBindingScope {
+    Current,
+    BindingOwner,
+}
 
 impl ModuleInfoExtractor {
     pub(super) fn extract_angular_inject_target(
@@ -148,6 +152,337 @@ impl ModuleInfoExtractor {
         self.record_object_binding_targets_at_path(binding_name, binding_name, obj);
     }
 
+    pub(super) fn preseed_direct_object_binding_targets(&mut self, statements: &[Statement<'_>]) {
+        for statement in statements {
+            let Some(Declaration::VariableDeclaration(declaration)) = statement.as_declaration()
+            else {
+                continue;
+            };
+            self.preseed_direct_object_binding_declaration(declaration);
+        }
+    }
+
+    pub(super) fn preseed_direct_object_binding_declaration(
+        &mut self,
+        declaration: &VariableDeclaration<'_>,
+    ) {
+        if !declaration.kind.is_lexical() {
+            return;
+        }
+        for declarator in &declaration.declarations {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                continue;
+            };
+            let Some(Expression::ObjectExpression(object)) = declarator.init.as_ref() else {
+                continue;
+            };
+            self.record_direct_object_binding_targets_at_path(
+                id.name.as_str(),
+                id.name.as_str(),
+                object,
+                DirectObjectBindingScope::Current,
+            );
+        }
+    }
+
+    pub(super) fn record_direct_object_binding_assignment(
+        &mut self,
+        binding_path: &str,
+        value: &Expression<'_>,
+        is_plain_assignment: bool,
+    ) {
+        let root_name = binding_path
+            .split_once('.')
+            .map_or(binding_path, |(root, _)| root);
+        if !is_plain_assignment {
+            return;
+        }
+
+        match value {
+            Expression::NewExpression(new_expression)
+                if let Expression::Identifier(callee) = &new_expression.callee
+                    && !super::super::helpers::is_builtin_constructor(callee.name.as_str()) =>
+            {
+                self.record_direct_object_binding_target(
+                    root_name,
+                    binding_path.to_string(),
+                    callee.name.to_string(),
+                    DirectObjectBindingScope::BindingOwner,
+                );
+            }
+            Expression::ObjectExpression(object) => {
+                self.record_direct_object_binding_targets_at_path(
+                    root_name,
+                    binding_path,
+                    object,
+                    DirectObjectBindingScope::BindingOwner,
+                );
+            }
+            _ => {
+                if let Some(source_path) = direct_object_binding_expression_path(value) {
+                    self.copy_direct_object_binding_targets(&source_path, binding_path);
+                }
+            }
+        }
+    }
+
+    fn copy_direct_object_binding_targets(&mut self, source_path: &str, target_path: &str) {
+        let source_root = source_path
+            .split_once('.')
+            .map_or(source_path, |(root, _)| root);
+        let nested_prefix = format!("{source_path}.");
+        let mut copied = Vec::new();
+        let mut shadowed = false;
+
+        for index in (0..self.scoped_direct_object_binding_targets.len()).rev() {
+            if let Some(paths) =
+                self.scoped_direct_object_binding_paths_by_root[index].get(source_root)
+            {
+                copied.extend(paths.iter().filter_map(|path| {
+                    if path != source_path && !path.starts_with(&nested_prefix) {
+                        return None;
+                    }
+                    let suffix = &path[source_path.len()..];
+                    self.scoped_direct_object_binding_targets[index]
+                        .get(path)
+                        .map(|targets| (format!("{target_path}{suffix}"), targets.clone()))
+                }));
+                shadowed = true;
+                break;
+            }
+            if self.scoped_direct_object_binding_roots[index].contains(source_root) {
+                shadowed = true;
+                break;
+            }
+        }
+
+        if !shadowed
+            && let Some(paths) = self
+                .module_direct_object_binding_paths_by_root
+                .get(source_root)
+        {
+            copied.extend(paths.iter().filter_map(|path| {
+                if path != source_path && !path.starts_with(&nested_prefix) {
+                    return None;
+                }
+                let suffix = &path[source_path.len()..];
+                self.module_direct_object_binding_targets
+                    .get(path)
+                    .map(|targets| (format!("{target_path}{suffix}"), targets.clone()))
+            }));
+        }
+
+        let target_root = target_path
+            .split_once('.')
+            .map_or(target_path, |(root, _)| root);
+        for (path, targets) in copied {
+            for class_name in targets {
+                self.record_direct_object_binding_target(
+                    target_root,
+                    path.clone(),
+                    class_name,
+                    DirectObjectBindingScope::BindingOwner,
+                );
+            }
+        }
+    }
+
+    fn object_binding_target_count(&self) -> usize {
+        self.object_binding_candidates
+            .len()
+            .saturating_add(self.direct_object_binding_target_count)
+    }
+
+    fn record_direct_object_binding_target(
+        &mut self,
+        root_name: &str,
+        binding_path: String,
+        class_name: String,
+        scope: DirectObjectBindingScope,
+    ) {
+        let scope_index = self.direct_object_binding_scope_index(scope, root_name);
+        if let Some(index) = scope_index {
+            self.scoped_direct_object_binding_roots[index].insert(root_name.to_string());
+        }
+        let is_new_target = if let Some(index) = scope_index {
+            self.scoped_direct_object_binding_targets[index]
+                .get(&binding_path)
+                .is_none_or(|targets| !targets.contains(&class_name))
+        } else {
+            self.module_direct_object_binding_targets
+                .get(&binding_path)
+                .is_none_or(|targets| !targets.contains(&class_name))
+        };
+        if self
+            .abstained_direct_object_binding_paths
+            .contains(&binding_path)
+            && self
+                .direct_object_binding_whole_object_uses
+                .insert(class_name.clone())
+        {
+            self.whole_object_uses.push(class_name.clone());
+        }
+        if is_new_target && self.object_binding_target_count() >= MAX_OBJECT_BINDING_TARGETS {
+            return;
+        }
+        if is_new_target {
+            self.direct_object_binding_target_count += 1;
+            self.direct_object_binding_generation =
+                self.direct_object_binding_generation.saturating_add(1);
+            if let Some(index) = scope_index {
+                self.scoped_direct_object_binding_generations[index]
+                    .insert(binding_path.clone(), self.direct_object_binding_generation);
+            } else {
+                self.module_direct_object_binding_generations
+                    .insert(binding_path.clone(), self.direct_object_binding_generation);
+            }
+        }
+
+        if let Some(index) = scope_index {
+            self.scoped_direct_object_binding_paths_by_root[index]
+                .entry(root_name.to_string())
+                .or_default()
+                .insert(binding_path.clone());
+            self.scoped_direct_object_binding_targets[index]
+                .entry(binding_path)
+                .or_default()
+                .insert(class_name);
+        } else {
+            self.module_direct_object_binding_paths_by_root
+                .entry(root_name.to_string())
+                .or_default()
+                .insert(binding_path.clone());
+            self.module_direct_object_binding_targets
+                .entry(binding_path)
+                .or_default()
+                .insert(class_name);
+        }
+    }
+
+    fn direct_object_binding_scope_index(
+        &self,
+        scope: DirectObjectBindingScope,
+        root_name: &str,
+    ) -> Option<usize> {
+        match scope {
+            DirectObjectBindingScope::Current => self
+                .scoped_direct_object_binding_targets
+                .len()
+                .checked_sub(1),
+            DirectObjectBindingScope::BindingOwner => self
+                .scoped_direct_object_binding_roots
+                .iter()
+                .rposition(|roots| roots.contains(root_name)),
+        }
+    }
+
+    fn record_direct_object_binding_targets_at_path(
+        &mut self,
+        root_name: &str,
+        object_path: &str,
+        obj: &ObjectExpression<'_>,
+        scope: DirectObjectBindingScope,
+    ) {
+        let mut seen_keys = FxHashSet::default();
+        for prop in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                self.remove_direct_object_binding_targets_at_or_below(object_path, scope);
+                seen_keys.clear();
+                continue;
+            };
+            let Some(key_name) = prop.key.static_name() else {
+                self.remove_direct_object_binding_targets_at_or_below(object_path, scope);
+                seen_keys.clear();
+                continue;
+            };
+            let binding_path = format!("{object_path}.{key_name}");
+            if !seen_keys.insert(key_name.to_string()) {
+                self.remove_direct_object_binding_targets_at_or_below(&binding_path, scope);
+            }
+            match &prop.value {
+                Expression::NewExpression(new_expr)
+                    if let Expression::Identifier(callee) = &new_expr.callee
+                        && !super::super::helpers::is_builtin_constructor(callee.name.as_str()) =>
+                {
+                    self.record_direct_object_binding_target(
+                        root_name,
+                        binding_path,
+                        callee.name.to_string(),
+                        scope,
+                    );
+                }
+                Expression::ObjectExpression(child) => {
+                    self.record_direct_object_binding_targets_at_path(
+                        root_name,
+                        &binding_path,
+                        child,
+                        scope,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn remove_direct_object_binding_targets_at_or_below(
+        &mut self,
+        prefix: &str,
+        scope: DirectObjectBindingScope,
+    ) {
+        let nested_prefix = format!("{prefix}.");
+        let root_name = prefix.split_once('.').map_or(prefix, |(root, _)| root);
+        if let Some(index) = self.direct_object_binding_scope_index(scope, root_name) {
+            let removed = self.scoped_direct_object_binding_paths_by_root[index]
+                .get(root_name)
+                .map(|paths| {
+                    paths
+                        .iter()
+                        .filter(|path| *path == prefix || path.starts_with(&nested_prefix))
+                        .cloned()
+                        .collect::<FxHashSet<_>>()
+                })
+                .unwrap_or_default();
+            for path in &removed {
+                self.scoped_direct_object_binding_targets[index].remove(path);
+                self.scoped_direct_object_binding_generations[index].remove(path);
+            }
+            if let Some(paths) =
+                self.scoped_direct_object_binding_paths_by_root[index].get_mut(root_name)
+            {
+                paths.retain(|path| !removed.contains(path));
+                if paths.is_empty() {
+                    self.scoped_direct_object_binding_paths_by_root[index].remove(root_name);
+                }
+            }
+        } else {
+            let removed = self
+                .module_direct_object_binding_paths_by_root
+                .get(root_name)
+                .map(|paths| {
+                    paths
+                        .iter()
+                        .filter(|path| *path == prefix || path.starts_with(&nested_prefix))
+                        .cloned()
+                        .collect::<FxHashSet<_>>()
+                })
+                .unwrap_or_default();
+            for path in &removed {
+                self.module_direct_object_binding_targets.remove(path);
+                self.module_direct_object_binding_generations.remove(path);
+            }
+            if let Some(paths) = self
+                .module_direct_object_binding_paths_by_root
+                .get_mut(root_name)
+            {
+                paths.retain(|path| !removed.contains(path));
+                if paths.is_empty() {
+                    self.module_direct_object_binding_paths_by_root
+                        .remove(root_name);
+                }
+            }
+        }
+    }
+
     fn record_object_binding_targets_at_path(
         &mut self,
         root_name: &str,
@@ -170,13 +505,12 @@ impl ModuleInfoExtractor {
                 // without bound. At capacity the arm falls through to the no-op
                 // `_ =>` arm, identical to skipping the push.
                 Expression::Identifier(ident)
-                    if self.object_binding_candidates.len() < MAX_OBJECT_BINDING_CANDIDATES =>
+                    if self.object_binding_target_count() < MAX_OBJECT_BINDING_TARGETS =>
                 {
                     // The candidate gives this placement a precise path, which
                     // `resolve_object_binding_candidates` turns back into
                     // `<source>.<member>` accesses, so a namespace placed here
                     // is resolved rather than handed over bare. What hands it
-                    // over is a bare reference to the root the object is bound
                     // to, which `record_object_literal_namespace_pass` covers.
                     // See issue #2377.
                     self.record_object_literal_namespace_placement(root_name, ident);
@@ -194,14 +528,47 @@ impl ModuleInfoExtractor {
     }
 }
 
+fn direct_object_binding_expression_path(expression: &Expression<'_>) -> Option<String> {
+    match expression {
+        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
+        Expression::StaticMemberExpression(member) => Some(format!(
+            "{}.{}",
+            direct_object_binding_expression_path(&member.object)?,
+            member.property.name
+        )),
+        Expression::ComputedMemberExpression(member) => Some(format!(
+            "{}.{}",
+            direct_object_binding_expression_path(&member.object)?,
+            member.static_property_name()?
+        )),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            direct_object_binding_expression_path(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(assertion) => {
+            direct_object_binding_expression_path(&assertion.expression)
+        }
+        Expression::TSSatisfiesExpression(assertion) => {
+            direct_object_binding_expression_path(&assertion.expression)
+        }
+        Expression::TSNonNullExpression(assertion) => {
+            direct_object_binding_expression_path(&assertion.expression)
+        }
+        Expression::TSTypeAssertion(assertion) => {
+            direct_object_binding_expression_path(&assertion.expression)
+        }
+        _ => None,
+    }
+}
+
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use super::MAX_OBJECT_BINDING_CANDIDATES;
-    use crate::visitor::ModuleInfoExtractor;
+    use super::MAX_OBJECT_BINDING_TARGETS;
+    use crate::visitor::{MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES, ModuleInfoExtractor};
     use oxc_allocator::Allocator;
     use oxc_ast_visit::Visit;
     use oxc_parser::Parser;
     use oxc_span::SourceType;
+    use rustc_hash::FxHashSet;
 
     /// A single object literal with far more identifier-valued properties than
     /// the per-module cap must not grow `object_binding_candidates` past the cap.
@@ -214,7 +581,7 @@ mod tests {
     fn object_binding_candidate_recording_is_bounded_on_dense_source() {
         use std::fmt::Write as _;
 
-        let over_cap = MAX_OBJECT_BINDING_CANDIDATES + 1000;
+        let over_cap = MAX_OBJECT_BINDING_TARGETS + 1000;
         let mut props = String::new();
         for k in 0..over_cap {
             // Each identifier-valued property seeds one object-binding candidate.
@@ -234,10 +601,222 @@ mod tests {
             "the cap must not zero out object-binding recording"
         );
         assert!(
-            extractor.object_binding_candidates.len() <= MAX_OBJECT_BINDING_CANDIDATES,
+            extractor.object_binding_candidates.len() <= MAX_OBJECT_BINDING_TARGETS,
             "object-binding candidate recording must stay bounded at the \
              per-module cap on dense source (got {})",
             extractor.object_binding_candidates.len()
+        );
+    }
+
+    #[test]
+    fn direct_object_binding_target_recording_is_bounded_on_dense_source() {
+        use std::fmt::Write as _;
+
+        let over_cap = MAX_OBJECT_BINDING_TARGETS + 1000;
+        let mut props = String::new();
+        for k in 0..over_cap {
+            let _ = write!(props, "k{k}: new Service(), ");
+        }
+        let source = format!("const big = {{ {props} }};");
+
+        let allocator = Allocator::default();
+        let parser_return = Parser::new(&allocator, &source, SourceType::ts()).parse();
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.visit_program(&parser_return.program);
+
+        assert_eq!(
+            extractor.direct_object_binding_target_count, MAX_OBJECT_BINDING_TARGETS,
+            "the direct target cap should engage on dense source"
+        );
+        assert!(
+            extractor.module_direct_object_binding_targets.len() <= MAX_OBJECT_BINDING_TARGETS,
+            "direct object binding targets must keep the scope map bounded"
+        );
+    }
+
+    #[test]
+    fn direct_object_binding_associations_are_bounded_on_repeated_path() {
+        use std::fmt::Write as _;
+
+        let over_cap = MAX_OBJECT_BINDING_TARGETS + 1000;
+        let mut assignments = String::new();
+        for k in 0..over_cap {
+            let _ = writeln!(assignments, "holder.property = new Service{k}();");
+        }
+        let source = format!("const holder = {{ property: new InitialService() }};\n{assignments}");
+
+        let allocator = Allocator::default();
+        let parser_return = Parser::new(&allocator, &source, SourceType::ts()).parse();
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.visit_program(&parser_return.program);
+
+        assert_eq!(
+            extractor.direct_object_binding_target_count, MAX_OBJECT_BINDING_TARGETS,
+            "the direct target cap should include repeated-path associations"
+        );
+        assert!(
+            extractor
+                .module_direct_object_binding_targets
+                .get("holder.property")
+                .is_some_and(|targets| targets.len() <= MAX_OBJECT_BINDING_TARGETS),
+            "a repeated path must not accumulate unbounded class targets"
+        );
+
+        extractor
+            .abstained_direct_object_binding_paths
+            .insert("holder.property".to_string());
+        extractor.record_direct_object_binding_target(
+            "holder",
+            "holder.property".to_string(),
+            "ServiceAfterCap".to_string(),
+            super::DirectObjectBindingScope::BindingOwner,
+        );
+        assert!(
+            extractor
+                .direct_object_binding_whole_object_uses
+                .contains("ServiceAfterCap"),
+            "an over-cap target on an abstained path must receive whole-object credit"
+        );
+    }
+
+    #[test]
+    fn direct_object_binding_member_access_emission_is_bounded_and_deduplicated() {
+        let mut extractor = ModuleInfoExtractor::new();
+        let classes = (0..128).map(|index| format!("Service{index}")).collect();
+        extractor
+            .module_direct_object_binding_targets
+            .insert("holder.property".to_string(), classes);
+
+        for index in 0..128 {
+            assert!(
+                extractor
+                    .record_walk_order_member_access("holder.property", &format!("member{index}"))
+            );
+        }
+        assert_eq!(
+            extractor.member_accesses.len(),
+            MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES,
+            "direct member access emission should stop at its module cap"
+        );
+
+        assert!(
+            extractor.record_walk_order_member_access("holder.property", "member128"),
+            "the direct receiver should remain resolved after reaching the cap"
+        );
+        assert_eq!(
+            extractor.member_accesses.len(),
+            MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES,
+            "an over-cap access must not grow the emitted vector"
+        );
+        assert_eq!(
+            extractor.direct_object_binding_whole_object_uses.len(),
+            128,
+            "cap exhaustion should conservatively abstain every possible class"
+        );
+    }
+
+    #[test]
+    fn repeated_multi_target_member_access_uses_generation_cache() {
+        let mut extractor = ModuleInfoExtractor::new();
+        let classes = (0..2048).map(|index| format!("Service{index}")).collect();
+        extractor
+            .module_direct_object_binding_targets
+            .insert("holder.property".to_string(), classes);
+
+        for _ in 0..2048 {
+            assert!(extractor.record_walk_order_member_access("holder.property", "run"));
+        }
+
+        assert_eq!(
+            extractor.member_accesses.len(),
+            2048,
+            "an unchanged repeated access should emit each class association once"
+        );
+        assert_eq!(
+            extractor
+                .direct_object_binding_access_generations
+                .get("holder.property")
+                .and_then(|members| members.get("run")),
+            Some(&0),
+            "the processed generation should be cached for constant-time repeats"
+        );
+    }
+
+    #[test]
+    fn abstained_path_does_not_suppress_shadowed_raw_access() {
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.module_direct_object_binding_targets.insert(
+            "holder.property".to_string(),
+            FxHashSet::from_iter(["Alpha".to_string()]),
+        );
+        extractor
+            .abstained_direct_object_binding_paths
+            .insert("holder.property".to_string());
+        extractor.push_direct_object_binding_scope(FxHashSet::from_iter(["holder".to_string()]));
+
+        assert!(
+            !extractor.record_walk_order_member_access("holder.property", "used"),
+            "a nearer shadow without a direct target must preserve the legacy raw access"
+        );
+        extractor.pop_direct_object_binding_scope();
+    }
+
+    #[test]
+    fn scoped_abstention_credits_same_path_targets_in_outer_scopes() {
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.module_direct_object_binding_targets.insert(
+            "holder.property".to_string(),
+            FxHashSet::from_iter(["Alpha".to_string()]),
+        );
+        extractor.push_direct_object_binding_scope(FxHashSet::from_iter(["holder".to_string()]));
+        extractor.scoped_direct_object_binding_targets[0].insert(
+            "holder.property".to_string(),
+            FxHashSet::from_iter(["Beta".to_string()]),
+        );
+        for index in 0..MAX_DIRECT_OBJECT_BINDING_MEMBER_ACCESSES {
+            extractor
+                .direct_object_binding_member_accesses
+                .insert((format!("Used{index}"), "member".to_string()));
+        }
+
+        assert!(extractor.record_walk_order_member_access("holder.property", "used"));
+        assert!(
+            extractor
+                .direct_object_binding_whole_object_uses
+                .contains("Alpha")
+                && extractor
+                    .direct_object_binding_whole_object_uses
+                    .contains("Beta"),
+            "scope-global abstention must credit both visible and shadowed targets"
+        );
+        extractor.pop_direct_object_binding_scope();
+        assert!(extractor.record_walk_order_member_access("holder.property", "used"));
+    }
+
+    #[test]
+    fn mixed_object_binding_targets_share_the_breadth_cap() {
+        use std::fmt::Write as _;
+
+        let over_cap = MAX_OBJECT_BINDING_TARGETS + 1000;
+        let mut props = String::new();
+        for k in 0..over_cap {
+            if k % 2 == 0 {
+                let _ = write!(props, "k{k}: new Service(), ");
+            } else {
+                let _ = write!(props, "k{k}: v{k}, ");
+            }
+        }
+        let source = format!("const big = {{ {props} }};");
+
+        let allocator = Allocator::default();
+        let parser_return = Parser::new(&allocator, &source, SourceType::ts()).parse();
+        let mut extractor = ModuleInfoExtractor::new();
+        extractor.visit_program(&parser_return.program);
+
+        assert_eq!(
+            extractor.object_binding_target_count(),
+            MAX_OBJECT_BINDING_TARGETS,
+            "identifier candidates and direct targets must share one cap"
         );
     }
 }

--- a/crates/extract/src/visitor/visit_impl_scope_bindings.rs
+++ b/crates/extract/src/visitor/visit_impl_scope_bindings.rs
@@ -2,6 +2,8 @@
 
 #[allow(clippy::wildcard_imports, reason = "many scope helper AST types used")]
 use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_semantic::ScopeFlags;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use fallow_types::extract::{SanitizerScope, SinkLiteralValue};
@@ -10,12 +12,41 @@ use super::super::helpers::array_element_type_from_type;
 use super::super::{ModuleInfoExtractor, SecurityPathSinkBinding};
 use super::{sink_literal_value, static_sink_literal_to_string, unwrap_static_expr};
 
+#[derive(Default)]
+struct FunctionVarRootCollector {
+    roots: FxHashSet<String>,
+}
+
+impl<'a> Visit<'a> for FunctionVarRootCollector {
+    fn visit_variable_declaration(&mut self, declaration: &VariableDeclaration<'a>) {
+        if declaration.kind.is_var() {
+            self.roots.extend(
+                declaration
+                    .declarations
+                    .iter()
+                    .flat_map(|declarator| declarator.id.get_binding_identifiers())
+                    .map(|id| id.name.to_string()),
+            );
+        }
+    }
+
+    fn visit_function(&mut self, _function: &Function<'a>, _flags: ScopeFlags) {}
+
+    fn visit_arrow_function_expression(&mut self, _expression: &ArrowFunctionExpression<'a>) {}
+
+    fn visit_class(&mut self, _class: &Class<'a>) {}
+
+    fn visit_ts_module_declaration(&mut self, _declaration: &TSModuleDeclaration<'a>) {}
+
+    fn visit_ts_global_declaration(&mut self, _declaration: &TSGlobalDeclaration<'a>) {}
+}
+
 impl ModuleInfoExtractor {
     pub(super) fn is_module_scope(&self) -> bool {
         self.block_depth == 0 && self.function_depth == 0 && self.namespace_depth == 0
     }
 
-    pub(super) fn is_module_or_function_runtime_scope(&self) -> bool {
+    pub(in crate::visitor) fn is_module_or_function_runtime_scope(&self) -> bool {
         self.namespace_depth == 0
     }
 
@@ -270,6 +301,14 @@ impl ModuleInfoExtractor {
         scope.extend(declarations.into_iter().map(|id| id.name.to_string()));
     }
 
+    pub(super) fn var_binding_roots<'a>(
+        statements: &oxc_allocator::Vec<'a, Statement<'a>>,
+    ) -> FxHashSet<String> {
+        let mut collector = FunctionVarRootCollector::default();
+        collector.visit_statements(statements);
+        collector.roots
+    }
+
     pub(super) fn push_function_declaration_scope(&mut self, params: &FormalParameters<'_>) {
         if self.namespace_depth > 0 {
             return;
@@ -342,6 +381,36 @@ impl ModuleInfoExtractor {
             self.risky_regex_binding_stack.pop();
             self.path_sink_binding_stack.pop();
             self.path_relative_binding_stack.pop();
+        }
+    }
+
+    pub(super) fn push_direct_object_binding_scope(&mut self, roots: FxHashSet<String>) {
+        self.scoped_direct_object_binding_roots.push(roots);
+        self.scoped_direct_object_binding_targets
+            .push(FxHashMap::default());
+        self.scoped_direct_object_binding_generations
+            .push(FxHashMap::default());
+        self.scoped_direct_object_binding_paths_by_root
+            .push(FxHashMap::default());
+    }
+
+    pub(super) fn push_var_owner_direct_object_binding_scope(&mut self, roots: FxHashSet<String>) {
+        self.push_direct_object_binding_scope(roots);
+    }
+
+    pub(super) fn pop_direct_object_binding_scope(&mut self) {
+        self.scoped_direct_object_binding_roots.pop();
+        self.scoped_direct_object_binding_targets.pop();
+        self.scoped_direct_object_binding_generations.pop();
+        self.scoped_direct_object_binding_paths_by_root.pop();
+    }
+
+    pub(super) fn record_direct_object_binding_scope_roots(
+        &mut self,
+        roots: impl IntoIterator<Item = String>,
+    ) {
+        if let Some(scope) = self.scoped_direct_object_binding_roots.last_mut() {
+            scope.extend(roots);
         }
     }
 

--- a/tests/fixtures/enum-class-members/src/definitions.ts
+++ b/tests/fixtures/enum-class-members/src/definitions.ts
@@ -11,3 +11,9 @@ export class MyService {
 
     unusedMethod() { return 'unused'; }
 }
+
+export class ObjectPropertyService {
+    usedThroughObject = 'used';
+
+    unusedThroughObject = 'unused';
+}

--- a/tests/fixtures/enum-class-members/src/index.ts
+++ b/tests/fixtures/enum-class-members/src/index.ts
@@ -1,5 +1,8 @@
-import { Status, MyService } from './definitions';
+import { Status, MyService, ObjectPropertyService } from './definitions';
 
 console.log(Status.Active);
 const svc = new MyService();
 svc.greet();
+
+const holder = { property: new ObjectPropertyService() };
+console.log(holder.property.usedThroughObject);


### PR DESCRIPTION
Fixes #2546.

Thanks @Ericlm for the report and public reproduction.

## Summary

- recognize class member use through object properties initialized with direct class instances
- preserve lexical shadowing while carrying statically known aliases and assignment possibilities
- keep dense inputs, repeated accesses, and conservative cap fallback bounded
- invalidate the extraction cache for the new member-access facts

## Verification

- `npm run verify:full`
- focused extractor and core regressions
- public `Ericlm/fallow-vue-class-unused` reproduction with installed dependencies and a no-cache JSON analysis

The public reproduction completes without unused class member findings on this branch.
