### PR TITLE
fix: let license refresh fall back to a full-access API key

### DIFF
--- a/.agents/skills/fallow/references/cli-reference.md
+++ b/.agents/skills/fallow/references/cli-reference.md
@@ -1112,7 +1112,7 @@ fallow license deactivate
 |------------|---------|
 | `activate` | Install a JWT or start a 30-day trial. JWT input precedence: positional arg > `--from-file` > `--stdin`. |
 | `status`   | Print tier, seats, features, days-until-expiry, and (when `refresh_after` has passed) a proactive refresh hint. |
-| `refresh`  | Fetch a fresh JWT using the currently stored one as identity proof. Exit 7 on network failure. |
+| `refresh`  | Fetch a fresh JWT using the currently stored one as identity proof, falling back to a full-access API key when that token is missing or too stale. Exit 7 on network failure. |
 | `deactivate` | Remove the local license file. |
 
 ### `activate` flags
@@ -1123,6 +1123,19 @@ fallow license deactivate
 | `--email <ADDR>` | string | Email for the trial flow. On success, `trialEndsAt` is printed to stdout so you can see the trial window without decoding the JWT. |
 | `--from-file <PATH>` | path | Read a JWT from a file. |
 | `--stdin` | bool | Read a JWT from stdin. Conflicts with `--from-file` and positional JWT. |
+
+### `refresh` flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--api-key <KEY>` | string | Full-access API key used as the bearer when the stored license JWT is missing or the cloud reports it as `token_stale`. Precedence: this flag > `$FALLOW_API_KEY`. Prefer the environment variable on shared runners so the key stays out of argv. |
+
+### Credential order for `refresh`
+
+1. The stored license JWT (`FALLOW_LICENSE`, `FALLOW_LICENSE_PATH`, or `~/.fallow/license.jwt`).
+2. A full-access API key, when the stored JWT is absent or the cloud answers `token_stale`.
+
+A machine that has not run fallow for weeks holds a JWT the cloud refuses, and the trial endpoint rejects an organisation that already pays, so the API key is the recovery path. With neither credential available, `refresh` names that route instead of the trial flow.
 
 ### Storage precedence
 
@@ -1144,7 +1157,7 @@ On HTTP error from `api.fallow.cloud`, fallow parses the `{error, message, code}
 
 | Operation + code | CLI message |
 |------------------|-------------|
-| `refresh` + `token_stale` | `your stored license is too stale to refresh. Reactivate with: fallow license activate --trial --email <addr>` |
+| `refresh` + `token_stale` | your stored license is too stale to refresh: set `FALLOW_API_KEY` to a full-access key and run `fallow license refresh` again (generate one at `https://fallow.cloud/settings#api-keys`) |
 | `refresh` + `invalid_token` | `your stored license token is missing required claims. Reactivate with: fallow license activate --trial --email <addr>` |
 | `refresh` or `trial` + `unauthorized` | `authentication failed. Reactivate with: fallow license activate --trial --email <addr>` |
 | `trial` + `rate_limit_exceeded` | `trial creation is rate-limited to 5 per hour per IP. Wait an hour or retry from a different network (in CI, start the trial locally and set FALLOW_LICENSE on the runner).` |

