### PR TITLE
fix: preserve quoted content in catalog and script parsing

### DIFF
--- a/crates/cli/src/architecture_boundaries.rs
+++ b/crates/cli/src/architecture_boundaries.rs
@@ -2017,7 +2017,7 @@ fn analysis_stage_diagnostics_are_recorded_only_from_the_dead_code_analyze_pass(
         "crates/cli/src/architecture_boundaries.rs",
     ];
     let expected = [
-        "crates/core/src/analyze/unused_catalog.rs",
+        "crates/core/src/analyze/unused_catalog/mod.rs",
         "crates/core/src/analyze/unused_overrides.rs",
     ];
 

--- a/crates/core/src/analyze/unused_catalog/mod.rs
+++ b/crates/core/src/analyze/unused_catalog/mod.rs
@@ -43,8 +43,11 @@ use fallow_config::{
     parse_pnpm_catalog_data, record_workspace_diagnostics,
 };
 use fallow_types::results::{EmptyCatalogGroup, UnresolvedCatalogReference, UnusedCatalogEntry};
-use fallow_types::suppress::IssueKind;
 use rustc_hash::FxHashSet;
+
+mod suppressions;
+
+use suppressions::suppressed_yaml_catalog_entries;
 
 const PNPM_WORKSPACE_FILE: &str = "pnpm-workspace.yaml";
 const PACKAGE_JSON_FILE: &str = "package.json";
@@ -93,38 +96,6 @@ pub fn gather_pnpm_catalog_state(
         source_path,
         suppressed_entry_lines,
     })
-}
-
-fn suppressed_yaml_catalog_entries(source: &str, data: &PnpmCatalogData) -> FxHashSet<u32> {
-    let lines: Vec<&str> = source.lines().collect();
-    data.catalogs
-        .iter()
-        .flat_map(|catalog| &catalog.entries)
-        .filter_map(|entry| {
-            let entry_index = (entry.line as usize).checked_sub(1)?;
-            let previous_line = lines.get(entry_index.checked_sub(1)?)?;
-            let entry_line = lines.get(entry_index)?;
-            // A more deeply indented line can be content of a YAML block scalar.
-            if previous_line.len() - previous_line.trim_start().len()
-                > entry_line.len() - entry_line.trim_start().len()
-            {
-                return None;
-            }
-            let comment = previous_line.trim_start().strip_prefix('#')?;
-            // Reuse the shared rule-list, alias, and optional-reason grammar.
-            let parsed =
-                fallow_extract::suppress::parse_suppressions_from_source(&format!("//{comment}"));
-            parsed
-                .suppressions
-                .iter()
-                .any(|suppression| {
-                    suppression.line != 0
-                        && suppression
-                            .matches_issue_kind(suppression.line, IssueKind::PnpmCatalogEntry)
-                })
-                .then_some(entry.line)
-        })
-        .collect()
 }
 
 /// Record the degraded-continue diagnostic for a `pnpm-workspace.yaml` that

