### PR TITLE
fix: preserve scoped package names in review brief

### DIFF
--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -832,9 +832,14 @@ fn dependency_key_names(keys: &[String]) -> String {
     keys.iter()
         .map(|key| {
             let (manifest, rest) = key.split_once("::").unwrap_or(("", key));
+            // A leading @ belongs to the scope; later @ signs may also occur
+            // inside npm alias ranges, so only split at the first non-leading one.
             let (name, range) = rest
-                .split_once('@')
-                .map_or((rest, None), |(name, range)| (name, range.split_once("->")));
+                .match_indices('@')
+                .find(|(index, _)| *index > 0)
+                .map_or((rest, None), |(index, _)| {
+                    (&rest[..index], rest[index + 1..].split_once("->"))
+                });
             let range_text = range
                 .map(|(from, to)| format!(" {from} to {to}"))
                 .unwrap_or_default();
@@ -1203,6 +1208,37 @@ mod tests {
     use rustc_hash::FxHashSet;
 
     use crate::audit::{AuditAttribution, AuditResult, AuditSummary, AuditVerdict};
+
+    #[test]
+    fn dependency_names_preserve_scopes_and_manifest_labels() {
+        let keys = [
+            "package.json::@scope/one",
+            "package.json::@scope/two",
+            "package.json::other",
+            "package.json::plain",
+            "packages/app/package.json::@scope/workspace",
+            "@scope/unqualified",
+        ]
+        .map(str::to_string);
+        assert_eq!(
+            dependency_key_names(&keys),
+            "@scope/one, @scope/two, other, plain, @scope/workspace (packages/app/package.json), @scope/unqualified"
+        );
+    }
+
+    #[test]
+    fn dependency_names_preserve_scoped_bumps_and_alias_ranges() {
+        let keys = [
+            "package.json::@scope/bumped@^1.0.0->^2.0.0",
+            "packages/app/package.json::plain@^1.0.0->^2.0.0",
+            "package.json::@scope/alias@npm:@other/pkg@^1.0.0->npm:@other/pkg@^2.0.0",
+        ]
+        .map(str::to_string);
+        assert_eq!(
+            dependency_key_names(&keys),
+            "@scope/bumped ^1.0.0 to ^2.0.0, plain ^1.0.0 to ^2.0.0 (packages/app/package.json), @scope/alias npm:@other/pkg@^1.0.0 to npm:@other/pkg@^2.0.0"
+        );
+    }
 
     fn str_set(files: &[&str]) -> FxHashSet<String> {
         files.iter().map(|file| (*file).to_string()).collect()

--- a/crates/cli/tests/audit_tests.rs
+++ b/crates/cli/tests/audit_tests.rs
@@ -5113,6 +5113,69 @@ fn create_dependency_decision_fixture() -> TempDir {
 }
 
 #[test]
+fn review_brief_preserves_scoped_dependency_names() {
+    let tmp = TempDir::new().expect("temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name":"scoped-deps","main":"src/index.ts","dependencies":{"@scope/bumped":"^1.0.0"}}"#,
+    )
+    .unwrap();
+    fs::write(dir.join("src/index.ts"), "import '@scope/bumped';\n").unwrap();
+    git(dir, &["init", "-b", "main"]);
+    commit_all(dir, "initial");
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name":"scoped-deps","main":"src/index.ts","dependencies":{"@scope/bumped":"^2.0.0","@scope/one":"^1.0.0","@scope/two":"^1.0.0","plain":"^1.0.0","other":"^1.0.0"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import '@scope/bumped';\nimport '@scope/one';\nimport '@scope/two';\nimport 'plain';\nimport 'other';\n",
+    )
+    .unwrap();
+
+    let output = Command::new(fallow_bin())
+        .args(["review", "--brief", "--base", "HEAD"])
+        .current_dir(dir)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("review runs");
+    assert!(matches!(output.status.code(), Some(0 | 1)), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("new third-party dependencies: @scope/one, @scope/two, other, plain"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("major version bump: @scope/bumped ^1.0.0 to ^2.0.0"),
+        "{stderr}"
+    );
+
+    let output = Command::new(fallow_bin())
+        .args(["review", "--brief", "--base", "HEAD", "--format", "json"])
+        .current_dir(dir)
+        .output()
+        .expect("JSON review runs");
+    let brief: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("review brief JSON");
+    assert_eq!(
+        brief["deltas"]["dependency_added"],
+        serde_json::json!([
+            "package.json::@scope/one",
+            "package.json::@scope/two",
+            "package.json::other",
+            "package.json::plain"
+        ])
+    );
+    assert_eq!(
+        brief["deltas"]["dependency_major_bumped"],
+        serde_json::json!(["package.json::@scope/bumped@^1.0.0->^2.0.0"])
+    );
+}
+
+#[test]
 fn dependency_bump_and_addition_surface_as_batched_decisions() {
     let tmp = create_dependency_decision_fixture();
     let guide = run_walkthrough_guide(tmp.path());


### PR DESCRIPTION
Scoped dependencies lost their names in the closing `review --brief` summary because the renderer treated the leading `@` as a version delimiter. Preserve the scope in both additions and major version bumps, including npm alias ranges and workspace manifest labels. JSON output remains unchanged.

Thanks @Elia97 for the precise reproduction.

Validation: the CLI regression fails with the existing binary and passes with the fix. The full CLI library and audit integration suites pass, as do formatting and scoped commit checks. A smoke test on public Fastify sources correctly renders a scoped dependency addition and major version bump. The combined fixes pass `npm run verify:full`, and an independent combined CLI smoke on Fastify also passes.

Fixes #2553