--- a/.agents/skills/fallow/references/gotchas.md
+++ b/.agents/skills/fallow/references/gotchas.md
@@ -600,14 +600,14 @@ Both require a `GITLAB_TOKEN` CI/CD variable (project access token with `api` sc
 `fallow license refresh` and `fallow license activate --trial` can fail with a backend error. The CLI always appends the raw HTTP status and the backend error code after the human hint, so scripts can grep for the code without parsing prose:
 
 ```
-fallow license refresh: your stored license is too stale to refresh. Reactivate with: fallow license activate --trial --email <addr> (HTTP 401, code token_stale)
+fallow license refresh: your stored license is too stale to refresh: set FALLOW_API_KEY to a full-access key and run `fallow license refresh` again (generate one at https://fallow.cloud/settings#api-keys) (HTTP 401, code token_stale)
 ```
 
 Stable codes the CLI surfaces today:
 
 | Code | Operation | Meaning |
 |------|-----------|---------|
-| `token_stale` | `refresh` | Stored JWT is more than 45 days past its `exp`. Reactivate. |
+| `token_stale` | `refresh` | Stored JWT is more than 45 days past its `exp`. Surfaced only when no full-access API key was available to retry with. |
 | `invalid_token` | `refresh` | Stored JWT is missing required claims (e.g. `sub`). Reactivate. |
 | `unauthorized` | `refresh` or `trial` | Auth failed. Reactivate. |
 | `rate_limit_exceeded` | `trial` | Trial endpoint is capped at 5 per hour per IP. Wait or use a different network. |

--- a/.claude/skills/fallow/references/cli-reference.md
+++ b/.claude/skills/fallow/references/cli-reference.md
@@ -1112,7 +1112,7 @@ fallow license deactivate
 |------------|---------|
 | `activate` | Install a JWT or start a 30-day trial. JWT input precedence: positional arg > `--from-file` > `--stdin`. |
 | `status`   | Print tier, seats, features, days-until-expiry, and (when `refresh_after` has passed) a proactive refresh hint. |
-| `refresh`  | Fetch a fresh JWT using the currently stored one as identity proof. Exit 7 on network failure. |
+| `refresh`  | Fetch a fresh JWT using the currently stored one as identity proof, falling back to a full-access API key when that token is missing or too stale. Exit 7 on network failure. |
 | `deactivate` | Remove the local license file. |
 
 ### `activate` flags
@@ -1123,6 +1123,19 @@ fallow license deactivate
 | `--email <ADDR>` | string | Email for the trial flow. On success, `trialEndsAt` is printed to stdout so you can see the trial window without decoding the JWT. |
 | `--from-file <PATH>` | path | Read a JWT from a file. |
 | `--stdin` | bool | Read a JWT from stdin. Conflicts with `--from-file` and positional JWT. |
+
+### `refresh` flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--api-key <KEY>` | string | Full-access API key used as the bearer when the stored license JWT is missing or the cloud reports it as `token_stale`. Precedence: this flag > `$FALLOW_API_KEY`. Prefer the environment variable on shared runners so the key stays out of argv. |
+
+### Credential order for `refresh`
+
+1. The stored license JWT (`FALLOW_LICENSE`, `FALLOW_LICENSE_PATH`, or `~/.fallow/license.jwt`).
+2. A full-access API key, when the stored JWT is absent or the cloud answers `token_stale`.
+
+A machine that has not run fallow for weeks holds a JWT the cloud refuses, and the trial endpoint rejects an organisation that already pays, so the API key is the recovery path. With neither credential available, `refresh` names that route instead of the trial flow.
 
 ### Storage precedence
 
@@ -1144,7 +1157,7 @@ On HTTP error from `api.fallow.cloud`, fallow parses the `{error, message, code}
 
 | Operation + code | CLI message |
 |------------------|-------------|
-| `refresh` + `token_stale` | `your stored license is too stale to refresh. Reactivate with: fallow license activate --trial --email <addr>` |
+| `refresh` + `token_stale` | your stored license is too stale to refresh: set `FALLOW_API_KEY` to a full-access key and run `fallow license refresh` again (generate one at `https://fallow.cloud/settings#api-keys`) |
 | `refresh` + `invalid_token` | `your stored license token is missing required claims. Reactivate with: fallow license activate --trial --email <addr>` |
 | `refresh` or `trial` + `unauthorized` | `authentication failed. Reactivate with: fallow license activate --trial --email <addr>` |
 | `trial` + `rate_limit_exceeded` | `trial creation is rate-limited to 5 per hour per IP. Wait an hour or retry from a different network (in CI, start the trial locally and set FALLOW_LICENSE on the runner).` |

--- a/.claude/skills/fallow/references/gotchas.md
+++ b/.claude/skills/fallow/references/gotchas.md
@@ -600,14 +600,14 @@ Both require a `GITLAB_TOKEN` CI/CD variable (project access token with `api` sc
 `fallow license refresh` and `fallow license activate --trial` can fail with a backend error. The CLI always appends the raw HTTP status and the backend error code after the human hint, so scripts can grep for the code without parsing prose:
 
 ```
-fallow license refresh: your stored license is too stale to refresh. Reactivate with: fallow license activate --trial --email <addr> (HTTP 401, code token_stale)
+fallow license refresh: your stored license is too stale to refresh: set FALLOW_API_KEY to a full-access key and run `fallow license refresh` again (generate one at https://fallow.cloud/settings#api-keys) (HTTP 401, code token_stale)
 ```
 
 Stable codes the CLI surfaces today:
 
 | Code | Operation | Meaning |
 |------|-----------|---------|
-| `token_stale` | `refresh` | Stored JWT is more than 45 days past its `exp`. Reactivate. |
+| `token_stale` | `refresh` | Stored JWT is more than 45 days past its `exp`. Surfaced only when no full-access API key was available to retry with. |
 | `invalid_token` | `refresh` | Stored JWT is missing required claims (e.g. `sub`). Reactivate. |
 | `unauthorized` | `refresh` or `trial` | Auth failed. Reactivate. |
 | `rate_limit_exceeded` | `trial` | Trial endpoint is capped at 5 per hour per IP. Wait or use a different network. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--debug-unmatched` flag lists every remaining unmatched runtime function on
   stderr, highest traffic first, so a residue can be read without a debugger.
 
+- **`fallow license refresh` can recover from a stale stored license.** The
+  command sent the locally stored JWT as its only identity proof. A paid user
+  who had not run the CLI for weeks held a token the cloud refuses as
+  `token_stale`, and `license activate --trial` refuses an organisation that
+  already pays, which left no way back in from the CLI. Refresh now retries
+  with a full-access API key, taken from `--api-key` or `FALLOW_API_KEY`, when
+  the stored JWT is missing or the cloud reports it as stale; the endpoint
+  already accepted that bearer. The stored JWT is still tried first and a
+  rejection the key cannot fix is not retried. When no credential works, the
+  error names the API-key route instead of the trial flow
+  (Closes [#2595](https://github.com/fallow-rs/fallow/issues/2595)).
+
 - **A quoted jq filter in a CI `run:` block is no longer read as an entry
   glob.** A workflow line like `jq -r '[((.proposals // {}) | to_entries[]) |
   .value.pr_number] | unique | sort[]'` warned `invalid entry pattern ...

--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -277,14 +277,33 @@ fn clamp_retry_delay(delay: Duration) -> Duration {
     delay.min(Duration::from_secs(RETRY_MAX_WAIT_SECONDS))
 }
 
+/// Backend error code for a stored license JWT the cloud considers too far
+/// past expiry to refresh. `fallow license refresh` retries such a response
+/// with a full-access API key before giving up.
+pub const TOKEN_STALE_CODE: &str = "token_stale";
+
+/// The recovery path for `fallow license refresh` when the stored license JWT
+/// cannot be exchanged for a fresh one. Declared as a macro so it can be
+/// `concat!`-ed into the `&'static str` hints below and still be referenced as
+/// a plain value through [`LICENSE_API_KEY_RECOVERY`].
+macro_rules! license_api_key_recovery {
+    () => {
+        "set FALLOW_API_KEY to a full-access key and run `fallow license refresh` again (generate one at https://fallow.cloud/settings#api-keys)"
+    };
+}
+
+/// See [`license_api_key_recovery`].
+pub const LICENSE_API_KEY_RECOVERY: &str = license_api_key_recovery!();
+
 /// Map a backend error-code + operation pair to an actionable user-facing
 /// hint. Returns `None` for unknown codes; callers fall back to the generic
 /// "HTTP N: body" shape produced by [`http_status_message`].
 pub fn actionable_error_hint(operation: &str, code: &str) -> Option<&'static str> {
     match (operation, code) {
-        ("refresh", "token_stale") => Some(
-            "your stored license is too stale to refresh. Reactivate with: fallow license activate --trial --email <addr>",
-        ),
+        ("refresh", "token_stale") => Some(concat!(
+            "your stored license is too stale to refresh: ",
+            license_api_key_recovery!()
+        )),
         ("refresh", "invalid_token") => Some(
             "your stored license token is missing required claims. Reactivate with: fallow license activate --trial --email <addr>",
         ),
@@ -440,23 +459,50 @@ const fn is_token_byte(byte: u8) -> bool {
     matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'.' | b'-' | b'=')
 }
 
-/// Format a non-2xx response into a user-facing error string.
+/// A non-2xx fallow-cloud response, split into the machine-readable backend
+/// code and the user-facing message rendered from it.
+///
+/// The body can only be read once, so callers that need to branch on the code
+/// (for example the license-refresh credential fallback) take both halves from
+/// a single [`http_status_failure`] call.
+#[derive(Debug)]
+pub struct HttpFailure {
+    /// Backend `code` from the error envelope, when the body carried one.
+    pub code: Option<String>,
+    /// User-facing message, identical to what [`http_status_message`] renders.
+    pub message: String,
+}
+
+/// Read a non-2xx response into its backend code plus a user-facing message.
 ///
 /// Tries to parse the body as an [`ErrorEnvelope`]. When the envelope has a
 /// known `code` for the given `operation`, the mapped hint is returned with
 /// the HTTP status and code appended. Otherwise the backend's `message`
 /// (or raw body) is appended to a generic "HTTP N" line.
-pub fn http_status_message(response: &mut impl ResponseBodyReader, operation: &str) -> String {
+pub fn http_status_failure(response: &mut impl ResponseBodyReader, operation: &str) -> HttpFailure {
     let status = response.status();
     let body = response.read_to_string().unwrap_or_default();
     let envelope = parse_error_envelope(&body);
-    if let Some(code) = envelope.code()
-        && let Some(hint) = actionable_error_hint(operation, code)
-    {
-        return format!("{hint} (HTTP {status}, code {code})");
-    }
-    let body_suffix = response_message_suffix(&body, &envelope);
-    format!("{operation} request failed with HTTP {status}{body_suffix}")
+    let code = envelope.code().map(str::to_owned);
+    let hint = code
+        .as_deref()
+        .and_then(|code| actionable_error_hint(operation, code).map(|hint| (hint, code)));
+    let message = match hint {
+        Some((hint, code)) => format!("{hint} (HTTP {status}, code {code})"),
+        None => {
+            let body_suffix = response_message_suffix(&body, &envelope);
+            format!("{operation} request failed with HTTP {status}{body_suffix}")
+        }
+    };
+    HttpFailure { code, message }
+}
+
+/// Format a non-2xx response into a user-facing error string.
+///
+/// Thin wrapper over [`http_status_failure`] for callers that do not branch on
+/// the backend code.
+pub fn http_status_message(response: &mut impl ResponseBodyReader, operation: &str) -> String {
+    http_status_failure(response, operation).message
 }
 
 #[cfg(test)]
@@ -483,17 +529,43 @@ mod tests {
     }
 
     #[test]
-    fn refresh_token_stale_hint_points_to_reactivation() {
+    fn refresh_token_stale_hint_points_to_the_api_key_route() {
         let mut response = StubResponse {
             status: 401,
             body: r#"{"error":true,"message":"token stale","code":"token_stale"}"#.to_owned(),
         };
         let message = http_status_message(&mut response, "refresh");
         assert!(
-            message.contains("Reactivate with: fallow license activate --trial"),
-            "expected reactivation hint, got: {message}"
+            message.contains(LICENSE_API_KEY_RECOVERY),
+            "expected the API-key recovery route, got: {message}"
+        );
+        assert!(
+            !message.contains("--trial"),
+            "a stale token cannot be recovered through the trial flow, got: {message}"
         );
         assert!(message.contains("token_stale"));
+    }
+
+    #[test]
+    fn http_status_failure_exposes_the_backend_code_with_the_message() {
+        let mut response = StubResponse {
+            status: 401,
+            body: r#"{"error":true,"code":"token_stale"}"#.to_owned(),
+        };
+        let failure = http_status_failure(&mut response, "refresh");
+        assert_eq!(failure.code.as_deref(), Some(TOKEN_STALE_CODE));
+        assert!(failure.message.contains(LICENSE_API_KEY_RECOVERY));
+    }
+
+    #[test]
+    fn http_status_failure_reports_no_code_when_the_body_carries_none() {
+        let mut response = StubResponse {
+            status: 500,
+            body: "upstream exploded".to_owned(),
+        };
+        let failure = http_status_failure(&mut response, "refresh");
+        assert!(failure.code.is_none());
+        assert!(failure.message.contains("HTTP 500"));
     }
 
     #[test]
@@ -786,6 +858,11 @@ mod tests {
             LICENSE,
             "ActivateArgs",
             r#".field("raw_jwt", &self.raw_jwt.as_ref().map(|_| "***"))"#,
+        );
+        assert_manual_debug_mask(
+            LICENSE,
+            "RefreshArgs",
+            r#".field("api_key", &self.api_key.as_ref().map(|_| "***"))"#,
         );
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1996,7 +1996,23 @@ enum LicenseCli {
     /// Show the active license tier, seats, features, and days remaining.
     Status,
     /// Fetch a fresh JWT from `api.fallow.cloud` (network-only).
-    Refresh,
+    ///
+    /// The stored license JWT is the primary identity proof. When it is
+    /// missing, or the cloud reports it as too stale to exchange, the request
+    /// is retried with a full-access API key.
+    Refresh {
+        /// Fallow cloud API key (bearer token) used when the stored license
+        /// JWT cannot be refreshed.
+        ///
+        /// Precedence: this flag > $FALLOW_API_KEY. Generate at
+        /// <https://fallow.cloud/settings#api-keys>.
+        ///
+        /// Security: prefer $FALLOW_API_KEY on shared CI runners. Passing a
+        /// secret on the command line may be visible to other processes via
+        /// `ps` and can leak into shell history or process audit logs.
+        #[arg(long, value_name = "KEY")]
+        api_key: Option<String>,
+    },
     /// Remove the local license file.
     Deactivate,
 }
@@ -4933,7 +4949,9 @@ fn map_license_subcommand(sub: LicenseCli) -> license::LicenseSubcommand {
             email,
         }),
         LicenseCli::Status => license::LicenseSubcommand::Status,
-        LicenseCli::Refresh => license::LicenseSubcommand::Refresh,
+        LicenseCli::Refresh { api_key } => {
+            license::LicenseSubcommand::Refresh(license::RefreshArgs { api_key })
+        }
         LicenseCli::Deactivate => license::LicenseSubcommand::Deactivate,
     }
 }

