### PR TITLE
fix: honor inline suppressions for pnpm catalog entries

### DIFF
--- a/crates/core/src/analyze/unused_catalog.rs
+++ b/crates/core/src/analyze/unused_catalog.rs
@@ -43,6 +43,7 @@ use fallow_config::{
     parse_pnpm_catalog_data, record_workspace_diagnostics,
 };
 use fallow_types::results::{EmptyCatalogGroup, UnresolvedCatalogReference, UnusedCatalogEntry};
+use fallow_types::suppress::IssueKind;
 use rustc_hash::FxHashSet;
 
 const PNPM_WORKSPACE_FILE: &str = "pnpm-workspace.yaml";
@@ -54,6 +55,7 @@ pub struct PnpmCatalogState {
     data: PnpmCatalogData,
     consumers: CatalogConsumers,
     source_path: PathBuf,
+    suppressed_entry_lines: FxHashSet<u32>,
 }
 
 /// Read catalog declarations and walk workspace `package.json` files to build
@@ -65,21 +67,23 @@ pub fn gather_pnpm_catalog_state(
     workspaces: &[WorkspaceInfo],
 ) -> Option<PnpmCatalogState> {
     let yaml_path = config.root.join(PNPM_WORKSPACE_FILE);
-    let (data, source_path) = if let Ok(yaml_source) = std::fs::read_to_string(&yaml_path) {
-        let data = parse_pnpm_catalog_data(&yaml_source).unwrap_or_else(|error| {
-            report_malformed_pnpm_workspace_yaml(&config.root, &yaml_path, error);
-            PnpmCatalogData::default()
-        });
-        (data, PathBuf::from(PNPM_WORKSPACE_FILE))
-    } else {
-        let package_json_path = config.root.join(PACKAGE_JSON_FILE);
-        let package_json_source = std::fs::read_to_string(&package_json_path).ok()?;
-        let data = parse_package_json_catalog_data(&package_json_source);
-        if data.catalogs.is_empty() && data.empty_named_catalog_groups.is_empty() {
-            return None;
-        }
-        (data, PathBuf::from(PACKAGE_JSON_FILE))
-    };
+    let (data, source_path, suppressed_entry_lines) =
+        if let Ok(yaml_source) = std::fs::read_to_string(&yaml_path) {
+            let data = parse_pnpm_catalog_data(&yaml_source).unwrap_or_else(|error| {
+                report_malformed_pnpm_workspace_yaml(&config.root, &yaml_path, error);
+                PnpmCatalogData::default()
+            });
+            let suppressed = suppressed_yaml_catalog_entries(&yaml_source, &data);
+            (data, PathBuf::from(PNPM_WORKSPACE_FILE), suppressed)
+        } else {
+            let package_json_path = config.root.join(PACKAGE_JSON_FILE);
+            let package_json_source = std::fs::read_to_string(&package_json_path).ok()?;
+            let data = parse_package_json_catalog_data(&package_json_source);
+            if data.catalogs.is_empty() && data.empty_named_catalog_groups.is_empty() {
+                return None;
+            }
+            (data, PathBuf::from(PACKAGE_JSON_FILE), FxHashSet::default())
+        };
     let consumer_pkg_paths = collect_consumer_pkg_paths(config, workspaces);
     let consumers = collect_catalog_consumers(&consumer_pkg_paths, &config.root);
 
@@ -87,7 +91,40 @@ pub fn gather_pnpm_catalog_state(
         data,
         consumers,
         source_path,
+        suppressed_entry_lines,
     })
+}
+
+fn suppressed_yaml_catalog_entries(source: &str, data: &PnpmCatalogData) -> FxHashSet<u32> {
+    let lines: Vec<&str> = source.lines().collect();
+    data.catalogs
+        .iter()
+        .flat_map(|catalog| &catalog.entries)
+        .filter_map(|entry| {
+            let entry_index = (entry.line as usize).checked_sub(1)?;
+            let previous_line = lines.get(entry_index.checked_sub(1)?)?;
+            let entry_line = lines.get(entry_index)?;
+            // A more deeply indented line can be content of a YAML block scalar.
+            if previous_line.len() - previous_line.trim_start().len()
+                > entry_line.len() - entry_line.trim_start().len()
+            {
+                return None;
+            }
+            let comment = previous_line.trim_start().strip_prefix('#')?;
+            // Reuse the shared rule-list, alias, and optional-reason grammar.
+            let parsed =
+                fallow_extract::suppress::parse_suppressions_from_source(&format!("//{comment}"));
+            parsed
+                .suppressions
+                .iter()
+                .any(|suppression| {
+                    suppression.line != 0
+                        && suppression
+                            .matches_issue_kind(suppression.line, IssueKind::PnpmCatalogEntry)
+                })
+                .then_some(entry.line)
+        })
+        .collect()
 }
 
 /// Record the degraded-continue diagnostic for a `pnpm-workspace.yaml` that
