### PR TITLE
fix(review-electron): say the brief schema version is a floor, not the version

### DIFF
--- a/apps/review-electron/src/main/fallowContract.test.ts
+++ b/apps/review-electron/src/main/fallowContract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { toWalkthroughDocument } from "../model/adapter";
 import {
-  REVIEW_BRIEF_SCHEMA_VERSION,
+  MIN_REVIEW_BRIEF_SCHEMA_VERSION,
   parseGuideContract,
   parseReviewContract,
   parseWalkthroughValidationContract,
@@ -14,19 +14,19 @@ const compatibilityError = (kind: string): string => {
       : kind === "review-walkthrough-guide"
         ? "fallow review --walkthrough-guide"
         : "fallow review --walkthrough-file";
-  return `${command} returned incompatible JSON; expected ${kind} schema version ${REVIEW_BRIEF_SCHEMA_VERSION}.`;
+  return `${command} returned incompatible JSON; expected ${kind} schema version ${MIN_REVIEW_BRIEF_SCHEMA_VERSION} or newer.`;
 };
 
 const minimumReview = (): Record<string, unknown> => ({
   kind: "audit-brief",
   command: "audit-brief",
-  schema_version: REVIEW_BRIEF_SCHEMA_VERSION,
+  schema_version: MIN_REVIEW_BRIEF_SCHEMA_VERSION,
 });
 
 const minimumGuide = (): Record<string, unknown> => ({
   kind: "review-walkthrough-guide",
   command: "review-walkthrough-guide",
-  schema_version: REVIEW_BRIEF_SCHEMA_VERSION,
+  schema_version: MIN_REVIEW_BRIEF_SCHEMA_VERSION,
   graph_snapshot_hash: "graph:1",
   digest: { decisions: { emitted_signal_ids: [] } },
   direction: { order: [] },
@@ -37,15 +37,17 @@ const minimumGuide = (): Record<string, unknown> => ({
 const minimumValidation = (): Record<string, unknown> => ({
   kind: "review-walkthrough-validation",
   command: "review-walkthrough-validation",
-  schema_version: REVIEW_BRIEF_SCHEMA_VERSION,
+  schema_version: MIN_REVIEW_BRIEF_SCHEMA_VERSION,
   graph_snapshot_hash: "graph:1",
   stale: false,
   accepted: [],
   rejected: [],
 });
 
-it("tracks the current Review Brief schema version", () => {
-  expect(REVIEW_BRIEF_SCHEMA_VERSION).toBe(8);
+it("pins the oldest Review Brief schema version it can read", () => {
+  // A floor, not the current version: fallow is on a newer brief schema and
+  // `hasHeader` accepts it. Raising this rejects envelopes the app can parse.
+  expect(MIN_REVIEW_BRIEF_SCHEMA_VERSION).toBe(8);
 });
 
 describe("parseReviewContract", () => {
@@ -69,7 +71,7 @@ describe("parseReviewContract", () => {
 
   it.each([
     ["missing", undefined],
-    ["older", REVIEW_BRIEF_SCHEMA_VERSION - 1],
+    ["older", MIN_REVIEW_BRIEF_SCHEMA_VERSION - 1],
   ])("rejects a %s schema version", (_label, schemaVersion) => {
     const value = minimumReview();
     if (schemaVersion === undefined) delete value["schema_version"];
@@ -84,7 +86,7 @@ describe("parseReviewContract", () => {
   // lockstep: a newer fallow build must not strand the app.
   it("accepts a newer schema version", () => {
     const value = minimumReview();
-    value["schema_version"] = REVIEW_BRIEF_SCHEMA_VERSION + 1;
+    value["schema_version"] = MIN_REVIEW_BRIEF_SCHEMA_VERSION + 1;
     expect(() => parseReviewContract(JSON.stringify(value))).not.toThrow();
   });
 
@@ -111,7 +113,7 @@ describe("parseReviewContract", () => {
     );
 
     expect(toWalkthroughDocument(parsed)).toMatchObject({
-      schemaVersion: REVIEW_BRIEF_SCHEMA_VERSION,
+      schemaVersion: MIN_REVIEW_BRIEF_SCHEMA_VERSION,
       stages: [],
       decisions: [],
     });

--- a/apps/review-electron/src/main/fallowContract.ts
+++ b/apps/review-electron/src/main/fallowContract.ts
@@ -1,6 +1,12 @@
 import type { AuditBrief } from "../model/adapter";
 
-export const REVIEW_BRIEF_SCHEMA_VERSION = 8;
+/**
+ * Oldest review-brief envelope this app can read. The header guard accepts this
+ * version or newer, so a fallow release that bumps the brief schema keeps
+ * working as long as the fields below stay present. Raise it only when an older
+ * envelope genuinely cannot be parsed.
+ */
+export const MIN_REVIEW_BRIEF_SCHEMA_VERSION = 8;
 
 type JsonRecord = Record<string, unknown>;
 type Guard<T> = (value: unknown) => value is T;
@@ -72,7 +78,7 @@ const hasHeader = (value: unknown, kind: string): value is JsonRecord =>
   value["kind"] === kind &&
   value["command"] === kind &&
   isNumber(value["schema_version"]) &&
-  value["schema_version"] >= REVIEW_BRIEF_SCHEMA_VERSION;
+  value["schema_version"] >= MIN_REVIEW_BRIEF_SCHEMA_VERSION;
 
 const isScore = (value: unknown): value is JsonRecord =>
   isRecord(value) &&
@@ -214,7 +220,7 @@ const parseContract = <T>(stdout: string, command: string, kind: string, guard: 
   const value = parseJson(stdout);
   if (guard(value)) return value;
   throw new Error(
-    `${command} returned incompatible JSON; expected ${kind} schema version ${REVIEW_BRIEF_SCHEMA_VERSION}.`,
+    `${command} returned incompatible JSON; expected ${kind} schema version ${MIN_REVIEW_BRIEF_SCHEMA_VERSION} or newer.`,
   );
 };
 


### PR DESCRIPTION
Follow-up to [#2563](https://github.com/fallow-rs/fallow/pull/2563), which moved the review-brief `schema_version` 8 -> 9.

`hasHeader` in `apps/review-electron/src/main/fallowContract.ts` accepts `schema_version >= REVIEW_BRIEF_SCHEMA_VERSION`, and a test pins that `+ 1` is accepted, so the constant has always been a **minimum**. The name and the parse error both read as an exact version:

    fallow review returned incompatible JSON; expected audit-brief schema version 8.

That was harmless while 8 was the only version fallow emitted. #2563 made it wrong: the app accepts 9, receives 9, and would still tell a user it expected 8.

- renamed to `MIN_REVIEW_BRIEF_SCHEMA_VERSION`
- message now says "schema version 8 or newer"
- the constant carries the reason not to raise it, so the next brief bump is not tempted to move the floor with it
- the test that asserted "tracks the current schema version" now says it pins the oldest readable one, which is what it actually checks

The value stays 8 deliberately. Raising it to 9 would reject schema-8 envelopes the app parses fine, since none of the fields it reads (`coordination_gap`, `focus`, `decisions`, `partition`) changed.

Verified: `typecheck`, `lint`, `test` (26 files, 165 tests) in `apps/review-electron`, plus `npm run verify:fast` at the repo root.