--- a/crates/cli/src/license/mod.rs
+++ b/crates/cli/src/license/mod.rs
@@ -24,7 +24,8 @@ use fallow_license::{
 use serde::{Deserialize, Serialize};
 
 use crate::api::{
-    NETWORK_EXIT_CODE, api_url, http_status_message, sanitize_network_error, try_api_agent,
+    LICENSE_API_KEY_RECOVERY, NETWORK_EXIT_CODE, TOKEN_STALE_CODE, api_url, http_status_failure,
+    http_status_message, sanitize_network_error, try_api_agent,
 };
 use crate::exit_codes::RESOURCE_UNAVAILABLE_EXIT_CODE as LICENSE_UNAVAILABLE_EXIT_CODE;
 use crate::json_style::JsonStyle;
@@ -54,7 +55,7 @@ pub enum LicenseSubcommand {
     Status,
     /// Fetch a fresh JWT from `api.fallow.cloud`, verify it offline, and
     /// persist it to the active license path.
-    Refresh,
+    Refresh(RefreshArgs),
     /// Remove the local license file.
     Deactivate,
 }
@@ -84,6 +85,23 @@ impl std::fmt::Debug for ActivateArgs {
             .field("from_stdin", &self.from_stdin)
             .field("trial", &self.trial)
             .field("email", &self.email)
+            .finish()
+    }
+}
+
+/// Arguments for `fallow license refresh`.
+#[derive(Clone, Default)]
+pub struct RefreshArgs {
+    /// Full-access API key used as the bearer when the stored license JWT is
+    /// missing or too stale to refresh. Overrides `$FALLOW_API_KEY`.
+    pub api_key: Option<String>,
+}
+
+// Manual `Debug` masks the API key in logs.
+impl std::fmt::Debug for RefreshArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshArgs")
+            .field("api_key", &self.api_key.as_ref().map(|_| "***"))
             .finish()
     }
 }
