### PR TITLE
chore(audit): drop unused derives on MaterializationScope

### DIFF
--- a/crates/engine/src/repo_refs.rs
+++ b/crates/engine/src/repo_refs.rs
@@ -671,7 +671,6 @@ struct TreeEntry {
 ///
 /// Both probes fail open to full materialization: a probe error is at worst a
 /// slower snapshot, never a missing-file misattribution.
-#[derive(Debug, Clone, Default)]
 struct MaterializationScope {
     /// Forward-slash repo-relative analysis subdir (e.g. `apps/web`), or
     /// `None` when the requested root is the repository top level.


### PR DESCRIPTION
Slop-audit follow-up to the sparse base-snapshot change (#2615): the private scope struct is only borrowed, so Debug, Clone, and Default have no users. Compiler-verified (removal would fail to compile otherwise); check, clippy, and all 28 repo_refs tests green.