### PR TITLE
fix(coverage): point the post-upload dashboard link at the repository route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unaffected; it keys on content hashes and deliberately avoids `ctime`, since
   `cp -Rp` and CI cache restores preserve mtime but reset it.
 
+- **The dashboard link printed after a coverage upload no longer 404s.**
+  `fallow coverage upload-inventory` and `fallow coverage upload-static-findings`
+  printed `https://fallow.cloud/<project-id>`, but the dashboard serves a
+  repository at `/repo/<project-id>`. Both commands now print that route, and
+  the project id is percent-encoded, so a slash-scoped id such as
+  `owner/my-service` becomes `owner%2Fmy-service` and resolves to the same page
+  a bare id does
+  (Closes [#2597](https://github.com/fallow-rs/fallow/issues/2597)).
+
 - **A quoted jq filter in a CI `run:` block is no longer read as an entry
   glob.** A workflow line like `jq -r '[((.proposals // {}) | to_entries[]) |
   .value.pr_number] | unique | sort[]'` warned `invalid entry pattern ...

--- a/crates/cli/src/coverage/upload_common.rs
+++ b/crates/cli/src/coverage/upload_common.rs
@@ -161,6 +161,18 @@ pub fn url_encode_path_segment(value: &str) -> String {
     out
 }
 
+/// Build the dashboard URL for a repository page.
+///
+/// The dashboard serves a repository at `/repo/{repo}`, and the project id is a
+/// single route segment, so a slash-scoped id such as `owner/my-service` must be
+/// percent-encoded (`owner%2Fmy-service`) or the link resolves to a 404.
+pub(super) fn dashboard_repo_url(project_id: &str) -> String {
+    format!(
+        "https://fallow.cloud/repo/{}",
+        url_encode_path_segment(project_id)
+    )
+}
+
 pub(super) fn resolve_git_sha(
     explicit_git_sha: Option<&str>,
     root: &Path,
@@ -351,6 +363,22 @@ mod tests {
         assert!(validate_project_id("../etc/passwd").is_err());
         assert!(validate_project_id("acme/../secret").is_err());
         assert!(validate_project_id("").is_err());
+    }
+
+    #[test]
+    fn dashboard_repo_url_targets_the_repo_route() {
+        assert_eq!(
+            dashboard_repo_url("my-service"),
+            "https://fallow.cloud/repo/my-service"
+        );
+    }
+
+    #[test]
+    fn dashboard_repo_url_encodes_a_slash_scoped_project_id() {
+        assert_eq!(
+            dashboard_repo_url("owner/my-service"),
+            "https://fallow.cloud/repo/owner%2Fmy-service"
+        );
     }
 
     #[test]

--- a/crates/cli/src/coverage/upload_inventory.rs
+++ b/crates/cli/src/coverage/upload_inventory.rs
@@ -947,7 +947,8 @@ fn upload(
             format_bytes(data.data.blob_size),
         );
         println!(
-            "  -> Inventory stored. The Untracked filter lights up once runtime coverage arrives for this SHA. Dashboard: https://fallow.cloud/{project_id}"
+            "  -> Inventory stored. The Untracked filter lights up once runtime coverage arrives for this SHA. Dashboard: {}",
+            upload_common::dashboard_repo_url(project_id)
         );
         if let Some(overlap) = data.data.path_overlap.as_ref() {
             print_overlap_warning_if_needed(overlap);

--- a/crates/cli/src/coverage/upload_static_findings.rs
+++ b/crates/cli/src/coverage/upload_static_findings.rs
@@ -361,7 +361,8 @@ fn upload(
             data.data.git_sha,
         );
         println!(
-            "  -> Static findings stored. View them on the source-evidence viewer: https://fallow.cloud/{project_id}"
+            "  -> Static findings stored. View them on the source-evidence viewer: {}",
+            upload_common::dashboard_repo_url(project_id)
         );
         return Ok(());
     }


### PR DESCRIPTION
## What changed

`fallow coverage upload-inventory` printed `Dashboard: https://fallow.cloud/{project_id}` after a successful upload. The dashboard serves a repository at `/repo/{project_id}`, so that link was always a 404. `fallow coverage upload-static-findings` printed the same wrong shape in its "View them on the source-evidence viewer" line.

Both commands now build the link through a shared `dashboard_repo_url` helper in `crates/cli/src/coverage/upload_common.rs`. It targets `/repo/{project_id}` and percent-encodes the project id with the existing `url_encode_path_segment`, so a slash-scoped id such as `owner/my-service` becomes `owner%2Fmy-service` and stays a single route segment.

`upload-source-maps` prints no dashboard link, so it needed no change.

## How it was verified

- New unit tests assert both acceptance shapes: `my-service` renders `https://fallow.cloud/repo/my-service`, and `owner/my-service` renders `https://fallow.cloud/repo/owner%2Fmy-service`.
- `cargo test -p fallow-cli --lib` passes.
- `cargo fmt --all -- --check` and `cargo clippy -p fallow-cli --all-targets -- -D warnings` are clean.
- No JSON output shape changed, so `docs/output-schema.json` is untouched.

Closes #2597