@@ -140,7 +158,7 @@ pub fn run(
     match subcommand {
         LicenseSubcommand::Activate(args) => run_activate(args, json, json_style),
         LicenseSubcommand::Status => run_status(json, json_style),
-        LicenseSubcommand::Refresh => run_refresh(json, json_style),
+        LicenseSubcommand::Refresh(args) => run_refresh(args, json, json_style),
         LicenseSubcommand::Deactivate => run_deactivate(json, json_style),
     }
 }
@@ -243,8 +261,8 @@ fn run_status(json: bool, json_style: JsonStyle) -> ExitCode {
     }
 }
 
-fn run_refresh(json: bool, json_style: JsonStyle) -> ExitCode {
-    match refresh_active_license(json) {
+fn run_refresh(args: &RefreshArgs, json: bool, json_style: JsonStyle) -> ExitCode {
+    match refresh_active_license(args.api_key.as_deref(), json) {
         Ok(status) => {
             emit_status(&status, LicenseKind::Refresh, json, json_style);
             ExitCode::SUCCESS
@@ -396,31 +414,115 @@ pub fn activate_trial(email: &str, json: bool) -> Result<LicenseStatus, String> 
     store_verified_jwt(&mut response, "trial", json)
 }
 
-pub fn refresh_active_license(json: bool) -> Result<LicenseStatus, String> {
-    let current = load_current_jwt()?;
-    let mut response = try_api_agent()
-        .map_err(|err| err.to_string())?
-        .post(&api_url("/v1/auth/license/refresh"))
-        .header("Authorization", &format!("Bearer {current}"))
-        .send_empty()
-        .map_err(|err| {
-            sanitize_network_error(&format!("failed to refresh the current license: {err}"))
-        })?;
-    if !response.status().is_success() {
-        return Err(http_status_message(&mut response, "refresh"));
-    }
-    store_verified_jwt(&mut response, "refresh", json)
+/// Outcome of a single refresh call, seen from the credential that was sent.
+enum RefreshAttempt<T> {
+    /// The cloud accepted the credential and returned a fresh license.
+    Accepted(T),
+    /// The credential is too stale to exchange; another credential may still
+    /// work, so the caller may retry.
+    Stale(String),
+    /// The attempt failed for a reason no other credential can fix.
+    Rejected(String),
 }
 
-fn load_current_jwt() -> Result<String, String> {
-    match fallow_license::load_raw_jwt() {
-        Ok(Some(jwt)) => Ok(jwt),
-        Ok(None) => Err(
-            "no license found. Run: fallow license activate --trial --email you@company.com"
-                .to_owned(),
-        ),
-        Err(err) => Err(format!("failed to read the current license: {err}")),
+/// Exchange the machine's credentials for a fresh license JWT.
+///
+/// The stored license JWT is the primary identity proof. It stops working once
+/// the cloud considers it stale, and it is absent on a machine that never
+/// activated, so both cases fall back to a full-access API key (`--api-key`,
+/// otherwise `$FALLOW_API_KEY`) which the refresh endpoint accepts as an
+/// equivalent bearer.
+pub fn refresh_active_license(api_key: Option<&str>, json: bool) -> Result<LicenseStatus, String> {
+    let stored = load_stored_jwt()?;
+    let api_key = resolve_refresh_api_key(api_key);
+    refresh_with_credentials(stored.as_deref(), api_key.as_deref(), |bearer| {
+        attempt_refresh(bearer, json)
+    })
+}
+
+/// Drive the credential order: stored JWT first, API key second.
+///
+/// Split from the transport so the order and the terminal error text are unit
+/// testable without a network round-trip.
+fn refresh_with_credentials<T>(
+    stored_jwt: Option<&str>,
+    api_key: Option<&str>,
+    mut attempt: impl FnMut(&str) -> RefreshAttempt<T>,
+) -> Result<T, String> {
+    let stale = match stored_jwt {
+        Some(jwt) => match attempt(jwt) {
+            RefreshAttempt::Accepted(status) => return Ok(status),
+            RefreshAttempt::Rejected(message) => return Err(message),
+            RefreshAttempt::Stale(message) => Some(message),
+        },
+        None => None,
+    };
+    let Some(api_key) = api_key else {
+        return Err(
+            stale.unwrap_or_else(|| format!("no license found: {LICENSE_API_KEY_RECOVERY}"))
+        );
+    };
+    match attempt(api_key) {
+        RefreshAttempt::Accepted(status) => Ok(status),
+        RefreshAttempt::Stale(message) | RefreshAttempt::Rejected(message) => Err(message),
     }
+}
+
+/// Send one refresh request with `bearer` as the credential.
+fn attempt_refresh(bearer: &str, json: bool) -> RefreshAttempt<LicenseStatus> {
+    let agent = match try_api_agent() {
+        Ok(agent) => agent,
+        Err(err) => return RefreshAttempt::Rejected(err.to_string()),
+    };
+    let sent = agent
+        .post(&api_url("/v1/auth/license/refresh"))
+        .header("Authorization", &format!("Bearer {bearer}"))
+        .send_empty();
+    let mut response = match sent {
+        Ok(response) => response,
+        Err(err) => return RefreshAttempt::Rejected(refresh_transport_error(&err)),
+    };
+    if !response.status().is_success() {
+        let failure = http_status_failure(&mut response, "refresh");
+        return if failure.code.as_deref() == Some(TOKEN_STALE_CODE) {
+            RefreshAttempt::Stale(failure.message)
+        } else {
+            RefreshAttempt::Rejected(failure.message)
+        };
+    }
+    match store_verified_jwt(&mut response, "refresh", json) {
+        Ok(status) => RefreshAttempt::Accepted(status),
+        Err(message) => RefreshAttempt::Rejected(message),
+    }
+}
+
+/// Render a refresh transport failure with any bearer token redacted.
+fn refresh_transport_error(err: &ureq::Error) -> String {
+    sanitize_network_error(&format!("failed to refresh the current license: {err}"))
+}
+
+/// Read the stored license JWT. A machine with no license at all is a
+/// recoverable absence (the API key can still refresh), while an unreadable
+/// license file is a local problem no credential fixes.
+fn load_stored_jwt() -> Result<Option<String>, String> {
+    fallow_license::load_raw_jwt()
+        .map_err(|err| format!("failed to read the current license: {err}"))
+}
+
+/// Resolve the fallback API key: `--api-key` first, then `$FALLOW_API_KEY`.
+fn resolve_refresh_api_key(explicit: Option<&str>) -> Option<String> {
+    select_api_key(explicit, std::env::var("FALLOW_API_KEY").ok().as_deref())
+}
+
+/// [`resolve_refresh_api_key`] over injected values, so the precedence and the
+/// blank-value handling are testable without mutating the process environment.
+fn select_api_key(explicit: Option<&str>, from_env: Option<&str>) -> Option<String> {
+    [explicit, from_env]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
 }
 
 fn store_verified_jwt(
@@ -795,6 +897,116 @@ mod tests {
         let bare = ActivateArgs::default();
         assert!(format!("{bare:?}").contains("raw_jwt: None"));
         assert!(formatted.contains("email: Some(\"alice@example.com\")"));
+    }
+
+    #[test]
+    fn refresh_args_debug_masks_the_api_key() {
+        let args = RefreshArgs {
+            api_key: Some("fallow_live_secret".to_owned()),
+        };
+        let formatted = format!("{args:?}");
+        assert!(
+            !formatted.contains("fallow_live_secret"),
+            "api_key leaked through Debug: {formatted}"
+        );
+        assert!(formatted.contains("api_key: Some(\"***\")"));
+        assert!(format!("{:?}", RefreshArgs::default()).contains("api_key: None"));
+    }
+
+    #[test]
+    fn refresh_sends_the_stored_jwt_first() {
+        let mut sent = Vec::new();
+        let result = refresh_with_credentials(Some("stored-jwt"), Some("api-key"), |bearer| {
+            sent.push(bearer.to_owned());
+            RefreshAttempt::Accepted("fresh")
+        });
+
+        assert_eq!(result, Ok("fresh"));
+        assert_eq!(sent, ["stored-jwt"], "the API key must stay unused");
+    }
+
+    #[test]
+    fn refresh_falls_back_to_the_api_key_when_the_stored_jwt_is_stale() {
+        let mut sent = Vec::new();
+        let result = refresh_with_credentials(Some("stored-jwt"), Some("api-key"), |bearer| {
+            sent.push(bearer.to_owned());
+            if bearer == "stored-jwt" {
+                RefreshAttempt::Stale("stale".to_owned())
+            } else {
+                RefreshAttempt::Accepted("fresh")
+            }
+        });
+
+        assert_eq!(result, Ok("fresh"));
+        assert_eq!(sent, ["stored-jwt", "api-key"]);
+    }
+
+    #[test]
+    fn refresh_uses_the_api_key_when_no_license_is_stored() {
+        let mut sent = Vec::new();
+        let result = refresh_with_credentials(None, Some("api-key"), |bearer| {
+            sent.push(bearer.to_owned());
+            RefreshAttempt::Accepted("fresh")
+        });
+
+        assert_eq!(result, Ok("fresh"));
+        assert_eq!(sent, ["api-key"]);
+    }
+
+    #[test]
+    fn refresh_does_not_retry_a_credential_the_cloud_rejected() {
+        let mut sent = Vec::new();
+        let result = refresh_with_credentials(Some("stored-jwt"), Some("api-key"), |bearer| {
+            sent.push(bearer.to_owned());
+            RefreshAttempt::<&str>::Rejected("server error".to_owned())
+        });
+
+        assert_eq!(result, Err("server error".to_owned()));
+        assert_eq!(sent, ["stored-jwt"], "only a stale token earns a retry");
+    }
+
+    #[test]
+    fn refresh_without_a_license_or_an_api_key_names_the_api_key_route() {
+        let result =
+            refresh_with_credentials(None, None, |_| RefreshAttempt::Accepted("unreachable"));
+
+        let error = result.expect_err("no credential can refresh");
+        assert!(
+            error.contains(LICENSE_API_KEY_RECOVERY),
+            "expected the API-key recovery route, got: {error}"
+        );
+        assert!(
+            !error.contains("--trial"),
+            "the trial flow does not recover a paid license, got: {error}"
+        );
+    }
+
+    #[test]
+    fn refresh_reports_the_stale_response_when_no_api_key_is_available() {
+        let stale = format!("too stale: {LICENSE_API_KEY_RECOVERY}");
+        let result = refresh_with_credentials(Some("stored-jwt"), None, |_| {
+            RefreshAttempt::<&str>::Stale(stale.clone())
+        });
+
+        assert_eq!(result, Err(stale));
+    }
+
+    #[test]
+    fn api_key_selection_prefers_the_flag_over_the_environment() {
+        assert_eq!(
+            select_api_key(Some("from-flag"), Some("from-env")).as_deref(),
+            Some("from-flag")
+        );
+    }
+
+    #[test]
+    fn api_key_selection_falls_through_blank_values() {
+        assert_eq!(
+            select_api_key(Some("  "), Some(" from-env ")).as_deref(),
+            Some("from-env")
+        );
+        assert_eq!(select_api_key(None, Some("   ")), None);
+        assert_eq!(select_api_key(None, None), None);
     }
 
     #[test]

--- a/crates/cli/src/schema.rs
+++ b/crates/cli/src/schema.rs
@@ -772,7 +772,7 @@ const ENVIRONMENT_VARIABLES: &[(&str, &str)] = &[
     ),
     (
         "FALLOW_API_KEY",
-        "fallow cloud bearer token for coverage upload commands.",
+        "fallow cloud bearer token for coverage upload commands, and the fallback bearer for fallow license refresh when the stored license JWT is missing or too stale.",
     ),
     (
         "FALLOW_CA_BUNDLE",

--- a/crates/cli/tests/license_refresh_tests.rs
+++ b/crates/cli/tests/license_refresh_tests.rs
@@ -1,0 +1,196 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "tests and benches use unwrap and expect to keep fixture setup concise"
+)]
+
+//! End-to-end coverage for the `fallow license refresh` credential fallback.
+//!
+//! A paying user who has not run the CLI for weeks holds a license JWT the
+//! cloud refuses as `token_stale`, and the trial endpoint rejects an
+//! organisation that already pays. The refresh endpoint accepts a full-access
+//! API key as an equivalent bearer, so the CLI retries with one before giving
+//! up. These tests drive the real binary against a stub of that endpoint and
+//! assert the request sequence and the terminal error text.
+
+mod common;
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use common::fallow_bin;
+
+struct MockResponse {
+    status: u16,
+    body: &'static str,
+}
+
+/// Serve exactly `responses.len()` requests, returning the raw request text of
+/// each in order.
+fn serve(responses: Vec<MockResponse>) -> (String, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+    let url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let handle = {
+        let requests = Arc::clone(&requests);
+        thread::spawn(move || {
+            for response in responses {
+                let Some(mut stream) = accept_before_deadline(&listener) else {
+                    break;
+                };
+                let request = read_request(&mut stream);
+                requests.lock().expect("request lock").push(request);
+                write_response(&mut stream, response.status, response.body);
+            }
+            Arc::try_unwrap(requests)
+                .expect("request refs released")
+                .into_inner()
+                .expect("request lock")
+        })
+    };
+    (url, handle)
+}
+
+/// Accept one connection, giving up after ten seconds.
+///
+/// A regression that stops retrying leaves the second request unmade, and the
+/// deadline turns that into a failed assertion on the captured requests
+/// instead of a hung test.
+fn accept_before_deadline(listener: &TcpListener) -> Option<TcpStream> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    listener
+        .set_nonblocking(true)
+        .expect("non-blocking listener");
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream.set_nonblocking(false).expect("blocking stream");
+                return Some(stream);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                if std::time::Instant::now() >= deadline {
+                    return None;
+                }
+                thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(err) => panic!("accept request: {err}"),
+        }
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .expect("set read timeout");
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    loop {
+        let len = stream.read(&mut buffer).expect("read request");
+        if len == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..len]);
+        // The refresh request carries no body, so the header terminator ends it.
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    String::from_utf8_lossy(&request).to_string()
+}
+
+fn write_response(stream: &mut TcpStream, status: u16, body: &str) {
+    let reason = if status == 200 { "OK" } else { "Unauthorized" };
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write response");
+}
+
+fn refresh_command(home: &std::path::Path) -> Command {
+    let mut command = Command::new(fallow_bin());
+    command
+        .args(["license", "refresh"])
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("NO_COLOR", "1")
+        .env("RUST_LOG", "")
+        .env("FALLOW_UPDATE_CHECK", "off")
+        .env("FALLOW_TELEMETRY", "off")
+        .env_remove("FALLOW_LICENSE")
+        .env_remove("FALLOW_LICENSE_PATH")
+        .env_remove("FALLOW_API_KEY");
+    command
+}
+
+fn authorization(request: &str) -> String {
+    request
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("authorization")
+                .then(|| value.trim().to_owned())
+        })
+        .unwrap_or_else(|| panic!("no authorization header in:\n{request}"))
+}
+
+#[test]
+fn refresh_retries_with_the_api_key_when_the_stored_jwt_is_stale() {
+    let home = tempfile::tempdir().expect("temp home");
+    let (endpoint, server) = serve(vec![
+        MockResponse {
+            status: 401,
+            body: r#"{"error":true,"message":"token stale","code":"token_stale"}"#,
+        },
+        MockResponse {
+            status: 200,
+            body: r#"{"jwt":"header.payload.signature"}"#,
+        },
+    ]);
+
+    let output = refresh_command(home.path())
+        .env("FALLOW_API_URL", &endpoint)
+        .env("FALLOW_LICENSE", "stale.stored.jwt")
+        .env("FALLOW_API_KEY", "fallow_live_test")
+        .output()
+        .expect("run fallow license refresh");
+    let requests = server.join().expect("server joins");
+
+    assert_eq!(requests.len(), 2, "expected a retry, got: {requests:?}");
+    assert_eq!(authorization(&requests[0]), "Bearer stale.stored.jwt");
+    assert_eq!(authorization(&requests[1]), "Bearer fallow_live_test");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("fallow_live_test"),
+        "the API key must never be echoed, got: {stderr}"
+    );
+}
+
+#[test]
+fn refresh_without_a_license_or_an_api_key_names_the_api_key_route() {
+    let home = tempfile::tempdir().expect("temp home");
+
+    let output = refresh_command(home.path())
+        .env("FALLOW_API_URL", "http://127.0.0.1:1")
+        .output()
+        .expect("run fallow license refresh");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("FALLOW_API_KEY"),
+        "expected the API-key recovery route, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("fallow license refresh"),
+        "expected the command to retry, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("--trial"),
+        "the trial flow does not recover a paid license, got: {stderr}"
+    );
+}

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -74,7 +74,7 @@ documented here for completeness but stay out of the manifest.
 | Variable | Description | Default | Example |
 | --- | --- | --- | --- |
 | `FALLOW_API_URL` | Base URL override for fallow cloud API calls (license refresh, trial, coverage uploads). Trailing slashes are trimmed. | `https://api.fallow.cloud` | `FALLOW_API_URL=https://staging.fallow.cloud` |