--- a/crates/core/src/analyze/unused_catalog/suppressions.rs
+++ b/crates/core/src/analyze/unused_catalog/suppressions.rs
@@ -1,0 +1,161 @@
+//! Recognize suppression comments using the same YAML parser as catalog discovery.
+
+use std::fmt::Write;
+
+use fallow_config::PnpmCatalogData;
+use fallow_types::suppress::IssueKind;
+use rustc_hash::FxHashSet;
+use serde_yaml_ng::Value;
+
+const MARKER_PREFIX: &str = "fallow_yaml_comment_";
+
+pub(super) fn suppressed_yaml_catalog_entries(
+    source: &str,
+    data: &PnpmCatalogData,
+) -> FxHashSet<u32> {
+    let candidates = suppression_candidates(source, data);
+    if candidates.is_empty() {
+        return candidates;
+    }
+    let Ok(original) = serde_yaml_ng::from_str::<Value>(source) else {
+        return FxHashSet::default();
+    };
+    let mut used_nonces = value_marker_ids(&original, MARKER_PREFIX);
+    used_nonces.extend(marker_ids(source, MARKER_PREFIX));
+    let nonce = (0..=used_nonces.len())
+        .find(|nonce| !used_nonces.contains(nonce))
+        .unwrap_or(used_nonces.len());
+    let prefix = format!("{MARKER_PREFIX}{nonce}_");
+
+    // Actual comments disappear during YAML parsing; marker text inside any
+    // scalar survives. One instrumented parse handles every candidate without
+    // per-directive reparsing or a separate YAML grammar.
+    let marked = mark_candidates(source, &candidates, &prefix);
+    let Ok(parsed) = serde_yaml_ng::from_str::<Value>(&marked) else {
+        return FxHashSet::default();
+    };
+    let scalar_lines = value_marker_ids(&parsed, &prefix);
+    candidates
+        .into_iter()
+        .filter(|line| !scalar_lines.contains(&(*line as usize)))
+        .collect()
+}
+
+fn suppression_candidates(source: &str, data: &PnpmCatalogData) -> FxHashSet<u32> {
+    let lines: Vec<&str> = source.lines().collect();
+    data.catalogs
+        .iter()
+        .flat_map(|catalog| &catalog.entries)
+        .filter_map(|entry| {
+            let comment_index = (entry.line as usize).checked_sub(2)?;
+            let comment = lines.get(comment_index)?.trim_start().strip_prefix('#')?;
+            let parsed =
+                fallow_extract::suppress::parse_suppressions_from_source(&format!("//{comment}"));
+            parsed
+                .suppressions
+                .iter()
+                .any(|suppression| {
+                    suppression.line != 0
+                        && suppression
+                            .matches_issue_kind(suppression.line, IssueKind::PnpmCatalogEntry)
+                })
+                .then_some(entry.line)
+        })
+        .collect()
+}
+
+fn mark_candidates(source: &str, candidates: &FxHashSet<u32>, prefix: &str) -> String {
+    let mut marked = String::with_capacity(source.len());
+    for (index, line) in source.split_inclusive('\n').enumerate() {
+        let entry_line = u32::try_from(index)
+            .ok()
+            .and_then(|line| line.checked_add(2));
+        if let Some(entry_line) = entry_line
+            && candidates.contains(&entry_line)
+            && let Some(hash) = line.find('#')
+        {
+            marked.push_str(&line[..=hash]);
+            let _ = write!(marked, "{prefix}{entry_line}_");
+            marked.push_str(&line[hash + 1..]);
+        } else {
+            marked.push_str(line);
+        }
+    }
+    marked
+}
+
+fn marker_ids<'a>(text: &'a str, prefix: &'a str) -> impl Iterator<Item = usize> + 'a {
+    text.match_indices(prefix)
+        .filter_map(move |(index, _)| text[index + prefix.len()..].split_once('_')?.0.parse().ok())
+}
+
+fn value_marker_ids(value: &Value, prefix: &str) -> FxHashSet<usize> {
+    let mut ids = FxHashSet::default();
+    let mut pending = vec![value];
+    while let Some(value) = pending.pop() {
+        match value {
+            Value::String(text) => ids.extend(marker_ids(text, prefix)),
+            Value::Sequence(values) => pending.extend(values),
+            Value::Mapping(mapping) => {
+                pending.extend(mapping.iter().flat_map(<[&Value; 2]>::from));
+            }
+            Value::Tagged(tagged) => pending.push(&tagged.value),
+            Value::Null | Value::Bool(_) | Value::Number(_) => {}
+        }
+    }
+    ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comments_can_be_more_indented_than_the_catalog_entry() {
+        let source =
+            "catalog:\n    # fallow-ignore-next-line unused-catalog-entry\n  target: ^1.0.0\n";
+        let data = fallow_config::parse_pnpm_catalog_data(source).expect("valid YAML");
+        assert_eq!(
+            suppressed_yaml_catalog_entries(source, &data),
+            FxHashSet::from_iter([3])
+        );
+    }
+
+    #[test]
+    fn multiline_quoted_scalar_text_does_not_suppress_the_next_entry() {
+        for quote in ['\'', '"'] {
+            let source = format!(
+                "catalog:\n  scalar: {quote}hello\n  # fallow-ignore-next-line unused-catalog-entry -- reason{quote}\n  victim: ^1.0.0\n"
+            );
+            let data = fallow_config::parse_pnpm_catalog_data(&source).expect("valid YAML");
+            assert!(suppressed_yaml_catalog_entries(&source, &data).is_empty());
+        }
+    }
+
+    #[test]
+    fn escaped_marker_text_cannot_collide_with_instrumented_comments() {
+        let source = concat!(
+            "metadata: \"\\x66allow_yaml_comment_0_4_\"\n",
+            "catalog:\n",
+            "  # fallow-ignore-next-line unused-catalog-entry\n",
+            "  target: ^1.0.0\n",
+        );
+        let data = fallow_config::parse_pnpm_catalog_data(source).expect("valid YAML");
+        assert_eq!(
+            suppressed_yaml_catalog_entries(source, &data),
+            FxHashSet::from_iter([4])
+        );
+    }
+
+    #[test]
+    fn marker_scan_covers_mapping_keys_sequences_and_tagged_values() {
+        let value: Value = serde_yaml_ng::from_str(
+            "fallow_yaml_comment_0_: [fallow_yaml_comment_1_, !custom fallow_yaml_comment_2_]\n",
+        )
+        .expect("valid YAML");
+        assert_eq!(
+            value_marker_ids(&value, MARKER_PREFIX),
+            FxHashSet::from_iter([0, 1, 2])
+        );
+    }
+}

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -645,10 +645,8 @@ pub fn referenced_package_scripts(command: &str, catalog: &ScriptCatalog) -> FxH
     let mut names = FxHashSet::default();
 
     for segment in shell::split_shell_operators(command) {
-        let tokens: Vec<&str> = segment
-            .split_whitespace()
-            .map(strip_surrounding_quotes)
-            .collect();
+        let words = shell::split_words(segment);
+        let tokens: Vec<&str> = words.iter().map(|word| word.value.as_ref()).collect();
         let Some(idx) = shell::skip_initial_wrappers(&tokens, 0) else {
             continue;
         };
@@ -688,10 +686,8 @@ pub fn referenced_package_scripts(command: &str, catalog: &ScriptCatalog) -> FxH
 pub fn referenced_workspace_scripts(command: &str) -> Vec<(String, String)> {
     let mut references = Vec::new();
     for segment in shell::split_shell_operators(command) {
-        let tokens: Vec<&str> = segment
-            .split_whitespace()
-            .map(strip_surrounding_quotes)
-            .collect();
+        let words = shell::split_words(segment);
+        let tokens: Vec<&str> = words.iter().map(|word| word.value.as_ref()).collect();
         let Some(idx) = shell::skip_initial_wrappers(&tokens, 0) else {
             continue;
         };
@@ -1087,10 +1083,8 @@ fn parse_command_segment(
     advance_package_manager: &impl Fn(&[&str], usize) -> Option<PackageManagerTarget>,
 ) -> Vec<SegmentOutcome> {
     let mut outcomes = Vec::new();
-    let tokens: Vec<&str> = segment
-        .split_whitespace()
-        .map(strip_surrounding_quotes)
-        .collect();
+    let words = shell::split_words(segment);
+    let tokens: Vec<&str> = words.iter().map(|word| word.value.as_ref()).collect();
     let Some(mut idx) = shell::skip_initial_wrappers(&tokens, 0) else {
         return outcomes;
     };
@@ -1106,7 +1100,7 @@ fn parse_command_segment(
             } => {
                 outcomes.push(SegmentOutcome::ScriptCall {
                     name,
-                    extra_args: forwarded_arguments(segment, extra_args_from),
+                    extra_args: forwarded_arguments(segment, &words, extra_args_from),
                 });
                 return outcomes;
             }
@@ -1157,12 +1151,10 @@ fn parse_command_segment(
 
 /// The raw tail of a segment, keeping quoting intact so the re-scanned script
 /// body sees the arguments as the shell would pass them.
-fn forwarded_arguments(segment: &str, from_token: usize) -> String {
-    segment
-        .split_whitespace()
-        .skip(from_token)
-        .collect::<Vec<_>>()
-        .join(" ")
+fn forwarded_arguments(segment: &str, words: &[shell::ShellWord<'_>], from_token: usize) -> String {
+    words
+        .get(from_token)
+        .map_or_else(String::new, |word| segment[word.start..].to_string())
 }
 
 /// Extract a config file path from a `--config` or `-c` flag.
@@ -2881,19 +2873,84 @@ mod tests {
     }
 
     #[test]
-    fn token_with_internal_single_quote_unchanged() {
-        // A token whose quote is internal (not surrounding) must not be mangled.
-        // Use a file arg that contains an internal apostrophe but is not shell-quoted.
-        // We exercise strip_surrounding_quotes directly via a known non-file-path
-        // context: confirm parse_script does not mangle such a token.
-        assert_eq!(super::strip_surrounding_quotes("can't"), "can't");
-        assert_eq!(super::strip_surrounding_quotes("'quoted'"), "quoted");
-        assert_eq!(super::strip_surrounding_quotes("\"quoted\""), "quoted");
-        assert_eq!(
-            super::strip_surrounding_quotes("'mismatched\""),
-            "'mismatched\""
+    fn varlock_preserves_quoted_argument_boundaries() {
+        for command in [
+            r#"varlock run -p "./env -- is-ci ignored" -- publint"#,
+            "varlock run -p './env -- is-ci ignored' -- publint",
+            r"varlock run -p ./env\ --\ is-ci\ ignored -- publint",
+            r#"varlock run -p "./env \" -- is-ci ignored" -- publint"#,
+        ] {
+            let result = analyze_scripts_with_dependencies(
+                &HashMap::from([("check".to_string(), command.to_string())]),
+                Path::new("/nonexistent"),
+                &FxHashMap::default(),
+                &package_set(&["varlock", "is-ci", "publint"]),
+            );
+            assert_eq!(
+                result.used_packages,
+                package_set(&["varlock", "publint"]),
+                "{command}"
+            );
+        }
+    }
+
+    #[test]
+    fn varlock_forwards_quoted_arguments_to_package_scripts() {
+        let result = analyze_ci_command(
+            r#"varlock run -p "./env with spaces" -- npm run child -- -p "./env -- is-ci ignored" -- publint"#,
+            &[("child", "varlock run")],
+            &["varlock", "is-ci", "publint"],
         );
-        assert_eq!(super::strip_surrounding_quotes(""), "");
+        assert_eq!(result.used_packages, package_set(&["varlock", "publint"]));
+    }
+
+    #[test]
+    fn varlock_preserves_quoted_child_paths() {
+        let commands = parse_script(r#"varlock run -- node "./scripts/worker with spaces.js""#);
+        assert!(commands.iter().any(|command| {
+            command
+                .file_args
+                .contains(&"./scripts/worker with spaces.js".to_string())
+        }));
+    }
+
+    #[test]
+    fn varlock_does_not_guess_through_unbalanced_or_dynamic_words() {
+        for command in [
+            r#"varlock run -p "./env -- is-ci ignored -- publint"#,
+            "varlock run -p './env -- is-ci ignored -- publint",
+            "varlock run -p $(echo -- is-ci) -- publint",
+            "varlock run -p `echo -- is-ci` -- publint",
+        ] {
+            let commands = parse_script(command);
+            assert_eq!(
+                commands
+                    .iter()
+                    .map(|command| command.binary.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["varlock"],
+                "{command}"
+            );
+        }
+    }
+
+    #[test]
+    fn varlock_keeps_known_child_before_dynamic_arguments() {
+        for command in [
+            "varlock run -- vite --host=$(hostname)",
+            "varlock run -- vite $(pwd)",
+            "varlock run -- vite `pwd`",
+        ] {
+            let commands = parse_script(command);
+            assert_eq!(
+                commands
+                    .iter()
+                    .map(|command| command.binary.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["varlock", "vite"],
+                "{command}"
+            );
+        }
     }
 
     mod proptests {

--- a/crates/core/src/scripts/shell.rs
+++ b/crates/core/src/scripts/shell.rs
@@ -1,6 +1,96 @@
 //! Shell tokenization: splitting on operators, skipping env wrappers and package managers.
 
 use super::ENV_WRAPPERS;
+use std::borrow::Cow;
+
+/// A literal shell argument with its original position for script forwarding.
+pub(super) struct ShellWord<'a> {
+    pub value: Cow<'a, str>,
+    pub start: usize,
+}
+
+/// Preserve the literal argument prefix without evaluating shell expansions.
+pub(super) fn split_words(source: &str) -> Vec<ShellWord<'_>> {
+    let mut words = Vec::new();
+    let mut rest = source.trim_start();
+    while !rest.is_empty() {
+        let Some(end) = shell_word_end(rest) else {
+            break;
+        };
+        words.push(ShellWord {
+            value: decode_shell_word(&rest[..end]),
+            start: source.len() - rest.len(),
+        });
+        rest = rest[end..].trim_start();
+    }
+    words
+}
+
+fn shell_word_end(source: &str) -> Option<usize> {
+    let mut quote = None;
+    let windows_path = starts_windows_path(source);
+    let mut chars = source.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '\\' if quote != Some('\'') && !windows_path => {
+                chars.next()?;
+            }
+            '\'' | '"' if quote.is_none() => quote = Some(ch),
+            ch if Some(ch) == quote => quote = None,
+            // Dynamic command substitutions can produce arbitrary argument boundaries.
+            '`' if quote != Some('\'') => return None,
+            '$' if quote != Some('\'') && chars.peek().is_some_and(|(_, ch)| *ch == '(') => {
+                return None;
+            }
+            ch if quote.is_none() && ch.is_whitespace() => return Some(index),
+            _ => {}
+        }
+    }
+    quote.is_none().then_some(source.len())
+}
+
+fn decode_shell_word(raw: &str) -> Cow<'_, str> {
+    // package.json scripts also run under cmd.exe, where these are path separators.
+    if starts_windows_path(raw) {
+        return Cow::Borrowed(
+            raw.strip_prefix('"')
+                .and_then(|path| path.strip_suffix('"'))
+                .unwrap_or(raw),
+        );
+    }
+    if !raw.contains(['\'', '"', '\\']) {
+        return Cow::Borrowed(raw);
+    }
+    let mut value = String::with_capacity(raw.len());
+    let mut quote = None;
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' if quote != Some('\'') => {
+                if let Some(next) = chars.next() {
+                    if quote == Some('"') && !matches!(next, '"' | '\\' | '$' | '`' | '\n') {
+                        value.push('\\');
+                    }
+                    if next != '\n' {
+                        value.push(next);
+                    }
+                }
+            }
+            '\'' | '"' if quote.is_none() => quote = Some(ch),
+            ch if Some(ch) == quote => quote = None,
+            _ => value.push(ch),
+        }
+    }
+    Cow::Owned(value)
+}
+
+fn starts_windows_path(source: &str) -> bool {
+    let source = source.strip_prefix('"').unwrap_or(source);
+    source.starts_with(".\\")
+        || source.starts_with("..\\")
+        || source.starts_with("\\\\")
+        || matches!(source.as_bytes(), [drive, b':', b'\\', ..] if drive.is_ascii_alphabetic())
+}
 
 /// Bun runtime boolean flags that may precede an executed file/binary
 /// (`bun --bun <bin>`, `bun --watch <file>`, `bun --hot run dev`). Bun documents
@@ -20,11 +110,17 @@ pub fn split_shell_operators(script: &str) -> Vec<&str> {
     let bytes = script.as_bytes();
     let len = bytes.len();
     let mut i = 0;
+    let mut word_start = 0;
     let mut in_single_quote = false;
     let mut in_double_quote = false;
 
     while i < len {
         let b = bytes[i];
+
+        if b == b'\\' && !in_single_quote && !starts_windows_path(&script[word_start..]) {
+            i = (i + 2).min(len);
+            continue;
+        }
 
         if b == b'\'' && !in_double_quote {
             in_single_quote = !in_single_quote;
@@ -46,9 +142,13 @@ pub fn split_shell_operators(script: &str) -> Vec<&str> {
             segments.push(&script[start..i]);
             i += op_len;
             start = i;
+            word_start = i;
             continue;
         }
 
+        if b.is_ascii_whitespace() {
+            word_start = i + 1;
+        }
         i += 1;
     }
 
@@ -163,6 +263,113 @@ pub fn advance_past_package_manager(tokens: &[&str], mut idx: usize) -> Option<u
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn literal_words_preserve_quoted_and_escaped_boundaries() {
+        for (source, expected) in [
+            (
+                r#"varlock run -p "./env -- is-ci ignored" -- publint"#,
+                vec![
+                    "varlock",
+                    "run",
+                    "-p",
+                    "./env -- is-ci ignored",
+                    "--",
+                    "publint",
+                ],
+            ),
+            (
+                r"varlock run -p ./env\ --\ is-ci\ ignored -- publint",
+                vec![
+                    "varlock",
+                    "run",
+                    "-p",
+                    "./env -- is-ci ignored",
+                    "--",
+                    "publint",
+                ],
+            ),
+            (
+                r#"va"r"lock run -- 'is-ci'"#,
+                vec!["varlock", "run", "--", "is-ci"],
+            ),
+            (r#"echo "one\q" """#, vec!["echo", r"one\q", ""]),
+            (
+                r#""C:\Program Files\tool.exe" arg"#,
+                vec![r"C:\Program Files\tool.exe", "arg"],
+            ),
+            (
+                r".\tools\runner.exe arg",
+                vec![r".\tools\runner.exe", "arg"],
+            ),
+            (
+                r"\\server\share\runner.exe arg",
+                vec![r"\\server\share\runner.exe", "arg"],
+            ),
+        ] {
+            let words = split_words(source);
+            assert_eq!(
+                words
+                    .iter()
+                    .map(|word| word.value.as_ref())
+                    .collect::<Vec<_>>(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn literal_words_keep_raw_offsets_for_forwarding() {
+        let source = r#" npm --prefix "./path with spaces" run task -- -p "./env -- ignored""#;
+        let words = split_words(source);
+        assert_eq!(&source[words[6].start..], r#"-p "./env -- ignored""#);
+    }
+
+    #[test]
+    fn literal_words_stop_at_opaque_argument_after_known_prefix() {
+        for source in [
+            "vite $(pwd) -- is-ci",
+            "vite `pwd` -- is-ci",
+            "vite 'unclosed",
+            "vite \\",
+        ] {
+            let words = split_words(source);
+            assert_eq!(
+                words
+                    .iter()
+                    .map(|word| word.value.as_ref())
+                    .collect::<Vec<_>>(),
+                vec!["vite"],
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn escaped_operators_remain_inside_the_argument() {
+        assert_eq!(
+            split_shell_operators(r"echo value\;tail && publint"),
+            vec![r"echo value\;tail ", " publint"]
+        );
+    }
+
+    #[test]
+    fn quoted_windows_path_retains_following_shell_command() {
+        let source = r#""C:\Program Files\" && publint"#;
+        assert_eq!(
+            split_shell_operators(source),
+            vec![r#""C:\Program Files\" "#, " publint"]
+        );
+        let commands = super::super::parse_script(source);
+        assert_eq!(
+            commands
+                .iter()
+                .map(|command| command.binary.as_str())
+                .collect::<Vec<_>>(),
+            vec!["C:\\Program Files\\", "publint"]
+        );
+    }
 
     #[test]
     fn operator_len_double_ampersand() {

--- a/crates/core/tests/integration_test/bin_script_deps.rs
+++ b/crates/core/tests/integration_test/bin_script_deps.rs
@@ -1,6 +1,29 @@
 use super::common::{create_config, fixture_path};
 
 #[test]
+fn quoted_wrapper_option_does_not_credit_a_dependency_named_inside_it() {
+    let config = create_config(fixture_path("varlock-quoted-args"));
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused: Vec<&str> = results
+        .unused_dev_dependencies
+        .iter()
+        .map(|finding| finding.dep.package_name.as_str())
+        .collect();
+    assert!(
+        unused.contains(&"is-ci"),
+        "option content is not a child executable: {unused:?}"
+    );
+    assert!(
+        !unused.contains(&"publint"),
+        "the real child must be credited: {unused:?}"
+    );
+    assert!(
+        !unused.contains(&"varlock"),
+        "the wrapper must be credited: {unused:?}"
+    );
+}
+
+#[test]
 fn divergent_binary_name_not_flagged_as_unused() {
     let root = fixture_path("bin-script-deps");
     let config = create_config(root);

--- a/crates/core/tests/integration_test/issue_329_pnpm_catalog.rs
+++ b/crates/core/tests/integration_test/issue_329_pnpm_catalog.rs
@@ -127,6 +127,10 @@ fn yaml_catalog_next_line_suppressions_preserve_unrelated_entries() {
         ("default", "after-block"),
         ("default", "file-marker"),
         ("default", "unknown-rule"),
+        ("default", "multiline-double"),
+        ("default", "after-multiline-double"),
+        ("default", "multiline-single"),
+        ("default", "after-multiline-single"),
         ("future", "retained-neighbor"),
         ("current", "@sveltejs/adapter-static"),
     ]);

--- a/tests/fixtures/issue-2548-catalog-suppression/pnpm-workspace.yaml
+++ b/tests/fixtures/issue-2548-catalog-suppression/pnpm-workspace.yaml
@@ -26,6 +26,15 @@ catalog:
   # fallow-ignore-next-line unused-dependency, unused-catalog-entry -- Reserved.
   multiple-rules: ^1.0.0
 
+  multiline-double: "hello
+  # fallow-ignore-next-line unused-catalog-entry -- String content"
+  after-multiline-double: ^1.0.0
+  multiline-single: 'hello
+  # fallow-ignore-next-line unused-catalog-entry -- String content'
+  after-multiline-single: ^1.0.0
+    # fallow-ignore-next-line unused-catalog-entry -- Valid indented comment.
+  deeper-comment: ^1.0.0
+
 catalogs:
   future:
     # fallow-ignore-next-line unused-catalog-entries -- Reserved for migration.

--- a/tests/fixtures/varlock-quoted-args/index.js
+++ b/tests/fixtures/varlock-quoted-args/index.js
@@ -1,0 +1,1 @@
+console.log("wrapper argument regression");

--- a/tests/fixtures/varlock-quoted-args/package.json
+++ b/tests/fixtures/varlock-quoted-args/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "varlock-quoted-args",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "check": "varlock run -p \"./env -- is-ci ignored\" -- publint"
+  },
+  "devDependencies": {
+    "is-ci": "4.1.0",
+    "publint": "0.3.12",
+    "varlock": "1.18.0"
+  }
+}


### PR DESCRIPTION
A `# fallow-ignore-next-line unused-catalog-entry` line inside a multiline YAML string could hide the following catalog entry. A `--` inside a quoted `varlock run -p` value could also credit an unused dependency while missing the actual child command. These were found while independently checking #2548 and #2551. Thanks for the original reports.

Catalog suppression now uses the existing YAML parser to distinguish real comments from scalar content, including quoted, tagged and anchored values. This also accepts valid comments with deeper indentation. Script parsing preserves quoted argument boundaries and raw forwarded arguments while retaining known executable prefixes and Windows paths.

Validation: both counterexamples fail on the previous main and pass with the fix. Focused core/parser and integration tests pass. Independent CLI checks pass on public SvelteKit, the official varlock Express example, Fastify and Zod, including cold/warm/no-cache and manifest edits. Existing scoped-name rendering and clone-review evidence remain correct. The canonical `npm run verify:full` gate passes, including workspace tests, generated contracts, conformance checks, benchmark compilation, Rust documentation and Node bindings. PR CI and [merged-commit CI](https://github.com/fallow-rs/fallow/actions/runs/33993729228) pass.
