### PR TITLE
fix: disclose populations in compact health output

### DIFF
--- a/crates/api/src/compact_output.rs
+++ b/crates/api/src/compact_output.rs
@@ -738,6 +738,26 @@ fn push_vital_signs_compact(lines: &mut Vec<String>, report: &fallow_output::Hea
             parts.push(format!("unused_dep_count={v}"));
         }
         lines.push(format!("vital-signs:{}", parts.join(",")));
+        push_cyclomatic_population_compact(lines, vs);
+    }
+}
+
+fn push_cyclomatic_population_compact(lines: &mut Vec<String>, vs: &fallow_output::VitalSigns) {
+    let Some(population) = &vs.cyclomatic_population else {
+        return;
+    };
+    for (kind, group) in [
+        ("functions", &population.functions),
+        ("modules", &population.modules),
+        ("templates", &population.templates),
+    ] {
+        let max = group
+            .max
+            .map_or_else(|| "null".to_string(), |value| value.to_string());
+        lines.push(format!(
+            "cyclomatic-population:{kind}:count={},sum={},max={max}",
+            group.count, group.sum
+        ));
     }
 }
 
@@ -1285,6 +1305,77 @@ mod tests {
         assert_eq!(
             lines[1],
             "vital-signs:total_loc=120,avg_cyclomatic=3.4,p90_cyclomatic=8"
+        );
+        assert!(
+            lines
+                .iter()
+                .all(|line| !line.starts_with("cyclomatic-population:"))
+        );
+    }
+
+    #[test]
+    fn health_compact_population_rows_preserve_vital_signs_and_order() {
+        let root = PathBuf::from("/project");
+        let vitals = fallow_output::VitalSigns {
+            avg_cyclomatic: 16.0,
+            p90_cyclomatic: 31,
+            ..Default::default()
+        };
+        let legacy = build_health_compact_lines(
+            &fallow_output::HealthReport {
+                vital_signs: Some(vitals.clone()),
+                ..Default::default()
+            },
+            &root,
+        );
+        let report = fallow_output::HealthReport {
+            vital_signs: Some(fallow_output::VitalSigns {
+                cyclomatic_population: Some(fallow_output::CyclomaticPopulation {
+                    functions: fallow_output::CyclomaticUnitPopulation {
+                        count: 1,
+                        sum: 1,
+                        max: Some(1),
+                    },
+                    modules: fallow_output::CyclomaticUnitPopulation {
+                        count: 1,
+                        sum: 31,
+                        max: Some(31),
+                    },
+                    templates: fallow_output::CyclomaticUnitPopulation::default(),
+                }),
+                ..vitals
+            }),
+            ..Default::default()
+        };
+        let lines = build_health_compact_lines(&report, &root);
+        assert_eq!(lines[0], legacy[0]);
+        assert_eq!(
+            &lines[1..],
+            [
+                "cyclomatic-population:functions:count=1,sum=1,max=1",
+                "cyclomatic-population:modules:count=1,sum=31,max=31",
+                "cyclomatic-population:templates:count=0,sum=0,max=null",
+            ]
+        );
+    }
+
+    #[test]
+    fn health_compact_measured_empty_populations_keep_null_maxima() {
+        let report = fallow_output::HealthReport {
+            vital_signs: Some(fallow_output::VitalSigns {
+                cyclomatic_population: Some(fallow_output::CyclomaticPopulation::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let lines = build_health_compact_lines(&report, &PathBuf::from("/project"));
+        assert_eq!(
+            &lines[1..],
+            [
+                "cyclomatic-population:functions:count=0,sum=0,max=null",
+                "cyclomatic-population:modules:count=0,sum=0,max=null",
+                "cyclomatic-population:templates:count=0,sum=0,max=null",
+            ]
         );
     }
 

--- a/crates/cli/tests/health_tests.rs
+++ b/crates/cli/tests/health_tests.rs
@@ -70,6 +70,20 @@ fn module_scope_cyclomatic_population_explains_aggregate_without_function_findin
         human.stdout
     );
 
+    let compact = run_fallow_in_root("health", dir.path(), &["--format", "compact", "--no-cache"]);
+    assert_eq!(
+        compact
+            .stdout
+            .lines()
+            .filter(|line| line.starts_with("cyclomatic-population:"))
+            .collect::<Vec<_>>(),
+        [
+            "cyclomatic-population:functions:count=1,sum=1,max=1",
+            "cyclomatic-population:modules:count=1,sum=31,max=31",
+            "cyclomatic-population:templates:count=0,sum=0,max=null",
+        ]
+    );
+
     let markdown = run_fallow_in_root("health", dir.path(), &["--format", "markdown"]);
     assert!(
         markdown

--- a/docs/reference/cli-internals.md
+++ b/docs/reference/cli-internals.md
@@ -127,6 +127,25 @@ an exit code.
   `attribution.duplication_demoted` and a per-group `demotion_reason` field;
   human output names the deciding diff source in the demotion note.
 
+## Compact health populations
+
+Compact health output keeps the existing `vital-signs:` payload unchanged and
+appends population rows immediately after it, in `functions`, `modules`, then
+`templates` order:
+
+```text
+cyclomatic-population:functions:count=1,sum=1,max=1
+cyclomatic-population:modules:count=1,sum=31,max=31
+cyclomatic-population:templates:count=0,sum=0,max=null
+```
+
+Each row mirrors the matching `vital_signs.cyclomatic_population` JSON group.
+Counts and sums are decimal integers; `max` is a decimal integer or literal
+`null`. A measured-empty group has `count=0,sum=0,max=null`. Older reports without
+population metadata emit no population rows. Sum the group sums and counts to
+reconstruct the cyclomatic mean; module scopes remain aggregate-only and do not
+produce function findings. These rows describe metrics, not findings.
+
 ## Viz lenses and availability
 
 `fallow viz` runs one engine-owned project analysis with complexity artifacts


### PR DESCRIPTION
Compact health output showed cyclomatic averages and percentiles without the population information already available in JSON. It now emits count, sum and maximum rows for authored functions, module scopes and templates, so consumers can reconcile aggregate complexity with function findings.

The existing `vital-signs:` payload is unchanged. New `cyclomatic-population:` rows have a fixed functions/modules/templates order. Reports without population metadata omit them; measured-empty groups retain `max=null`.

Validation: the minimal regression failed before the fix and passes through the API and CLI. Public Zod output matches JSON and preserves every previous compact row. `npm run verify:full` and repository hooks pass. Independent smoke checks also pass for the original destructuring regression, extraction-cache upgrade, module complexity reconstruction, and Zod/TanStack Query cache parity.

Completes compact-format coverage for #2519. Public documentation: https://github.com/fallow-rs/docs/pull/25