@@ -123,7 +160,9 @@ pub fn find_unused_catalog_entries(state: &PnpmCatalogState) -> Vec<UnusedCatalo
                 package_name: entry.package_name.as_str(),
                 catalog_name: catalog.name.as_str(),
             };
-            if state.consumers.references.contains(&key.owned()) {
+            if state.suppressed_entry_lines.contains(&entry.line)
+                || state.consumers.references.contains(&key.owned())
+            {
                 continue;
             }
 

--- a/crates/core/tests/integration_test/issue_329_pnpm_catalog.rs
+++ b/crates/core/tests/integration_test/issue_329_pnpm_catalog.rs
@@ -101,3 +101,37 @@ fn path_is_relative_pnpm_workspace_yaml() {
         assert!(entry.line > 0, "catalog entry line must be 1-based");
     }
 }
+
+#[test]
+fn yaml_catalog_next_line_suppressions_preserve_unrelated_entries() {
+    let root = fixture_path("issue-2548-catalog-suppression");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let actual: FxHashSet<(&str, &str)> = results
+        .unused_catalog_entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.entry.catalog_name.as_str(),
+                entry.entry.entry_name.as_str(),
+            )
+        })
+        .collect();
+    let expected = FxHashSet::from_iter([
+        ("default", "retained-neighbor"),
+        ("default", "wrong-rule"),
+        ("default", "separated"),
+        ("default", "directive-value"),
+        ("default", "after-value"),
+        ("default", "block-value"),
+        ("default", "after-block"),
+        ("default", "file-marker"),
+        ("default", "unknown-rule"),
+        ("future", "retained-neighbor"),
+        ("current", "@sveltejs/adapter-static"),
+    ]);
+    assert_eq!(
+        actual, expected,
+        "suppressions must target only their entry"
+    );
+}

--- a/tests/fixtures/issue-2548-catalog-suppression/package.json
+++ b/tests/fixtures/issue-2548-catalog-suppression/package.json
@@ -1,0 +1,1 @@
+{"name":"catalog-suppression-repro","private":true}

--- a/tests/fixtures/issue-2548-catalog-suppression/pnpm-workspace.yaml
+++ b/tests/fixtures/issue-2548-catalog-suppression/pnpm-workspace.yaml
@@ -1,0 +1,35 @@
+packages:
+  - packages/*
+
+catalog:
+  # fallow-ignore-next-line unused-catalog-entry
+  '@sveltejs/adapter-static': 4.0.0-next.4
+  retained-neighbor: ^1.0.0
+  # fallow-ignore-next-line unused-catalog-entry -- Reserved for a scaffold archetype.
+  reserved: ^1.0.0
+  # fallow-ignore-next-line unused-dependency
+  wrong-rule: ^1.0.0
+  # fallow-ignore-next-line unused-catalog-entry
+
+  separated: ^1.0.0
+  directive-value: '# fallow-ignore-next-line unused-catalog-entry'
+  after-value: ^1.0.0
+  block-value: |
+    # fallow-ignore-next-line unused-catalog-entry
+  after-block: ^1.0.0
+  # fallow-ignore-file unused-catalog-entry
+  file-marker: ^1.0.0
+  # fallow-ignore-next-line unused-catalog-entri
+  unknown-rule: ^1.0.0
+  # fallow-ignore-next-line
+  blanket: ^1.0.0
+  # fallow-ignore-next-line unused-dependency, unused-catalog-entry -- Reserved.
+  multiple-rules: ^1.0.0
+
+catalogs:
+  future:
+    # fallow-ignore-next-line unused-catalog-entries -- Reserved for migration.
+    '@sveltejs/adapter-static': 4.0.0-next.4
+    retained-neighbor: ^1.0.0
+  current:
+    '@sveltejs/adapter-static': 4.0.0-next.4


### PR DESCRIPTION
Fixes #2548.

Thanks @michalius for the clear reproduction. Honor the suggested YAML next-line suppression above unused entries in default and named pnpm catalogs, including optional reasons, rule aliases, and rule lists. Comments apply only to the targeted entry; adjacent findings and directive text inside YAML values remain reportable.

Validation: the regression fails before the fix; the full core suite, core Rust lint, formatting, and staged hygiene checks pass. A public SvelteKit checkout confirms the targeted default/named entries disappear while unrelated findings remain, with cold, warm, and disabled caches. The combined fixes also pass `npm run verify:full` and an independent SvelteKit CLI smoke.