-| `FALLOW_API_KEY` | fallow cloud bearer token for coverage upload commands. | unset | `FALLOW_API_KEY=fk_live_...` |
+| `FALLOW_API_KEY` | fallow cloud bearer token for coverage upload commands, and the fallback bearer for fallow license refresh when the stored license JWT is missing or too stale. | unset | `FALLOW_API_KEY=fk_live_...` |
 | `FALLOW_API_RETRIES` | Maximum HTTP attempts for review-comment reconciliation API calls. | `3` | `FALLOW_API_RETRIES=5` |
 | `FALLOW_API_RETRY_DELAY` | Floor delay in seconds between HTTP retry attempts; a server-supplied `Retry-After` overrides it on 429 responses. | `2` | `FALLOW_API_RETRY_DELAY=5` |
 | `FALLOW_CA_BUNDLE` | Path to a PEM certificate bundle for fallow cloud and provider HTTP calls; replaces the default WebPKI roots. Relative paths resolve from the process cwd. | unset | `FALLOW_CA_BUNDLE=/etc/ssl/corp-bundle.pem` |

--- a/npm/fallow/capabilities.json
+++ b/npm/fallow/capabilities.json
@@ -6055,7 +6055,7 @@
     "FALLOW_RUNTIME_COVERAGE_SOURCE": "Set to cloud to select cloud runtime coverage in fallow coverage analyze without passing --cloud.",
     "FALLOW_REPO": "owner/repo fallback for fallow coverage analyze --cloud when --repo is not passed (otherwise parsed from the git origin remote).",
     "FALLOW_API_URL": "Base URL override for fallow cloud API calls (license refresh, trial, coverage uploads).",
