### PR TITLE
feat: support positional PATH scope across file commands

### DIFF
--- a/crates/api/src/runtime/mod.rs
+++ b/crates/api/src/runtime/mod.rs
@@ -439,6 +439,7 @@ fn derive_programmatic_health_execution_options<'a>(
         churn_file: None,
         analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
         group_by: None,
+        scope: None,
         ownership_emails: run
             .ownership_emails
             .map(crate::ownership_email_mode_to_config),

--- a/crates/benchmarks/benches/component_engine.rs
+++ b/crates/benchmarks/benches/component_engine.rs
@@ -773,6 +773,7 @@ fn warm_health_options(fixture: &WarmEngineFixture) -> HealthExecutionOptions<'_
         churn_file: None,
         analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
         group_by: None,
+        scope: None,
     }
 }
 

--- a/crates/cli/src/audit.rs
+++ b/crates/cli/src/audit.rs
@@ -190,6 +190,11 @@ pub struct AuditOptions<'a> {
     /// regardless; this only re-expands the human render (collapse-by-default).
     /// Only consulted on the brief path.
     pub show_deprioritized: bool,
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Narrows the changed-file universe before base focus, head
+    /// analyses, attribution, and verdict, so the whole audit reads as the
+    /// scoped slice. `None` means whole-project scope.
+    pub scope: Option<std::path::PathBuf>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -618,6 +623,12 @@ fn build_base_audit_options<'a>(
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        // Deliberately unscoped: the base pass runs in another worktree whose
+        // path spelling differs, so a head-root scope would narrow the base
+        // focus to empty and misattribute everything as introduced. The head
+        // pass is already scope-narrowed; a full base snapshot joins correctly
+        // against it.
+        scope: None,
     }
 }
 
@@ -1382,6 +1393,9 @@ pub fn execute_audit_with_type_aware(
     {
         changed_files.remove(&walkthrough_file);
     }
+    if let Some(scope) = opts.scope.as_deref() {
+        changed_files.retain(|file| crate::scope_path::scope_covers(scope, file));
+    }
     let changed_files_count = changed_files.len();
 
     if changed_files.is_empty() {
@@ -1755,6 +1769,7 @@ fn audit_review_benchmark_options<'a>(
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     }
 }
 
@@ -2911,6 +2926,9 @@ fn run_audit_check<'a>(
         explain: opts.explain,
         top: None,
         file: &[],
+        // Scope travels with the changed set (already intersected at the
+        // audit prelude); the sub-passes stay unscoped.
+        scope: None,
         include_entry_exports: opts.include_entry_exports,
         summary: false,
         regression_opts: crate::regression::RegressionOpts {
@@ -3021,6 +3039,9 @@ fn build_audit_dupes_options<'a>(
         group_by: opts.group_by,
         performance: false,
         include_fragments: true,
+        // Scope travels with the changed set (already intersected at the
+        // audit prelude); the sub-passes stay unscoped.
+        scope: None,
     }
 }
 
@@ -3129,6 +3150,9 @@ fn build_audit_health_options<'a>(
         analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
         complexity_breakdown: false,
         group_by: opts.group_by.map(Into::into),
+        // Scope travels with the changed set (already intersected at the
+        // audit prelude); the sub-passes stay unscoped.
+        scope: None,
     }
 }
 
