### PR TITLE
feat(plugins): recognize the Expo Router SuspenseFallback route export

### DIFF
--- a/crates/core/src/plugins/expo_router.rs
+++ b/crates/core/src/plugins/expo_router.rs
@@ -10,6 +10,7 @@ use super::{PathRule, Plugin, PluginResult, UsedExportRule, config_parser};
 const ROUTE_FILE_EXPORTS: &[&str] = &[
     "default",
     "ErrorBoundary",
+    "SuspenseFallback",
     "loader",
     "generateStaticParams",
     "unstable_settings",

--- a/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
+++ b/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
@@ -54,6 +54,7 @@ fn expo_router_special_files_and_exports_are_covered() {
     for (path, export) in [
         ("src/app/_layout.tsx", "default"),
         ("src/app/_layout.tsx", "ErrorBoundary"),
+        ("src/app/_layout.tsx", "SuspenseFallback"),
         ("src/app/_layout.tsx", "unstable_settings"),
         ("src/app/index.tsx", "default"),
         ("src/app/index.tsx", "ErrorBoundary"),

--- a/tests/fixtures/expo-router-conventions/src/app/_layout.tsx
+++ b/tests/fixtures/expo-router-conventions/src/app/_layout.tsx
@@ -6,6 +6,10 @@ export function ErrorBoundary() {
     return null;
 }
 
+export function SuspenseFallback() {
+    return null;
+}
+
 export const unstable_settings = {
     initialRouteName: "index",
 };


### PR DESCRIPTION
## Summary

Adds `SuspenseFallback` to `ROUTE_FILE_EXPORTS` in the Expo Router plugin, so a
route file exporting it is no longer reported as an unused export.

## Convention evidence

Expo Router SDK 56 added a customizable Suspense fallback. `LoadedRoute` on
`expo/expo@main` now declares it alongside the exports the plugin already knows:

```ts
export type LoadedRoute = {
  ErrorBoundary?: ComponentType<ErrorBoundaryProps>;
  SuspenseFallback?: ComponentType<SuspenseFallbackProps>;
  default?: ComponentType<any>;
  unstable_settings?: Record<string, any>;
  getNavOptions?: (args: any) => any;
  generateStaticParams?: (props: { params?: Params }) => Params[];
  loader?: LoaderFunction;
  generateMetadata?: GenerateMetadataFunction;
};
```

- [Error handling and loading states](https://docs.expo.dev/router/error-handling/):
  "Custom suspense fallbacks are available in SDK 56 and later."

## Scope note

The runtime honors `SuspenseFallback` only on layout nodes — `useScreens.tsx`
gates the read behind `value.type === 'layout'`, and non-layout routes fall back
to inherited context. This change follows the existing treatment of
`unstable_settings`, which is likewise layout-oriented but lives in the shared
`ROUTE_FILE_EXPORTS` list rather than a layout-specific rule. Tightening both to
a `_layout`-scoped rule is a reasonable follow-up if the narrower reporting is
wanted; it would need the generic rule's exclude globs reworked so layout files
do not lose the ordinary route exports.

## Verification

- `expo_router_special_files_and_exports_are_covered` fails without the plugin
  change (`src/app/_layout.tsx:SuspenseFallback` reported unused) and passes
  with it.
- `cargo test -p fallow-core`: 1141 passed, 0 failed.
- `npm run verify:fast` could not complete locally: this machine's toolchain has
  no `rustfmt` or `clippy` component and no `rustup` to add them, so
  `cargo fmt --all -- --check` and `cargo clippy` were not run. The runnable
  pre-commit checks (hidden-unicode, narrator-comment) pass. The staged `.tsx`
  fixture is outside the oxlint/oxfmt scopes. CI still enforces all of these.

## Follow-up

`getNavOptions` and `generateMetadata` are also in `LoadedRoute` but missing
from `ROUTE_FILE_EXPORTS`. Left out to keep this change to the one export.
