### PR TITLE
fix(cli): print forward slashes in the check and health human output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`check` and `health` print forward slashes on Windows.** Both human
+  renderers rendered the platform separator, so a Windows user was told
+  `src\a.ts` while `dupes`, `list`, `fix` and the JSON surfaces all said
+  `src/a.ts`. The dimmed-directory / bold-filename split keys on `/`, so the
+  whole path also lost its emphasis. Every path the two renderers put on screen
+  now normalises the same way the rest of the CLI already did; on-disk path
+  handling is untouched. The scope tests that caught this compare normalised
+  output, so their negative assertions now fail on a leaked out-of-scope file
+  under either separator instead of passing vacuously
+  (Closes [#2611](https://github.com/fallow-rs/fallow/issues/2611)).
+
 - **`fallow coverage analyze --cloud` no longer drops callbacks, object
   members and accessors.** The static index the cloud answer is joined against
   was built from the health/complexity pass, which enumerates declarations and

--- a/crates/cli/src/report/human/check.rs
+++ b/crates/cli/src/report/human/check.rs
@@ -20,7 +20,8 @@ use super::{
 use crate::report::grouping::OwnershipResolver;
 use crate::report::shared::NAMESPACE_BARREL_HINT;
 use crate::report::{
-    Level, elide_common_prefix, plural, relative_path, severity_to_level, split_dir_filename,
+    Level, elide_common_prefix, format_display_path, plural, relative_path, severity_to_level,
+    split_dir_filename,
 };
 
 /// Minimum number of duplicate-export findings before the human section is
@@ -480,13 +481,13 @@ fn format_dep_with_pkg(
     used_in_workspaces: &[PathBuf],
     root: &Path,
 ) -> String {
-    let pkg_label = relative_path(pkg_path, root).display().to_string();
+    let pkg_label = format_display_path(pkg_path, root);
     let workspace_context = if used_in_workspaces.is_empty() {
         String::new()
     } else {
         let workspaces = used_in_workspaces
             .iter()
-            .map(|path| relative_path(path, root).display().to_string())
+            .map(|path| format_display_path(path, root))
             .collect::<Vec<_>>()
             .join(", ");
         format!("; imported in {workspaces}")
@@ -742,9 +743,7 @@ fn push_unused_files_section(input: &mut UnusedCodeSectionInput<'_>) {
                 total_issues: input.total_issues,
             },
             |file| {
-                let path_str = relative_path(&file.file.path, input.root)
-                    .display()
-                    .to_string();
+                let path_str = format_display_path(&file.file.path, input.root);
                 vec![format!(
                     "  {}{}",
                     format_path(&path_str),
@@ -1157,10 +1156,7 @@ fn push_unused_catalog_entries_section(
                 catalog = entry.catalog_name.dimmed(),
                 loc = format!(
                     "{}:{}",
-                    path_display
-                        .strip_prefix(ctx.root)
-                        .unwrap_or(&path_display)
-                        .display(),
+                    format_display_path(&path_display, ctx.root),
                     entry.line
                 )
                 .dimmed(),
@@ -1170,7 +1166,7 @@ fn push_unused_catalog_entries_section(
                 let consumers = entry
                     .hardcoded_consumers
                     .iter()
-                    .map(|p| p.strip_prefix(ctx.root).unwrap_or(p).display().to_string())
+                    .map(|p| format_display_path(p, ctx.root))
                     .collect::<Vec<_>>()
                     .join(", ");
                 row = format!("    {}: {consumers}", "hardcoded in".dimmed());
@@ -1207,10 +1203,7 @@ fn push_empty_catalog_groups_section(
                 catalog = group.catalog_name.bold(),
                 loc = format!(
                     "{}:{}",
-                    path_display
-                        .strip_prefix(ctx.root)
-                        .unwrap_or(&path_display)
-                        .display(),
+                    format_display_path(&path_display, ctx.root),
                     group.line
                 )
                 .dimmed(),
@@ -1266,10 +1259,7 @@ fn format_unresolved_catalog_reference(
         catalog = catalog_label.dimmed(),
         loc = format!(
             "{}:{}",
-            path_display
-                .strip_prefix(root)
-                .unwrap_or(&path_display)
-                .display(),
+            format_display_path(&path_display, root),
             finding.line
         )
         .dimmed(),
@@ -1337,10 +1327,7 @@ fn push_unused_dependency_overrides_section(input: UnusedDependencyOverridesInpu
                 source = finding.source.as_label().dimmed(),
                 loc = format!(
                     "{}:{}",
-                    path_display
-                        .strip_prefix(input.root)
-                        .unwrap_or(&path_display)
-                        .display(),
+                    format_display_path(&path_display, input.root),
                     finding.line
                 )
                 .dimmed(),
@@ -1393,10 +1380,7 @@ fn push_misconfigured_dependency_overrides_section(
                 source = finding.source.as_label().dimmed(),
                 loc = format!(
                     "{}:{}",
-                    path_display
-                        .strip_prefix(root)
-                        .unwrap_or(&path_display)
-                        .display(),
+                    format_display_path(&path_display, root),
                     finding.line
                 )
                 .dimmed(),
@@ -2096,7 +2080,7 @@ fn build_policy_violations_section(
     let shown = items.len().min(MAX_FLAT_ITEMS);
     for entry in &items[..shown] {
         let v = &entry.violation;
-        let path = relative_path(&v.path, root).display().to_string();
+        let path = format_display_path(&v.path, root);
         let detail = match &v.message {
             Some(message) => format!("banned by `{}/{}`: {message}", v.pack, v.rule_id),
             None => format!("banned by `{}/{}`", v.pack, v.rule_id),
@@ -2496,7 +2480,7 @@ fn collect_duplicate_export_pairs<'a>(
         let mut paths: Vec<String> = dup
             .locations
             .iter()
-            .map(|loc| relative_path(&loc.path, root).display().to_string())
+            .map(|loc| format_display_path(&loc.path, root))
             .collect();
         paths.sort();
         paths.dedup();
@@ -2605,7 +2589,7 @@ fn circular_dependency_hub_groups<'a>(
         let hub = cycle
             .files
             .first()
-            .map(|path| relative_path(path, root).display().to_string())
+            .map(|path| format_display_path(path, root))
             .unwrap_or_default();
         if let Some(&idx) = hub_map.get(&hub) {
             hub_groups[idx].1.push(cycle);
@@ -2636,7 +2620,7 @@ fn circular_dependency_cycle_line(
     let rel_paths: Vec<String> = cycle
         .files
         .iter()
-        .map(|path| relative_path(path, root).display().to_string())
+        .map(|path| format_display_path(path, root))
         .collect();
     let mut chain_parts: Vec<String> = rel_paths[1..]
         .iter()
@@ -2699,7 +2683,7 @@ fn build_re_export_cycles_section(
         let first_path = cycle
             .files
             .first()
-            .map(|p| relative_path(p, root).display().to_string())
+            .map(|p| format_display_path(p, root))
             .unwrap_or_default();
         lines.push(format!("  {}", format_path(&first_path)));
         let header_line = match cycle.kind {
@@ -2710,7 +2694,7 @@ fn build_re_export_cycles_section(
         };
         lines.push(format!("    {}", header_line.dimmed()));
         for path in &cycle.files {
-            let rel = relative_path(path, root).display().to_string();
+            let rel = format_display_path(path, root);
             lines.push(format!("      - {}", format_path(&rel)));
         }
         let fix_hint = match cycle.kind {
@@ -2755,8 +2739,8 @@ fn build_boundary_violations_section(
     let shown = items.len().min(MAX_FLAT_ITEMS);
     for entry in &items[..shown] {
         let v = &entry.violation;
-        let from = relative_path(&v.from_path, root).display().to_string();
-        let to = relative_path(&v.to_path, root).display().to_string();
+        let from = format_display_path(&v.from_path, root);
+        let to = format_display_path(&v.to_path, root);
         lines.push(format!(
             "  {}:{} {} {} {} {}",
             from,
@@ -2795,7 +2779,7 @@ fn build_boundary_coverage_violations_section(
     let shown = items.len().min(MAX_FLAT_ITEMS);
     for entry in &items[..shown] {
         let v = &entry.violation;
-        let path = relative_path(&v.path, root).display().to_string();
+        let path = format_display_path(&v.path, root);
         lines.push(format!(
             "  {}:{} {}",
             path,
@@ -2833,7 +2817,7 @@ fn build_boundary_call_violations_section(
     let shown = items.len().min(MAX_FLAT_ITEMS);
     for entry in &items[..shown] {
         let v = &entry.violation;
-        let path = relative_path(&v.path, root).display().to_string();
+        let path = format_display_path(&v.path, root);
         lines.push(format!(
             "  {}:{} {} {}",
             path,
@@ -2876,7 +2860,7 @@ fn build_stale_suppressions_section(
 
     let shown = items.len().min(MAX_FLAT_ITEMS);
     for s in &items[..shown] {
-        let path_str = relative_path(&s.path, root).display().to_string();
+        let path_str = format_display_path(&s.path, root);
         lines.push(format!(
             "  {}:{}:{} {} {}",
             path_str,
@@ -3929,6 +3913,31 @@ mod tests {
         assert!(
             matched.iter().any(|r| r.contains("src")),
             "mixed-barrel path must route through the ownership resolver, got: {matched:?}"
+        );
+    }
+
+    #[test]
+    fn unused_file_lines_normalize_backslash_separators() {
+        // A Windows path reaches the renderer with native separators. The human
+        // report is read by people and matched by tooling, so it must show the
+        // same forward-slash form on every platform.
+        let root = PathBuf::from("/project");
+        let mut results = AnalysisResults::default();
+        results
+            .unused_files
+            .push(UnusedFileFinding::with_actions(UnusedFile {
+                path: root.join("src\\dead.ts"),
+            }));
+        let rules = RulesConfig::default();
+        let text = super::super::plain(&build_human_lines(&results, &root, &rules, None));
+
+        assert!(
+            text.contains("src/dead.ts"),
+            "unused-file lines must use forward slashes: {text}"
+        );
+        assert!(
+            !text.contains("src\\dead.ts"),
+            "unused-file lines must not leak native separators: {text}"
         );
     }
 

--- a/crates/cli/src/report/human/cross_ref.rs
+++ b/crates/cli/src/report/human/cross_ref.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use colored::Colorize;
 use fallow_config::OutputFormat;
 
-use super::{plural, relative_path};
+use super::plural;
+use crate::report::format_display_path;
 
 pub(in crate::report) fn print_cross_reference_findings(
     cross_ref: &fallow_engine::cross_reference::CrossReferenceResult,
@@ -64,12 +65,10 @@ fn build_cross_reference_lines(
     lines.push(String::new());
 
     for finding in &cross_ref.combined_findings {
-        let relative = relative_path(&finding.clone_instance.file, root);
+        let relative = format_display_path(&finding.clone_instance.file, root);
         let location = format!(
             "{}:{}-{}",
-            relative.display(),
-            finding.clone_instance.start_line,
-            finding.clone_instance.end_line
+            relative, finding.clone_instance.start_line, finding.clone_instance.end_line
         );
 
         let reason = match &finding.dead_code_kind {

--- a/crates/cli/src/report/human/health.rs
+++ b/crates/cli/src/report/human/health.rs
@@ -10,12 +10,12 @@ use super::health_hotspots::render_hotspots;
 use super::health_runtime::render_runtime_coverage;
 use super::health_targets::render_refactoring_targets;
 use super::{
-    MAX_FLAT_ITEMS, format_path, plural, print_explain_tip_if_tty, relative_path,
-    split_dir_filename, thousands,
+    MAX_FLAT_ITEMS, format_path, plural, print_explain_tip_if_tty, split_dir_filename, thousands,
 };
 use crate::health::scoring::{
     FileScoreConcern, file_score_concern_axis, file_score_fully_crap_exempt,
 };
+use crate::report::format_display_path;
 
 /// Docs base URL for health explanations.
 const DOCS_HEALTH: &str = "https://docs.fallow.tools/explanations/health";
@@ -1012,7 +1012,7 @@ fn render_coverage_intelligence(
         return;
     }
     for finding in intelligence.findings.iter().take(MAX_FLAT_ITEMS) {
-        let relative = relative_path(&finding.path, root);
+        let relative = format_display_path(&finding.path, root);
         let identity = finding
             .identity
             .as_deref()
@@ -1029,7 +1029,7 @@ fn render_coverage_intelligence(
             .map_or("Review this finding", |action| action.description.as_str());
         lines.push(format!(
             "  {}:{}{} {} [{}]",
-            format_path(&relative.display().to_string()),
+            format_path(&relative),
             finding.line,
             identity,
             finding.verdict,
@@ -1597,7 +1597,7 @@ fn render_large_functions(
 
     let mut last_file = String::new();
     for entry in report.large_functions.iter().take(MAX_FLAT_ITEMS) {
-        let file_str = relative_path(&entry.path, root).display().to_string();
+        let file_str = format_display_path(&entry.path, root);
         if file_str != last_file {
             lines.push(format!("  {}", format_path(&file_str)));
             last_file = file_str;
@@ -2405,7 +2405,7 @@ fn render_file_score_row(
     root: &Path,
     max_crap_threshold: f64,
 ) {
-    let file_str = relative_path(&score.path, root).display().to_string();
+    let file_str = format_display_path(&score.path, root);
     let (dir, filename) = split_dir_filename(&file_str);
     const CONCERN_TAG_COLUMN: usize = 48;
     let pad = CONCERN_TAG_COLUMN
@@ -2614,7 +2614,7 @@ fn push_coverage_gap_files(
     let shown_files = gaps.files.len().min(MAX_FLAT_ITEMS);
     lines.push(format!("  {}", "Files".dimmed()));
     for item in &gaps.files[..shown_files] {
-        let file_str = relative_path(&item.file.path, root).display().to_string();
+        let file_str = format_display_path(&item.file.path, root);
         let (dir, filename) = split_dir_filename(&file_str);
         lines.push(format!("  {}{}", dir.dimmed(), filename));
     }
@@ -2681,7 +2681,7 @@ fn push_coverage_gap_export_rows(
         if shown >= MAX_FLAT_ITEMS {
             break;
         }
-        let file_str = relative_path(file_path, root).display().to_string();
+        let file_str = format_display_path(file_path, root);
         if exports.len() > 10 {
             lines.push(format!(
                 "  {} ({} untested re-exports)",
@@ -4777,6 +4777,41 @@ mod tests {
         assert!(text.contains("3 fan-out"));
         assert!(text.contains("15% dead"));
         assert!(text.contains("0.42 density"));
+    }
+
+    #[test]
+    fn file_score_rows_normalize_backslash_separators() {
+        // A Windows path reaches the renderer with native separators. The human
+        // report is read by people and matched by tooling, so it must show the
+        // same forward-slash form on every platform.
+        let root = PathBuf::from("/project");
+        let mut report = empty_report();
+        report.file_scores = vec![fallow_output::FileHealthScore {
+            path: root.join("src\\utils.ts"),
+            fan_in: 5,
+            fan_out: 3,
+            dead_code_ratio: 0.15,
+            complexity_density: 0.42,
+            maintainability_index: 85.3,
+            total_cyclomatic: 12,
+            total_cognitive: 8,
+            function_count: 4,
+            lines: 200,
+            crap_max: 0.0,
+            crap_above_threshold: 0,
+            crap_exempted: 0,
+            crap_effective_threshold: None,
+        }];
+        let text = plain(&build_health_human_lines(&report, &root));
+
+        assert!(
+            text.contains("src/utils.ts"),
+            "file-score rows must use forward slashes: {text}"
+        );
+        assert!(
+            !text.contains("src\\utils.ts"),
+            "file-score rows must not leak native separators: {text}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/report/human/health_hotspots.rs
+++ b/crates/cli/src/report/human/health_hotspots.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use colored::Colorize;
 
-use super::{plural, relative_path, split_dir_filename};
+use super::{plural, split_dir_filename};
+use crate::report::format_display_path;
 
 const DOCS_HEALTH: &str = "https://docs.fallow.tools/explanations/health";
 
@@ -176,7 +177,7 @@ fn push_hotspots_header(lines: &mut Vec<String>, report: &fallow_output::HealthR
 }
 
 fn push_hotspot_row(lines: &mut Vec<String>, entry: &fallow_output::HotspotEntry, root: &Path) {
-    let file_str = relative_path(&entry.path, root).display().to_string();
+    let file_str = format_display_path(&entry.path, root);
     let (dir, filename) = split_dir_filename(&file_str);
     lines.push(format!(
         "  {} {}  {}{}{}",

--- a/crates/cli/src/report/human/health_runtime.rs
+++ b/crates/cli/src/report/human/health_runtime.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use colored::Colorize;
 
-use super::{MAX_FLAT_ITEMS, format_path, health::format_window, relative_path, thousands};
+use super::{MAX_FLAT_ITEMS, format_path, health::format_window, thousands};
+use crate::report::format_display_path;
 
 pub(super) fn render_runtime_coverage(
     lines: &mut Vec<String>,
@@ -82,7 +83,7 @@ fn render_runtime_findings(
 ) {
     let shown_findings = production.findings.len().min(MAX_FLAT_ITEMS);
     for finding in &production.findings[..shown_findings] {
-        let relative = format_path(&relative_path(&finding.path, root).display().to_string());
+        let relative = format_path(&format_display_path(&finding.path, root));
         let invocations = finding.invocations.map_or_else(
             || "untracked".to_owned(),
             |hits| format!("{hits} invocations"),
@@ -111,7 +112,7 @@ fn render_runtime_hot_paths(
     if !production.hot_paths.is_empty() {
         lines.push("  hot paths:".to_owned());
         for entry in production.hot_paths.iter().take(5) {
-            let relative = format_path(&relative_path(&entry.path, root).display().to_string());
+            let relative = format_path(&format_display_path(&entry.path, root));
             lines.push(format!(
                 "    {relative}:{} {} ({} invocations, p{})",
                 entry.line,

--- a/crates/cli/src/report/human/health_targets.rs
+++ b/crates/cli/src/report/human/health_targets.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use colored::Colorize;
 
-use super::{MAX_FLAT_ITEMS, relative_path, split_dir_filename};
+use super::{MAX_FLAT_ITEMS, split_dir_filename};
+use crate::report::format_display_path;
 
 const DOCS_HEALTH: &str = "https://docs.fallow.tools/explanations/health";
 
@@ -98,7 +99,7 @@ fn push_refactoring_target_row(
     target: &fallow_output::RefactoringTarget,
     root: &Path,
 ) {
-    let file_str = relative_path(&target.path, root).display().to_string();
+    let file_str = format_display_path(&target.path, root);
     let (dir, filename) = split_dir_filename(&file_str);
     lines.push(format!(
         "  {}  {}    {}{}",
@@ -183,7 +184,7 @@ fn render_target_evidence(
             .direct_callers
             .iter()
             .map(|caller| {
-                let path = relative_path(&caller.path, root).display().to_string();
+                let path = format_display_path(&caller.path, root);
                 if caller.symbols.is_empty() {
                     path
                 } else {
@@ -209,7 +210,7 @@ fn render_target_evidence(
             .clone_siblings
             .iter()
             .map(|sibling| {
-                let path = relative_path(&sibling.path, root).display().to_string();
+                let path = format_display_path(&sibling.path, root);
                 format!(
                     "{}:{}-{} {}",
                     path, sibling.start_line, sibling.end_line, sibling.fingerprint

--- a/crates/cli/src/report/human/mod.rs
+++ b/crates/cli/src/report/human/mod.rs
@@ -23,7 +23,7 @@ use colored::Colorize;
 use fallow_types::issue_meta::{issue_meta_by_kind, issue_meta_for_contract_token};
 use fallow_types::suppress::{IssueKind, issue_kind_to_kebab};
 
-use super::{Level, plural, relative_path, split_dir_filename};
+use super::{Level, format_display_path, plural, relative_path, split_dir_filename};
 
 /// Maximum items shown per flat section (unused files, deps, etc.).
 pub(super) const MAX_FLAT_ITEMS: usize = 10;
@@ -513,7 +513,7 @@ where
     let mut file_map: rustc_hash::FxHashMap<String, usize> = rustc_hash::FxHashMap::default();
 
     for (i, item) in items.iter().enumerate() {
-        let file_str = relative_path(get_path(item), root).display().to_string();
+        let file_str = format_display_path(get_path(item), root);
         if let Some(&group_idx) = file_map.get(&file_str) {
             file_groups[group_idx].1.push(i);
         } else {

--- a/crates/cli/tests/scope_path_tests.rs
+++ b/crates/cli/tests/scope_path_tests.rs
@@ -94,6 +94,15 @@ fn has_clone_group_with_files(json: &serde_json::Value, expected: &[&str]) -> bo
         })
 }
 
+/// Rendered paths use forward slashes on every platform, but a renderer that
+/// regressed to the native separator would make a `!contains("other/c.ts")`
+/// assertion pass while the file was on screen. Normalising the captured text
+/// once keeps the negative assertions meaningful on Windows: a leaked
+/// `other\c.ts` still trips them.
+fn slashed(text: &str) -> String {
+    text.replace('\\', "/")
+}
+
 #[test]
 fn dupes_dir_scope_reports_only_scoped_clones() {
     let tmp = create_scope_fixture();
@@ -191,15 +200,14 @@ fn dupes_outside_root_path_is_exit_two() {
 fn check_file_scope_narrows_to_the_file() {
     let tmp = create_scope_fixture();
     let output = run_fallow_in_root("check", tmp.path(), &["src/a.ts"]);
+    let stdout = slashed(&output.stdout);
     assert!(
-        output.stdout.contains("src/a.ts"),
-        "scoped check should report the file. stdout: {}",
-        output.stdout
+        stdout.contains("src/a.ts"),
+        "scoped check should report the file. stdout: {stdout}"
     );
     assert!(
-        !output.stdout.contains("src/b.ts") && !output.stdout.contains("other/c.ts"),
-        "scoped check should hide other files. stdout: {}",
-        output.stdout
+        !stdout.contains("src/b.ts") && !stdout.contains("other/c.ts"),
+        "scoped check should hide other files. stdout: {stdout}"
     );
 }
 
@@ -207,15 +215,14 @@ fn check_file_scope_narrows_to_the_file() {
 fn check_dir_scope_narrows_to_the_directory() {
     let tmp = create_scope_fixture();
     let output = run_fallow_in_root("check", tmp.path(), &["src"]);
+    let stdout = slashed(&output.stdout);
     assert!(
-        output.stdout.contains("src/a.ts") || output.stdout.contains("src/b.ts"),
-        "scoped check should report src findings. stdout: {}",
-        output.stdout
+        stdout.contains("src/a.ts") || stdout.contains("src/b.ts"),
+        "scoped check should report src findings. stdout: {stdout}"
     );
     assert!(
-        !output.stdout.contains("other/c.ts"),
-        "scoped check should hide other/ findings. stdout: {}",
-        output.stdout
+        !stdout.contains("other/c.ts"),
+        "scoped check should hide other/ findings. stdout: {stdout}"
     );
 }
 
@@ -231,7 +238,7 @@ fn bare_combined_path_scope_narrows_report() {
         .env("NO_COLOR", "1")
         .output()
         .expect("failed to run fallow binary");
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stdout = slashed(&String::from_utf8_lossy(&output.stdout));
     assert!(
         stdout.contains("src/a.ts") || stdout.contains("src/b.ts"),
         "scoped bare run should report src findings. stdout: {stdout}"
@@ -251,15 +258,14 @@ fn list_files_scope_narrows_inventory() {
         "list should succeed. stderr: {}",
         output.stderr
     );
+    let stdout = slashed(&output.stdout);
     assert!(
-        output.stdout.contains("src/a.ts") && output.stdout.contains("src/b.ts"),
-        "scoped list should show src files. stdout: {}",
-        output.stdout
+        stdout.contains("src/a.ts") && stdout.contains("src/b.ts"),
+        "scoped list should show src files. stdout: {stdout}"
     );
     assert!(
-        !output.stdout.contains("other/c.ts"),
-        "scoped list should hide other/ files. stdout: {}",
-        output.stdout
+        !stdout.contains("other/c.ts"),
+        "scoped list should hide other/ files. stdout: {stdout}"
     );
 }
 
@@ -267,15 +273,14 @@ fn list_files_scope_narrows_inventory() {
 fn health_dir_scope_runs_scoped() {
     let tmp = create_scope_fixture();
     let output = run_fallow_in_root("health", tmp.path(), &["--file-scores", "src"]);
+    let stdout = slashed(&output.stdout);
     assert!(
-        output.stdout.contains("src/"),
-        "scoped health should mention scoped files. stdout: {}",
-        output.stdout
+        stdout.contains("src/"),
+        "scoped health should mention scoped files. stdout: {stdout}"
     );
     assert!(
-        !output.stdout.contains("other/c.ts"),
-        "scoped health should hide other/ files. stdout: {}",
-        output.stdout
+        !stdout.contains("other/c.ts"),
+        "scoped health should hide other/ files. stdout: {stdout}"
     );
 }
 
@@ -356,17 +361,13 @@ fn audit_scope_narrows_changed_universe() {
     .unwrap();
 
     let output = run_fallow_in_root("audit", dir, &["--gate", "all", "src"]);
-    let combined = format!("{}\n{}", output.stdout, output.stderr);
+    let combined = slashed(&format!("{}\n{}", output.stdout, output.stderr));
     assert!(
         combined.contains("src/a.ts"),
-        "scoped audit should report scoped changes. stdout: {} stderr: {}",
-        output.stdout,
-        output.stderr
+        "scoped audit should report scoped changes. output: {combined}"
     );
     assert!(
         !combined.contains("other/c.ts"),
-        "scoped audit should hide out-of-scope changes. stdout: {} stderr: {}",
-        output.stdout,
-        output.stderr
+        "scoped audit should hide out-of-scope changes. output: {combined}"
     );
 }


### PR DESCRIPTION
`release-validation.yml` was red on main: the "Windows correctness and lifecycle" job failed `cargo test -p fallow-cli --test scope_path_tests` with three failures (`check_file_scope_narrows_to_the_file`, `check_dir_scope_narrows_to_the_directory`, `health_dir_scope_runs_scoped`). The scoping itself was correct; the display convention was not.

## The defect

The `check` and `health` human renderers rendered the platform path separator, so a Windows user was told `src\a.ts` while `dupes`, `list`, `fix` and every JSON surface said `src/a.ts`. It was not only cosmetic: `split_dir_filename` keys on `/`, so a native-separator path also lost its dimmed-directory / bold-filename split and rendered as one bold blob.

Every path those renderers put on screen now goes through the existing `format_display_path` helper, the way the rest of the CLI already did (same convention as c716033 for `fallow fix`). On-disk path handling is untouched: only the rendered text changes, and it is byte-identical on POSIX, verified by diffing `check` and `health` output against a pre-change baseline.

## The weaker half of the test

`scope_path_tests` caught this as three failures, and its negative assertions are the reason it caught no more: `!stdout.contains("other/c.ts")` passed while the file was on screen as `other\c.ts`, so on Windows the suite proved less than it looked. All twelve assertion sites now compare output normalised once through a `slashed` helper, so a leaked out-of-scope file trips the suite under either separator, which is the acceptance criterion on the issue.

Because the integration assertions are now separator-agnostic, two renderer unit tests pin the forward-slash convention itself: `unused_file_lines_normalize_backslash_separators` and `file_score_rows_normalize_backslash_separators`. Both were confirmed to fail against the unfixed renderer before being kept.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib --bins --tests --examples`, `npm run verify:fast`: green.
- `release-validation.yml` dispatched on this branch: green, including the Windows job. That is the gate the issue asks for, since the failure cannot be reproduced on macOS.

Closes #2611
