### PR TITLE
fix: explain cyclomatic complexity populations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Health reports expose the authored-function, module-scope, and template
+  populations behind cyclomatic averages and percentiles. Each population has
+  a count, sum, and maximum, so module-scope branching can explain a high
+  aggregate even when no function exceeds its threshold (#2519).
+
 - **The rest of the human review brief holds to eighty columns too.** The
   decision surface printed its question, trade-off and expert list on single
   unbounded lines, and the focus map put an un-elided path and an unbounded

--- a/crates/api/src/markdown_output.rs
+++ b/crates/api/src/markdown_output.rs
@@ -1675,6 +1675,19 @@ fn write_vital_signs_section(out: &mut String, report: &fallow_output::HealthRep
     }
     let _ = writeln!(out, "| Avg Cyclomatic | {:.1} |", vs.avg_cyclomatic);
     let _ = writeln!(out, "| P90 Cyclomatic | {} |", vs.p90_cyclomatic);
+    if let Some(population) = &vs.cyclomatic_population {
+        let _ = writeln!(
+            out,
+            "| Cyclomatic units | Functions: {}, module scopes: {}, templates: {} |",
+            population.functions.count, population.modules.count, population.templates.count
+        );
+        if let Some(max) = population.modules.max {
+            let _ = writeln!(
+                out,
+                "| Module-scope max cyclomatic (aggregate only) | {max} |"
+            );
+        }
+    }
     if let Some(v) = vs.dead_file_pct {
         let _ = writeln!(out, "| Dead Files | {v:.1}% |");
     }

--- a/crates/cli/src/report/github_summary.rs
+++ b/crates/cli/src/report/github_summary.rs
@@ -2960,6 +2960,24 @@ fn combined_vitals(env: &Value) -> String {
             pct(avg_cyclomatic),
         );
     }
+    if let Some(population) = vitals
+        .get("cyclomatic_population")
+        .filter(|value| value.is_object())
+    {
+        let _ = writeln!(
+            out,
+            "| Cyclomatic units | Functions: {}, module scopes: {}, templates: {} |",
+            num(&population["functions"], "count"),
+            num(&population["modules"], "count"),
+            num(&population["templates"], "count")
+        );
+        if let Some(max) = population["modules"]["max"].as_u64() {
+            let _ = writeln!(
+                out,
+                "| Module-scope max cyclomatic (aggregate only) | {max} |"
+            );
+        }
+    }
     out.push('\n');
     out
 }

--- a/crates/cli/src/report/human/health.rs
+++ b/crates/cli/src/report/human/health.rs
@@ -1061,6 +1061,12 @@ fn health_explain_for_header(line: &str) -> Option<String> {
                 .to_string(),
         );
     }
