### PR TITLE
feat(review): replace the duplicated blast-radius list with a count and a rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The review brief no longer spends half its bytes on one list, printed
+  twice.** `fallow review --format json` and `fallow audit --brief --format
+  json` carried the impact closure's affected-but-not-in-diff paths in two
+  places, `graph_facts.reachable_from` and `impact_closure.affected_not_shown`,
+  with identical contents and no cap on either. On a one-file change to a
+  mid-sized project those two lists were more than half the envelope while the
+  focus map and the decision surface, the judgement the brief exists to
+  deliver, were under three percent of it. The brief is read into an agent's
+  context, so those bytes came straight out of the reviewing budget.
+
+  `graph_facts.reachable_from` is gone. `impact_closure` now reports
+  `affected_count`, the exact number of affected files, alongside a capped
+  ten-path sample and `affected_by_dir`, a rollup of the affected files by
+  parent directory with an exact count per directory, heaviest first. The
+  rollup is the part worth reading: it says whether a change stayed inside the
+  module it touched or leaked into somewhere new, which a truncated list of
+  paths cannot, and it does so in a fraction of the bytes the full list took.
+  The human brief reports the same shape: the file and directory totals, then
+  the heaviest directory with its exact share, then a pointer at the rest.
+
+  Decisions, ranks, verdicts, and exit codes are unchanged; the decision
+  surface takes its blast metric from the graph, not from this envelope. The
+  brief `schema_version` moves to 9. See
+  [backwards compatibility](docs/backwards-compatibility.md) for the field-level
+  contract.
+
 ## [3.23.0] - 2026-09-07
 
 ### Added