@@ -3158,6 +3182,7 @@ pub fn run_audit_with_type_aware(
     let resolved_opts = AuditOptions {
         coverage: coverage_resolved.as_deref(),
         runtime_coverage: runtime_coverage_resolved.as_deref(),
+        scope: opts.scope.clone(),
         ..*opts
     };
     match execute_audit_with_type_aware(&resolved_opts, type_aware) {
@@ -3287,6 +3312,7 @@ pub fn run_decision_surface(opts: &AuditOptions<'_>) -> ExitCode {
     // Force brief mode: the decision surface is only computed on the brief path.
     let brief_opts = AuditOptions {
         brief: true,
+        scope: opts.scope.clone(),
         ..*opts
     };
     match execute_audit(&brief_opts) {

--- a/crates/cli/src/audit_tests.rs
+++ b/crates/cli/src/audit_tests.rs
@@ -2781,6 +2781,7 @@ fn audit_base_snapshot_cache_roundtrips_from_disk() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
     let key = AuditBaseSnapshotCacheKey {
         hash: 0xfeed,
@@ -2859,6 +2860,7 @@ fn audit_base_snapshot_cache_rejects_mismatched_key() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
     let key = AuditBaseSnapshotCacheKey {
         hash: 0xbeef,
@@ -2951,6 +2953,7 @@ fn audit_base_snapshot_cache_key_includes_extended_config() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let first = config_file_fingerprint(&opts).expect("fingerprint should be computed");
@@ -3036,6 +3039,7 @@ fn audit_gate_all_skips_base_snapshot() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -3141,6 +3145,7 @@ fn audit_gate_new_only_skips_base_snapshot_for_docs_only_diff() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -3247,6 +3252,7 @@ fn audit_reuses_dead_code_parse_for_health_when_production_matches() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -3348,6 +3354,7 @@ fn audit_new_only_does_not_gate_reshaped_clone_group_without_added_lines() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -3544,6 +3551,7 @@ fn audit_new_only_still_gates_pasted_clone_as_introduced() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -3664,6 +3672,7 @@ fn audit_dupes_falls_back_to_own_discovery_when_health_off() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -3872,6 +3881,7 @@ fn audit_gate_new_only_inherits_pre_existing_duplicates_in_focused_files() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -4019,6 +4029,7 @@ export function App() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -4173,6 +4184,7 @@ export function App() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -4267,6 +4279,7 @@ fn audit_base_uses_new_explicit_config_without_hard_failure() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute with a new explicit config");
@@ -4356,6 +4369,7 @@ fn audit_base_uses_current_discovered_config_for_attribution() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");
@@ -4454,6 +4468,7 @@ fn audit_base_current_config_attribution_survives_cache_hit() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let first = execute_audit(&opts).expect("first audit should execute");
@@ -4572,6 +4587,7 @@ fn audit_dupes_only_materializes_groups_touching_changed_files() {
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     };
 
     let result = execute_audit(&opts).expect("audit should execute");

--- a/crates/cli/src/check/mod.rs
+++ b/crates/cli/src/check/mod.rs
@@ -351,6 +351,12 @@ pub struct CheckOptions<'a> {
     pub top: Option<usize>,
     /// Only report issues in these file(s). Empty means no file filter.
     pub file: &'a [std::path::PathBuf],
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Appended to the workspace-roots channel, so it composes with
+    /// `--workspace` the way multiple workspace roots compose (union), and
+    /// intersects with `--changed-since` / `--diff-file` like every other
+    /// scope flag. `None` means whole-project scope.
+    pub scope: Option<std::path::PathBuf>,
     /// Report unused exports in entry files instead of auto-marking them as used.
     pub include_entry_exports: bool,
     /// When true, emit a condensed summary instead of full item-level output.
@@ -1000,12 +1006,15 @@ pub fn execute_check(opts: &CheckOptions<'_>) -> Result<CheckResult, ExitCode> {
     let config = prepare_check_config(opts)?;
     validate_effective_type_aware_output(opts.output, config.type_aware.enabled)?;
 
-    let ws_roots = filtering::resolve_workspace_scope(
+    let mut ws_roots = filtering::resolve_workspace_scope(
         opts.root,
         opts.workspace,
         opts.changed_workspaces,
         opts.output,
     )?;
+    if let Some(scope) = opts.scope.as_ref() {
+        ws_roots.get_or_insert_with(Vec::new).push(scope.clone());
+    }
 
     let changed_files: Option<rustc_hash::FxHashSet<std::path::PathBuf>> = opts
         .changed_since
@@ -1196,6 +1205,7 @@ pub fn benchmark_dead_code_json(
         explain: false,
         top: None,
         file: &[],
+        scope: None,
         include_entry_exports: false,
         summary: false,
         regression_opts: RegressionOpts {

--- a/crates/cli/src/combined/mod.rs
+++ b/crates/cli/src/combined/mod.rs
@@ -72,6 +72,10 @@ pub struct CombinedOptions<'a> {
     pub coverage: Option<&'a std::path::Path>,
     pub coverage_root: Option<&'a std::path::Path>,
     pub include_entry_exports: bool,
+    /// Positional `[PATH]` scope from bare `fallow [PATH]`: root-joined
+    /// absolute file or directory inside the root, threaded into the
+    /// check/dupes/health sub-pipelines. `None` means whole-project scope.
+    pub scope: Option<std::path::PathBuf>,
     pub regression_opts: regression::RegressionOpts<'a>,
 }
 
@@ -173,6 +177,7 @@ fn build_combined_check_options<'a>(
         explain: opts.explain,
         top: None,
         file: &[],
+        scope: opts.scope.clone(),
         include_entry_exports: opts.include_entry_exports,
         summary: opts.summary,
         regression_opts: opts.regression_opts,
@@ -515,6 +520,7 @@ fn build_combined_dupes_options<'a>(
         group_by: opts.group_by,
         performance: false,
         include_fragments: true,
+        scope: opts.scope.clone(),
     }
 }
 
@@ -594,6 +600,7 @@ fn build_health_opts<'a>(opts: &'a CombinedOptions<'a>) -> HealthOptions<'a> {
         analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
         complexity_breakdown: false,
         group_by: opts.group_by.map(Into::into),
+        scope: opts.scope.clone(),
     }
 }
 
@@ -712,6 +719,7 @@ mod tests {
             coverage: None,
             coverage_root: None,
             include_entry_exports: false,
+            scope: None,
             regression_opts: RegressionOpts {
                 fail_on_regression: false,
                 tolerance: Tolerance::Absolute(0),

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -269,6 +269,7 @@ fn local_health_options<'a>(
         analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
         complexity_breakdown: false,
         group_by: None,
+        scope: None,
     }
 }
 

--- a/crates/cli/src/dupes.rs
+++ b/crates/cli/src/dupes.rs
@@ -59,6 +59,12 @@ pub struct DupesOptions<'a> {
     /// detection. `None` defers to the config value (which defaults to `true`);
     /// `Some(false)` is the explicit opt-out (`--no-ignore-imports`).
     pub ignore_imports: Option<bool>,
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Appended to the workspace-roots channel, so it composes with
+    /// `--workspace` the way multiple workspace roots compose (union), and
+    /// intersects with `--changed-since` / `--diff-file` like every other
+    /// scope flag. `None` means whole-project scope.
+    pub scope: Option<std::path::PathBuf>,
     pub top: Option<usize>,
     pub baseline_path: Option<&'a std::path::Path>,
     pub save_baseline_path: Option<&'a std::path::Path>,
@@ -329,13 +335,18 @@ fn filter_dupes_report(
         filter_by_diff(report, diff_index, &config.root);
     }
 
-    if let Some(ws_roots) = resolve_workspace_scope(
+    if let Some(mut ws_roots) = resolve_workspace_scope(
         opts.root,
         opts.workspace,
         opts.changed_workspaces,
         opts.output,
     )? {
+        if let Some(scope) = opts.scope.as_ref() {
+            ws_roots.push(scope.clone());
+        }
         filter_by_workspaces(report, &ws_roots, &config.root);
+    } else if let Some(scope) = opts.scope.as_ref() {
+        filter_by_workspaces(report, std::slice::from_ref(scope), &config.root);
     }
 
     if let Some(n) = opts.top {
@@ -1076,6 +1087,7 @@ mod tests {
             group_by: None,
             performance: false,
             include_fragments: true,
+            scope: None,
         }
     }
 

--- a/crates/cli/src/fix/mod.rs
+++ b/crates/cli/src/fix/mod.rs
@@ -129,6 +129,11 @@ pub struct FixOptions<'a> {
     pub type_aware: Option<bool>,
     pub type_aware_projects: &'a [PathBuf],
     pub type_aware_require: Option<fallow_config::TypeAwareRequire>,
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Only fixes touching scoped files are planned and applied;
+    /// the analysis itself still runs whole-project so fixability stays sound.
+    /// `None` means whole-project scope.
+    pub scope: Option<PathBuf>,
 }
 
 pub fn run_fix(opts: &FixOptions<'_>) -> ExitCode {
@@ -178,6 +183,11 @@ fn run_fix_impl(opts: &FixOptions<'_>, fix_count: &mut usize) -> ExitCode {
         Ok(r) => r,
         Err(code) => return code,
     };
+
+    let mut results = results;
+    if let Some(scope) = opts.scope.as_ref() {
+        fallow_engine::dead_code::filter_to_workspaces(&mut results, std::slice::from_ref(scope));
+    }
 
     if results.total_issues() == 0 {
         return if opts.emit_output {

--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -166,12 +166,15 @@ fn build_health_scope_inputs<'a>(
         .changed_since
         .and_then(|git_ref| get_changed_files(opts.root, git_ref));
     let diff_index = health_diff_index(opts);
-    let ws_roots = resolve_workspace_scope(
+    let mut ws_roots = resolve_workspace_scope(
         opts.root,
         opts.workspace,
         opts.changed_workspaces,
         opts.output,
     )?;
+    if let Some(scope) = opts.scope.as_ref() {
+        ws_roots.get_or_insert_with(Vec::new).push(scope.clone());
+    }
     let group_resolver = build_health_group_resolver(opts, config)?;
     Ok(HealthScopeInputs {
         changed_files,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -77,6 +77,7 @@ pub mod report;
 mod rule_pack;
 mod runtime_support;
 mod schema;
+mod scope_path;
 mod security;
 mod security_help;
 mod selector;
@@ -261,6 +262,11 @@ const TOP_LEVEL_AFTER_LONG_HELP: &str = concat!(
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
+
+    /// Scope reported findings to this file or directory (default: whole project).
+    /// The full project graph is still built; only reported items are narrowed.
+    #[arg(value_name = "PATH")]
+    path: Option<PathBuf>,
 
     /// Print version.
     /// Accepts `-v`, `-V`, and `--version`; TS/JS tooling (node, npm, pnpm,
@@ -815,6 +821,11 @@ enum Command {
         /// are reported. Useful for lint-staged pre-commit hooks.
         #[arg(long, value_name = "PATH")]
         file: Vec<std::path::PathBuf>,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<std::path::PathBuf>,
     },
 
     /// Watch for changes and re-run analysis
@@ -859,6 +870,11 @@ enum Command {
         /// Report pairs touching one of these project-relative files.
         #[arg(long, value_name = "PATH")]
         file: Vec<PathBuf>,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Inspect one file or exported symbol as a bundled evidence query
@@ -994,6 +1010,12 @@ enum Command {
         /// normally.
         #[arg(long)]
         no_create_config: bool,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        /// Only fixes touching scoped files are planned and applied.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Initialize a .fallowrc.json configuration file, AGENTS.md guide, or git
@@ -1137,6 +1159,11 @@ enum Command {
         /// tsconfig references).
         #[arg(long)]
         workspaces: bool,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Show monorepo workspaces and any workspace-discovery diagnostics.
@@ -1219,6 +1246,11 @@ enum Command {
         /// Trace all clones at a specific location (format: `FILE:LINE`)
         #[arg(long, value_name = "FILE:LINE")]
         trace: Option<String>,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Analyze function complexity (cyclomatic + cognitive)
@@ -1411,6 +1443,11 @@ enum Command {
         /// default (0.001).
         #[arg(long, value_name = "RATIO")]
         low_traffic_threshold: Option<f64>,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Detect feature flag patterns in the codebase
@@ -1634,9 +1671,14 @@ enum Command {
         /// focus map ("show me what you de-prioritized"). The `deprioritized`
         /// escape-hatch list is ALWAYS present in `--format json` regardless; this
         /// flag only re-expands the collapse-by-default human focus render. Only
-        /// consulted on the brief path.
+        /// consulted on the `--walkthrough` path.
         #[arg(long)]
         show_deprioritized: bool,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Maintain reusable audit base-snapshot caches.
@@ -1753,6 +1795,11 @@ enum Command {
         /// Include the agent-facing attack-surface inventory in JSON output.
         #[arg(long)]
         surface: bool,
+
+        /// Scope reported findings to this file or directory (default: whole project).
+        /// The full project graph is still built; only reported items are narrowed.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
     },
 
     /// Render a saved `--format json` results file in another format without
@@ -3083,6 +3130,7 @@ pub fn benchmark_fix_dry_run(root: &Path, threads: usize) -> (ExitCode, usize) {
         type_aware: None,
         type_aware_projects: &[],
         type_aware_require: None,
+        scope: None,
     })
 }
 
@@ -3587,6 +3635,15 @@ fn run_bare_combined(
     let cli = dispatch.cli;
     let (output, quiet, fail_on_issues) =
         (dispatch.output, dispatch.quiet, dispatch.fail_on_issues);
+    let scope = match crate::scope_path::resolve_command_scope(
+        dispatch.root,
+        dispatch.output,
+        cli.path.clone(),
+    ) {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
+    };
+    let scoped_run = scope.is_some();
     combined::run_combined(&combined::CombinedOptions {
         root: dispatch.root,
         config_path: &cli.config,
@@ -3637,10 +3694,12 @@ fn run_bare_combined(
         coverage: coverage_inputs.coverage.as_deref(),
         coverage_root: coverage_inputs.coverage_root.as_deref(),
         include_entry_exports: cli.include_entry_exports,
+        scope,
         regression_opts: dispatch.regression_opts(
             cli.changed_since.is_some()
                 || cli.workspace.is_some()
-                || cli.changed_workspaces.is_some(),
+                || cli.changed_workspaces.is_some()
+                || scoped_run,
         ),
     })
 }
@@ -3665,26 +3724,38 @@ fn dispatch_subcommand(command: Command, dispatch: &DispatchContext<'_>) -> Exit
             min_lines,
             top,
             file,
-        } => similar_code_cli::run(similar_code_cli::SimilarCodeCliInput {
-            root,
-            config_path: cli.config.as_deref(),
-            allow_remote_extends: cli.allow_remote_extends,
-            no_cache: cli.no_cache,
-            threads: dispatch.threads,
-            changed_since: cli.changed_since.as_deref(),
-            diff_file: cli.diff_file.as_deref(),
-            workspace: cli.workspace.as_deref(),
-            changed_workspaces: cli.changed_workspaces.as_deref(),
-            explain: cli.explain,
-            quiet,
-            output,
-            json_style: dispatch.json_style,
-            threshold,
-            min_lines,
-            top,
-            files: file,
-            subcommand,
-        }),
+            path,
+        } => {
+            let scope = match crate::scope_path::resolve_command_scope(
+                dispatch.root,
+                dispatch.output,
+                path,
+            ) {
+                Ok(scope) => scope,
+                Err(code) => return code,
+            };
+            similar_code_cli::run(similar_code_cli::SimilarCodeCliInput {
+                root,
+                config_path: cli.config.as_deref(),
+                allow_remote_extends: cli.allow_remote_extends,
+                no_cache: cli.no_cache,
+                threads: dispatch.threads,
+                changed_since: cli.changed_since.as_deref(),
+                diff_file: cli.diff_file.as_deref(),
+                workspace: cli.workspace.as_deref(),
+                changed_workspaces: cli.changed_workspaces.as_deref(),
+                explain: cli.explain,
+                quiet,
+                output,
+                json_style: dispatch.json_style,
+                threshold,
+                min_lines,
+                top,
+                files: file,
+                scope,
+                subcommand,
+            })
+        }
         Command::Inspect {
             file,
             symbol,
@@ -3921,10 +3992,17 @@ fn dispatch_check_command(command: Command, dispatch: &DispatchContext<'_>) -> E
         symbol_impact,
         top,
         file,
+        path,
         ..
     } = command
     else {
         unreachable!("check dispatcher only handles check commands");
+    };
+
+    let scope = match crate::scope_path::resolve_command_scope(dispatch.root, dispatch.output, path)
+    {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
     };
 
     dispatch_check(
@@ -3945,6 +4023,7 @@ fn dispatch_check_command(command: Command, dispatch: &DispatchContext<'_>) -> E
             type_aware_require: dispatch.cli.type_aware_require,
             top,
             file,
+            scope,
         },
     )
 }
@@ -4199,9 +4278,16 @@ fn dispatch_security_command(command: Command, dispatch: &DispatchContext<'_>) -
         file,
         gate,
         surface,
+        path,
     } = command
     else {
         unreachable!("security dispatcher only handles security commands");
+    };
+
+    let scope = match crate::scope_path::resolve_command_scope(dispatch.root, dispatch.output, path)
+    {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
     };
 
     let gate = gate.map(security::SecurityGateArg::into_mode);
@@ -4236,6 +4322,7 @@ fn dispatch_security_command(command: Command, dispatch: &DispatchContext<'_>) -
             min_invocations_hot,
             gate,
             surface,
+            scope,
         },
         &derived_flags,
     )
@@ -4250,6 +4337,7 @@ struct SecurityRunInputs<'a> {
     min_invocations_hot: u64,
     gate: Option<security::SecurityGateMode>,
     surface: bool,
+    scope: Option<PathBuf>,
 }
 
 /// Build `SecurityOptions` and run either the blind-spots or default analysis.
@@ -4279,6 +4367,7 @@ fn run_security_blind_spots_or_default(
         changed_workspaces: cli.changed_workspaces.as_deref(),
         file: inputs.scoped_files,
         surface: inputs.surface,
+        scope: inputs.scope.clone(),
         gate: inputs.gate,
         runtime_coverage: inputs.runtime_coverage,
         min_invocations_hot: inputs.min_invocations_hot,
@@ -4430,9 +4519,16 @@ fn dispatch_dupes_command(command: Command, dispatch: &DispatchContext<'_>) -> E
         top,
         no_fragments,
         trace,
+        path,
     } = command
     else {
         unreachable!("dupes dispatcher only handles dupes commands");
+    };
+
+    let scope = match crate::scope_path::resolve_command_scope(dispatch.root, dispatch.output, path)
+    {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
     };
 
     dispatch_dupes(
@@ -4451,6 +4547,7 @@ fn dispatch_dupes_command(command: Command, dispatch: &DispatchContext<'_>) -> E
             top,
             no_fragments,
             trace,
+            scope,
         },
     )
 }
@@ -4493,40 +4590,63 @@ fn dispatch_fix_command(command: &Command, dispatch: &DispatchContext<'_>) -> Ex
         dry_run,
         yes,
         no_create_config,
+        path,
     } = command
     else {
         unreachable!("fix dispatcher only handles fix commands");
     };
 
+    let scope = match crate::scope_path::resolve_command_scope(
+        dispatch.root,
+        dispatch.output,
+        path.clone(),
+    ) {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
+    };
+
     dispatch_fix(
         dispatch,
-        FixDispatchArgs {
+        &FixDispatchArgs {
             dry_run: *dry_run,
             yes: *yes,
             no_create_config: *no_create_config,
+            scope,
         },
     )
 }
 
 fn dispatch_list_command(command: &Command, dispatch: &DispatchContext<'_>) -> ExitCode {
     match command {
-        Command::Workspaces => dispatch_list(dispatch, ListDispatchArgs::workspaces()),
+        Command::Workspaces => dispatch_list(dispatch, &ListDispatchArgs::workspaces()),
         Command::List {
             entry_points,
             files,
             plugins,
             boundaries,
             workspaces,
-        } => dispatch_list(
-            dispatch,
-            ListDispatchArgs {
-                entry_points: *entry_points,
-                files: *files,
-                plugins: *plugins,
-                boundaries: *boundaries,
-                workspaces: *workspaces,
-            },
-        ),
+            path,
+        } => {
+            let scope = match crate::scope_path::resolve_command_scope(
+                dispatch.root,
+                dispatch.output,
+                path.clone(),
+            ) {
+                Ok(scope) => scope.map(|resolved| resolved.absolute),
+                Err(code) => return code,
+            };
+            dispatch_list(
+                dispatch,
+                &ListDispatchArgs {
+                    entry_points: *entry_points,
+                    files: *files,
+                    plugins: *plugins,
+                    boundaries: *boundaries,
+                    workspaces: *workspaces,
+                    scope,
+                },
+            )
+        }
         _ => unreachable!("list dispatcher only handles list commands"),
     }
 }
@@ -4614,9 +4734,16 @@ fn dispatch_health_command(command: Command, dispatch: &DispatchContext<'_>) -> 
         min_invocations_hot,
         min_observation_volume,
         low_traffic_threshold,
+        path,
     } = command
     else {
         unreachable!("health dispatcher only handles health commands");
+    };
+
+    let scope = match crate::scope_path::resolve_command_scope(dispatch.root, dispatch.output, path)
+    {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
     };
 
     let ownership = ownership || ownership_emails.is_some();
@@ -4652,6 +4779,7 @@ fn dispatch_health_command(command: Command, dispatch: &DispatchContext<'_>) -> 
         min_invocations_hot,
         min_observation_volume,
         low_traffic_threshold,
+        scope,
     };
     dispatch_health(dispatch, &args)
 }
@@ -4709,6 +4837,7 @@ fn dispatch_audit_command(command: Command, dispatch: &DispatchContext<'_>) -> E
         mark_viewed,
         show_cleared,
         show_deprioritized,
+        path,
     } = command
     else {
         unreachable!("audit dispatcher only handles audit commands");
@@ -4717,6 +4846,12 @@ fn dispatch_audit_command(command: Command, dispatch: &DispatchContext<'_>) -> E
     // The walkthrough flags imply the brief path (the guide digest + the
     // graph-snapshot pin are brief-path data).
     let brief = brief || walkthrough_guide || walkthrough || walkthrough_file.is_some();
+
+    let scope = match crate::scope_path::resolve_command_scope(dispatch.root, dispatch.output, path)
+    {
+        Ok(scope) => scope.map(|resolved| resolved.absolute),
+        Err(code) => return code,
+    };
 
     dispatch_audit(
         dispatch,
@@ -4745,6 +4880,7 @@ fn dispatch_audit_command(command: Command, dispatch: &DispatchContext<'_>) -> E
             mark_viewed,
             show_cleared,
             show_deprioritized,
+            scope,
         },
     )
 }
@@ -5277,15 +5413,17 @@ struct CheckDispatchArgs {
     type_aware_require: Option<TypeAwareRequireArg>,
     top: Option<usize>,
     file: Vec<std::path::PathBuf>,
+    scope: Option<std::path::PathBuf>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ListDispatchArgs {
     entry_points: bool,
     files: bool,
     plugins: bool,
     boundaries: bool,
     workspaces: bool,
+    scope: Option<std::path::PathBuf>,
 }
 
 impl ListDispatchArgs {
@@ -5296,6 +5434,7 @@ impl ListDispatchArgs {
             plugins: false,
             boundaries: false,
             workspaces: true,
+            scope: None,
         }
     }
 }
@@ -5350,14 +5489,14 @@ fn dispatch_watch(dispatch: &DispatchContext<'_>, no_clear: bool) -> ExitCode {
     })
 }
 
-#[derive(Clone, Copy)]
 struct FixDispatchArgs {
     dry_run: bool,
     yes: bool,
     no_create_config: bool,
+    scope: Option<std::path::PathBuf>,
 }
 
-fn dispatch_fix(dispatch: &DispatchContext<'_>, args: FixDispatchArgs) -> ExitCode {
+fn dispatch_fix(dispatch: &DispatchContext<'_>, args: &FixDispatchArgs) -> ExitCode {
     let cli = dispatch.cli;
     let production = match dispatch.production_for(fallow_config::ProductionAnalysis::DeadCode) {
         Ok(production) => production,
@@ -5380,10 +5519,11 @@ fn dispatch_fix(dispatch: &DispatchContext<'_>, args: FixDispatchArgs) -> ExitCo
         type_aware: cli.type_aware_override(),
         type_aware_projects: &cli.type_aware_project,
         type_aware_require: cli.type_aware_require.map(Into::into),
+        scope: args.scope.clone(),
     })
 }
 
-fn dispatch_list(dispatch: &DispatchContext<'_>, args: ListDispatchArgs) -> ExitCode {
+fn dispatch_list(dispatch: &DispatchContext<'_>, args: &ListDispatchArgs) -> ExitCode {
     let cli = dispatch.cli;
     let production = match dispatch.production_for(fallow_config::ProductionAnalysis::DeadCode) {
         Ok(production) => production,
@@ -5403,6 +5543,7 @@ fn dispatch_list(dispatch: &DispatchContext<'_>, args: ListDispatchArgs) -> Exit
         workspaces: args.workspaces,
         production,
         allow_remote_extends: cli.allow_remote_extends,
+        scope: args.scope.clone(),
     })
 }
 
@@ -5448,13 +5589,15 @@ fn dispatch_check(dispatch: &DispatchContext<'_>, args: &CheckDispatchArgs) -> E
         explain: cli.explain,
         top: args.top,
         file: &args.file,
+        scope: args.scope.clone(),
         include_entry_exports: cli.include_entry_exports,
         summary: cli.summary,
         regression_opts: dispatch.regression_opts(
             cli.changed_since.is_some()
                 || cli.workspace.is_some()
                 || cli.changed_workspaces.is_some()
-                || !args.file.is_empty(),
+                || !args.file.is_empty()
+                || args.scope.is_some(),
         ),
         retain_modules_for_health: false,
         defer_performance: false,
@@ -5558,6 +5701,7 @@ struct DupesDispatchArgs {
     top: Option<usize>,
     no_fragments: bool,
     trace: Option<String>,
+    scope: Option<std::path::PathBuf>,
 }
 
 fn dispatch_dupes(dispatch: &DispatchContext<'_>, args: &DupesDispatchArgs) -> ExitCode {
@@ -5604,6 +5748,7 @@ fn dispatch_dupes(dispatch: &DispatchContext<'_>, args: &DupesDispatchArgs) -> E
         group_by: cli.group_by,
         performance: cli.performance,
         include_fragments: !args.no_fragments,
+        scope: args.scope.clone(),
     })
 }
 
@@ -5639,6 +5784,7 @@ struct AuditDispatchArgs {
     show_cleared: bool,
     /// Expand the de-prioritized units in the human focus map.
     show_deprioritized: bool,
+    scope: Option<PathBuf>,
 }
 
 struct ResolvedAuditInputs {
@@ -5800,6 +5946,7 @@ fn run_resolved_audit(
             show_cleared: args.show_cleared,
             walkthrough_file: args.walkthrough_file.as_deref(),
             show_deprioritized: args.show_deprioritized,
+            scope: args.scope.clone(),
         },
         args.gate_marker.as_deref(),
         audit::AuditTypeAwareOptions {
@@ -5853,6 +6000,7 @@ fn decision_surface_audit_args(max_decisions: usize) -> AuditDispatchArgs {
         mark_viewed: Vec::new(),
         show_cleared: false,
         show_deprioritized: false,
+        scope: None,
     }
 }
 
@@ -5905,6 +6053,7 @@ fn decision_surface_audit_options<'a>(
         show_cleared: false,
         walkthrough_file: None,
         show_deprioritized: false,
+        scope: None,
     }
 }
 
@@ -5939,6 +6088,7 @@ struct HealthDispatchArgs<'a> {
     min_invocations_hot: u64,
     min_observation_volume: Option<u32>,
     low_traffic_threshold: Option<f64>,
+    scope: Option<std::path::PathBuf>,
 }
 
 type ResolvedHealthCoverageInputs = fallow_api::CoverageInputs;
@@ -6234,6 +6384,7 @@ fn run_health_dispatch(
             analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
             complexity_breakdown: args.complexity_breakdown,
             group_by: cli.group_by.map(Into::into),
+            scope: args.scope.clone(),
         },
         dispatch.json_style,
         &health::TypeAwareHealthOptions {

--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -21,6 +21,11 @@ pub struct ListOptions<'a> {
     pub workspaces: bool,
     pub production: bool,
     pub allow_remote_extends: bool,
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Narrows the file and entry-point inventory to the scope;
+    /// plugins, boundaries metadata, and workspaces stay whole-project.
+    /// `None` means whole-project scope.
+    pub scope: Option<std::path::PathBuf>,
 }
 
 /// Owned listing data assembled by [`collect_list_data`] and borrowed by the
@@ -103,6 +108,7 @@ pub fn benchmark_list_json(
         workspaces: false,
         production: false,
         allow_remote_extends: false,
+        scope: None,
     };
     let (data, rendered_bytes) = benchmark_list_data_json(&opts)?;
     let file_count = data.discovered.as_deref().map_or(0, <[_]>::len);
@@ -141,6 +147,7 @@ pub fn benchmark_list_boundaries_json(
         workspaces: false,
         production: false,
         allow_remote_extends: false,
+        scope: None,
     };
     let (data, rendered_bytes) = benchmark_list_data_json(&opts)?;
     let Some(boundary_data) = data.boundary_data else {
@@ -206,7 +213,15 @@ fn collect_list_data(
     } else {
         None
     };
-    let discovered = session.as_ref().map(|session| session.files().to_vec());
+    let mut discovered = session.as_ref().map(|session| session.files().to_vec());
+    if let Some(scope) = opts.scope.as_deref() {
+        discovered = discovered.map(|files| {
+            files
+                .into_iter()
+                .filter(|file| crate::scope_path::scope_covers(scope, &file.path))
+                .collect()
+        });
+    }
     let session_workspaces = session.as_ref().map(|session| session.workspaces());
     let session_workspace_diagnostics = session
         .as_ref()
@@ -775,6 +790,7 @@ mod tests {
             workspaces: false,
             production: false,
             allow_remote_extends: false,
+            scope: None,
         }
     }
 

--- a/crates/cli/src/scope_path.rs
+++ b/crates/cli/src/scope_path.rs
@@ -1,0 +1,230 @@
+//! The shared positional `PATH` scope resolver.
+//!
+//! `check`, `dupes`, `health`, `audit`, `security`, `fix`, `list`,
+//! `similar-code`, and bare combined mode all accept an optional positional
+//! `[PATH]`. The scope narrows reported findings to that file or directory;
+//! the full project graph is still built first, so cross-file facts (unused
+//! exports, reachability, clone families) stay sound. This module owns the
+//! single resolution answer so a path accepted by one command behaves the
+//! same on every other.
+
+use std::path::{Path, PathBuf};
+
+/// A resolved positional scope: a path guaranteed inside the root.
+///
+/// `absolute` keeps the root-joined spelling (simplified, not fully
+/// canonicalized) so prefix matching agrees with finding paths.
+#[derive(Debug, Clone)]
+pub struct ScopePath {
+    /// Root-joined absolute path of the scope target.
+    pub absolute: PathBuf,
+    /// True when the target is a directory (prefix scope), false for a file.
+    pub is_dir: bool,
+}
+
+impl ScopePath {
+    /// True when the scope is the project root itself, which covers
+    /// everything and must behave exactly like no scope at all (in
+    /// particular it must not clear dependency-level findings the way a
+    /// narrower file scope does).
+    #[must_use]
+    pub fn covers_everything(&self, root: &Path) -> bool {
+        let root = dunce::simplified(root);
+        dunce::simplified(&self.absolute) == root
+            || dunce::canonicalize(root).is_ok_and(|canon| self.absolute == canon)
+    }
+}
+
+/// Resolve a user-supplied positional path against the project root.
+///
+/// Lookup order is root-first for bare relative paths: `root.join(raw)`,
+/// then the current working directory. An explicit `--root` declares the
+/// project, so a bare `src` under it wins over a same-named directory where
+/// the command happened to run (an agent's own working directory must not
+/// hijack the scope). Absolute paths are used as given; `./` and `../`
+/// prefixes are explicit current-directory claims and never consult the
+/// root. The target must exist and must resolve inside the root; anything
+/// else is an actionable exit-2 message, never a silent reinterpretation.
+///
+/// The returned path keeps the root-joined spelling (not the fully
+/// canonicalized one) so prefix matching agrees with finding paths, which
+/// are built as `root.join(...)` throughout the pipeline. Canonicalization
+/// is used only for the inside-root check.
+///
+/// # Errors
+///
+/// Returns a message when the path is empty, carries control characters,
+/// does not exist, or escapes the project root.
+pub fn resolve_scope_path(root: &Path, raw: &Path) -> Result<ScopePath, String> {
+    let raw_display = raw.display().to_string();
+    if raw.as_os_str().is_empty() {
+        return Err("PATH must not be empty".to_string());
+    }
+    if let Some(raw_str) = raw.to_str()
+        && let Err(detail) = fallow_engine::validate::validate_no_control_chars(raw_str, "PATH")
+    {
+        return Err(detail);
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let explicit_cwd_claim = matches!(
+        raw.components().next(),
+        Some(std::path::Component::CurDir | std::path::Component::ParentDir)
+    );
+    let candidates: Vec<PathBuf> = if raw.is_absolute() {
+        vec![raw.to_path_buf()]
+    } else if explicit_cwd_claim {
+        vec![cwd.join(raw)]
+    } else {
+        vec![root.join(raw), cwd.join(raw)]
+    };
+    let canonical_root = dunce::canonicalize(root)
+        .map_err(|err| format!("invalid project root '{}': {err}", root.display()))?;
+    let mut outside: Option<PathBuf> = None;
+    for candidate in &candidates {
+        if candidate.symlink_metadata().is_err() {
+            continue;
+        }
+        let Ok(canonical) = dunce::canonicalize(candidate) else {
+            continue;
+        };
+        if canonical != canonical_root && !canonical.starts_with(&canonical_root) {
+            outside.get_or_insert_with(|| candidate.clone());
+            continue;
+        }
+        let relative = match canonical.strip_prefix(&canonical_root) {
+            Ok(relative) => relative.to_path_buf(),
+            Err(_) => PathBuf::new(),
+        };
+        let absolute = if let Ok(lexical) = candidate.strip_prefix(root) {
+            dunce::simplified(&root.join(lexical)).to_path_buf()
+        } else {
+            dunce::simplified(&canonical_root.join(relative)).to_path_buf()
+        };
+        return Ok(ScopePath {
+            is_dir: canonical.is_dir(),
+            absolute,
+        });
+    }
+    if let Some(escaped) = outside {
+        return Err(format!(
+            "PATH '{raw_display}' (resolved to '{}') is outside the project root ('{}'). Pass --root <dir> for another project, or a path inside this root",
+            escaped.display(),
+            root.display()
+        ));
+    }
+    let searched = if dunce::simplified(&cwd) == dunce::simplified(root) {
+        format!("'{}'", root.display())
+    } else {
+        format!(
+            "the current directory and the project root '{}'",
+            root.display()
+        )
+    };
+    Err(format!(
+        "PATH '{raw_display}' does not exist (looked relative to {searched})"
+    ))
+}
+
+/// True when a finding path falls inside the scope: the finding is the scope
+/// target itself, or (for directory scopes) lives below it. Comparison is
+/// component-wise, so scope `/repo/src` never matches `/repo/src-extra`.
+#[must_use]
+pub fn scope_covers(scope: &Path, path: &Path) -> bool {
+    let simplified = dunce::simplified(path);
+    simplified == scope || simplified.starts_with(scope)
+}
+
+/// Resolve an optional positional `PATH` for a command dispatch.
+///
+/// `None` (no positional) and a scope covering the whole project root both
+/// yield `Ok(None)`, so `fallow dupes .` behaves exactly like `fallow dupes`.
+/// Anything unresolvable is an actionable exit-2 error, never a silent
+/// reinterpretation.
+pub fn resolve_command_scope(
+    root: &Path,
+    output: fallow_config::OutputFormat,
+    raw: Option<std::path::PathBuf>,
+) -> Result<Option<ScopePath>, std::process::ExitCode> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    match resolve_scope_path(root, &raw) {
+        Ok(scope) if scope.covers_everything(root) => Ok(None),
+        Ok(scope) => Ok(Some(scope)),
+        Err(message) => Err(crate::error::emit_error(&message, 2, output)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn fixture_root() -> PathBuf {
+        dunce::canonicalize(std::env::current_dir().expect("cwd")).expect("canonical cwd")
+    }
+
+    #[test]
+    fn resolves_file_inside_root() {
+        let root = fixture_root();
+        let scope = resolve_scope_path(&root, Path::new("Cargo.toml")).expect("Cargo.toml exists");
+        assert!(!scope.is_dir);
+        assert!(scope.absolute.starts_with(&root));
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        let root = fixture_root();
+        let err = resolve_scope_path(&root, Path::new("no-such-path-xyz-123")).unwrap_err();
+        assert!(err.contains("does not exist"), "{err}");
+    }
+
+    #[test]
+    fn rejects_outside_root() {
+        let root = fixture_root();
+        let outside = root.parent().expect("root has a parent").to_path_buf();
+        if outside == root {
+            return;
+        }
+        let err = resolve_scope_path(&root, &outside).unwrap_err();
+        assert!(err.contains("outside the project root"), "{err}");
+    }
+
+    #[test]
+    fn root_scope_covers_everything() {
+        let root = fixture_root();
+        let scope = resolve_scope_path(&root, &root).expect("root resolves");
+        assert!(scope.covers_everything(&root));
+    }
+
+    #[test]
+    fn dot_slash_prefix_claims_current_directory() {
+        let root = fixture_root();
+        let scope =
+            resolve_scope_path(&root, Path::new("./Cargo.toml")).expect("./Cargo.toml exists");
+        assert!(!scope.is_dir);
+        assert!(scope.absolute.starts_with(&root));
+    }
+
+    #[test]
+    fn bare_relative_prefers_root_over_cwd() {
+        let root = tempfile::tempdir().expect("temporary scope root");
+        let cwd_file = fixture_root().join("Cargo.toml");
+        assert!(cwd_file.is_file(), "test cwd must hold Cargo.toml");
+        fs::write(root.path().join("Cargo.toml"), "[package]\n").expect("scope file");
+        let scope =
+            resolve_scope_path(root.path(), Path::new("Cargo.toml")).expect("root file wins");
+        assert!(scope.absolute.starts_with(dunce::simplified(root.path())));
+        assert!(!scope.absolute.starts_with(fixture_root()));
+    }
+
+    #[test]
+    fn scope_covers_file_and_children_only() {
+        let scope = Path::new("/repo/src");
+        assert!(scope_covers(scope, Path::new("/repo/src")));
+        assert!(scope_covers(scope, Path::new("/repo/src/a.ts")));
+        assert!(!scope_covers(scope, Path::new("/repo/src-extra/a.ts")));
+        assert!(!scope_covers(scope, Path::new("/repo/other/a.ts")));
+    }
+}

--- a/crates/cli/src/security.rs
+++ b/crates/cli/src/security.rs
@@ -121,6 +121,12 @@ pub struct SecurityOptions<'a> {
     pub changed_workspaces: Option<&'a str>,
     /// `--file <PATH>`: scope findings to selected files or trace hops.
     pub file: &'a [PathBuf],
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Appended to the workspace-roots channel, so it composes with
+    /// `--workspace` the way multiple workspace roots compose (union), and
+    /// intersects with `--changed-since` / `--diff-file` like every other
+    /// scope flag. `None` means whole-project scope.
+    pub scope: Option<PathBuf>,
     /// `--surface`: include the top-level attack-surface inventory in JSON.
     pub surface: bool,
     /// `--gate <mode>`: opt-in regression gate. `new` requires a diff source and
@@ -258,6 +264,7 @@ pub fn benchmark_security_json(root: &Path, threads: usize) -> Result<(usize, us
         changed_workspaces: None,
         file: files,
         surface: false,
+        scope: None,
         gate: None,
         runtime_coverage: None,
         min_invocations_hot: crate::DEFAULT_MIN_INVOCATIONS_HOT,
@@ -305,6 +312,7 @@ pub fn create_security_survivors_benchmark_corpus(
         changed_workspaces: None,
         file: files,
         surface: false,
+        scope: None,
         gate: None,
         runtime_coverage: None,
         min_invocations_hot: crate::DEFAULT_MIN_INVOCATIONS_HOT,
@@ -965,12 +973,15 @@ fn apply_security_scopes(
     opts: &SecurityOptions<'_>,
     analysis: &mut SecurityAnalysisState,
 ) -> Result<(), ExitCode> {
-    let ws_roots = crate::check::filtering::resolve_workspace_scope(
+    let mut ws_roots = crate::check::filtering::resolve_workspace_scope(
         opts.root,
         opts.workspace,
         opts.changed_workspaces,
         opts.output,
     )?;
+    if let Some(scope) = opts.scope.as_ref() {
+        ws_roots.get_or_insert_with(Vec::new).push(scope.clone());
+    }
     if let Some(ref roots) = ws_roots {
         crate::check::filtering::filter_to_workspaces(&mut analysis.results, roots);
     }
@@ -1164,6 +1175,11 @@ fn base_snapshot_security_options<'a>(
         changed_workspaces: None,
         file: &[],
         surface: false,
+        // Deliberately unscoped: the base pass runs in another worktree whose
+        // path spelling differs, so a head-root scope would empty the base
+        // snapshot. The head pass is already scope-narrowed; a full base
+        // snapshot joins correctly against it.
+        scope: None,
         gate: None,
         runtime_coverage: None,
         min_invocations_hot: opts.min_invocations_hot,
@@ -1494,6 +1510,7 @@ fn security_runtime_health_options<'a>(
         analysis_identity: fallow_types::semantic::SemanticAnalysisIdentity::default(),
         complexity_breakdown: false,
         group_by: None,
+        scope: opts.scope.clone(),
     }
 }
 
@@ -4551,6 +4568,7 @@ mod tests {
             changed_workspaces: None,
             file: &[],
             surface: false,
+            scope: None,
             gate: None,
             runtime_coverage: None,
             min_invocations_hot: 100,

--- a/crates/cli/src/similar_code_cli.rs
+++ b/crates/cli/src/similar_code_cli.rs
@@ -105,6 +105,10 @@ pub struct SimilarCodeCliInput<'a> {
     pub(crate) min_lines: Option<usize>,
     pub(crate) top: Option<usize>,
     pub(crate) files: Vec<PathBuf>,
+    /// Positional `[PATH]` scope. A file scope narrows inference through
+    /// `files`; a directory scope retains reported pairs touching the scope
+    /// (the full corpus is still compared). `None` means whole-project scope.
+    pub(crate) scope: Option<crate::scope_path::ScopePath>,
     pub(crate) subcommand: Option<SimilarCodeSubcommand>,
 }
 
@@ -181,7 +185,11 @@ pub fn run(input: SimilarCodeCliInput<'_>) -> ExitCode {
                 }
             }
             match run_similar_code(&similar_code_options) {
-                Ok(output) => emit_discovery(output, input.output, input.json_style),
+                Ok(output) => emit_discovery(
+                    filter_discovery_to_scope(output, &input),
+                    input.output,
+                    input.json_style,
+                ),
                 Err(error) => programmatic_failure(&error, input.output, input.json_style),
             }
         }
@@ -295,6 +303,12 @@ fn review_file_error(message: impl Into<String>) -> fallow_api::ProgrammaticErro
 }
 
 fn options(input: &SimilarCodeCliInput<'_>) -> SimilarCodeOptions {
+    let mut files = input.files.clone();
+    if let Some(scope) = input.scope.as_ref().filter(|scope| !scope.is_dir)
+        && let Ok(relative) = scope.absolute.strip_prefix(input.root)
+    {
+        files.push(relative.to_path_buf());
+    }
     SimilarCodeOptions {
         analysis: AnalysisOptions {
             root: Some(input.root.to_path_buf()),
@@ -312,9 +326,39 @@ fn options(input: &SimilarCodeCliInput<'_>) -> SimilarCodeOptions {
         threshold: input.threshold,
         min_lines: input.min_lines,
         top: input.top,
-        files: input.files.clone(),
+        files,
         adapter_provider_path: None,
     }
+}
+
+/// Retain only discovery candidates touching a directory scope.
+///
+/// File scopes narrow inference through `files` in [`options`] instead, so
+/// they never reach this filter. The full corpus is still compared; only
+/// reported pairs are narrowed, mirroring every other positional scope.
+fn filter_discovery_to_scope(
+    mut output: SimilarCodeOutput,
+    input: &SimilarCodeCliInput<'_>,
+) -> SimilarCodeOutput {
+    let Some(scope) = input.scope.as_ref().filter(|scope| scope.is_dir) else {
+        return output;
+    };
+    output
+        .candidates
+        .retain(|candidate| candidate_touches_scope(candidate, input.root, &scope.absolute));
+    output
+}
+
+/// True when either side of a candidate lives inside the scope. Candidate
+/// paths are root-relative; the scope is a canonical absolute path.
+fn candidate_touches_scope(
+    candidate: &fallow_output::SimilarCodeCandidate,
+    root: &std::path::Path,
+    scope: &std::path::Path,
+) -> bool {
+    [&candidate.left.path, &candidate.right.path]
+        .iter()
+        .any(|relative| crate::scope_path::scope_covers(scope, &root.join(relative)))
 }
 
 fn run_status(output: OutputFormat, json_style: JsonStyle) -> ExitCode {
@@ -847,9 +891,9 @@ mod tests {
     };
 
     use super::{
-        MAX_CANDIDATE_INPUT_BYTES, inspect_command, read_bounded_candidate_file,
-        read_bounded_verdict_file, render_posix_argument, render_powershell_argument,
-        render_reviewed_candidate, review_summary,
+        MAX_CANDIDATE_INPUT_BYTES, candidate_touches_scope, inspect_command,
+        read_bounded_candidate_file, read_bounded_verdict_file, render_posix_argument,
+        render_powershell_argument, render_reviewed_candidate, review_summary,
     };
 
     fn reviewed_candidate(
@@ -1044,5 +1088,35 @@ mod tests {
             review_summary(2, 1, fallow_output::SimilarCodeCompletionStatus::Partial),
             "\nReviewed: 2 candidates, 1 matched verdict, 1 unmatched candidate\nSource completion: partial\n"
         );
+    }
+
+    #[test]
+    fn scope_matches_candidates_touching_either_side() {
+        let reviewed = reviewed_candidate(
+            None,
+            SimilarCodeVerdictMatch::CandidateId,
+            SimilarCodeDomainOutcome::NeedsHumanReview,
+        );
+        let root = std::path::Path::new("/project");
+        assert!(candidate_touches_scope(
+            &reviewed.candidate,
+            root,
+            &root.join("src")
+        ));
+        assert!(candidate_touches_scope(
+            &reviewed.candidate,
+            root,
+            &root.join("src/left.ts")
+        ));
+        assert!(!candidate_touches_scope(
+            &reviewed.candidate,
+            root,
+            &root.join("other")
+        ));
+        assert!(!candidate_touches_scope(
+            &reviewed.candidate,
+            root,
+            &root.join("src-extra")
+        ));
     }
 }

--- a/crates/cli/src/viz.rs
+++ b/crates/cli/src/viz.rs
@@ -291,6 +291,7 @@ fn viz_health_options<'a>(
         churn_file: None,
         analysis_identity: SemanticAnalysisIdentity::default(),
         group_by: None,
+        scope: None,
     }
 }
 

--- a/crates/cli/tests/scope_path_tests.rs
+++ b/crates/cli/tests/scope_path_tests.rs
@@ -42,6 +42,20 @@ fn create_scope_fixture() -> TempDir {
     tmp
 }
 
+/// Temp project with a clone pair straddling the `src/` / `other/` boundary,
+/// for the 1-in-rest-out filter variant: a group must survive when ANY
+/// instance touches the scope, mirroring the workspace and diff filters.
+fn create_cross_scope_fixture() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::create_dir_all(dir.join("other")).unwrap();
+    fs::write(dir.join("package.json"), r#"{"name":"cross-scope-test"}"#).unwrap();
+    fs::write(dir.join("src/a.ts"), DUPLICATED_MODULE).unwrap();
+    fs::write(dir.join("other/c.ts"), DUPLICATED_MODULE).unwrap();
+    tmp
+}
+
 fn git(dir: &std::path::Path, args: &[&str]) {
     let output = Command::new("git")
         .args(args)
@@ -110,6 +124,26 @@ fn dupes_file_scope_reports_touching_groups() {
         has_clone_group_with_files(&json, &["src/a.ts", "src/b.ts"]),
         "file scope should keep groups touching the file. stdout: {}",
         output.stdout
+    );
+}
+
+#[test]
+fn dupes_scope_keeps_groups_touching_scope_from_outside() {
+    let tmp = create_cross_scope_fixture();
+    let from_src = run_fallow_in_root("dupes", tmp.path(), &["--format", "json", "src"]);
+    let json = parse_json(&from_src);
+    assert!(
+        has_clone_group_with_files(&json, &["src/a.ts", "other/c.ts"]),
+        "scope should keep groups with any instance inside it. stdout: {}",
+        from_src.stdout
+    );
+
+    let from_other = run_fallow_in_root("dupes", tmp.path(), &["--format", "json", "other"]);
+    let json = parse_json(&from_other);
+    assert!(
+        has_clone_group_with_files(&json, &["src/a.ts", "other/c.ts"]),
+        "scope should keep the same group from the other side. stdout: {}",
+        from_other.stdout
     );
 }
 

--- a/crates/cli/tests/scope_path_tests.rs
+++ b/crates/cli/tests/scope_path_tests.rs
@@ -1,0 +1,338 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "tests and benches use unwrap and expect to keep fixture setup concise"
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::fs;
+use std::process::Command;
+
+use common::{parse_json, run_fallow_in_root};
+use tempfile::TempDir;
+
+const DUPLICATED_MODULE: &str = r"export function add(a: number, b: number): number {
+  return a + b;
+}
+export function sub(a: number, b: number): number {
+  return a - b;
+}
+export function mul(a: number, b: number): number {
+  return a * b;
+}
+export function div(a: number, b: number): number {
+  return a / b;
+}
+";
+
+/// Temp project with a duplicated pair under `src/` and a unique module
+/// under `other/`. Returns the `TempDir` guard so the directory outlives the
+/// caller.
+fn create_scope_fixture() -> TempDir {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::create_dir_all(dir.join("other")).unwrap();
+    fs::write(dir.join("package.json"), r#"{"name":"scope-test"}"#).unwrap();
+    fs::write(dir.join("src/a.ts"), DUPLICATED_MODULE).unwrap();
+    fs::write(dir.join("src/b.ts"), DUPLICATED_MODULE).unwrap();
+    fs::write(dir.join("other/c.ts"), "export const solo = 1;\n").unwrap();
+    tmp
+}
+
+fn git(dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@test.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@test.com")
+        .output()
+        .expect("git command failed");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn has_clone_group_with_files(json: &serde_json::Value, expected: &[&str]) -> bool {
+    json["clone_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|group| {
+            expected.iter().all(|file| {
+                group["instances"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|instance| instance["file"].as_str() == Some(*file))
+            })
+        })
+}
+
+#[test]
+fn dupes_dir_scope_reports_only_scoped_clones() {
+    let tmp = create_scope_fixture();
+    let scoped = run_fallow_in_root("dupes", tmp.path(), &["--format", "json", "src"]);
+    let json = parse_json(&scoped);
+    assert!(
+        has_clone_group_with_files(&json, &["src/a.ts", "src/b.ts"]),
+        "scoped run should report the src clone. stdout: {}",
+        scoped.stdout
+    );
+
+    let empty = run_fallow_in_root("dupes", tmp.path(), &["--format", "json", "other"]);
+    let json = parse_json(&empty);
+    assert_eq!(
+        json["clone_groups"].as_array().unwrap().len(),
+        0,
+        "out-of-clone scope should report no groups. stdout: {}",
+        empty.stdout
+    );
+}
+
+#[test]
+fn dupes_file_scope_reports_touching_groups() {
+    let tmp = create_scope_fixture();
+    let output = run_fallow_in_root("dupes", tmp.path(), &["--format", "json", "src/a.ts"]);
+    let json = parse_json(&output);
+    assert!(
+        has_clone_group_with_files(&json, &["src/a.ts", "src/b.ts"]),
+        "file scope should keep groups touching the file. stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn dupes_missing_path_is_exit_two() {
+    let tmp = create_scope_fixture();
+    let output = run_fallow_in_root("dupes", tmp.path(), &["nosuchdir"]);
+    assert_eq!(
+        output.code, 2,
+        "missing PATH should exit 2. stderr: {}",
+        output.stderr
+    );
+    assert!(
+        output.stdout.contains("does not exist") || output.stderr.contains("does not exist"),
+        "missing PATH should name the problem. stdout: {} stderr: {}",
+        output.stdout,
+        output.stderr
+    );
+}
+
+#[test]
+fn dupes_outside_root_path_is_exit_two() {
+    let tmp = create_scope_fixture();
+    let outside = tmp.path().parent().expect("temp dir has a parent");
+    let output = run_fallow_in_root(
+        "dupes",
+        tmp.path(),
+        &[outside.to_str().expect("parent is utf-8")],
+    );
+    assert_eq!(
+        output.code, 2,
+        "outside-root PATH should exit 2. stderr: {}",
+        output.stderr
+    );
+    assert!(
+        output.stdout.contains("outside the project root")
+            || output.stderr.contains("outside the project root"),
+        "outside-root PATH should name the problem. stdout: {} stderr: {}",
+        output.stdout,
+        output.stderr
+    );
+}
+
+#[test]
+fn check_file_scope_narrows_to_the_file() {
+    let tmp = create_scope_fixture();
+    let output = run_fallow_in_root("check", tmp.path(), &["src/a.ts"]);
+    assert!(
+        output.stdout.contains("src/a.ts"),
+        "scoped check should report the file. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("src/b.ts") && !output.stdout.contains("other/c.ts"),
+        "scoped check should hide other files. stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn check_dir_scope_narrows_to_the_directory() {
+    let tmp = create_scope_fixture();
+    let output = run_fallow_in_root("check", tmp.path(), &["src"]);
+    assert!(
+        output.stdout.contains("src/a.ts") || output.stdout.contains("src/b.ts"),
+        "scoped check should report src findings. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("other/c.ts"),
+        "scoped check should hide other/ findings. stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn bare_combined_path_scope_narrows_report() {
+    let tmp = create_scope_fixture();
+    let bin = common::fallow_bin();
+    let output = std::process::Command::new(&bin)
+        .arg("--root")
+        .arg(tmp.path())
+        .arg("src")
+        .env("RUST_LOG", "")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run fallow binary");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(
+        stdout.contains("src/a.ts") || stdout.contains("src/b.ts"),
+        "scoped bare run should report src findings. stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("other/c.ts"),
+        "scoped bare run should hide other/ findings. stdout: {stdout}"
+    );
+}
+
+#[test]
+fn list_files_scope_narrows_inventory() {
+    let tmp = create_scope_fixture();
+    let output = run_fallow_in_root("list", tmp.path(), &["--files", "src"]);
+    assert_eq!(
+        output.code, 0,
+        "list should succeed. stderr: {}",
+        output.stderr
+    );
+    assert!(
+        output.stdout.contains("src/a.ts") && output.stdout.contains("src/b.ts"),
+        "scoped list should show src files. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("other/c.ts"),
+        "scoped list should hide other/ files. stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn health_dir_scope_runs_scoped() {
+    let tmp = create_scope_fixture();
+    let output = run_fallow_in_root("health", tmp.path(), &["--file-scores", "src"]);
+    assert!(
+        output.stdout.contains("src/"),
+        "scoped health should mention scoped files. stdout: {}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("other/c.ts"),
+        "scoped health should hide other/ files. stdout: {}",
+        output.stdout
+    );
+}
+
+#[test]
+fn fix_dry_run_scope_limits_plan() {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let dir = tmp.path();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::create_dir_all(dir.join("other")).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name":"fix-test","main":"src/index.ts"}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import { used } from './utils';\nused();\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/utils.ts"),
+        "export const used = (): number => 42;\nexport const unusedExtra = (): number => 0;\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("other/stuff.ts"),
+        "export const otherUnused = 1;\n",
+    )
+    .unwrap();
+
+    let scoped = run_fallow_in_root("fix", dir, &["--dry-run", "--format", "json", "src"]);
+    let json = parse_json(&scoped);
+    let fixes = json["fixes"].as_array().unwrap();
+    assert!(
+        !fixes.is_empty(),
+        "scoped fix plan should contain fixes. stdout: {}",
+        scoped.stdout
+    );
+    assert!(
+        fixes.iter().all(|fix| {
+            fix["path"]
+                .as_str()
+                .is_some_and(|path| path.starts_with("src/"))
+        }),
+        "scoped fix plan should only touch src files. stdout: {}",
+        scoped.stdout
+    );
+
+    let empty = run_fallow_in_root("fix", dir, &["--dry-run", "--format", "json", "other"]);
+    let json = parse_json(&empty);
+    assert_eq!(
+        json["fixes"].as_array().unwrap().len(),
+        0,
+        "out-of-scope fix plan should be empty. stdout: {}",
+        empty.stdout
+    );
+}
+
+#[test]
+fn audit_scope_narrows_changed_universe() {
+    let tmp = create_scope_fixture();
+    let dir = tmp.path();
+    git(dir, &["init", "-b", "main"]);
+    git(dir, &["add", "."]);
+    git(
+        dir,
+        &["-c", "commit.gpgsign=false", "commit", "-m", "initial"],
+    );
+    fs::write(
+        dir.join("src/a.ts"),
+        format!("{DUPLICATED_MODULE}export const touched = 1;\n"),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("other/c.ts"),
+        "export const solo = 1;\nexport const changed = 2;\n",
+    )
+    .unwrap();
+
+    let output = run_fallow_in_root("audit", dir, &["--gate", "all", "src"]);
+    let combined = format!("{}\n{}", output.stdout, output.stderr);
+    assert!(
+        combined.contains("src/a.ts"),
+        "scoped audit should report scoped changes. stdout: {} stderr: {}",
+        output.stdout,
+        output.stderr
+    );
+    assert!(
+        !combined.contains("other/c.ts"),
+        "scoped audit should hide out-of-scope changes. stdout: {} stderr: {}",
+        output.stdout,
+        output.stderr
+    );
+}

--- a/crates/engine/src/health/mod.rs
+++ b/crates/engine/src/health/mod.rs
@@ -483,6 +483,11 @@ pub struct HealthExecutionOptions<'a> {
     pub workspace: Option<&'a [String]>,
     /// Git ref selecting only workspaces with changes since it.
     pub changed_workspaces: Option<&'a str>,
+    /// Positional `[PATH]` scope: root-joined absolute file or directory inside
+    /// the root. Consumed CLI-side as one more workspace root (prefix scope),
+    /// so it composes with `workspace` the way multiple workspace roots
+    /// compose. `None` means whole-project scope.
+    pub scope: Option<PathBuf>,
     /// Baseline file to compare finding counts against.
     pub baseline: Option<&'a Path>,
     /// Path to write the run's finding counts as a new baseline.
@@ -830,6 +835,7 @@ mod tests {
             use_shared_diff_index: false,
             workspace: Some(&workspace),
             changed_workspaces: None,
+            scope: None,
             baseline: Some(Path::new(".fallow/health-baseline.json")),
             save_baseline: None,
             baseline_mode: crate::baseline::HealthBaselineMode::Count,
@@ -935,6 +941,7 @@ mod tests {
                 use_shared_diff_index: false,
                 workspace: None,
                 changed_workspaces: None,
+                scope: None,
                 baseline: None,
                 save_baseline: None,
                 baseline_mode: crate::baseline::HealthBaselineMode::Count,

--- a/npm/fallow/capabilities.json
+++ b/npm/fallow/capabilities.json
@@ -5,6 +5,12 @@
   "description": "Codebase analyzer for TypeScript/JavaScript: unused code, circular dependencies, code duplication, complexity hotspots, and architecture boundary violations",
   "global_flags": [
     {
+      "name": "path",
+      "type": "string",
+      "required": false,
+      "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
+    },
+    {
       "name": "--root",
       "type": "string",
       "required": false,
@@ -882,6 +888,12 @@
           "type": "string",
           "required": false,
           "description": "Only report issues in the specified file(s). Accepts multiple values. The full project graph is still built, but only issues in matching files are reported. Useful for lint-staged pre-commit hooks"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },
@@ -938,6 +950,12 @@
           "type": "string",
           "required": false,
           "description": "Report pairs touching one of these project-relative files"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },
@@ -1068,6 +1086,12 @@
             "true",
             "false"
           ]
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed. Only fixes touching scoped files are planned and applied"
         }
       ]
     },
@@ -1249,6 +1273,12 @@
             "true",
             "false"
           ]
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },
@@ -1368,6 +1398,12 @@
           "type": "string",
           "required": false,
           "description": "Trace all clones at a specific location (format: `FILE:LINE`)"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },
@@ -1626,6 +1662,12 @@
           "type": "string",
           "required": false,
           "description": "Fraction of total trace count below which an invoked function is classified as `low_traffic` rather than `active`. Expressed as a decimal (e.g. `0.001` for 0.1%). Omit to use the sidecar's spec default (0.001)"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },
@@ -1857,11 +1899,17 @@
           "name": "--show-deprioritized",
           "type": "bool",
           "required": false,
-          "description": "Expand the de-prioritized units in the review brief's weighted focus map (\"show me what you de-prioritized\"). The `deprioritized` escape-hatch list is ALWAYS present in `--format json` regardless; this flag only re-expands the collapse-by-default human focus render. Only consulted on the brief path",
+          "description": "Expand the de-prioritized units in the review brief's weighted focus map (\"show me what you de-prioritized\"). The `deprioritized` escape-hatch list is ALWAYS present in `--format json` regardless; this flag only re-expands the collapse-by-default human focus render. Only consulted on the `--walkthrough` path",
           "possible_values": [
             "true",
             "false"
           ]
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },
@@ -1960,6 +2008,12 @@
             "true",
             "false"
           ]
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
         }
       ]
     },

--- a/npm/fallow/skills/fallow/references/cli-reference.md
+++ b/npm/fallow/skills/fallow/references/cli-reference.md
@@ -1808,6 +1808,7 @@ Available on all commands:
 <!-- generated:flags:global:start -->
 | Flag | Type | Default | Description |
 |---|---|---|---|
+| `path` | `string` | - | Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed |
 | `-r, --root` | `string` | - | Project root directory |
 | `-c, --config` | `string` | - | Config file path |
 | `--allow-remote-extends` | `bool` | `false` | Allow trusted config files to extend HTTPS URLs |

--- a/scripts/agent-doc-curated-seeds.json
+++ b/scripts/agent-doc-curated-seeds.json
@@ -174,7 +174,7 @@
       "section": "commands",
       "row": "fix",
       "column": "Key Flags",
-      "seed": "`--dry-run`, `--yes`, `--no-create-config`"
+      "seed": "`--dry-run`, `--yes`, `--no-create-config`, `path`"
     },
     {
       "section": "commands",
@@ -282,7 +282,7 @@
       "section": "commands",
       "row": "list",
       "column": "Key Flags",
-      "seed": "`--entry-points`, `--files`, `--plugins`, `--boundaries`, `--workspaces`"
+      "seed": "`--entry-points`, `--files`, `--plugins`, `--boundaries`, `--workspaces`, `path`"
     },
     {
       "section": "commands",
@@ -390,7 +390,7 @@
       "section": "commands",
       "row": "security",
       "column": "Key Flags",
-      "seed": "`--runtime-coverage`, `--min-invocations-hot`, `--file`, `--gate`, `--surface`"
+      "seed": "`--runtime-coverage`, `--min-invocations-hot`, `--file`, `--gate`, `--surface`, `path`"
     },
     {
       "section": "commands",
@@ -414,7 +414,7 @@
       "section": "commands",
       "row": "similar-code",
       "column": "Key Flags",
-      "seed": "`--threshold`, `--min-lines`, `--top`, `--file`"
+      "seed": "`--threshold`, `--min-lines`, `--top`, `--file`, `path`"
     },
     {
       "section": "commands",
@@ -642,7 +642,7 @@
       "section": "flags:audit",
       "row": "--show-deprioritized",
       "column": "Description",
-      "seed": "Expand the de-prioritized units in the review brief's weighted focus map (\"show me what you de-prioritized\"). The `deprioritized` escape-hatch list is ALWAYS present in `--format json` regardless; this flag only re-expands the collapse-by-default human focus render. Only consulted on the brief path"
+      "seed": "Expand the de-prioritized units in the review brief's weighted focus map (\"show me what you de-prioritized\"). The `deprioritized` escape-hatch list is ALWAYS present in `--format json` regardless; this flag only re-expands the collapse-by-default human focus render. Only consulted on the `--walkthrough` path"
     },
     {
       "section": "flags:audit",
@@ -1483,6 +1483,12 @@
       "row": "--workspace",
       "column": "Description",
       "seed": "Scope output to selected workspaces. Accepts exact names, glob patterns, and `!`-prefixed negations. Values can be comma-separated or repeated"
+    },
+    {
+      "section": "flags:global",
+      "row": "path",
+      "column": "Description",
+      "seed": "Scope reported findings to this file or directory (default: whole project). The full project graph is still built; only reported items are narrowed"
     },
     {
       "section": "flags:health",

--- a/scripts/cli-global-flag-surfaces.test.mjs
+++ b/scripts/cli-global-flag-surfaces.test.mjs
@@ -30,12 +30,21 @@ const declaredGlobalFlags = () => {
   const names = [];
   for (const [, attributes, field] of body.matchAll(ARG_FIELD)) {
     const explicit = attributes.match(/\blong\s*=\s*"([^"]+)"/);
-    const name = explicit ? `--${explicit[1]}` : `--${field.replaceAll("_", "-")}`;
-    if (!explicit && !/\blong\b/.test(attributes)) {
+    if (explicit) {
+      const name = `--${explicit[1]}`;
+      if (!SCHEMA_EXCLUDED_FLAGS.has(name)) {
+        names.push(name);
+      }
       continue;
     }
-    if (!SCHEMA_EXCLUDED_FLAGS.has(name)) {
-      names.push(name);
+    if (/\blong\b/.test(attributes)) {
+      names.push(`--${field.replaceAll("_", "-")}`);
+      continue;
+    }
+    // Bare positionals (e.g. `[PATH]`) carry `value_name` instead of `long`
+    // and surface in the manifest under their clap id.
+    if (/\bvalue_name\b/.test(attributes)) {
+      names.push(field);
     }
   }
   assert.ok(names.length > 10, "root flag extraction should find the global flag block");


### PR DESCRIPTION
Adds an optional positional `[PATH]` to bare `fallow`, `check`, `dupes`, `health`, `audit`, `security`, `fix`, `list`, and `similar-code`.

The scope narrows reported findings to the file or directory while the full project graph is still built, so cross-file facts stay sound (`fallow dupes fixtures/` instead of `cd fixtures && fallow dupes`).

Resolution is root-first for bare relative paths, honors `./` and `../` as current-directory claims, and rejects missing or outside-root paths with an actionable exit-2 error. Scope composes with `--workspace` as one more workspace root and intersects with `--changed-since` and `--diff-file`. Audit narrows its changed-file universe so verdict and base attribution stay coherent; its base pass stays unscoped because it runs in another worktree.

Validation: `npm run verify:fast` green, `generate:contracts:check` green, new unit tests (`scope_path`) plus CLI integration tests (`scope_path_tests`, 11 tests), real-project smoke on this repo, and the cwd != root != base-worktree audit smoke.

Follow-ups: curated per-command PATH prose in the CLI reference, `viz` subgraph scoping.