-    "FALLOW_API_KEY": "fallow cloud bearer token for coverage upload commands.",
+    "FALLOW_API_KEY": "fallow cloud bearer token for coverage upload commands, and the fallback bearer for fallow license refresh when the stored license JWT is missing or too stale.",
     "FALLOW_CA_BUNDLE": "Path to a PEM certificate bundle for fallow cloud and provider HTTP calls (replaces the default WebPKI roots).",
     "FALLOW_UPDATE_CHECK": "Set to off/0/false to disable the human-TTY upgrade nudge and its background version check.",
     "FALLOW_SUGGESTIONS": "Set to off/0/false/no/disabled to suppress the next_steps[] array of read-only follow-up commands in JSON output (and the human Next: line). Useful for CI consumers that snapshot-diff raw --format json output. Default on.",


### PR DESCRIPTION
## What changed

`fallow license refresh` sent the locally stored license JWT as its only identity proof. The cloud refuses a token more than 45 days past expiry with `token_stale`, and `fallow license activate --trial` refuses an organisation that is already on a paid tier, so a paying user who had not run the CLI for weeks had no recovery path from the CLI at all. The refresh endpoint already accepts a full-access API key as an equivalent bearer; only the client never sent one.

- Refresh now retries with a full-access API key, taken from the new `--api-key` flag or `FALLOW_API_KEY`, when the stored JWT is missing or the cloud answers `token_stale`. The stored JWT is still tried first, and a rejection that no other credential can fix is not retried.
- With neither credential usable, the error names the API-key route instead of the trial flow, and the `token_stale` hint now says the same thing.
- `--api-key` on `refresh` mirrors the upload commands: the flag wins over the environment variable, blank values fall through, and the value is masked in `Debug` output.
- Reading a non-2xx cloud response is split into `http_status_failure`, which returns the backend code alongside the message that `http_status_message` already rendered, since the body can only be read once.

Docs updated: the license section of the CLI reference (subcommand purpose, a `refresh` flags table, the credential order, the changed hint), the license error-code gotcha, the `FALLOW_API_KEY` description in the environment-variable reference and the capability manifest, and a changelog entry.

## How it was verified

- New unit tests cover the credential order through an injected attempt: stored JWT first, API key second, no retry after a rejection, the terminal error text, and the flag-over-environment precedence.
- A new integration test drives the real binary against a stub of the refresh endpoint: the stale response is followed by a second request bearing the API key, and a run with neither credential names the key route. Both assertions fail against the previous behaviour, which stopped after one request and printed the trial hint.
- Manual end-to-end run against a local stub with a test-signed JWT: with a stale stored token and `FALLOW_API_KEY` set, refresh exits 0, prints `license: VALID`, and writes the returned JWT to the license path; `--api-key` does the same; with neither credential it exits 7 naming the API-key route.
- `npm run verify:fast`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p fallow-cli` all pass.

Closes #2595
