### PR TITLE
fix(coverage): index instrumenter-named callbacks and object members for the cloud join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [backwards compatibility](docs/backwards-compatibility.md)
   (Closes [#2607](https://github.com/fallow-rs/fallow/issues/2607)).
 
+### Fixed
+
+- **`fallow coverage analyze --cloud` no longer drops callbacks, object
+  members and accessors.** The static index the cloud answer is joined against
+  was built from the health/complexity pass, which enumerates declarations and
+  bindings only. Every other function the runtime instrumenter names, an arrow
+  passed to a call and named after its callee (`rows.map(...)`,
+  `sqliteTable("t", {}, (table) => [...])`, `.references(() => ...)`), an
+  object-literal method, a getter or setter, and a function assigned to a
+  member, was missing from the index, so the cloud row for it had nothing to
+  join against and was counted in `cloud_functions_unmatched` instead of
+  reaching `findings` and `hot_paths`. Those are the highest-traffic functions
+  in a typical service, so the hot-path list was led by whatever declaration
+  happened to be enumerated. The index now also carries every function the
+  instrumenter would name, resolved through the same walker the static
+  inventory upload uses, so the identity matches the `stable_id` the cloud
+  stores. A function known only by the callee it was passed to is flagged as a
+  callback and its verdict copy names the call site ("Callback passed to
+  `map`; ...") instead of pointing at a declaration that does not exist
+  (Closes [#2606](https://github.com/fallow-rs/fallow/issues/2606)).
+- **The static function inventory names object members, accessors and default
+  exports the way the instrumenter does.** The inventory walker left an
+  object-literal method, a function-valued property, a getter or setter, a
+  function assigned to a member expression, and an anonymous `export default`
+  at their `(anonymous_N)` placeholder, while `oxc-coverage-instrument` names
+  them `run`, `execute`, `get closed`, `rollback` and `default`. Both sides now
+  agree, so an uploaded inventory entry and the runtime row for the same
+  function share one identity.
+
 ## [3.24.1] - 2026-09-09
 
 ### Fixed

--- a/crates/cli/src/coverage/analyze.rs
+++ b/crates/cli/src/coverage/analyze.rs
@@ -8,7 +8,11 @@ use std::time::Instant;
 use fallow_config::OutputFormat;
 use fallow_cov_protocol::function_identity_id;
 use fallow_engine::changed_files::clear_ambient_git_env;
+use fallow_engine::source::inventory::{
+    InventoryComplexity, InventoryEntry, walk_source_with_complexity,
+};
 use fallow_types::cloud::CLOUD_API_KEY_MISSING_MESSAGE;
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::coverage::RunContext;
@@ -17,6 +21,7 @@ use crate::coverage::cloud_client::{
     CloudRuntimeProvenance, CloudRuntimeWarning, CloudTrackingState, fetch_runtime_context,
 };
 use crate::coverage::upload_common::parse_git_remote_to_project_id;
+use crate::coverage::upload_inventory::extension_supported;
 use crate::error::emit_error;
 use crate::health::HealthOptions;
 use fallow_output::{
@@ -434,6 +439,12 @@ struct StaticFunctionInfo {
     /// finding built from this function carries a line-move-immune key for
     /// baseline suppression.
     source_hash: Option<String>,
+    /// Whether `name` is the callee this function was passed to
+    /// (`arr.map(cb)` -> `map`) rather than a declared or bound name. The
+    /// runtime instrumenter names callbacks that way, so the join key reads
+    /// like a declaration while the source has no declaration to point at;
+    /// the verdict copy says "callback passed to X" instead.
+    is_callback: bool,
 }
 
 #[derive(Default)]
@@ -549,6 +560,7 @@ fn build_index_from_analysis(
     };
     let mut out = StaticIndex::default();
     let graph = analysis_output.graph.as_ref();
+    let mut walked = Vec::with_capacity(modules.len());
     for module in modules {
         let Some(path) = file_paths.get(&module.file_id) else {
             continue;
@@ -568,8 +580,116 @@ fn build_index_from_analysis(
             );
             index_static_function(&mut out, &rel, info);
         }
+        walked.push(ModuleIndexContext {
+            path: (*path).clone(),
+            rel,
+            caller_count,
+            owner_count,
+        });
     }
+    index_instrumenter_functions(&mut out, &walked, &reachability);
     out
+}
+
+/// The per-file facts the instrumenter-name pass needs after the complexity
+/// pass has consumed the parsed module.
+struct ModuleIndexContext {
+    /// Absolute path of the file on disk, re-read by the inventory walker.
+    path: PathBuf,
+    /// Repo-relative posix path, the one the identity hash is taken over.
+    rel: String,
+    caller_count: u32,
+    owner_count: Option<u32>,
+}
+
+/// Index every function the runtime instrumenter would name, on top of the
+/// complexity pass.
+///
+/// The health/complexity pass enumerates declarations, so a callback passed to
+/// a call (`sqliteTable("t", {}, (table) => [...])`, `.references(() => ...)`,
+/// `rows.map(...)`), an object-literal method, and an accessor never enter the
+/// index. A cloud row for one of those carries the instrumenter's name, so it
+/// has nothing to join against and the hottest functions in a service are
+/// dropped from `findings` and `hot_paths`. The inventory walker already
+/// reproduces `oxc-coverage-instrument`'s naming for exactly this contract, so
+/// walking the same files with it closes the gap on the identity the cloud
+/// stores. Complexity-pass entries win every collision; only identities the
+/// first pass never produced are added.
+fn index_instrumenter_functions(
+    out: &mut StaticIndex,
+    contexts: &[ModuleIndexContext],
+    reachability: &Reachability<'_>,
+) {
+    let per_file: Vec<Vec<StaticFunctionInfo>> = contexts
+        .par_iter()
+        .map(|context| instrumenter_functions_for_file(context, reachability))
+        .collect();
+    for (context, functions) in contexts.iter().zip(per_file) {
+        for info in functions {
+            if out.by_stable_id.contains_key(&info.stable_id) {
+                continue;
+            }
+            index_static_function(out, &context.rel, info);
+        }
+    }
+}
+
+/// Walk one file with the inventory walker and build static info for every
+/// function it names. A file the walker cannot parse, or cannot read, yields
+/// nothing: the complexity-pass entries for it stay as they are.
+fn instrumenter_functions_for_file(
+    context: &ModuleIndexContext,
+    reachability: &Reachability<'_>,
+) -> Vec<StaticFunctionInfo> {
+    if !extension_supported(&context.path) {
+        return Vec::new();
+    }
+    let Ok(source) = std::fs::read_to_string(&context.path) else {
+        return Vec::new();
+    };
+    let (entries, complexity) = walk_source_with_complexity(&context.path, &source);
+    entries
+        .into_iter()
+        .map(|entry| {
+            // Complexity is paired by `source_hash`, which the walker derives
+            // from the same full-span slice it hashes for the entry, so the
+            // lookup is exact.
+            let metrics = complexity.get(&entry.source_hash).copied();
+            instrumenter_function_info(entry, metrics, context, reachability)
+        })
+        .collect()
+}
+
+/// Build a `StaticFunctionInfo` for one inventory entry.
+fn instrumenter_function_info(
+    entry: InventoryEntry,
+    metrics: Option<InventoryComplexity>,
+    context: &ModuleIndexContext,
+    reachability: &Reachability<'_>,
+) -> StaticFunctionInfo {
+    let static_used =
+        reachability
+            .analysed
+            .function_is_used(&context.path, &entry.name, entry.line);
+    let stable_id = function_identity_id(&context.rel, &entry.name, entry.line);
+    let test_only_reference = reachability
+        .full_tree
+        .map(|full| !static_used && full.function_is_used(&context.path, &entry.name, entry.line));
+    StaticFunctionInfo {
+        path: PathBuf::from(&context.rel),
+        name: entry.name,
+        start_line: entry.line,
+        end_line: entry.end_line,
+        static_used,
+        test_only_reference,
+        test_covered: false,
+        cyclomatic: metrics.map_or(0, |metrics| u32::from(metrics.cyclomatic)),
+        caller_count: context.caller_count,
+        owner_count: context.owner_count,
+        stable_id,
+        source_hash: Some(entry.source_hash),
+        is_callback: entry.is_callback,
+    }
 }
 
 /// Per-file sets of statically-unused files and exports, used to flag whether a
@@ -659,6 +779,9 @@ fn static_function_info(
         owner_count,
         stable_id: function_identity_id(rel, &function.name, function.line),
         source_hash: function.source_hash.clone(),
+        // The complexity pass only enumerates declarations and bindings, so
+        // nothing it produces is a callee-named callback.
+        is_callback: false,
     }
 }
 
@@ -1082,7 +1205,11 @@ fn cloud_finding(
             observation_days,
             deployments_observed: function.deployments_observed,
         },
-        actions: runtime_actions(verdict, local.test_only_reference == Some(true)),
+        actions: runtime_actions(
+            verdict,
+            local.test_only_reference == Some(true),
+            local.is_callback.then_some(local.name.as_str()),
+        ),
         // The cloud-join path (analyze --cloud) does not carry the window
         // trace_count + thresholds here, so it omits the #321 discriminator
         // block; that surface's discriminator contract is #328 territory.
@@ -1503,14 +1630,28 @@ fn normalize_runtime_path(path: &Path) -> String {
 /// review-required advice to the case where the only remaining callers live in
 /// files production mode excluded, because there the reviewer has a concrete
 /// choice to make rather than a general "look at this".
+/// Build the action list for one runtime finding.
+///
+/// `callback_callee` is set when the function has no declared name of its own
+/// and is known only as the callee it was passed to, so the copy can point at
+/// the call site (`callback passed to map`) rather than tell the reader to go
+/// find a declaration that does not exist.
 fn runtime_actions(
     verdict: RuntimeCoverageVerdict,
     test_only_reference: bool,
+    callback_callee: Option<&str>,
 ) -> Vec<RuntimeCoverageAction> {
     match verdict {
         RuntimeCoverageVerdict::SafeToDelete => vec![RuntimeCoverageAction {
             kind: "delete-cold-code".to_owned(),
-            description: "Remove cold code after confirming ownership.".to_owned(),
+            description: callback_callee.map_or_else(
+                || "Remove cold code after confirming ownership.".to_owned(),
+                |callee| {
+                    format!(
+                        "Callback passed to {callee}; remove the cold code after confirming ownership."
+                    )
+                },
+            ),
             auto_fixable: false,
         }],
         RuntimeCoverageVerdict::ReviewRequired if test_only_reference => {
@@ -1523,7 +1664,12 @@ fn runtime_actions(
         }
         RuntimeCoverageVerdict::ReviewRequired => vec![RuntimeCoverageAction {
             kind: "review-runtime".to_owned(),
-            description: "Review runtime-cold code before changing it.".to_owned(),
+            description: callback_callee.map_or_else(
+                || "Review runtime-cold code before changing it.".to_owned(),
+                |callee| {
+                    format!("Callback passed to {callee}; review the runtime-cold code before changing it.")
+                },
+            ),
             auto_fixable: false,
         }],
         RuntimeCoverageVerdict::CoverageUnavailable
@@ -1938,6 +2084,7 @@ mod tests {
             owner_count: None,
             stable_id: function_identity_id("src/a.ts", "oldFlow", 10),
             source_hash: None,
+            is_callback: false,
         };
         index_static_function(&mut static_index, "src/a.ts", info);
         let mut snapshot = cloud_context(1, 0);
@@ -2105,10 +2252,18 @@ export const register = (app: { get: (path: string, handler: () => string) => vo
 ";
 
     fn fixture_static_index(source: &str) -> (tempfile::TempDir, StaticIndex) {
+        fixture_static_index_at("src/db/file-client.ts", source)
+    }
+
+    fn fixture_static_index_at(
+        relative_path: &str,
+        source: &str,
+    ) -> (tempfile::TempDir, StaticIndex) {
         let dir = tempfile::TempDir::new().expect("temp dir should be created");
-        std::fs::create_dir_all(dir.path().join("src/db")).expect("src/db should be created");
-        std::fs::write(dir.path().join("src/db/file-client.ts"), source)
-            .expect("fixture source should be written");
+        let file = dir.path().join(relative_path);
+        std::fs::create_dir_all(file.parent().expect("fixture path should have a parent"))
+            .expect("fixture directory should be created");
+        std::fs::write(&file, source).expect("fixture source should be written");
         std::fs::write(
             dir.path().join("package.json"),
             r#"{"name":"fixture","version":"0.0.0","type":"module"}"#,
@@ -2323,6 +2478,169 @@ export const orphan = () => {
         );
     }
 
+    /// Fixture project carrying the shapes the health/complexity pass does not
+    /// enumerate: a Drizzle-style schema whose table and column callbacks are
+    /// anonymous arrows, an object returned from a factory with methods, a
+    /// getter, and a `.map(...)` chain. Runtime instrumentation names each of
+    /// them after the callee it was passed to or after the property key.
+    const SCHEMA_FIXTURE_SOURCE: &str = r"declare const sqliteTable: (
+  name: string,
+  columns: Record<string, unknown>,
+  extra?: (table: Record<string, unknown>) => unknown[],
+) => Record<string, unknown>;
+declare const text: (name: string) => {
+  primaryKey: () => unknown;
+  references: (target: () => unknown) => unknown;
+};
+declare const index: (name: string) => { on: (column: unknown) => unknown };
+
+export const orgs = sqliteTable('orgs', {
+  id: text('id').primaryKey(),
+});
+
+export const users = sqliteTable(
+  'users',
+  {
+    id: text('id').primaryKey(),
+    orgId: text('org_id').references(() => orgs.id),
+  },
+  (table) => [index('users_org_idx').on(table.orgId)],
+);
+
+export const createStore = (rows: string[]) => {
+  return {
+    execute: async (sql: string) => {
+      return rows.map((row) => row + sql.length);
+    },
+    rollback: () => rows.length,
+    get closed() {
+      return rows.length === 0;
+    },
+  };
+};
+";
+
+    /// A cloud row for `SCHEMA_FIXTURE_SOURCE`, carrying the container-prefixed
+    /// runtime path the service reports and the `stable_id` the cloud hashes
+    /// over the repo-relative path, so the join has to land on the stable-id
+    /// tier rather than on a positional fallback.
+    fn schema_cloud_function(
+        name: &str,
+        start_line: u32,
+        end_line: u32,
+        hits: u64,
+    ) -> CloudRuntimeFunction {
+        let mut function = cloud_function(
+            "/app/src/db/schema.ts",
+            name,
+            Some(start_line),
+            Some(start_line),
+            Some(end_line),
+        );
+        function.stable_id = Some(function_identity_id("src/db/schema.ts", name, start_line));
+        function.tracking_state = CloudTrackingState::Called;
+        function.hit_count = Some(hits);
+        function
+    }
+
+    #[test]
+    fn instrumenter_named_callbacks_and_members_match_on_stable_id() {
+        let (_dir, static_index) =
+            fixture_static_index_at("src/db/schema.ts", SCHEMA_FIXTURE_SOURCE);
+        let functions = vec![
+            schema_cloud_function("references", 20, 20, 27),
+            schema_cloud_function("sqliteTable", 22, 22, 25),
+            schema_cloud_function("createStore", 25, 35, 611),
+            schema_cloud_function("execute", 27, 29, 100_000),
+            schema_cloud_function("map", 28, 28, 21_200_000),
+            schema_cloud_function("rollback", 30, 30, 33),
+            schema_cloud_function("get closed", 31, 33, 36_800_000),
+        ];
+        let identities: Vec<(String, String)> = functions
+            .iter()
+            .map(|function| {
+                (
+                    function.function_name.clone(),
+                    function
+                        .stable_id
+                        .clone()
+                        .expect("the fixture sets a stable id"),
+                )
+            })
+            .collect();
+        let mut snapshot = cloud_context(functions.len(), 0);
+        snapshot.functions = functions;
+
+        let CloudMergeOutput { report, unmatched } =
+            merge_cloud_snapshot(&snapshot, &static_index, 1);
+
+        assert!(
+            unmatched.is_empty(),
+            "every instrumenter-named function has a local counterpart, got {unmatched:?}"
+        );
+        for (name, stable_id) in &identities {
+            let indexed = static_index.by_stable_id.get(stable_id);
+            assert_eq!(
+                indexed.map(|info| info.name.as_str()),
+                Some(name.as_str()),
+                "{name} must join on the stable-id tier, not on a positional fallback"
+            );
+        }
+        let mut hot: Vec<(String, u64)> = report
+            .hot_paths
+            .iter()
+            .map(|path| (path.function.clone(), path.invocations))
+            .collect();
+        hot.sort_by_key(|(_, invocations)| std::cmp::Reverse(*invocations));
+        assert_eq!(
+            hot.first().map(|(name, hits)| (name.as_str(), *hits)),
+            Some(("get closed", 36_800_000)),
+            "the busiest instrumenter-named function must lead the hot paths"
+        );
+        assert!(
+            hot.iter()
+                .any(|(name, hits)| name == "map" && *hits == 21_200_000),
+            "the map callback must reach the hot paths with its invocation count, got {hot:?}"
+        );
+        for hot_path in &report.hot_paths {
+            assert_eq!(hot_path.path, PathBuf::from("src/db/schema.ts"));
+        }
+    }
+
+    #[test]
+    fn cold_callback_verdict_copy_points_at_the_call_site() {
+        let (_dir, static_index) =
+            fixture_static_index_at("src/db/schema.ts", SCHEMA_FIXTURE_SOURCE);
+        let mut cold = schema_cloud_function("references", 20, 20, 0);
+        cold.tracking_state = CloudTrackingState::NeverCalled;
+        cold.never_called_source = CloudNeverCalledSource::RuntimeObserved;
+        let mut snapshot = cloud_context(1, 0);
+        snapshot.summary.trace_count = 100;
+        snapshot.functions = vec![cold];
+
+        let CloudMergeOutput { report, unmatched } =
+            merge_cloud_snapshot(&snapshot, &static_index, 1);
+
+        assert!(
+            unmatched.is_empty(),
+            "the callback must match, got {unmatched:?}"
+        );
+        let finding = report
+            .findings
+            .iter()
+            .find(|finding| finding.function == "references")
+            .expect("the cold callback must produce a finding");
+        let description = finding
+            .actions
+            .first()
+            .map(|action| action.description.clone())
+            .unwrap_or_default();
+        assert!(
+            description.starts_with("Callback passed to references;"),
+            "callback copy must name the call site, got {description:?}"
+        );
+    }
+
     #[test]
     fn cloud_function_without_local_counterpart_stays_unmatched() {
         let (_dir, static_index) = fixture_static_index(CLOUD_FIXTURE_SOURCE);
@@ -2403,7 +2721,7 @@ export const orphan = () => {
 
     #[test]
     fn cloud_never_called_static_used_emits_review_runtime_action() {
-        let actions = runtime_actions(RuntimeCoverageVerdict::ReviewRequired, false);
+        let actions = runtime_actions(RuntimeCoverageVerdict::ReviewRequired, false, None);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].kind, "review-runtime");
     }
@@ -2730,11 +3048,11 @@ export const orphan = () => {
 
     #[test]
     fn runtime_helper_tables_cover_actions_ranks_tracking_and_paths() {
-        let delete_actions = runtime_actions(RuntimeCoverageVerdict::SafeToDelete, false);
+        let delete_actions = runtime_actions(RuntimeCoverageVerdict::SafeToDelete, false, None);
         assert_eq!(delete_actions.len(), 1);
         assert_eq!(delete_actions[0].kind, "delete-cold-code");
-        assert!(runtime_actions(RuntimeCoverageVerdict::Active, false).is_empty());
-        assert!(runtime_actions(RuntimeCoverageVerdict::Unknown, false).is_empty());
+        assert!(runtime_actions(RuntimeCoverageVerdict::Active, false, None).is_empty());
+        assert!(runtime_actions(RuntimeCoverageVerdict::Unknown, false, None).is_empty());
 
         assert!(
             runtime_verdict_rank(RuntimeCoverageVerdict::SafeToDelete)
@@ -2829,6 +3147,7 @@ export const orphan = () => {
             owner_count: None,
             stable_id: function_identity_id(&rel, name, start_line),
             source_hash: None,
+            is_callback: false,
         }
     }
 

--- a/crates/cli/src/coverage/upload_inventory.rs
+++ b/crates/cli/src/coverage/upload_inventory.rs
@@ -525,7 +525,9 @@ fn normalize_path_prefix(raw: Option<&str>) -> Result<Option<String>, UploadErro
     Ok(Some(trimmed.trim_end_matches('/').to_owned()))
 }
 
-fn extension_supported(path: &Path) -> bool {
+/// Whether the inventory walker can parse this file. Shared with the cloud
+/// analyze path, which walks the same tree to index instrumenter names.
+pub(super) fn extension_supported(path: &Path) -> bool {
     if is_typescript_declaration(path) {
         return false;
     }
@@ -1504,6 +1506,7 @@ mod tests {
             end_line: 50,
             end_column: 2,
             source_hash: "0123456789abcdef".to_owned(),
+            is_callback: false,
         }
     }
 
@@ -1870,6 +1873,7 @@ mod tests {
             end_line: line + 1,
             end_column: 2,
             source_hash: hash.to_owned(),
+            is_callback: false,
         }
     }
 

--- a/crates/engine/src/source.rs
+++ b/crates/engine/src/source.rs
@@ -56,6 +56,10 @@ pub mod inventory {
         pub end_column: u32,
         /// Content digest of the function's full-span source slice.
         pub source_hash: String,
+        /// Whether the name came from the callee of the call this function is
+        /// passed to (`arr.map(cb)` -> `map`) rather than from a declaration,
+        /// a binding, or a property key.
+        pub is_callback: bool,
     }
 
     impl From<fallow_extract::inventory::InventoryEntry> for InventoryEntry {
@@ -67,6 +71,7 @@ pub mod inventory {
                 end_line: entry.end_line,
                 end_column: entry.end_column,
                 source_hash: entry.source_hash,
+                is_callback: entry.is_callback,
             }
         }
     }

--- a/crates/extract/src/inventory.rs
+++ b/crates/extract/src/inventory.rs
@@ -15,11 +15,15 @@
 //! starts at 0 and increments in pre-order AST traversal each time a function
 //! is entered without a resolvable explicit name. Name resolution precedence:
 //!
-//! 1. Parent-provided `pending_name`: from a `MethodDefinition` /
-//!    `VariableDeclarator` binding, OR from the callee of the call / `new`
-//!    expression a function is passed to as an argument (`arr.map(cb)` ->
-//!    "map", `foo(cb)` -> "foo", `new Promise(cb)` -> "Promise"). The callee
-//!    case matches `oxc-coverage-instrument`'s opt-in `name_callback_arguments`
+//! 1. Parent-provided `pending_name`: from a `MethodDefinition` (accessors
+//!    carry the instrumenter's `get ` / `set ` label), an `ObjectProperty` key
+//!    (shorthand methods, accessors, and function-valued data properties), a
+//!    `VariableDeclarator` binding, a member-assignment target
+//!    (`o.foo = () => {}` -> "foo"), or an anonymous `export default`
+//!    (-> "default"), OR from the callee of the call / `new` expression a
+//!    function is passed to as an argument (`arr.map(cb)` -> "map",
+//!    `foo(cb)` -> "foo", `new Promise(cb)` -> "Promise"). The callee case
+//!    matches `oxc-coverage-instrument`'s opt-in `name_callback_arguments`
 //!    (which the Fallow runtime beacon enables), so a callback's static name
 //!    lines up with its runtime-instrumented name instead of both sides drifting
 //!    to different anonymous placeholders.
@@ -75,6 +79,11 @@ pub struct InventoryEntry {
     /// `ArrowFunctionExpression`. Stable across line moves, so a
     /// moved-but-unedited function keeps the same hash.
     pub source_hash: String,
+    /// Whether the name was taken from the callee of the call this function is
+    /// passed to (`arr.map(cb)` -> `map`) instead of from a declaration, a
+    /// binding, or a property key. Lets a consumer describe the function as a
+    /// callback passed to that callee rather than as a declaration.
+    pub is_callback: bool,
 }
 
 /// Rolling state for [`InventoryVisitor::line_col_utf16`]: the last resolved
@@ -84,6 +93,22 @@ struct ColCache {
     line_idx: usize,
     byte_end: usize,
     utf16_units: usize,
+}
+
+/// A resolved function name plus how it was resolved.
+struct ResolvedName {
+    name: String,
+    /// `true` only when the name came from a call / `new` callee.
+    is_callback: bool,
+}
+
+impl ResolvedName {
+    const fn named(name: String) -> Self {
+        Self {
+            name,
+            is_callback: false,
+        }
+    }
 }
 
 /// Visitor that collects [`InventoryEntry`] values in file traversal order.
@@ -129,22 +154,25 @@ impl<'a> InventoryVisitor<'a> {
     /// Name precedence, matching the instrumenter's `resolve_function_name`:
     /// parent `pending_name` (method key / variable binding) → function's own
     /// `id` → call/`new` callee (`pending_callee_name`) → counter.
-    fn resolve_name(&mut self, explicit: Option<&str>) -> String {
+    fn resolve_name(&mut self, explicit: Option<&str>) -> ResolvedName {
         let n = self.anonymous_counter;
         self.anonymous_counter += 1;
         if let Some(pending) = self.pending_name.take() {
-            return pending;
+            return ResolvedName::named(pending);
         }
         if let Some(name) = explicit {
-            return name.to_owned();
+            return ResolvedName::named(name.to_owned());
         }
         if let Some(callee) = self.pending_callee_name.take() {
-            return callee;
+            return ResolvedName {
+                name: callee,
+                is_callback: true,
+            };
         }
-        format!("(anonymous_{n})")
+        ResolvedName::named(format!("(anonymous_{n})"))
     }
 
-    fn record(&mut self, name: String, span: Span) {
+    fn record(&mut self, resolved: ResolvedName, span: Span) {
         let (line, start_column) = self.line_col_utf16(span.start);
         let (end_line, end_column) = self.line_col_utf16(span.end);
         let source_hash = self
@@ -155,12 +183,13 @@ impl<'a> InventoryVisitor<'a> {
                 |slice| fallow_cov_protocol::source_hash_for(slice.as_bytes()),
             );
         self.entries.push(InventoryEntry {
-            name,
+            name: resolved.name,
             line,
             start_column,
             end_line,
             end_column,
             source_hash,
+            is_callback: resolved.is_callback,
         });
     }
 
@@ -227,20 +256,24 @@ impl<'ast> Visit<'ast> for InventoryVisitor<'_> {
             walk::walk_function(self, func, flags);
             return;
         }
-        let name = self.resolve_name(func.id.as_ref().map(|id| id.name.as_str()));
-        self.record(name, func.span);
+        let resolved = self.resolve_name(func.id.as_ref().map(|id| id.name.as_str()));
+        self.record(resolved, func.span);
         walk::walk_function(self, func, flags);
     }
 
     fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'ast>) {
-        let name = self.resolve_name(None);
-        self.record(name, arrow.span);
+        let resolved = self.resolve_name(None);
+        self.record(resolved, arrow.span);
         walk::walk_arrow_function_expression(self, arrow);
     }
 
     fn visit_method_definition(&mut self, method: &MethodDefinition<'ast>) {
         if let Some(name) = method.key.static_name() {
-            self.pending_name = Some(name.to_string());
+            self.pending_name = Some(accessor_label(
+                matches!(method.kind, MethodDefinitionKind::Get),
+                matches!(method.kind, MethodDefinitionKind::Set),
+                &name,
+            ));
         }
         walk::walk_method_definition(self, method);
         self.pending_name = None;
@@ -261,9 +294,65 @@ impl<'ast> Visit<'ast> for InventoryVisitor<'_> {
         self.pending_name = None;
     }
 
+    /// Carry an object-literal key into the function it holds, matching the
+    /// instrumenter's `register_object_property`: shorthand methods, accessors
+    /// (prefixed `get ` / `set `), and function-valued data properties inherit
+    /// the key name. A data property holding anything else (a call whose
+    /// argument is a callback, most of all) inherits nothing, so the callback
+    /// still takes its own callee's name.
     fn visit_object_property(&mut self, prop: &ObjectProperty<'ast>) {
-        self.pending_name = None;
+        let is_method_like =
+            prop.method || matches!(prop.kind, PropertyKind::Get | PropertyKind::Set);
+        let is_function_valued = matches!(
+            prop.value,
+            Expression::FunctionExpression(_) | Expression::ArrowFunctionExpression(_)
+        );
+        self.pending_name = if is_method_like || is_function_valued {
+            prop.key.static_name().map(|name| {
+                accessor_label(
+                    matches!(prop.kind, PropertyKind::Get),
+                    matches!(prop.kind, PropertyKind::Set),
+                    &name,
+                )
+            })
+        } else {
+            None
+        };
         walk::walk_object_property(self, prop);
+        self.pending_name = None;
+    }
+
+    /// Carry a member-assignment target into the function assigned to it
+    /// (`client.execute = () => {}` -> "execute"), matching the instrumenter's
+    /// `assignment_target_name`. A plain identifier target takes its name from
+    /// the binding instead, so it is left alone.
+    fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'ast>) {
+        if matches!(expr.operator, AssignmentOperator::Assign)
+            && matches!(
+                expr.right,
+                Expression::FunctionExpression(_)
+                    | Expression::ArrowFunctionExpression(_)
+                    | Expression::ClassExpression(_)
+            )
+        {
+            self.pending_name = assignment_target_name(&expr.left);
+        }
+        walk::walk_assignment_expression(self, expr);
+        self.pending_name = None;
+    }
+
+    /// Name an anonymous default export "default", matching the instrumenter's
+    /// `name_anonymous_default_export`. A named one keeps its own identifier.
+    fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'ast>) {
+        let anonymous = match &decl.declaration {
+            ExportDefaultDeclarationKind::FunctionDeclaration(func) => func.id.is_none(),
+            ExportDefaultDeclarationKind::ArrowFunctionExpression(_) => true,
+            _ => false,
+        };
+        if anonymous {
+            self.pending_name = Some("default".to_owned());
+        }
+        walk::walk_export_default_declaration(self, decl);
         self.pending_name = None;
     }
 
@@ -294,6 +383,33 @@ impl<'ast> Visit<'ast> for InventoryVisitor<'_> {
             self.visit_argument(argument);
         }
         self.pending_callee_name = None;
+    }
+}
+
+/// Prefix an accessor's name the way `oxc-coverage-instrument` labels one, so
+/// a getter reads `get closed` on both sides of the join. A plain method or
+/// data property keeps its bare key.
+fn accessor_label(is_getter: bool, is_setter: bool, name: &str) -> String {
+    if is_getter {
+        return format!("get {name}");
+    }
+    if is_setter {
+        return format!("set {name}");
+    }
+    name.to_owned()
+}
+
+/// Extract a name from a member-assignment target, matching the instrumenter's
+/// `assignment_target_name`: a static member uses the property, a computed
+/// member uses a string-literal key, and anything else yields no name.
+fn assignment_target_name(target: &AssignmentTarget<'_>) -> Option<String> {
+    match target {
+        AssignmentTarget::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        AssignmentTarget::ComputedMemberExpression(member) => match &member.expression {
+            Expression::StringLiteral(lit) => Some(lit.value.to_string()),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -608,10 +724,17 @@ mod tests {
     }
 
     #[test]
-    fn export_default_anonymous_function_uses_counter() {
+    fn export_default_anonymous_function_is_named_default() {
         let entries = walk("export default function() { return 1; }");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].name, "(anonymous_0)");
+        assert_eq!(entries[0].name, "default");
+    }
+
+    #[test]
+    fn export_default_anonymous_arrow_is_named_default() {
+        let entries = walk("export default () => 1;");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "default");
     }
 
     #[test]
@@ -642,10 +765,109 @@ mod tests {
     }
 
     #[test]
-    fn object_method_shorthand_uses_anonymous_counter() {
+    fn object_method_shorthand_uses_the_key_name() {
         let entries = walk("const obj = { run() { return 1; } };");
         let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
-        assert_eq!(names, vec!["(anonymous_0)"]);
+        assert_eq!(names, vec!["run"]);
+    }
+
+    #[test]
+    fn object_accessors_carry_the_get_and_set_label() {
+        let entries = walk(
+            r"
+            const obj = {
+              get closed() { return true; },
+              set closed(value) { this.value = value; },
+            };",
+        );
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["get closed", "set closed"]);
+    }
+
+    #[test]
+    fn function_valued_object_property_uses_the_key_name() {
+        let entries = walk("const client = { execute: async (sql) => sql.length };");
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["execute"]);
+    }
+
+    #[test]
+    fn object_property_holding_a_call_leaves_the_callback_to_its_callee() {
+        // The key names only a function-valued property. A property whose value
+        // is a call must not steal the name from that call's callback.
+        let entries = walk("const column = { references: memo(() => other.id) };");
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["memo"]);
+    }
+
+    #[test]
+    fn class_accessors_carry_the_get_and_set_label() {
+        let entries = walk(
+            r"
+            class Client {
+              get closed() { return true; }
+              set closed(value) { this.value = value; }
+            }",
+        );
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["get closed", "set closed"]);
+    }
+
+    #[test]
+    fn member_assignment_target_names_the_assigned_function() {
+        let entries = walk(
+            r#"
+            client.execute = async (sql) => sql;
+            client["rollback"] = function () { return 1; };
+            "#,
+        );
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["execute", "rollback"]);
+    }
+
+    #[test]
+    fn only_callee_named_functions_are_flagged_as_callbacks() {
+        let entries = walk(
+            r"
+            function declared() { return 1; }
+            const bound = () => 2;
+            const obj = { run() { return 3; } };
+            [1].map(() => 4);
+            (function () { return 5; })();
+            ",
+        );
+        let flags: Vec<_> = entries
+            .iter()
+            .map(|e| (e.name.as_str(), e.is_callback))
+            .collect();
+        assert_eq!(
+            flags,
+            vec![
+                ("declared", false),
+                ("bound", false),
+                ("run", false),
+                ("map", true),
+                ("(anonymous_4)", false),
+            ]
+        );
+    }
+
+    #[test]
+    fn drizzle_style_schema_names_every_callback_after_its_callee() {
+        // The shape a Drizzle schema module has: a table callback, a column
+        // reference callback, and an index callback, all anonymous arrows that
+        // the instrumenter names after the function they are passed to.
+        let entries = walk(
+            r#"
+            export const users = sqliteTable("users", {
+              id: text("id").primaryKey(),
+              orgId: text("org_id").references(() => orgs.id),
+            }, (table) => [index("users_org_idx").on(table.orgId)]);
+            "#,
+        );
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["references", "sqliteTable"]);
+        assert!(entries.iter().all(|entry| entry.is_callback));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

The static index that `fallow coverage analyze --cloud` joins the cloud answer against was built from the health/complexity pass, which enumerates declarations and bindings only. Every other function the runtime instrumenter names was absent from it:

- an arrow passed to a call and named after its callee (`rows.map(...)`, `sqliteTable("t", {}, (table) => [...])`, `.references(() => ...)`),
- an object-literal method, a getter or a setter,
- a function assigned to a member expression.

A cloud row for one of those had nothing to join against on the local side. It was either counted in `cloud_functions_unmatched` and dropped from `findings` and `hot_paths`, or attached by the name-free positional fallback to whatever declaration happened to open on the same line, which put the wrong function name on the busiest rows in the report.

This adds a second indexing pass that walks the same files with the inventory walker, the component that already reproduces `oxc-coverage-instrument`'s naming for the static-inventory upload. Its entries produce the same `(path, name, line)` identity hash the cloud stores, so the join lands on the `stable_id` tier instead of a positional guess. Complexity-pass entries win every collision, so nothing that already matched changes. A function that is known only by the callee it was passed to is flagged as a callback, and its verdict copy names the call site ("Callback passed to `map`; review the runtime-cold code before changing it.") rather than telling the reader to go find a declaration that does not exist.

The inventory walker itself was leaving object-literal methods, function-valued properties, accessors, member assignment targets and anonymous default exports at their `(anonymous_N)` placeholder while the instrumenter names them `run`, `execute`, `get closed`, `rollback` and `default`. Both sides now agree, verified line by line against `oxc_coverage_instrument`'s `enter_object_property`, `enter_method_definition`, `enter_assignment_expression` and `enter_export_default_declaration`. That also means an uploaded inventory entry and the runtime row for the same function share one identity.

## How it was verified

A fixture project carrying exactly the shapes the issue names (a schema-builder call with a table callback and a `.references(() => ...)` column callback, an object returned from a factory with methods, a getter and a `.map(...)` chain) is joined against a cloud payload that names them the instrumenter's way and carries the repo-relative `stable_id`. The test asserts every one of them resolves on the stable-id tier, that the hot paths carry their invocation counts, and that a cold callback's action copy points at the call site. Both new tests fail with the new pass disabled.

Measured against a containerised Bun service with roughly 1,800 functions and a live cloud runtime context, same checkout and same window:

| | `cloud_functions_unmatched` | hot path #1 | hot path #2 |
| --- | --- | --- | --- |
| before | 53 | `exact`, 73,548,240 | `matches`, 43,577,092 |
| after | 20 | `find`, 73,548,240 | `filter`, 43,577,092 |

The top two rows are the `find` and `filter` callbacks the issue names. Before, the positional fallback had attributed their traffic to the `const` bindings that hold the results of those calls (`const exact = rows.find(...)`, `const matches = rows.filter(...)`), so the report named a function that never ran 73M times.

Of the 20 rows still unmatched, 7 are the `(anonymous_N)` class the issue's acceptance criterion sets aside. The other 13 are declarations in two files where the deployed commit and the local checkout differ by about 19 lines; they are outside this issue's class and behave the same before and after. That is the honest reading of "drops to the `(anonymous_N)` rows only": the naming gap is closed, and what is left is line drift between the deployed SHA and the working tree.

Local gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `cargo check --workspace --benches`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`, `npm run generate:contracts:check`, `npm run check:agent-adapters`, `npm run verify:fast` and `npm run verify:full` all pass. No wire shape changed, so no contract surface regenerated.

Closes #2606