+    if line.contains("Cyclomatic units:") {
+        return Some(
+            "Cyclomatic averages and percentiles include authored functions, module scopes, and templates. JSON population counts and sums reconstruct the mean. Module scopes contribute to metrics without function findings."
+                .to_string(),
+        );
+    }
     if line.contains("Metrics:") {
         return Some(
             "Vital signs summarize the analyzed project before truncation: dead-code percentages, maintainability index, hotspot count, circular dependencies, unused dependencies, and duplication where available."
@@ -1383,12 +1389,14 @@ fn push_trend_metric_rows(lines: &mut Vec<String>, trend: &fallow_output::Health
 }
 
 fn render_vital_signs(lines: &mut Vec<String>, report: &fallow_output::HealthReport) {
-    if report.health_trend.is_some() {
-        return;
-    }
     let Some(ref vs) = report.vital_signs else {
         return;
     };
+
+    if report.health_trend.is_some() {
+        render_cyclomatic_population(lines, vs);
+        return;
+    }
 
     let mut parts = Vec::new();
     push_vital_core_parts(&mut parts, vs);
@@ -1399,7 +1407,23 @@ fn render_vital_signs(lines: &mut Vec<String>, report: &fallow_output::HealthRep
         "Metrics:".dimmed(),
         parts.join(" \u{00b7} ").dimmed()
     ));
+    render_cyclomatic_population(lines, vs);
     lines.push(String::new());
+}
+
+fn render_cyclomatic_population(lines: &mut Vec<String>, vs: &fallow_output::VitalSigns) {
+    let Some(population) = &vs.cyclomatic_population else {
+        return;
+    };
+    lines.push(format!(
+        "  Cyclomatic units: functions {}, module scopes {}, templates {}",
+        population.functions.count, population.modules.count, population.templates.count
+    ));
+    if let Some(max) = population.modules.max {
+        lines.push(format!(
+            "  Module scope: max cyclomatic {max}; included in metrics, not function findings"
+        ));
+    }
 }
 
 /// Appends the LOC, dead-code, cyclomatic, and maintainability vital-sign parts.

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -22,6 +22,147 @@ fn write_file(path: &Path, contents: &str) {
     std::fs::write(path, contents).expect("write file");
 }
 
+#[test]
+fn module_scope_cyclomatic_population_explains_aggregate_without_function_findings() {
+    let dir = tempdir().unwrap();
+    write_file(
+        &dir.path().join("package.json"),
+        r#"{"name":"module-population","main":"index.ts"}"#,
+    );
+    let mut source = String::from("const mode = process.env.MODE; let level = 0;\n");
+    for index in 0..30 {
+        writeln!(source, "if (mode === 'k{index}') {{ level = {index}; }}").unwrap();
+    }
+    source.push_str("export function tiny(a: number): number { return a; }\n");
+    write_file(&dir.path().join("index.ts"), &source);
+
+    for args in [
+        vec!["--format", "json", "--quiet", "--no-cache"],
+        vec!["--format", "json", "--quiet"],
+        vec!["--format", "json", "--quiet"],
+    ] {
+        let output = run_fallow_in_root("health", dir.path(), &args);
+        let json = parse_json(&output);
+        assert_eq!(json["summary"]["functions_analyzed"], 1);
+        assert_eq!(json["vital_signs"]["avg_cyclomatic"], 16.0);
+        assert_eq!(json["vital_signs"]["p90_cyclomatic"], 31);
+        assert_eq!(
+            json["vital_signs"]["cyclomatic_population"],
+            serde_json::json!({
+                "functions": {"count": 1, "sum": 1, "max": 1},
+                "modules": {"count": 1, "sum": 31, "max": 31},
+                "templates": {"count": 0, "sum": 0, "max": null}
+            })
+        );
+        assert_eq!(json["findings"], serde_json::json!([]));
+    }
+    let human = run_fallow_in_root("health", dir.path(), &["--no-cache"]);
+    assert!(
+        human
+            .stdout
+            .contains("Cyclomatic units: functions 1, module scopes 1, templates 0"),
+        "{}",
+        human.stdout
+    );
+    assert!(
+        human.stdout.contains("Module scope: max cyclomatic 31"),
+        "{}",
+        human.stdout
+    );
+
+    let markdown = run_fallow_in_root("health", dir.path(), &["--format", "markdown"]);
+    assert!(
+        markdown
+            .stdout
+            .contains("Functions: 1, module scopes: 1, templates: 0")
+    );
+    assert!(
+        markdown
+            .stdout
+            .contains("Module-scope max cyclomatic (aggregate only) | 31")
+    );
+    let explained = run_fallow_in_root("health", dir.path(), &["--format", "json", "--explain"]);
+    let explained = parse_json(&explained);
+    assert!(
+        explained["_meta"]["metrics"]["cyclomatic_population.count"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("disjoint")
+    );
+}
+
+#[test]
+fn module_only_and_grouped_cyclomatic_populations_keep_separate_denominators() {
+    let dir = tempdir().unwrap();
+    write_file(
+        &dir.path().join("package.json"),
+        r#"{"name":"module-population","main":"index.ts"}"#,
+    );
+    write_file(
+        &dir.path().join("index.ts"),
+        "if (process.env.MODE) { console.log('on'); }\n",
+    );
+    let output = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &["--format", "json", "--quiet", "--no-cache"],
+    );
+    let json = parse_json(&output);
+    assert_eq!(json["summary"]["functions_analyzed"], 0);
+    assert_eq!(json["vital_signs"]["avg_cyclomatic"], 2.0);
+    assert_eq!(
+        json["vital_signs"]["cyclomatic_population"]["modules"]["count"],
+        1
+    );
+    assert_eq!(
+        json["vital_signs"]["cyclomatic_population"]["functions"]["max"],
+        serde_json::Value::Null
+    );
+
+    write_file(
+        &dir.path().join("helpers/tiny.ts"),
+        "export function tiny() { return 1; }\n",
+    );
+    let grouped = run_fallow_in_root(
+        "health",
+        dir.path(),
+        &[
+            "--format",
+            "json",
+            "--quiet",
+            "--no-cache",
+            "--group-by",
+            "directory",
+        ],
+    );
+    let grouped = parse_json(&grouped);
+    let groups = grouped["groups"].as_array().unwrap();
+    let helper = groups
+        .iter()
+        .find(|group| group["key"] == "helpers")
+        .unwrap();
+    assert_eq!(
+        helper["vital_signs"]["cyclomatic_population"]["functions"]["count"],
+        1
+    );
+    assert_eq!(
+        helper["vital_signs"]["cyclomatic_population"]["modules"]["count"],
+        0
+    );
+    let module = groups
+        .iter()
+        .find(|group| group["key"] == "index.ts")
+        .unwrap();
+    assert_eq!(
+        module["vital_signs"]["cyclomatic_population"]["functions"]["count"],
+        0
+    );
+    assert_eq!(
+        module["vital_signs"]["cyclomatic_population"]["modules"]["max"],
+        2
+    );
+}
+
 fn copy_dir_recursive(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).expect("create destination directory");
     for entry in std::fs::read_dir(src).expect("read source directory") {

--- a/crates/cli/tests/snapshots/health_tests__health_human_complexity.snap
+++ b/crates/cli/tests/snapshots/health_tests__health_human_complexity.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/health_tests.rs
 expression: redacted
 ---
 ■ Metrics: 21 LOC · dead files 33.3% · dead exports 0.0% · avg cyclomatic 7.0 · p90 cyclomatic 13 · maintainability 85.8 (good)
+  Cyclomatic units: functions 2, module scopes 0, templates 0
 
 ● High complexity functions (1)
   CRAP scores are estimated from export references; run `fallow health --coverage <coverage-final.json>` for exact scores.

--- a/crates/engine/src/vital_signs.rs
+++ b/crates/engine/src/vital_signs.rs
@@ -147,12 +147,14 @@ struct SelectedModuleMetrics {
     total_loc: u64,
     line_counts: Vec<u32>,
     param_counts: Vec<u8>,
+    cyclomatic_population: fallow_output::CyclomaticPopulation,
 }
 
 fn selected_module_metrics(input: &VitalSignsInput<'_>) -> SelectedModuleMetrics {
     let mut total_loc = 0;
     let mut line_counts = Vec::new();
     let mut param_counts = Vec::new();
+    let mut cyclomatic_population = fallow_output::CyclomaticPopulation::default();
 
     for module in input.selected_modules() {
         total_loc += module.line_offsets.len() as u64;
@@ -160,11 +162,21 @@ fn selected_module_metrics(input: &VitalSignsInput<'_>) -> SelectedModuleMetrics
         // It has no parameter list, and its size is the distance between its
         // first and last decision point rather than a body anyone can shorten,
         // so it is not a refactoring signal in the unit-size profile.
-        let units = module
-            .complexity
-            .iter()
-            .filter(|c| !fallow_types::extract::is_synthetic_module_unit(&c.name));
-        for unit in units {
+        for unit in &module.complexity {
+            let is_module = fallow_types::extract::is_synthetic_module_unit(&unit.name);
+            let population = if is_module {
+                &mut cyclomatic_population.modules
+            } else if fallow_types::extract::is_synthetic_template_unit(&unit.name) {
+                &mut cyclomatic_population.templates
+            } else {
+                &mut cyclomatic_population.functions
+            };
+            population.count += 1;
+            population.sum += u64::from(unit.cyclomatic);
+            population.max = Some(population.max.unwrap_or_default().max(unit.cyclomatic));
+            if is_module {
+                continue;
+            }
             line_counts.push(unit.line_count);
             param_counts.push(unit.param_count);
         }
@@ -174,6 +186,7 @@ fn selected_module_metrics(input: &VitalSignsInput<'_>) -> SelectedModuleMetrics
         total_loc,
         line_counts,
         param_counts,
+        cyclomatic_population,
     }
 }
 
@@ -228,6 +241,7 @@ pub(crate) fn compute_vital_signs(input: &VitalSignsInput<'_>) -> VitalSigns {
         avg_cyclomatic,
         critical_complexity_pct,
         p90_cyclomatic,
+        cyclomatic_population: Some(module_metrics.cyclomatic_population),
         duplication_pct: None, // Lazy: only set if duplication pipeline was run
         hotspot_count,
         hotspot_top_pct_count,
@@ -1200,6 +1214,38 @@ mod tests {
     }
 
     #[test]
+    fn cyclomatic_population_partitions_units_and_respects_module_filter() {
+        let mut mixed = make_module(0, 1);
+        let mut module_unit = mixed.complexity[0].clone();
+        module_unit.name = "<module>".into();
+        module_unit.cyclomatic = 31;
+        let mut template_unit = module_unit.clone();
+        template_unit.name = "<template>".into();
+        template_unit.cyclomatic = 4;
+        mixed.complexity.extend([module_unit, template_unit]);
+        let modules = [mixed, make_module(1, 100)];
+        let filter = rustc_hash::FxHashSet::from_iter([crate::discover::FileId(0)]);
+        let input = VitalSignsInput {
+            modules: &modules,
+            module_filter: Some(&filter),
+            file_scores: None,
+            hotspots: None,
+            total_files: 1,
+            analysis_counts: None,
+        };
+        let vs = compute_vital_signs(&input);
+        let population = vs.cyclomatic_population.unwrap();
+        assert_eq!(population.functions.count, 1);
+        assert_eq!(population.modules.count, 1);
+        assert_eq!(population.templates.count, 1);
+        assert_eq!(population.functions.sum, 1);
+        assert_eq!(population.modules.sum, 31);
+        assert_eq!(population.templates.sum, 4);
+        assert_close(vs.avg_cyclomatic, 12.0);
+        assert_eq!(vs.p90_cyclomatic, 31);
+    }
+
+    #[test]
     fn compute_with_analysis_counts() {
         let modules = make_modules();
         let input = VitalSignsInput {
@@ -1279,6 +1325,31 @@ mod tests {
         let vs = compute_vital_signs(&input);
         assert_eq!(vs.hotspot_count, Some(2)); // 80.0 and 50.0 meet threshold
         assert_eq!(vs.hotspot_top_pct_count, Some(1)); // top 1% bucket rounds up to one file
+    }
+
+    #[test]
+    fn empty_cyclomatic_population_is_measured_not_unknown() {
+        let vs = compute_vital_signs(&VitalSignsInput {
+            modules: &[],
+            module_filter: None,
+            file_scores: None,
+            hotspots: None,
+            total_files: 0,
+            analysis_counts: None,
+        });
+        let population = vs.cyclomatic_population.unwrap();
+        for group in [
+            population.functions,
+            population.modules,
+            population.templates,
+        ] {
+            assert_eq!(group.count, 0);
+            assert_eq!(group.sum, 0);
+            assert_eq!(group.max, None);
+        }
+        assert_close(vs.avg_cyclomatic, 0.0);
+        assert_eq!(vs.p90_cyclomatic, 0);
+        assert_eq!(vs.critical_complexity_pct, None);
     }
 
     #[test]
@@ -1546,6 +1617,7 @@ mod tests {
     #[test]
     fn health_score_duplication_penalty() {
         let vs = VitalSigns {
+            cyclomatic_population: None,
             dead_file_pct: None,
             dead_export_pct: None,
             avg_cyclomatic: 1.0,

--- a/crates/output/src/health_scores.rs
+++ b/crates/output/src/health_scores.rs
@@ -895,13 +895,11 @@ pub struct HealthBaselineStaleness {
 pub struct HealthSummary {
     /// Files included in the health analysis.
     pub files_analyzed: usize,
-    /// Real functions scored across the analyzed files. This counts functions
-    /// only, so it is smaller than the sum of `file_scores[].function_count`,
-    /// which also counts the synthetic per-file units (`<module>` for
-    /// module-scope branching, `<template>` and `<snippet:NAME>` for component
-    /// templates). The complexity aggregates below, including
-    /// `average_cyclomatic` and `p90_cyclomatic`, are computed over that larger
-    /// population rather than over this count.
+    /// Functions and template units checked for threshold findings across the
+    /// analyzed files. Synthetic module-scope units are excluded. Cyclomatic
+    /// aggregates include module units too; `vital_signs.cyclomatic_population`
+    /// reports the disjoint authored-function, module, and template populations
+    /// behind those aggregates.
     pub functions_analyzed: usize,
     /// Functions exceeding at least one complexity or CRAP threshold.
     pub functions_above_threshold: usize,
@@ -998,11 +996,11 @@ pub struct FileHealthScore {
     pub complexity_density: f64,
     /// Maintainability index (0-100); higher is healthier.
     pub maintainability_index: f64,
-    /// Summed cyclomatic complexity over the file's functions.
+    /// Summed cyclomatic complexity over all units, including module and template scope.
     pub total_cyclomatic: u32,
-    /// Summed cognitive complexity over the file's functions.
+    /// Summed cognitive complexity over all units, including module and template scope.
     pub total_cognitive: u32,
-    /// Functions in the file.
+    /// Complexity units in the file, including synthetic module and template units.
     pub function_count: usize,
     /// Lines of code in the file.
     pub lines: u32,

--- a/crates/output/src/health_vital_signs.rs
+++ b/crates/output/src/health_vital_signs.rs
@@ -31,14 +31,19 @@ pub struct VitalSigns {
     /// Percentage of exports never imported by other modules.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dead_export_pct: Option<f64>,
-    /// Average cyclomatic complexity across all functions.
+    /// Average cyclomatic complexity across authored functions, module-scope
+    /// units, and template units. See `cyclomatic_population` for the denominator.
     pub avg_cyclomatic: f64,
-    /// Percentage of functions at or above the critical cyclomatic threshold.
+    /// Percentage of complexity units at or above the critical cyclomatic threshold.
     /// Used by the scale-invariant health score.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub critical_complexity_pct: Option<f64>,
-    /// 90th percentile cyclomatic complexity.
+    /// 90th percentile cyclomatic complexity across the same unit population.
     pub p90_cyclomatic: u32,
+    /// Population behind the cyclomatic mean, percentile, and critical share.
+    /// Present on current analyses; absent on older saved snapshots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cyclomatic_population: Option<CyclomaticPopulation>,
     /// Code duplication percentage (None if duplication pipeline was not run).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duplication_pct: Option<f64>,
@@ -129,6 +134,32 @@ pub struct VitalSigns {
     /// Total lines of code across all parsed modules.
     #[serde(default)]
     pub total_loc: u64,
+}
+
+/// Disjoint populations feeding the cyclomatic distribution. Counts and sums
+/// across all three groups reconstruct its weighted mean. Module-scope units
+/// contribute to aggregates only and do not produce function findings.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CyclomaticPopulation {
+    /// Authored functions, excluding synthetic module and template units.
+    pub functions: CyclomaticUnitPopulation,
+    /// Synthetic module-scope units, emitted only when top-level code branches.
+    pub modules: CyclomaticUnitPopulation,
+    /// Synthetic template and snippet units.
+    pub templates: CyclomaticUnitPopulation,
+}
+
+/// Cyclomatic measurements for one kind of complexity unit.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct CyclomaticUnitPopulation {
+    /// Number of units measured, including those below finding thresholds.
+    pub count: usize,
+    /// Sum of cyclomatic complexity, before rounding or threshold filtering.
+    pub sum: u64,
+    /// Highest cyclomatic complexity, or null when this population is empty.
+    pub max: Option<u16>,
 }
 
 /// One located high-fan-in React/Preact component for the descriptive
@@ -256,6 +287,19 @@ pub struct VitalSignsSnapshot {
 )]
 mod tests {
     use super::*;
+
+    #[test]
+    fn legacy_vital_signs_preserve_unknown_cyclomatic_population() {
+        let legacy: VitalSigns =
+            serde_json::from_str(r#"{"avg_cyclomatic":16.0,"p90_cyclomatic":31}"#).unwrap();
+        assert!(legacy.cyclomatic_population.is_none());
+        assert!(
+            serde_json::to_value(legacy)
+                .unwrap()
+                .get("cyclomatic_population")
+                .is_none()
+        );
+    }
 
     #[test]
     fn vital_signs_optional_fields_are_omitted() {

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -235,8 +235,8 @@ pub use health_targets::{
 };
 pub use health_trends::{HealthTrend, TrendCount, TrendDirection, TrendMetric, TrendPoint};
 pub use health_vital_signs::{
-    RenderFanInTopComponent, RiskProfile, SNAPSHOT_SCHEMA_VERSION, VitalSigns, VitalSignsCounts,
-    VitalSignsSnapshot,
+    CyclomaticPopulation, CyclomaticUnitPopulation, RenderFanInTopComponent, RiskProfile,
+    SNAPSHOT_SCHEMA_VERSION, VitalSigns, VitalSignsCounts, VitalSignsSnapshot,
 };
 pub use impact::{
     ContainmentEvent, CrossRepoImpactReport, CrossRepoImpactSchemaVersion, CrossRepoProjectEntry,

--- a/crates/output/src/report_contract.rs
+++ b/crates/output/src/report_contract.rs
@@ -365,11 +365,59 @@ fn security_field_definitions() -> BTreeMap<String, String> {
 fn health_metrics() -> BTreeMap<String, MetaMetric> {
     let mut metrics = BTreeMap::new();
     metrics.extend(health_complexity_metrics());
+    metrics.extend(health_population_metrics());
     metrics.extend(health_churn_and_target_metrics());
     metrics.extend(health_ownership_metrics());
     metrics.extend(health_runtime_metrics());
     metrics.extend(health_styling_metrics());
     metrics
+}
+
+fn health_population_metrics() -> [(String, MetaMetric); 6] {
+    [
+        health_metric(
+            "avg_cyclomatic",
+            "Average Cyclomatic Complexity",
+            "Mean over authored function, module-scope, and template units before finding filters. Divide the sum of cyclomatic_population group sums by the sum of their counts, rounded to one decimal.",
+            Some("[0, infinity)"),
+            "zero for an empty population; lower is better",
+        ),
+        health_metric(
+            "p90_cyclomatic",
+            "P90 Cyclomatic Complexity",
+            "Nearest-rank 90th percentile over the same units as avg_cyclomatic, including module scopes and templates.",
+            Some("[0, infinity)"),
+            "zero for an empty population; lower is better",
+        ),
+        health_metric(
+            "critical_complexity_pct",
+            "Critical Cyclomatic Share",
+            "Percentage of the cyclomatic unit population at or above the critical threshold, including module scopes and templates.",
+            Some("[0, 100]"),
+            "absent for an empty population; lower is better",
+        ),
+        health_metric(
+            "cyclomatic_population.count",
+            "Cyclomatic Population Count",
+            "Unit count in each disjoint functions, modules, or templates group. Modules contribute to aggregate metrics without producing function findings.",
+            Some("[0, infinity)"),
+            "sum the three counts to obtain the distribution denominator",
+        ),
+        health_metric(
+            "cyclomatic_population.sum",
+            "Cyclomatic Population Sum",
+            "Sum of cyclomatic values in each functions, modules, or templates group before rounding and threshold filtering.",
+            Some("[0, infinity)"),
+            "sum the three groups to obtain the mean numerator",
+        ),
+        health_metric(
+            "cyclomatic_population.max",
+            "Cyclomatic Population Maximum",
+            "Highest cyclomatic value within each functions, modules, or templates group; null when that group has no units.",
+            Some("[1, infinity) or null"),
+            "identifies which kind of unit drives the tail; module units remain aggregate-only",
+        ),
+    ]
 }
 
 fn health_complexity_metrics() -> [(String, MetaMetric); 11] {

--- a/docs/backwards-compatibility.md
+++ b/docs/backwards-compatibility.md
@@ -61,6 +61,18 @@ These interfaces are covered by semver , breaking changes only happen in major v
 - **MCP shared parameter descriptions are one sentence**: the six parameters nearly every tool carries (`root`, `config`, `allow_remote_extends`, `workspace`, `no_cache`, `threads`) describe themselves in one sentence, worded identically on every tool that takes them, including the `symbol_impact` schema mirror that had drifted to its own phrasing. Two facts the trim removed are back, because each one bounded behavior the shortened sentence left undiscoverable: `allow_remote_extends` states again that it defaults to false and never grants process-global trust, the only statement bounding a trust-boundary flag, and `workspace` names the repo-relative path again, because patterns still match against both the package name and that path and the unmatched-pattern refusal lists only names. Only the `description` prose changed: no parameter was added, removed, renamed, retyped, or given a different default, no `schema_version` moves, and no request that was accepted before is refused now.
 
 
+#### Cyclomatic metric populations
+
+Health vital signs include optional `cyclomatic_population` metadata alongside
+`avg_cyclomatic`, `p90_cyclomatic`, and `critical_complexity_pct`. Its `functions`,
+`modules`, and `templates` groups each carry a unit `count`, cyclomatic `sum`, and
+nullable `max`. Sum the groups' sums and divide by their counts to reconstruct
+the mean before rounding. The percentile and critical share use that same
+population. Module-scope units contribute to aggregates without creating
+function findings. Existing threshold, suppression, and baseline behavior is
+unchanged. Older snapshots omit the metadata, indicating unknown population
+rather than zero units. No metric formula or envelope version changes.
+
 #### Report ordering and colliding duplication handles
 
 Health complexity findings retain the requested descending metric priority.

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -2914,7 +2914,7 @@
         },
         "functions_analyzed": {
           "type": "integer",
-          "description": "Real functions scored across the analyzed files. This counts functions\nonly, so it is smaller than the sum of `file_scores[].function_count`,\nwhich also counts the synthetic per-file units (`<module>` for\nmodule-scope branching, `<template>` and `<snippet:NAME>` for component\ntemplates). The complexity aggregates below, including\n`average_cyclomatic` and `p90_cyclomatic`, are computed over that larger\npopulation rather than over this count."
+          "description": "Functions and template units checked for threshold findings across the\nanalyzed files. Synthetic module-scope units are excluded. Cyclomatic\naggregates include module units too; `vital_signs.cyclomatic_population`\nreports the disjoint authored-function, module, and template populations\nbehind those aggregates."
         },
         "functions_above_threshold": {
           "type": "integer",
@@ -3274,15 +3274,15 @@
         },
         "total_cyclomatic": {
           "type": "integer",
-          "description": "Summed cyclomatic complexity over the file's functions."
+          "description": "Summed cyclomatic complexity over all units, including module and template scope."
         },
         "total_cognitive": {
           "type": "integer",
-          "description": "Summed cognitive complexity over the file's functions."
+          "description": "Summed cognitive complexity over all units, including module and template scope."
         },
         "function_count": {
           "type": "integer",
-          "description": "Functions in the file."
+          "description": "Complexity units in the file, including synthetic module and template units."
         },
         "lines": {
           "type": "integer",
@@ -3990,18 +3990,29 @@
         },
         "avg_cyclomatic": {
           "type": "number",
-          "description": "Average cyclomatic complexity across all functions."
+          "description": "Average cyclomatic complexity across authored functions, module-scope\nunits, and template units. See `cyclomatic_population` for the denominator."
         },
         "critical_complexity_pct": {
           "type": [
             "number",
             "null"
           ],
-          "description": "Percentage of functions at or above the critical cyclomatic threshold.\nUsed by the scale-invariant health score."
+          "description": "Percentage of complexity units at or above the critical cyclomatic threshold.\nUsed by the scale-invariant health score."
         },
         "p90_cyclomatic": {
           "type": "integer",
-          "description": "90th percentile cyclomatic complexity."
+          "description": "90th percentile cyclomatic complexity across the same unit population."
+        },
+        "cyclomatic_population": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CyclomaticPopulation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Population behind the cyclomatic mean, percentile, and critical share.\nPresent on current analyses; absent on older saved snapshots."
         },
         "duplication_pct": {
           "type": [
@@ -25799,6 +25810,54 @@
         "count"
       ],
       "description": "One directory of the blast radius and how many affected files it holds."
+    },
+    "CyclomaticPopulation": {
+      "type": "object",
+      "properties": {
+        "functions": {
+          "description": "Authored functions, excluding synthetic module and template units.",
+          "$ref": "#/definitions/CyclomaticUnitPopulation"
+        },
+        "modules": {
+          "description": "Synthetic module-scope units, emitted only when top-level code branches.",
+          "$ref": "#/definitions/CyclomaticUnitPopulation"
+        },
+        "templates": {
+          "description": "Synthetic template and snippet units.",
+          "$ref": "#/definitions/CyclomaticUnitPopulation"
+        }
+      },
+      "required": [
+        "functions",
+        "modules",
+        "templates"
+      ],
+      "description": "Disjoint populations feeding the cyclomatic distribution. Counts and sums\nacross all three groups reconstruct its weighted mean. Module-scope units\ncontribute to aggregates only and do not produce function findings."
+    },
+    "CyclomaticUnitPopulation": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "description": "Number of units measured, including those below finding thresholds."
+        },
+        "sum": {
+          "type": "integer",
+          "description": "Sum of cyclomatic complexity, before rounding or threshold filtering."
+        },
+        "max": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Highest cyclomatic complexity, or null when this population is empty."
+        }
+      },
+      "required": [
+        "count",
+        "sum"
+      ],
+      "description": "Cyclomatic measurements for one kind of complexity unit."
     }
   }
 }

--- a/editors/vscode/src/generated/output-contract.d.ts
+++ b/editors/vscode/src/generated/output-contract.d.ts
@@ -5907,13 +5907,11 @@ export interface HealthSummary {
  */
 files_analyzed: number
 /**
- * Real functions scored across the analyzed files. This counts functions
- * only, so it is smaller than the sum of `file_scores[].function_count`,
- * which also counts the synthetic per-file units (`<module>` for
- * module-scope branching, `<template>` and `<snippet:NAME>` for component
- * templates). The complexity aggregates below, including
- * `average_cyclomatic` and `p90_cyclomatic`, are computed over that larger
- * population rather than over this count.
+ * Functions and template units checked for threshold findings across the
+ * analyzed files. Synthetic module-scope units are excluded. Cyclomatic
+ * aggregates include module units too; `vital_signs.cyclomatic_population`
+ * reports the disjoint authored-function, module, and template populations
+ * behind those aggregates.
  */
 functions_analyzed: number
 /**
@@ -6148,18 +6146,24 @@ dead_file_pct?: (number | null)
  */
 dead_export_pct?: (number | null)
 /**
- * Average cyclomatic complexity across all functions.
+ * Average cyclomatic complexity across authored functions, module-scope
+ * units, and template units. See `cyclomatic_population` for the denominator.
  */
 avg_cyclomatic: number
 /**
- * Percentage of functions at or above the critical cyclomatic threshold.
+ * Percentage of complexity units at or above the critical cyclomatic threshold.
  * Used by the scale-invariant health score.
  */
 critical_complexity_pct?: (number | null)
 /**
- * 90th percentile cyclomatic complexity.
+ * 90th percentile cyclomatic complexity across the same unit population.
  */
 p90_cyclomatic: number
+/**
+ * Population behind the cyclomatic mean, percentile, and critical share.
+ * Present on current analyses; absent on older saved snapshots.
+ */
+cyclomatic_population?: (CyclomaticPopulation | null)
 /**
  * Code duplication percentage (None if duplication pipeline was not run).
  */
@@ -6272,6 +6276,33 @@ top_render_fan_in?: RenderFanInTopComponent[]
  * Total lines of code across all parsed modules.
  */
 total_loc?: number
+}
+/**
+ * Disjoint populations feeding the cyclomatic distribution. Counts and sums
+ * across all three groups reconstruct its weighted mean. Module-scope units
+ * contribute to aggregates only and do not produce function findings.
+ */
+export interface CyclomaticPopulation {
+functions: CyclomaticUnitPopulation
+modules: CyclomaticUnitPopulation
+templates: CyclomaticUnitPopulation
+}
+/**
+ * Cyclomatic measurements for one kind of complexity unit.
+ */
+export interface CyclomaticUnitPopulation {
+/**
+ * Number of units measured, including those below finding thresholds.
+ */
+count: number
+/**
+ * Sum of cyclomatic complexity, before rounding or threshold filtering.
+ */
+sum: number
+/**
+ * Highest cyclomatic complexity, or null when this population is empty.
+ */
+max?: (number | null)
 }
 /**
  * Raw counts backing the vital signs percentages.
@@ -6489,15 +6520,15 @@ complexity_density: number
  */
 maintainability_index: number
 /**
- * Summed cyclomatic complexity over the file's functions.
+ * Summed cyclomatic complexity over all units, including module and template scope.
  */
 total_cyclomatic: number
 /**
- * Summed cognitive complexity over the file's functions.
+ * Summed cognitive complexity over all units, including module and template scope.
  */
 total_cognitive: number
 /**
- * Functions in the file.
+ * Complexity units in the file, including synthetic module and template units.
  */
 function_count: number
 /**

--- a/npm/fallow/types/output-contract.d.ts
+++ b/npm/fallow/types/output-contract.d.ts
@@ -5907,13 +5907,11 @@ export interface HealthSummary {
  */
 files_analyzed: number
 /**
- * Real functions scored across the analyzed files. This counts functions
- * only, so it is smaller than the sum of `file_scores[].function_count`,
- * which also counts the synthetic per-file units (`<module>` for
- * module-scope branching, `<template>` and `<snippet:NAME>` for component
- * templates). The complexity aggregates below, including
- * `average_cyclomatic` and `p90_cyclomatic`, are computed over that larger
- * population rather than over this count.
+ * Functions and template units checked for threshold findings across the
+ * analyzed files. Synthetic module-scope units are excluded. Cyclomatic
+ * aggregates include module units too; `vital_signs.cyclomatic_population`
+ * reports the disjoint authored-function, module, and template populations
+ * behind those aggregates.
  */
 functions_analyzed: number
 /**
@@ -6148,18 +6146,24 @@ dead_file_pct?: (number | null)
  */
 dead_export_pct?: (number | null)
 /**
- * Average cyclomatic complexity across all functions.
+ * Average cyclomatic complexity across authored functions, module-scope
+ * units, and template units. See `cyclomatic_population` for the denominator.
  */
 avg_cyclomatic: number
 /**
- * Percentage of functions at or above the critical cyclomatic threshold.
+ * Percentage of complexity units at or above the critical cyclomatic threshold.
  * Used by the scale-invariant health score.
  */
 critical_complexity_pct?: (number | null)
 /**
- * 90th percentile cyclomatic complexity.
+ * 90th percentile cyclomatic complexity across the same unit population.
  */
 p90_cyclomatic: number
+/**
+ * Population behind the cyclomatic mean, percentile, and critical share.
+ * Present on current analyses; absent on older saved snapshots.
+ */
+cyclomatic_population?: (CyclomaticPopulation | null)
 /**
  * Code duplication percentage (None if duplication pipeline was not run).
  */
@@ -6272,6 +6276,33 @@ top_render_fan_in?: RenderFanInTopComponent[]
  * Total lines of code across all parsed modules.
  */
 total_loc?: number
+}
+/**
+ * Disjoint populations feeding the cyclomatic distribution. Counts and sums
+ * across all three groups reconstruct its weighted mean. Module-scope units
+ * contribute to aggregates only and do not produce function findings.
+ */
+export interface CyclomaticPopulation {
+functions: CyclomaticUnitPopulation
+modules: CyclomaticUnitPopulation
+templates: CyclomaticUnitPopulation
+}
+/**
+ * Cyclomatic measurements for one kind of complexity unit.
+ */
+export interface CyclomaticUnitPopulation {
+/**
+ * Number of units measured, including those below finding thresholds.
+ */
+count: number
+/**
+ * Sum of cyclomatic complexity, before rounding or threshold filtering.
+ */
+sum: number
+/**
+ * Highest cyclomatic complexity, or null when this population is empty.
+ */
+max?: (number | null)
 }
 /**
  * Raw counts backing the vital signs percentages.
@@ -6489,15 +6520,15 @@ complexity_density: number
  */
 maintainability_index: number
 /**
- * Summed cyclomatic complexity over the file's functions.
+ * Summed cyclomatic complexity over all units, including module and template scope.
  */
 total_cyclomatic: number
 /**
- * Summed cognitive complexity over the file's functions.
+ * Summed cognitive complexity over all units, including module and template scope.
  */
 total_cognitive: number
 /**
- * Functions in the file.
+ * Complexity units in the file, including synthetic module and template units.
  */
 function_count: number
 /**


### PR DESCRIPTION
Health metrics include top-level branching, so a file can report high cyclomatic complexity while its authored functions have no findings. Add `vital_signs.cyclomatic_population` to explain the measured population through separate function, module-scope, and template counts, sums, and maxima.

Human output, Markdown, GitHub summaries, and `--explain` now describe that population. JSON schemas and Node/editor types expose the same optional metadata; older snapshots retain an unknown population. Existing metrics, findings, suppression rules, and function counts keep their behavior.

Fixes #2519.

This PR is based on #2568; the diff contains only the complexity-population changes.

Validation:

- Original top-level-branching regression fails against the parent binary and passes with this change, including cold, warm, and disabled caches.
- Module-only, grouped, template, empty, and legacy-snapshot coverage passes.
- Public Zod smoke reconciles the weighted mean and preserves existing metrics and findings.
- Local canonical repository gates and editor type/generated-contract checks pass.