--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -2674,7 +2674,6 @@ mod walkthrough_markdown_tests {
             graph_facts: GraphFacts {
                 exports_added: 0,
                 api_width_delta: 0,
-                reachable_from: Vec::new(),
                 boundaries_touched: Vec::new(),
             },
             partition: PartitionFacts::default(),

--- a/crates/cli/src/audit_brief.rs
+++ b/crates/cli/src/audit_brief.rs
@@ -112,15 +112,12 @@ pub fn build_triage(
 /// Derive the Stage 1 graph facts from the analysis results plus the impact
 /// closure.
 ///
-/// `boundaries_touched` is the deduped, sorted boundary-violation zone set;
-/// `reachable_from` is the impact closure's affected-not-shown set (modules the
-/// changed code reaches / affects, none in the diff). `exports_added` /
-/// `api_width_delta` stay stubbed until the export-surface delta.
+/// `boundaries_touched` is the deduped, sorted boundary-violation zone set.
+/// `exports_added` / `api_width_delta` stay stubbed until the export-surface
+/// delta. The set of modules the changed code reaches is Stage 3's impact
+/// closure, which owns both its magnitude and its paths.
 #[must_use]
-pub fn derive_graph_facts(
-    results: &AnalysisResults,
-    closure: Option<&fallow_engine::module_graph::ImpactClosurePaths>,
-) -> GraphFacts {
+pub fn derive_graph_facts(results: &AnalysisResults) -> GraphFacts {
     let mut zones: FxHashSet<String> = FxHashSet::default();
     for finding in &results.boundary_violations {
         zones.insert(finding.violation.from_zone.clone());
@@ -129,14 +126,9 @@ pub fn derive_graph_facts(
     let mut boundaries_touched: Vec<String> = zones.into_iter().collect();
     boundaries_touched.sort();
 
-    let reachable_from = closure
-        .map(|c| c.affected_not_shown.clone())
-        .unwrap_or_default();
-
     GraphFacts {
         exports_added: 0,
         api_width_delta: 0,
-        reachable_from,
         boundaries_touched,
     }
 }
@@ -163,10 +155,7 @@ fn build_impact_closure_facts(result: &AuditResult) -> ImpactClosureFacts {
             note: COORDINATION_GAP_NOTE.to_string(),
         })
         .collect();
-    ImpactClosureFacts {
-        affected_not_shown: closure.affected_not_shown.clone(),
-        coordination_gap,
-    }
+    ImpactClosureFacts::new(&closure.affected_not_shown, coordination_gap)
 }
 
 /// Build the Stage 2 partition facts from the audit result's retained
@@ -414,19 +403,14 @@ pub fn build_brief_output_with_diff(
     diff_index: Option<&fallow_output::DiffIndex>,
 ) -> ReviewBriefOutput {
     let triage = build_triage(result, diff_index);
-    let closure = result
-        .check
-        .as_ref()
-        .and_then(|c| c.impact_closure.as_ref());
     let deltas = result.review_deltas.clone().unwrap_or_default();
     let mut graph_facts = result.check.as_ref().map_or_else(
         || GraphFacts {
             exports_added: 0,
             api_width_delta: 0,
-            reachable_from: Vec::new(),
             boundaries_touched: Vec::new(),
         },
-        |check| derive_graph_facts(&check.results, closure),
+        |check| derive_graph_facts(&check.results),
     );
     // The exports-aware delta fills the previously-stubbed export facts:
     // `exports_added` / `api_width_delta` count the public-API surface the change
@@ -715,16 +699,72 @@ fn unit_label(module_dir: &str) -> String {
     }
 }
 
-/// Print the Stage 3 impact-closure summary on the human brief: the count of
-/// affected-but-not-shown files and each coordination gap (the precise
+/// The impact-closure lines: the magnitude, then the single heaviest directory
+/// with its exact share and a pointer at the rest.
+///
+/// Split out from the printer so the wording and the width are testable, the
+/// way `branching_human_lines` is: every line has to hold under 80 columns.
+/// The heaviest directory carries a count because the names alone cannot say
+/// whether the reach is concentrated or diffuse, which is the only question
+/// this section exists to answer. One name plus its share beats two names
+/// without: it costs half the width, and the count is what makes the line
+/// readable at a glance ("88 of 326 in tests" is the answer; two bare names
+/// are not).
+///
+/// The line names the rollup's own top row, so it never disagrees with
+/// `affected_by_dir` in the JSON. That row is often a test directory, because
+/// tests import broadly; the count is what tells a reader that, which is why
+/// it is not omitted.
+fn affected_lines(closure: &ImpactClosureFacts) -> Vec<String> {
+    if closure.affected_count == 0 {
+        return Vec::new();
+    }
+    let dirs = closure.affected_by_dir.len() + closure.affected_by_dir_omitted;
+    let mut lines = vec![format!(
+        "  impact closure: {} file{} affected beyond the diff{}",
+        closure.affected_count,
+        crate::report::plural(closure.affected_count),
+        if dirs < 2 {
+            String::new()
+        } else {
+            format!(" across {dirs} directories")
+        },
+    )];
+    // One directory says nothing the count did not already say.
+    let Some(heaviest) = closure.affected_by_dir.first().filter(|_| dirs > 1) else {
+        return lines;
+    };
+    lines.push(format!(
+        "         heaviest {} ({} file{})",
+        elide_path(&unit_label(&heaviest.dir), 48),
+        heaviest.count,
+        crate::report::plural(heaviest.count),
+    ));
+    let remaining = dirs - 1;
+    // The rollup itself is capped, so the JSON holds the whole breakdown only
+    // when nothing was omitted from it. Promising a full list past that point
+    // would send a reader on a round-trip that cannot answer them.
+    let route = if closure.affected_by_dir_omitted == 0 {
+        "--format json for full list".to_string()
+    } else {
+        format!(
+            "{} of them in --format json",
+            closure.affected_by_dir.len() - 1
+        )
+    };
+    lines.push(format!(
+        "         and {remaining} more director{} ({route})",
+        if remaining == 1 { "y" } else { "ies" },
+    ));
+    lines
+}
+
+/// Print the Stage 3 impact-closure summary on the human brief: the blast
+/// radius and its heaviest directory, then each coordination gap (the precise
 /// inter-module attention pointer). Caller has already gated on `!quiet`.
 fn print_impact_closure_human(closure: &ImpactClosureFacts) {
-    if !closure.affected_not_shown.is_empty() {
-        eprintln!(
-            "  impact closure: {} file{} affected beyond the diff",
-            closure.affected_not_shown.len(),
-            crate::report::plural(closure.affected_not_shown.len()),
-        );
+    for line in affected_lines(closure) {
+        eprintln!("{line}");
     }
     for gap in &closure.coordination_gap {
         eprintln!(
@@ -1456,23 +1496,120 @@ mod tests {
     }
 
     #[test]
-    fn derive_graph_facts_populates_reachable_from_from_closure() {
-        use fallow_engine::module_graph::{CoordinationGapPaths, ImpactClosurePaths};
-        let results = AnalysisResults::default();
-        let closure = ImpactClosurePaths {
-            in_diff: vec!["src/core.ts".to_string()],
-            affected_not_shown: vec!["src/app.ts".to_string(), "src/mid.ts".to_string()],
-            coordination_gap: vec![CoordinationGapPaths {
-                changed_file: "src/core.ts".to_string(),
-                consumer_file: "src/mid.ts".to_string(),
-                consumed_symbols: vec!["compute".to_string()],
-            }],
-        };
-        let facts = derive_graph_facts(&results, Some(&closure));
+    fn graph_facts_carry_no_file_list() {
+        // The blast radius is Stage 3's alone. Stage 1 used to clone it verbatim,
+        // which put the same list on the wire twice and made half the envelope a
+        // duplicate.
+        let facts = derive_graph_facts(&AnalysisResults::default());
+        let value = serde_json::to_value(&facts).expect("graph facts serialize");
+        let keys: Vec<&str> = value
+            .as_object()
+            .expect("graph facts are an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
         assert_eq!(
-            facts.reachable_from,
-            vec!["src/app.ts".to_string(), "src/mid.ts".to_string()]
+            keys,
+            vec!["exports_added", "api_width_delta", "boundaries_touched"]
         );
+    }
+
+    fn spread_closure(affected: &[&str]) -> ImpactClosureFacts {
+        let mut paths: Vec<String> = affected.iter().map(|p| (*p).to_string()).collect();
+        paths.sort();
+        ImpactClosureFacts::new(&paths, Vec::new())
+    }
+
+    #[test]
+    fn human_impact_lines_report_the_full_count_not_the_sample() {
+        // Distinct file and directory totals, so a line that printed one where
+        // the other belongs cannot pass.
+        let mut affected: Vec<String> = (0..40).map(|i| format!("src/zone{i:03}/a.ts")).collect();
+        affected.extend((0..40).map(|i| format!("src/zone{i:03}/b.ts")));
+        affected.sort();
+        let closure = ImpactClosureFacts::new(&affected, Vec::new());
+        assert!(
+            closure.affected_not_shown.len() < closure.affected_count,
+            "the fixture must exercise the sample cap"
+        );
+        assert!(
+            closure.affected_by_dir.len() < 40,
+            "the fixture must exercise the rollup cap too"
+        );
+        let lines = affected_lines(&closure);
+        assert!(
+            lines[0].contains("80 files affected") && lines[0].contains("across 40 directories"),
+            "both totals survive capping, and neither stands in for the other: {lines:?}"
+        );
+        assert!(
+            lines[2].contains("and 39 more directories"),
+            "the remainder counts every directory, not just the kept rollup rows: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn the_json_route_is_only_promised_when_the_json_holds_the_breakdown() {
+        let complete: Vec<String> = (0..3).map(|i| format!("src/z{i}/file.ts")).collect();
+        let lines = affected_lines(&ImpactClosureFacts::new(&complete, Vec::new()));
+        assert!(
+            lines[2].ends_with("(--format json for full list)"),
+            "an uncapped rollup really is the full list: {lines:?}"
+        );
+
+        let mut capped: Vec<String> = (0..40).map(|i| format!("src/z{i:03}/file.ts")).collect();
+        capped.sort();
+        let closure = ImpactClosureFacts::new(&capped, Vec::new());
+        assert!(closure.affected_by_dir_omitted > 0, "fixture must cap");
+        let lines = affected_lines(&closure);
+        assert!(
+            lines[2].ends_with("(24 of them in --format json)"),
+            "past the rollup cap the JSON has no full list either, so do not promise one: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn the_repository_root_is_never_a_blank_token() {
+        let closure = spread_closure(&["setup.ts", "playground.ts", "src/app.ts"]);
+        let lines = affected_lines(&closure);
+        assert!(
+            lines[1].contains("heaviest <root> (2 files)"),
+            "a root-level directory must render as `<root>`, not as nothing: {lines:?}"
+        );
+        assert!(
+            lines[2].contains("and 1 more directory ("),
+            "a single remaining directory is not plural: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn impact_closure_lines_fit_eighty_columns() {
+        let deep = "packages/platform/features/checkout/pricing/discounts/rules/seasonal";
+        let mut affected: Vec<String> = (0..40).map(|i| format!("{deep}/rule{i:03}.ts")).collect();
+        affected.extend((0..999).map(|i| format!("src/z{i:04}/file.ts")));
+        affected.sort();
+        for line in affected_lines(&ImpactClosureFacts::new(&affected, Vec::new())) {
+            assert!(
+                line.chars().count() <= 80,
+                "brief lines hold under 80 columns: {} chars in {line:?}",
+                line.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn a_single_directory_reach_says_only_the_count() {
+        let lines = affected_lines(&spread_closure(&["src/a.ts", "src/b.ts"]));
+        assert_eq!(
+            lines,
+            vec!["  impact closure: 2 files affected beyond the diff".to_string()],
+            "naming the one directory would repeat what the count said"
+        );
+    }
+
+    #[test]
+    fn an_empty_closure_prints_nothing() {
+        assert!(affected_lines(&ImpactClosureFacts::new(&[], Vec::new())).is_empty());
+        assert!(affected_lines(&ImpactClosureFacts::default()).is_empty());
     }
 
     #[test]

--- a/crates/cli/src/audit_walkthrough.rs
+++ b/crates/cli/src/audit_walkthrough.rs
@@ -971,7 +971,6 @@ mod tests {
             graph_facts: crate::audit_brief::GraphFacts {
                 exports_added: 0,
                 api_width_delta: 0,
-                reachable_from: Vec::new(),
                 boundaries_touched: Vec::new(),
             },
             partition: crate::audit_brief::PartitionFacts::default(),

--- a/crates/cli/src/report/human/walkthrough.rs
+++ b/crates/cli/src/report/human/walkthrough.rs
@@ -493,11 +493,11 @@ fn focus_subline(guide: &StandardWalkthroughGuide) -> Option<String> {
             plural(facts.boundaries_touched.len())
         ));
     }
-    if !closure.affected_not_shown.is_empty() {
+    if closure.affected_count > 0 {
         parts.push(format!(
             "{} file{} affected beyond the diff",
-            closure.affected_not_shown.len(),
-            plural(closure.affected_not_shown.len())
+            closure.affected_count,
+            plural(closure.affected_count)
         ));
     }
     if parts.is_empty() {
@@ -620,7 +620,6 @@ mod tests {
             graph_facts: fallow_output::GraphFacts {
                 exports_added: 0,
                 api_width_delta: 0,
-                reachable_from: Vec::new(),
                 boundaries_touched: Vec::new(),
             },
             partition: PartitionFacts::default(),

--- a/crates/output/src/audit_brief.rs
+++ b/crates/output/src/audit_brief.rs
@@ -6,7 +6,24 @@ use serde::Serialize;
 use serde_json::Value;
 
 /// Wire version for the `fallow audit --brief --format json` envelope.
-pub const REVIEW_BRIEF_SCHEMA_VERSION: u32 = 8;
+pub const REVIEW_BRIEF_SCHEMA_VERSION: u32 = 9;
+
+/// Maximum number of affected-but-not-in-diff paths sampled into
+/// [`ImpactClosureFacts::affected_not_shown`].
+///
+/// The full count is preserved in [`ImpactClosureFacts::affected_count`]
+/// (aggregate-before-truncate), so capping the sample never distorts the count,
+/// and the SHAPE of the reach is carried by
+/// [`ImpactClosureFacts::affected_by_dir`] rather than by which files landed in
+/// the sample. Nothing that ranks or gates reads this list: the decision surface
+/// takes its blast metric from the uncapped engine closure.
+pub const AFFECTED_SAMPLE_CAP: usize = 10;
+
+/// Maximum number of directories reported in
+/// [`ImpactClosureFacts::affected_by_dir`]. Directories beyond the cap are the
+/// lightest ones and are counted in
+/// [`ImpactClosureFacts::affected_by_dir_omitted`].
+pub const AFFECTED_DIR_CAP: usize = 25;
 
 /// Independently-versioned wire-version newtype for the brief envelope.
 /// Serializes as the integer `REVIEW_BRIEF_SCHEMA_VERSION`.
@@ -74,12 +91,11 @@ pub struct DiffTriage {
 
 /// Stage 1 of the brief: graph-derived orientation facts.
 ///
-/// `boundaries_touched` is derived from the run's boundary-violation zones;
-/// `reachable_from` is populated by the impact closure (the affected-not-shown
-/// set: modules the changed code is reachable from / affects, none in the diff).
-/// `exports_added` and `api_width_delta` both report the exports-aware public API
-/// widening count. Removed exports are not represented in this widening-only
-/// signal.
+/// `boundaries_touched` is derived from the run's boundary-violation zones.
+/// `exports_added` and `api_width_delta` both report the exports-aware public
+/// API widening count. Removed exports are not represented in this
+/// widening-only signal. The set of modules the changed code reaches is Stage
+/// 3's `impact_closure`, which owns both its magnitude and its paths.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct GraphFacts {
@@ -90,10 +106,6 @@ pub struct GraphFacts {
     /// Removed exports are not represented, so zero means no public API exports
     /// were added.
     pub api_width_delta: i64,
-    /// Root-relative paths of modules the changed code is reachable from / affects
-    /// (the impact closure's affected-but-not-in-diff set), deduped and sorted.
-    /// Empty when no graph was retained or nothing depends on the changed files.
-    pub reachable_from: Vec<String>,
     /// Architecture boundary zones touched by the changeset, deduped and sorted.
     /// Derived from the run's boundary-violation findings.
     pub boundaries_touched: Vec<String>,
@@ -108,12 +120,98 @@ pub struct GraphFacts {
 #[derive(Debug, Clone, Default, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ImpactClosureFacts {
-    /// Root-relative paths transitively affected by the changeset (reverse-deps +
-    /// re-export chains) that are NOT in the diff, deduped and sorted.
+    /// The FULL number of files transitively affected by the changeset
+    /// (reverse-deps + re-export chains) that are NOT in the diff. Computed
+    /// BEFORE [`affected_not_shown`](Self::affected_not_shown) is capped to a
+    /// sample, so it is always the true magnitude of the blast radius.
+    pub affected_count: usize,
+    /// A capped, path-sorted sample of the affected root-relative paths (at most
+    /// [`AFFECTED_SAMPLE_CAP`]), deduped. The full count lives in
+    /// [`affected_count`](Self::affected_count) and the distribution in
+    /// [`affected_by_dir`](Self::affected_by_dir); use this list to jump to
+    /// representative files, NEVER to enumerate the blast radius or to infer its
+    /// shape. Because it is a prefix of the sorted set, it clusters in whichever
+    /// directory sorts first. To reconstruct the full set, run
+    /// `fallow check --impact-closure <path>` once per changed file and union the
+    /// results: that flag seeds from a single file, so no single command
+    /// reproduces this changeset-wide union.
     pub affected_not_shown: Vec<String>,
+    /// The blast radius rolled up by parent directory: how the affected files
+    /// distribute, heaviest directory first, ties broken by directory path so the
+    /// order is deterministic. This is the SHAPE signal, and unlike
+    /// [`affected_not_shown`](Self::affected_not_shown) its counts are exact for
+    /// every directory it lists. At most [`AFFECTED_DIR_CAP`] entries.
+    pub affected_by_dir: Vec<AffectedDirectory>,
+    /// How many directories did not fit within [`AFFECTED_DIR_CAP`] and are
+    /// absent from [`affected_by_dir`](Self::affected_by_dir). They are the
+    /// lightest ones; their files are still counted in
+    /// [`affected_count`](Self::affected_count). Zero when nothing was omitted.
+    /// Add this to `affected_by_dir.len()` for the true number of directories
+    /// the change reaches.
+    pub affected_by_dir_omitted: usize,
     /// Coordination gaps: a changed file exports a contract consumed by a module
-    /// absent from the diff. One entry per (changed file, consumer) pair.
+    /// absent from the diff. One entry per (changed file, consumer) pair. NOT a
+    /// subset of [`affected_not_shown`](Self::affected_not_shown): the gap
+    /// deliberately skips story and test consumers that the affected set counts.
     pub coordination_gap: Vec<CoordinationGapFact>,
+}
+
+impl ImpactClosureFacts {
+    /// Build the facts from the full closure, capping the file sample and the
+    /// directory rollup while preserving the exact total.
+    ///
+    /// `affected` must arrive deduped and path-sorted (the engine closure
+    /// guarantees both); the sample is its prefix.
+    #[must_use]
+    pub fn new(affected: &[String], coordination_gap: Vec<CoordinationGapFact>) -> Self {
+        let (affected_by_dir, affected_by_dir_omitted) = roll_up_by_directory(affected);
+        Self {
+            affected_count: affected.len(),
+            affected_not_shown: affected.iter().take(AFFECTED_SAMPLE_CAP).cloned().collect(),
+            affected_by_dir,
+            affected_by_dir_omitted,
+            coordination_gap,
+        }
+    }
+}
+
+/// One directory of the blast radius and how many affected files it holds.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AffectedDirectory {
+    /// Root-relative parent directory, forward-slashed. The empty string is the
+    /// repository root.
+    pub dir: String,
+    /// How many affected-but-not-in-diff files live directly in `dir`. Exact,
+    /// never sampled.
+    pub count: usize,
+}
+
+/// Roll the affected paths up by parent directory, heaviest first, capped at
+/// [`AFFECTED_DIR_CAP`]. Returns the kept rows and how many directories were
+/// dropped.
+///
+/// Sorting by count descending keeps the heaviest directories, which is the
+/// question a reviewer is actually asking ("did this leak somewhere new, or is
+/// it all inside the module I already changed?"). The directory path breaks
+/// ties so the order is total and stable across runs.
+fn roll_up_by_directory(affected: &[String]) -> (Vec<AffectedDirectory>, usize) {
+    let mut counts: rustc_hash::FxHashMap<&str, usize> = rustc_hash::FxHashMap::default();
+    for path in affected {
+        let dir = path.rsplit_once('/').map_or("", |(head, _)| head);
+        *counts.entry(dir).or_default() += 1;
+    }
+    let mut rows: Vec<AffectedDirectory> = counts
+        .into_iter()
+        .map(|(dir, count)| AffectedDirectory {
+            dir: dir.to_string(),
+            count,
+        })
+        .collect();
+    rows.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.dir.cmp(&b.dir)));
+    let omitted = rows.len().saturating_sub(AFFECTED_DIR_CAP);
+    rows.truncate(AFFECTED_DIR_CAP);
+    (rows, omitted)
 }
 
 /// One coordination-gap entry: a changed file exports symbols consumed by a
@@ -559,7 +657,6 @@ mod tests {
             graph_facts: GraphFacts {
                 exports_added: 0,
                 api_width_delta: 0,
-                reachable_from: Vec::new(),
                 boundaries_touched: Vec::new(),
             },
             partition: PartitionFacts::default(),
@@ -705,5 +802,112 @@ mod tests {
             value["_meta"]["telemetry"]["analysis_run_id"],
             "run-decision"
         );
+    }
+
+    /// `<dirs>` directories holding `<per_dir>` files each, path-sorted the way
+    /// the engine closure hands them over.
+    fn affected(dirs: usize, per_dir: usize) -> Vec<String> {
+        let mut paths: Vec<String> = (0..dirs)
+            .flat_map(|d| (0..per_dir).map(move |f| format!("src/zone{d:03}/file{f:03}.ts")))
+            .collect();
+        paths.sort();
+        paths
+    }
+
+    #[test]
+    fn a_closure_within_the_caps_is_reported_whole() {
+        let paths = affected(2, 3);
+        let facts = ImpactClosureFacts::new(&paths, Vec::new());
+
+        assert_eq!(facts.affected_count, 6);
+        assert_eq!(facts.affected_not_shown, paths);
+        assert_eq!(facts.affected_by_dir_omitted, 0);
+        assert_eq!(
+            facts
+                .affected_by_dir
+                .iter()
+                .map(|row| (row.dir.as_str(), row.count))
+                .collect::<Vec<_>>(),
+            vec![("src/zone000", 3), ("src/zone001", 3)]
+        );
+    }
+
+    #[test]
+    fn the_count_survives_capping_the_sample() {
+        let paths = affected(4, 40);
+        let facts = ImpactClosureFacts::new(&paths, Vec::new());
+
+        assert_eq!(
+            facts.affected_count, 160,
+            "the magnitude is computed before the sample is capped"
+        );
+        assert_eq!(facts.affected_not_shown.len(), AFFECTED_SAMPLE_CAP);
+        assert_eq!(
+            facts
+                .affected_by_dir
+                .iter()
+                .map(|row| row.count)
+                .sum::<usize>(),
+            facts.affected_count,
+            "an uncapped rollup accounts for every affected file"
+        );
+    }
+
+    #[test]
+    fn the_rollup_carries_weight_the_sample_cannot() {
+        // A prefix sample lands entirely in the directory that sorts first, so
+        // the rollup is the only thing that can say where the reach actually is.
+        let mut paths = affected(1, 12);
+        paths.extend((0..90).map(|f| format!("src/zzz_heavy/file{f:03}.ts")));
+        paths.sort();
+        let facts = ImpactClosureFacts::new(&paths, Vec::new());
+
+        assert!(
+            facts
+                .affected_not_shown
+                .iter()
+                .all(|path| path.starts_with("src/zone000/")),
+            "the fixture must produce a one-directory sample: {:?}",
+            facts.affected_not_shown
+        );
+        let heaviest = facts.affected_by_dir.first().expect("a rollup row");
+        assert_eq!(
+            (heaviest.dir.as_str(), heaviest.count),
+            ("src/zzz_heavy", 90)
+        );
+    }
+
+    #[test]
+    fn rollup_rows_beyond_the_cap_are_counted_not_dropped_silently() {
+        let paths = affected(AFFECTED_DIR_CAP + 7, 1);
+        let facts = ImpactClosureFacts::new(&paths, Vec::new());
+
+        assert_eq!(facts.affected_by_dir.len(), AFFECTED_DIR_CAP);
+        assert_eq!(facts.affected_by_dir_omitted, 7);
+        assert_eq!(facts.affected_count, AFFECTED_DIR_CAP + 7);
+    }
+
+    #[test]
+    fn equal_weight_directories_are_ordered_by_path() {
+        let facts = ImpactClosureFacts::new(&affected(3, 2), Vec::new());
+        let dirs: Vec<&str> = facts
+            .affected_by_dir
+            .iter()
+            .map(|row| row.dir.as_str())
+            .collect();
+        assert_eq!(
+            dirs,
+            vec!["src/zone000", "src/zone001", "src/zone002"],
+            "the path is the tie-break, so the order is total across runs"
+        );
+    }
+
+    #[test]
+    fn root_level_files_roll_up_under_the_empty_directory() {
+        let facts =
+            ImpactClosureFacts::new(&["play.ts".to_string(), "setup.ts".to_string()], Vec::new());
+        assert_eq!(facts.affected_by_dir.len(), 1);
+        assert_eq!(facts.affected_by_dir[0].dir, "");
+        assert_eq!(facts.affected_by_dir[0].count, 2);
     }
 }

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -83,10 +83,11 @@ pub use audit_branching::{
     BranchingSnapshot, CognitiveAttribution, DEFAULT_BRANCHING_TOLERANCE, SplitInPlace,
 };
 pub use audit_brief::{
-    CoordinationGapFact, DiffTriage, GraphFacts, ImpactClosureFacts, PartitionFacts,
-    REVIEW_BRIEF_SCHEMA_VERSION, ReviewBriefHeader, ReviewBriefOutput, ReviewBriefSchemaVersion,
-    ReviewBriefSubtractSections, ReviewBriefWireOutput, ReviewDeltas, ReviewEffort, ReviewUnitFact,
-    RiskClass, StandardReviewBriefOutput, build_review_brief_json_output,
+    AFFECTED_DIR_CAP, AFFECTED_SAMPLE_CAP, AffectedDirectory, CoordinationGapFact, DiffTriage,
+    GraphFacts, ImpactClosureFacts, PartitionFacts, REVIEW_BRIEF_SCHEMA_VERSION, ReviewBriefHeader,
+    ReviewBriefOutput, ReviewBriefSchemaVersion, ReviewBriefSubtractSections,
+    ReviewBriefWireOutput, ReviewDeltas, ReviewEffort, ReviewUnitFact, RiskClass,
+    StandardReviewBriefOutput, build_review_brief_json_output,
     serialize_decision_surface_json_output, serialize_review_brief_json_output,
     serialize_walkthrough_guide_json_output, serialize_walkthrough_validation_json_output,
 };

--- a/crates/output/src/walkthrough_render.rs
+++ b/crates/output/src/walkthrough_render.rs
@@ -308,7 +308,6 @@ mod tests {
             graph_facts: GraphFacts {
                 exports_added: 0,
                 api_width_delta: 0,
-                reachable_from: Vec::new(),
                 boundaries_touched: Vec::new(),
             },
             partition: PartitionFacts::default(),

--- a/docs/backwards-compatibility.md
+++ b/docs/backwards-compatibility.md
@@ -245,6 +245,50 @@ These are documented for the rare CI script that depended on the old behavior. N
   unchanged; only the exit code is. To keep the previous outcome, set the rule
   to `off` rather than `warn`, or drop the strict flag for that job.
 
+- **Review brief schema 9 replaces the duplicated blast-radius list with a
+  count, a capped sample, and a directory rollup.** The `audit-brief` envelope
+  shared by `fallow audit --brief --format json` and `fallow review --format
+  json`, and the brief digest embedded in the review walkthrough guide, used to
+  carry the impact closure's affected-but-not-in-diff paths TWICE, in full:
+  `graph_facts.reachable_from` was a verbatim clone of
+  `impact_closure.affected_not_shown`, and neither was capped. On a
+  single-file change to a mid-sized project the two lists together were more
+  than half the envelope, dwarfing the judgement payload the brief exists to
+  deliver.
+
+  `graph_facts.reachable_from` is REMOVED. Stage 1 keeps `exports_added`,
+  `api_width_delta`, and `boundaries_touched`; the blast radius belongs to
+  Stage 3, which now owns both its magnitude and its paths. Consumers reading
+  `graph_facts.reachable_from` read `impact_closure` instead.
+
+  `impact_closure` gains three fields and caps one. `affected_count` is the
+  FULL number of affected-but-not-in-diff files, computed before any capping,
+  so the magnitude is never understated. `affected_not_shown` is now a capped,
+  path-sorted SAMPLE of at most 10 paths: it is a prefix of the sorted set, so
+  it clusters in whichever directory sorts first and must not be used to
+  enumerate the blast radius or to infer its shape. `affected_by_dir` is the
+  shape: the affected files rolled up by parent directory as `{ dir, count }`
+  rows, heaviest directory first with the directory path breaking ties, at most
+  25 rows, with `affected_by_dir_omitted` counting the lighter directories that
+  did not fit. Every row's `count` is exact.
+
+  Nothing that ranks or gates moved. The decision surface reads its blast
+  metric from the uncapped engine closure, not from this envelope, so decisions,
+  ranks, verdicts, and exit codes are unchanged. The human brief and the human
+  walkthrough report `affected_count`, so their counts are unchanged too, and
+  the human brief additionally names the heaviest directory with its exact
+  share. That line routes a reader to `--format json` only when nothing was
+  omitted from `affected_by_dir`; past the rollup cap it says how many of the
+  remaining directories the JSON actually carries. `coordination_gap`
+  is untouched and uncapped; it is not a subset of `affected_not_shown`,
+  because the gap deliberately skips story and test consumers that the affected
+  set counts. To reconstruct the full affected set, run
+  `fallow check --impact-closure <path>` once per changed file and union the
+  results: that flag seeds from a single file, so no single command reproduces
+  the changeset-wide union.
+
+  Consumers that pinned `schema_version` to 8 must accept 9.
+
 - **Review brief schema 8 adds author actions, test adjacency, independent
   slices, and dependency decisions.** All additive. A `--walkthrough-file`
   judgment may carry `action` (`block`, `address`, `consider`, `fyi`); any

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -17747,7 +17747,7 @@
     },
     "ReviewBriefSchemaVersion": {
       "type": "integer",
-      "const": 8,
+      "const": 9,
       "description": "Independently-versioned wire-version newtype for the brief envelope.\nSerializes as the integer `REVIEW_BRIEF_SCHEMA_VERSION`."
     },
     "RiskClass": {
@@ -17838,13 +17838,6 @@
           "type": "integer",
           "description": "Widening-only public API delta, currently equal to `exports_added`.\nRemoved exports are not represented, so zero means no public API exports\nwere added."
         },
-        "reachable_from": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Root-relative paths of modules the changed code is reachable from / affects\n(the impact closure's affected-but-not-in-diff set), deduped and sorted.\nEmpty when no graph was retained or nothing depends on the changed files."
-        },
         "boundaries_touched": {
           "type": "array",
           "items": {
@@ -17856,31 +17849,48 @@
       "required": [
         "exports_added",
         "api_width_delta",
-        "reachable_from",
         "boundaries_touched"
       ],
-      "description": "Stage 1 of the brief: graph-derived orientation facts.\n\n`boundaries_touched` is derived from the run's boundary-violation zones;\n`reachable_from` is populated by the impact closure (the affected-not-shown\nset: modules the changed code is reachable from / affects, none in the diff).\n`exports_added` and `api_width_delta` both report the exports-aware public API\nwidening count. Removed exports are not represented in this widening-only\nsignal."
+      "description": "Stage 1 of the brief: graph-derived orientation facts.\n\n`boundaries_touched` is derived from the run's boundary-violation zones.\n`exports_added` and `api_width_delta` both report the exports-aware public\nAPI widening count. Removed exports are not represented in this\nwidening-only signal. The set of modules the changed code reaches is Stage\n3's `impact_closure`, which owns both its magnitude and its paths."
     },
     "ImpactClosureFacts": {
       "type": "object",
       "properties": {
+        "affected_count": {
+          "type": "integer",
+          "description": "The FULL number of files transitively affected by the changeset\n(reverse-deps + re-export chains) that are NOT in the diff. Computed\nBEFORE [`affected_not_shown`](Self::affected_not_shown) is capped to a\nsample, so it is always the true magnitude of the blast radius."
+        },
         "affected_not_shown": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Root-relative paths transitively affected by the changeset (reverse-deps +\nre-export chains) that are NOT in the diff, deduped and sorted."
+          "description": "A capped, path-sorted sample of the affected root-relative paths (at most\n[`AFFECTED_SAMPLE_CAP`]), deduped. The full count lives in\n[`affected_count`](Self::affected_count) and the distribution in\n[`affected_by_dir`](Self::affected_by_dir); use this list to jump to\nrepresentative files, NEVER to enumerate the blast radius or to infer its\nshape. Because it is a prefix of the sorted set, it clusters in whichever\ndirectory sorts first. To reconstruct the full set, run\n`fallow check --impact-closure <path>` once per changed file and union the\nresults: that flag seeds from a single file, so no single command\nreproduces this changeset-wide union."
+        },
+        "affected_by_dir": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AffectedDirectory"
+          },
+          "description": "The blast radius rolled up by parent directory: how the affected files\ndistribute, heaviest directory first, ties broken by directory path so the\norder is deterministic. This is the SHAPE signal, and unlike\n[`affected_not_shown`](Self::affected_not_shown) its counts are exact for\nevery directory it lists. At most [`AFFECTED_DIR_CAP`] entries."
+        },
+        "affected_by_dir_omitted": {
+          "type": "integer",
+          "description": "How many directories did not fit within [`AFFECTED_DIR_CAP`] and are\nabsent from [`affected_by_dir`](Self::affected_by_dir). They are the\nlightest ones; their files are still counted in\n[`affected_count`](Self::affected_count). Zero when nothing was omitted.\nAdd this to `affected_by_dir.len()` for the true number of directories\nthe change reaches."
         },
         "coordination_gap": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/CoordinationGapFact"
           },
-          "description": "Coordination gaps: a changed file exports a contract consumed by a module\nabsent from the diff. One entry per (changed file, consumer) pair."
+          "description": "Coordination gaps: a changed file exports a contract consumed by a module\nabsent from the diff. One entry per (changed file, consumer) pair. NOT a\nsubset of [`affected_not_shown`](Self::affected_not_shown): the gap\ndeliberately skips story and test consumers that the affected set counts."
         }
       },
       "required": [
+        "affected_count",
         "affected_not_shown",
+        "affected_by_dir",
+        "affected_by_dir_omitted",
         "coordination_gap"
       ],
       "description": "Stage 3 of the brief: the impact closure. The transitive\naffected-but-not-in-diff set plus the coordination gap. The differentiator a\ndiff tool fundamentally cannot do, because it has no graph.\n\nHonest scope (ADR-001, syntactic): the coordination gap is an attention\npointer at the exact inter-module failure mode, NOT a correctness proof."
@@ -25088,6 +25098,24 @@
       "type": "string",
       "description": "Schema projection for `.` as the privacy-safe diagnosed project root.",
       "const": "."
+    },
+    "AffectedDirectory": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Root-relative parent directory, forward-slashed. The empty string is the\nrepository root."
+        },
+        "count": {
+          "type": "integer",
+          "description": "How many affected-but-not-in-diff files live directly in `dir`. Exact,\nnever sampled."
+        }
+      },
+      "required": [
+        "dir",
+        "count"
+      ],
+      "description": "One directory of the blast radius and how many affected files it holds."
     }
   }
 }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -992,7 +992,7 @@ export type FeatureFlagActionType = ("investigate-flag" | "suppress-line")
  * Independently-versioned wire-version newtype for the brief envelope.
  * Serializes as the integer `REVIEW_BRIEF_SCHEMA_VERSION`.
  */
-export type ReviewBriefSchemaVersion = 8
+export type ReviewBriefSchemaVersion = 9
 /**
  * The exactly-three shippable decision categories (the SOLID-3). No cut category
  * (abstraction / deletion / convention / irreversibility) is representable: this
@@ -12530,12 +12530,11 @@ review_effort: ReviewEffort
 /**
  * Stage 1 of the brief: graph-derived orientation facts.
  *
- * `boundaries_touched` is derived from the run's boundary-violation zones;
- * `reachable_from` is populated by the impact closure (the affected-not-shown
- * set: modules the changed code is reachable from / affects, none in the diff).
- * `exports_added` and `api_width_delta` both report the exports-aware public API
- * widening count. Removed exports are not represented in this widening-only
- * signal.
+ * `boundaries_touched` is derived from the run's boundary-violation zones.
+ * `exports_added` and `api_width_delta` both report the exports-aware public
+ * API widening count. Removed exports are not represented in this
+ * widening-only signal. The set of modules the changed code reaches is Stage
+ * 3's `impact_closure`, which owns both its magnitude and its paths.
  */
 export interface GraphFacts {
 /**
@@ -12549,12 +12548,6 @@ exports_added: number
  * were added.
  */
 api_width_delta: number
-/**
- * Root-relative paths of modules the changed code is reachable from / affects
- * (the impact closure's affected-but-not-in-diff set), deduped and sorted.
- * Empty when no graph was retained or nothing depends on the changed files.
- */
-reachable_from: string[]
 /**
  * Architecture boundary zones touched by the changeset, deduped and sorted.
  * Derived from the run's boundary-violation findings.
@@ -12619,15 +12612,64 @@ files: string[]
  */
 export interface ImpactClosureFacts {
 /**
- * Root-relative paths transitively affected by the changeset (reverse-deps +
- * re-export chains) that are NOT in the diff, deduped and sorted.
+ * The FULL number of files transitively affected by the changeset
+ * (reverse-deps + re-export chains) that are NOT in the diff. Computed
+ * BEFORE [`affected_not_shown`](Self::affected_not_shown) is capped to a
+ * sample, so it is always the true magnitude of the blast radius.
+ */
+affected_count: number
+/**
+ * A capped, path-sorted sample of the affected root-relative paths (at most
+ * [`AFFECTED_SAMPLE_CAP`]), deduped. The full count lives in
+ * [`affected_count`](Self::affected_count) and the distribution in
+ * [`affected_by_dir`](Self::affected_by_dir); use this list to jump to
+ * representative files, NEVER to enumerate the blast radius or to infer its
+ * shape. Because it is a prefix of the sorted set, it clusters in whichever
+ * directory sorts first. To reconstruct the full set, run
+ * `fallow check --impact-closure <path>` once per changed file and union the
+ * results: that flag seeds from a single file, so no single command
+ * reproduces this changeset-wide union.
  */
 affected_not_shown: string[]
 /**
+ * The blast radius rolled up by parent directory: how the affected files
+ * distribute, heaviest directory first, ties broken by directory path so the
+ * order is deterministic. This is the SHAPE signal, and unlike
+ * [`affected_not_shown`](Self::affected_not_shown) its counts are exact for
+ * every directory it lists. At most [`AFFECTED_DIR_CAP`] entries.
+ */
+affected_by_dir: AffectedDirectory[]
+/**
+ * How many directories did not fit within [`AFFECTED_DIR_CAP`] and are
+ * absent from [`affected_by_dir`](Self::affected_by_dir). They are the
+ * lightest ones; their files are still counted in
+ * [`affected_count`](Self::affected_count). Zero when nothing was omitted.
+ * Add this to `affected_by_dir.len()` for the true number of directories
+ * the change reaches.
+ */
+affected_by_dir_omitted: number
+/**
  * Coordination gaps: a changed file exports a contract consumed by a module
- * absent from the diff. One entry per (changed file, consumer) pair.
+ * absent from the diff. One entry per (changed file, consumer) pair. NOT a
+ * subset of [`affected_not_shown`](Self::affected_not_shown): the gap
+ * deliberately skips story and test consumers that the affected set counts.
  */
 coordination_gap: CoordinationGapFact[]
+}
+/**
+ * One directory of the blast radius and how many affected files it holds.
+ */
+export interface AffectedDirectory {
+/**
+ * Root-relative parent directory, forward-slashed. The empty string is the
+ * repository root.
+ */
+dir: string
+/**
+ * How many affected-but-not-in-diff files live directly in `dir`. Exact,
+ * never sampled.
+ */
+count: number
 }
 /**
  * One coordination-gap entry: a changed file exports symbols consumed by a

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -992,7 +992,7 @@ export type FeatureFlagActionType = ("investigate-flag" | "suppress-line")
  * Independently-versioned wire-version newtype for the brief envelope.
  * Serializes as the integer `REVIEW_BRIEF_SCHEMA_VERSION`.
  */
-export type ReviewBriefSchemaVersion = 8
+export type ReviewBriefSchemaVersion = 9
 /**
  * The exactly-three shippable decision categories (the SOLID-3). No cut category
  * (abstraction / deletion / convention / irreversibility) is representable: this
@@ -12530,12 +12530,11 @@ review_effort: ReviewEffort
 /**
  * Stage 1 of the brief: graph-derived orientation facts.
  *
- * `boundaries_touched` is derived from the run's boundary-violation zones;
- * `reachable_from` is populated by the impact closure (the affected-not-shown
- * set: modules the changed code is reachable from / affects, none in the diff).
- * `exports_added` and `api_width_delta` both report the exports-aware public API
- * widening count. Removed exports are not represented in this widening-only
- * signal.
+ * `boundaries_touched` is derived from the run's boundary-violation zones.
+ * `exports_added` and `api_width_delta` both report the exports-aware public
+ * API widening count. Removed exports are not represented in this
+ * widening-only signal. The set of modules the changed code reaches is Stage
+ * 3's `impact_closure`, which owns both its magnitude and its paths.
  */
 export interface GraphFacts {
 /**
@@ -12549,12 +12548,6 @@ exports_added: number
  * were added.
  */
 api_width_delta: number
-/**
- * Root-relative paths of modules the changed code is reachable from / affects
- * (the impact closure's affected-but-not-in-diff set), deduped and sorted.
- * Empty when no graph was retained or nothing depends on the changed files.
- */
-reachable_from: string[]
 /**
  * Architecture boundary zones touched by the changeset, deduped and sorted.
  * Derived from the run's boundary-violation findings.
@@ -12619,15 +12612,64 @@ files: string[]
  */
 export interface ImpactClosureFacts {
 /**
- * Root-relative paths transitively affected by the changeset (reverse-deps +
- * re-export chains) that are NOT in the diff, deduped and sorted.
+ * The FULL number of files transitively affected by the changeset
+ * (reverse-deps + re-export chains) that are NOT in the diff. Computed
+ * BEFORE [`affected_not_shown`](Self::affected_not_shown) is capped to a
+ * sample, so it is always the true magnitude of the blast radius.
+ */
+affected_count: number
+/**
+ * A capped, path-sorted sample of the affected root-relative paths (at most
+ * [`AFFECTED_SAMPLE_CAP`]), deduped. The full count lives in
+ * [`affected_count`](Self::affected_count) and the distribution in
+ * [`affected_by_dir`](Self::affected_by_dir); use this list to jump to
+ * representative files, NEVER to enumerate the blast radius or to infer its
+ * shape. Because it is a prefix of the sorted set, it clusters in whichever
+ * directory sorts first. To reconstruct the full set, run
+ * `fallow check --impact-closure <path>` once per changed file and union the
+ * results: that flag seeds from a single file, so no single command
+ * reproduces this changeset-wide union.
  */
 affected_not_shown: string[]
 /**
+ * The blast radius rolled up by parent directory: how the affected files
+ * distribute, heaviest directory first, ties broken by directory path so the
+ * order is deterministic. This is the SHAPE signal, and unlike
+ * [`affected_not_shown`](Self::affected_not_shown) its counts are exact for
+ * every directory it lists. At most [`AFFECTED_DIR_CAP`] entries.
+ */
+affected_by_dir: AffectedDirectory[]
+/**
+ * How many directories did not fit within [`AFFECTED_DIR_CAP`] and are
+ * absent from [`affected_by_dir`](Self::affected_by_dir). They are the
+ * lightest ones; their files are still counted in
+ * [`affected_count`](Self::affected_count). Zero when nothing was omitted.
+ * Add this to `affected_by_dir.len()` for the true number of directories
+ * the change reaches.
+ */
+affected_by_dir_omitted: number
+/**
  * Coordination gaps: a changed file exports a contract consumed by a module
- * absent from the diff. One entry per (changed file, consumer) pair.
+ * absent from the diff. One entry per (changed file, consumer) pair. NOT a
+ * subset of [`affected_not_shown`](Self::affected_not_shown): the gap
+ * deliberately skips story and test consumers that the affected set counts.
  */
 coordination_gap: CoordinationGapFact[]
+}
+/**
+ * One directory of the blast radius and how many affected files it holds.
+ */
+export interface AffectedDirectory {
+/**
+ * Root-relative parent directory, forward-slashed. The empty string is the
+ * repository root.
+ */
+dir: string
+/**
+ * How many affected-but-not-in-diff files live directly in `dir`. Exact,
+ * never sampled.
+ */
+count: number
 }
 /**
  * One coordination-gap entry: a changed file exports symbols consumed by a


### PR DESCRIPTION
## Problem

The review-brief envelope carried the impact closure's affected-but-not-in-diff paths **twice, in full**: `graph_facts.reachable_from` was a verbatim clone of `impact_closure.affected_not_shown` (`derive_graph_facts` cloned the closure), and neither was capped.

Measured on `colinhacks/zod` at `7a00236`, one-file change to `packages/zod/src/v4/core/parse.ts`, `fallow review --base HEAD --format json --quiet --no-cache`:

| | bytes |
|---|---|
| envelope | 52,676 |
| `graph_facts.reachable_from` (326 paths) | 14,186 |
| `impact_closure.affected_not_shown` (326 paths) | 14,186 |
| `focus` + `decisions` (the judgement) | 1,276 |

The brief is read into an agent's context, so those bytes came out of the reviewing budget.

## Change

`graph_facts.reachable_from` is removed. It had no reader anywhere: human renderers, walkthrough, MCP, LSP, VS Code, viz, the Action's jq filters and the review-electron adapter all ignored it.

`impact_closure` gains three fields and caps one:

- `affected_count` — exact, computed before capping
- `affected_not_shown` — path-sorted prefix sample, at most 10
- `affected_by_dir` — `{dir, count}` rows, heaviest first with the path breaking ties, at most 25
- `affected_by_dir_omitted` — the lighter directories that did not fit

A cap alone would have made the field worse. On a 20-file zod diff a 25-path prefix covers **one** of 24 directories (`packages/bench`) while the weight is in `packages/zod/src/v4/classic/tests` (88) and `.../v4/locales` (63). No selection strategy fixes that, so the shape moved into counts.

The count-plus-capped-sample shape follows `TokenConsumers { consumer_count, consumers }`, not `DecisionSurface.truncated`: an explicit aggregate beats one a consumer must reconstruct. That also avoids reusing `TruncationNote`, whose `collapsed` doc comment says "decisions" and ships verbatim into the public `.d.ts`.

## Human output

```
  impact closure: 326 files affected beyond the diff across 24 directories
         heaviest packages/zod/src/v4/classic/tests (88 files)
         and 23 more directories (--format json for full list)
```

Both renderers read `affected_count`, so their totals are unchanged. The JSON route is promised only when `affected_by_dir_omitted == 0`; past the rollup cap the line says how many of the remaining directories the JSON actually carries, because it does not carry all of them.

## Contract

`schema_version` 8 -> 9. `docs/output-schema.json`, both generated `.d.ts` files, `docs/backwards-compatibility.md` and the changelog are updated. The single bump covers all three sibling envelopes, which share the `ReviewBriefSchemaVersion` newtype.

Decisions, ranks, verdicts and exit codes are untouched: both decision-surface call sites read the blast metric off the uncapped engine `ImpactClosurePaths`, not this envelope.

`coordination_gap` stays uncapped. It is the precise attributed signal and is not a subset of the affected set, since it deliberately skips story and test consumers the affected set counts.

## Result

Envelope 52,676 -> 25,818 bytes on the same reproduction (-50%); `graph_facts` 14,267 -> 63; `impact_closure` 16,041 -> 3,387. `affected_count` is 326 on both sides.

## Verification

`verify:full`, the affected crates' suites, `node --test scripts/*.test.mjs`, `editors/vscode` `tsc --noEmit`, `generate:contracts:check`, `check:agent-adapters`. Reviewed by the json-output, rust and cli-output lenses; the cli-output lens blocked twice (a blank `<root>` token, then a JSON route that did not hold the list it promised) and both are fixed with tests pinning them.

A companion `fallow-docs` paragraph is held on `docs/impact-closure-blast-radius-shape` until the release that ships schema 9.